### PR TITLE
Extending valid names recognized by the linter.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -109,7 +109,14 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,n,m,ex,Run,_,logger
+# i,j,k = typical indices
+# n,m = typical numbers
+# v,w = typical vectors
+# x,y,z = typical axes
+# _ = placeholder name
+# qr,cr,qc = quantum and classical registers, and quantum circuit
+# pi = the PI constant
+good-names=i,j,k,n,m,ex,v,w,x,y,z,Run,_,logger,qr,cr,qc,pi
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,toto,tutu,tata
@@ -150,10 +157,10 @@ function-rgx=[a-z_][a-z0-9_]{2,30}$
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=(([a-z_][a-z0-9_]{2,})|(assert[A-Z][a-zA-Z0-9_]*))$
 
 # Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
+method-name-hint=[a-z_][a-z0-9_]{2,30}$ or camelCase `assert*` in tests.
 
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$

--- a/.pylintrc
+++ b/.pylintrc
@@ -157,7 +157,7 @@ function-rgx=[a-z_][a-z0-9_]{2,30}$
 function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct method names
-method-rgx=(([a-z_][a-z0-9_]{2,})|(assert[A-Z][a-zA-Z0-9_]*))$
+method-rgx=(([a-z_][a-z0-9_]{2,49})|(assert[A-Z][a-zA-Z0-9]{2,43}))$
 
 # Naming hint for method names
 method-name-hint=[a-z_][a-z0-9_]{2,30}$ or camelCase `assert*` in tests.

--- a/.pylintrc
+++ b/.pylintrc
@@ -111,6 +111,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # Good variable names which should always be accepted, separated by a comma
 # i,j,k = typical indices
 # n,m = typical numbers
+# ex = for exceptions and errors
 # v,w = typical vectors
 # x,y,z = typical axes
 # _ = placeholder name

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -88,7 +88,6 @@ class QiskitTestCase(unittest.TestCase):
         Context manager to test that no message is sent to the specified
         logger and level (the opposite of TestCase.assertLogs()).
         """
-        # pylint: disable=invalid-name
         return _AssertNoLogsContext(self, logger, level)
 
     def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
@@ -115,7 +114,6 @@ class QiskitTestCase(unittest.TestCase):
         Raises:
             TypeError: raises TestCase failureException if the test fails.
         """
-        # pylint: disable=invalid-name
         if dict1 == dict2:
             # Shortcut
             return
@@ -202,7 +200,6 @@ class JobTestCase(QiskitTestCase):
     def assertStatus(self, job, status):
         """Assert the intenal job status is the expected one and also tests
         if the shorthand method for that status returns `True`."""
-        # pylint: disable=invalid-name
         self.assertEqual(job.status['status'], status)
         if status == JobStatus.CANCELLED:
             self.assertTrue(job.cancelled)
@@ -299,9 +296,9 @@ def requires_qe_access(func):
         * if the `USE_ALTERNATE_ENV_CREDENTIALS` environment variable is
           set, it reads the credentials from an alternative set of environment
           variables.
-        * if the test is not skipped, it reads `QE_TOKEN` and `QE_URL` from
+        * if the test is not skipped, it reads `qe_token` and `qe_url` from
             `Qconfig.py`, environment variables or qiskitrc.
-        * if the test is not skipped, it appends `QE_TOKEN` and `QE_URL` as
+        * if the test is not skipped, it appends `qe_token` and `qe_url` as
             arguments to the test function.
     Args:
         func (callable): test function to be decorated.
@@ -311,8 +308,7 @@ def requires_qe_access(func):
     """
 
     @functools.wraps(func)
-    def _(*args, **kwargs):
-        # pylint: disable=invalid-name
+    def _decorator(*args, **kwargs):
         if SKIP_ONLINE_TESTS:
             raise unittest.SkipTest('Skipping online tests')
 
@@ -325,8 +321,8 @@ def requires_qe_access(func):
             # load them from different environment variables. This assumes they
             # will always be in place, as is used by the Travis setup.
             kwargs.update({
-                'QE_TOKEN': os.getenv('IBMQ_TOKEN'),
-                'QE_URL': os.getenv('IBMQ_URL'),
+                'qe_token': os.getenv('IBMQ_TOKEN'),
+                'qe_url': os.getenv('IBMQ_URL'),
                 'hub': os.getenv('IBMQ_HUB'),
                 'group': os.getenv('IBMQ_GROUP'),
                 'project': os.getenv('IBMQ_PROJECT'),
@@ -339,8 +335,8 @@ def requires_qe_access(func):
             if account_name in discovered_credentials.keys():
                 credentials = discovered_credentials[account_name]
                 kwargs.update({
-                    'QE_TOKEN': credentials.get('token'),
-                    'QE_URL': credentials.get('url'),
+                    'qe_token': credentials.get('token'),
+                    'qe_url': credentials.get('url'),
                     'hub': credentials.get('hub'),
                     'group': credentials.get('group'),
                     'project': credentials.get('project'),
@@ -353,7 +349,7 @@ def requires_qe_access(func):
 
         return func(*args, **kwargs)
 
-    return _
+    return _decorator
 
 
 def _is_ci_fork_pull_request():

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -251,12 +251,12 @@ def slow_test(func):
     """
 
     @functools.wraps(func)
-    def _(*args, **kwargs):
+    def _wrapper(*args, **kwargs):
         if SKIP_SLOW_TESTS:
             raise unittest.SkipTest('Skipping slow tests')
         return func(*args, **kwargs)
 
-    return _
+    return _wrapper
 
 
 def is_cpp_simulator_available():

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -308,7 +308,7 @@ def requires_qe_access(func):
     """
 
     @functools.wraps(func)
-    def _decorator(*args, **kwargs):
+    def _wrapper(*args, **kwargs):
         if SKIP_ONLINE_TESTS:
             raise unittest.SkipTest('Skipping online tests')
 
@@ -349,7 +349,7 @@ def requires_qe_access(func):
 
         return func(*args, **kwargs)
 
-    return _decorator
+    return _wrapper
 
 
 def _is_ci_fork_pull_request():

--- a/test/python/test_backend_name_resolution.py
+++ b/test/python/test_backend_name_resolution.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
 
 """Test backend name resolution for functionality groups, deprecations and
 aliases."""
@@ -21,10 +20,10 @@ class TestBackendNameResolution(QiskitTestCase):
     """
 
     @requires_qe_access
