### PR TITLE
Remove shots from statevector simulators

### DIFF
--- a/qiskit/backends/local/qasm_simulator_cpp.py
+++ b/qiskit/backends/local/qasm_simulator_cpp.py
@@ -83,7 +83,8 @@ class QasmSimulatorCpp(BaseBackend):
     def _validate(self, qobj):
         if qobj['config']['shots'] == 1:
             warnings.warn('The behavior of getting statevector from simulators '
-                          'by setting shots=1 is deprecated and will be removed. '
+                          'by setting shots=1 is deprecated and has been removed '
+                          'for this simulator. '
                           'Use the local_statevector_simulator instead, or place '
                           'explicit snapshot instructions.',
                           DeprecationWarning)

--- a/qiskit/backends/local/statevector_simulator_cpp.py
+++ b/qiskit/backends/local/statevector_simulator_cpp.py
@@ -72,17 +72,21 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
         1. No shots
         2. No measurements in the middle
         """
-        if qobj['config']['shots'] != 1:
-            logger.info("statevector simulator only supports 1 shot. "
-                        "Setting shots=1.")
-            qobj['config']['shots'] = 1
+        self._set_shots_to_1(qobj, False)
         for circuit in qobj['circuits']:
-            if 'shots' in circuit['config'] and circuit['config']['shots'] != 1:
-                logger.info("statevector simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s", circuit['name'])
-                circuit['config']['shots'] = 1
-            for op in circuit['compiled_circuit']['operations']:
-                if op['name'] in ['measure', 'reset']:
+            self._set_shots_to_1(circuit, True)
+            for operator in circuit['compiled_circuit']['operations']:
+                if operator['name'] in ['measure', 'reset']:
                     raise SimulatorError("In circuit {}: statevector simulator does "
                                          "not support measure or reset.".format(circuit['name']))
-        return
+
+    def _set_shots_to_1(self, dictionary, include_name):
+        if 'config' not in dictionary:
+            dictionary['config'] = {}
+        if 'shots' in dictionary['config'] and dictionary['config']['shots'] != 1:
+            warn = 'statevector simulator only supports 1 shot. Setting shots=1'
+            if include_name:
+                warn += 'Setting shots=1 for circuit' + dictionary['name']
+            warn += '.'
+            logger.info(warn)
+        dictionary['config']['shots'] = 1

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -88,17 +88,21 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         1. No shots
         2. No measurements in the middle
         """
-        if qobj['config']['shots'] != 1:
-            logger.info("statevector simulator only supports 1 shot. "
-                        "Setting shots=1.")
-            qobj['config']['shots'] = 1
+        self._set_shots_to_1(qobj, False)
         for circuit in qobj['circuits']:
-            if 'shots' in circuit['config'] and circuit['config']['shots'] != 1:
-                logger.info("statevector simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", circuit['name'])
-                circuit['config']['shots'] = 1
-            for op in circuit['compiled_circuit']['operations']:
-                if op['name'] in ['measure', 'reset']:
+            self._set_shots_to_1(circuit, True)
+            for operator in circuit['compiled_circuit']['operations']:
+                if operator['name'] in ['measure', 'reset']:
                     raise SimulatorError("In circuit {}: statevector simulator does "
                                          "not support measure or reset.".format(circuit['name']))
-        return
+
+    def _set_shots_to_1(self, dictionary, include_name):
+        if 'config' not in dictionary:
+            dictionary['config'] = {}
+        if 'shots' in dictionary['config'] and dictionary['config']['shots'] != 1:
+            warn = 'statevector simulator only supports 1 shot. Setting shots=1'
+            if include_name:
+                warn += 'Setting shots=1 for circuit' + dictionary['name']
+            warn += '.'
+            logger.info(warn)
+        dictionary['config']['shots'] = 1

