### PR TITLE
Update Qobj to the 1.0.0 schema

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 - Use ``Qobj`` as the formally defined schema for sending information to the
   devices:
     - introduce the ``qiskit.qobj`` module. (#589, #655)
+    - update the ``Qobj`` JSON schema. (#668, #677)
     - update the local simulators for accepting ``Qobj`` as input. (#667)
 - Use ``get_status_job()`` for checking IBMQJob status. (#641)
 

--- a/qiskit/backends/local/qasm_simulator_py.py
+++ b/qiskit/backends/local/qasm_simulator_py.py
@@ -375,7 +375,7 @@ class QasmSimulatorPy(BaseBackend):
                 elif operation.name == 'barrier':
                     pass
                 # Check if snapshot command
-                elif operation.name == 'snapshot':
+                elif operation.name == '#snapshot':
                     params = operation.params
                     self._add_qasm_snapshot(params[0])
                 else:

--- a/qiskit/backends/local/statevector_simulator_cpp.py
+++ b/qiskit/backends/local/statevector_simulator_cpp.py
@@ -48,7 +48,7 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction.from_dict({'name': 'snapshot', 'params': [final_state_key]})
+                QobjInstruction.from_dict({'name': '#snapshot', 'params': [final_state_key]})
             )
         result = super()._run_job(qobj)
         # Extract final state snapshot and move to 'statevector' data field

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -62,7 +62,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction.from_dict({'name': 'snapshot', 'params': [final_state_key]})
+                QobjInstruction.from_dict({'name': '#snapshot', 'params': [final_state_key]})
             )
         result = super()._run_job(qobj)._result
         # Replace backend name with current backend

--- a/qiskit/qobj/_converter.py
+++ b/qiskit/qobj/_converter.py
@@ -72,7 +72,7 @@ def qobj_to_dict_previous_version(qobj):
 
     # Update configuration: qobj.config might have extra items.
     for key, value in qobj.config.__dict__.items():
-        if key not in ('shots', 'register_slots', 'max_credits', 'seed'):
+        if key not in ('shots', 'memory_slots', 'max_credits', 'seed'):
             converted['config'][key] = value
 
     # Add circuits.
@@ -82,13 +82,19 @@ def qobj_to_dict_previous_version(qobj):
             circuit_config = circuit_config.as_dict()
             circuit_config['seed'] = getattr(qobj.config, 'seed', None)
 
+        # Convert '#snapshot' to 'snapshot' in the instructions.
+        instructions = []
+        for instruction in experiment.instructions:
+            instructions.append(instruction.as_dict())
+            if instruction.name == '#snapshot':
+                instructions[-1]['name'] = 'snapshot'
+
         circuit = {
             'name': getattr(experiment.header, 'name', None),
             'config': circuit_config,
             'compiled_circuit': {
                 'header': experiment.header.as_dict(),
-                'operations': [instruction.as_dict() for instruction in
-                               experiment.instructions]
+                'operations': instructions
             },
             'compiled_circuit_qasm': getattr(experiment.header,
                                              'compiled_circuit_qasm', None)

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -12,8 +12,9 @@ from types import SimpleNamespace
 from ._utils import QobjValidationError, QobjType
 
 # Current version of the Qobj schema.
-QOBJ_VERSION = '0.0.2'
-# Previous Qobj schema versions:
+QOBJ_VERSION = '1.0.0'
+# Qobj schema versions:
+# * 1.0.0: Qiskit 0.6
 # * 0.0.1: Qiskit 0.5.x format (pre-schemas).
 
 
@@ -100,7 +101,7 @@ class Qobj(QobjItem):
         experiments (list[QobjExperiment]): list of experiments.
         header (QobjHeader): headers.
         type (str): experiment type (QASM/PULSE).
-        _version (str): Qobj version.
+        schema_version (str): Qobj version.
     """
 
     REQUIRED_ARGS = ['id', 'config', 'experiments', 'header']
@@ -113,7 +114,7 @@ class Qobj(QobjItem):
         self.header = header
 
         self.type = QobjType.QASM.value
-        self._version = QOBJ_VERSION
+        self.schema_version = QOBJ_VERSION
 
         super().__init__(**kwargs)
 
@@ -123,17 +124,18 @@ class QobjConfig(QobjItem):
 
     Attributes:
         shots (int): number of shots.
-        register_slots (int): number of classical register slots.
+        memory_slots (int): number of measurements slots in the classical
+            memory on the backend.
 
     Attributes defined in the schema but not required:
         max_credits (int): number of credits.
         seed (int): random seed.
     """
-    REQUIRED_ARGS = ['shots', 'register_slots']
+    REQUIRED_ARGS = ['shots', 'memory_slots']
 
-    def __init__(self, shots, register_slots, **kwargs):
+    def __init__(self, shots, memory_slots, **kwargs):
         self.shots = shots
-        self.register_slots = register_slots
+        self.memory_slots = memory_slots
 
         super().__init__(**kwargs)
 
@@ -145,7 +147,7 @@ class QobjHeader(QobjItem):
         backend_name (str): name of the backend
         backend_version (str): the backend version this set of experiments was generated for.
         qubit_labels (list): map physical qubits to qregs (for QASM).
-        clbit_labels (list): map classical clbits to register_slots (for QASM).
+        clbit_labels (list): map classical clbits to memory_slots (for QASM).
     """
     pass
 

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -133,7 +133,7 @@ def compile(circuits, backend,
             'basis_gates': basis_gates,
             'layout': list_layout,
             'memory_slots': sum(register.size for register
-                                  in circuit.get_cregs().values())})
+                                in circuit.get_cregs().values())})
         experiment.config = QobjItem(**experiment_config)
 
         # set eval_symbols=True to evaluate each symbolic expression

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -89,58 +89,9 @@ def compile(circuits, backend,
 
     # Step 2 and 3: transpile and populate the circuits
     for circuit in circuits:
-        # TODO: A better solution is to have options to enable/disable optimizations
-        num_qubits = sum((len(qreg) for qreg in circuit.get_qregs().values()))
-        if num_qubits == 1 or coupling_map == "all-to-all":
-            coupling_map = None
-        # Step 2a: circuit -> dag
-        dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
-
-        # TODO: move this inside the mapper pass
-        # pick a good initial layout if coupling_map is not already satisfied
-        # otherwise keep it as q[i]->q[i]
-        if (initial_layout is None and
-                not backend_conf['simulator'] and
-                not _matches_coupling_map(circuit.data, coupling_map)):
-            initial_layout = _pick_best_layout(backend, num_qubits, circuit.get_qregs())
-
-        # Step 2b: transpile (dag -> dag)
-        dag_circuit, final_layout = transpile(
-            dag_circuit,
-            basis_gates=basis_gates,
-            coupling_map=coupling_map,
-            initial_layout=initial_layout,
-            get_layout=True,
-            seed=seed,
-            pass_manager=pass_manager)
-
-        # Step 2c: dag -> json
-        # the compiled circuit to be run saved as a dag
-        # we assume that transpile() has already expanded gates
-        # to the target basis, so we just need to generate json
-        list_layout = [[k, v] for k, v in final_layout.items()] if final_layout else None
-
-        json_circuit = DagUnroller(dag_circuit, JsonBackend(dag_circuit.basis)).execute()
-
-        # Step 3a: create the Experiment based on json_circuit
-        experiment = QobjExperiment.from_dict(json_circuit)
-        # Step 3b: populate the Experiment configuration and header
-        experiment.header.name = circuit.name
-        # TODO: place in header or config?
-        experiment_config = deepcopy(config or {})
-        experiment_config.update({
-            'coupling_map': coupling_map,
-            'basis_gates': basis_gates,
-            'layout': list_layout,
-            'memory_slots': sum(register.size for register
-                                in circuit.get_cregs().values())})
-        experiment.config = QobjItem(**experiment_config)
-
-        # set eval_symbols=True to evaluate each symbolic expression
-        # TODO after transition to qobj, we can drop this
-        experiment.header.compiled_circuit_qasm = dag_circuit.qasm(
-            qeflag=True, eval_symbols=True)
-
+        experiment = _compile_single_circuit(
+            circuit, backend, config, basis_gates, coupling_map, initial_layout,
+            seed, pass_manager)
         # Step 3c: add the Experiment to the Qobj
         qobj.experiments.append(experiment)
 
@@ -150,6 +101,79 @@ def compile(circuits, backend,
                                    experiment in qobj.experiments)
 
     return qobj
+
+
+def _compile_single_circuit(circuit, backend,
+                            config=None, basis_gates=None, coupling_map=None,
+                            initial_layout=None, seed=None, pass_manager=None):
+    """Compile a single circuit into a QobjExperiment.
+
+    Args:
+        circuit (QuantumCircuit): circuit to compile
+        backend (BaseBackend): a backend to compile for
+        config (dict): dictionary of parameters (e.g. noise) used by runner
+        basis_gates (str): comma-separated basis gate set to compile to
+        coupling_map (list): coupling map (perhaps custom) to target in mapping
+        initial_layout (list): initial layout of qubits in mapping
+        seed (int): random seed for simulators
+        pass_manager (PassManager): a pass_manager for the transpiler stage
+
+    Returns:
+        QobjExperiment: the QobjExperiment to be run on the backends
+    """
+    # TODO: A better solution is to have options to enable/disable optimizations
+    num_qubits = sum((len(qreg) for qreg in circuit.get_qregs().values()))
+    if num_qubits == 1 or coupling_map == "all-to-all":
+        coupling_map = None
+    # Step 2a: circuit -> dag
+    dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
+
+    # TODO: move this inside the mapper pass
+    # pick a good initial layout if coupling_map is not already satisfied
+    # otherwise keep it as q[i]->q[i]
+    if (initial_layout is None and
+            not backend.configuration['simulator'] and
+            not _matches_coupling_map(circuit.data, coupling_map)):
+        initial_layout = _pick_best_layout(backend, num_qubits, circuit.get_qregs())
+
+    # Step 2b: transpile (dag -> dag)
+    dag_circuit, final_layout = transpile(
+        dag_circuit,
+        basis_gates=basis_gates,
+        coupling_map=coupling_map,
+        initial_layout=initial_layout,
+        get_layout=True,
+        seed=seed,
+        pass_manager=pass_manager)
+
+    # Step 2c: dag -> json
+    # the compiled circuit to be run saved as a dag
+    # we assume that transpile() has already expanded gates
+    # to the target basis, so we just need to generate json
+    list_layout = [[k, v] for k, v in final_layout.items()] if final_layout else None
+
+    json_circuit = DagUnroller(dag_circuit, JsonBackend(dag_circuit.basis)).execute()
+
+    # Step 3a: create the Experiment based on json_circuit
+    experiment = QobjExperiment.from_dict(json_circuit)
+    # Step 3b: populate the Experiment configuration and header
+    experiment.header.name = circuit.name
+    # TODO: place in header or config?
+    experiment_config = deepcopy(config or {})
+    experiment_config.update({
+        'coupling_map': coupling_map,
+        'basis_gates': basis_gates,
+        'layout': list_layout,
+        'memory_slots': sum(register.size for register
+                            in circuit.get_cregs().values())})
+    experiment.config = QobjItem(**experiment_config)
+
+    # set eval_symbols=True to evaluate each symbolic expression
+    # TODO after transition to qobj, we can drop this
+    experiment.header.compiled_circuit_qasm = dag_circuit.qasm(
+        qeflag=True, eval_symbols=True)
+
+    return experiment
 
 
 # pylint: disable=redefined-builtin

--- a/qiskit/unroll/_jsonbackend.py
+++ b/qiskit/unroll/_jsonbackend.py
@@ -39,6 +39,12 @@ from qiskit.unroll import UnrollerBackend
 from qiskit import QISKitError
 
 
+# Special commands reserved for simulators, that are ignored by backends
+# that do not support them. In practice, they are prepended a `#` in the
+# resulting json.
+SIMULATION_COMMANDS = ('snapshot',)
+
+
 class JsonBackend(UnrollerBackend):
     """Backend for the unroller that makes a Json quantum circuit."""
 
@@ -202,7 +208,8 @@ class JsonBackend(UnrollerBackend):
         self.circuit['instructions'].append({
             'name': 'measure',
             'qubits': qubit_indices,
-            'clbits': clbit_indices
+            'clbits': clbit_indices,
+            'memory': clbit_indices.copy()
         })
         self._add_condition()
 
@@ -270,6 +277,9 @@ class JsonBackend(UnrollerBackend):
             self.listen = False
             qubit_indices = [self._qubit_order_internal.get(qubit)
                              for qubit in qubits]
+            # Check for special simulator commands.
+            if name in SIMULATION_COMMANDS:
+                name = '#%s' % name
             self.circuit['instructions'].append({
                 'name': name,
                 # TODO: keep these real for now, until a later time

--- a/test/python/test_qasm_simulator_py.py
+++ b/test/python/test_qasm_simulator_py.py
@@ -57,7 +57,7 @@ class TestLocalQasmSimulatorPy(QiskitTestCase):
 
         self.qobj = Qobj(id='test_sim_single_shot',
                          config=QobjConfig(shots=1024,
-                                           register_slots=6,
+                                           memory_slots=6,
                                            max_credits=3),
                          experiments=[circuit],
                          header=QobjHeader(
@@ -130,7 +130,7 @@ class TestLocalQasmSimulatorPy(QiskitTestCase):
         qobj = Qobj(id='test_if_qobj',
                     config=QobjConfig(max_credits=3,
                                       shots=shots,
-                                      register_slots=max_qubits),
+                                      memory_slots=max_qubits),
                     experiments=[ucircuit_true, ucircuit_false],
                     header=QobjHeader(backend_name='local_qasm_simulator_py'))
 

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -27,6 +27,7 @@ class TestQobj(QiskitTestCase):
         expected = {
             'id': '12345',
             'type': 'QASM',
+            'schema_version': '1.0.0',
             'header': {},
             'config': {'max_credits': 10, 'memory_slots': 2, 'shots': 1024},
             'experiments': [

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -15,7 +15,7 @@ class TestQobj(QiskitTestCase):
     """Tests for Qobj."""
     def test_create_qobj(self):
         """Test creation of a Qobj based on the individual elements."""
-        config = QobjConfig(max_credits=10, shots=1024, register_slots=2)
+        config = QobjConfig(max_credits=10, shots=1024, memory_slots=2)
         instruction_1 = QobjInstruction(name='u1', qubits=[1], params=[0.4])
         instruction_2 = QobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2])
         instructions = [instruction_1, instruction_2]
@@ -28,7 +28,7 @@ class TestQobj(QiskitTestCase):
             'id': '12345',
             'type': 'QASM',
             'header': {},
-            'config': {'max_credits': 10, 'register_slots': 2, 'shots': 1024},
+            'config': {'max_credits': 10, 'memory_slots': 2, 'shots': 1024},
             'experiments': [
                 {'instructions': [
                     {'name': 'u1', 'params': [0.4], 'qubits': [1]},

--- a/test/python/test_unitary_simulator_py.py
+++ b/test/python/test_unitary_simulator_py.py
@@ -47,7 +47,7 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
 
         qobj = Qobj(id='unitary',
                     config=QobjConfig(shots=1,
-                                      register_slots=6,
+                                      memory_slots=6,
                                       max_credits=None),
                     experiments=[circuit],
                     header=QobjHeader(


### PR DESCRIPTION
Update the Qobj classes and the codebase for adjusting to the 1.0.0
schema:
* 'snapshot' operation name is '#snapshot' in the json
* add `qobj.schema_version` field, defaulting to `1.0.0`
* replace `qobj.register_slots` with `qobj.memory_slots`
* add `memory` attribute to the `measure` instruction.

Update the codebase for accounting for the changes:
* update `qasm_simulator_py` for accepting `#snapshot`
* update the qobj converter to convert `#snapshot` to `snapshot`
* update `JsonBackend` to append the `#` to `snapshot` at that level.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