-    def test_deprecated(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_deprecated(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test that deprecated names map the same backends as the new names.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         deprecated_names = _DEFAULT_PROVIDER.deprecated_backend_names()
         for oldname, newname in deprecated_names.items():
             if newname == 'local_qasm_simulator_cpp' and not is_cpp_simulator_available():
@@ -35,10 +34,10 @@ class TestBackendNameResolution(QiskitTestCase):
 
     @requires_qe_access
     # pylint: disable=unused-argument
-    def test_aliases(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_aliases(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test that display names of devices map the same backends as the
         regular names."""
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         aliased_names = _DEFAULT_PROVIDER.aliased_backend_names()
         for display_name, backend_name in aliased_names.items():
             with self.subTest(display_name=display_name,

--- a/test/python/test_backend_names.py
+++ b/test/python/test_backend_names.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring,broad-except
+# pylint: disable=missing-docstring,broad-except
 
 """Backend grouped/deprecated/aliased test."""
 

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
 
 """Backends Test."""
 
@@ -39,39 +38,39 @@ class TestBackends(QiskitTestCase):
         self.assertTrue(len(local) > 0)
 
     @requires_qe_access
-    def test_remote_backends_exist(self, QE_TOKEN, QE_URL,
+    def test_remote_backends_exist(self, qe_token, qe_url,
                                    hub=None, group=None, project=None):
         """Test if there are remote backends.
 
         If all correct some should exists.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remotes = ibmq_provider.available_backends()
         remotes = remove_backends_from_list(remotes)
         self.log.info(remotes)
         self.assertTrue(len(remotes) > 0)
 
     @requires_qe_access
-    def test_remote_backends_exist_real_device(self, QE_TOKEN, QE_URL,
+    def test_remote_backends_exist_real_device(self, qe_token, qe_url,
                                                hub=None, group=None, project=None):
         """Test if there are remote backends that are devices.
 
         If all correct some should exists.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remote = ibmq_provider.available_backends()
         remote = [r for r in remote if not r.configuration['simulator']]
         self.log.info(remote)
         self.assertTrue(remote)
 
     @requires_qe_access
-    def test_remote_backends_exist_simulator(self, QE_TOKEN, QE_URL,
+    def test_remote_backends_exist_simulator(self, qe_token, qe_url,
                                              hub=None, group=None, project=None):
         """Test if there are remote backends that are simulators.
 
         If all correct some should exists.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remote = ibmq_provider.available_backends()
         remote = [r for r in remote if r.configuration['simulator']]
         self.log.info(remote)
@@ -105,7 +104,7 @@ class TestBackends(QiskitTestCase):
         jsonschema.validate(status, schema)
 
     @requires_qe_access
-    def test_remote_backend_status(self, QE_TOKEN, QE_URL,
+    def test_remote_backend_status(self, qe_token, qe_url,
                                    hub=None, group=None, project=None):
         """Test backend_status.
 
@@ -114,7 +113,7 @@ class TestBackends(QiskitTestCase):
         # FIXME: reintroduce in 0.6
         self.skipTest('Skipping due to available vs operational')
 
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remotes = ibmq_provider.available_backends()
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
@@ -143,13 +142,13 @@ class TestBackends(QiskitTestCase):
             jsonschema.validate(configuration, schema)
 
     @requires_qe_access
-    def test_remote_backend_configuration(self, QE_TOKEN, QE_URL,
+    def test_remote_backend_configuration(self, qe_token, qe_url,
                                           hub=None, group=None, project=None):
         """Test backend configuration.
 
         If all correct should pass the validation.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remotes = ibmq_provider.available_backends()
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
@@ -174,13 +173,13 @@ class TestBackends(QiskitTestCase):
             self.assertEqual(len(calibration), 0)
 
     @requires_qe_access
-    def test_remote_backend_calibration(self, QE_TOKEN, QE_URL,
+    def test_remote_backend_calibration(self, qe_token, qe_url,
                                         hub=None, group=None, project=None):
         """Test backend calibration.
 
         If all correct should pass the validation.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remotes = ibmq_provider.available_backends()
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
@@ -206,13 +205,13 @@ class TestBackends(QiskitTestCase):
             self.assertEqual(len(parameters), 0)
 
     @requires_qe_access
-    def test_remote_backend_parameters(self, QE_TOKEN, QE_URL,
+    def test_remote_backend_parameters(self, qe_token, qe_url,
                                        hub=None, group=None, project=None):
         """Test backend parameters.
 
         If all correct should pass the validation.
         """
-        ibmq_provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmq_provider = IBMQProvider(qe_token, qe_url, hub, group, project)
         remotes = ibmq_provider.available_backends()
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:

--- a/test/python/test_circuit_combine_extend.py
+++ b/test/python/test_circuit_combine_extend.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name, unused-import
+# pylint: disable=unused-import
 
 """Tests for combining and extending circuits across width and depth"""
 
@@ -61,12 +61,12 @@ class TestCircuitCombineExtend(QiskitTestCase):
         If two circuits have same name register of different size or type
         it should raise a QISKitError.
         """
-        q1 = QuantumRegister(1, "q")
-        q2 = QuantumRegister(2, "q")
-        c1 = ClassicalRegister(1, "q")
-        qc1 = QuantumCircuit(q1)
-        qc2 = QuantumCircuit(q2)
-        qc3 = QuantumCircuit(c1)
+        qr1 = QuantumRegister(1, "q")
+        qr2 = QuantumRegister(2, "q")
+        cr1 = ClassicalRegister(1, "q")
+        qc1 = QuantumCircuit(qr1)
+        qc2 = QuantumCircuit(qr2)
+        qc3 = QuantumCircuit(cr1)
 
         self.assertRaises(QISKitError, qc1.__add__, qc2)
         self.assertRaises(QISKitError, qc1.__add__, qc3)
@@ -139,12 +139,12 @@ class TestCircuitCombineExtend(QiskitTestCase):
         If two circuits have same name register of different size or type
         it should raise a QISKitError.
         """
-        q1 = QuantumRegister(1, "q")
-        q2 = QuantumRegister(2, "q")
-        c1 = ClassicalRegister(1, "q")
-        qc1 = QuantumCircuit(q1)
-        qc2 = QuantumCircuit(q2)
-        qc3 = QuantumCircuit(c1)
+        qr1 = QuantumRegister(1, "q")
+        qr2 = QuantumRegister(2, "q")
+        cr1 = ClassicalRegister(1, "q")
+        qc1 = QuantumCircuit(qr1)
+        qc2 = QuantumCircuit(qr2)
+        qc3 = QuantumCircuit(cr1)
 
         self.assertRaises(QISKitError, qc1.__iadd__, qc2)
         self.assertRaises(QISKitError, qc1.__iadd__, qc3)

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
 
 """Compiler Test."""
 
@@ -148,12 +147,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(results, Result)
 
     @requires_qe_access
-    def test_compile_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_compile_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Compiler remote.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = least_busy(available_backends())
         backend = get_backend(backend)
 
@@ -170,12 +169,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(qobj, Qobj)
 
     @requires_qe_access
-    def test_compile_two_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_compile_two_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Compiler remote on two circuits.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = least_busy(available_backends())
         backend = get_backend(backend)
 
@@ -193,12 +192,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(qobj, Qobj)
 
     @requires_qe_access
-    def test_compile_run_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_compile_run_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Compiler and run remote.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = available_backends({'local': False, 'simulator': True})[0]
         backend = get_backend(backend)
         qubit_reg = qiskit.QuantumRegister(2, name='q')
@@ -213,12 +212,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
-    def test_compile_two_run_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_compile_two_run_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Compiler and run two circuits.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = available_backends({'local': False, 'simulator': True})[0]
         backend = get_backend(backend)
         qubit_reg = qiskit.QuantumRegister(2, name='q')
@@ -235,12 +234,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(result, Result)
 
     @requires_qe_access
-    def test_execute_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_execute_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Execute remote.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = available_backends({'local': False, 'simulator': True})[0]
         backend = get_backend(backend)
         qubit_reg = qiskit.QuantumRegister(2)
@@ -255,12 +254,12 @@ class TestCompiler(QiskitTestCase):
         self.assertIsInstance(results, Result)
 
     @requires_qe_access
-    def test_execute_two_remote(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_execute_two_remote(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test execute two remote.
 
         If all correct some should exists.
         """
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         backend = available_backends({'local': False, 'simulator': True})[0]
         backend = get_backend(backend)
         qubit_reg = qiskit.QuantumRegister(2)
@@ -279,61 +278,61 @@ class TestCompiler(QiskitTestCase):
         """Test mapping works in previous failed case.
         """
         backend = FakeBackEnd()
-        q = qiskit.QuantumRegister(name='qr', size=11)
-        c = qiskit.ClassicalRegister(name='qc', size=11)
-        circuit = qiskit.QuantumCircuit(q, c)
-        circuit.u3(1.564784764685993, -1.2378965763410095, 2.9746763177861713, q[3])
-        circuit.u3(1.2269835563676523, 1.1932982847014162, -1.5597357740824318, q[5])
-        circuit.cx(q[5], q[3])
-        circuit.u1(0.856768317675967, q[3])
-        circuit.u3(-3.3911273825190915, 0.0, 0.0, q[5])
-        circuit.cx(q[3], q[5])
-        circuit.u3(2.159209321625547, 0.0, 0.0, q[5])
-        circuit.cx(q[5], q[3])
-        circuit.u3(0.30949966910232335, 1.1706201763833217, 1.738408691990081, q[3])
-        circuit.u3(1.9630571407274755, -0.6818742967975088, 1.8336534616728195, q[5])
-        circuit.u3(1.330181833806101, 0.6003162754946363, -3.181264980452862, q[7])
-        circuit.u3(0.4885914820775024, 3.133297443244865, -2.794457469189904, q[8])
-        circuit.cx(q[8], q[7])
-        circuit.u1(2.2196187596178616, q[7])
-        circuit.u3(-3.152367609631023, 0.0, 0.0, q[8])
-        circuit.cx(q[7], q[8])
-        circuit.u3(1.2646005789809263, 0.0, 0.0, q[8])
-        circuit.cx(q[8], q[7])
-        circuit.u3(0.7517780502091939, 1.2828514296564781, 1.6781179605443775, q[7])
-        circuit.u3(0.9267400575390405, 2.0526277839695153, 2.034202361069533, q[8])
-        circuit.u3(2.550304293455634, 3.8250017126569698, -2.1351609599720054, q[1])
-        circuit.u3(0.9566260876600556, -1.1147561503064538, 2.0571590492298797, q[4])
-        circuit.cx(q[4], q[1])
-        circuit.u1(2.1899329069137394, q[1])
-        circuit.u3(-1.8371715243173294, 0.0, 0.0, q[4])
-        circuit.cx(q[1], q[4])
-        circuit.u3(0.4717053496327104, 0.0, 0.0, q[4])
-        circuit.cx(q[4], q[1])
-        circuit.u3(2.3167620677708145, -1.2337330260253256, -0.5671322899563955, q[1])
-        circuit.u3(1.0468499525240678, 0.8680750644809365, -1.4083720073192485, q[4])
-        circuit.u3(2.4204244021892807, -2.211701932616922, 3.8297006565735883, q[10])
-        circuit.u3(0.36660280497727255, 3.273119149343493, -1.8003362351299388, q[6])
-        circuit.cx(q[6], q[10])
-        circuit.u1(1.067395863586385, q[10])
-        circuit.u3(-0.7044917541291232, 0.0, 0.0, q[6])
-        circuit.cx(q[10], q[6])
-        circuit.u3(2.1830003849921527, 0.0, 0.0, q[6])
-        circuit.cx(q[6], q[10])
-        circuit.u3(2.1538343756723917, 2.2653381826084606, -3.550087952059485, q[10])
-        circuit.u3(1.307627685019188, -0.44686656993522567, -2.3238098554327418, q[6])
-        circuit.u3(2.2046797998462906, 0.9732961754855436, 1.8527865921467421, q[9])
-        circuit.u3(2.1665254613904126, -1.281337664694577, -1.2424905413631209, q[0])
-        circuit.cx(q[0], q[9])
-        circuit.u1(2.6209599970201007, q[9])
-        circuit.u3(0.04680566321901303, 0.0, 0.0, q[0])
-        circuit.cx(q[9], q[0])
-        circuit.u3(1.7728411151289603, 0.0, 0.0, q[0])
-        circuit.cx(q[0], q[9])
-        circuit.u3(2.4866395967434443, 0.48684511243566697, -3.0069186877854728, q[9])
-        circuit.u3(1.7369112924273789, -4.239660866163805, 1.0623389015296005, q[0])
-        circuit.barrier(q)
-        circuit.measure(q, c)
+        qr = qiskit.QuantumRegister(name='qr', size=11)
+        cr = qiskit.ClassicalRegister(name='qc', size=11)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.u3(1.564784764685993, -1.2378965763410095, 2.9746763177861713, qr[3])
+        circuit.u3(1.2269835563676523, 1.1932982847014162, -1.5597357740824318, qr[5])
+        circuit.cx(qr[5], qr[3])
+        circuit.u1(0.856768317675967, qr[3])
+        circuit.u3(-3.3911273825190915, 0.0, 0.0, qr[5])
+        circuit.cx(qr[3], qr[5])
+        circuit.u3(2.159209321625547, 0.0, 0.0, qr[5])
+        circuit.cx(qr[5], qr[3])
+        circuit.u3(0.30949966910232335, 1.1706201763833217, 1.738408691990081, qr[3])
+        circuit.u3(1.9630571407274755, -0.6818742967975088, 1.8336534616728195, qr[5])
+        circuit.u3(1.330181833806101, 0.6003162754946363, -3.181264980452862, qr[7])
+        circuit.u3(0.4885914820775024, 3.133297443244865, -2.794457469189904, qr[8])
+        circuit.cx(qr[8], qr[7])
+        circuit.u1(2.2196187596178616, qr[7])
+        circuit.u3(-3.152367609631023, 0.0, 0.0, qr[8])
+        circuit.cx(qr[7], qr[8])
+        circuit.u3(1.2646005789809263, 0.0, 0.0, qr[8])
+        circuit.cx(qr[8], qr[7])
+        circuit.u3(0.7517780502091939, 1.2828514296564781, 1.6781179605443775, qr[7])
+        circuit.u3(0.9267400575390405, 2.0526277839695153, 2.034202361069533, qr[8])
+        circuit.u3(2.550304293455634, 3.8250017126569698, -2.1351609599720054, qr[1])
+        circuit.u3(0.9566260876600556, -1.1147561503064538, 2.0571590492298797, qr[4])
+        circuit.cx(qr[4], qr[1])
+        circuit.u1(2.1899329069137394, qr[1])
+        circuit.u3(-1.8371715243173294, 0.0, 0.0, qr[4])
+        circuit.cx(qr[1], qr[4])
+        circuit.u3(0.4717053496327104, 0.0, 0.0, qr[4])
+        circuit.cx(qr[4], qr[1])
+        circuit.u3(2.3167620677708145, -1.2337330260253256, -0.5671322899563955, qr[1])
+        circuit.u3(1.0468499525240678, 0.8680750644809365, -1.4083720073192485, qr[4])
+        circuit.u3(2.4204244021892807, -2.211701932616922, 3.8297006565735883, qr[10])
+        circuit.u3(0.36660280497727255, 3.273119149343493, -1.8003362351299388, qr[6])
+        circuit.cx(qr[6], qr[10])
+        circuit.u1(1.067395863586385, qr[10])
+        circuit.u3(-0.7044917541291232, 0.0, 0.0, qr[6])
+        circuit.cx(qr[10], qr[6])
+        circuit.u3(2.1830003849921527, 0.0, 0.0, qr[6])
+        circuit.cx(qr[6], qr[10])
+        circuit.u3(2.1538343756723917, 2.2653381826084606, -3.550087952059485, qr[10])
+        circuit.u3(1.307627685019188, -0.44686656993522567, -2.3238098554327418, qr[6])
+        circuit.u3(2.2046797998462906, 0.9732961754855436, 1.8527865921467421, qr[9])
+        circuit.u3(2.1665254613904126, -1.281337664694577, -1.2424905413631209, qr[0])
+        circuit.cx(qr[0], qr[9])
+        circuit.u1(2.6209599970201007, qr[9])
+        circuit.u3(0.04680566321901303, 0.0, 0.0, qr[0])
+        circuit.cx(qr[9], qr[0])
+        circuit.u3(1.7728411151289603, 0.0, 0.0, qr[0])
+        circuit.cx(qr[0], qr[9])
+        circuit.u3(2.4866395967434443, 0.48684511243566697, -3.0069186877854728, qr[9])
+        circuit.u3(1.7369112924273789, -4.239660866163805, 1.0623389015296005, qr[0])
+        circuit.barrier(qr)
+        circuit.measure(qr, cr)
 
         try:
             qobj = transpiler.compile(circuit, backend)
@@ -345,15 +344,15 @@ class TestCompiler(QiskitTestCase):
         """Test mapping works for multiple qregs.
         """
         backend = FakeBackEnd()
-        q = qiskit.QuantumRegister(3, name='qr')
-        q2 = qiskit.QuantumRegister(1, name='qr2')
-        q3 = qiskit.QuantumRegister(4, name='qr3')
-        c = qiskit.ClassicalRegister(3, name='cr')
-        qc = qiskit.QuantumCircuit(q, q2, q3, c)
-        qc.h(q[0])
-        qc.cx(q[0], q2[0])
-        qc.cx(q[1], q3[2])
-        qc.measure(q, c)
+        qr = qiskit.QuantumRegister(3, name='qr')
+        qr2 = qiskit.QuantumRegister(1, name='qr2')
+        qr3 = qiskit.QuantumRegister(4, name='qr3')
+        cr = qiskit.ClassicalRegister(3, name='cr')
+        qc = qiskit.QuantumCircuit(qr, qr2, qr3, cr)
+        qc.h(qr[0])
+        qc.cx(qr[0], qr2[0])
+        qc.cx(qr[1], qr3[2])
+        qc.measure(qr, cr)
 
         try:
             qobj = transpiler.compile(qc, backend)
@@ -365,23 +364,23 @@ class TestCompiler(QiskitTestCase):
         """Test compiler doesn't change circuit already matching backend coupling
         """
         backend = FakeBackEnd()
-        q = qiskit.QuantumRegister(16)
-        c = qiskit.ClassicalRegister(16)
-        qc = qiskit.QuantumCircuit(q, c)
-        qc.h(q[1])
-        qc.x(q[2])
-        qc.x(q[3])
-        qc.x(q[4])
-        qc.cx(q[1], q[2])
-        qc.cx(q[2], q[3])
-        qc.cx(q[3], q[4])
-        qc.cx(q[3], q[14])
-        qc.measure(q, c)
+        qr = qiskit.QuantumRegister(16)
+        cr = qiskit.ClassicalRegister(16)
+        qc = qiskit.QuantumCircuit(qr, cr)
+        qc.h(qr[1])
+        qc.x(qr[2])
+        qc.x(qr[3])
+        qc.x(qr[4])
+        qc.cx(qr[1], qr[2])
+        qc.cx(qr[2], qr[3])
+        qc.cx(qr[3], qr[4])
+        qc.cx(qr[3], qr[14])
+        qc.measure(qr, cr)
         qobj = transpiler.compile(qc, backend)
         compiled_ops = qobj.experiments[0].instructions
-        for op in compiled_ops:
-            if op.name == 'cx':
-                self.assertIn(op.qubits, backend.configuration['coupling_map'])
+        for operation in compiled_ops:
+            if operation.name == 'cx':
+                self.assertIn(operation.qubits, backend.configuration['coupling_map'])
 
 
 if __name__ == '__main__':

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """Test for the DAGCircuit object"""
 
@@ -17,8 +17,6 @@ from .common import QiskitTestCase
 
 class TestDagCircuit(QiskitTestCase):
     """QasmParser"""
-    def setUp(self):
-        self.QASM_FILE_PATH = self._get_resource_path('qasm/example.qasm')
 
     def test_create(self):
         qubit0 = ('qr', 0)

--- a/test/python/test_extensions_simulator.py
+++ b/test/python/test_extensions_simulator.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,unused-import
+# pylint: disable=unused-import
 
 """Tests for verifying the correctness of simulator extension instructions."""
 
@@ -26,18 +26,18 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_save_load(self):
         """save |+>|0>, do some stuff, then load"""
-        q = qiskit.QuantumRegister(2)
-        c = qiskit.ClassicalRegister(2)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.save(1)
-        circ.cx(q[0], q[1])
-        circ.cx(q[1], q[0])
-        circ.h(q[1])
-        circ.load(1)
+        qr = qiskit.QuantumRegister(2)
+        cr = qiskit.ClassicalRegister(2)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.save(1)
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[0])
+        circuit.h(qr[1])
+        circuit.load(1)
 
         sim = 'local_statevector_simulator_cpp'
-        result = execute(circ, sim).result()
+        result = execute(circuit, sim).result()
         statevector = result.get_statevector()
         target = [0.70710678 + 0.j, 0.70710678 + 0.j, 0. + 0.j, 0. + 0.j]
         fidelity = state_fidelity(statevector, target)
@@ -47,17 +47,17 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_snapshot(self):
         """snapshot a bell state in the middle of circuit"""
-        q = qiskit.QuantumRegister(2)
-        c = qiskit.ClassicalRegister(2)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.snapshot(3)
-        circ.cx(q[0], q[1])
-        circ.h(q[1])
+        qr = qiskit.QuantumRegister(2)
+        cr = qiskit.ClassicalRegister(2)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.snapshot(3)
+        circuit.cx(qr[0], qr[1])
+        circuit.h(qr[1])
 
         sim = 'local_statevector_simulator_cpp'
-        result = execute(circ, sim).result()
+        result = execute(circuit, sim).result()
         snapshot = result.get_snapshot(slot='3')
         target = [0.70710678 + 0.j, 0. + 0.j, 0. + 0.j, 0.70710678 + 0.j]
         fidelity = state_fidelity(snapshot, target)
@@ -67,15 +67,15 @@ class TestExtensionsSimulator(QiskitTestCase):
 
     def test_noise(self):
         """turn on a pauli x noise for qubits 0 and 2"""
-        q = qiskit.QuantumRegister(3)
-        c = qiskit.ClassicalRegister(3)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.iden(q[0])
-        circ.noise(0)
-        circ.iden(q[1])
-        circ.noise(1)
-        circ.iden(q[2])
-        circ.measure(q, c)
+        qr = qiskit.QuantumRegister(3)
+        cr = qiskit.ClassicalRegister(3)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.iden(qr[0])
+        circuit.noise(0)
+        circuit.iden(qr[1])
+        circuit.noise(1)
+        circuit.iden(qr[2])
+        circuit.measure(qr, cr)
 
         config = {
             'noise_params': {
@@ -84,7 +84,7 @@ class TestExtensionsSimulator(QiskitTestCase):
         }
         sim = 'local_qasm_simulator_cpp'
         shots = 1000
-        result = execute(circ, sim, config=config, shots=shots).result()
+        result = execute(circuit, sim, config=config, shots=shots).result()
         counts = result.get_counts()
         target = {'101': shots}
         self.assertEqual(counts, target)

--- a/test/python/test_extensions_standard.py
+++ b/test/python/test_extensions_standard.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 import unittest
 
@@ -45,35 +45,35 @@ from .common import QiskitTestCase
 
 
 class StandardExtensionTest(QiskitTestCase):
-    def assertResult(self, t, qasm_txt, qasm_txt_):
+    def assertResult(self, type_, qasm_txt, qasm_txt_):
         """
-        Assert the single gate in self.circuit is of the type t, the QASM
+        Assert the single gate in self.circuit is of the type type_, the QASM
         representation matches qasm_txt and the QASM representation of
         inverse maches qasm_txt_.
 
         Args:
-            t (type): a gate type.
+            type_ (type): a gate type.
             qasm_txt (str): QASM representation of the gate.
             qasm_txt_ (str): QASM representation of the inverse gate.
         """
-        c = self.circuit
-        self.assertEqual(type(c[0]), t)
+        circuit = self.circuit
+        self.assertEqual(type(circuit[0]), type_)
         self.assertQasm(qasm_txt)
-        c[0].reapply(c)
+        circuit[0].reapply(circuit)
         self.assertQasm(qasm_txt + '\n' + qasm_txt)
-        self.assertEqual(c[0].inverse(), c[0])
+        self.assertEqual(circuit[0].inverse(), circuit[0])
         self.assertQasm(qasm_txt_ + '\n' + qasm_txt)
 
-    def assertStmtsType(self, stmts, t):
+    def assertStmtsType(self, stmts, type_):
         """
-        Assert a list of statements stmts is of a type t.
+        Assert a list of statements stmts is of a type type_.
 
         Args:
             stmts (list): list of statements.
-            t (type): a gate type.
+            type_ (type): a gate type.
         """
         for stmt in stmts:
-            self.assertEqual(type(stmt), t)
+            self.assertEqual(type(stmt), type_)
 
     def assertQasm(self, qasm_txt, offset=1):
         """
@@ -85,663 +85,664 @@ class StandardExtensionTest(QiskitTestCase):
             qasm_txt (str): a string with QASM code
             offset (int): the offset in which qasm_txt should be found.
         """
-        c = self.circuit
+        circuit = self.circuit
         c_txt = len(qasm_txt)
-        self.assertIn('\n' + qasm_txt + '\n', c.qasm())
-        self.assertEqual(self.c_header + c_txt + offset, len(c.qasm()))  # pylint: disable=no-member
+        self.assertIn('\n' + qasm_txt + '\n', circuit.qasm())
+        # pylint: disable=no-member
+        self.assertEqual(self.c_header + c_txt + offset, len(circuit.qasm()))
 
 
 class TestStandard1Q(StandardExtensionTest):
     """Standard Extension Test. Gates with a single Qubit"""
 
     def setUp(self):
-        self.q = QuantumRegister(3, "q")
-        self.r = QuantumRegister(3, "r")
-        self.c = ClassicalRegister(3, "c")
-        self.circuit = QuantumCircuit(self.q, self.r, self.c)
+        self.qr = QuantumRegister(3, "q")
+        self.qr2 = QuantumRegister(3, "r")
+        self.cr = ClassicalRegister(3, "c")
+        self.circuit = QuantumCircuit(self.qr, self.qr2, self.cr)
         self.c_header = 69  # lenght of the header
 
     def test_barrier(self):
-        self.circuit.barrier(self.q[1])
+        self.circuit.barrier(self.qr[1])
         qasm_txt = 'barrier q[1];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
     def test_barrier_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.barrier, self.c[0])
-        self.assertRaises(QISKitError, c.barrier, self.c)
-        self.assertRaises(QISKitError, c.barrier, (self.q, 3))
-        self.assertRaises(QISKitError, c.barrier, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.barrier, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.barrier, self.cr[0])
+        self.assertRaises(QISKitError, qc.barrier, self.cr)
+        self.assertRaises(QISKitError, qc.barrier, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.barrier, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.barrier, 0)
 
     def test_barrier_reg(self):
-        self.circuit.barrier(self.q)
+        self.circuit.barrier(self.qr)
         qasm_txt = 'barrier q[0],q[1],q[2];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
-    def test_barrier_None(self):
+    def test_barrier_none(self):
         self.circuit.barrier()
         qasm_txt = 'barrier q[0],q[1],q[2],r[0],r[1],r[2];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
     def test_ccx(self):
-        self.circuit.ccx(self.q[0], self.q[1], self.q[2])
+        self.circuit.ccx(self.qr[0], self.qr[1], self.qr[2])
         qasm_txt = 'ccx q[0],q[1],q[2];'
         self.assertResult(ToffoliGate, qasm_txt, qasm_txt)
 
     def test_ccx_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.ccx, self.c[0], self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.ccx, self.q[0], self.q[0], self.q[2])
-        self.assertRaises(QISKitError, c.ccx, 0, self.q[0], self.q[2])
-        self.assertRaises(QISKitError, c.ccx, (self.q, 3), self.q[1], self.q[2])
-        self.assertRaises(QISKitError, c.ccx, self.c, self.q, self.q)
-        self.assertRaises(QISKitError, c.ccx, 'a', self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.ccx, self.cr[0], self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.ccx, self.qr[0], self.qr[0], self.qr[2])
+        self.assertRaises(QISKitError, qc.ccx, 0, self.qr[0], self.qr[2])
+        self.assertRaises(QISKitError, qc.ccx, (self.qr, 3), self.qr[1], self.qr[2])
+        self.assertRaises(QISKitError, qc.ccx, self.cr, self.qr, self.qr)
+        self.assertRaises(QISKitError, qc.ccx, 'a', self.qr[1], self.qr[2])
 
     def test_ch(self):
-        self.circuit.ch(self.q[0], self.q[1])
+        self.circuit.ch(self.qr[0], self.qr[1])
         qasm_txt = 'ch q[0],q[1];'
         self.assertResult(CHGate, qasm_txt, qasm_txt)
 
     def test_ch_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.ch, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.ch, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.ch, 0, self.q[0])
-        self.assertRaises(QISKitError, c.ch, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.ch, self.c, self.q)
-        self.assertRaises(QISKitError, c.ch, 'a', self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.ch, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.ch, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.ch, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.ch, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.ch, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.ch, 'a', self.qr[1])
 
     def test_crz(self):
-        self.circuit.crz(1, self.q[0], self.q[1])
+        self.circuit.crz(1, self.qr[0], self.qr[1])
         self.assertResult(CrzGate, 'crz(1) q[0],q[1];', 'crz(-1) q[0],q[1];')
 
     def test_crz_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.crz, 0, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.crz, 0, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.crz, 0, 0, self.q[0])
-        # TODO self.assertRaises(QISKitError, c.crz, self.q[2], self.q[1], self.q[0])
-        self.assertRaises(QISKitError, c.crz, 0, self.q[1], self.c[2])
-        self.assertRaises(QISKitError, c.crz, 0, (self.q, 3), self.q[1])
-        self.assertRaises(QISKitError, c.crz, 0, self.c, self.q)
-        # TODO self.assertRaises(QISKitError, c.crz, 'a', self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.crz, 0, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.crz, 0, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.crz, 0, 0, self.qr[0])
+        # TODO self.assertRaises(QISKitError, qc.crz, self.qr[2], self.qr[1], self.qr[0])
+        self.assertRaises(QISKitError, qc.crz, 0, self.qr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.crz, 0, (self.qr, 3), self.qr[1])
+        self.assertRaises(QISKitError, qc.crz, 0, self.cr, self.qr)
+        # TODO self.assertRaises(QISKitError, qc.crz, 'a', self.qr[1], self.qr[2])
 
     def test_cswap(self):
-        self.circuit.cswap(self.q[0], self.q[1], self.q[2])
+        self.circuit.cswap(self.qr[0], self.qr[1], self.qr[2])
         qasm_txt = 'cswap q[0],q[1],q[2];'
         self.assertResult(FredkinGate, qasm_txt, qasm_txt)
 
     def test_cswap_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cswap, self.c[0], self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cswap, self.q[1], self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cswap, self.q[1], 0, self.q[0])
-        self.assertRaises(QISKitError, c.cswap, self.c[0], self.c[1], self.q[0])
-        self.assertRaises(QISKitError, c.cswap, self.q[0], self.q[0], self.q[1])
-        self.assertRaises(QISKitError, c.cswap, 0, self.q[0], self.q[1])
-        self.assertRaises(QISKitError, c.cswap, (self.q, 3), self.q[0], self.q[1])
-        self.assertRaises(QISKitError, c.cswap, self.c, self.q[0], self.q[1])
-        self.assertRaises(QISKitError, c.cswap, 'a', self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cswap, self.cr[0], self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cswap, self.qr[1], self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cswap, self.qr[1], 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cswap, self.cr[0], self.cr[1], self.qr[0])
+        self.assertRaises(QISKitError, qc.cswap, self.qr[0], self.qr[0], self.qr[1])
+        self.assertRaises(QISKitError, qc.cswap, 0, self.qr[0], self.qr[1])
+        self.assertRaises(QISKitError, qc.cswap, (self.qr, 3), self.qr[0], self.qr[1])
+        self.assertRaises(QISKitError, qc.cswap, self.cr, self.qr[0], self.qr[1])
+        self.assertRaises(QISKitError, qc.cswap, 'a', self.qr[1], self.qr[2])
 
     def test_cu1(self):
-        self.circuit.cu1(1, self.q[1], self.q[2])
+        self.circuit.cu1(1, self.qr[1], self.qr[2])
         self.assertResult(Cu1Gate, 'cu1(1) q[1],q[2];', 'cu1(-1) q[1],q[2];')
 
     def test_cu1_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cu1, self.c[0], self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cu1, 1, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cu1, self.q[1], 0, self.q[0])
-        self.assertRaises(QISKitError, c.cu1, 0, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.cu1, 0, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cu1, 0, 0, self.q[0])
-        # TODO self.assertRaises(QISKitError, c.cu1, self.q[2], self.q[1], self.q[0])
-        self.assertRaises(QISKitError, c.cu1, 0, self.q[1], self.c[2])
-        self.assertRaises(QISKitError, c.cu1, 0, (self.q, 3), self.q[1])
-        self.assertRaises(QISKitError, c.cu1, 0, self.c, self.q)
-        # TODO self.assertRaises(QISKitError, c.cu1, 'a', self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cu1, self.cr[0], self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cu1, 1, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cu1, self.qr[1], 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cu1, 0, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.cu1, 0, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cu1, 0, 0, self.qr[0])
+        # TODO self.assertRaises(QISKitError, qc.cu1, self.qr[2], self.qr[1], self.qr[0])
+        self.assertRaises(QISKitError, qc.cu1, 0, self.qr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cu1, 0, (self.qr, 3), self.qr[1])
+        self.assertRaises(QISKitError, qc.cu1, 0, self.cr, self.qr)
+        # TODO self.assertRaises(QISKitError, qc.cu1, 'a', self.qr[1], self.qr[2])
 
     def test_cu3(self):
-        self.circuit.cu3(1, 2, 3, self.q[1], self.q[2])
+        self.circuit.cu3(1, 2, 3, self.qr[1], self.qr[2])
         self.assertResult(Cu3Gate, 'cu3(1,2,3) q[1],q[2];', 'cu3(-1,-3,-2) q[1],q[2];')
 
     def test_cu3_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cu3, 0, 0, self.q[0], self.q[1], self.c[2])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, 0, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, self.q[1], 0, self.q[0])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, 0, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, 0, 0, self.q[0])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, 0, (self.q, 3), self.q[1])
-        self.assertRaises(QISKitError, c.cu3, 0, 0, 0, self.c, self.q)
-        # TODO self.assertRaises(QISKitError, c.cu3, 0, 0, 'a', self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, self.qr[0], self.qr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, 0, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, self.qr[1], 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, 0, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, 0, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, 0, (self.qr, 3), self.qr[1])
+        self.assertRaises(QISKitError, qc.cu3, 0, 0, 0, self.cr, self.qr)
+        # TODO self.assertRaises(QISKitError, qc.cu3, 0, 0, 'a', self.qr[1], self.qr[2])
 
     def test_cx(self):
-        self.circuit.cx(self.q[1], self.q[2])
+        self.circuit.cx(self.qr[1], self.qr[2])
         qasm_txt = 'cx q[1],q[2];'
         self.assertResult(CnotGate, qasm_txt, qasm_txt)
 
     def test_cx_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cx, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cx, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cx, 0, self.q[0])
-        self.assertRaises(QISKitError, c.cx, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.cx, self.c, self.q)
-        self.assertRaises(QISKitError, c.cx, 'a', self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cx, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cx, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cx, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cx, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.cx, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.cx, 'a', self.qr[1])
 
     def test_cxbase(self):
         qasm_txt = 'CX q[1],q[2];'
-        self.circuit.cx_base(self.q[1], self.q[2])
+        self.circuit.cx_base(self.qr[1], self.qr[2])
         self.assertResult(CXBase, qasm_txt, qasm_txt)
 
     def test_cxbase_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cx_base, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cx_base, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cx_base, 0, self.q[0])
-        self.assertRaises(QISKitError, c.cx_base, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.cx_base, self.c, self.q)
-        self.assertRaises(QISKitError, c.cx_base, 'a', self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cx_base, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cx_base, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cx_base, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cx_base, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.cx_base, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.cx_base, 'a', self.qr[1])
 
     def test_cy(self):
         qasm_txt = 'cy q[1],q[2];'
-        self.circuit.cy(self.q[1], self.q[2])
+        self.circuit.cy(self.qr[1], self.qr[2])
         self.assertResult(CyGate, qasm_txt, qasm_txt)
 
     def test_cy_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cy, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cy, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cy, 0, self.q[0])
