### PR TITLE
DAGCircuit layers uses a shallow copy

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1255,8 +1255,8 @@ class DAGCircuit:
                         del predecessor_count[successor]
 
             yield next_layer
-            next_layer = []
             cur_layer = next_layer
+            next_layer = []
 
     def collect_runs(self, namelist):
         """Return a set of runs of "op" nodes with the given names.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -17,15 +17,14 @@ to the input of B. The object's methods allow circuits to be constructed,
 composed, and modified. Some natural properties like depth can be computed
 directly from the graph.
 """
-import itertools
-import copy
 from collections import OrderedDict
+import copy
+import itertools
+
 import networkx as nx
 import sympy
 
-from qiskit import QuantumRegister
-from qiskit import QISKitError
-from qiskit import CompositeGate
+from qiskit import QuantumRegister, QISKitError, CompositeGate
 from ._dagcircuiterror import DAGCircuitError
 
 
@@ -1139,7 +1138,7 @@ class DAGCircuit:
                 self._remove_op_node(n)
 
     def layers(self):
-        """Yield a layer for all d layers of this circuit.
+        """Yield a shallow view on a layer of this DAGCircuit for all d layers of this circuit.
 
         A layer is a circuit whose gates act on disjoint qubits, i.e.
         a layer has depth 1. The total number of layers equals the
@@ -1153,84 +1152,46 @@ class DAGCircuit:
         layers as this is currently implemented. This may not be
         the desired behavior.
         """
-        # node_map contains an input node or previous layer node for
-        # each wire in the circuit.
-        node_map = self.input_map.copy()
-        # wires_with_ops_remaining is a set of wire names that have
-        # operations we still need to assign to layers
-        wires_with_ops_remaining = sorted(set(self.input_map.keys()))
+        graph_layers = self.multigraph_layers()
+        next(graph_layers)  # Remove input nodes
+        for graph_layer in graph_layers:
+            # Construct a shallow copy of self
+            new_layer = copy.copy(self)
+            new_layer.multi_graph = nx.MultiDiGraph()
 
-        while wires_with_ops_remaining:
-            # Create a new circuit graph and populate with regs and basis
-            new_layer = DAGCircuit()
-            for k, v in self.qregs.items():
-                new_layer.add_qreg(k, v)
-            for k, v in self.cregs.items():
-                new_layer.add_creg(k, v)
-            new_layer.basis = self.basis.copy()
-            new_layer.gates = self.gates.copy()
-            # Save the support of each operation we add to the layer
-            support_list = []
-            # Determine what operations to add in this layer
-            # ops_touched is a map from operation nodes touched in this
-            # iteration to the set of their unvisited input wires. When all
-            # of the inputs of a touched node are visited, the node is a
-            # foreground node we can add to the current layer.
-            ops_touched = {}
-            wires_loop = list(wires_with_ops_remaining)
-            emit = False
-            for w in wires_loop:
-                oe = [x for x in self.multi_graph.out_edges(nbunch=[node_map[w]],
-                                                            data=True) if
-                      x[2]["name"] == w]
-                if len(oe) != 1:
-                    raise QISKitError("should only be one out-edge per (qu)bit")
+            def nodes_data(nodes):
+                """Construct full nodes from just node ids."""
+                return (
+                    (node_id, self.multi_graph.node[node_id]) for node_id in nodes
+                    )
 
-                nxt_nd_idx = oe[0][1]
-                nxt_nd = self.multi_graph.node[nxt_nd_idx]
-                # If we reach an output node, we are done with this wire.
-                if nxt_nd["type"] == "out":
-                    wires_with_ops_remaining.remove(w)
-                # Otherwise, we are somewhere inside the circuit
-                elif nxt_nd["type"] == "op":
-                    # Operation data
-                    qa = copy.copy(nxt_nd["qargs"])
-                    ca = copy.copy(nxt_nd["cargs"])
-                    pa = copy.copy(nxt_nd["params"])
-                    co = copy.copy(nxt_nd["condition"])
-                    cob = self._bits_in_condition(co)
-                    # First time we see an operation, add to ops_touched
-                    if nxt_nd_idx not in ops_touched:
-                        ops_touched[nxt_nd_idx] = set(qa) | set(ca) | set(cob)
-                    # Mark inputs visited by deleting from set
-                    # NOTE: expect trouble with if(c==1) measure q -> c;
-                    if w not in ops_touched[nxt_nd_idx]:
-                        raise QISKitError("expected wire")
+            new_layer.multi_graph.add_nodes_from(nodes_data(self.input_map.values()))
+            new_layer.multi_graph.add_nodes_from(nodes_data(self.output_map.values()))
 
-                    ops_touched[nxt_nd_idx].remove(w)
-                    # Node becomes "foreground" if set becomes empty,
-                    # i.e. every input is available for this operation
-                    if not ops_touched[nxt_nd_idx]:
-                        # Add node to new_layer
-                        new_layer.apply_operation_back(nxt_nd["name"],
-                                                       qa, ca, pa, co)
-                        # Update node_map to point to this op
-                        for v in itertools.chain(qa, ca, cob):
-                            node_map[v] = nxt_nd_idx
-                        # Add operation to partition
-                        if nxt_nd["name"] not in ["barrier",
-                                                  "snapshot", "save", "load", "noise"]:
-                            # support_list.append(list(set(qa) | set(ca) |
-                            #                          set(cob)))
-                            support_list.append(list(qa))
-                        emit = True
-            if emit:
-                l_dict = {"graph": new_layer, "partition": support_list}
-                yield l_dict
-                emit = False
-            else:
-                if wires_with_ops_remaining:
-                    raise QISKitError("not finished but empty?")
+            op_nodes = list(filter(lambda node: node[1]["type"] == "op",
+                                   nodes_data(graph_layer)
+                                   ))
+            # The quantum registers that have an operation in this layer.
+            support_list = [qarg
+                            for op_node in op_nodes if op_node[1]["name"] != "barrier"
+                            for qarg in op_node[1]["qargs"]
+                            ]
+            new_layer.multi_graph.add_nodes_from(op_nodes)
+
+            # Now add the edges to the multi_graph
+            # By default we just wire inputs to the outputs.
+            wires = {self.input_map[register]: self.output_map[register]
+                     for register in self.wire_type}
+            # Wire inputs to op nodes, and op nodes to outputs.
+            for op_node in op_nodes:
+                args = self._bits_in_condition(op_node[1]["condition"]) \
+                       + op_node[1]["cargs"] + op_node[1]["qargs"]
+                arg_ids = map(lambda arg: self.input_map[arg], args)  # map from ("q",0) to node id.
+                for arg_id in arg_ids:
+                    wires[arg_id], wires[op_node[0]] = op_node[0], wires[arg_id]
+
+            new_layer.multi_graph.add_edges_from(wires.items())
+            yield {"graph": new_layer, "support": support_list}
 
     def serial_layers(self):
         """Yield a layer for all gates of this circuit.
