### PR TITLE
A more generic re expression

### DIFF
--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -86,7 +86,7 @@ class TestQuantumProgram(QiskitTestCase):
         """
         # pylint: disable=unused-argument
         import re
-        self.assertTrue(re.match('https://[-a-z.]*bluemix.net/api', QE_URL))
+        self.assertTrue(re.match('^https?://[0-9.:/A-Za-z_-]+/api', QE_URL))
 
     def test_create_classical_register(self):
         """Test create_classical_register.


### PR DESCRIPTION
### Summary

While working on #234, I'm setting the `QE_URL` to things like `http://127.0.0.1:5000/<test_name>/api`. The test `test.python.test_quantumprogram.TestQuantumProgram.test_config_scripts_file` checks a regexp that is a bit too restrictive in this new setting. This PR is a bit more generic and works in both cases. 