-        self.assertRaises(QISKitError, c.cy, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.cy, self.c, self.q)
-        self.assertRaises(QISKitError, c.cy, 'a', self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cy, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cy, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cy, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cy, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.cy, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.cy, 'a', self.qr[1])
 
     def test_cz(self):
         qasm_txt = 'cz q[1],q[2];'
-        self.circuit.cz(self.q[1], self.q[2])
+        self.circuit.cz(self.qr[1], self.qr[2])
         self.assertResult(CzGate, qasm_txt, qasm_txt)
 
     def test_cz_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.cz, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.cz, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.cz, 0, self.q[0])
-        self.assertRaises(QISKitError, c.cz, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.cz, self.c, self.q)
-        self.assertRaises(QISKitError, c.cz, 'a', self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.cz, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.cz, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.cz, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.cz, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.cz, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.cz, 'a', self.qr[1])
 
     def test_h(self):
         qasm_txt = 'h q[1];'
-        self.circuit.h(self.q[1])
+        self.circuit.h(self.qr[1])
         self.assertResult(HGate, qasm_txt, qasm_txt)
 
     def test_h_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.h, self.c[0])
-        self.assertRaises(QISKitError, c.h, self.c)
-        self.assertRaises(QISKitError, c.h, (self.q, 3))
-        self.assertRaises(QISKitError, c.h, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.h, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.h, self.cr[0])
+        self.assertRaises(QISKitError, qc.h, self.cr)
+        self.assertRaises(QISKitError, qc.h, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.h, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.h, 0)
 
     def test_h_reg(self):
         qasm_txt = 'h q[0];\nh q[1];\nh q[2];'
-        instruction_set = self.circuit.h(self.q)
+        instruction_set = self.circuit.h(self.qr)
         self.assertStmtsType(instruction_set.instructions, HGate)
         self.assertQasm(qasm_txt)
 
     def test_h_reg_inv(self):
         qasm_txt = 'h q[0];\nh q[1];\nh q[2];'
-        instruction_set = self.circuit.h(self.q).inverse()
+        instruction_set = self.circuit.h(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, HGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 22)
 
     def test_iden(self):
-        self.circuit.iden(self.q[1])
+        self.circuit.iden(self.qr[1])
         self.assertResult(IdGate, 'id q[1];', 'id q[1];')
 
     def test_iden_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.iden, self.c[0])
-        self.assertRaises(QISKitError, c.iden, self.c)
-        self.assertRaises(QISKitError, c.iden, (self.q, 3))
-        self.assertRaises(QISKitError, c.iden, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.iden, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.iden, self.cr[0])
+        self.assertRaises(QISKitError, qc.iden, self.cr)
+        self.assertRaises(QISKitError, qc.iden, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.iden, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.iden, 0)
 
     def test_iden_reg(self):
         qasm_txt = 'id q[0];\nid q[1];\nid q[2];'
-        instruction_set = self.circuit.iden(self.q)
+        instruction_set = self.circuit.iden(self.qr)
         self.assertStmtsType(instruction_set.instructions, IdGate)
         self.assertQasm(qasm_txt)
 
     def test_iden_reg_inv(self):
         qasm_txt = 'id q[0];\nid q[1];\nid q[2];'
-        instruction_set = self.circuit.iden(self.q).inverse()
+        instruction_set = self.circuit.iden(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, IdGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 25)
 
     def test_rx(self):
-        self.circuit.rx(1, self.q[1])
+        self.circuit.rx(1, self.qr[1])
         self.assertResult(RXGate, 'rx(1) q[1];', 'rx(-1) q[1];')
 
     def test_rx_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.rx, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.rx, self.q[1], 0)
-        self.assertRaises(QISKitError, c.rx, 0, self.c[0])
-        self.assertRaises(QISKitError, c.rx, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.rx, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.rx, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.rx, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.rx, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.rx, 0, 'a')
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.rx, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.rx, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.rx, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.rx, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.rx, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.rx, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.rx, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.rx, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.rx, 0, 'a')
 
     def test_rx_reg(self):
         qasm_txt = 'rx(1) q[0];\nrx(1) q[1];\nrx(1) q[2];'
-        instruction_set = self.circuit.rx(1, self.q)
+        instruction_set = self.circuit.rx(1, self.qr)
         self.assertStmtsType(instruction_set.instructions, RXGate)
         self.assertQasm(qasm_txt)
 
     def test_rx_reg_inv(self):
         qasm_txt = 'rx(-1) q[0];\nrx(-1) q[1];\nrx(-1) q[2];'
-        instruction_set = self.circuit.rx(1, self.q).inverse()
+        instruction_set = self.circuit.rx(1, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, RXGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 37)
 
     def test_rx_pi(self):
-        c = self.circuit
-        c.rx(pi / 2, self.q[1])
+        qc = self.circuit
+        qc.rx(pi / 2, self.qr[1])
         self.assertResult(RXGate, 'rx(pi/2) q[1];', 'rx(-pi/2) q[1];')
 
     def test_ry(self):
-        self.circuit.ry(1, self.q[1])
+        self.circuit.ry(1, self.qr[1])
         self.assertResult(RYGate, 'ry(1) q[1];', 'ry(-1) q[1];')
 
     def test_ry_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.ry, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.ry, self.q[1], 0)
-        self.assertRaises(QISKitError, c.ry, 0, self.c[0])
-        self.assertRaises(QISKitError, c.ry, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.ry, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.ry, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.ry, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.ry, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.ry, 0, 'a')
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.ry, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.ry, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.ry, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.ry, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.ry, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.ry, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.ry, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.ry, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.ry, 0, 'a')
 
     def test_ry_reg(self):
         qasm_txt = 'ry(1) q[0];\nry(1) q[1];\nry(1) q[2];'
-        instruction_set = self.circuit.ry(1, self.q)
+        instruction_set = self.circuit.ry(1, self.qr)
         self.assertStmtsType(instruction_set.instructions, RYGate)
         self.assertQasm(qasm_txt)
 
     def test_ry_reg_inv(self):
         qasm_txt = 'ry(-1) q[0];\nry(-1) q[1];\nry(-1) q[2];'
-        instruction_set = self.circuit.ry(1, self.q).inverse()
+        instruction_set = self.circuit.ry(1, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, RYGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 37)
 
     def test_ry_pi(self):
-        c = self.circuit
-        c.ry(pi / 2, self.q[1])
+        qc = self.circuit
+        qc.ry(pi / 2, self.qr[1])
         self.assertResult(RYGate, 'ry(pi/2) q[1];', 'ry(-pi/2) q[1];')
 
     def test_rz(self):
-        self.circuit.rz(1, self.q[1])
+        self.circuit.rz(1, self.qr[1])
         self.assertResult(RZGate, 'rz(1) q[1];', 'rz(-1) q[1];')
 
     def test_rz_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.rz, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.rz, self.q[1], 0)
-        self.assertRaises(QISKitError, c.rz, 0, self.c[0])
-        self.assertRaises(QISKitError, c.rz, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.rz, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.rz, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.rz, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.rz, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.rz, 0, 'a')
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.rz, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.rz, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.rz, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.rz, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.rz, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.rz, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.rz, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.rz, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.rz, 0, 'a')
 
     def test_rz_reg(self):
         qasm_txt = 'rz(1) q[0];\nrz(1) q[1];\nrz(1) q[2];'
-        instruction_set = self.circuit.rz(1, self.q)
+        instruction_set = self.circuit.rz(1, self.qr)
         self.assertStmtsType(instruction_set.instructions, RZGate)
         self.assertQasm(qasm_txt)
 
     def test_rz_reg_inv(self):
         qasm_txt = 'rz(-1) q[0];\nrz(-1) q[1];\nrz(-1) q[2];'
-        instruction_set = self.circuit.rz(1, self.q).inverse()
+        instruction_set = self.circuit.rz(1, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, RZGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 37)
 
     def test_rz_pi(self):
-        c = self.circuit
-        c.rz(pi / 2, self.q[1])
+        qc = self.circuit
+        qc.rz(pi / 2, self.qr[1])
         self.assertResult(RZGate, 'rz(pi/2) q[1];', 'rz(-pi/2) q[1];')
 
     def test_s(self):
-        self.circuit.s(self.q[1])
+        self.circuit.s(self.qr[1])
         self.assertResult(SGate, 's q[1];', 'sdg q[1];')
 
     def test_s_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.s, self.c[0])
-        self.assertRaises(QISKitError, c.s, self.c)
-        self.assertRaises(QISKitError, c.s, (self.q, 3))
-        self.assertRaises(QISKitError, c.s, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.s, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.s, self.cr[0])
+        self.assertRaises(QISKitError, qc.s, self.cr)
+        self.assertRaises(QISKitError, qc.s, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.s, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.s, 0)
 
     def test_s_reg(self):
         qasm_txt = 's q[0];\ns q[1];\ns q[2];'
-        instruction_set = self.circuit.s(self.q)
+        instruction_set = self.circuit.s(self.qr)
         self.assertStmtsType(instruction_set.instructions, SGate)
         self.assertQasm(qasm_txt)
 
     def test_s_reg_inv(self):
         qasm_txt = 'sdg q[0];\nsdg q[1];\nsdg q[2];'
-        instruction_set = self.circuit.s(self.q).inverse()
+        instruction_set = self.circuit.s(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, SGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 28)
 
     def test_sdg(self):
-        self.circuit.sdg(self.q[1])
+        self.circuit.sdg(self.qr[1])
         self.assertResult(SGate, 'sdg q[1];', 's q[1];')
 
     def test_sdg_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.sdg, self.c[0])
-        self.assertRaises(QISKitError, c.sdg, self.c)
-        self.assertRaises(QISKitError, c.sdg, (self.q, 3))
-        self.assertRaises(QISKitError, c.sdg, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.sdg, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.sdg, self.cr[0])
+        self.assertRaises(QISKitError, qc.sdg, self.cr)
+        self.assertRaises(QISKitError, qc.sdg, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.sdg, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.sdg, 0)
 
     def test_sdg_reg(self):
         qasm_txt = 'sdg q[0];\nsdg q[1];\nsdg q[2];'
-        instruction_set = self.circuit.sdg(self.q)
+        instruction_set = self.circuit.sdg(self.qr)
         self.assertStmtsType(instruction_set.instructions, SGate)
         self.assertQasm(qasm_txt)
 
     def test_sdg_reg_inv(self):
         qasm_txt = 's q[0];\ns q[1];\ns q[2];'
-        instruction_set = self.circuit.sdg(self.q).inverse()
+        instruction_set = self.circuit.sdg(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, SGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 22)
 
     def test_swap(self):
-        self.circuit.swap(self.q[1], self.q[2])
+        self.circuit.swap(self.qr[1], self.qr[2])
         self.assertResult(SwapGate, 'swap q[1],q[2];', 'swap q[1],q[2];')
 
     def test_swap_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.swap, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.swap, self.q[0], self.q[0])
-        self.assertRaises(QISKitError, c.swap, 0, self.q[0])
-        self.assertRaises(QISKitError, c.swap, (self.q, 3), self.q[0])
-        self.assertRaises(QISKitError, c.swap, self.c, self.q)
-        self.assertRaises(QISKitError, c.swap, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.swap, self.q, self.r[1])
-        self.assertRaises(QISKitError, c.swap, self.q[1], self.r)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.swap, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.swap, self.qr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.swap, 0, self.qr[0])
+        self.assertRaises(QISKitError, qc.swap, (self.qr, 3), self.qr[0])
+        self.assertRaises(QISKitError, qc.swap, self.cr, self.qr)
+        self.assertRaises(QISKitError, qc.swap, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.swap, self.qr, self.qr2[1])
+        self.assertRaises(QISKitError, qc.swap, self.qr[1], self.qr2)
 
     def test_t(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.t, self.c[0])
-        # TODO self.assertRaises(QISKitError, c.t, 1)
-        c.t(self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.t, self.cr[0])
+        # TODO self.assertRaises(QISKitError, qc.t, 1)
+        qc.t(self.qr[1])
         self.assertResult(TGate, 't q[1];', 'tdg q[1];')
 
     def test_t_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.t, self.c[0])
-        self.assertRaises(QISKitError, c.t, self.c)
-        self.assertRaises(QISKitError, c.t, (self.q, 3))
-        self.assertRaises(QISKitError, c.t, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.t, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.t, self.cr[0])
+        self.assertRaises(QISKitError, qc.t, self.cr)
+        self.assertRaises(QISKitError, qc.t, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.t, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.t, 0)
 
     def test_t_reg(self):
         qasm_txt = 't q[0];\nt q[1];\nt q[2];'
-        instruction_set = self.circuit.t(self.q)
+        instruction_set = self.circuit.t(self.qr)
         self.assertStmtsType(instruction_set.instructions, TGate)
         self.assertQasm(qasm_txt)
 
     def test_t_reg_inv(self):
         qasm_txt = 'tdg q[0];\ntdg q[1];\ntdg q[2];'
-        instruction_set = self.circuit.t(self.q).inverse()
+        instruction_set = self.circuit.t(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, TGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 28)
 
     def test_tdg(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.tdg, self.c[0])
-        # TODO self.assertRaises(QISKitError, c.tdg, 1)
-        c.tdg(self.q[1])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.tdg, self.cr[0])
+        # TODO self.assertRaises(QISKitError, qc.tdg, 1)
+        qc.tdg(self.qr[1])
         self.assertResult(TGate, 'tdg q[1];', 't q[1];')
 
     def test_tdg_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.tdg, self.c[0])
-        self.assertRaises(QISKitError, c.tdg, self.c)
-        self.assertRaises(QISKitError, c.tdg, (self.q, 3))
-        self.assertRaises(QISKitError, c.tdg, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.tdg, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.tdg, self.cr[0])
+        self.assertRaises(QISKitError, qc.tdg, self.cr)
+        self.assertRaises(QISKitError, qc.tdg, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.tdg, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.tdg, 0)
 
     def test_tdg_reg(self):
         qasm_txt = 'tdg q[0];\ntdg q[1];\ntdg q[2];'
-        instruction_set = self.circuit.tdg(self.q)
+        instruction_set = self.circuit.tdg(self.qr)
         self.assertStmtsType(instruction_set.instructions, TGate)
         self.assertQasm(qasm_txt)
 
     def test_tdg_reg_inv(self):
         qasm_txt = 't q[0];\nt q[1];\nt q[2];'
-        instruction_set = self.circuit.tdg(self.q).inverse()
+        instruction_set = self.circuit.tdg(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, TGate)
         self.assertQasm(qasm_txt, offset=len(qasm_txt) - 22)
 
     def test_u1(self):
-        self.circuit.u1(1, self.q[1])
+        self.circuit.u1(1, self.qr[1])
         self.assertResult(U1Gate, 'u1(1) q[1];', 'u1(-1) q[1];')
 
     def test_u1_invalid(self):
-        c = self.circuit
-        # CHECKME? self.assertRaises(QISKitError, c.u1, self.c[0], self.q[0])
-        self.assertRaises(QISKitError, c.u1, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.u1, self.q[1], 0)
-        self.assertRaises(QISKitError, c.u1, 0, self.c[0])
-        self.assertRaises(QISKitError, c.u1, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.u1, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.u1, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.u1, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.u1, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.u1, 0, 'a')
+        qc = self.circuit
+        # CHECKME? self.assertRaises(QISKitError, qc.u1, self.cr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.u1, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.u1, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.u1, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.u1, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.u1, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.u1, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.u1, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.u1, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.u1, 0, 'a')
 
     def test_u1_reg(self):
         qasm_txt = 'u1(1) q[0];\nu1(1) q[1];\nu1(1) q[2];'
-        instruction_set = self.circuit.u1(1, self.q)
+        instruction_set = self.circuit.u1(1, self.qr)
         self.assertStmtsType(instruction_set.instructions, U1Gate)
         self.assertQasm(qasm_txt)
 
     def test_u1_reg_inv(self):
         qasm_txt = 'u1(-1) q[0];\nu1(-1) q[1];\nu1(-1) q[2];'
-        instruction_set = self.circuit.u1(1, self.q).inverse()
+        instruction_set = self.circuit.u1(1, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, U1Gate)
         self.assertQasm(qasm_txt)
 
     def test_u1_pi(self):
-        c = self.circuit
-        c.u1(pi / 2, self.q[1])
+        qc = self.circuit
+        qc.u1(pi / 2, self.qr[1])
         self.assertResult(U1Gate, 'u1(pi/2) q[1];', 'u1(-pi/2) q[1];')
 
     def test_u2(self):
-        self.circuit.u2(1, 2, self.q[1])
+        self.circuit.u2(1, 2, self.qr[1])
         self.assertResult(U2Gate, 'u2(1,2) q[1];', 'u2(-pi - 2,-1 + pi) q[1];')
 
     def test_u2_invalid(self):
-        c = self.circuit
-        # CHECKME? self.assertRaises(QISKitError, c.u2, 0, self.c[0], self.q[0])
-        self.assertRaises(QISKitError, c.u2, 0, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.u2, 0, self.q[1], 0)
-        self.assertRaises(QISKitError, c.u2, 0, 0, self.c[0])
-        self.assertRaises(QISKitError, c.u2, 0, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.u2, 0, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.u2, 0, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.u2, 0, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.u2, 0, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.u2, 0, 0, 'a')
+        qc = self.circuit
+        # CHECKME? self.assertRaises(QISKitError, qc.u2, 0, self.cr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.u2, 0, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.u2, 0, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.u2, 0, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.u2, 0, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.u2, 0, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.u2, 0, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.u2, 0, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.u2, 0, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.u2, 0, 0, 'a')
 
     def test_u2_reg(self):
         qasm_txt = 'u2(1,2) q[0];\nu2(1,2) q[1];\nu2(1,2) q[2];'
-        instruction_set = self.circuit.u2(1, 2, self.q)
+        instruction_set = self.circuit.u2(1, 2, self.qr)
         self.assertStmtsType(instruction_set.instructions, U2Gate)
         self.assertQasm(qasm_txt)
 
     def test_u2_reg_inv(self):
         qasm_txt = 'u2(-pi - 2,-1 + pi) q[0];\nu2(-pi - 2,-1 + pi) q[1];\nu2(-pi - 2,-1 + pi) q[2];'
-        instruction_set = self.circuit.u2(1, 2, self.q).inverse()
+        instruction_set = self.circuit.u2(1, 2, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, U2Gate)
         self.assertQasm(qasm_txt)
 
     def test_u2_pi(self):
-        c = self.circuit
-        c.u2(pi / 2, 0.3 * pi, self.q[1])
+        qc = self.circuit
+        qc.u2(pi / 2, 0.3 * pi, self.qr[1])
         self.assertResult(U2Gate, 'u2(pi/2,0.3*pi) q[1];', 'u2(-1.3*pi,pi/2) q[1];')
 
     def test_u3(self):
-        self.circuit.u3(1, 2, 3, self.q[1])
+        self.circuit.u3(1, 2, 3, self.qr[1])
         self.assertResult(U3Gate, 'u3(1,2,3) q[1];', 'u3(-1,-3,-2) q[1];')
 
     def test_u3_invalid(self):
-        c = self.circuit
-        # CHECKME? self.assertRaises(QISKitError, c.u3, 0, self.c[0], self.q[0])
-        self.assertRaises(QISKitError, c.u3, 0, 0, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.u3, 0, 0, self.q[1], 0)
-        self.assertRaises(QISKitError, c.u3, 0, 0, 0, self.c[0])
-        self.assertRaises(QISKitError, c.u3, 0, 0, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.u3, 0, 0, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.u3, 0, 0, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.u3, 0, 0, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.u3, 0, 0, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.u3, 0, 0, 0, 'a')
+        qc = self.circuit
+        # CHECKME? self.assertRaises(QISKitError, qc.u3, 0, self.cr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.u3, 0, 0, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.u3, 0, 0, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.u3, 0, 0, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.u3, 0, 0, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.u3, 0, 0, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.u3, 0, 0, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.u3, 0, 0, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.u3, 0, 0, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.u3, 0, 0, 0, 'a')
 
     def test_u3_reg(self):
         qasm_txt = 'u3(1,2,3) q[0];\nu3(1,2,3) q[1];\nu3(1,2,3) q[2];'
-        instruction_set = self.circuit.u3(1, 2, 3, self.q)
+        instruction_set = self.circuit.u3(1, 2, 3, self.qr)
         self.assertStmtsType(instruction_set.instructions, U3Gate)
         self.assertQasm(qasm_txt)
 
     def test_u3_reg_inv(self):
         qasm_txt = 'u3(-1,-3,-2) q[0];\nu3(-1,-3,-2) q[1];\nu3(-1,-3,-2) q[2];'
-        instruction_set = self.circuit.u3(1, 2, 3, self.q).inverse()
+        instruction_set = self.circuit.u3(1, 2, 3, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, U3Gate)
         self.assertQasm(qasm_txt)
 
     def test_u3_pi(self):
-        c = self.circuit
-        c.u3(pi, pi / 2, 0.3 * pi, self.q[1])
+        qc = self.circuit
+        qc.u3(pi, pi / 2, 0.3 * pi, self.qr[1])
         self.assertResult(U3Gate, 'u3(pi,pi/2,0.3*pi) q[1];', 'u3(-pi,-0.3*pi,-pi/2) q[1];')
 
     def test_ubase(self):
-        self.circuit.u_base(1, 2, 3, self.q[1])
+        self.circuit.u_base(1, 2, 3, self.qr[1])
         self.assertResult(UBase, 'U(1,2,3) q[1];', 'U(-1,-3,-2) q[1];')
 
     def test_ubase_invalid(self):
