### PR TITLE
Adding Python 3.7 to appveyor matrix.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,11 @@ version: 1.0.{build}
 
 environment:
     matrix:
-        - PYTHON_VERSION: 3.5
-          MINICONDA: C:\Miniconda35
-        - PYTHON_VERSION: 3.6
-          MINICONDA: C:\Miniconda36
+        # - PYTHON_VERSION: 3.5
+        #   MINICONDA: C:\Miniconda35
+        # - PYTHON_VERSION: 3.6
+        #   MINICONDA: C:\Miniconda36
         - PYTHON_VERSION: 3.7
-          MINICONDA: C:\Miniconda36
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
     TRAVIS_REPO_SLUG: invalid-but-different
@@ -22,12 +21,6 @@ deploy: false
 skip_branch_with_pr: true
 
 install:
-    - "%MINICONDA%/Scripts/activate.bat"
-    # Install each dependency in requires.txt individually *from conda*. It
-    # cannot be pointed to "requirements.txt" directly as IBMQuantumExperience
-    # is not on the conda repositories.
-    - for /F "tokens=*" %%A in (requirements.txt) do conda install -y -q %%A
-    # Install the rest of dependencies via pip.
     - pip.exe install -r requirements.txt
     - pip.exe install pytest
     - pip.exe install jsonschema

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,10 +7,8 @@ version: 1.0.{build}
 
 environment:
     matrix:
-        # - PYTHON_VERSION: 3.5
-        #   MINICONDA: C:\Miniconda35
-        # - PYTHON_VERSION: 3.6
-        #   MINICONDA: C:\Miniconda36
+        - PYTHON: C:\Python35
+        - PYTHON: C:\Python36
         - PYTHON: C:\Python37
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ environment:
           MINICONDA: C:\Miniconda35
         - PYTHON_VERSION: 3.6
           MINICONDA: C:\Miniconda36
+        - PYTHON_VERSION: 3.7
+          MINICONDA: C:\Miniconda36
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
     TRAVIS_REPO_SLUG: invalid-but-different

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
         #   MINICONDA: C:\Miniconda35
         # - PYTHON_VERSION: 3.6
         #   MINICONDA: C:\Miniconda36
-        - PYTHON_VERSION: 3.7
+        - PYTHON: C:\Python37
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
     TRAVIS_REPO_SLUG: invalid-but-different
@@ -21,6 +21,8 @@ deploy: false
 skip_branch_with_pr: true
 
 install:
+    - "%PYTHON%\\python.exe -m venv venv"
+    - venv\Scripts\activate.bat
     - pip.exe install -r requirements.txt
     - pip.exe install pytest
     - pip.exe install jsonschema


### PR DESCRIPTION
Fix #643 

### Details and comments
Removes Miniconda and uses `venv` directly as virtual environment.
