### PR TITLE
Removing unnecessary uses of `from_dict` method.

### DIFF
--- a/qiskit/backends/local/statevector_simulator_cpp.py
+++ b/qiskit/backends/local/statevector_simulator_cpp.py
@@ -48,7 +48,7 @@ class StatevectorSimulatorCpp(QasmSimulatorCpp):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction.from_dict({'name': '#snapshot', 'params': [final_state_key]})
+                QobjInstruction(name='#snapshot', params=[final_state_key])
             )
         result = super()._run_job(qobj)
         # Extract final state snapshot and move to 'statevector' data field

--- a/qiskit/backends/local/statevector_simulator_py.py
+++ b/qiskit/backends/local/statevector_simulator_py.py
@@ -62,7 +62,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction.from_dict({'name': '#snapshot', 'params': [final_state_key]})
+                QobjInstruction(name='#snapshot', params=[final_state_key])
             )
         result = super()._run_job(qobj)._result
         # Replace backend name with current backend

--- a/qiskit/qobj/__init__.py
+++ b/qiskit/qobj/__init__.py
@@ -8,5 +8,5 @@
 """Module for the Qobj structure."""
 
 from ._qobj import (Qobj, QobjConfig, QobjExperiment, QobjInstruction,
-                    QobjItem, QobjHeader)
+                    QobjItem, QobjHeader, QobjExperimentHeader)
 from ._converter import qobj_to_dict

--- a/test/python/_mockutils.py
+++ b/test/python/_mockutils.py
@@ -144,11 +144,11 @@ class DummyJob(BaseJob):
 
 
 def new_fake_qobj():
