### PR TITLE
update device display names in `backend.status`

### DIFF
--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -136,6 +136,16 @@ class IBMQBackend(BaseBackend):
             # be fixed in api
             if status['name'] == 'ibmqx_hpc_qasm_simulator':
                 status['available'] = True
+            # FIXME a hack to show the new device display names. Needs to
+            # be fixed in the API.
+            if status['name'] == 'ibmqx2':
+                status['name'] = 'ibmq_5_yorktown'
+            if status['name'] == 'ibmqx4':
+                status['name'] = 'ibmq_5_tenerife'
+            if status['name'] == 'ibmqx5':
+                status['name'] = 'ibmq_16_rueschlikon'
+            if status['name'] == 'QS1_1':
+                status['name'] = 'ibmq_20_austin'
 
             # FIXME: this needs to be replaced at the API level - eventually
             # it will.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -17,6 +17,21 @@ from qiskit.backends import BaseBackend
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from qiskit.backends import JobStatus
 
+# FIXME (new_backend_names): these two dicts are placed here to avoid cyclic
+# imports. Once fixed, their place should be `ibmqprovider.py`.
+
+# Dict with the form {'new_name': 'previous_name'}
+ALIASED_BACKEND_NAMES = {
+    'ibmq_5_yorktown': 'ibmqx2',
+    'ibmq_5_tenerife': 'ibmqx4',
+    'ibmq_16_rueschlikon': 'ibmqx5',
+    'ibmq_20_austin': 'QS1_1'
+}
+
+# Dict with the form {'previous_name': 'new_name'}
+ALIASED_BACKEND_NAMES_REVERSED = {name: alias for alias, name in
+                                  ALIASED_BACKEND_NAMES.items()}
+
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +275,6 @@ class IBMQBackend(BaseBackend):
         Returns:
             str: name valid for the api
         """
-        from qiskit.backends.ibmq.ibmqprovider import ALIASED_BACKEND_NAMES
         return ALIASED_BACKEND_NAMES.get(self.name) or self.name
 
     def _update_dict_name_from_api(self, status, field='name'):
@@ -277,7 +291,6 @@ class IBMQBackend(BaseBackend):
         Returns:
             dict: dict with the 'name' replaced.
         """
-        from qiskit.backends.ibmq.ibmqprovider import ALIASED_BACKEND_NAMES_REVERSED
         if field in status.keys():
             status[field] = ALIASED_BACKEND_NAMES_REVERSED.get(
                 status[field]) or status[field]

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -269,6 +269,7 @@ class IBMQBackend(BaseBackend):
 
         Args:
             status (dict): dict with optionally a 'name' key.
+            field (str): the field to replace in the dict.
 
         FIXME (new_backend_names): a hack to show the new device display
         names. Needs to be fixed in the API.
@@ -282,7 +283,6 @@ class IBMQBackend(BaseBackend):
                 status[field]) or status[field]
 
         return status
-
 
 
 class IBMQBackendError(QISKitError):

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -17,6 +17,7 @@ from qiskit.backends import BaseBackend
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from qiskit.backends import JobStatus
 
+
 logger = logging.getLogger(__name__)
 
 
@@ -68,7 +69,7 @@ class IBMQBackend(BaseBackend):
             LookupError: If a configuration for the backend can't be found.
         """
         try:
-            backend_name = self.configuration['name']
+            backend_name = self._name_for_api
             calibrations = self._api.backend_calibration(backend_name)
             # FIXME a hack to remove calibration data that is none.
             # Needs to be fixed in api
@@ -83,6 +84,9 @@ class IBMQBackend(BaseBackend):
             new_key = _camel_case_to_snake_case(key)
             calibrations_edit[new_key] = vals
 
+        calibrations_edit = self._update_dict_name_from_api(calibrations_edit,
+                                                            field='backend')
+
         return calibrations_edit
 
     @property
@@ -96,7 +100,7 @@ class IBMQBackend(BaseBackend):
             LookupError: If parameters for the backend can't be found.
         """
         try:
