### PR TITLE
Use Qobj schema in qiskit.qobj, add converter to old schema

### DIFF
--- a/qiskit/_quantumprogram.py
+++ b/qiskit/_quantumprogram.py
@@ -15,6 +15,7 @@ import logging
 import warnings
 
 import qiskit.wrapper
+from qiskit.qobj import qobj_to_dict
 
 from ._classicalregister import ClassicalRegister
 from ._logging import set_qiskit_logger, unset_qiskit_logger
@@ -972,7 +973,7 @@ class QuantumProgram(object):
             If the inputs are left as None then the qobj is not updated
 
         Args:
-            qobj (dict): already compile qobj
+            qobj (Qobj): already compile qobj
             backend (str): see .compile
             config (dict): see .compile
             shots (int): see .compile
@@ -989,12 +990,12 @@ class QuantumProgram(object):
         if max_credits is not None:
             qobj.config.max_credits = max_credits
 
-        for circuit in qobj.circuits:
+        for experiment in qobj.experiments:
             if seed is not None:
-                circuit.config.seed = seed
+                experiment.config.seed = seed
             if config is not None:
                 for key, value in config.items():
-                    setattr(circuit.config, key, value)
+                    setattr(experiment.config, key, value)
 
         return qobj
 
@@ -1014,7 +1015,7 @@ class QuantumProgram(object):
             print_func("no executions to run")
         execution_list = []
 
-        qobj = qobj.as_dict()
+        qobj = qobj_to_dict(qobj, version='0.0.1')
 
         print_func("id: %s" % qobj['id'])
         print_func("backend: %s" % qobj['config']['backend_name'])
@@ -1044,9 +1045,9 @@ class QuantumProgram(object):
             QISKitError: if the circuit has no configurations
         """
         try:
-            for index in range(len(qobj.circuits)):
-                if qobj.circuits[index].name == name:
-                    return qobj.circuits[index].config.as_dict()
+            for index in range(len(qobj.experiments)):
+                if qobj.experiments[index].header.name == name:
+                    return qobj.experiments[index].config.as_dict()
         except KeyError:
             pass
         raise QISKitError('No compiled configurations for circuit "{0}"'.format(name))
@@ -1065,9 +1066,9 @@ class QuantumProgram(object):
             QISKitError: if the circuit has no configurations
         """
         try:
-            for index in range(len(qobj.circuits)):
-                if qobj.circuits[index].name == name:
-                    return qobj.circuits[index].compiled_circuit_qasm
+            for index in range(len(qobj.experiments)):
+                if qobj.experiments[index].header.name == name:
+                    return qobj.experiments[index].header.compiled_circuit_qasm
         except KeyError:
             pass
         raise QISKitError('No compiled qasm for circuit "{0}"'.format(name))
@@ -1118,7 +1119,7 @@ class QuantumProgram(object):
     def _run_internal(self, qobj_list):
         job_list = []
         for qobj in qobj_list:
-            backend = qiskit.wrapper.get_backend(qobj.config.backend_name)
+            backend = qiskit.wrapper.get_backend(qobj.header.backend_name)
             job = backend.run(qobj)
             job_list.append(job)
         return job_list

--- a/qiskit/_result.py
+++ b/qiskit/_result.py
@@ -201,7 +201,7 @@ class Result(object):
             if len(self._result['result']) == 1:
                 return self._result['result'][0]['data']
             else:
