### PR TITLE
Use get_status_job() in IBMQJob, bump 1.9.8

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Changed
 -------
 - Renamed ``QISKit`` to ``Qiskit`` in the documentation. (#634)
 - Introduce a ``QObj`` class replacing the previous dictionaries (#589).
+- Use ``get_status_job()`` for checking IBMQJob status. (#641)
 
 Removed
 -------

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -193,7 +193,11 @@ class IBMQJob(BaseJob):
             return None
 
         try:
-            api_job = self._api.get_job(self.id)
+            api_job = self._api.get_status_job(self.id)
+            if api_job['status'] in ['COMPLETED', 'CANCELLED', 'ERROR']:
+                # Call the endpoint that returns full information.
+                api_job = self._api.get_job(self.id)
+
             if 'status' not in api_job:
                 raise QISKitError('get_job didn\'t return status: %s' %
                                   pprint.pformat(api_job))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.9.6
+IBMQuantumExperience>=1.9.8
 matplotlib>=2.1
 networkx>=2.0
 numpy>=1.13

--- a/setup.py.in
+++ b/setup.py.in
@@ -17,7 +17,7 @@ from setuptools.dist import Distribution
 
 
 requirements = [
-    "IBMQuantumExperience>=1.9.6",
+    "IBMQuantumExperience>=1.9.8",
     "matplotlib>=2.1",
     "networkx>=2.0",
     "numpy>=1.13",

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -307,6 +307,9 @@ class BaseFakeAPI():
             return {'status': 'Error', 'error': 'Job ID not specified'}
         return self._job_status[self._state]
 
+    def get_status_job(self, job_id):
+        return self.get_job(job_id)
+
     def run_job(self, *_args, **_kwargs):
         time.sleep(0.2)
         return {'id': 'TEST_ID'}


### PR DESCRIPTION
Use the recently included `api.get_status_job()` for checking the
status of an online job, as it is more performant than the existing
`api.get_job()`. Bump IBMQuantumExperience dependency.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