-    """Creates a fake qobj dictionary."""
+    """Create fake `Qobj` and backend instances."""
     backend = FakeBackend()
     return Qobj(
-        'test-id',
-        config=QobjConfig(1024, 1, max_credits=100),
+        id='test-id',
+        config=QobjConfig(shots=1024, memory_slots=1, max_credits=100),
         header=QobjHeader(backend_name=backend.name),
         experiments=[QobjExperiment(
             instructions=[],

--- a/test/python/_mockutils.py
+++ b/test/python/_mockutils.py
@@ -22,6 +22,8 @@ import time
 from qiskit import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends import BaseJob
+from qiskit.qobj import Qobj, QobjItem, QobjConfig, QobjHeader
+from qiskit.qobj import QobjExperiment, QobjExperimentHeader
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.baseprovider import BaseProvider
 
@@ -143,21 +145,17 @@ class DummyJob(BaseJob):
 
 def new_fake_qobj():
     """Creates a fake qobj dictionary."""
-    return {
-        'id': 'test-id',
-        'config': {
-            'shots': 1024,
-            'max_credits': 100
-        },
-        'experiments': [{
-            'header': {'compiled_circuit_qasm': 'fake-code'},
-            'config': {
-                'seed': 123456
-            },
-            'instructions': []
-        }],
-        'header': {'backend_name': 'test-backend'}
-    }
+    backend = FakeBackend()
+    return Qobj(
+        'test-id',
+        config=QobjConfig(1024, 1, max_credits=100),
+        header=QobjHeader(backend_name=backend.name),
+        experiments=[QobjExperiment(
+            instructions=[],
+            header=QobjExperimentHeader(compiled_circuit_qasm='fake-code'),
+            config=QobjItem(seed=123456)
+        )]
+    )
 
 
 class FakeBackend():

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -16,7 +16,6 @@ from IBMQuantumExperience import ApiError
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
 from qiskit.backends.ibmq.ibmqjob import API_FINAL_STATES
-from qiskit.qobj import Qobj
 from .common import QiskitTestCase
 from ._mockutils import new_fake_qobj
 
@@ -291,8 +290,7 @@ class TestIBMQJobStates(QiskitTestCase):
         """Creates a new `IBMQJob` instance running with the provided API
         object."""
         self._current_api = api
-        self._current_qjob = IBMQJob(Qobj.from_dict(new_fake_qobj()), api,
-                                     False)
+        self._current_qjob = IBMQJob(new_fake_qobj(), api, False)
         return self._current_qjob
 
 

--- a/test/python/test_localjob.py
+++ b/test/python/test_localjob.py
@@ -20,8 +20,8 @@ from qiskit.backends.local import QasmSimulatorPy
 from qiskit.backends.local import StatevectorSimulatorCpp
 from qiskit.backends.local import StatevectorSimulatorPy
 from qiskit.backends.local import UnitarySimulatorPy
-from qiskit.qobj import Qobj
 from .common import QiskitTestCase
+from ._mockutils import new_fake_qobj
 
 
 class TestLocalJob(QiskitTestCase):
@@ -44,7 +44,7 @@ class TestLocalJob(QiskitTestCase):
                 with self.subTest(backend=backend_constructor):
                     self.log.info('Backend under test: %s', backend_constructor)
                     backend = backend_constructor()
-                    job = backend.run(fake_qobj())
+                    job = backend.run(new_fake_qobj())
                     self.assertIsInstance(job, LocalJob)
 
     def test_multiple_execution(self):
@@ -58,7 +58,7 @@ class TestLocalJob(QiskitTestCase):
         # pylint: disable=redefined-outer-name
         with intercepted_executor_for_localjob() as (LocalJob, executor):
             for index in range(taskcount):
-                LocalJob(target_tasks[index], fake_qobj())
+                LocalJob(target_tasks[index], new_fake_qobj())
 
         self.assertEqual(executor.submit.call_count, taskcount)
         for index in range(taskcount):
@@ -74,7 +74,7 @@ class TestLocalJob(QiskitTestCase):
 
         # pylint: disable=redefined-outer-name
         with intercepted_executor_for_localjob() as (LocalJob, executor):
-            job = LocalJob(lambda: None, fake_qobj())
+            job = LocalJob(lambda: None, new_fake_qobj())
             job.cancel()
 
         self.assertCalledOnce(executor.submit)
@@ -87,7 +87,7 @@ class TestLocalJob(QiskitTestCase):
 
         # pylint: disable=redefined-outer-name
         with intercepted_executor_for_localjob() as (LocalJob, executor):
-            job = LocalJob(lambda: None, fake_qobj())
+            job = LocalJob(lambda: None, new_fake_qobj())
             _ = job.done
 
         self.assertCalledOnce(executor.submit)
@@ -101,24 +101,6 @@ class TestLocalJob(QiskitTestCase):
             call_count, 1,
             'Callable object has been called more than once ({})'.format(
                 call_count))
-
-
-def fake_qobj():
-    backend = FakeBackend()
-    qobj = {
-        'id': 'test-id',
-        'config': {
-            'shots': 1024,
-            'max_credits': 100
-            },
-        'experiments': [{
-            'header': {'compiled_circuit_qasm': 'fake-code'},
-            'config': {'seed': 123456},
-            'instructions': []
-        }],
-        'header': {'backend_name': backend.name}
-    }
-    return Qobj.from_dict(qobj)
 
 
 class FakeBackend():

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -55,9 +55,9 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
                       format='json'))
 
         self.qobj = Qobj(
-            'test_qobj',
+            id='test_qobj',
             config=QobjConfig(
-                2000, 1,
+                shots=2000, memory_slots=1,
                 max_credits=3,
                 seed=1111
             ),

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -21,7 +21,7 @@ from qiskit.backends.local.qasm_simulator_cpp import (QasmSimulatorCpp,
                                                       cx_error_matrix,
                                                       x90_error_matrix)
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.qobj import Qobj, QobjItem
+from qiskit.qobj import Qobj, QobjItem, QobjConfig, QobjHeader, QobjExperiment
 from qiskit.transpiler import transpile
 from .common import QiskitTestCase
 
@@ -45,18 +45,25 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         qc.h(qr[0])
         qc.measure(qr[0], cr[0])
         self.qc = qc
+
         # create qobj
-        compiled_circuit1 = transpile(DAGCircuit.fromQuantumCircuit(self.qc), format='json')
-        compiled_circuit2 = transpile(DAGCircuit.fromQuantumCircuit(self.qasm_circ), format='json')
-        self.qobj = {'id': 'test_qobj',
-                     'config': {
-                         'max_credits': 3,
-                         'shots': 2000,
-                         'seed': 1111
-                     },
-                     'experiments': [compiled_circuit1, compiled_circuit2],
-                     'header': {'backend_name': 'local_qasm_simulator_cpp'}}
-        self.qobj = Qobj.from_dict(self.qobj)
+        compiled_circuit1 = QobjExperiment.from_dict(
+            transpile(DAGCircuit.fromQuantumCircuit(self.qc), format='json'))
+
+        compiled_circuit2 = QobjExperiment.from_dict(
+            transpile(DAGCircuit.fromQuantumCircuit(self.qasm_circ),
+                      format='json'))
+
+        self.qobj = Qobj(
+            'test_qobj',
+            config=QobjConfig(
+                2000, 1,
+                max_credits=3,
+                seed=1111
+            ),
+            experiments=[compiled_circuit1, compiled_circuit2],
+            header=QobjHeader(backend_name='local_qasm_simulator_cpp')
+        )
         self.qobj.experiments[0].header.name = 'test_circuit1'
         self.qobj.experiments[0].config = QobjItem(basis_gates='u1,u2,u3,cx,id')
         self.qobj.experiments[1].header.name = 'test_circuit2'

--- a/test/python/test_qobj.py
+++ b/test/python/test_qobj.py
@@ -13,16 +13,20 @@ from .common import QiskitTestCase
 
 class TestQobj(QiskitTestCase):
     """Tests for Qobj."""
+
     def test_create_qobj(self):
         """Test creation of a Qobj based on the individual elements."""
-        config = QobjConfig(max_credits=10, shots=1024, memory_slots=2)
-        instruction_1 = QobjInstruction(name='u1', qubits=[1], params=[0.4])
-        instruction_2 = QobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2])
-        instructions = [instruction_1, instruction_2]
-        experiment_1 = QobjExperiment(instructions=instructions)
-        experiments = [experiment_1]
-
-        qobj = Qobj(id='12345', config=config, experiments=experiments, header={})
+        qobj = Qobj(
+            id='12345',
+            header={},
+            config=QobjConfig(shots=1024, memory_slots=2, max_credits=10),
+            experiments=[
+                QobjExperiment(instructions=[
+                    QobjInstruction(name='u1', qubits=[1], params=[0.4]),
+                    QobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2])
+                ])
+            ]
+        )
 
         expected = {
             'id': '12345',
@@ -35,7 +39,7 @@ class TestQobj(QiskitTestCase):
                     {'name': 'u1', 'params': [0.4], 'qubits': [1]},
                     {'name': 'u2', 'params': [0.4, 0.2], 'qubits': [1]}
                 ]}
-            ],
-            }
+            ]
+        }
 
         self.assertEqual(qobj.as_dict(), expected)


### PR DESCRIPTION
See #652 

There are two use-cases that seem legit to me:

1. The one for loading from a file.
Although it would make sense to rename it to `from_json`.

2. The one for loading from the result of the `Unroller#execute()`.
Although I think that the method should return a `QobjExperiment` instance.

@diego-plan9 what do you think?


