### PR TITLE
Let initial_layout be a list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 - Introduced new options for handling credentials (qiskitrc file, environment
   variables) and automatic registration. (#547)
 - Add OpenMP parallelization for Apple builds of the cpp simulator (#698).
+- Allow list to be used as ``initial_layout`` (#727).
 
 Changed
 -------

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -42,7 +42,7 @@ def compile(circuits, backend,
         config (dict): dictionary of parameters (e.g. noise) used by runner
         basis_gates (str): comma-separated basis gate set to compile to
         coupling_map (list): coupling map (perhaps custom) to target in mapping
-        initial_layout (list): initial layout of qubits in mapping
+        initial_layout (dict or list): initial layout of qubits in mapping
         shots (int): number of repetitions of each circuit, for sampling
         max_credits (int): maximum credits to use
         seed (int): random seed for simulators
@@ -114,8 +114,8 @@ def _compile_single_circuit(circuit, backend,
         backend (BaseBackend): a backend to compile for
         config (dict): dictionary of parameters (e.g. noise) used by runner
         basis_gates (str): comma-separated basis gate set to compile to
-        coupling_map (list): coupling map (perhaps custom) to target in mapping
-        initial_layout (list): initial layout of qubits in mapping
+        coupling_map (dict or list): coupling map (perhaps custom) to target in mapping
+        initial_layout (list): Initial layout of qubits in mapping
         seed (int): random seed for simulators
         pass_manager (PassManager): a pass_manager for the transpiler stage
 
@@ -129,7 +129,12 @@ def _compile_single_circuit(circuit, backend,
     # Step 2a: circuit -> dag
     dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
 
-    # TODO: move this inside the mapper pass
+    # Simplify the input of an initial layout in many cases by allowing
+    # the user to pass a simple list as the desired layout.  Here we
+    # convert the list to the appropriate dict.
+    if isinstance(initial_layout, list):
+        initial_layout = layout_as_list(initial_layout, circuit.get_qregs())
+
     # pick a good initial layout if coupling_map is not already satisfied
     # otherwise keep it as q[i]->q[i]
     if (initial_layout is None and
@@ -332,6 +337,35 @@ def _best_subset(backend, n_qubits):
             best = connection_count
             best_map = bfs[0:n_qubits]
     return best_map
+
+
+def layout_as_list(layout_list, qregs):
+    """Takes a list of unique integers for a qubit layout
+    and returns the correct dict structure.
+
+    Args:
+        layout_list (array_like): Qubit layout in list form.
+        qregs (dict): Quantum registers from a quantum circuit.
+
+    Returns:
+        layout: The corresponding layout dict.
+
+    Raises:
+        QISKitError: Input layout is invalid.
+    """
+    layout_list = np.asarray(layout_list)
+    num_qubits = sum((len(qr) for qr in qregs.values()))
+    if layout_list.shape[0] != num_qubits:
+        raise QISKitError('Length of layout list does not match number of qubits.')
+    if np.unique(layout_list).shape[0] != layout_list.shape[0]:
+        raise QISKitError('Layout list cannot have duplicate entries.')
+    layout = {}
+    map_iter = 0
+    for key, value in qregs.items():
+        for i in range(value.size):
+            layout[(key, i)] = ('q', layout_list[map_iter])
+            map_iter += 1
+    return layout
 
 
 def _matches_coupling_map(instructions, coupling_map):

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -411,10 +411,5 @@ def _pick_best_layout(backend, num_qubits, qregs):
 
     """
     best_sub = _best_subset(backend, num_qubits)
-    layout = {}
-    map_iter = 0
-    for key, value in qregs.items():
-        for i in range(value.size):
-            layout[(key, i)] = ('q', best_sub[map_iter])
-            map_iter += 1
+    layout = layout_as_list(best_sub, qregs)
     return layout

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -139,7 +139,7 @@ def _compile_single_circuit(circuit, backend,
     # the user to pass a simple list as the desired layout.  Here we
     # convert the list to the appropriate dict.
     if isinstance(initial_layout, list):
-        initial_layout = layout_as_list(initial_layout, circuit.get_qregs())
+        initial_layout = layout_list_to_dict(initial_layout, circuit.get_qregs())
 
     # pick a good initial layout if coupling_map is not already satisfied
     # otherwise keep it as q[i]->q[i]
@@ -348,7 +348,7 @@ def _best_subset(backend, n_qubits):
     return best_map
 
 
-def layout_as_list(layout_list, qregs):
+def layout_list_to_dict(layout_list, qregs):
     """Takes a list of unique integers for a qubit layout
     and returns the correct dict structure.
 
@@ -411,5 +411,5 @@ def _pick_best_layout(backend, num_qubits, qregs):
 
     """
     best_sub = _best_subset(backend, num_qubits)
-    layout = layout_as_list(best_sub, qregs)
+    layout = layout_list_to_dict(best_sub, qregs)
     return layout

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -307,7 +307,7 @@ def execute(circuits, backend,
         config (dict): dictionary of parameters (e.g. noise) used by runner
         basis_gates (str): comma-separated basis gate set to compile to
         coupling_map (list): coupling map (perhaps custom) to target in mapping
-        initial_layout (list): initial layout of qubits in mapping
+        initial_layout (list or dict): initial layout of qubits in mapping
         shots (int): number of repetitions of each circuit, for sampling
         max_credits (int): maximum credits to use
         seed (int): random seed for simulators

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -383,6 +383,23 @@ class TestCompiler(QiskitTestCase):
             if op.name == 'cx':
                 self.assertIn(op.qubits, backend.configuration['coupling_map'])
 
+    def test_mapping_initial_layout_list(self):
+        """Test mapping when initial_layout is a list of qubits.
+        """
+        backend = FakeBackEnd()
+        q = qiskit.QuantumRegister(3, name='qr')
+        q2 = qiskit.QuantumRegister(1, name='qr2')
+        q3 = qiskit.QuantumRegister(4, name='qr3')
+        c = qiskit.ClassicalRegister(3, name='cr')
+        qc = qiskit.QuantumCircuit(q, q2, q3, c)
+        qc.h(q[0])
+        qc.cx(q[0], q2[0])
+        qc.cx(q[1], q3[2])
+        qc.measure(q, c)
+        layout = [0, 1, 2, 3, 4, 5, 6, 7]
+        qobj = transpiler.compile(qc, backend, initial_layout=layout)
+        self.assertIsInstance(qobj, Qobj)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fix #735 

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR lets the user pass a list of numbers as an `initial_layout` to the `compile` function that maps the circuit from top to bottom in the quantum registers.

### Details and comments

Passing a custom `initial_layout` is a headache, when it should be a simple process.  This PR makes it simple.