@@ -1266,6 +1227,28 @@ class DAGCircuit:
                     support_list.append(list(qa))
                 l_dict = {"graph": new_layer, "partition": support_list}
                 yield l_dict
+
+    def multigraph_layers(self):
+        """Yield layers of the multigraph."""
+        predecessor_count = dict()  # Dict[node, predecessors not visited]
+        cur_layer = [node for node in self.input_map.values()]
+        yield cur_layer
+        next_layer = []
+        while cur_layer:
+            for node in cur_layer:
+                for successor in self.multi_graph.successors(node):
+                    if successor in predecessor_count:
+                        predecessor_count[successor] -= 1
+                    else:
+                        predecessor_count[successor] = self.multi_graph.in_degree(successor) - 1
+
+                    if predecessor_count[successor] == 0:
+                        next_layer.append(successor)
+                        del predecessor_count[successor]
+
+            yield next_layer
+            next_layer = []
+            cur_layer = next_layer
 
     def collect_runs(self, namelist):
         """Return a set of runs of "op" nodes with the given names.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1244,11 +1244,13 @@ class DAGCircuit:
         next_layer = []
         while cur_layer:
             for node in cur_layer:
+                # Count multiedges with multiplicity.
                 for successor in self.multi_graph.successors(node):
+                    multiplicity = self.multi_graph.number_of_edges(node, successor)
                     if successor in predecessor_count:
-                        predecessor_count[successor] -= 1
+                        predecessor_count[successor] -= multiplicity
                     else:
-                        predecessor_count[successor] = self.multi_graph.in_degree(successor) - 1
+                        predecessor_count[successor] = self.multi_graph.in_degree(successor) - multiplicity
 
                     if predecessor_count[successor] == 0:
                         next_layer.append(successor)

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1199,7 +1199,7 @@ class DAGCircuit:
 
             # Add wiring to/from the operations and between unused inputs & outputs.
             new_layer.multi_graph.add_edges_from(wires.items())
-            yield {"graph": new_layer, "support": support_list}
+            yield {"graph": new_layer, "partition": support_list}
 
     def serial_layers(self):
         """Yield a layer for all gates of this circuit.

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1179,10 +1179,10 @@ class DAGCircuit:
             new_layer.multi_graph.add_nodes_from(nodes_data(self.output_map.values()))
 
             # The quantum registers that have an operation in this layer.
