### PR TITLE
use block matrix to build matrix in pauli class for efficiency

### DIFF
--- a/qiskit/tools/qi/pauli.py
+++ b/qiskit/tools/qi/pauli.py
@@ -130,26 +130,18 @@ class Pauli:
             scipy.sparse.csr_matrix: a sparse matrix with CSR format that
             represnets the pauli.
         """
-        x = sparse.csr_matrix(np.array([[0, 1], [1, 0]], dtype=complex))
-        y = sparse.csr_matrix(np.array([[0, -1j], [1j, 0]], dtype=complex))
-        z = sparse.csr_matrix(np.array([[1, 0], [0, -1]], dtype=complex))
-        id_ = sparse.csr_matrix(np.array([[1, 0], [0, 1]], dtype=complex))
-        matrix = 1
+        matrix = sparse.csr_matrix(np.array([[1]], dtype=complex))
         for k in range(self.numberofqubits):
             if self.v[k] == 0 and self.w[k] == 0:
-                new = id_
+                matrix = sparse.bmat([[matrix, None], [None, matrix]], "csr")
             elif self.v[k] == 1 and self.w[k] == 0:
-                new = z
+                matrix = sparse.bmat([[matrix, None], [None, -matrix]], "csr")
             elif self.v[k] == 0 and self.w[k] == 1:
-                new = x
+                matrix = sparse.bmat([[None, matrix], [matrix, None]], "csr")
             elif self.v[k] == 1 and self.w[k] == 1:
-                new = y
-            else:
-                print('the string is not of the form 0 and 1')
-            matrix = sparse.kron(new, matrix, 'csr')
+                matrix = sparse.bmat([[None, matrix * -1j], [matrix * 1j, None]], "csr")
 
         return matrix
-
 
 def random_pauli(number_qubits):
     """Return a random Pauli on numberofqubits."""

--- a/qiskit/tools/qi/pauli.py
+++ b/qiskit/tools/qi/pauli.py
@@ -130,18 +130,18 @@ class Pauli:
             scipy.sparse.csr_matrix: a sparse matrix with CSR format that
             represnets the pauli.
         """
-        matrix = sparse.csr_matrix(np.array([[1]], dtype=complex))
+        matrix = sparse.coo_matrix(np.array([[1]], dtype=complex))
         for k in range(self.numberofqubits):
             if self.v[k] == 0 and self.w[k] == 0:
-                matrix = sparse.bmat([[matrix, None], [None, matrix]], "csr")
+                matrix = sparse.bmat([[matrix, None], [None, matrix]], "coo")
             elif self.v[k] == 1 and self.w[k] == 0:
-                matrix = sparse.bmat([[matrix, None], [None, -matrix]], "csr")
+                matrix = sparse.bmat([[matrix, None], [None, -matrix]], "coo")
             elif self.v[k] == 0 and self.w[k] == 1:
-                matrix = sparse.bmat([[None, matrix], [matrix, None]], "csr")
+                matrix = sparse.bmat([[None, matrix], [matrix, None]], "coo")
             elif self.v[k] == 1 and self.w[k] == 1:
-                matrix = sparse.bmat([[None, matrix * -1j], [matrix * 1j, None]], "csr")
+                matrix = sparse.bmat([[None, matrix * -1j], [matrix * 1j, None]], "coo")
 
-        return matrix
+        return matrix.tocsr()
 
 def random_pauli(number_qubits):
     """Return a random Pauli on numberofqubits."""


### PR DESCRIPTION
Fix #745 
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since we know all matrix form for all paulis rather than the random matrix, we can use the simple way to build the matrix rather than general Kronecker product. 

### Details and comments

Use `bmat` to build block matrix rather than Kronecker product.

Note that I only edit the method of sparse matrix.