-                raise QISKitError("You have to select a circuit when there is more than"
+                raise QISKitError("You have to select a circuit when there is more than "
                                   "one available")
 
         if not isinstance(circuit, str):
@@ -327,7 +327,7 @@ class Result(object):
                 if len(slots) == 1:
                     slot = slots[0]
                 else:
-                    raise QISKitError("You have to select a slot when there"
+                    raise QISKitError("You have to select a slot when there "
                                       "is more than one available")
             snapshot_dict = snapshots_dict[slot]
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -380,7 +380,7 @@ class IBMQJob(BaseJob):
                 job['qasm'] = circuit['compiled_circuit_qasm'].decode()
             else:
                 job['qasm'] = circuit['compiled_circuit_qasm']
-            if getattr(circuit, 'name', None):
+            if circuit.get('name', None):
                 job['name'] = circuit['name']
             # convert numpy types for json serialization
             compiled_circuit = json.loads(
@@ -407,7 +407,6 @@ class IBMQJob(BaseJob):
             raise QISKitError("inconsistent qobj backend "
                               "name ({0} != {1})".format(backend_name,
                                                          self._backend_name))
-        submit_info = {}
         try:
             submit_info = self._api.run_job(api_jobs, backend=backend_name,
                                             shots=qobj['config']['shots'],

--- a/qiskit/backends/local/localjob.py
+++ b/qiskit/backends/local/localjob.py
@@ -33,7 +33,7 @@ class LocalJob(BaseJob):
     def __init__(self, fn, qobj):
         super().__init__()
         self._qobj = qobj
-        self._backend_name = qobj.config.backend_name
+        self._backend_name = qobj.header.backend_name
         self._future = self._executor.submit(fn, qobj)
 
     def result(self, timeout=None):

--- a/qiskit/backends/local/statevector_simulator_cpp.py
+++ b/qiskit/backends/local/statevector_simulator_cpp.py
@@ -46,8 +46,8 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
         self._validate(qobj)
         final_state_key = 32767  # Internal key for final state snapshot
         # Add final snapshots to circuits
-        for circuit in qobj.circuits:
-            circuit.compiled_circuit.operations.append(
+        for experiment in qobj.experiments:
+            experiment.instructions.append(
                 QobjInstruction.from_dict({'name': 'snapshot', 'params': [final_state_key]})
             )
         result = super()._run_job(qobj)
@@ -77,13 +77,13 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
             logger.info("statevector simulator only supports 1 shot. "
                         "Setting shots=1.")
             qobj.config.shots = 1
-        for circuit in qobj.circuits:
-            if getattr(circuit.config, 'shots', 1) != 1:
+        for experiment in qobj.experiments:
+            if getattr(experiment.config, 'shots', 1) != 1:
                 logger.info("statevector simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", circuit.name)
-                circuit.config.shots = 1
-            for op in circuit.compiled_circuit.operations:
+                            "Setting shots=1 for circuit %s.", experiment.name)
+                experiment.config.shots = 1
+            for op in experiment.instructions:
                 if op.name in ['measure', 'reset']:
                     raise SimulatorError(
                         "In circuit {}: statevector simulator does not support "
-                        "measure or reset.".format(circuit.name))
+                        "measure or reset.".format(experiment.header.name))

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -60,8 +60,8 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         self._validate(qobj)
         final_state_key = 32767  # Internal key for final state snapshot
         # Add final snapshots to circuits
-        for circuit in qobj.circuits:
-            circuit.compiled_circuit.operations.append(
+        for experiment in qobj.experiments:
+            experiment.instructions.append(
                 QobjInstruction.from_dict({'name': 'snapshot', 'params': [final_state_key]})
             )
         result = super()._run_job(qobj)._result
@@ -93,13 +93,13 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
             logger.info("statevector simulator only supports 1 shot. "
                         "Setting shots=1.")
             qobj.config.shots = 1
-        for circuit in qobj.circuits:
-            if getattr(circuit.config, 'shots', 1) != 1:
+        for experiment in qobj.experiments:
+            if getattr(experiment.config, 'shots', 1) != 1:
                 logger.info("statevector simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", circuit.name)
-                circuit.config.shots = 1
-            for op in circuit.compiled_circuit.operations:
+                            "Setting shots=1 for circuit %s.", experiment.name)
+                experiment.config.shots = 1
+            for op in experiment.instructions:
                 if op.name in ['measure', 'reset']:
                     raise SimulatorError(
                         "In circuit {}: statevector simulator does not support "
-                        "measure or reset.".format(circuit.name))
+                        "measure or reset.".format(experiment.header.name))

--- a/qiskit/backends/local/unitary_simulator_py.py
+++ b/qiskit/backends/local/unitary_simulator_py.py
@@ -88,6 +88,7 @@ import numpy as np
 from qiskit._result import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends.local.localjob import LocalJob
+from qiskit.qobj import qobj_to_dict
 from ._simulatortools import enlarge_single_opt, enlarge_two_opt, single_gate_matrix
 
 logger = logging.getLogger(__name__)
@@ -161,8 +162,9 @@ class UnitarySimulatorPy(BaseBackend):
             Result: Result object
         """
         result_list = []
-        for circuit in qobj.circuits:
-            result_list.append(self.run_circuit(circuit.as_dict()))
+        qobj_converted = qobj_to_dict(qobj, version='0.0.1')
+        for circuit in qobj_converted['circuits']:
+            result_list.append(self.run_circuit(circuit))
         job_id = str(uuid.uuid4())
         return Result(
             {'job_id': job_id, 'result': result_list, 'status': 'COMPLETED'})

--- a/qiskit/qobj/__init__.py
+++ b/qiskit/qobj/__init__.py
@@ -7,5 +7,5 @@
 
 """Module for the Qobj structure."""
 
-from ._qobj import (Qobj, QobjCompiledCircuit, QobjConfig, QobjExperiment,
-                    QobjExperimentConfig, QobjInstruction, QobjItem)
+from ._qobj import (Qobj, QobjConfig, QobjExperiment, QobjInstruction, QobjItem)
+from ._converter import qobj_to_dict

--- a/qiskit/qobj/_converter.py
+++ b/qiskit/qobj/_converter.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Qobj conversion helpers."""
+import logging
+
+from qiskit import QISKitError
+from ._qobj import QOBJ_VERSION
+
+
+logger = logging.getLogger(__name__)
+
+
+def qobj_to_dict(qobj, version=QOBJ_VERSION):
+    """Convert a Qobj to another version of the schema.
+
+    Args:
+        qobj (Qobj): input Qobj.
+        version (string): target version for conversion.
+
+    Returns:
+        dict: dictionary representing the qobj for the specified schema version.
+
+    Raises:
+        QISKitError: if the target version is not supported.
+    """
+    if version == QOBJ_VERSION:
+        return qobj_to_dict_current_version(qobj)
+    elif version == '0.0.1':
+        return qobj_to_dict_previous_version(qobj)
+    else:
+        raise QISKitError('Invalid target version for conversion.')
+
+
+def qobj_to_dict_current_version(qobj):
+    """
+    Return a dictionary representation of the QobjItem, recursively converting
+    its public attributes.
+
+    Args:
+        qobj (Qobj): input Qobj.
+
+    Returns:
+        dict: dictionary representing the qobj.
+    """
+    return qobj.as_dict()
+
+
+def qobj_to_dict_previous_version(qobj):
+    """Convert a Qobj to the 0.0.1 version of the schema.
+
+    Args:
+        qobj (Qobj): input Qobj.
+
+    Returns:
+        dict: dictionary representing the qobj for the specified schema version.
+    """
+    # Build the top Qobj element.
+    converted = {
+        'id': qobj.id,
+        'config': {
+            'shots': qobj.config.shots,
+            'backend_name': getattr(qobj.header, 'backend_name', None),
+            'max_credits': getattr(qobj.config, 'max_credits', None)
+        },
+        'circuits': []
+    }
+
+    # Update configuration:
+    # Add circuits.
+    for experiment in qobj.experiments:
+        circuit_config = getattr(experiment, 'config', {})
+        if circuit_config:
+            circuit_config = circuit_config.as_dict()
+            circuit_config['seed'] = getattr(qobj.config, 'seed', None)
+
+        circuit = {
+            'name': getattr(experiment.header, 'name', None),
+            'config': circuit_config,
+            'compiled_circuit': {
+                'header': experiment.header.as_dict(),
+                'operations': [instruction.as_dict() for instruction in
+                               experiment.instructions]
+            },
+            'compiled_circuit_qasm': getattr(experiment.header,
+                                             'compiled_circuit_qasm', None)
+        }
+
+        converted['circuits'].append(circuit)
+
+    return converted

--- a/qiskit/qobj/_converter.py
+++ b/qiskit/qobj/_converter.py
@@ -70,7 +70,11 @@ def qobj_to_dict_previous_version(qobj):
         'circuits': []
     }
 
-    # Update configuration:
+    # Update configuration: qobj.config might have extra items.
+    for key, value in qobj.config.__dict__.items():
+        if key not in ('shots', 'register_slots', 'max_credits', 'seed'):
+            converted['config'][key] = value
+
     # Add circuits.
     for experiment in qobj.experiments:
         circuit_config = getattr(experiment, 'config', {})

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -127,7 +127,7 @@ class QobjConfig(QobjItem):
 
     Attributes defined in the schema but not required:
         max_credits (int): number of credits.
-        seed (int):
+        seed (int): random seed.
     """
     REQUIRED_ARGS = ['shots', 'register_slots']
 
@@ -143,9 +143,9 @@ class QobjHeader(QobjItem):
 
     Attributes defined in the schema but not required:
         backend_name (str): name of the backend
-        backend_version (str):
-        qubit_labels (list):
-        clbit_labels (list):
+        backend_version (str): the backend version this set of experiments was generated for.
+        qubit_labels (list): map physical qubits to qregs (for QASM).
+        clbit_labels (list): map classical clbits to register_slots (for QASM).
     """
     pass
 
@@ -156,8 +156,8 @@ class QobjExperiment(QobjItem):
         instructions (list[QobjInstruction)): list of instructions.
 
     Attributes defined in the schema but not required:
-        header (QobjExperimentHeader):
-        config (QobjItem):
+        header (QobjExperimentHeader): header.
+        config (QobjItem): config settings for the Experiment.
     """
     REQUIRED_ARGS = ['instructions']
 

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -9,7 +9,7 @@
 
 from types import SimpleNamespace
 
-from . import _utils
+from ._utils import QobjValidationError, QobjType
 
 # Current version of the Qobj schema.
 QOBJ_VERSION = '0.0.2'
@@ -60,7 +60,7 @@ class QobjItem(SimpleNamespace):
                 required attributes for that class.
         """
         if not all(key in obj.keys() for key in cls.REQUIRED_ARGS):
-            raise _utils.QobjValidationError(
+            raise QobjValidationError(
                 'The dict does not contain all required keys: missing "%s"' %
                 [key for key in cls.REQUIRED_ARGS if key not in obj.keys()])
 
@@ -112,7 +112,7 @@ class Qobj(QobjItem):
         self.experiments = experiments
         self.header = header
 
-        self.type = _utils.QobjType.QASM.value
+        self.type = QobjType.QASM.value
         self._version = QOBJ_VERSION
 
         super().__init__(**kwargs)

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -376,7 +376,7 @@ class QCircuitImage(object):
         columns = 2     # wires in the beginning and end
         is_occupied = [False] * self.img_width
         max_column_width = {}
-        for op in self.circuit['operations']:
+        for op in self.circuit['instructions']:
             # useful information for determining row spacing
             boxed_gates = ['u0', 'u1', 'u2', 'u3', 'x', 'y', 'z', 'h', 's', 'sdg',
                            't', 'tdg', 'rx', 'ry', 'rz', 'ch', 'cy', 'crz', 'cu3']
@@ -655,7 +655,7 @@ class QCircuitImage(object):
         else:
             qregdata = self.qregs
 
-        for _, op in enumerate(self.circuit['operations']):
+        for _, op in enumerate(self.circuit['instructions']):
             if 'conditional' in op:
                 mask = int(op['conditional']['mask'], 16)
                 cl_reg = self.clbit_list[self._ffs(mask)]
@@ -1360,7 +1360,7 @@ class MatplotlibDrawer:
         u.execute()
         self._ast = u.backend.circuit
         self._registers()
-        self._ops = self._ast['operations']
+        self._ops = self._ast['instructions']
 
     def _registers(self):
         # NOTE: formats of clbit and qubit are different!

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -60,14 +60,15 @@ def compile(circuits, backend,
     backend_conf = backend.configuration
     backend_name = backend_conf['name']
 
-    # TODO: solve "config" and "shots" arguments
-    # TODO: calculate "register_slots"
-
     # Step 1: create the Qobj, with empty experiments.
+    # Copy the configuration: the values in `config` have prefern
+    qobj_config = (config or {}).copy()
+    qobj_config.update({'shots': shots,
+                        'max_credits': max_credits,
+                        'register_slots': 0})  # TODO: fix"register_slots"
+
     qobj = Qobj(id=qobj_id or str(uuid.uuid4()),
-                config=QobjConfig(shots=shots,
-                                  max_credits=max_credits,
-                                  register_slots=1234),
+                config=QobjConfig(**qobj_config),
                 experiments=[],
                 header=QobjHeader(backend_name=backend_name))
     if seed:

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -7,13 +7,13 @@
 
 """Tools for compiling a batch of quantum circuits."""
 import logging
-import copy
 import uuid
 
 import numpy as np
 import scipy.sparse as sp
 import scipy.sparse.csgraph as cs
 
+from qiskit.qobj._qobj import QobjHeader
 from qiskit.transpiler._transpilererror import TranspilerError
 from qiskit._qiskiterror import QISKitError
 from qiskit._quantumcircuit import QuantumCircuit
@@ -22,7 +22,7 @@ from qiskit.unroll import DagUnroller, DAGBackend, JsonBackend
 from qiskit.mapper import (Coupling, optimize_1q_gates, coupling_list2dict, swap_mapper,
                            cx_cancellation, direction_mapper)
 from qiskit._gate import Gate
-from qiskit.qobj import Qobj, QobjConfig, QobjExperiment, QobjExperimentConfig, QobjCompiledCircuit
+from qiskit.qobj import Qobj, QobjConfig, QobjExperiment, QobjItem
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +60,18 @@ def compile(circuits, backend,
     backend_conf = backend.configuration
     backend_name = backend_conf['name']
 
-    # Step 1: create the Qobj, with empty circuits
+    # TODO: solve "config" and "shots" arguments
+    # TODO: calculate "register_slots"
+
+    # Step 1: create the Qobj, with empty experiments.
     qobj = Qobj(id=qobj_id or str(uuid.uuid4()),
-                config=QobjConfig(max_credits=max_credits,
-                                  shots=shots,
-                                  backend_name=backend_name),
-                circuits=[])
+                config=QobjConfig(shots=shots,
+                                  max_credits=max_credits,
+                                  register_slots=1234),
+                experiments=[],
+                header=QobjHeader(backend_name=backend_name))
+    if seed:
+        qobj.config.seed = seed
 
     # Check for valid parameters for the experiments.
     if hpc is not None and \
@@ -74,28 +80,13 @@ def compile(circuits, backend,
     basis_gates = basis_gates or backend_conf['basis_gates']
     coupling_map = coupling_map or backend_conf['coupling_map']
 
+    # Step 2 and 3: transpile and populate the circuits
     for circuit in circuits:
-        # Step 1: create the experiment configuration.
-        config = config or {}
-        circuit_config = copy.deepcopy(config)
-
         # TODO: A better solution is to have options to enable/disable optimizations
         num_qubits = sum((len(qreg) for qreg in circuit.get_qregs().values()))
         if num_qubits == 1 or coupling_map == "all-to-all":
             coupling_map = None
-        circuit_config["coupling_map"] = coupling_map
-        circuit_config["basis_gates"] = basis_gates
-        circuit_config["seed"] = seed
-        circuit_config["layout"] = None  # set during step 3.
-
-        # Step 2: create the QobjExperiment, with empty compiled circuits.
-        experiment = QobjExperiment(name=circuit.name,
-                                    config=QobjExperimentConfig(**circuit_config),
-                                    compiled_circuit=None,
-                                    compiled_circuit_qasm=None)
-
-        # Step 3: populate the circuit `instructions` after compilation
-        # Step 3a: circuit -> dag
+        # Step 2a: circuit -> dag
         dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
 
         # TODO: move this inside the mapper pass
@@ -106,7 +97,7 @@ def compile(circuits, backend,
                 not _matches_coupling_map(circuit.data, coupling_map)):
             initial_layout = _pick_best_layout(backend, num_qubits, circuit.get_qregs())
 
-        # Step 3b: transpile (dag -> dag)
+        # Step 2b: transpile (dag -> dag)
         dag_circuit, final_layout = transpile(
             dag_circuit,
             basis_gates=basis_gates,
@@ -116,22 +107,30 @@ def compile(circuits, backend,
             seed=seed,
             pass_manager=pass_manager)
 
-        # Step 3c: dag -> json
+        # Step 2c: dag -> json
         # the compiled circuit to be run saved as a dag
         # we assume that transpile() has already expanded gates
         # to the target basis, so we just need to generate json
         list_layout = [[k, v] for k, v in final_layout.items()] if final_layout else None
-        experiment.config.layout = list_layout
+
         json_circuit = DagUnroller(dag_circuit, JsonBackend(dag_circuit.basis)).execute()
-        experiment.compiled_circuit = QobjCompiledCircuit.from_dict(json_circuit)
+
+        # Step 3a: create the Experiment based on json_circuit
+        experiment = QobjExperiment.from_dict(json_circuit)
+        # Step 3b: populate the Experiment configuration and header
+        experiment.header.name = circuit.name
+        # TODO: place in header or config?
+        experiment.config = QobjItem(coupling_map=coupling_map,
+                                     basis_gates=basis_gates,
+                                     layout=list_layout)
 
         # set eval_symbols=True to evaluate each symbolic expression
         # TODO after transition to qobj, we can drop this
-        experiment.compiled_circuit_qasm = dag_circuit.qasm(
+        experiment.header.compiled_circuit_qasm = dag_circuit.qasm(
             qeflag=True, eval_symbols=True)
 
-        # add job to the qobj
-        qobj.circuits.append(experiment)
+        # Step 3c: add the Experiment to the Qobj
+        qobj.experiments.append(experiment)
 
     return qobj
 

--- a/qiskit/unroll/_jsonbackend.py
+++ b/qiskit/unroll/_jsonbackend.py
@@ -16,7 +16,7 @@ The input is a AST and a basis set and returns a json memory object::
      "qubit_labels": [["q", 0], ["v", 0]], // list[list[string, int]]
      "clbit_labels": [["c", 2]], // list[list[string, int]]
      }
-     "operations": // list[map]
+     "instructions": // list[map]
         [
             {
                 "name": , // required -- string
@@ -50,7 +50,7 @@ class JsonBackend(UnrollerBackend):
         """
         super().__init__(basis)
         self.circuit = {}
-        self.circuit['operations'] = []
+        self.circuit['instructions'] = []
         self.circuit['header'] = {
             'number_of_qubits': 0,
             'number_of_clbits': 0,
@@ -138,7 +138,7 @@ class JsonBackend(UnrollerBackend):
             if "U" not in self.basis:
                 self.basis.append("U")
             qubit_indices = [self._qubit_order_internal.get(qubit)]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': "U",
                 # TODO: keep these real for now, until a later time
                 'params': [float(arg[0].real(nested_scope)),
@@ -170,7 +170,7 @@ class JsonBackend(UnrollerBackend):
                     'mask': "0x%X" % mask,
                     'val': "0x%X" % self.cval
                 }
-            self.circuit['operations'][-1]['conditional'] = conditional
+            self.circuit['instructions'][-1]['conditional'] = conditional
 
     def cx(self, qubit0, qubit1):
         """Fundamental two-qubit gate.
@@ -183,7 +183,7 @@ class JsonBackend(UnrollerBackend):
                 self.basis.append("CX")
             qubit_indices = [self._qubit_order_internal.get(qubit0),
                              self._qubit_order_internal.get(qubit1)]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': 'CX',
                 'qubits': qubit_indices,
             })
@@ -199,7 +199,7 @@ class JsonBackend(UnrollerBackend):
             self.basis.append("measure")
         qubit_indices = [self._qubit_order_internal.get(qubit)]
         clbit_indices = [self._cbit_order_internal.get(bit)]
-        self.circuit['operations'].append({
+        self.circuit['instructions'].append({
             'name': 'measure',
             'qubits': qubit_indices,
             'clbits': clbit_indices
@@ -218,7 +218,7 @@ class JsonBackend(UnrollerBackend):
             for qubitlist in qubitlists:
                 for qubits in qubitlist:
                     qubit_indices.append(self._qubit_order_internal.get(qubits))
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': 'barrier',
                 'qubits': qubit_indices,
             })
@@ -233,7 +233,7 @@ class JsonBackend(UnrollerBackend):
         if "reset" not in self.basis:
             self.basis.append("reset")
         qubit_indices = [self._qubit_order_internal.get(qubit)]
-        self.circuit['operations'].append({
+        self.circuit['instructions'].append({
             'name': 'reset',
             'qubits': qubit_indices,
         })
@@ -270,7 +270,7 @@ class JsonBackend(UnrollerBackend):
             self.listen = False
             qubit_indices = [self._qubit_order_internal.get(qubit)
                              for qubit in qubits]
-            self.circuit['operations'].append({
+            self.circuit['instructions'].append({
                 'name': name,
                 # TODO: keep these real for now, until a later time
                 'params': list(map(lambda x: float(x.real(nested_scope)),
@@ -306,4 +306,4 @@ class JsonBackend(UnrollerBackend):
     def _is_circuit_valid(self):
         """Checks whether the circuit object is a valid one or not."""
         return (len(self.circuit['header']) > 0 and
-                len(self.circuit['operations']) > 0)
+                len(self.circuit['instructions']) > 0)

--- a/test/python/_mockutils.py
+++ b/test/python/_mockutils.py
@@ -146,17 +146,17 @@ def new_fake_qobj():
     return {
         'id': 'test-id',
         'config': {
-            'backend_name': 'test-backend',
             'shots': 1024,
             'max_credits': 100
         },
-        'circuits': [{
-            'compiled_circuit_qasm': 'fake-code',
+        'experiments': [{
+            'header': {'compiled_circuit_qasm': 'fake-code'},
             'config': {
                 'seed': 123456
             },
-            'compiled_circuit': {}
-        }]
+            'instructions': []
+        }],
+        'header': {'backend_name': 'test-backend'}
     }
 
 

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -2,153 +2,147 @@
     "id": "test_conditionals",
     "config": {
         "shots": 1,
-        "seed": 1,
+        "seed": 1
+    },
+    "header": {
         "backend_name": "local_qasm_simulator_cpp"
     },
-    "circuits": [
+    "experiments": [
         {
-            "name": "single creg (c0=0)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
+            "header": {
+                "name": "single creg (c0=0)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0]
                 },
-                "operations": [
-                	{
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0]
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0], 
-                    	"conditional": {"type": "equals", "mask": "0x1", "val": "0x0"}
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [1], 
-                    	"conditional": {"type": "equals", "mask": "0x1", "val": "0x1"}
-                    },
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0],
+                    "conditional": {"type": "equals", "mask": "0x1", "val": "0x0"}
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [1],
+                    "conditional": {"type": "equals", "mask": "0x1", "val": "0x1"}
+                },
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "single creg (c0=1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
+            "header": {
+                "name": "single creg (c0=1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0]
                 },
-                "operations": [
-                	{
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0]
-                    },
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0], 
-                    	"conditional": {"type": "equals", "mask": "0x1", "val": "0x0"}
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [1], 
-                    	"conditional": {"type": "equals", "mask": "0x1", "val": "0x1"}
-                    },
-                    {"name": "snapshot", "params": [0]}
-                ]
-            }
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0],
+                    "conditional": {"type": "equals", "mask": "0x1", "val": "0x0"}
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [1],
+                    "conditional": {"type": "equals", "mask": "0x1", "val": "0x1"}
+                },
+                {"name": "snapshot", "params": [0]}
+            ]
         },
         {
-            "name": "two creg (c1=0)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1], ["c1", 1]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
+            "header": {
+                "name": "two creg (c1=0)",
+                "clbit_labels": [["c0", 1], ["c1", 1]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0]
                 },
-                "operations": [
-                	{
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0]
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0], 
-                    	"conditional": {"type": "equals", "mask": "0x2", "val": "0x0"}
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [1], 
-                    	"conditional": {"type": "equals", "mask": "0x2", "val": "0x1"}
-                    },
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0],
+                    "conditional": {"type": "equals", "mask": "0x2", "val": "0x0"}
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [1],
+                    "conditional": {"type": "equals", "mask": "0x2", "val": "0x1"}
+                },
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "two creg (c1=1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1], ["c1", 1]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
+            "header": {
+                "name": "two creg (c1=1)",
+                "clbit_labels": [["c0", 1], ["c1", 1]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0]
                 },
-                "operations": [
-                	{
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0]
-                    },
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [1]
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [0], 
-                    	"conditional": {"type": "equals", "mask": "0x2", "val": "0x0"}
-                    },
-                    {
-                    	"name": "U", 
-                    	"params": [3.14159265358979, 0.0, 3.14159265358979], 
-                    	"qubits": [1], 
-                    	"conditional": {"type": "equals", "mask": "0x2", "val": "0x1"}
-                    },
-                    {"name": "snapshot", "params": [0]}
-                ]
-            }
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [1]
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [0],
+                    "conditional": {"type": "equals", "mask": "0x2", "val": "0x0"}
+                },
+                {
+                    "name": "U",
+                    "params": [3.14159265358979, 0.0, 3.14159265358979],
+                    "qubits": [1],
+                    "conditional": {"type": "equals", "mask": "0x2", "val": "0x1"}
+                },
+                {"name": "snapshot", "params": [0]}
+            ]
         }
     ]
 }

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -3,199 +3,179 @@
     "config": {
         "shots": 2000,
         "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp",
         "data" : ["density_matrix", "probabilities"]
     },