-            support_list = [qarg
-                            for op_node in op_nodes if op_node[1]["name"] != "barrier"
-                            for qarg in op_node[1]["qargs"]
-                            ]
+            support_list = [
+                op_node[1]["qargs"]
+                for op_node in op_nodes if op_node[1]["name"] != "barrier"
+                ]
             new_layer.multi_graph.add_nodes_from(op_nodes)
 
             # Now add the edges to the multi_graph

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1153,19 +1153,21 @@ class DAGCircuit:
         the desired behavior.
         """
         graph_layers = self.multigraph_layers()
-        next(graph_layers)  # Remove input nodes
+        try:
+            next(graph_layers)  # Remove input nodes
+        except StopIteration:
+            return
 
         def nodes_data(nodes):
             """Construct full nodes from just node ids."""
             return (
-                (node_id, self.multi_graph.node[node_id]) for node_id in nodes
+                (node_id, self.multi_graph.nodes[node_id]) for node_id in nodes
                 )
 
         for graph_layer in graph_layers:
             # Get the op nodes from the layer, removing any input and ouput nodes.
             op_nodes = list(filter(lambda node: node[1]["type"] == "op",
-                                   nodes_data(graph_layer)
-                                   ))
+                                   nodes_data(graph_layer)))
 
             # Stop yielding once there are no more op_nodes in a layer.
             if not op_nodes:
@@ -1250,7 +1252,8 @@ class DAGCircuit:
                     if successor in predecessor_count:
                         predecessor_count[successor] -= multiplicity
                     else:
-                        predecessor_count[successor] = self.multi_graph.in_degree(successor) - multiplicity
+                        predecessor_count[successor] =\
+                            self.multi_graph.in_degree(successor) - multiplicity
 
                     if predecessor_count[successor] == 0:
                         next_layer.append(successor)

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -87,11 +87,9 @@ class TestDagCircuit(QiskitTestCase):
         self.assertEqual(5, len(layers))
 
         name_layers = [
-            [
-                node[1]["name"]
-                for node in layer["graph"].multi_graph.nodes(data=True)
-                if node[1]["type"] == "op"
-            ] for layer in layers ]
+            [node[1]["name"]
+             for node in layer["graph"].multi_graph.nodes(data=True)
+             if node[1]["type"] == "op"] for layer in layers]
 
         self.assertEqual([
             ['h'],

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -65,23 +65,20 @@ class TestDagCircuit(QiskitTestCase):
         qubit1 = ('qr', 1)
         clbit0 = ('cr', 0)
         clbit1 = ('cr', 1)
-        condition = None
+        condition = ('cr', 3)
         dag = DAGCircuit()
         dag.add_basis_element('h', 1, number_classical=0, number_parameters=0)
         dag.add_basis_element('cx', 2)
         dag.add_basis_element('x', 1)
-        dag.add_basis_element('measure', 1, number_classical=1,
-                              number_parameters=0)
+        dag.add_basis_element('measure', 1, number_classical=1, number_parameters=0)
         dag.add_qreg('qr', 2)
         dag.add_creg('cr', 2)
-        dag.apply_operation_back('h', [qubit0], [], [], condition)
-        dag.apply_operation_back('cx', [qubit0, qubit1], [],
-                                 [], condition)
-        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
-        # Not sure what is going on here?
-        dag.apply_operation_back('x', [qubit1], [], [], clbit1)
-        dag.apply_operation_back('measure', [qubit0], [clbit0], [], condition)
-        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
+        dag.apply_operation_back('h', [qubit0], [], [], condition=None)
+        dag.apply_operation_back('cx', [qubit0, qubit1], [], [], condition=None)
+        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition=None)
+        dag.apply_operation_back('x', [qubit1], [], [], condition=condition)
+        dag.apply_operation_back('measure', [qubit0], [clbit0], [], condition=None)
+        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition=None)
 
         layers = list(dag.layers())
         self.assertEqual(5, len(layers))
@@ -95,8 +92,8 @@ class TestDagCircuit(QiskitTestCase):
             ['h'],
             ['cx'],
             ['measure'],
-            ['x', 'measure'],
-            ['measure']
+            ['x'],
+            ['measure', 'measure']
             ], name_layers)
 
 

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -17,7 +17,6 @@ from .common import QiskitTestCase
 
 class TestDagCircuit(QiskitTestCase):
     """Testing the dag circuit representation"""
-
     def test_create(self):
         qubit0 = ('qr', 0)
         qubit1 = ('qr', 1)
@@ -60,6 +59,47 @@ class TestDagCircuit(QiskitTestCase):
             (('q', 2), ('q', 1)),
             (('q', 0), ('q', 2))}
         self.assertEqual(expected_gates, node_qargs)
+
+    def test_layers_basic(self):
+        qubit0 = ('qr', 0)
+        qubit1 = ('qr', 1)
+        clbit0 = ('cr', 0)
+        clbit1 = ('cr', 1)
+        condition = None
+        dag = DAGCircuit()
+        dag.add_basis_element('h', 1, number_classical=0, number_parameters=0)
+        dag.add_basis_element('cx', 2)
+        dag.add_basis_element('x', 1)
+        dag.add_basis_element('measure', 1, number_classical=1,
+                              number_parameters=0)
+        dag.add_qreg('qr', 2)
+        dag.add_creg('cr', 2)
+        dag.apply_operation_back('h', [qubit0], [], [], condition)
+        dag.apply_operation_back('cx', [qubit0, qubit1], [],
+                                 [], condition)
+        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
+        # Not sure what is going on here?
+        dag.apply_operation_back('x', [qubit1], [], [], clbit1)
+        dag.apply_operation_back('measure', [qubit0], [clbit0], [], condition)
+        dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
+
+        layers = list(dag.layers())
+        self.assertEqual(5, len(layers))
+
+        name_layers = [
+            [
+                node[1]["name"]
+                for node in layer["graph"].multi_graph.nodes(data=True)
+                if node[1]["type"] == "op"
+            ] for layer in layers ]
+
+        self.assertEqual([
+            ['h'],
+            ['cx'],
+            ['measure'],
+            ['x', 'measure'],
+            ['measure']
+            ], name_layers)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #749 

In my profiling the `DAGCircuit.layers()` function came forward as the main culprit to my runtime, at about 90% of the total run time.  60% of the total time is spent in a the function `_add_wire` which is of course a bit silly considering the trivial thing it does. Turns out that DAGCircuit constructs a full copy of itself besides the gates, which turns out to be very slow. Instead of making a full copy it now returns a shallow copy.

## Description
The layers function now constructs a shallow copy of DAGCircuit and modifies it such that it only contains the nodes of the current layer. That being: All input and output nodes disregarding whether they are used or not, and exactly one layer of op_nodes.

### Profiling results
On a relatively small circuit containing a 1000 gates my runtime goes from 22 minutes on the `dag-generators` branch (#371 ) to 16 minutes by using this change. The total runtime of `layers` goes from 18 minutes to 9 minutes. Still not quite satisfactory but closer.

## Motivation and Context
I use the layers functionality extremely often to iterate through the layers and compare the cost of running a circuit between slight variations of the circuit.

## How Has This Been Tested?
I added a test case for the layers functionality. (I was surprised to see that nothing was being tested before.) The test case is the only one that fails. There is some strange behavior in how the multi_graph in the DAGCircuit is constructed.

I'm inspecting the DAG multigraph when making a test and it just doesnt make sense. I have nodes that have edges to nodes that should be unrelated. E.g
```py
dag.apply_operation_back('h', [qubit0], [], [], condition)
dag.apply_operation_back('cx', [qubit0, qubit1], [],
                        [], condition)
dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
dag.apply_operation_back('x', [qubit1], [], [], clbit1)
dag.apply_operation_back('measure', [qubit0], [clbit0], [], condition)
dag.apply_operation_back('measure', [qubit1], [clbit1], [], condition)
```
from test_dagcircuit.py will have some strange edges. It has an edge from clbit0 to the `x` operation being performed on qubit1 with clbit1. It seems related to how `_def_bits_in_condition` adds all classical bits of a register to the operation dependencies.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Breaking: layers now is a generator. Supersedes #371 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.