-        c = self.circuit
-        # CHECKME? self.assertRaises(QISKitError, c.u_base, 0, self.c[0], self.q[0])
-        self.assertRaises(QISKitError, c.u_base, 0, 0, self.c[0], self.c[1])
-        self.assertRaises(QISKitError, c.u_base, 0, 0, self.q[1], 0)
-        self.assertRaises(QISKitError, c.u_base, 0, 0, 0, self.c[0])
-        self.assertRaises(QISKitError, c.u_base, 0, 0, 0, 0)
-        # TODO self.assertRaises(QISKitError, c.u_base, 0, 0, self.q[2], self.q[1])
-        self.assertRaises(QISKitError, c.u_base, 0, 0, 0, (self.q, 3))
-        self.assertRaises(QISKitError, c.u_base, 0, 0, 0, self.c)
-        # TODO self.assertRaises(QISKitError, c.u_base, 0, 0, 'a', self.q[1])
-        self.assertRaises(QISKitError, c.u_base, 0, 0, 0, 'a')
+        qc = self.circuit
+        # CHECKME? self.assertRaises(QISKitError, qc.u_base, 0, self.cr[0], self.qr[0])
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, self.cr[0], self.cr[1])
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, self.qr[1], 0)
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, 0, self.cr[0])
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, 0, 0)
+        # TODO self.assertRaises(QISKitError, qc.u_base, 0, 0, self.qr[2], self.qr[1])
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, 0, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, 0, self.cr)
+        # TODO self.assertRaises(QISKitError, qc.u_base, 0, 0, 'a', self.qr[1])
+        self.assertRaises(QISKitError, qc.u_base, 0, 0, 0, 'a')
 
     def test_ubase_reg(self):
         qasm_txt = 'U(1,2,3) q[0];\nU(1,2,3) q[1];\nU(1,2,3) q[2];'
-        instruction_set = self.circuit.u_base(1, 2, 3, self.q)
+        instruction_set = self.circuit.u_base(1, 2, 3, self.qr)
         self.assertStmtsType(instruction_set.instructions, UBase)
         self.assertQasm(qasm_txt)
 
     def test_ubase_reg_inv(self):
         qasm_txt = 'U(-1,-3,-2) q[0];\nU(-1,-3,-2) q[1];\nU(-1,-3,-2) q[2];'
-        instruction_set = self.circuit.u_base(1, 2, 3, self.q).inverse()
+        instruction_set = self.circuit.u_base(1, 2, 3, self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, UBase)
         self.assertQasm(qasm_txt)
 
     def test_ubase_pi(self):
-        c = self.circuit
-        c.u_base(pi, pi / 2, 0.3 * pi, self.q[1])
+        qc = self.circuit
+        qc.u_base(pi, pi / 2, 0.3 * pi, self.qr[1])
         self.assertResult(UBase, 'U(pi,pi/2,0.3*pi) q[1];', 'U(-pi,-0.3*pi,-pi/2) q[1];')
 
     def test_x(self):
-        self.circuit.x(self.q[1])
+        self.circuit.x(self.qr[1])
         self.assertResult(XGate, 'x q[1];', 'x q[1];')
 
     def test_x_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.x, self.c[0])
-        self.assertRaises(QISKitError, c.x, self.c)
-        self.assertRaises(QISKitError, c.x, (self.q, 3))
-        self.assertRaises(QISKitError, c.x, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.x, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.x, self.cr[0])
+        self.assertRaises(QISKitError, qc.x, self.cr)
+        self.assertRaises(QISKitError, qc.x, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.x, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.x, 0)
 
     def test_x_reg(self):
         qasm_txt = 'x q[0];\nx q[1];\nx q[2];'
-        instruction_set = self.circuit.x(self.q)
+        instruction_set = self.circuit.x(self.qr)
         self.assertStmtsType(instruction_set.instructions, XGate)
         self.assertQasm(qasm_txt)
 
     def test_x_reg_inv(self):
         qasm_txt = 'x q[0];\nx q[1];\nx q[2];'
-        instruction_set = self.circuit.x(self.q).inverse()
+        instruction_set = self.circuit.x(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, XGate)
         self.assertQasm(qasm_txt)
 
     def test_y(self):
-        self.circuit.y(self.q[1])
+        self.circuit.y(self.qr[1])
         self.assertResult(YGate, 'y q[1];', 'y q[1];')
 
     def test_y_invalid(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.y, self.c[0])
-        self.assertRaises(QISKitError, c.y, self.c)
-        self.assertRaises(QISKitError, c.y, (self.q, 3))
-        self.assertRaises(QISKitError, c.y, (self.q, 'a'))
-        self.assertRaises(QISKitError, c.y, 0)
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.y, self.cr[0])
+        self.assertRaises(QISKitError, qc.y, self.cr)
+        self.assertRaises(QISKitError, qc.y, (self.qr, 3))
+        self.assertRaises(QISKitError, qc.y, (self.qr, 'a'))
+        self.assertRaises(QISKitError, qc.y, 0)
 
     def test_y_reg(self):
         qasm_txt = 'y q[0];\ny q[1];\ny q[2];'
-        instruction_set = self.circuit.y(self.q)
+        instruction_set = self.circuit.y(self.qr)
         self.assertStmtsType(instruction_set.instructions, YGate)
         self.assertQasm(qasm_txt)
 
     def test_y_reg_inv(self):
         qasm_txt = 'y q[0];\ny q[1];\ny q[2];'
-        instruction_set = self.circuit.y(self.q).inverse()
+        instruction_set = self.circuit.y(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, YGate)
         self.assertQasm(qasm_txt)
 
     def test_z(self):
-        self.circuit.z(self.q[1])
+        self.circuit.z(self.qr[1])
         self.assertResult(ZGate, 'z q[1];', 'z q[1];')
 
     def test_rzz(self):
-        c = self.circuit
-        self.assertRaises(QISKitError, c.rzz, 0.1, self.c[1], self.c[2])
-        self.assertRaises(QISKitError, c.rzz, 0.1, self.q[0], self.q[0])
-        c.rzz(pi/2, self.q[1], self.q[2])
+        qc = self.circuit
+        self.assertRaises(QISKitError, qc.rzz, 0.1, self.cr[1], self.cr[2])
+        self.assertRaises(QISKitError, qc.rzz, 0.1, self.qr[0], self.qr[0])
+        qc.rzz(pi/2, self.qr[1], self.qr[2])
         self.assertResult(RZZGate, 'rzz(pi/2) q[1],q[2];', 'rzz(-pi/2) q[1],q[2];')
 
     def test_z_reg(self):
         qasm_txt = 'z q[0];\nz q[1];\nz q[2];'
-        instruction_set = self.circuit.z(self.q)
+        instruction_set = self.circuit.z(self.qr)
         self.assertStmtsType(instruction_set.instructions, ZGate)
         self.assertQasm(qasm_txt)
 
     def test_z_reg_inv(self):
         qasm_txt = 'z q[0];\nz q[1];\nz q[2];'
-        instruction_set = self.circuit.z(self.q).inverse()
+        instruction_set = self.circuit.z(self.qr).inverse()
         self.assertStmtsType(instruction_set.instructions, ZGate)
         self.assertQasm(qasm_txt)
 
@@ -750,319 +751,319 @@ class TestStandard2Q(StandardExtensionTest):
     """Standard Extension Test. Gates with two Qubits"""
 
     def setUp(self):
-        self.q = QuantumRegister(3, "q")
-        self.r = QuantumRegister(3, "r")
-        self.c = ClassicalRegister(3, "c")
-        self.circuit = QuantumCircuit(self.q, self.r, self.c)
+        self.qr = QuantumRegister(3, "q")
+        self.qr2 = QuantumRegister(3, "r")
+        self.cr = ClassicalRegister(3, "c")
+        self.circuit = QuantumCircuit(self.qr, self.qr2, self.cr)
         self.c_header = 69  # lenght of the header
 
-    def test_barrier_None(self):
+    def test_barrier_none(self):
         self.circuit.barrier()
         qasm_txt = 'barrier q[0],q[1],q[2],r[0],r[1],r[2];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
     def test_barrier_reg_bit(self):
-        self.circuit.barrier(self.q, self.r[0])
+        self.circuit.barrier(self.qr, self.qr2[0])
         qasm_txt = 'barrier q[0],q[1],q[2],r[0];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
     def test_ch_reg_reg(self):
         qasm_txt = 'ch q[0],r[0];\nch q[1],r[1];\nch q[2],r[2];'