-    "circuits": [
+    "header": {
+        "backend_name": "local_qasm_simulator_cpp"
+    },
+    "experiments": [
         {
-            "name": "measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "x0 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "x", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "x0 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "x", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "x1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "x", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "x1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "x", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "x0 x1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "x", "qubits": [0]},
-                    {"name": "x", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "x0 x1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "x", "qubits": [0]},
+                {"name": "x", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "y0 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "y", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "y0 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "y", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "y1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "y", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "y1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "y", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "y0 y1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "y", "qubits": [0]},
-                    {"name": "y", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "y0 y1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "y", "qubits": [0]},
+                {"name": "y", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "h0 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "h0 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "h1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "h1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "h0 h1 measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "h", "qubits": [1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "h0 h1 measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "h", "qubits": [1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         },
         {
-            "name": "bell measure (opt)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 2,
-                    "qubit_labels": [["q", 0], ["q", 1]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "cx", "qubits": [0, 1]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [1], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "bell measure (opt)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 2,
+                "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "cx", "qubits": [0, 1]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [1], "clbits": [1]}
+            ]
         }
     ]
 }

--- a/test/python/qobj/cpp_measure_opt_flag.json
+++ b/test/python/qobj/cpp_measure_opt_flag.json
@@ -2,161 +2,143 @@
     "id": "test_measure_opt_flag",
     "config": {
         "shots": 5,
-        "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "seed": 1
     },
-    "circuits": [
+    "header": {"backend_name": "local_qasm_simulator_cpp"},
+    "experiments": [
         {
-            "name": "measure (sampled)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "measure (sampled)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]}
+            ]
         },
         {
-            "name": "trivial (sampled)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "trivial (sampled)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "reset1 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "reset1 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "reset", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]}
+            ]
         },
         {
-            "name": "reset2 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]},
-                    {"name": "reset", "qubits": [0]}
-                ]
-            }
+            "header": {
+                "name": "reset2 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]},
+                {"name": "reset", "qubits": [0]}
+            ]
         },
         {
-            "name": "reset3 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "reset3 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "reset", "qubits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]}
+            ]
         },
         {
-            "name": "gate1 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "gate1 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]}
+            ]
         },
         {
-            "name": "gate2 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]},
-                    {"name": "snapshot", "params": [0]}
-                ]
-            }
+            "header": {
+                "name": "gate2 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]},
+                {"name": "snapshot", "params": [0]}
+            ]
         },
         {
-            "name": "gate3 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "u1", "qubits": [0], "params": [0.0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]}
-                ]
-            }
+            "header": {
+                "name": "gate3 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "u1", "qubits": [0], "params": [0.0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]}
+            ]
         },
         {
-            "name": "gate4 (shots)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c", 2]],
-                    "number_of_clbits": 2,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [0]},
-                    {"name": "measure", "qubits": [0], "clbits": [1]},
-                    {"name": "u1", "qubits": [0], "params": [0.0]}
-                ]
-            }
+            "header": {
+                "name": "gate4 (shots)",
+                "clbit_labels": [["c", 2]],
+                "number_of_clbits": 2,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [0]},
+                {"name": "measure", "qubits": [0], "clbits": [1]},
+                {"name": "u1", "qubits": [0], "params": [0.0]}
+            ]
         }
     ]
 }

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -2,92 +2,84 @@
     "id": "test_reset",
     "config": {
         "shots": 1,
-        "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "seed": 1
     },
