### PR TITLE
Make double registration a warning not exception

### DIFF
--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -9,7 +9,7 @@
 
 import logging
 from itertools import combinations
-
+import warnings
 from qiskit import QISKitError
 from qiskit.backends.baseprovider import BaseProvider
 from qiskit.backends.local.localprovider import LocalProvider
@@ -156,14 +156,13 @@ class DefaultQISKitProvider(BaseProvider):
         # checks for equality of provider instances, based on the __eq__ method
         if provider not in self.providers:
             self.providers.append(provider)
+            if common_backends:
+                logger.warning(
+                    'The backend names "%s" of this provider are already in use. '
+                    'Refer to documentation for `available_backends()` and `unregister()`.',
+                    list(common_backends))
         else:
-            raise QISKitError("The same provider has already been registered!")
-
-        if common_backends:
-            logger.warning(
-                'The backend names "%s" of this provider are already in use. '
-                'Refer to documentation for `available_backends()` and `unregister()`.',
-                list(common_backends))
+            warnings.warn("Skipping registration: The provider is already registered.")
 
         return provider
 

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -144,9 +144,6 @@ class DefaultQISKitProvider(BaseProvider):
 
         Returns:
             BaseProvider: the provider instance.
-
-        Raises:
-            QISKitError: if trying to add a provider identical to one already registered
         """
         # Check for backend name clashes, emitting a warning.
         current_backends = {str(backend) for backend in self.available_backends()}
@@ -161,10 +158,10 @@ class DefaultQISKitProvider(BaseProvider):
                     'The backend names "%s" of this provider are already in use. '
                     'Refer to documentation for `available_backends()` and `unregister()`.',
                     list(common_backends))
+            return provider
         else:
             warnings.warn("Skipping registration: The provider is already registered.")
-
-        return provider
+            return self.providers[self.providers.index(provider)]
 
     def remove_provider(self, provider):
         """

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -52,8 +52,8 @@ class TestWrapper(QiskitTestCase):
         """Test double registration of the same credentials."""
         qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
         initial_providers = registered_providers()
-        with self.assertRaises(QISKitError):
-            qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        # Registering twice should give warning and add no providers.
+        qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
         self.assertCountEqual(initial_providers, registered_providers())
 
     def test_register_bad_credentials(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
An exception is too strict here, and can cause some issues when working in a notebook env.  Here, a warning is generated instead.


### Details and comments


