### PR TITLE
Testing non commercial backends accepts cancellation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ The format is based on `Keep a Changelog`_.
 Added
 -----
 - Added decorator to check for C++ simulator availability (#662)
+- It is possible to cancel jobs in non comercial backends (#687)
 - Introduced new options for handling credentials (qiskitrc file, environment
   variables) and automatic registration. (#547)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.9.8
+IBMQuantumExperience>=2.0.1
 matplotlib>=2.1
 networkx>=2.0
 numpy>=1.13

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -214,6 +214,7 @@ class TestIBMQJob(QiskitTestCase):
         job_ids = [job.id for job in job_array]
         self.assertEqual(sorted(job_ids), sorted(list(set(job_ids))))
 
+    @slow_test
     def test_cancel(self):
         backend = self._provider.get_backend('ibmqx4')
         qobj = transpiler.compile(self._qc, backend)

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -23,7 +23,7 @@ from qiskit.backends import JobStatus
 from qiskit.backends.ibmq import IBMQProvider
 from qiskit.backends.ibmq.ibmqbackend import IBMQBackendError
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
-from .common import requires_qe_access, QiskitTestCase, slow_test
+from .common import requires_qe_access, JobTestCase, slow_test
 
 
 def _least_busy(backends):
@@ -39,7 +39,7 @@ def _least_busy(backends):
                key=lambda b: b.status['pending_jobs'])
 
 
-class TestIBMQJob(QiskitTestCase):
+class TestIBMQJob(JobTestCase):
     """
     Test ibmqjob module.
     """
@@ -304,35 +304,6 @@ class TestIBMQJob(QiskitTestCase):
         for i, job in enumerate(job_list):
             self.log.info('match #%d: %s', i, job.creation_date)
             self.assertTrue(job.creation_date < past_day_30.isoformat())
-
-    def wait_for_initialization(self, job, timeout=1):
-        """Waits until the job progress from `INITIALIZING` to a different
-        status."""
-        waited = 0
-        wait = 0.1
-        while job.status['status'] == JobStatus.INITIALIZING:
-            time.sleep(wait)
-            waited += wait
-            if waited > timeout:
-                self.fail(
-                    msg="The JOB is still initializing after timeout ({}s)"
-                    .format(timeout)
-                )
-
-    def assertStatus(self, job, status):
-        """Assert the intenal job status is the expected one and also tests
-        if the shorthand method for that status returns `True`."""
-        self.assertEqual(job.status['status'], status)
-        if status == JobStatus.CANCELLED:
-            self.assertTrue(job.cancelled)
-        elif status == JobStatus.DONE:
-            self.assertTrue(job.done)
-        elif status == JobStatus.VALIDATING:
-            self.assertTrue(job.validating)
-        elif status == JobStatus.RUNNING:
-            self.assertTrue(job.running)
-        elif status == JobStatus.QUEUED:
-            self.assertTrue(job.queued)
 
 
 if __name__ == '__main__':

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -216,7 +216,9 @@ class TestIBMQJob(JobTestCase):
 
     @slow_test
     def test_cancel(self):
-        backend = self._provider.get_backend('ibmqx4')
+        backend_name = ('ibmq_20_tokyo'
+                        if self.using_ibmq_credentials else 'ibmqx4')
+        backend = self._provider.get_backend(backend_name)
         qobj = transpiler.compile(self._qc, backend)
         job = backend.run(qobj)
         self.wait_for_initialization(job, timeout=5)

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -219,7 +219,7 @@ class TestIBMQJob(JobTestCase):
         backend = self._provider.get_backend('ibmqx4')
         qobj = transpiler.compile(self._qc, backend)
         job = backend.run(qobj)
-        self.wait_for_initialization(job, timeout=3)
+        self.wait_for_initialization(job, timeout=5)
         can_cancel = job.cancel()
         self.assertTrue(can_cancel)
         self.assertStatus(job, JobStatus.CANCELLED)

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -18,11 +18,11 @@ import numpy
 from scipy.stats import chi2_contingency
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit import transpiler, available_backends, execute
+from qiskit import transpiler
 from qiskit.backends import JobStatus
 from qiskit.backends.ibmq import IBMQProvider
 from qiskit.backends.ibmq.ibmqbackend import IBMQBackendError
-from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
+from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from .common import requires_qe_access, QiskitTestCase, slow_test
 
 

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -16,11 +16,11 @@ from IBMQuantumExperience import ApiError
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobError
 from qiskit.backends.ibmq.ibmqjob import API_FINAL_STATES
-from .common import QiskitTestCase
+from .common import JobTestCase
 from ._mockutils import new_fake_qobj
 
 
-class TestIBMQJobStates(QiskitTestCase):
+class TestIBMQJobStates(JobTestCase):
     """
     Test ibmqjob module.
     """
@@ -256,35 +256,6 @@ class TestIBMQJobStates(QiskitTestCase):
                         self.assertTrue(self._current_api.get_job.called)
                     else:
                         self.assertFalse(self._current_api.get_job.called)
-
-    def wait_for_initialization(self, job, timeout=1):
-        """Waits until the job progress from `INITIALIZING` to a different
-        status."""
-        waited = 0
-        wait = 0.1
-        while job.status['status'] == JobStatus.INITIALIZING:
-            time.sleep(wait)
-            waited += wait
-            if waited > timeout:
-                self.fail(
-                    msg="The JOB is still initializing after timeout ({}s)"
-                    .format(timeout)
-                )
-
-    def assertStatus(self, job, status):
-        """Assert the intenal job status is the expected one and also tests
-        if the shorthand method for that status returns `True`."""
-        self.assertEqual(job.status['status'], status)
-        if status == JobStatus.CANCELLED:
-            self.assertTrue(job.cancelled)
-        elif status == JobStatus.DONE:
-            self.assertTrue(job.done)
-        elif status == JobStatus.VALIDATING:
-            self.assertTrue(job.validating)
-        elif status == JobStatus.RUNNING:
-            self.assertTrue(job.running)
-        elif status == JobStatus.QUEUED:
-            self.assertTrue(job.queued)
 
     def run_with_api(self, api):
         """Creates a new `IBMQJob` instance running with the provided API

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -78,6 +78,7 @@ class TestCrossSimulation(QiskitTestCase):
         circ.snapshot(2)
         circ.reset(q)
         circ.snapshot(3)
+        circ.measure(q, c)
 
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'


### PR DESCRIPTION
Fix #687

Uses `ibmqx4` to test the jobs can be cancelled.


