### PR TITLE
Parallel circuit compilation 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Added
 -----
 - Introduced new options for handling credentials (qiskitrc file, environment
   variables) and automatic registration. (#547)
+- Compile circuits in parallel
 
 Changed
 -------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Compile circuits in parallel, a re-implementation of #627 with the newest master branch.

### Details and comments
Simple wrapper to submit job concurrently; however, at least for macOS, there is no obvious speed up since we use `ThreadPoolExecutor` rather than `ProcessPoolExecutor` but as pointed in #627, use `ProcessPoolExecutor` may result in crashing for macOS. 

For change log, I add the item without no PR number.
