### PR TITLE
Fixes final states for `get_status_job()` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,18 +155,13 @@ jobs:
     # GNU/Linux, Python 3.7
     - stage: test
       <<: *stage_linux
-      # Compiling Python 3.7 requires an Ubuntu Xenial distribution.
-      # Try removing once python: 3.7 is available in Travis.
+      # Compiling Python 3.7 requires an Ubuntu Xenial distribution
+      # and sudo set to true
+      # Fix when this is solved:
+      # https://github.com/travis-ci/travis-ci/issues/9815
       dist: xenial
-      # Enable Travis native Python and remove before_install when the following
-      # is resolved: https://github.com/travis-ci/travis-ci/issues/9815
-      # python: 3.7
-      before_install:
-        - sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev
-        - cd /opt/pyenv/ && git pull origin master && cd -
-        - pyenv install 3.7.0
-        - /opt/pyenv/versions/3.7.0/bin/python -m venv .venv
-        - source .venv/bin/activate
+      python: 3.7
+      sudo: true
 
     # OSX, Python 3.6.5 (via pyenv)
 #    - stage: test

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -29,6 +29,15 @@ from qiskit._resulterror import ResultError
 logger = logging.getLogger(__name__)
 
 
+API_FINAL_STATES = (
+    'COMPLETED',
+    'CANCELLED',
+    'ERROR_CREATING_JOB',
+    'ERROR_VALIDATING_JOB',
+    'ERROR_RUNNING_JOB'
+)
+
+
 class IBMQJob(BaseJob):
     """IBM Q Job class
 
@@ -36,14 +45,6 @@ class IBMQJob(BaseJob):
         _executor (futures.Executor): executor to handle asynchronous jobs
         _final_states (list(JobStatus)): terminal states of async jobs
     """
-    api_final_states = [
-        'COMPLETED',
-        'CANCELLED',
-        'ERROR_CREATING_JOB',
-        'ERROR_VALIDATING_JOB',
-        'ERROR_RUNNING_JOB'
-    ]
-
     _executor = futures.ThreadPoolExecutor()
     _final_states = [
         JobStatus.DONE,
@@ -202,7 +203,7 @@ class IBMQJob(BaseJob):
 
         try:
             api_job = self._api.get_status_job(self.id)
-            if api_job['status'] in self.api_final_states:
+            if api_job['status'] in API_FINAL_STATES:
                 # Call the endpoint that returns full information.
                 api_job = self._api.get_job(self.id)
 

--- a/qiskit/backends/jobstatus.py
+++ b/qiskit/backends/jobstatus.py
@@ -19,3 +19,10 @@ class JobStatus(enum.Enum):
     CANCELLED = 'job has been cancelled'
     DONE = 'job has successfully run'
     ERROR = 'job incurred error'
+
+
+JOB_FINAL_STATES = (
+    JobStatus.DONE,
+    JobStatus.CANCELLED,
+    JobStatus.ERROR
+)

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -233,6 +233,34 @@ class TestIBMQJobStates(QiskitTestCase):
         job.cancel()
         self.assertStatus(job, JobStatus.CANCELLED)
 
+    def test_only_final_states_cause_datailed_request(self):
+        from unittest import mock
+
+        # The state ERROR_CREATING_JOB is only handled when running the job,
+        # and not while checking the status, so it is not tested.
+        all_state_apis = {'COMPLETED': NonQueuedAPI,
+                          'CANCELLED': CancellableAPI,
+                          'ERROR_VALIDATING_JOB': ErrorWhileValidatingAPI,
+                          'ERROR_RUNNING_JOB': ErrorWhileRunningAPI}
+
+        for status, api in all_state_apis.items():
+            with self.subTest(status=status):
+                job = self.run_with_api(api())
+                self.wait_for_initialization(job)
+
+                try:
+                    self._current_api.progress()
+                except BaseFakeAPI.NoMoreStatesError:
+                    pass
+
+                with mock.patch.object(self._current_api, 'get_job',
+                                       wraps=self._current_api.get_job):
+                    _ = job.status
+                    if status in IBMQJob.api_final_states:
+                        self.assertTrue(self._current_api.get_job.called)
+                    else:
+                        self.assertFalse(self._current_api.get_job.called)
+
     def wait_for_initialization(self, job, timeout=1):
         """Waits until the job progress from `INITIALIZING` to a different
         status."""
@@ -308,7 +336,10 @@ class BaseFakeAPI():
         return self._job_status[self._state]
 
     def get_status_job(self, job_id):
-        return self.get_job(job_id)
+        summary_fields = ['status', 'infoQueue']
+        complete_response = self.get_job(job_id)
+        return {key: value for key, value in complete_response.items()
+                if key in summary_fields}
 
     def run_job(self, *_args, **_kwargs):
         time.sleep(0.2)

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -15,6 +15,7 @@ import time
 from IBMQuantumExperience import ApiError
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
+from qiskit.backends.ibmq.ibmqjob import API_FINAL_STATES
 from qiskit.qobj import Qobj
 from .common import QiskitTestCase
 from ._mockutils import new_fake_qobj
@@ -256,7 +257,7 @@ class TestIBMQJobStates(QiskitTestCase):
                 with mock.patch.object(self._current_api, 'get_job',
                                        wraps=self._current_api.get_job):
                     _ = job.status
-                    if status in IBMQJob.api_final_states:
+                    if status in API_FINAL_STATES:
                         self.assertTrue(self._current_api.get_job.called)
                     else:
                         self.assertFalse(self._current_api.get_job.called)


### PR DESCRIPTION
### Summary
In order to avoid wasting bandwidth, IBM QE now provides a `get_status_job()` method. Only if the status is final, the `IBMQJob` instance will query for more info. Checking whether a state was final or not was incorrectly implemented.

Fortunately, the current implementation does not retrieve any additional data aside from the status (double check if this is an error).

### Details and comments
The patch also adds a test to ensure that final states do indeed perform a query for getting the details (although we should check if this is something needed for `ERROR_*` status).