--- a/test/python/test_statevector_simulator_cpp.py
+++ b/test/python/test_statevector_simulator_cpp.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring,broad-except
+
+# Copyright 2018 IBM RESEARCH. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+
+from test.python.common import QiskitTestCase
+import unittest
+from qiskit import qasm, unroll, QuantumProgram, QuantumJob
+from qiskit.backends.local.statevector_simulator_cpp import StatevectorSimulatorCpp
+
+import qiskit.backends.local.qasm_simulator_cpp as cpp_simulator
+try:
+    cpp_simulator = cpp_simulator.QasmSimulatorCpp()
+except Exception as err:
+    _skip_class = True
+else:
+    _skip_class = False
+
+
+@unittest.skipIf(_skip_class, 'C++ simulator unavailable')
+class StatevectorSimulatorCppTest(QiskitTestCase):
+    """Test C++ statevector simulator."""
+
+    def setUp(self):
+        self.qasm_filename = self._get_resource_path('qasm/simple.qasm')
+        self.qp = QuantumProgram()
+        self.qp.load_qasm_file(self.qasm_filename, name='example')
+        basis_gates = []  # unroll to base gates
+        unroller = unroll.Unroller(
+            qasm.Qasm(data=self.qp.get_qasm('example')).parse(),
+            unroll.JsonBackend(basis_gates))
+        circuit = unroller.execute()
+        circuit_config = {'coupling_map': None,
+                          'basis_gates': 'u1,u2,u3,cx,id',
+                          'layout': None}
+        self.qobj = {'id': 'test_sim_single_shot',
+                     'circuits': [
+                         {
+                             'name': 'test',
+                             'compiled_circuit': circuit,
+                             'config': circuit_config
+                         }
+                     ]}
+
+        self.q_job = QuantumJob(self.qobj,
+                                backend=StatevectorSimulatorCpp(),
+                                circuit_config=circuit_config,
+                                preformatted=True)
+
+    def test_statevector_simulator_cpp(self):
+        """Test final state vector for single circuit run."""
+        result = StatevectorSimulatorCpp().run(self.q_job).result()
+        actual = result.get_data('test')['statevector']
+        self.assertEqual(result.get_status(), 'COMPLETED')
+
+        # state is 1/sqrt(2)|00> + 1/sqrt(2)|11>, up to a global phase
+        self.assertAlmostEqual((abs(actual[0]))**2, 1/2)
+        self.assertEqual(actual[1], 0)
+        self.assertEqual(actual[2], 0)
+        self.assertAlmostEqual((abs(actual[3]))**2, 1/2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fix #748 

This pull request was originally opened for a ProjectQ statevector simulator, then its focus shifted. 

**The updated description is:** 
Stop statevector simulators from requiring that the user provides the number of shots.

**Here is the original description:**

Improve the way that QISKit connects with ProjectQ API, when using ProjectQ C++ simulator as a backend. In particular, added snapshot functionality, and the capability of using this simulator as a statevector simulator.

## Description
1) Added snapshot functionality in qasm_simulator_projectq.py. Interface is identical to qasm_simulator_cpp.py.
2) Wrote statevector_simulator_projectq.py. Interface is identical to statevector_simulator_cpp.py.

As part of this work, the following bugs were fixed:
1) A bug in qasm_simulator_projectq.py, where new qubits were allocated in ProjectQ with every shot. So if running with more than one shot, each shot was run on an entirely different circuit.
2) A bug in qasm_simulator_projectq.py. The bug has to do with the fact that ProjectQ forbids de-allocation if there are qubits in superposition. To ensure that all qubits have been measured, the code maintained a list of unmeasured qubits, which were measured at the end. However this list was not updated when there were measurements along the circuit - i.e., when measured qubits become unmeasured. The fix makes the code measure all qubits at the end of a circuit. This fixes the bug while results in identical intended functionality and no noticeable runtime difference.

In addition, we removed request for parameter 'shots' in statevector simulators.

## Motivation and Context
Resolving part of Issue #425. This is part of the effort to make the various simulators interchangeable.

## How Has This Been Tested?
I ran existing and new tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
      General documentation of simulators is still missing.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.