-        instruction_set = self.circuit.ch(self.q, self.r)
+        instruction_set = self.circuit.ch(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_ch_reg_reg_inv(self):
         qasm_txt = 'ch q[0],r[0];\nch q[1],r[1];\nch q[2],r[2];'
-        instruction_set = self.circuit.ch(self.q, self.r).inverse()
+        instruction_set = self.circuit.ch(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_ch_reg_bit(self):
         qasm_txt = 'ch q[0],r[1];\nch q[1],r[1];\nch q[2],r[1];'
-        instruction_set = self.circuit.ch(self.q, self.r[1])
+        instruction_set = self.circuit.ch(self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_ch_reg_bit_inv(self):
         qasm_txt = 'ch q[0],r[1];\nch q[1],r[1];\nch q[2],r[1];'
-        instruction_set = self.circuit.ch(self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.ch(self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_ch_bit_reg(self):
         qasm_txt = 'ch q[1],r[0];\nch q[1],r[1];\nch q[1],r[2];'
-        instruction_set = self.circuit.ch(self.q[1], self.r)
+        instruction_set = self.circuit.ch(self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_ch_bit_reg_inv(self):
         qasm_txt = 'ch q[1],r[0];\nch q[1],r[1];\nch q[1],r[2];'
-        instruction_set = self.circuit.ch(self.q[1], self.r).inverse()
+        instruction_set = self.circuit.ch(self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CHGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_reg_reg(self):
         qasm_txt = 'crz(1) q[0],r[0];\ncrz(1) q[1],r[1];\ncrz(1) q[2],r[2];'
-        instruction_set = self.circuit.crz(1, self.q, self.r)
+        instruction_set = self.circuit.crz(1, self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_reg_reg_inv(self):
         qasm_txt = 'crz(-1) q[0],r[0];\ncrz(-1) q[1],r[1];\ncrz(-1) q[2],r[2];'
-        instruction_set = self.circuit.crz(1, self.q, self.r).inverse()
+        instruction_set = self.circuit.crz(1, self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_reg_bit(self):
         qasm_txt = 'crz(1) q[0],r[1];\ncrz(1) q[1],r[1];\ncrz(1) q[2],r[1];'
-        instruction_set = self.circuit.crz(1, self.q, self.r[1])
+        instruction_set = self.circuit.crz(1, self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_reg_bit_inv(self):
         qasm_txt = 'crz(-1) q[0],r[1];\ncrz(-1) q[1],r[1];\ncrz(-1) q[2],r[1];'
-        instruction_set = self.circuit.crz(1, self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.crz(1, self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_bit_reg(self):
         qasm_txt = 'crz(1) q[1],r[0];\ncrz(1) q[1],r[1];\ncrz(1) q[1],r[2];'
-        instruction_set = self.circuit.crz(1, self.q[1], self.r)
+        instruction_set = self.circuit.crz(1, self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_crz_bit_reg_inv(self):
         qasm_txt = 'crz(-1) q[1],r[0];\ncrz(-1) q[1],r[1];\ncrz(-1) q[1],r[2];'
-        instruction_set = self.circuit.crz(1, self.q[1], self.r).inverse()
+        instruction_set = self.circuit.crz(1, self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CrzGate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_reg_reg(self):
         qasm_txt = 'cu1(1) q[0],r[0];\ncu1(1) q[1],r[1];\ncu1(1) q[2],r[2];'
-        instruction_set = self.circuit.cu1(1, self.q, self.r)
+        instruction_set = self.circuit.cu1(1, self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_reg_reg_inv(self):
         qasm_txt = 'cu1(-1) q[0],r[0];\ncu1(-1) q[1],r[1];\ncu1(-1) q[2],r[2];'
-        instruction_set = self.circuit.cu1(1, self.q, self.r).inverse()
+        instruction_set = self.circuit.cu1(1, self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_reg_bit(self):
         qasm_txt = 'cu1(1) q[0],r[1];\ncu1(1) q[1],r[1];\ncu1(1) q[2],r[1];'
-        instruction_set = self.circuit.cu1(1, self.q, self.r[1])
+        instruction_set = self.circuit.cu1(1, self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_reg_bit_inv(self):
         qasm_txt = 'cu1(-1) q[0],r[1];\ncu1(-1) q[1],r[1];\ncu1(-1) q[2],r[1];'
-        instruction_set = self.circuit.cu1(1, self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cu1(1, self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_bit_reg(self):
         qasm_txt = 'cu1(1) q[1],r[0];\ncu1(1) q[1],r[1];\ncu1(1) q[1],r[2];'
-        instruction_set = self.circuit.cu1(1, self.q[1], self.r)
+        instruction_set = self.circuit.cu1(1, self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu1_bit_reg_inv(self):
         qasm_txt = 'cu1(-1) q[1],r[0];\ncu1(-1) q[1],r[1];\ncu1(-1) q[1],r[2];'
-        instruction_set = self.circuit.cu1(1, self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cu1(1, self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu1Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_reg_reg(self):
         qasm_txt = 'cu3(1,2,3) q[0],r[0];\ncu3(1,2,3) q[1],r[1];\ncu3(1,2,3) q[2],r[2];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q, self.r)
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_reg_reg_inv(self):
         qasm_txt = 'cu3(-1,-3,-2) q[0],r[0];\ncu3(-1,-3,-2) q[1],r[1];\ncu3(-1,-3,-2) q[2],r[2];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q, self.r).inverse()
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_reg_bit(self):
         qasm_txt = 'cu3(1,2,3) q[0],r[1];\ncu3(1,2,3) q[1],r[1];\ncu3(1,2,3) q[2],r[1];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q, self.r[1])
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_reg_bit_inv(self):
         qasm_txt = 'cu3(-1,-3,-2) q[0],r[1];\ncu3(-1,-3,-2) q[1],r[1];\ncu3(-1,-3,-2) q[2],r[1];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_bit_reg(self):
         qasm_txt = 'cu3(1,2,3) q[1],r[0];\ncu3(1,2,3) q[1],r[1];\ncu3(1,2,3) q[1],r[2];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q[1], self.r)
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cu3_bit_reg_inv(self):
         qasm_txt = 'cu3(-1,-3,-2) q[1],r[0];\ncu3(-1,-3,-2) q[1],r[1];\ncu3(-1,-3,-2) q[1],r[2];'
-        instruction_set = self.circuit.cu3(1, 2, 3, self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cu3(1, 2, 3, self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, Cu3Gate)
         self.assertQasm(qasm_txt)
 
     def test_cx_reg_reg(self):
         qasm_txt = 'cx q[0],r[0];\ncx q[1],r[1];\ncx q[2],r[2];'
-        instruction_set = self.circuit.cx(self.q, self.r)
+        instruction_set = self.circuit.cx(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cx_reg_reg_inv(self):
         qasm_txt = 'cx q[0],r[0];\ncx q[1],r[1];\ncx q[2],r[2];'
-        instruction_set = self.circuit.cx(self.q, self.r).inverse()
+        instruction_set = self.circuit.cx(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cx_reg_bit(self):
         qasm_txt = 'cx q[0],r[1];\ncx q[1],r[1];\ncx q[2],r[1];'
-        instruction_set = self.circuit.cx(self.q, self.r[1])
+        instruction_set = self.circuit.cx(self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cx_reg_bit_inv(self):
         qasm_txt = 'cx q[0],r[1];\ncx q[1],r[1];\ncx q[2],r[1];'
-        instruction_set = self.circuit.cx(self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cx(self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cx_bit_reg(self):
         qasm_txt = 'cx q[1],r[0];\ncx q[1],r[1];\ncx q[1],r[2];'
-        instruction_set = self.circuit.cx(self.q[1], self.r)
+        instruction_set = self.circuit.cx(self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cx_bit_reg_inv(self):
         qasm_txt = 'cx q[1],r[0];\ncx q[1],r[1];\ncx q[1],r[2];'
-        instruction_set = self.circuit.cx(self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cx(self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CnotGate)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_reg_reg(self):
         qasm_txt = 'CX q[0],r[0];\nCX q[1],r[1];\nCX q[2],r[2];'
-        instruction_set = self.circuit.cx_base(self.q, self.r)
+        instruction_set = self.circuit.cx_base(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_reg_reg_inv(self):
         qasm_txt = 'CX q[0],r[0];\nCX q[1],r[1];\nCX q[2],r[2];'
-        instruction_set = self.circuit.cx_base(self.q, self.r).inverse()
+        instruction_set = self.circuit.cx_base(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_reg_bit(self):
         qasm_txt = 'CX q[0],r[1];\nCX q[1],r[1];\nCX q[2],r[1];'
-        instruction_set = self.circuit.cx_base(self.q, self.r[1])
+        instruction_set = self.circuit.cx_base(self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_reg_bit_inv(self):
         qasm_txt = 'CX q[0],r[1];\nCX q[1],r[1];\nCX q[2],r[1];'
-        instruction_set = self.circuit.cx_base(self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cx_base(self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_bit_reg(self):
         qasm_txt = 'CX q[1],r[0];\nCX q[1],r[1];\nCX q[1],r[2];'
-        instruction_set = self.circuit.cx_base(self.q[1], self.r)
+        instruction_set = self.circuit.cx_base(self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cxbase_bit_reg_inv(self):
         qasm_txt = 'CX q[1],r[0];\nCX q[1],r[1];\nCX q[1],r[2];'
-        instruction_set = self.circuit.cx_base(self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cx_base(self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CXBase)
         self.assertQasm(qasm_txt)
 
     def test_cy_reg_reg(self):
         qasm_txt = 'cy q[0],r[0];\ncy q[1],r[1];\ncy q[2],r[2];'
-        instruction_set = self.circuit.cy(self.q, self.r)
+        instruction_set = self.circuit.cy(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cy_reg_reg_inv(self):
         qasm_txt = 'cy q[0],r[0];\ncy q[1],r[1];\ncy q[2],r[2];'
-        instruction_set = self.circuit.cy(self.q, self.r).inverse()
+        instruction_set = self.circuit.cy(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cy_reg_bit(self):
         qasm_txt = 'cy q[0],r[1];\ncy q[1],r[1];\ncy q[2],r[1];'
-        instruction_set = self.circuit.cy(self.q, self.r[1])
+        instruction_set = self.circuit.cy(self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cy_reg_bit_inv(self):
         qasm_txt = 'cy q[0],r[1];\ncy q[1],r[1];\ncy q[2],r[1];'
-        instruction_set = self.circuit.cy(self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cy(self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cy_bit_reg(self):
         qasm_txt = 'cy q[1],r[0];\ncy q[1],r[1];\ncy q[1],r[2];'
-        instruction_set = self.circuit.cy(self.q[1], self.r)
+        instruction_set = self.circuit.cy(self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cy_bit_reg_inv(self):
         qasm_txt = 'cy q[1],r[0];\ncy q[1],r[1];\ncy q[1],r[2];'
-        instruction_set = self.circuit.cy(self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cy(self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CyGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_reg_reg(self):
         qasm_txt = 'cz q[0],r[0];\ncz q[1],r[1];\ncz q[2],r[2];'
-        instruction_set = self.circuit.cz(self.q, self.r)
+        instruction_set = self.circuit.cz(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_reg_reg_inv(self):
         qasm_txt = 'cz q[0],r[0];\ncz q[1],r[1];\ncz q[2],r[2];'
-        instruction_set = self.circuit.cz(self.q, self.r).inverse()
+        instruction_set = self.circuit.cz(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_reg_bit(self):
         qasm_txt = 'cz q[0],r[1];\ncz q[1],r[1];\ncz q[2],r[1];'
-        instruction_set = self.circuit.cz(self.q, self.r[1])
+        instruction_set = self.circuit.cz(self.qr, self.qr2[1])
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_reg_bit_inv(self):
         qasm_txt = 'cz q[0],r[1];\ncz q[1],r[1];\ncz q[2],r[1];'
-        instruction_set = self.circuit.cz(self.q, self.r[1]).inverse()
+        instruction_set = self.circuit.cz(self.qr, self.qr2[1]).inverse()
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_bit_reg(self):
         qasm_txt = 'cz q[1],r[0];\ncz q[1],r[1];\ncz q[1],r[2];'
-        instruction_set = self.circuit.cz(self.q[1], self.r)
+        instruction_set = self.circuit.cz(self.qr[1], self.qr2)
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_cz_bit_reg_inv(self):
         qasm_txt = 'cz q[1],r[0];\ncz q[1],r[1];\ncz q[1],r[2];'
-        instruction_set = self.circuit.cz(self.q[1], self.r).inverse()
+        instruction_set = self.circuit.cz(self.qr[1], self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, CzGate)
         self.assertQasm(qasm_txt)
 
     def test_swap_reg_reg(self):
         qasm_txt = 'swap q[0],r[0];\nswap q[1],r[1];\nswap q[2],r[2];'
-        instruction_set = self.circuit.swap(self.q, self.r)
+        instruction_set = self.circuit.swap(self.qr, self.qr2)
         self.assertStmtsType(instruction_set.instructions, SwapGate)
         self.assertQasm(qasm_txt)
 
     def test_swap_reg_reg_inv(self):
         qasm_txt = 'swap q[0],r[0];\nswap q[1],r[1];\nswap q[2],r[2];'
-        instruction_set = self.circuit.swap(self.q, self.r).inverse()
+        instruction_set = self.circuit.swap(self.qr, self.qr2).inverse()
         self.assertStmtsType(instruction_set.instructions, SwapGate)
         self.assertQasm(qasm_txt)
 
@@ -1071,27 +1072,27 @@ class TestStandard3Q(StandardExtensionTest):
     """Standard Extension Test. Gates with three Qubits"""
 
     def setUp(self):
-        self.q = QuantumRegister(3, "q")
-        self.r = QuantumRegister(3, "r")
-        self.s = QuantumRegister(3, "s")
-        self.c = ClassicalRegister(3, "c")
-        self.circuit = QuantumCircuit(self.q, self.r, self.s, self.c)
+        self.qr = QuantumRegister(3, "q")
+        self.qr2 = QuantumRegister(3, "r")
+        self.qr3 = QuantumRegister(3, "s")
+        self.cr = ClassicalRegister(3, "c")
+        self.circuit = QuantumCircuit(self.qr, self.qr2, self.qr3, self.cr)
         self.c_header = 80  # lenght of the header
 
-    def test_barrier_None(self):
+    def test_barrier_none(self):
         self.circuit.barrier()
         qasm_txt = 'barrier q[0],q[1],q[2],r[0],r[1],r[2],s[0],s[1],s[2];'
         self.assertResult(Barrier, qasm_txt, qasm_txt)
 
     def test_ccx_reg_reg_reg(self):
         qasm_txt = 'ccx q[0],r[0],s[0];\nccx q[1],r[1],s[1];\nccx q[2],r[2],s[2];'
-        instruction_set = self.circuit.ccx(self.q, self.r, self.s)
+        instruction_set = self.circuit.ccx(self.qr, self.qr2, self.qr3)
         self.assertStmtsType(instruction_set.instructions, ToffoliGate)
         self.assertQasm(qasm_txt)
 
     def test_ccx_reg_reg_inv(self):
         qasm_txt = 'ccx q[0],r[0],s[0];\nccx q[1],r[1],s[1];\nccx q[2],r[2],s[2];'
-        instruction_set = self.circuit.ccx(self.q, self.r, self.s).inverse()
+        instruction_set = self.circuit.ccx(self.qr, self.qr2, self.qr3).inverse()
         self.assertStmtsType(instruction_set.instructions, ToffoliGate)
         self.assertQasm(qasm_txt)
 
@@ -1099,7 +1100,7 @@ class TestStandard3Q(StandardExtensionTest):
         qasm_txt = 'cswap q[0],r[0],s[0];\n' \
                    'cswap q[1],r[1],s[1];\n' \
                    'cswap q[2],r[2],s[2];'
-        instruction_set = self.circuit.cswap(self.q, self.r, self.s)
+        instruction_set = self.circuit.cswap(self.qr, self.qr2, self.qr3)
         self.assertStmtsType(instruction_set.instructions, FredkinGate)
         self.assertQasm(qasm_txt)
 
@@ -1107,7 +1108,7 @@ class TestStandard3Q(StandardExtensionTest):
         qasm_txt = 'cswap q[0],r[0],s[0];\n' \
                    'cswap q[1],r[1],s[1];\n' \
                    'cswap q[2],r[2],s[2];'
-        instruction_set = self.circuit.cswap(self.q, self.r, self.s).inverse()
+        instruction_set = self.circuit.cswap(self.qr, self.qr2, self.qr3).inverse()
         self.assertStmtsType(instruction_set.instructions, FredkinGate)
         self.assertQasm(qasm_txt)
 

--- a/test/python/test_filter_backends.py
+++ b/test/python/test_filter_backends.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
-
 """Backends Filtering Test."""
 
 from qiskit.wrapper import register, available_backends, least_busy
@@ -17,34 +15,34 @@ class TestBackendFilters(QiskitTestCase):
     """QISKit Backend Filtering Tests."""
 
     @requires_qe_access
-    def test_filter_config_dict(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_filter_config_dict(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test filtering by dictionary of configuration properties"""
         n_qubits = 20 if self.using_ibmq_credentials else 5
 
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         filter_ = {'n_qubits': n_qubits, 'local': False}
         filtered_backends = available_backends(filter_)
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_status_config_dict(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_filter_status_config_dict(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test filtering by dictionary of mixed status/configuration properties"""
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         filter_ = {'operational': True, 'local': False, 'simulator': True}
         filtered_backends = available_backends(filter_)
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_config_callable(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_filter_config_callable(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test filtering by lambda function on configuration properties"""
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         filtered_backends = available_backends(lambda x: (not x.configuration['simulator'] and
                                                           x.configuration['n_qubits'] > 5))
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
-    def test_filter_least_busy(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_filter_least_busy(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test filtering by least busy function"""
-        register(QE_TOKEN, QE_URL, hub, group, project)
+        register(qe_token, qe_url, hub, group, project)
         filtered_backends = least_busy(available_backends())
         self.assertTrue(filtered_backends)

--- a/test/python/test_ibmqjob.py
+++ b/test/python/test_ibmqjob.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring,broad-except
+# pylint: disable=missing-docstring,broad-except
 
 """IBMQJob Test."""
 
@@ -45,7 +45,7 @@ class TestIBMQJob(JobTestCase):
     """
 
     @requires_qe_access
-    def setUp(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def setUp(self, qe_token, qe_url, hub=None, group=None, project=None):
         # pylint: disable=arguments-differ
         super().setUp()
         # create QuantumCircuit
@@ -56,7 +56,7 @@ class TestIBMQJob(JobTestCase):
         qc.cx(qr[0], qr[1])
         qc.measure(qr, cr)
         self._qc = qc
-        self._provider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        self._provider = IBMQProvider(qe_token, qe_url, hub, group, project)
 
     def test_run_simulator(self):
         backend = self._provider.get_backend('ibmq_qasm_simulator')

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring,broad-except
+# pylint: disable=missing-docstring,broad-except
 
 
 """IBMQJob states test-suite."""

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -223,7 +223,9 @@ class TestIBMQJobStates(JobTestCase):
         self.assertEqual(job.result(timeout=1).get_status(), 'ERROR')
         self.assertStatus(job, JobStatus.RUNNING)
 
-    def test_cancel_while_initializing_is_not_possible_but_does_not_fail(self):
+    def test_cancel_while_initializing_should_not_raise(self):
+        """Trying to cancel while initializing is not possible but should
+        not raise."""
         job = self.run_with_api(CancellableAPI())
         can_cancel = job.cancel()
         self.assertFalse(can_cancel)

--- a/test/python/test_identifiers.py
+++ b/test/python/test_identifiers.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring,broad-except
+# pylint: disable=missing-docstring,broad-except
 
 """Non-string identifiers for circuit and record identifiers test"""
 
@@ -21,7 +21,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
     """Circuits and records can have no name"""
 
     def setUp(self):
-        self.QPS_SPECS_NONAMES = {
+        self.qps_specs_nonames = {
             "circuits": [{
                 "quantum_registers": [{
                     "size": 3}],
@@ -38,7 +38,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
         """Test Quantum Object Factory creation using Specs definition
         object with no names for circuit nor records.
         """
-        result = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        result = QuantumProgram(specs=self.qps_specs_nonames)
         self.assertIsInstance(result, QuantumProgram)
 
     def test_create_anonymous_classical_register(self):
@@ -118,24 +118,24 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
         self.assertEqual(len(qcn), 3)
 
     def test_get_circuit_noname(self):
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qc = q_program.get_circuit()
         self.assertIsInstance(qc, QuantumCircuit)
 
     def test_get_quantum_register_noname(self):
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qr = q_program.get_quantum_register()
         self.assertIsInstance(qr, QuantumRegister)
 
     def test_get_classical_register_noname(self):
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         cr = q_program.get_classical_register()
         self.assertIsInstance(cr, ClassicalRegister)
 
     def test_get_qasm_noname(self):
         """Test the get_qasm using an specification without names.
         """
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qc = q_program.get_circuit()
 
         qrn = list(q_program.get_quantum_register_names())
@@ -182,7 +182,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
     def test_get_qasm_all_gates(self):
         """Test the get_qasm for more gates, using an specification without names.
         """
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qc = q_program.get_circuit()
         qr = q_program.get_quantum_register()
         cr = q_program.get_classical_register()
@@ -214,7 +214,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
     def test_compile_program_noname(self):
         """Test compile with a no name.
         """
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qc = q_program.get_circuit()
         qr = q_program.get_quantum_register()
         cr = q_program.get_classical_register()
@@ -229,7 +229,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
     def test_get_execution_list_noname(self):
         """Test get_execution_list for circuits without name.
         """
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qc = q_program.get_circuit()
         qr = q_program.get_quantum_register()
         cr = q_program.get_classical_register()
@@ -242,7 +242,7 @@ class TestAnonymousIdsInQuantumProgram(QiskitTestCase):
         self.assertEqual(len(result), 1)
 
     def test_change_circuit_qobj_after_compile_noname(self):
-        q_program = QuantumProgram(specs=self.QPS_SPECS_NONAMES)
+        q_program = QuantumProgram(specs=self.qps_specs_nonames)
         qr = q_program.get_quantum_register()
         cr = q_program.get_classical_register()
         qc2 = q_program.create_circuit(qregisters=[qr], cregisters=[cr])
@@ -314,44 +314,44 @@ class TestQobj(QiskitTestCase):
     def test_local_qasm_simulator_py(self):
         backend = wrapper.get_backend('local_qasm_simulator_py')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.experiments[0]
-        ccq = qobj.experiments[0].header.compiled_circuit_qasm
-        self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
-        self.assertIn(self.qr_name, ccq)
-        self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
-        self.assertIn(self.cr_name, ccq)
+        compiled_circuit = qobj.experiments[0]
+        compiled_circuit_qasm = qobj.experiments[0].header.compiled_circuit_qasm
+        self.assertIn(self.qr_name, map(lambda x: x[0], compiled_circuit.header.qubit_labels))
+        self.assertIn(self.qr_name, compiled_circuit_qasm)
+        self.assertIn(self.cr_name, map(lambda x: x[0], compiled_circuit.header.clbit_labels))
+        self.assertIn(self.cr_name, compiled_circuit_qasm)
 
     @requires_cpp_simulator
     def test_local_clifford_simulator_cpp(self):
         backend = wrapper.get_backend('local_clifford_simulator_cpp')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.experiments[0]
-        ccq = qobj.experiments[0].header.compiled_circuit_qasm
-        self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
-        self.assertIn(self.qr_name, ccq)
-        self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
-        self.assertIn(self.cr_name, ccq)
+        compiled_circuit = qobj.experiments[0]
+        compiled_circuit_qasm = qobj.experiments[0].header.compiled_circuit_qasm
+        self.assertIn(self.qr_name, map(lambda x: x[0], compiled_circuit.header.qubit_labels))
+        self.assertIn(self.qr_name, compiled_circuit_qasm)
+        self.assertIn(self.cr_name, map(lambda x: x[0], compiled_circuit.header.clbit_labels))
+        self.assertIn(self.cr_name, compiled_circuit_qasm)
 
     @requires_cpp_simulator
     def test_local_qasm_simulator_cpp(self):
         backend = wrapper.get_backend('local_qasm_simulator_cpp')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.experiments[0]
-        ccq = qobj.experiments[0].header.compiled_circuit_qasm
-        self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
-        self.assertIn(self.qr_name, ccq)
-        self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
-        self.assertIn(self.cr_name, ccq)
+        compiled_circuit = qobj.experiments[0]
+        compiled_circuit_qasm = qobj.experiments[0].header.compiled_circuit_qasm
+        self.assertIn(self.qr_name, map(lambda x: x[0], compiled_circuit.header.qubit_labels))
+        self.assertIn(self.qr_name, compiled_circuit_qasm)
+        self.assertIn(self.cr_name, map(lambda x: x[0], compiled_circuit.header.clbit_labels))
+        self.assertIn(self.cr_name, compiled_circuit_qasm)
 
     def test_local_unitary_simulator(self):
         backend = wrapper.get_backend('local_unitary_simulator_py')
         qobj = wrapper.compile(self.circuits, backend=backend)
-        cc = qobj.experiments[0]
-        ccq = qobj.experiments[0].header.compiled_circuit_qasm
-        self.assertIn(self.qr_name, map(lambda x: x[0], cc.header.qubit_labels))
-        self.assertIn(self.qr_name, ccq)
-        self.assertIn(self.cr_name, map(lambda x: x[0], cc.header.clbit_labels))
-        self.assertIn(self.cr_name, ccq)
+        compiled_circuit = qobj.experiments[0]
+        compiled_circuit_qasm = qobj.experiments[0].header.compiled_circuit_qasm
+        self.assertIn(self.qr_name, map(lambda x: x[0], compiled_circuit.header.qubit_labels))
+        self.assertIn(self.qr_name, compiled_circuit_qasm)
+        self.assertIn(self.cr_name, map(lambda x: x[0], compiled_circuit.header.clbit_labels))
+        self.assertIn(self.cr_name, compiled_circuit_qasm)
 
 
 class TestAnonymousIds(QiskitTestCase):
@@ -433,11 +433,11 @@ class TestInvalidIds(QiskitTestCase):
         self.assertRaises(QISKitError, ClassicalRegister, size=3, name=1)
 
     def test_invalid_type_qr_spec(self):
-        """QPS_SPECS_NONAMES defines a quantum register with an invalid type name
+        """qps_specs_nonames defines a quantum register with an invalid type name
 
         Note: remove after QuantumProgram deprecation.
         """
-        QPS_SPECS_NONAMES = {
+        qps_specs_nonames = {
             "circuits": [{
                 "quantum_registers": [{
                     "name": 1,
@@ -447,14 +447,14 @@ class TestInvalidIds(QiskitTestCase):
             }]
         }
 
-        self.assertRaises(QISKitError, QuantumProgram, specs=QPS_SPECS_NONAMES)
+        self.assertRaises(QISKitError, QuantumProgram, specs=qps_specs_nonames)
 
     def test_invalid_type_cr_spec(self):
-        """QPS_SPECS_NONAMES defines a classical register with an invalid type name
+        """qps_specs_nonames defines a classical register with an invalid type name
 
         Note: remove after QuantumProgram deprecation.
         """
-        QPS_SPECS_NONAMES = {
+        qps_specs_nonames = {
             "circuits": [{
                 "quantum_registers": [{
                     "size": 3}],
@@ -464,7 +464,7 @@ class TestInvalidIds(QiskitTestCase):
             }]
         }
 
-        self.assertRaises(QISKitError, QuantumProgram, specs=QPS_SPECS_NONAMES)
+        self.assertRaises(QISKitError, QuantumProgram, specs=qps_specs_nonames)
 
     def test_invalid_qasmname_qr(self):
         """Test QuantumRegister() with an invalid QASM name (do not start with lowercase).
@@ -477,12 +477,12 @@ class TestInvalidIds(QiskitTestCase):
         self.assertRaises(QISKitError, ClassicalRegister, size=3, name='Cr')
 
     def test_invalid_qasmname_qr_spec(self):
-        """QPS_SPECS_NONAMES defines a quantum register with invalid QASM name (do not start
+        """qps_specs_nonames defines a quantum register with invalid QASM name (do not start
         with lowercase).
 
         Note: remove after QuantumProgram deprecation.
         """
-        QPS_SPECS_NONAMES = {
+        qps_specs_nonames = {
             "circuits": [{
                 "quantum_registers": [{
                     "name": 'Qr',
@@ -492,15 +492,15 @@ class TestInvalidIds(QiskitTestCase):
             }]
         }
 
-        self.assertRaises(QISKitError, QuantumProgram, specs=QPS_SPECS_NONAMES)
+        self.assertRaises(QISKitError, QuantumProgram, specs=qps_specs_nonames)
 
     def test_invalid_qasmname_cr_spec(self):
-        """QPS_SPECS_NONAMES defines a classical register with invalid QASM name (do not start
+        """qps_specs_nonames defines a classical register with invalid QASM name (do not start
         with lowercase).
 
         Note: remove after QuantumProgram deprecation.
         """
-        QPS_SPECS_NONAMES = {
+        qps_specs_nonames = {
             "circuits": [{
                 "quantum_registers": [{
                     "size": 3}],
@@ -510,7 +510,7 @@ class TestInvalidIds(QiskitTestCase):
             }]
         }
 
-        self.assertRaises(QISKitError, QuantumProgram, specs=QPS_SPECS_NONAMES)
+        self.assertRaises(QISKitError, QuantumProgram, specs=qps_specs_nonames)
 
 
 if __name__ == '__main__':

--- a/test/python/test_initializer.py
+++ b/test/python/test_initializer.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """
 InitializeGate (CompositeGate instance) test.

--- a/test/python/test_jsonoutput.py
+++ b/test/python/test_jsonoutput.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """Quick program to test json backend
 """
@@ -23,15 +23,15 @@ class TestJsonOutput(QiskitTestCase):
     here for convenience.
     """
     def setUp(self):
-        self.QASM_FILE_PATH = self._get_resource_path(
+        self.qasm_file_path = self._get_resource_path(
             'qasm/entangled_registers.qasm', Path.EXAMPLES)
 
     def test_json_output(self):
-        qp = QuantumProgram()
-        qp.load_qasm_file(self.QASM_FILE_PATH, name="example")
+        qprogram = QuantumProgram()
+        qprogram.load_qasm_file(self.qasm_file_path, name="example")
 
         basis_gates = []  # unroll to base gates, change to test
-        unroller = unroll.Unroller(qasm.Qasm(data=qp.get_qasm("example")).parse(),
+        unroller = unroll.Unroller(qasm.Qasm(data=qprogram.get_qasm("example")).parse(),
                                    unroll.JsonBackend(basis_gates))
         circuit = unroller.execute()
         self.log.info('test_json_ouptut: %s', circuit)

--- a/test/python/test_load_qasm.py
+++ b/test/python/test_load_qasm.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name,missing-docstring
 #
 # Copyright 2017 IBM RESEARCH. All Rights Reserved.
 #
@@ -16,6 +15,8 @@
 # limitations under the License.
 # =============================================================================
 
+# pylint: disable=missing-docstring
+
 from qiskit import QISKitError
 from qiskit.wrapper import load_qasm_file, load_qasm_string
 from .common import QiskitTestCase, Path
@@ -25,20 +26,20 @@ class LoadQasmTest(QiskitTestCase):
     """Test load_qasm_* set of methods."""
 
     def setUp(self):
-        self.QASM_FILE_NAME = 'entangled_registers.qasm'
-        self.QASM_FILE_PATH = self._get_resource_path(
-            'qasm/' + self.QASM_FILE_NAME, Path.EXAMPLES)
+        self._qasm_file_name = 'entangled_registers.qasm'
+        self._qasm_file_path = self._get_resource_path(
+            'qasm/' + self._qasm_file_name, Path.EXAMPLES)
 
     def test_load_qasm_file(self):
         """Test load_qasm_file and get_circuit.
 
-        If all is correct we should get the qasm file loaded in QASM_FILE_PATH
+        If all is correct we should get the qasm file loaded in _qasm_file_path
 
         Previously:
             Libraries:
                 from qiskit.wrapper import load_qasm_file
         """
-        q_circuit = load_qasm_file(self.QASM_FILE_PATH)
+        q_circuit = load_qasm_file(self._qasm_file_path)
         qasm_string = q_circuit.qasm()
         self.log.info(qasm_string)
         expected_qasm_string = """\

--- a/test/python/test_load_qasm.py
+++ b/test/python/test_load_qasm.py
@@ -26,9 +26,9 @@ class LoadQasmTest(QiskitTestCase):
     """Test load_qasm_* set of methods."""
 
     def setUp(self):
-        self._qasm_file_name = 'entangled_registers.qasm'
-        self._qasm_file_path = self._get_resource_path(
-            'qasm/' + self._qasm_file_name, Path.EXAMPLES)
+        self.qasm_file_name = 'entangled_registers.qasm'
+        self.qasm_file_path = self._get_resource_path(
+            'qasm/' + self.qasm_file_name, Path.EXAMPLES)
 
     def test_load_qasm_file(self):
         """Test load_qasm_file and get_circuit.
@@ -39,7 +39,7 @@ class LoadQasmTest(QiskitTestCase):
             Libraries:
                 from qiskit.wrapper import load_qasm_file
         """
-        q_circuit = load_qasm_file(self._qasm_file_path)
+        q_circuit = load_qasm_file(self.qasm_file_path)
         qasm_string = q_circuit.qasm()
         self.log.info(qasm_string)
         expected_qasm_string = """\

--- a/test/python/test_localjob.py
+++ b/test/python/test_localjob.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """LocalJob creation and test suite."""
 
@@ -55,8 +55,8 @@ class TestLocalJob(QiskitTestCase):
         taskcount = 10
         target_tasks = [lambda: None for _ in range(taskcount)]
 
-        # pylint: disable=redefined-outer-name
-        with intercepted_executor_for_localjob() as (LocalJob, executor):
+        # pylint: disable=invalid-name,redefined-outer-name
+        with mocked_executor() as (LocalJob, executor):
             for index in range(taskcount):
                 LocalJob(target_tasks[index], new_fake_qobj())
 
@@ -72,8 +72,8 @@ class TestLocalJob(QiskitTestCase):
         # we only check if we delegate on the proper method of the underlaying
         # future object.
 
-        # pylint: disable=redefined-outer-name
-        with intercepted_executor_for_localjob() as (LocalJob, executor):
+        # pylint: disable=invalid-name,redefined-outer-name
+        with mocked_executor() as (LocalJob, executor):
             job = LocalJob(lambda: None, new_fake_qobj())
             job.cancel()
 
@@ -85,8 +85,8 @@ class TestLocalJob(QiskitTestCase):
         # Once more, testing that reading the `done` property delegates into
         # the proper future API.
 
-        # pylint: disable=redefined-outer-name
-        with intercepted_executor_for_localjob() as (LocalJob, executor):
+        # pylint: disable=invalid-name,redefined-outer-name
+        with mocked_executor() as (LocalJob, executor):
             job = LocalJob(lambda: None, new_fake_qobj())
             _ = job.done
 
@@ -110,7 +110,7 @@ class FakeBackend():
 
 
 @contextmanager
-def intercepted_executor_for_localjob():
+def mocked_executor():
     """Context that patches the derived executor classes to return the same
     executor object. Also patches the future object returned by executor's
     submit()."""

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 import unittest
 
@@ -46,19 +46,20 @@ class MapperTest(QiskitTestCase):
 
     def setUp(self):
         self.seed = 42
-        self.qp = QuantumProgram()
+        self.qprogram = QuantumProgram()
 
     def test_mapper_overoptimization(self):
         """
         The mapper should not change the semantics of the input. An overoptimization introduced
         the issue #81: https://github.com/QISKit/qiskit-terra/issues/81
         """
-        self.qp.load_qasm_file(self._get_resource_path('qasm/overoptimization.qasm'), name='test')
+        self.qprogram.load_qasm_file(
+            self._get_resource_path('qasm/overoptimization.qasm'), name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
-        result1 = self.qp.execute(["test"], backend="local_qasm_simulator",
-                                  coupling_map=coupling_map)
+        result1 = self.qprogram.execute(["test"], backend="local_qasm_simulator",
+                                        coupling_map=coupling_map)
         count1 = result1.get_counts("test")
-        result2 = self.qp.execute(["test"], backend="local_qasm_simulator", coupling_map=None)
+        result2 = self.qprogram.execute(["test"], backend="local_qasm_simulator", coupling_map=None)
         count2 = result2.get_counts("test")
         self.assertEqual(count1.keys(), count2.keys(), )
 
@@ -68,12 +69,13 @@ class MapperTest(QiskitTestCase):
         avoided.
         See: https://github.com/QISKit/qiskit-terra/issues/111
         """
-        self.qp.load_qasm_file(self._get_resource_path('qasm/math_domain_error.qasm'), name='test')
+        self.qprogram.load_qasm_file(self._get_resource_path('qasm/math_domain_error.qasm'),
+                                     name='test')
         coupling_map = [[0, 2], [1, 2], [2, 3]]
         shots = 2000
-        result = self.qp.execute("test", backend="local_qasm_simulator",
-                                 coupling_map=coupling_map,
-                                 seed=self.seed, shots=shots)
+        result = self.qprogram.execute("test", backend="local_qasm_simulator",
+                                       coupling_map=coupling_map,
+                                       seed=self.seed, shots=shots)
         counts = result.get_counts("test")
         target = {'0001': shots / 2, '0101':  shots / 2}
         threshold = 0.04 * shots
@@ -84,10 +86,10 @@ class MapperTest(QiskitTestCase):
 
         See: https://github.com/QISKit/qiskit-terra/issues/159
         """
-        self.qp = QuantumProgram()
-        qr = self.qp.create_quantum_register('qr', 2)
-        cr = self.qp.create_classical_register('cr', 2)
-        qc = self.qp.create_circuit('Bell', [qr], [cr])
+        self.qprogram = QuantumProgram()
+        qr = self.qprogram.create_quantum_register('qr', 2)
+        cr = self.qprogram.create_classical_register('cr', 2)
+        qc = self.qprogram.create_circuit('Bell', [qr], [cr])
         qc.h(qr[0])
         qc.cx(qr[1], qr[0])
         qc.cx(qr[1], qr[0])
@@ -97,18 +99,18 @@ class MapperTest(QiskitTestCase):
         backend = 'local_qasm_simulator'
         coupling_map = [[1, 0], [2, 0], [2, 1], [2, 4], [3, 2], [3, 4]]
         initial_layout = {('qr', 0): ('q', 1), ('qr', 1): ('q', 0)}
-        qobj = self.qp.compile(["Bell"], backend=backend,
-                               initial_layout=initial_layout, coupling_map=coupling_map)
+        qobj = self.qprogram.compile(["Bell"], backend=backend,
+                                     initial_layout=initial_layout, coupling_map=coupling_map)
 
-        self.assertEqual(self.qp.get_compiled_qasm(qobj, "Bell"), EXPECTED_QASM_1Q_GATES_3_5)
+        self.assertEqual(self.qprogram.get_compiled_qasm(qobj, "Bell"), EXPECTED_QASM_1Q_GATES_3_5)
 
     def test_random_parameter_circuit(self):
         """Run a circuit with randomly generated parameters."""
-        self.qp.load_qasm_file(self._get_resource_path('qasm/random_n5_d5.qasm'), name='rand')
+        self.qprogram.load_qasm_file(self._get_resource_path('qasm/random_n5_d5.qasm'), name='rand')
         coupling_map = [[0, 1], [1, 2], [2, 3], [3, 4]]
         shots = 1024
-        result1 = self.qp.execute(["rand"], backend="local_qasm_simulator",
-                                  coupling_map=coupling_map, shots=shots, seed=self.seed)
+        result1 = self.qprogram.execute(["rand"], backend="local_qasm_simulator",
+                                        coupling_map=coupling_map, shots=shots, seed=self.seed)
         counts = result1.get_counts("rand")
         expected_probs = {
             '00000': 0.079239867254200971,
@@ -201,10 +203,10 @@ class MapperTest(QiskitTestCase):
 
         See: https://github.com/QISKit/qiskit-terra/issues/342
         """
-        self.qp = QuantumProgram()
-        qr = self.qp.create_quantum_register('qr', 16)
-        cr = self.qp.create_classical_register('cr', 16)
-        qc = self.qp.create_circuit('native_cx', [qr], [cr])
+        self.qprogram = QuantumProgram()
+        qr = self.qprogram.create_quantum_register('qr', 16)
+        cr = self.qprogram.create_classical_register('cr', 16)
+        qc = self.qprogram.create_circuit('native_cx', [qr], [cr])
         qc.cx(qr[3], qr[14])
         qc.cx(qr[5], qr[4])
         qc.h(qr[9])
@@ -220,7 +222,7 @@ class MapperTest(QiskitTestCase):
                         [6, 5], [6, 7], [6, 11], [7, 10], [8, 7], [9, 8],
                         [9, 10], [11, 10], [12, 5], [12, 11], [12, 13],
                         [13, 4], [13, 14], [15, 0], [15, 2], [15, 14]]
-        qobj = self.qp.compile(["native_cx"], backend=backend, coupling_map=coupling_map)
+        qobj = self.qprogram.compile(["native_cx"], backend=backend, coupling_map=coupling_map)
         cx_qubits = [x.qubits
                      for x in qobj.experiments[0].instructions
                      if x.name == "cx"]
@@ -233,10 +235,10 @@ class MapperTest(QiskitTestCase):
         See: https://github.com/QISKit/qiskit-terra/issues/607
         """
         backend = FakeQX4BackEnd()
-        circ1 = load_qasm_string(yzy_zyz_1)
+        circ1 = load_qasm_string(YZY_ZYZ_1)
         qobj1 = qiskit.wrapper.compile(circ1, backend)
         self.assertIsInstance(qobj1, Qobj)
-        circ2 = load_qasm_string(yzy_zyz_2)
+        circ2 = load_qasm_string(YZY_ZYZ_2)
         qobj2 = qiskit.wrapper.compile(circ2, backend)
         self.assertIsInstance(qobj2, Qobj)
 
@@ -324,7 +326,7 @@ u1(pi) qr[0];
 u1((0.3+(-pi))^2) qr[0];
 measure qr[0] -> cr[0];"""
 
-yzy_zyz_1 = """OPENQASM 2.0;
+YZY_ZYZ_1 = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg qr[2];
 cx qr[0],qr[1];
@@ -332,7 +334,7 @@ rz(0.7) qr[1];
 rx(1.570796) qr[1];
 """
 
-yzy_zyz_2 = """OPENQASM 2.0;
+YZY_ZYZ_2 = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg qr[2];
 y qr[0];

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """Test for the QASM parser"""
 
@@ -31,16 +31,16 @@ def parse(file_path, prec=15):
 class TestParser(QiskitTestCase):
     """QasmParser"""
     def setUp(self):
-        self.QASM_FILE_PATH = self._get_resource_path('qasm/example.qasm')
-        self.QASM_FILE_PATH_FAIL = self._get_resource_path(
+        self.qasm_file_path = self._get_resource_path('qasm/example.qasm')
+        self.qasm_file_path_fail = self._get_resource_path(
             'qasm/example_fail.qasm')
-        self.QASM_FILE_PATH_IF = self._get_resource_path(
+        self.qasm_file_path_if = self._get_resource_path(
             'qasm/example_if.qasm')
 
     def test_parser(self):
         """should return a correct response for a valid circuit."""
 
-        res = parse(self.QASM_FILE_PATH)
+        res = parse(self.qasm_file_path)
         self.log.info(res)
         # TODO: For now only some basic checks.
         self.assertEqual(len(res), 1563)
@@ -52,7 +52,7 @@ class TestParser(QiskitTestCase):
         """should fail a for a  not valid circuit."""
 
         self.assertRaisesRegex(QasmError, "Perhaps there is a missing",
-                               parse, file_path=self.QASM_FILE_PATH_FAIL)
+                               parse, file_path=self.qasm_file_path_fail)
 
     def test_all_valid_nodes(self):
         """Test that the tree contains only Node subclasses."""
@@ -62,18 +62,18 @@ class TestParser(QiskitTestCase):
                 inspect(child)
 
         # Test the canonical example file.
-        qasm = Qasm(self.QASM_FILE_PATH)
+        qasm = Qasm(self.qasm_file_path)
         res = qasm.parse()
         inspect(res)
 
         # Test a file containing if instructions.
-        qasm_if = Qasm(self.QASM_FILE_PATH_IF)
+        qasm_if = Qasm(self.qasm_file_path_if)
         res_if = qasm_if.parse()
         inspect(res_if)
 
     def test_get_tokens(self):
         """Test whether we get only valid tokens."""
-        qasm = Qasm(self.QASM_FILE_PATH)
+        qasm = Qasm(self.qasm_file_path)
         for token in qasm.get_tokens():
             self.assertTrue(isinstance(token, ply.lex.LexToken))
 

--- a/test/python/test_qasm_simulator_cpp.py
+++ b/test/python/test_qasm_simulator_cpp.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 import json
 import unittest
@@ -72,38 +72,38 @@ class TestLocalQasmSimulatorCpp(QiskitTestCase):
         self.backend = QasmSimulatorCpp()
 
     def test_x90_coherent_error_matrix(self):
-        X90 = np.array([[1, -1j], [-1j, 1]]) / np.sqrt(2)
-        U = x90_error_matrix(0., 0.).dot(X90)
-        target = X90
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10,
+        x90 = np.array([[1, -1j], [-1j, 1]]) / np.sqrt(2)
+        u_matrix = x90_error_matrix(0., 0.).dot(x90)
+        target = x90
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10,
                                msg="identity error matrix")
-        U = x90_error_matrix(np.pi / 2., 0.).dot(X90)
+        u_matrix = x90_error_matrix(np.pi / 2., 0.).dot(x90)
         target = -1j * np.array([[0, 1], [1, 0]])
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10)
-        U = x90_error_matrix(0., np.pi / 2.).dot(X90)
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10)
+        u_matrix = x90_error_matrix(0., np.pi / 2.).dot(x90)
         target = np.array([[1., -1], [1, 1.]]) / np.sqrt(2.)
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10)
-        U = x90_error_matrix(np.pi / 2, np.pi / 2.).dot(X90)
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10)
+        u_matrix = x90_error_matrix(np.pi / 2, np.pi / 2.).dot(x90)
         target = np.array([[0., -1], [1, 0.]])
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10)
-        U = x90_error_matrix(0.02, -0.03)
-        self.assertAlmostEqual(norm(U.dot(U.conj().T) - np.eye(2)), 0.0,
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10)
+        u_matrix = x90_error_matrix(0.02, -0.03)
+        self.assertAlmostEqual(norm(u_matrix.dot(u_matrix.conj().T) - np.eye(2)), 0.0,
                                places=10, msg="Test error matrix is unitary")
 
     def test_cx_coherent_error_matrix(self):
-        CX = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]])
-        U = cx_error_matrix(0., 0.).dot(CX)
-        target = CX
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10,
+        cx_matrix = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]])
+        u_matrix = cx_error_matrix(0., 0.).dot(cx_matrix)
+        target = cx_matrix
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10,
                                msg="identity error matrix")
-        U = cx_error_matrix(np.pi / 2., 0.).dot(CX)
+        u_matrix = cx_error_matrix(np.pi / 2., 0.).dot(cx_matrix)
         target = np.array([[1, 0, 1j, 0],
                            [0, -1j, 0, 1],
                            [1j, 0, 1, 0],
                            [0, 1, 0, -1j]]) / np.sqrt(2)
-        self.assertAlmostEqual(norm(U - target), 0.0, places=10)
-        U = cx_error_matrix(0.03, -0.04)
-        self.assertAlmostEqual(norm(U.dot(U.conj().T) - np.eye(4)), 0.0,
+        self.assertAlmostEqual(norm(u_matrix - target), 0.0, places=10)
+        u_matrix = cx_error_matrix(0.03, -0.04)
+        self.assertAlmostEqual(norm(u_matrix.dot(u_matrix.conj().T) - np.eye(4)), 0.0,
                                places=10, msg="Test error matrix is unitary")
 
     def test_run_qobj(self):

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -26,9 +26,9 @@ class TestQuantumProgram(QiskitTestCase):
     """QISKit QuantumProgram Object Tests."""
 
     def setUp(self):
-        self.QASM_FILE_PATH = self._get_resource_path(
+        self.qasm_file_path = self._get_resource_path(
             'qasm/entangled_registers.qasm', Path.EXAMPLES)
-        self.QASM_FILE_PATH_2 = self._get_resource_path(
+        self.qasm_file_path_2 = self._get_resource_path(
             'qasm/plaquette_check.qasm', Path.EXAMPLES)
 
         self.QPS_SPECS = {
@@ -75,10 +75,10 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertIsInstance(result, QuantumProgram)
 
     @requires_qe_access
-    def test_config_scripts_file(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_config_scripts_file(self, qe_token, qe_url, hub=None, group=None, project=None):
         """Test Qconfig.
 
-        in this case we check if the QE_URL API is defined.
+        in this case we check if the qe_url API is defined.
 
         Previously:
             Libraries:
@@ -86,7 +86,7 @@ class TestQuantumProgram(QiskitTestCase):
         """
         # pylint: disable=unused-argument
         import re
-        self.assertTrue(re.match('^https?://[0-9.:/A-Za-z_-]+/api', QE_URL))
+        self.assertTrue(re.match('^https?://[0-9.:/A-Za-z_-]+/api', qe_url))
 
     def test_create_classical_register(self):
         """Test create_classical_register.
@@ -298,14 +298,14 @@ class TestQuantumProgram(QiskitTestCase):
     def test_load_qasm_file(self):
         """Test load_qasm_file and get_circuit.
 
-        If all is correct we should get the qasm file loaded in QASM_FILE_PATH
+        If all is correct we should get the qasm file loaded in qasm_file_path
 
         Previously:
             Libraries:
                 from qiskit import QuantumProgram
         """
         q_program = QuantumProgram()
-        name = q_program.load_qasm_file(self.QASM_FILE_PATH, name="")
+        name = q_program.load_qasm_file(self.qasm_file_path, name="")
         result = q_program.get_circuit(name)
         to_check = result.qasm()
         self.log.info(to_check)
@@ -551,64 +551,64 @@ class TestQuantumProgram(QiskitTestCase):
     ###############################################################
 
     @requires_qe_access
-    def test_setup_api(self, QE_TOKEN, QE_URL,
+    def test_setup_api(self, qe_token, qe_url,
                        hub=None, group=None, project=None):
         """Check the api is set up.
 
         If all correct is should be true.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         config = q_program.get_api_config()
         self.assertTrue(config)
 
     @requires_qe_access
-    def test_available_backends_exist(self, QE_TOKEN, QE_URL,
+    def test_available_backends_exist(self, qe_token, qe_url,
                                       hub=None, group=None, project=None):
         """Test if there are available backends.
 
         If all correct some should exists (even if offline).
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         available_backends = q_program.available_backends()
         self.assertTrue(available_backends)
 
     @requires_qe_access
-    def test_online_backends_exist(self, QE_TOKEN, QE_URL,
+    def test_online_backends_exist(self, qe_token, qe_url,
                                    hub=None, group=None, project=None):
         """Test if there are online backends.
 
         If all correct some should exists.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         online_backends = q_program.online_backends()
         self.log.info(online_backends)
         self.assertTrue(online_backends)
 
     @requires_qe_access
-    def test_online_simulators(self, QE_TOKEN, QE_URL,
+    def test_online_simulators(self, qe_token, qe_url,
                                hub=None, group=None, project=None):
         """Test if there are online backends (which are simulators).
 
         If all correct some should exists. NEED internet connection for this.
         """
         qp = QuantumProgram(specs=self.QPS_SPECS)
-        qp.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        qp.set_api(qe_token, qe_url, hub, group, project)
         online_simulators = qp.online_simulators()
         self.log.info(online_simulators)
         self.assertTrue(isinstance(online_simulators, list))
 
     @requires_qe_access
-    def test_online_devices(self, QE_TOKEN, QE_URL,
+    def test_online_devices(self, qe_token, qe_url,
                             hub=None, group=None, project=None):
         """Test if there are online backends (which are devices).
 
         If all correct some should exists. NEED internet connection for this.
         """
         qp = QuantumProgram(specs=self.QPS_SPECS)
-        qp.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        qp.set_api(qe_token, qe_url, hub, group, project)
         online_devices = qp.online_devices()
         self.log.info(online_devices)
         self.assertTrue(isinstance(online_devices, list))
@@ -643,7 +643,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertTrue(config_keys < backend_config.keys())
 
     @requires_qe_access
-    def test_get_backend_configuration_online(self, QE_TOKEN, QE_URL,
+    def test_get_backend_configuration_online(self, qe_token, qe_url,
                                               hub=None, group=None, project=None):
         """Test configuration.
 
@@ -653,7 +653,7 @@ class TestQuantumProgram(QiskitTestCase):
         qp = QuantumProgram(specs=self.QPS_SPECS)
         config_keys = {'name', 'simulator', 'local', 'description',
                        'coupling_map', 'basis_gates'}
-        qp.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        qp.set_api(qe_token, qe_url, hub, group, project)
         backend_list = qp.available_backends()
         backend_list.remove('ibmq_qasm_simulator')
         if backend_list:
@@ -671,14 +671,14 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertRaises(LookupError, qp.get_backend_configuration, "fail")
 
     @requires_qe_access
-    def test_get_backend_calibration(self, QE_TOKEN, QE_URL,
+    def test_get_backend_calibration(self, qe_token, qe_url,
                                      hub=None, group=None, project=None):
         """Test get_backend_calibration.
 
         If all correct should return dictionary on length 4.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend_list = q_program.online_devices()
         if backend_list:
             backend = backend_list[0]
@@ -687,14 +687,14 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(len(result), 4)
 
     @requires_qe_access
-    def test_get_backend_parameters(self, QE_TOKEN, QE_URL,
+    def test_get_backend_parameters(self, qe_token, qe_url,
                                     hub=None, group=None, project=None):
         """Test get_backend_parameters.
 
         If all correct should return dictionary on length 4.
         """
         q_program = QuantumProgram(specs=self.QPS_SPECS)
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend_list = q_program.online_devices()
         if backend_list:
             backend = backend_list[0]
@@ -1065,7 +1065,7 @@ class TestQuantumProgram(QiskitTestCase):
         initial_layout = {("q", 0): ("q", 0), ("q", 1): ("q", 1),
                           ("q", 2): ("q", 2), ("q", 3): ("q", 3),
                           ("q", 4): ("q", 4)}
-        q_program.load_qasm_file(self.QASM_FILE_PATH_2, name="circuit-dev")
+        q_program.load_qasm_file(self.qasm_file_path_2, name="circuit-dev")
         circuits = ["circuit-dev"]
         qobj = q_program.compile(circuits, backend=backend, shots=shots,
                                  max_credits=max_credits, seed=65,
@@ -1087,7 +1087,7 @@ class TestQuantumProgram(QiskitTestCase):
         initial_layout = {("q", 0): ("q", 0), ("q", 1): ("q", 1),
                           ("q", 2): ("q", 2), ("q", 3): ("q", 3),
                           ("q", 4): ("q", 4)}
-        q_program.load_qasm_file(self.QASM_FILE_PATH_2, "circuit-dev")
+        q_program.load_qasm_file(self.qasm_file_path_2, "circuit-dev")
         circuits = ["circuit-dev"]
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    max_credits=max_credits,
@@ -1123,7 +1123,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertAlmostEqual(mean_iz, 0, places=1)
 
     @requires_qe_access
-    def test_execute_one_circuit_simulator_online(self, QE_TOKEN, QE_URL,
+    def test_execute_one_circuit_simulator_online(self, qe_token, qe_url,
                                                   hub=None, group=None, project=None):
         """Test execute_one_circuit_simulator_online.
 
@@ -1136,7 +1136,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc.h(qr[0])
         qc.measure(qr[0], cr[0])
         shots = 1024
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend = 'ibmq_qasm_simulator'
         result = q_program.execute(['qc'], backend=backend,
                                    shots=shots, max_credits=3,
@@ -1147,7 +1147,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertDictAlmostEqual(counts, target, threshold)
 
     @requires_qe_access
-    def test_simulator_online_size(self, QE_TOKEN, QE_URL,
+    def test_simulator_online_size(self, qe_token, qe_url,
                                    hub=None, group=None, project=None):
         """Test test_simulator_online_size.
 
@@ -1161,13 +1161,13 @@ class TestQuantumProgram(QiskitTestCase):
         qc.h(qr)
         qc.measure(qr, cr)
         shots = 1
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         result = q_program.execute(['qc'], backend=backend_name, shots=shots,
                                    max_credits=3, seed=73846087)
         self.assertRaises(QISKitError, result.get_data, 'qc')
 
     @requires_qe_access
-    def test_execute_several_circuits_simulator_online(self, QE_TOKEN, QE_URL,
+    def test_execute_several_circuits_simulator_online(self, qe_token, qe_url,
                                                        hub=None, group=None, project=None):
         """Test execute_several_circuits_simulator_online.
 
@@ -1187,7 +1187,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(qr[1], cr[1])
         circuits = ['qc1', 'qc2']
         shots = 1024
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend = 'ibmq_qasm_simulator'
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    max_credits=3, seed=1287126141)
@@ -1201,7 +1201,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertDictAlmostEqual(counts2, target2, threshold)
 
     @requires_qe_access
-    def test_execute_one_circuit_real_online(self, QE_TOKEN, QE_URL,
+    def test_execute_one_circuit_real_online(self, qe_token, qe_url,
                                              hub=None, group=None, project=None):
         """Test execute_one_circuit_real_online.
 
@@ -1213,7 +1213,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc = q_program.create_circuit("circuitName", [qr], [cr])
         qc.h(qr)
         qc.measure(qr[0], cr[0])
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend = 'ibmq_qasm_simulator'
         shots = 1
         status = q_program.get_backend_status(backend)
@@ -1261,7 +1261,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertEqual(result2, {'10 00': 1024})
 
     @requires_qe_access
-    def test_online_qasm_simulator_two_registers(self, QE_TOKEN, QE_URL,
+    def test_online_qasm_simulator_two_registers(self, qe_token, qe_url,
                                                  hub=None, group=None, project=None):
         """Test online_qasm_simulator_two_registers.
 
@@ -1287,7 +1287,7 @@ class TestQuantumProgram(QiskitTestCase):
         qc2.measure(q2[1], c2[1])
         circuits = ['qc1', 'qc2']
         shots = 1024
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         backend = 'ibmq_qasm_simulator'
         result = q_program.execute(circuits, backend=backend, shots=shots,
                                    seed=8458)
@@ -1621,7 +1621,7 @@ class TestQuantumProgram(QiskitTestCase):
                           timeout=0.01)
 
     @requires_qe_access
-    def test_hpc_parameter_is_correct(self, QE_TOKEN, QE_URL,
+    def test_hpc_parameter_is_correct(self, qe_token, qe_url,
                                       hub=None, group=None, project=None):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmq_qasm_simulator (HPC).
@@ -1639,7 +1639,7 @@ class TestQuantumProgram(QiskitTestCase):
         circuits = ['qc2']
         shots = 1
         backend = 'ibmq_qasm_simulator'
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         qobj = q_program.compile(circuits, backend=backend, shots=shots,
                                  seed=88,
                                  hpc={'multi_shot_optimization': True,
@@ -1647,7 +1647,7 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertTrue(qobj)
 
     @requires_qe_access
-    def test_hpc_parameter_is_incorrect(self, QE_TOKEN, QE_URL,
+    def test_hpc_parameter_is_incorrect(self, qe_token, qe_url,
                                         hub=None, group=None, project=None):
         """Test for checking HPC parameter in compile() method.
         It must be only used when the backend is ibmq_qasm_simulator (HPC).
@@ -1664,7 +1664,7 @@ class TestQuantumProgram(QiskitTestCase):
         circuits = ['qc2']
         shots = 1
         backend = 'ibmq_qasm_simulator'
-        q_program.set_api(QE_TOKEN, QE_URL, hub, group, project)
+        q_program.set_api(qe_token, qe_url, hub, group, project)
         self.assertRaises(QISKitError, q_program.compile, circuits,
                           backend=backend, shots=shots, seed=88,
                           hpc={'invalid_key': None})

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -225,9 +225,9 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertNotIn('c1', q_program.get_classical_register_names())
 
         # Destroying an invalid register should fail.
-        with self.assertRaises(QISKitError) as context:
+        with self.assertRaises(QISKitError) as context_manager:
             q_program.destroy_classical_register('c1')
-        self.assertIn('Not present', str(context.exception))
+        self.assertIn('Not present', str(context_manager.exception))
 
     def test_destroy_quantum_register(self):
         """Test destroy_quantum_register."""
@@ -238,9 +238,9 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertNotIn('q1', q_program.get_quantum_register_names())
 
         # Destroying an invalid register should fail.
-        with self.assertRaises(QISKitError) as context:
+        with self.assertRaises(QISKitError) as context_manager:
             q_program.destroy_quantum_register('q1')
-        self.assertIn('Not present', str(context.exception))
+        self.assertIn('Not present', str(context_manager.exception))
 
     def test_create_circuit(self):
         """Test create_circuit.
@@ -291,9 +291,9 @@ class TestQuantumProgram(QiskitTestCase):
         self.assertNotIn('qc', q_program.get_circuit_names())
 
         # Destroying an invalid register should fail.
-        with self.assertRaises(QISKitError) as context:
+        with self.assertRaises(QISKitError) as context_manager:
             q_program.destroy_circuit('qc')
-        self.assertIn('Not present', str(context.exception))
+        self.assertIn('Not present', str(context_manager.exception))
 
     def test_load_qasm_file(self):
         """Test load_qasm_file and get_circuit.

--- a/test/python/test_registration.py
+++ b/test/python/test_registration.py
@@ -35,10 +35,10 @@ class TestWrapperCredentials(QiskitTestCase):
     def test_autoregister_no_credentials(self):
         """Test register() with no credentials available."""
         with no_file('Qconfig.py'), custom_qiskitrc(), no_envs():
-            with self.assertRaises(QISKitError) as context:
+            with self.assertRaises(QISKitError) as context_manager:
                 qiskit.wrapper.register()
 
-        self.assertIn('No IBMQ credentials found', str(context.exception))
+        self.assertIn('No IBMQ credentials found', str(context_manager.exception))
 
     def test_store_credentials(self):
         """Test storing credentials and using them for autoregister."""
@@ -54,9 +54,9 @@ class TestWrapperCredentials(QiskitTestCase):
         with custom_qiskitrc():
             qiskit.wrapper.store_credentials('QISKITRC_TOKEN', hub='HUB')
             # Attempt overwriting.
-            with self.assertRaises(QISKitError) as context:
+            with self.assertRaises(QISKitError) as context_manager:
                 qiskit.wrapper.store_credentials('QISKITRC_TOKEN')
-            self.assertIn('already present', str(context.exception))
+            self.assertIn('already present', str(context_manager.exception))
 
             with no_file('Qconfig.py'), no_envs(), mock_ibmq_provider():
                 # Attempt overwriting.

--- a/test/python/test_registration.py
+++ b/test/python/test_registration.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
 
 """
 Test the registration and credentials features of the wrapper.
@@ -36,10 +35,10 @@ class TestWrapperCredentials(QiskitTestCase):
     def test_autoregister_no_credentials(self):
         """Test register() with no credentials available."""
         with no_file('Qconfig.py'), custom_qiskitrc(), no_envs():
-            with self.assertRaises(QISKitError) as cm:
+            with self.assertRaises(QISKitError) as context:
                 qiskit.wrapper.register()
 
-        self.assertIn('No IBMQ credentials found', str(cm.exception))
+        self.assertIn('No IBMQ credentials found', str(context.exception))
 
     def test_store_credentials(self):
         """Test storing credentials and using them for autoregister."""
@@ -55,9 +54,9 @@ class TestWrapperCredentials(QiskitTestCase):
         with custom_qiskitrc():
             qiskit.wrapper.store_credentials('QISKITRC_TOKEN', hub='HUB')
             # Attempt overwriting.
-            with self.assertRaises(QISKitError) as cm:
+            with self.assertRaises(QISKitError) as context:
                 qiskit.wrapper.store_credentials('QISKITRC_TOKEN')
-            self.assertIn('already present', str(cm.exception))
+            self.assertIn('already present', str(context.exception))
 
             with no_file('Qconfig.py'), no_envs(), mock_ibmq_provider():
                 # Attempt overwriting.
@@ -136,13 +135,13 @@ def custom_qiskitrc(contents=b''):
     tmp_file.flush()
 
     # Temporarily modify the default location of the qiskitrc file.
-    DEFAULT_QISKITRC_FILE_original = _configrc.DEFAULT_QISKITRC_FILE
+    default_qiskitrc_file_original = _configrc.DEFAULT_QISKITRC_FILE
     _configrc.DEFAULT_QISKITRC_FILE = tmp_file.name
     yield
 
     # Delete the temporary file and restore the default location.
     tmp_file.close()
-    _configrc.DEFAULT_QISKITRC_FILE = DEFAULT_QISKITRC_FILE_original
+    _configrc.DEFAULT_QISKITRC_FILE = default_qiskitrc_file_original
 
 
 @contextmanager
@@ -154,13 +153,13 @@ def custom_qconfig(contents=b''):
     tmp_file.flush()
 
     # Temporarily modify the default location of the qiskitrc file.
-    DEFAULT_QCONFIG_FILE_original = _qconfig.DEFAULT_QCONFIG_FILE
+    default_qconfig_file_original = _qconfig.DEFAULT_QCONFIG_FILE
     _qconfig.DEFAULT_QCONFIG_FILE = tmp_file.name
     yield
 
     # Delete the temporary file and restore the default location.
     tmp_file.close()
-    _qconfig.DEFAULT_QCONFIG_FILE = DEFAULT_QCONFIG_FILE_original
+    _qconfig.DEFAULT_QCONFIG_FILE = default_qconfig_file_original
 
 
 @contextmanager

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,no-value-for-parameter,broad-except
+# pylint: disable=no-value-for-parameter,broad-except
 
 """Tests for bit reordering fix."""
 
@@ -24,24 +24,24 @@ class TestBitReordering(QiskitTestCase):
     """
     @slow_test
     @requires_qe_access
-    def test_basic_reordering(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_basic_reordering(self, qe_token, qe_url, hub=None, group=None, project=None):
         """a simple reordering within a 2-qubit register"""
         sim_backend_name, real_backend_name = self._get_backends(
-            QE_TOKEN, QE_URL, hub, group, project)
+            qe_token, qe_url, hub, group, project)
         sim = get_backend(sim_backend_name)
         real = get_backend(real_backend_name)
         if not sim or not real:
             raise unittest.SkipTest('no remote device available')
-        q = qiskit.QuantumRegister(2)
-        c = qiskit.ClassicalRegister(2)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.measure(q[0], c[1])
-        circ.measure(q[1], c[0])
+        qr = qiskit.QuantumRegister(2)
+        cr = qiskit.ClassicalRegister(2)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.measure(qr[0], cr[1])
+        circuit.measure(qr[1], cr[0])
 
         shots = 2000
-        qobj_real = transpiler.compile(circ, real, shots=shots)
-        qobj_sim = transpiler.compile(circ, sim, shots=shots)
+        qobj_real = transpiler.compile(circuit, real, shots=shots)
+        qobj_sim = transpiler.compile(circuit, sim, shots=shots)
         result_real = real.run(qobj_real).result(timeout=600)
         result_sim = sim.run(qobj_sim).result(timeout=600)
         counts_real = result_real.get_counts()
@@ -53,38 +53,38 @@ class TestBitReordering(QiskitTestCase):
 
     @slow_test
     @requires_qe_access
-    def test_multi_register_reordering(self, QE_TOKEN, QE_URL,
+    def test_multi_register_reordering(self, qe_token, qe_url,
                                        hub=None, group=None, project=None):
         """a more complicated reordering across 3 registers of different sizes"""
         sim_backend_name, real_backend_name = self._get_backends(
-            QE_TOKEN, QE_URL, hub, group, project)
+            qe_token, qe_url, hub, group, project)
         if not sim_backend_name or not real_backend_name:
             raise unittest.SkipTest('no remote device available')
         sim = get_backend(sim_backend_name)
         real = get_backend(real_backend_name)
 
-        q0 = qiskit.QuantumRegister(2)
-        q1 = qiskit.QuantumRegister(2)
-        q2 = qiskit.QuantumRegister(1)
-        c0 = qiskit.ClassicalRegister(2)
-        c1 = qiskit.ClassicalRegister(2)
-        c2 = qiskit.ClassicalRegister(1)
-        circ = qiskit.QuantumCircuit(q0, q1, q2, c0, c1, c2)
-        circ.h(q0[0])
-        circ.cx(q0[0], q2[0])
-        circ.x(q1[1])
-        circ.h(q2[0])
-        circ.ccx(q2[0], q1[1], q1[0])
-        circ.barrier()
-        circ.measure(q0[0], c2[0])
-        circ.measure(q0[1], c0[1])
-        circ.measure(q1[0], c0[0])
-        circ.measure(q1[1], c1[0])
-        circ.measure(q2[0], c1[1])
+        qr0 = qiskit.QuantumRegister(2)
+        qr1 = qiskit.QuantumRegister(2)
+        qr2 = qiskit.QuantumRegister(1)
+        cr0 = qiskit.ClassicalRegister(2)
+        cr1 = qiskit.ClassicalRegister(2)
+        cr2 = qiskit.ClassicalRegister(1)
+        circuit = qiskit.QuantumCircuit(qr0, qr1, qr2, cr0, cr1, cr2)
+        circuit.h(qr0[0])
+        circuit.cx(qr0[0], qr2[0])
+        circuit.x(qr1[1])
+        circuit.h(qr2[0])
+        circuit.ccx(qr2[0], qr1[1], qr1[0])
+        circuit.barrier()
+        circuit.measure(qr0[0], cr2[0])
+        circuit.measure(qr0[1], cr0[1])
+        circuit.measure(qr1[0], cr0[0])
+        circuit.measure(qr1[1], cr1[0])
+        circuit.measure(qr2[0], cr1[1])
 
         shots = 4000
-        qobj_real = transpiler.compile(circ, real, shots=shots)
-        qobj_sim = transpiler.compile(circ, sim, shots=shots)
+        qobj_real = transpiler.compile(circuit, real, shots=shots)
+        qobj_sim = transpiler.compile(circuit, sim, shots=shots)
         result_real = real.run(qobj_real).result(timeout=600)
         result_sim = sim.run(qobj_sim).result(timeout=600)
         counts_real = result_real.get_counts()
@@ -92,10 +92,10 @@ class TestBitReordering(QiskitTestCase):
         threshold = 0.2 * shots
         self.assertDictAlmostEqual(counts_real, counts_sim, threshold)
 
-    def _get_backends(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def _get_backends(self, qe_token, qe_url, hub=None, group=None, project=None):
         sim_backend = 'local_qasm_simulator'
         try:
-            register(QE_TOKEN, QE_URL, hub, group, project)
+            register(qe_token, qe_url, hub, group, project)
             real_backends = available_backends({'simulator': False})
             real_backend = least_busy(real_backends)
         except Exception:

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -44,7 +44,7 @@ class TestCrossSimulation(QiskitTestCase):
     @requires_qe_access
     def test_qasm(self, qe_token, qe_url):
         """counts from a GHZ state"""
-        register(qe_token, qe_url, hub, group, project)
+        register(qe_token, qe_url)
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)
         circuit = qiskit.QuantumCircuit(qr, cr)

--- a/test/python/test_simulator_interfaces.py
+++ b/test/python/test_simulator_interfaces.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,unused-import
+# pylint: disable=unused-import
 
 """Tests for checking qiskit interfaces to simulators."""
 
@@ -25,15 +25,15 @@ class TestCrossSimulation(QiskitTestCase):
 
     def test_statevector(self):
         """statevector from a bell state"""
-        q = qiskit.QuantumRegister(2)
-        circ = qiskit.QuantumCircuit(q)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
+        qr = qiskit.QuantumRegister(2)
+        circuit = qiskit.QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
 
         sim_cpp = 'local_statevector_simulator_cpp'
         sim_py = 'local_statevector_simulator_py'
-        result_cpp = execute(circ, sim_cpp).result()
-        result_py = execute(circ, sim_py).result()
+        result_cpp = execute(circuit, sim_cpp).result()
+        result_py = execute(circuit, sim_py).result()
         statevector_cpp = result_cpp.get_statevector()
         statevector_py = result_py.get_statevector()
         fidelity = state_fidelity(statevector_cpp, statevector_py)
@@ -42,24 +42,24 @@ class TestCrossSimulation(QiskitTestCase):
             "cpp vs. py statevector has low fidelity{0:.2g}.".format(fidelity))
 
     @requires_qe_access
-    def test_qasm(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_qasm(self, qe_token, qe_url, hub=None, group=None, project=None):
         """counts from a GHZ state"""
-        register(QE_TOKEN, QE_URL, hub, group, project)
-        q = qiskit.QuantumRegister(3)
-        c = qiskit.ClassicalRegister(3)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.cx(q[1], q[2])
-        circ.measure(q, c)
+        register(qe_token, qe_url, hub, group, project)
+        qr = qiskit.QuantumRegister(3)
+        cr = qiskit.ClassicalRegister(3)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+        circuit.measure(qr, cr)
 
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'
         sim_ibmq = 'ibmq_qasm_simulator'
         shots = 2000
-        result_cpp = execute(circ, sim_cpp, shots=shots).result()
-        result_py = execute(circ, sim_py, shots=shots).result()
-        result_ibmq = execute(circ, sim_ibmq, shots=shots).result()
+        result_cpp = execute(circuit, sim_cpp, shots=shots).result()
+        result_py = execute(circuit, sim_py, shots=shots).result()
+        result_ibmq = execute(circuit, sim_ibmq, shots=shots).result()
         counts_cpp = result_cpp.get_counts()
         counts_py = result_py.get_counts()
         counts_ibmq = result_ibmq.get_counts()
@@ -68,22 +68,22 @@ class TestCrossSimulation(QiskitTestCase):
 
     def test_qasm_snapshot(self):
         """snapshot a circuit at multiple places"""
-        q = qiskit.QuantumRegister(3)
-        c = qiskit.ClassicalRegister(3)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.snapshot(1)
-        circ.ccx(q[0], q[1], q[2])
-        circ.snapshot(2)
-        circ.reset(q)
-        circ.snapshot(3)
-        circ.measure(q, c)
+        qr = qiskit.QuantumRegister(3)
+        cr = qiskit.ClassicalRegister(3)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.snapshot(1)
+        circuit.ccx(qr[0], qr[1], qr[2])
+        circuit.snapshot(2)
+        circuit.reset(qr)
+        circuit.snapshot(3)
+        circuit.measure(qr, cr)
 
         sim_cpp = 'local_qasm_simulator_cpp'
         sim_py = 'local_qasm_simulator_py'
-        result_cpp = execute(circ, sim_cpp, shots=2).result()
-        result_py = execute(circ, sim_py, shots=2).result()
+        result_cpp = execute(circuit, sim_cpp, shots=2).result()
+        result_py = execute(circuit, sim_py, shots=2).result()
         snapshots_cpp = result_cpp.get_snapshots()
         snapshots_py = result_py.get_snapshots()
         self.assertEqual(snapshots_cpp.keys(), snapshots_py.keys())
@@ -94,20 +94,20 @@ class TestCrossSimulation(QiskitTestCase):
         self.assertGreater(fidelity, self._desired_fidelity)
 
     @requires_qe_access
-    def test_qasm_reset_measure(self, QE_TOKEN, QE_URL, hub=None, group=None, project=None):
+    def test_qasm_reset_measure(self, qe_token, qe_url, hub=None, group=None, project=None):
         """counts from a qasm program with measure and reset in the middle"""
-        register(QE_TOKEN, QE_URL, hub, group, project)
-        q = qiskit.QuantumRegister(3)
-        c = qiskit.ClassicalRegister(3)
-        circ = qiskit.QuantumCircuit(q, c)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.reset(q[0])
-        circ.cx(q[1], q[2])
-        circ.t(q)
-        circ.measure(q[1], c[1])
-        circ.h(q[2])
-        circ.measure(q[2], c[2])
+        register(qe_token, qe_url, hub, group, project)
+        qr = qiskit.QuantumRegister(3)
+        cr = qiskit.ClassicalRegister(3)
+        circuit = qiskit.QuantumCircuit(qr, cr)
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.reset(qr[0])
+        circuit.cx(qr[1], qr[2])
+        circuit.t(qr)
+        circuit.measure(qr[1], cr[1])
+        circuit.h(qr[2])
+        circuit.measure(qr[2], cr[2])
 
         # TODO: bring back online simulator tests when reset/measure doesn't
         # get rejected by the api
@@ -115,8 +115,8 @@ class TestCrossSimulation(QiskitTestCase):
         sim_py = 'local_qasm_simulator_py'
         # sim_ibmq = 'ibmq_qasm_simulator'
         shots = 1000
-        result_cpp = execute(circ, sim_cpp, shots=shots, seed=1).result()
-        result_py = execute(circ, sim_py, shots=shots, seed=1).result()
+        result_cpp = execute(circuit, sim_cpp, shots=shots, seed=1).result()
+        result_py = execute(circuit, sim_py, shots=shots, seed=1).result()
         # result_ibmq = execute(circ, sim_ibmq, {'shots': shots}).result()
         counts_cpp = result_cpp.get_counts()
         counts_py = result_py.get_counts()

--- a/test/python/test_skip_transpiler.py
+++ b/test/python/test_skip_transpiler.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 import unittest
 
@@ -22,34 +22,34 @@ class CompileSkipTranslationTest(QiskitTestCase):
         Compares with and without skip_transpiler
         """
         name = 'test_simple'
-        qp = QuantumProgram()
-        qr = qp.create_quantum_register('qr', 2)
-        cr = qp.create_classical_register('cr', 2)
-        qc = qp.create_circuit(name, [qr], [cr])
+        qprogram = QuantumProgram()
+        qr = qprogram.create_quantum_register('qr', 2)
+        cr = qprogram.create_classical_register('cr', 2)
+        qc = qprogram.create_circuit(name, [qr], [cr])
         qc.u1(3.14, qr[0])
         qc.u2(3.14, 1.57, qr[0])
         qc.measure(qr, cr)
 
-        rtrue = qp.compile([name], backend='local_qasm_simulator', shots=1024,
-                           skip_transpiler=True)
-        rfalse = qp.compile([name], backend='local_qasm_simulator', shots=1024,
-                            skip_transpiler=False)
+        rtrue = qprogram.compile([name], backend='local_qasm_simulator', shots=1024,
+                                 skip_transpiler=True)
+        rfalse = qprogram.compile([name], backend='local_qasm_simulator', shots=1024,
+                                  skip_transpiler=False)
         self.assertEqual(rtrue.config, rfalse.config)
         self.assertEqual(rtrue.experiments, rfalse.experiments)
 
     def test_simple_execute(self):
         name = 'test_simple'
         seed = 42
-        qp = QuantumProgram()
-        qr = qp.create_quantum_register('qr', 2)
-        cr = qp.create_classical_register('cr', 2)
-        qc = qp.create_circuit(name, [qr], [cr])
+        qprogram = QuantumProgram()
+        qr = qprogram.create_quantum_register('qr', 2)
+        cr = qprogram.create_classical_register('cr', 2)
+        qc = qprogram.create_circuit(name, [qr], [cr])
         qc.u1(3.14, qr[0])
         qc.u2(3.14, 1.57, qr[0])
         qc.measure(qr, cr)
 
-        rtrue = qp.execute(name, seed=seed, skip_transpiler=True)
-        rfalse = qp.execute(name, seed=seed, skip_transpiler=False)
+        rtrue = qprogram.execute(name, seed=seed, skip_transpiler=True)
+        rfalse = qprogram.execute(name, seed=seed, skip_transpiler=False)
         self.assertEqual(rtrue.get_counts(), rfalse.get_counts())
 
 

--- a/test/python/test_statevector_simulator_cpp.py
+++ b/test/python/test_statevector_simulator_cpp.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring,broad-except
+# pylint: disable=missing-docstring,broad-except
 
 import unittest
 from qiskit import execute, load_qasm_file

--- a/test/python/test_tomography.py
+++ b/test/python/test_tomography.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """Test of QCVV/tomography module."""
 
@@ -41,27 +41,27 @@ class TestTomography(QiskitTestCase):
         # Tomography set
         tomo_set = tomo.state_tomography_set([0])
         # Get test circuits
-        qp, qr, cr = _test_circuits_1qubit()
+        qprogram, qr, cr = _test_circuits_1qubit()
         # Test simulation and fitting
         shots = 2000
         threshold = 1e-2
-        rho = _tomography_test_data(qp, 'Zp', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Zp', qr, cr, tomo_set, shots)
         self.assertTrue(_tomography_test_fit(rho, [1, 0], threshold))
-        rho = _tomography_test_data(qp, 'Zm', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Zm', qr, cr, tomo_set, shots)
         self.assertTrue(_tomography_test_fit(rho, [0, 1], threshold))
-        rho = _tomography_test_data(qp, 'Xp', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Xp', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(rho, [1 / np.sqrt(2), 1 / np.sqrt(2)],
                                  threshold))
-        rho = _tomography_test_data(qp, 'Xm', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Xm', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(rho, [1 / np.sqrt(2), -1 / np.sqrt(2)],
                                  threshold))
-        rho = _tomography_test_data(qp, 'Yp', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Yp', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(rho, [1 / np.sqrt(2), 1j / np.sqrt(2)],
                                  threshold))
-        rho = _tomography_test_data(qp, 'Ym', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Ym', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(rho, [1 / np.sqrt(2), -1j / np.sqrt(2)],
                                  threshold))
@@ -70,30 +70,30 @@ class TestTomography(QiskitTestCase):
         # Tomography set
         tomo_set = tomo.state_tomography_set([0, 1])
         # Get test circuits
-        qp, qr, cr = _test_circuits_2qubit()
+        qprogram, qr, cr = _test_circuits_2qubit()
         shots = 2000
         threshold = 1e-2
         # Test simulation and fitting
-        rho = _tomography_test_data(qp, 'Bell', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'Bell', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(rho, [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)],
                                  threshold))
-        rho = _tomography_test_data(qp, 'X1Id0', qr, cr, tomo_set, shots)
+        rho = _tomography_test_data(qprogram, 'X1Id0', qr, cr, tomo_set, shots)
         self.assertTrue(_tomography_test_fit(rho, [0, 0, 1, 0], threshold))
 
     def test_process_tomography_1qubit(self):
         # Tomography set
         tomo_set = tomo.process_tomography_set([0])
         # Get test circuits
-        qp, qr, cr = _test_circuits_1qubit()
+        qprogram, qr, cr = _test_circuits_1qubit()
         # Test simulation and fitting
         shots = 2000
         threshold = 1e-2
-        choi = _tomography_test_data(qp, 'Zp', qr, cr, tomo_set, shots)
+        choi = _tomography_test_data(qprogram, 'Zp', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(choi, [1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)],
                                  threshold))
-        choi = _tomography_test_data(qp, 'Xp', qr, cr, tomo_set, shots)
+        choi = _tomography_test_data(qprogram, 'Xp', qr, cr, tomo_set, shots)
         self.assertTrue(
             _tomography_test_fit(choi, [0.5, 0.5, 0.5, -0.5], threshold))
 
@@ -101,20 +101,20 @@ class TestTomography(QiskitTestCase):
         # Tomography set
         tomo_set = tomo.process_tomography_set([0, 1])
         # Get test circuits
-        qp, qr, cr = _test_circuits_2qubit()
+        qprogram, qr, cr = _test_circuits_2qubit()
         # Test simulation and fitting
         shots = 1000
         threshold = 0.015
-        ref_X1Id0 = np.array(
+        ref_x1_id0 = np.array(
             [0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0]) / 2
-        choi = _tomography_test_data(qp, 'X1Id0', qr, cr, tomo_set, shots)
-        self.assertTrue(_tomography_test_fit(choi, ref_X1Id0, threshold))
+        choi = _tomography_test_data(qprogram, 'X1Id0', qr, cr, tomo_set, shots)
+        self.assertTrue(_tomography_test_fit(choi, ref_x1_id0, threshold))
 
 
-def _tomography_test_data(qp, name, qr, cr, tomoset, shots):
-    tomo.create_tomography_circuits(qp, name, qr, cr, tomoset)
-    result = qp.execute(tomo.tomography_circuit_names(tomoset, name),
-                        shots=shots, seed=42, timeout=180)
+def _tomography_test_data(qprogram, name, qr, cr, tomoset, shots):
+    tomo.create_tomography_circuits(qprogram, name, qr, cr, tomoset)
+    result = qprogram.execute(tomo.tomography_circuit_names(tomoset, name),
+                              shots=shots, seed=42, timeout=180)
     data = tomo.tomography_data(result, name, tomoset)
     return tomo.fit_tomography_data(data)
 
@@ -126,43 +126,43 @@ def _tomography_test_fit(fitted_rho, ref_state_vector, threshold=1e-2):
 
 
 def _test_circuits_1qubit():
-    qp = QuantumProgram()
-    qr = qp.create_quantum_register('qr', 1)
-    cr = qp.create_classical_register('cr', 1)
+    qprogram = QuantumProgram()
+    qr = qprogram.create_quantum_register('qr', 1)
+    cr = qprogram.create_classical_register('cr', 1)
 
     # Test Circuits Z eigenstate
-    circ = qp.create_circuit('Zp', [qr], [cr])
-    circ = qp.create_circuit('Zm', [qr], [cr])
+    circ = qprogram.create_circuit('Zp', [qr], [cr])
+    circ = qprogram.create_circuit('Zm', [qr], [cr])
     circ.x(qr[0])
     # Test Circuits X eigenstate
-    circ = qp.create_circuit('Xp', [qr], [cr])
+    circ = qprogram.create_circuit('Xp', [qr], [cr])
     circ.h(qr[0])
-    circ = qp.create_circuit('Xm', [qr], [cr])
+    circ = qprogram.create_circuit('Xm', [qr], [cr])
     circ.h(qr[0])
     circ.z(qr[0])
     # Test Circuits Y eigenstate
-    circ = qp.create_circuit('Yp', [qr], [cr])
+    circ = qprogram.create_circuit('Yp', [qr], [cr])
     circ.h(qr[0])
     circ.s(qr[0])
-    circ = qp.create_circuit('Ym', [qr], [cr])
+    circ = qprogram.create_circuit('Ym', [qr], [cr])
     circ.h(qr[0])
     circ.s(qr[0])
     circ.z(qr[0])
-    return qp, qr, cr
+    return qprogram, qr, cr
 
 
 def _test_circuits_2qubit():
-    qp = QuantumProgram()
-    qr = qp.create_quantum_register('qr', 2)
-    cr = qp.create_classical_register('cr', 2)
+    qprogram = QuantumProgram()
+    qr = qprogram.create_quantum_register('qr', 2)
+    cr = qprogram.create_classical_register('cr', 2)
 
     # Test Circuits Bell state
-    circ = qp.create_circuit('Bell', [qr], [cr])
+    circ = qprogram.create_circuit('Bell', [qr], [cr])
     circ.h(qr[0])
     circ.cx(qr[0], qr[1])
-    circ = qp.create_circuit('X1Id0', [qr], [cr])
+    circ = qprogram.create_circuit('X1Id0', [qr], [cr])
     circ.x(qr[1])
-    return qp, qr, cr
+    return qprogram, qr, cr
 
 
 if __name__ == '__main__':

--- a/test/python/test_transpiler.py
+++ b/test/python/test_transpiler.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
 
 # Copyright 2018, IBM.
 #
@@ -26,15 +25,15 @@ class TestTranspiler(QiskitTestCase):
 
         It should perform no transformations on the circuit.
         """
-        q = QuantumRegister(2)
-        circ = QuantumCircuit(q)
-        circ.h(q[0])
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        dag_circuit = DAGCircuit.fromQuantumCircuit(circ)
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
         resources_before = dag_circuit.count_ops()
 
         pass_manager = PassManager()
@@ -50,24 +49,24 @@ class TestTranspiler(QiskitTestCase):
         unroll, swap_mapper, direction_mapper, cx cancellation, optimize_1q_gates
         and should be equivalent to using wrapper.compile
         """
-        q = QuantumRegister(2)
-        circ = QuantumCircuit(q)
-        circ.h(q[0])
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
 
         coupling_map = [[1, 0]]
         basis_gates = 'u1,u2,u3,cx,id'
 
-        dag_circuit = DAGCircuit.fromQuantumCircuit(circ)
+        dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
         dag_circuit = transpile(dag_circuit, coupling_map=coupling_map,
                                 basis_gates=basis_gates, pass_manager=None)
         transpiler_json = DagUnroller(dag_circuit, JsonBackend(dag_circuit.basis)).execute()
 
-        qobj = wrapper.compile(circ, backend='local_qasm_simulator',
+        qobj = wrapper.compile(circuit, backend='local_qasm_simulator',
                                coupling_map=coupling_map, basis_gates=basis_gates)
         compiler_json = qobj.experiments[0].as_dict()
 
@@ -83,17 +82,17 @@ class TestTranspiler(QiskitTestCase):
 
         It should cancel consecutive cx pairs on same qubits.
         """
-        q = QuantumRegister(2)
-        circ = QuantumCircuit(q)
-        circ.h(q[0])
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[0], q[1])
-        circ.cx(q[1], q[0])
-        circ.cx(q[1], q[0])
-        dag_circuit = DAGCircuit.fromQuantumCircuit(circ)
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[0])
+        circuit.cx(qr[1], qr[0])
+        dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
 
         pass_manager = PassManager()
         pass_manager.add_pass(CXCancellation())

--- a/test/python/test_unitary_simulator_py.py
+++ b/test/python/test_unitary_simulator_py.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 # pylint: disable=redefined-builtin
 
 import cProfile
@@ -105,24 +105,24 @@ class LocalUnitarySimulatorTest(QiskitTestCase):
         n_circuits = 100
         max_depth = 40
         max_qubits = 5
-        pr = cProfile.Profile()
+        profile = cProfile.Profile()
         random_circuits = RandomQasmGenerator(seed=self.seed,
                                               max_depth=max_depth,
                                               max_qubits=max_qubits)
         random_circuits.add_circuits(n_circuits, do_measure=False)
-        qp = random_circuits.get_program()
-        pr.enable()
-        qp.execute(qp.get_circuit_names(),
-                   backend=UnitarySimulatorPy())
-        pr.disable()
+        qprogram = random_circuits.get_program()
+        profile.enable()
+        qprogram.execute(qprogram.get_circuit_names(),
+                         backend=UnitarySimulatorPy())
+        profile.disable()
         sout = io.StringIO()
-        ps = pstats.Stats(pr, stream=sout).sort_stats('cumulative')
+        profile_stats = pstats.Stats(profile, stream=sout).sort_stats('cumulative')
         self.log.info('------- start profiling UnitarySimulatorPy -----------')
-        ps.print_stats()
+        profile_stats.print_stats()
         self.log.info(sout.getvalue())
         self.log.info('------- stop profiling UnitarySimulatorPy -----------')
         sout.close()
-        pr.dump_stats(self.moduleName + '.prof')
+        profile.dump_stats(self.moduleName + '.prof')
 
 
 if __name__ == '__main__':

--- a/test/python/test_unroller.py
+++ b/test/python/test_unroller.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 from sys import version_info
 import unittest
@@ -21,7 +21,7 @@ class UnrollerTest(QiskitTestCase):
 
     def setUp(self):
         self.seed = 42
-        self.qp = QuantumProgram()
+        self.qprogram = QuantumProgram()
 
     @unittest.skipIf(version_info.minor == 5, "Python 3.5 dictionaries don't preserve \
                                                insertion order, so we need to skip this \

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name,missing-docstring
+# pylint: disable=missing-docstring
 
 """Tests for visualization tools."""
 
@@ -61,14 +61,14 @@ class TestLatexSourceGenerator(QiskitTestCase):
                 operands = random.sample(remaining_qubits, num_operands)
                 remaining_qubits = [q for q in remaining_qubits if q not in operands]
                 if num_operands == 1:
-                    op = random.choice(one_q_ops.split(','))
+                    operation = random.choice(one_q_ops.split(','))
                 elif num_operands == 2:
-                    op = random.choice(two_q_ops.split(','))
+                    operation = random.choice(two_q_ops.split(','))
                 elif num_operands == 3:
-                    op = random.choice(three_q_ops.split(','))
+                    operation = random.choice(three_q_ops.split(','))
                 # every gate is defined as a method of the QuantumCircuit class
                 # the code below is so we can call a gate by its name
-                gate = getattr(qiskit.QuantumCircuit, op)
+                gate = getattr(qiskit.QuantumCircuit, operation)
                 op_args = list(signature(gate).parameters.keys())
                 num_angles = len(op_args) - num_operands - 1    # -1 for the 'self' arg
                 angles = [random.uniform(0, 3.14) for x in range(num_angles)]
@@ -129,25 +129,25 @@ class TestLatexSourceGenerator(QiskitTestCase):
 
     def test_teleport(self):
         filename = self._get_resource_path('test_teleport.tex')
-        q = qiskit.QuantumRegister(3, 'q')
-        c = qiskit.ClassicalRegister(3, 'c')
-        qc = qiskit.QuantumCircuit(q, c)
+        qr = qiskit.QuantumRegister(3, 'q')
+        cr = qiskit.ClassicalRegister(3, 'c')
+        qc = qiskit.QuantumCircuit(qr, cr)
         # Prepare an initial state
-        qc.u3(0.3, 0.2, 0.1, q[0])
+        qc.u3(0.3, 0.2, 0.1, qr[0])
         # Prepare a Bell pair
-        qc.h(q[1])
-        qc.cx(q[1], q[2])
+        qc.h(qr[1])
+        qc.cx(qr[1], qr[2])
         # Barrier following state preparation
-        qc.barrier(q)
+        qc.barrier(qr)
         # Measure in the Bell basis
-        qc.cx(q[0], q[1])
-        qc.h(q[0])
-        qc.measure(q[0], c[0])
-        qc.measure(q[1], c[1])
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
         # Apply a correction
-        qc.z(q[2]).c_if(c, 1)
-        qc.x(q[2]).c_if(c, 2)
-        qc.measure(q[2], c[2])
+        qc.z(qr[2]).c_if(cr, 1)
+        qc.x(qr[2]).c_if(cr, 2)
+        qc.measure(qr[2], cr[2])
         try:
             generate_latex_source(qc, filename)
             self.assertNotEqual(os.path.exists(filename), False)

--- a/test/python/test_visualization_output.py
+++ b/test/python/test_visualization_output.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name, missing-docstring
+# pylint: disable=missing-docstring
 
 """Tests for comparing the outputs of visualization tools with expected ones.
 Useful for refactoring purposes."""

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=invalid-name
 
 """Tests for the wrapper functionality."""
 
@@ -26,25 +25,25 @@ from .test_backends import remove_backends_from_list
 class TestWrapper(QiskitTestCase):
     """Wrapper test case."""
     def setUp(self):
-        q = QuantumRegister(3)
-        c = ClassicalRegister(3)
-        self.circuit = QuantumCircuit(q, c)
-        self.circuit.ccx(q[0], q[1], q[2])
-        self.circuit.measure(q, c)
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(3)
+        self.circuit = QuantumCircuit(qr, cr)
+        self.circuit.ccx(qr[0], qr[1], qr[2])
+        self.circuit.measure(qr, cr)
 
     @requires_qe_access
-    def test_wrapper_register_ok(self, QE_TOKEN, QE_URL, hub, group, project):
+    def test_wrapper_register_ok(self, qe_token, qe_url, hub, group, project):
         """Test wrapper.register()."""
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        qiskit.wrapper.register(qe_token, qe_url, hub, group, project)
         backends = qiskit.wrapper.available_backends()
         backends = remove_backends_from_list(backends)
         self.log.info(backends)
         self.assertTrue(len(backends) > 0)
 
     @requires_qe_access
-    def test_backends_with_filter(self, QE_TOKEN, QE_URL, hub, group, project):
+    def test_backends_with_filter(self, qe_token, qe_url, hub, group, project):
         """Test wrapper.available_backends(filter=...)."""
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        qiskit.wrapper.register(qe_token, qe_url, hub, group, project)
         backends = qiskit.wrapper.available_backends({'local': False,
                                                       'simulator': True})
         self.log.info(backends)
@@ -57,12 +56,12 @@ class TestWrapper(QiskitTestCase):
         self.assertTrue(len(local_backends) > 0)
 
     @requires_qe_access
-    def test_register_twice(self, QE_TOKEN, QE_URL, hub, group, project):
+    def test_register_twice(self, qe_token, qe_url, hub, group, project):
         """Test double registration of the same credentials."""
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        qiskit.wrapper.register(qe_token, qe_url, hub, group, project)
         initial_providers = registered_providers()
         # Registering twice should give warning and add no providers.
-        qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        qiskit.wrapper.register(qe_token, qe_url, hub, group, project)
         self.assertCountEqual(initial_providers, registered_providers())
 
     def test_register_bad_credentials(self):
@@ -73,20 +72,20 @@ class TestWrapper(QiskitTestCase):
         self.assertEqual(initial_providers, registered_providers())
 
     @requires_qe_access
-    def test_unregister(self, QE_TOKEN, QE_URL, hub, group, project):
+    def test_unregister(self, qe_token, qe_url, hub, group, project):
         """Test unregistering."""
         initial_providers = registered_providers()
-        ibmqprovider = qiskit.wrapper.register(QE_TOKEN, QE_URL, hub, group, project)
+        ibmqprovider = qiskit.wrapper.register(qe_token, qe_url, hub, group, project)
         self.assertCountEqual(initial_providers + [ibmqprovider],
                               registered_providers())
         qiskit.wrapper.unregister(ibmqprovider)
         self.assertEqual(initial_providers, registered_providers())
 
     @requires_qe_access
-    def test_unregister_non_existent(self, QE_TOKEN, QE_URL, hub, group, project):
+    def test_unregister_non_existent(self, qe_token, qe_url, hub, group, project):
         """Test unregistering a non existent provider."""
         initial_providers = registered_providers()
-        ibmqprovider = IBMQProvider(QE_TOKEN, QE_URL, hub, group, project)
+        ibmqprovider = IBMQProvider(qe_token, qe_url, hub, group, project)
         with self.assertRaises(QISKitError):
             qiskit.wrapper.unregister(ibmqprovider)
         self.assertEqual(initial_providers, registered_providers())


### PR DESCRIPTION
Fix #729

Making the linter accept camelCase `assert*` method names. Also adding
some domain-specific names heavily used across the code base.

Removing as `disable=invalid-name` pylint directives as possible by renaming
some names. It remains:
- test_apps.py : no idea of what some variable names stand for.
- test_qi.py : the same.
- test_quantumprogram : it does not worth touching. It's going to be removed.
- test_localjob.py : legit uses