-            backend_name = self.configuration['name']
+            backend_name = self._name_for_api
             parameters = self._api.backend_parameters(backend_name)
             # FIXME a hack to remove parameters data that is none.
             # Needs to be fixed in api
@@ -111,6 +115,9 @@ class IBMQBackend(BaseBackend):
             new_key = _camel_case_to_snake_case(key)
             parameters_edit[new_key] = vals
 
+        parameters_edit = self._update_dict_name_from_api(parameters_edit,
+                                                          field='backend')
+
         return parameters_edit
 
     @property
@@ -124,7 +131,7 @@ class IBMQBackend(BaseBackend):
             LookupError: If status for the backend can't be found.
         """
         try:
-            backend_name = self.configuration['name']
+            backend_name = self._name_for_api
             status = self._api.backend_status(backend_name)
             # FIXME a hack to rename the key. Needs to be fixed in api
             status['name'] = status['backend']
@@ -136,16 +143,8 @@ class IBMQBackend(BaseBackend):
             # be fixed in api
             if status['name'] == 'ibmqx_hpc_qasm_simulator':
                 status['available'] = True
-            # FIXME a hack to show the new device display names. Needs to
-            # be fixed in the API.
-            if status['name'] == 'ibmqx2':
-                status['name'] = 'ibmq_5_yorktown'
-            if status['name'] == 'ibmqx4':
-                status['name'] = 'ibmq_5_tenerife'
-            if status['name'] == 'ibmqx5':
-                status['name'] = 'ibmq_16_rueschlikon'
-            if status['name'] == 'QS1_1':
-                status['name'] = 'ibmq_20_austin'
+
+            status = self._update_dict_name_from_api(status)
 
             # FIXME: this needs to be replaced at the API level - eventually
             # it will.
@@ -194,7 +193,8 @@ class IBMQBackend(BaseBackend):
         Raises:
             IBMQBackendValueError: status keyword value unrecognized
         """
-        backend_name = self.configuration['name']
+        backend_name = self._name_for_api
+
         api_filter = {}
         if status:
             if isinstance(status, str):
@@ -248,6 +248,41 @@ class IBMQBackend(BaseBackend):
         is_device = not bool(self._configuration.get('simulator'))
         job = IBMQJob.from_api(job_info, self._api, is_device)
         return job
+
+    @property
+    def _name_for_api(self):
+        """
+        Return the backend name as used in the API.
+
+        FIXME (new_backend_names): a hack to show the new device display
+        names. Needs to be fixed in the API.
+
+        Returns:
+            str: name valid for the api
+        """
+        from qiskit.backends.ibmq.ibmqprovider import ALIASED_BACKEND_NAMES
+        return ALIASED_BACKEND_NAMES.get(self.name) or self.name
+
+    def _update_dict_name_from_api(self, status, field='name'):
+        """
+        Update a dict['name'] with an aliased (new) backend name.
+
+        Args:
+            status (dict): dict with optionally a 'name' key.
+
+        FIXME (new_backend_names): a hack to show the new device display
+        names. Needs to be fixed in the API.
+
+        Returns:
+            dict: dict with the 'name' replaced.
+        """
+        from qiskit.backends.ibmq.ibmqprovider import ALIASED_BACKEND_NAMES_REVERSED
+        if field in status.keys():
+            status[field] = ALIASED_BACKEND_NAMES_REVERSED.get(
+                status[field]) or status[field]
+
+        return status
+
 
 
 class IBMQBackendError(QISKitError):

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -10,19 +10,7 @@ from IBMQuantumExperience import IBMQuantumExperience
 
 from qiskit._util import _camel_case_to_snake_case
 from qiskit.backends.baseprovider import BaseProvider