-    "circuits": [
+    "header": {"backend_name": "local_qasm_simulator_cpp"},
+    "experiments": [
         {
-            "name": "reset",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure",
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "reset",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "reset", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "x reset",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "x", "qubits": [0]},
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure",
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "x reset",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "x", "qubits": [0]},
+                {"name": "reset", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "y reset",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "y", "qubits": [0]},
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure",
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "y reset",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "y", "qubits": [0]},
+                {"name": "reset", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "h reset",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "reset", "qubits": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure",
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "h reset",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "reset", "qubits": [0]},
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         }
     ]
 }

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -2,36 +2,34 @@
     "id": "test_save_load",
     "config": {
         "shots": 1,
-        "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "seed": 1
     },
-    "circuits": [
+    "header": {"backend_name": "local_qasm_simulator_cpp"},
+    "experiments": [
         {
-            "name": "save_command",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "save", "params": [0]},
-                    {"name": "snapshot", "params": [0]},
-                    {"name": "h", "qubits": [0]},
-                    {"name": "save", "params": [1]},
-                    {"name": "snapshot", "params": [10]},
-                    {"name": "load", "params": [0]},
-                    {"name": "snapshot", "params": [1]},
-                    {"name": "load", "params": [1]},
-                    {"name": "snapshot", "params": [11]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "save_command",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "save", "params": [0]},
+                {"name": "snapshot", "params": [0]},
+                {"name": "h", "qubits": [0]},
+                {"name": "save", "params": [1]},
+                {"name": "snapshot", "params": [10]},
+                {"name": "load", "params": [0]},
+                {"name": "snapshot", "params": [1]},
+                {"name": "load", "params": [1]},
+                {"name": "snapshot", "params": [11]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         }
     ]
 }

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -2,728 +2,720 @@
     "id": "test_qasm_single_qubit_gates",
     "config": {
         "shots": 1,
-        "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "seed": 1
     },
