### PR TITLE
Fix #519 (use scipy.stats.unitary_group)

### DIFF
--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -18,6 +18,7 @@ import math
 
 import numpy as np
 import scipy.linalg as la
+from scipy.stats import unitary_group
 
 from qiskit import QISKitError
 from qiskit.tools.qi.pauli import pauli_group
@@ -335,8 +336,7 @@ def random_unitary_matrix(length):
     Returns:
         ndarray: U (length, length) unitary ndarray.
     """
-    q_matrix = la.qr(__ginibre_matrix(length))[0]  # Get only the first element
-    return q_matrix
+    return unitary_group.rvs(length)
 
 
 def random_density_matrix(length, rank=None, method='Hilbert-Schmidt'):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

To generate random unitary matrix from a Haar measure, I used scipy.stats.unitary_group.

Corresponding to: #519
