### PR TITLE
seeding remote executions to make deterministic HTTP requests

### DIFF
--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -207,7 +207,7 @@ class TestCompiler(QiskitTestCase):
         qc.h(qubit_reg[0])
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
-        qobj = transpiler.compile(qc, backend)
+        qobj = transpiler.compile(qc, backend, seed=42)
         job = backend.run(qobj)
         result = job.result(timeout=20)
         self.assertIsInstance(result, Result)
@@ -229,7 +229,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
-        qobj = transpiler.compile([qc, qc_extra], backend)
+        qobj = transpiler.compile([qc, qc_extra], backend, seed=42)
         job = backend.run(qobj)
         result = job.result()
         self.assertIsInstance(result, Result)
@@ -250,7 +250,7 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qubit_reg[0], qubit_reg[1])
         qc.measure(qubit_reg, clbit_reg)
 
-        job = execute(qc, backend)
+        job = execute(qc, backend, seed=42)
         results = job.result()
         self.assertIsInstance(results, Result)
 
@@ -271,7 +271,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
         qc_extra = qiskit.QuantumCircuit(qubit_reg, clbit_reg)
         qc_extra.measure(qubit_reg, clbit_reg)
-        job = execute([qc, qc_extra], backend)
+        job = execute([qc, qc_extra], backend, seed=42)
         results = job.result()
         self.assertIsInstance(results, Result)
 

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -12,7 +12,6 @@
 import time
 import unittest
 from concurrent import futures
-import datetime
 
 import numpy
 from scipy.stats import chi2_contingency
@@ -326,13 +325,12 @@ class TestIBMQJob(QiskitTestCase):
     def test_get_jobs_filter_date(self):
         backends = self._provider.available_backends()
         backend = _least_busy(backends)
-        past_day_30 = datetime.datetime.now() - datetime.timedelta(days=30)
-        my_filter = {'creationDate': {'lt': past_day_30.isoformat()}}
+        my_filter = {'creationDate': {'lt': '2017-01-01T00:00:00.00'}}
         job_list = backend.jobs(limit=5, db_filter=my_filter)
         self.log.info('found %s matching jobs', len(job_list))
         for i, job in enumerate(job_list):
             self.log.info('match #%d: %s', i, job.creation_date)
-            self.assertTrue(job.creation_date < past_day_30.isoformat())
+            self.assertTrue(job.creation_date < '2017-01-01T00:00:00.00')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

While working on #234, I'm noticing that the HTTP requests to remote executions do not define a seed. Therefore, the answers are non-deterministic. This is not a problem per-se, but it would be much easier to make sure that things did not change in on the server side if there is no change in the recorded answer from the server.