-    "circuits": [
+    "header": {"backend_name": "local_qasm_simulator_cpp"},
+    "experiments": [
         {
-            "name": "snapshot",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "snapshot",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "id(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "U", "params": [0.0, 0.0, 0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "id(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "U", "params": [0.0, 0.0, 0.0], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "id(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u3", "params": [0.0, 0.0, 0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "id(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u3", "params": [0.0, 0.0, 0.0], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "id(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u1", "params": [0.0], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+            "header": {
+                "name": "id(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u1", "params": [0.0], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
         },
         {
-            "name": "id(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "id", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "id(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "id", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "x(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "U", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "x(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "U", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "x(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u3", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "x(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u3", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "x(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "x", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "x(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "x", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "y(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "U", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "y(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "U", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "y(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u3", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "y(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u3", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "y(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "y", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "y(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "y", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "U", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "U", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u3", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u3", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(u2)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "u2", "params": [0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(u2)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "u2", "params": [0.0, 3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) z(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "U", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) z(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "U", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) z(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u3", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) z(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u3", "params": [0.0, 0.0, 3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) z(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u1", "params": [3.141592653589793], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) z(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u1", "params": [3.141592653589793], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) z(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "z", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) z(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "z", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) s(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "U", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) s(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "U", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) s(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u3", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) s(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u3", "params": [0.0, 0.0, 1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) s(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u1", "params": [1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) s(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u1", "params": [1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) s(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "s", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) s(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "s", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) sdg(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "U", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) sdg(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "U", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) sdg(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u3", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) sdg(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u3", "params": [0.0, 0.0, -1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) sdg(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u1", "params": [-1.5707963267948966], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) sdg(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u1", "params": [-1.5707963267948966], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) sdg(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "sdg", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) sdg(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "sdg", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) t(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "U", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) t(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "U", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) t(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u3", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) t(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u3", "params": [0.0, 0.0, 0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) t(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u1", "params": [0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) t(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u1", "params": [0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) t(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "t", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) t(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "t", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) tdg(U)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "U", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) tdg(U)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "U", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) tdg(u3)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u3", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) tdg(u3)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u3", "params": [0.0, 0.0, -0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) tdg(u1)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "u1", "params": [-0.7853981633974483], "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) tdg(u1)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "u1", "params": [-0.7853981633974483], "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         },
         {
-            "name": "h(direct) tdg(direct)",
-            "compiled_circuit": {
-                "header": {
-                    "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 1,
-                    "qubit_labels": [["q", 0]]
-                },
-                "operations": [
-                    {"name": "h", "qubits": [0]},
-                    {"name": "tdg", "qubits": [0]},
-                    {"name": "#snapshot", "params": [0]},
-                    {
-                    	"name": "measure", 
-                    	"qubits": [0],
-                    	"clbits": [0]
-                    }
-                ]
-            }
+
+            "header": {
+                "name": "h(direct) tdg(direct)",
+                "clbit_labels": [["c0", 1]],
+                "number_of_clbits": 1,
+                "number_of_qubits": 1,
+                "qubit_labels": [["q", 0]]
+            },
+            "instructions": [
+                {"name": "h", "qubits": [0]},
+                {"name": "tdg", "qubits": [0]},
+                {"name": "#snapshot", "params": [0]},
+                {
+                    "name": "measure",
+                    "qubits": [0],
+                    "clbits": [0]
+                }
+            ]
+
         }
     ]
 }

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -2,20 +2,19 @@
     "id": "test_two_qubit_gates",
     "config": {
         "shots": 1,
-        "seed": 1,
-        "backend_name": "local_qasm_simulator_cpp"
+        "seed": 1
     },
-    "circuits": [
+    "header": {"backend_name": "local_qasm_simulator_cpp"},
+    "experiments": [
         {
-            "name": "h0 CX01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 CX01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "CX", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -25,18 +24,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 CX10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 CX10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "CX", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -46,18 +44,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 CX01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 CX01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "CX", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -67,18 +64,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 CX10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 CX10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "CX", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -88,18 +84,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 cx01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 cx01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cx", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -109,18 +104,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 cx10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 cx10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cx", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -130,18 +124,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 cx01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 cx01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cx", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -151,18 +144,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 cx10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 cx10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cx", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -172,18 +164,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 cz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 cz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cz", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -193,18 +184,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 cz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 cz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "cz", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -214,18 +204,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 cz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 cz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -235,18 +224,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 cz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 cz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -256,18 +244,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 h1 cz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 h1 cz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [0, 1]},
@@ -278,18 +265,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 h1 cz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 h1 cz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "cz", "qubits": [1, 0]},
@@ -300,18 +286,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 rzz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 rzz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -321,18 +306,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 rzz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 rzz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -342,18 +326,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 rzz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 rzz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
                     {"name": "snapshot", "params": [0]},
@@ -363,18 +346,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h1 rzz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h1 rzz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
                     {"name": "snapshot", "params": [0]},
@@ -384,18 +366,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 h1 rzz01",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 h1 rzz01",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [0, 1]},
@@ -406,18 +387,17 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         },
         {
-            "name": "h0 h1 rzz10",
-            "compiled_circuit": {
                 "header": {
+                    "name": "h0 h1 rzz10",
                     "clbit_labels": [["c0", 1]],
                     "number_of_clbits": 1,
                     "number_of_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
-                "operations": [
+                "instructions": [
                     {"name": "h", "qubits": [0]},
                     {"name": "h", "qubits": [1]},
                     {"name": "rzz", "params": [1.5707963267948966], "qubits": [1, 0]},
@@ -428,7 +408,7 @@
                     	"clbits": [0]
                     }
                 ]
-            }
+
         }
     ]
 }

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -378,7 +378,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(q[3], q[14])
         qc.measure(q, c)
         qobj = transpiler.compile(qc, backend)
-        compiled_ops = qobj.circuits[0].compiled_circuit.operations
+        compiled_ops = qobj.experiments[0].instructions
         for op in compiled_ops:
             if op.name == 'cx':
                 self.assertIn(op.qubits, backend.configuration['coupling_map'])

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -303,6 +303,7 @@ class TestIBMQJob(QiskitTestCase):
 
     def test_get_jobs_filter_counts(self):
         # TODO: consider generalizing backend name
+        # TODO: this tests depends on the previous executions of the user
         backend = self._provider.get_backend('ibmq_qasm_simulator')
         my_filter = {'backend.name': 'ibmq_qasm_simulator',
                      'shots': 1024,
@@ -318,8 +319,9 @@ class TestIBMQJob(QiskitTestCase):
                                 for cresult in result._result['result']))
             for circuit_name in result.get_names():
                 self.log.info('\tcircuit_name: %s', circuit_name)
-                counts = result.get_counts(circuit_name)
-                self.log.info('\t%s', str(counts))
+                if circuit_name:
+                    counts = result.get_counts(circuit_name)
+                    self.log.info('\t%s', str(counts))
 
     def test_get_jobs_filter_date(self):
         backends = self._provider.available_backends()

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -25,10 +25,6 @@ class TestIBMQJobStates(QiskitTestCase):
     """
     Test ibmqjob module.
     """
-
-    def __init__(self, *args):
-        super().__init__(*args)
-
     def setUp(self):
         self._current_api = None
         self._current_qjob = None

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -11,13 +11,11 @@
 
 import unittest
 
-from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
-                    QuantumRegister, QuantumProgram)
-from qiskit.backends.local.qasm_simulator_cpp import QasmSimulatorCpp
+from qiskit import ClassicalRegister, QISKitError, QuantumCircuit, QuantumProgram, QuantumRegister
 from qiskit import wrapper
+from qiskit.backends.local.qasm_simulator_cpp import QasmSimulatorCpp
 from qiskit.qobj import Qobj
 from .common import QiskitTestCase
-
 
 # Cpp backend required
 try:
@@ -327,8 +325,8 @@ class TestQobj(QiskitTestCase):
     def test_local_qasm_simulator_py(self):
         backend = wrapper.get_backend('local_qasm_simulator_py')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.circuits[0].compiled_circuit
-        ccq = qobj.circuits[0].compiled_circuit_qasm
+        cc = qobj.experiments[0]
+        ccq = qobj.experiments[0].header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
         self.assertIn(self.qr_name, ccq)
         self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
@@ -338,8 +336,8 @@ class TestQobj(QiskitTestCase):
     def test_local_clifford_simulator_cpp(self):
         backend = wrapper.get_backend('local_clifford_simulator_cpp')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.circuits[0].compiled_circuit
-        ccq = qobj.circuits[0].compiled_circuit_qasm
+        cc = qobj.experiments[0]
+        ccq = qobj.experiments[0].header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
         self.assertIn(self.qr_name, ccq)
         self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
@@ -349,8 +347,8 @@ class TestQobj(QiskitTestCase):
     def test_local_qasm_simulator_cpp(self):
         backend = wrapper.get_backend('local_qasm_simulator_cpp')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.circuits[0].compiled_circuit
-        ccq = qobj.circuits[0].compiled_circuit_qasm
+        cc = qobj.experiments[0]
+        ccq = qobj.experiments[0].header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
         self.assertIn(self.qr_name, ccq)
         self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
@@ -359,8 +357,8 @@ class TestQobj(QiskitTestCase):
     def test_local_unitary_simulator(self):
         backend = wrapper.get_backend('local_unitary_simulator_py')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.circuits[0].compiled_circuit
-        ccq = qobj.circuits[0].compiled_circuit_qasm
+        cc = qobj.experiments[0]
+        ccq = qobj.experiments[0].header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
         self.assertIn(self.qr_name, ccq)
         self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -267,23 +267,21 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
         backend = 'local_qasm_simulator'
         config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
         qobj1 = q_program.compile(circuits, backend=backend, shots=shots, seed=88, config=config)
-        qobj1 = qobj1.as_dict()
-        qobj1['circuits'][0]['config']['shots'] = 50
-        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        qobj1.experiments[0].config.shots = 50
+        qobj1.experiments[0].config.xvals = [1, 1, 1]
         config['shots'] = 1000
         config['xvals'][0] = 'only for qobj2'
         qobj2 = q_program.compile(circuits, backend=backend, shots=shots, seed=88, config=config)
-        qobj2 = qobj2.as_dict()
-        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
-        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
-        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
-        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
-        self.assertTrue(qobj1['config']['shots'] == 1024)
-        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+        self.assertTrue(qobj1.experiments[0].config.shots == 50)
+        self.assertTrue(qobj1.experiments[1].config.shots == 1)
+        self.assertTrue(qobj1.experiments[0].config.xvals == [1, 1, 1])
+        self.assertTrue(qobj1.experiments[1].config.xvals == [1, 2, 3, 4])
+        self.assertTrue(qobj1.config.shots == 1024)
+        self.assertTrue(qobj2.experiments[0].config.shots == 1000)
+        self.assertTrue(qobj2.experiments[1].config.shots == 1000)
+        self.assertTrue(qobj2.experiments[0].config.xvals == [
             'only for qobj2', 2, 3, 4])
-        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+        self.assertTrue(qobj2.experiments[1].config.xvals == [
             'only for qobj2', 2, 3, 4])
 
     def test_add_circuit_noname(self):

--- a/test/python/test_localjob.py
+++ b/test/python/test_localjob.py
@@ -108,16 +108,15 @@ def fake_qobj():
     qobj = {
         'id': 'test-id',
         'config': {
-            'backend_name': backend.name,
             'shots': 1024,
             'max_credits': 100
             },
-        'circuits': [{
-            'compiled_circuit_qasm': 'fake-code',
-            'config': {
-                'seed': 123456
-            }
-        }]
+        'experiments': [{
+            'header': {'compiled_circuit_qasm': 'fake-code'},
+            'config': {'seed': 123456},
+            'instructions': []
+        }],
+        'header': {'backend_name': backend.name}
     }
     return Qobj.from_dict(qobj)
 

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -206,7 +206,7 @@ class MapperTest(QiskitTestCase):
                         [13, 4], [13, 14], [15, 0], [15, 2], [15, 14]]
         qobj = self.qp.compile(["native_cx"], backend=backend, coupling_map=coupling_map)
         cx_qubits = [x.qubits
-                     for x in qobj.circuits[0].compiled_circuit.operations
+                     for x in qobj.experiments[0].instructions
                      if x.name == "cx"]
 
         self.assertEqual(sorted(cx_qubits), [[3, 4], [3, 14], [5, 4], [9, 8], [12, 11], [13, 4]])

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -21,8 +21,7 @@ from qiskit.backends.local.qasm_simulator_cpp import (QasmSimulatorCpp,
                                                       cx_error_matrix,
                                                       x90_error_matrix)
 from qiskit.dagcircuit import DAGCircuit
-
-from qiskit.qobj import Qobj
+from qiskit.qobj import Qobj, QobjItem
 from qiskit.transpiler import transpile
 from .common import QiskitTestCase
 
@@ -53,24 +52,16 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
                      'config': {
                          'max_credits': 3,
                          'shots': 2000,
-                         'backend_name': 'local_qasm_simulator_cpp',
                          'seed': 1111
                      },
-                     'circuits': [
-                         {
-                             'name': 'test_circuit1',
-                             'compiled_circuit': compiled_circuit1,
-                             'basis_gates': 'u1,u2,u3,cx,id',
-                             'layout': None,
-                         },
-                         {
-                             'name': 'test_circuit2',
-                             'compiled_circuit': compiled_circuit2,
-                             'basis_gates': 'u1,u2,u3,cx,id',
-                             'layout': None,
-                         }
-                     ]}
+                     'experiments': [compiled_circuit1, compiled_circuit2],
+                     'header': {'backend_name': 'local_qasm_simulator_cpp'}}
         self.qobj = Qobj.from_dict(self.qobj)
+        self.qobj.experiments[0].header.name = 'test_circuit1'
+        self.qobj.experiments[0].config = QobjItem(basis_gates='u1,u2,u3,cx,id')
+        self.qobj.experiments[1].header.name = 'test_circuit2'
+        self.qobj.experiments[1].config = QobjItem(basis_gates='u1,u2,u3,cx,id')
+
         # Simulator backend
         try:
             self.backend = QasmSimulatorCpp()

--- a/test/python/test_qasm_simulator_py.py
+++ b/test/python/test_qasm_simulator_py.py
@@ -6,7 +6,6 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 # pylint: disable=invalid-name,missing-docstring
-
 from sys import version_info
 import cProfile
 import io
@@ -19,7 +18,7 @@ from matplotlib.backends.backend_pdf import PdfPages
 import numpy as np
 from qiskit import qasm, unroll, QuantumProgram
 from qiskit.backends.local.qasm_simulator_py import QasmSimulatorPy
-from qiskit.qobj import Qobj
+from qiskit.qobj import Qobj, QobjItem
 
 from ._random_qasm_generator import RandomQasmGenerator
 from .common import QiskitTestCase
@@ -61,20 +60,12 @@ class TestLocalQasmSimulatorPy(QiskitTestCase):
                      'config': {
                          'max_credits': resources['max_credits'],
                          'shots': 1024,
-                         'backend_name': 'local_qasm_simulator_py',
                      },
-                     'circuits': [
-                         {
-                             'name': 'test',
-                             'compiled_circuit': circuit,
-                             'compiled_circuit_qasm': None,
-                             'config': circuit_config
-                         }
-                     ]}
+                     'experiments': [circuit],
+                     'header': {'backend_name': 'local_qasm_simulator_py'}}
         self.qobj = Qobj.from_dict(self.qobj)
-
-    def tearDown(self):
-        pass
+        self.qobj.experiments[0].config = QobjItem.from_dict(circuit_config)
+        self.qobj.experiments[0].header.name = 'test'
 
     def test_qasm_simulator_single_shot(self):
         """Test single shot run."""
@@ -128,37 +119,29 @@ class TestLocalQasmSimulatorPy(QiskitTestCase):
             qasm.Qasm(data=qp.get_qasm('test_if_false')).parse(),
             unroll.JsonBackend(basis_gates))
         ucircuit_false = unroller.execute()
+
         qobj = {
             'id': 'test_if_qobj',
             'config': {
                 'max_credits': 3,
                 'shots': shots,
-                'backend_name': 'local_qasm_simulator_py',
             },
-            'circuits': [
-                {
-                    'name': 'test_if_true',
-                    'compiled_circuit': ucircuit_true,
-                    'compiled_circuit_qasm': None,
-                    'config': {
-                        'coupling_map': None,
-                        'basis_gates': 'u1,u2,u3,cx,id',
-                        'layout': None,
-                        'seed': None
-                    }
-                },
-                {
-                    'name': 'test_if_false',
-                    'compiled_circuit': ucircuit_false,
-                    'compiled_circuit_qasm': None,
-                    'config': {
-                        'coupling_map': None,
-                        'basis_gates': 'u1,u2,u3,cx,id',
-                        'layout': None,
-                        'seed': None
-                    }
-                }
-            ]
+            'experiments': [ucircuit_true, ucircuit_false],
+            'header': {'backend_name': 'local_qasm_simulator_py'}
+        }
+        qobj['experiments'][0]['header']['name'] = 'test_if_true'
+        qobj['experiments'][0]['config'] = {
+            'coupling_map': None,
+            'basis_gates': 'u1,u2,u3,cx,id',
+            'layout': None,
+            'seed': None
+        }
+        qobj['experiments'][1]['header']['name'] = 'test_if_false'
+        qobj['experiments'][1]['config'] = {
+            'coupling_map': None,
+            'basis_gates': 'u1,u2,u3,cx,id',
+            'layout': None,
+            'seed': None
         }
         qobj = Qobj.from_dict(qobj)
 

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -7,7 +7,7 @@
 
 """QOBj test."""
 from qiskit.qobj import (Qobj, QobjConfig, QobjExperiment,
-                         QobjInstruction, qobj_to_dict)
+                         QobjInstruction)
 from .common import QiskitTestCase
 
 
@@ -23,8 +23,7 @@ class TestQobj(QiskitTestCase):
         experiments = [experiment_1]
 
         qobj = Qobj(id='12345', config=config, experiments=experiments, header={})
-        import pprint
-        pprint.pprint(qobj_to_dict(qobj))
+
         expected = {
             'id': '12345',
             'type': 'QASM',

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -6,9 +6,8 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """QOBj test."""
-
-from qiskit.qobj import (Qobj, QobjCompiledCircuit, QobjConfig, QobjExperiment,
-                         QobjExperimentConfig, QobjInstruction)
+from qiskit.qobj import (Qobj, QobjConfig, QobjExperiment,
+                         QobjInstruction, qobj_to_dict)
 from .common import QiskitTestCase
 
 
@@ -16,41 +15,27 @@ class TestQobj(QiskitTestCase):
     """Tests for Qobj."""
     def test_create_qobj(self):
         """Test creation of a Qobj based on the individual elements."""
-        config = QobjConfig(max_credits=10, shots=1024, backend_name='backend')
-        circuit_config = QobjExperimentConfig(
-            seed=1234, basis_gates='u1,u2,u3,cx,id,snapshot',
-            coupling_map=None, layout=None)
-        circuit_config.seed = 1234
-
+        config = QobjConfig(max_credits=10, shots=1024, register_slots=2)
         instruction_1 = QobjInstruction(name='u1', qubits=[1], params=[0.4])
         instruction_2 = QobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2])
         instructions = [instruction_1, instruction_2]
-        compiled_circuit = QobjCompiledCircuit(header=None, operations=instructions)
-        experiment_1 = QobjExperiment(name='circuit1', config=circuit_config,
-                                      compiled_circuit=compiled_circuit,
-                                      compiled_circuit_qasm='compiled_qasm')
+        experiment_1 = QobjExperiment(instructions=instructions)
         experiments = [experiment_1]
 
-        qobj = Qobj(id='12345', config=config, circuits=experiments)
+        qobj = Qobj(id='12345', config=config, experiments=experiments, header={})
+        import pprint
+        pprint.pprint(qobj_to_dict(qobj))
+        expected = {
+            'id': '12345',
+            'type': 'QASM',
+            'header': {},
+            'config': {'max_credits': 10, 'register_slots': 2, 'shots': 1024},
+            'experiments': [
+                {'instructions': [
+                    {'name': 'u1', 'params': [0.4], 'qubits': [1]},
+                    {'name': 'u2', 'params': [0.4, 0.2], 'qubits': [1]}
+                ]}
+            ],
+            }
 
-        expected = {'id': '12345',
-                    'type': 'QASM',
-                    'config': {'max_credits': 10, 'shots': 1024,
-                               'backend_name': 'backend'},
-                    'circuits': [
-                        {
-                            'name': 'circuit1',
-                            'config': {
-                                'seed': 1234, 'basis_gates': 'u1,u2,u3,cx,id,snapshot',
-                                'coupling_map': None, 'layout': None},
-                            'compiled_circuit': {
-                                'header': None,
-                                'operations': [
-                                    {'name': 'u1', 'params': [0.4], 'qubits': [1]},
-                                    {'name': 'u2', 'params': [0.4, 0.2],
-                                     'qubits': [1]}]
-                            },
-                            'compiled_circuit_qasm': 'compiled_qasm'
-                        }
-                    ]}
         self.assertEqual(qobj.as_dict(), expected)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -731,7 +731,7 @@ class TestQuantumProgram(QiskitTestCase):
     def test_get_compiled_configuration(self):
         """Test compiled_configuration.
 
-        If all correct should return length 6 dictionary.
+        If all correct should return length 3 dictionary.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
         qc = q_program.get_circuit("circuitName")
@@ -747,7 +747,7 @@ class TestQuantumProgram(QiskitTestCase):
                                  coupling_map=coupling_map)
         result = q_program.get_compiled_configuration(qobj, 'circuitName')
         self.log.info(result)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 3)
 
     def test_get_compiled_qasm(self):
         """Test get_compiled_qasm.

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -731,7 +731,7 @@ class TestQuantumProgram(QiskitTestCase):
     def test_get_compiled_configuration(self):
         """Test compiled_configuration.
 
-        If all correct should return length 3 dictionary.
+        If all correct should return length 4 dictionary.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
         qc = q_program.get_circuit("circuitName")
@@ -747,7 +747,7 @@ class TestQuantumProgram(QiskitTestCase):
                                  coupling_map=coupling_map)
         result = q_program.get_compiled_configuration(qobj, 'circuitName')
         self.log.info(result)
-        self.assertEqual(len(result), 3)
+        self.assertEqual(len(result), 4)
 
     def test_get_compiled_qasm(self):
         """Test get_compiled_qasm.
@@ -878,24 +878,22 @@ class TestQuantumProgram(QiskitTestCase):
         config = {'seed': 10, 'shots': 1, 'xvals': [1, 2, 3, 4]}
         qobj1 = q_program.compile(circuits, backend=backend, shots=shots,
                                   seed=88, config=config)
-        qobj1 = qobj1.as_dict()
-        qobj1['circuits'][0]['config']['shots'] = 50
-        qobj1['circuits'][0]['config']['xvals'] = [1, 1, 1]
+        qobj1.experiments[0].config.shots = 50
+        qobj1.experiments[0].config.xvals = [1, 1, 1]
         config['shots'] = 1000
         config['xvals'][0] = 'only for qobj2'
         qobj2 = q_program.compile(circuits, backend=backend, shots=shots,
                                   seed=88, config=config)
-        qobj2 = qobj2.as_dict()
-        self.assertTrue(qobj1['circuits'][0]['config']['shots'] == 50)
-        self.assertTrue(qobj1['circuits'][1]['config']['shots'] == 1)
-        self.assertTrue(qobj1['circuits'][0]['config']['xvals'] == [1, 1, 1])
-        self.assertTrue(qobj1['circuits'][1]['config']['xvals'] == [1, 2, 3, 4])
-        self.assertTrue(qobj1['config']['shots'] == 1024)
-        self.assertTrue(qobj2['circuits'][0]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][1]['config']['shots'] == 1000)
-        self.assertTrue(qobj2['circuits'][0]['config']['xvals'] == [
+        self.assertTrue(qobj1.experiments[0].config.shots == 50)
+        self.assertTrue(qobj1.experiments[1].config.shots == 1)
+        self.assertTrue(qobj1.experiments[0].config.xvals == [1, 1, 1])
+        self.assertTrue(qobj1.experiments[1].config.xvals == [1, 2, 3, 4])
+        self.assertTrue(qobj1.config.shots == 1024)
+        self.assertTrue(qobj2.experiments[0].config.shots == 1000)
+        self.assertTrue(qobj2.experiments[1].config.shots == 1000)
+        self.assertTrue(qobj2.experiments[0].config.xvals == [
             'only for qobj2', 2, 3, 4])
-        self.assertTrue(qobj2['circuits'][1]['config']['xvals'] == [
+        self.assertTrue(qobj2.experiments[1].config.xvals == [
             'only for qobj2', 2, 3, 4])
 
     ###############################################################
@@ -1583,12 +1581,12 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(qobj.config.max_credits, 11)
         # change seed
         qobj = q_program.reconfig(qobj, seed=11)
-        self.assertEqual(qobj.circuits[0].config.seed, 11)
+        self.assertEqual(qobj.experiments[0].config.seed, 11)
         # change the config
         test_config_2 = {'foo': 2}
         qobj = q_program.reconfig(qobj, config=test_config_2)
-        self.assertEqual(qobj.circuits[0].config.foo, 2)
-        self.assertEqual(qobj.circuits[0].config.bar, 1)
+        self.assertEqual(qobj.experiments[0].config.foo, 2)
+        self.assertEqual(qobj.experiments[0].config.bar, 1)
 
     def test_timeout(self):
         """Test run.

--- a/test/python/test_skip_transpiler.py
+++ b/test/python/test_skip_transpiler.py
@@ -35,7 +35,7 @@ class CompileSkipTranslationTest(QiskitTestCase):
         rfalse = qp.compile([name], backend='local_qasm_simulator', shots=1024,
                             skip_transpiler=False)
         self.assertEqual(rtrue.config, rfalse.config)
-        self.assertEqual(rtrue.circuits, rfalse.circuits)
+        self.assertEqual(rtrue.experiments, rfalse.experiments)
 
     def test_simple_execute(self):
         name = 'test_simple'

--- a/test/python/test_transpiler.py
+++ b/test/python/test_transpiler.py
@@ -69,9 +69,14 @@ class TestTranspiler(QiskitTestCase):
 
         qobj = wrapper.compile(circ, backend='local_qasm_simulator',
                                coupling_map=coupling_map, basis_gates=basis_gates)
-        compiler_json = qobj.circuits[0].compiled_circuit
+        compiler_json = qobj.experiments[0].as_dict()
 
-        self.assertDictEqual(transpiler_json, compiler_json.as_dict())
+        # Remove extra Qobj header parameters.
+        compiler_json.pop('config')
+        compiler_json['header'].pop('name')
+        compiler_json['header'].pop('compiled_circuit_qasm')
+
+        self.assertDictEqual(transpiler_json, compiler_json)
 
     def test_pass_cx_cancellation(self):
         """Test the cx cancellation pass.


### PR DESCRIPTION
Fixes #647 
Fixes #648 

### Summary

Now that the `Qobj*` classes are in place after #589 , this PR tackles the next step:
* updates the `qiskit.qobj.*` classes in order to follow the `qiskit/schemas/qobj_schema.json` (only `QASM` type) schema. Please note that the focus has been placed in following the current version of that file (some finer points of the spec might need to be clarified/debated in a separate issue).
* adds a `qobj_to_dict()` function that converts the classes into dicts, in particular allowing generation of dicts that conform to the previous schema since there might be some time before every device and sim fully supports qobj - this allows the codebase to be working, isolating that translation into a single point.
* revise `transpiler.transpile()` in order to generate Qobjs with the new schema.
* update the local simulators and `IBMQJob` in order to accept the new `Qobj` classes and schema as an input for `run()` - however, please note that internally they still make use of the old format during `run_circuit` and equivalent functions.

As a result, with this PR technically we produce both valid `qobj_schema.json` objects  and valid previous schema dicts when needed. There are a lot of files changed by this PR, mostly due to the tests and adjustments, that mimic #589 .


Checklist
- [x] Update the `qiskit.qobj.*` classes to the real schema
- [x] Introduce a way for generating the old schema as an output
- [x] Adjust the Python local backends
- [x] Adjust the C++ local backends
- [x] Adjust IBMQJob (using the old schema)
- [x] Adjust all the tests
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->




### Details and comments


