### PR TITLE
Temporarily disable travis osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,12 +169,12 @@ jobs:
         - source .venv/bin/activate
 
     # OSX, Python 3.6.5 (via pyenv)
-    - stage: test
-      <<: *stage_osx
+#    - stage: test
+#      <<: *stage_osx
 
     # OSX, Python 3.7 (via pyenv)
-    - stage: test
-      <<: *stage_osx_python3_7
+#    - stage: tes
+#      <<: *stage_osx_python3_7
 
     # "deploy" stage.
     ###########################################################################


### PR DESCRIPTION
Disable the travis osx build temporarily, as they are returning an
error while using bottles.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