-from qiskit.backends.ibmq.ibmqbackend import IBMQBackend
-
-# Dict with the form {'new_name': 'previous_name'}
-ALIASED_BACKEND_NAMES = {
-    'ibmq_5_yorktown': 'ibmqx2',
-    'ibmq_5_tenerife': 'ibmqx4',
-    'ibmq_16_rueschlikon': 'ibmqx5',
-    'ibmq_20_austin': 'QS1_1'
-}
-
-# Dict with the form {'previous_name': 'new_name'}
-ALIASED_BACKEND_NAMES_REVERSED = {name: alias for alias, name in
-                                  ALIASED_BACKEND_NAMES.items()}
+from qiskit.backends.ibmq.ibmqbackend import IBMQBackend, ALIASED_BACKEND_NAMES_REVERSED
 
 
 class IBMQProvider(BaseProvider):

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -12,6 +12,18 @@ from qiskit._util import _camel_case_to_snake_case
 from qiskit.backends.baseprovider import BaseProvider
 from qiskit.backends.ibmq.ibmqbackend import IBMQBackend
 
+# Dict with the form {'new_name': 'previous_name'}
+ALIASED_BACKEND_NAMES = {
+    'ibmq_5_yorktown': 'ibmqx2',
+    'ibmq_5_tenerife': 'ibmqx4',
+    'ibmq_16_rueschlikon': 'ibmqx5',
+    'ibmq_20_austin': 'QS1_1'
+}
+
+# Dict with the form {'previous_name': 'new_name'}
+ALIASED_BACKEND_NAMES_REVERSED = {name: alias for alias, name in
+                                  ALIASED_BACKEND_NAMES.items()}
+
 
 class IBMQProvider(BaseProvider):
     """Provider for remote IbmQ backends."""
@@ -59,12 +71,7 @@ class IBMQProvider(BaseProvider):
             }
 
     def aliased_backend_names(self):
-        return {
-            'ibmq_5_yorktown': 'ibmqx2',
-            'ibmq_5_tenerife': 'ibmqx4',
-            'ibmq_16_rueschlikon': 'ibmqx5',
-            'ibmq_20_austin': 'QS1_1'
-            }
+        return ALIASED_BACKEND_NAMES_REVERSED
 
     @classmethod
     def _authenticate(cls, token, url,
@@ -123,6 +130,13 @@ class IBMQProvider(BaseProvider):
             if new_key not in ['id', 'serial_number', 'topology_id',
                                'status']:
                 edited_config[new_key] = config[key]
+
+        # FIXME (new_backend_names): a hack to show the new device display
+        # names. Needs to be fixed in the API.
+        if config.get('name') in ALIASED_BACKEND_NAMES_REVERSED.keys():
+            # Use the new name of the backend for `backend.name` if it is in
+            # the list of aliases.
+            edited_config['name'] = ALIASED_BACKEND_NAMES_REVERSED[config['name']]
 
         return edited_config
 

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -58,6 +58,10 @@ def compile(circuits, backend,
 
     backend_conf = backend.configuration
     backend_name = backend_conf['name']
+    # FIXME (new_backend_names): the API uses the old backend names, but in
+    # qiskit we are using the new ones. This makes the qobj names valid (old).
+    if getattr(backend, '_name_for_api', None):
+        backend_name = backend._name_for_api
 
     qobj = {}
 

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -533,7 +533,9 @@ class TestQuantumProgram(QiskitTestCase):
 
         check_result = q_program.get_qasm('circuitName')
         self.log.info(check_result)
-        self.assertEqual(len(check_result), 1775)
+        # TODO: revise Sympy 1.2 compatibility. The length is 1775 for
+        # sympy=1.1.x, and 1781 for sympy=1.2
+        self.assertIn(len(check_result), (1775, 1781))
 
     def test_load_wrong(self):
         """Test load Json.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is a temporary hack to show updated device display names when inquiring `backend.status`, until such names are updated in the API itself.

*Motivation*: we want to remove `ibmqx2`, `ibmqx4` and `ibmqx5` in favor of new, more descriptive names.
A previous PR (#566 ) created aliases that allowed the wrapper to work with both old names and new names (e.g. when calling `execute()`).