### PR TITLE
Add `n_qubits` to qobj.config and qobj.exp.config

### DIFF
--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -101,6 +101,12 @@ def compile(circuits, backend,
     qobj.config.memory_slots = max(experiment.config.memory_slots for
                                    experiment in qobj.experiments)
 
+    # Update the `n_qubits` global value.
+    # TODO: num_qubits is not part of the qobj specification, but needed
+    # for the simulator.
+    qobj.config.n_qubits = max(experiment.config.n_qubits for
+                               experiment in qobj.experiments)
+
     return qobj
 
 
@@ -166,7 +172,10 @@ def _compile_single_circuit(circuit, backend,
         'basis_gates': basis_gates,
         'layout': list_layout,
         'memory_slots': sum(register.size for register
-                            in circuit.get_cregs().values())})
+                            in circuit.get_cregs().values()),
+        # TODO: `n_qubits` is not part of the qobj specification, but needed
+        # for the simulator.
+        'n_qubits': num_qubits})
     experiment.config = QobjItem(**experiment_config)
 
     # set eval_symbols=True to evaluate each symbolic expression

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -747,7 +747,7 @@ class TestQuantumProgram(QiskitTestCase):
                                  coupling_map=coupling_map)
         result = q_program.get_compiled_configuration(qobj, 'circuitName')
         self.log.info(result)
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 5)
 
     def test_get_compiled_qasm(self):
         """Test get_compiled_qasm.


### PR DESCRIPTION
Add `qobj.config.n_qubits` and `qobj.experiment.config.n_qubits`
during `transpile()`. This field is not part of the `qobj_schema`, but
needed for the online simulator at the moment.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


