### PR TITLE
Add option to reverse qubit order in latex drawer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 - Introduced new options for handling credentials (qiskitrc file, environment
   variables) and automatic registration. (#547)
 - Add OpenMP parallelization for Apple builds of the cpp simulator (#698).
+- Added option to reverse the qubit order in latex drawer (#762)
 
 Changed
 -------

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -82,7 +82,7 @@ def circuit_drawer(circuit,
 def latex_circuit_drawer(circuit,
                          basis="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
                                "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap",
-                         scale=0.7, filename=None):
+                         scale=0.7, filename=None, reverse_bits=False):
     """Draw a quantum circuit based on latex (Qcircuit package)
 
     Args:
@@ -90,6 +90,7 @@ def latex_circuit_drawer(circuit,
         basis (str): comma separated list of gates
         scale (float): scaling factor
         filename (str): file path to save image to
+        reverse_bits (bool): reverse the order qubits are drawn
 
     Returns:
         PIL.Image: an in-memory representation of the circuit diagram
@@ -102,7 +103,8 @@ def latex_circuit_drawer(circuit,
     tmpfilename = 'circuit'
     with tempfile.TemporaryDirectory() as tmpdirname:
         tmppath = os.path.join(tmpdirname, tmpfilename + '.tex')
-        generate_latex_source(circuit, filename=tmppath, basis=basis, scale=scale)
+        generate_latex_source(circuit, filename=tmppath, basis=basis,
+                              scale=scale, reverse_bits=reverse_bits)
         im = None
         try:
             subprocess.run(["pdflatex", "-output-directory={}".format(tmpdirname),
@@ -162,7 +164,7 @@ def _trim(im):
 def generate_latex_source(circuit, filename=None,
                           basis="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
                           "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap",
-                          scale=0.7):
+                          scale=0.7, reverse_bits=False):
     """Convert QuantumCircuit to LaTeX string.
 
     Args:
@@ -170,6 +172,7 @@ def generate_latex_source(circuit, filename=None,
         scale (float): image scaling
         filename (str): optional filename to write latex
         basis (str): optional comma-separated list of gate names
+        reverse_bits (bool): reverse the order qubits are drawn
 
     Returns:
         str: Latex string appropriate for writing to file.
@@ -181,7 +184,7 @@ def generate_latex_source(circuit, filename=None,
     u = Unroller(ast, JsonBackend(basis))
     u.execute()
     json_circuit = u.backend.circuit
-    qcimg = QCircuitImage(json_circuit, scale)
+    qcimg = QCircuitImage(json_circuit, scale, reverse_bits=reverse_bits)
     latex = qcimg.latex()
     if filename:
         with open(filename, 'w') as latex_file:
@@ -197,11 +200,12 @@ class QCircuitImage(object):
 
     Thanks to Eric Sabo for the initial implementation for QISKit.
     """
-    def __init__(self, circuit, scale):
+    def __init__(self, circuit, scale, reverse_bits=False):
         """
         Args:
             circuit (dict): compiled_circuit from qobj
             scale (float): image scaling
+            reverse_bits (bool): reverse the order qubits are drawn
         """
         # compiled qobj circuit
         self.circuit = circuit
@@ -264,10 +268,32 @@ class QCircuitImage(object):
                 self.clbit_list.append((cr, i))
         self.ordered_regs = [(item[0], item[1]) for
                              item in self.header['qubit_labels']]
+        if reverse_bits:
+            reg_size = []
+            reg_labels = []
+            new_ordered_regs = []
+            for regs in self.ordered_regs:
+                if regs[0] in reg_labels:
+                    continue
+                reg_labels.append(regs[0])
+                reg_size.append(len(
+                    [x for x in self.ordered_regs if x[0] == regs[0]]))
+            index = 0
+            for size in reg_size:
+                new_index = index + size
+                for i in range(new_index - 1, index - 1, -1):
+                    new_ordered_regs.append(self.ordered_regs[i])
+                index = new_index
+            self.ordered_regs = new_ordered_regs
+
         if 'clbit_labels' in self.header:
             for clabel in self.header['clbit_labels']:
-                for cind in range(clabel[1]):
-                    self.ordered_regs.append((clabel[0], cind))
+                if reverse_bits:
+                    for cind in reversed(range(clabel[1])):
+                        self.ordered_regs.append((clabel[0], cind))
+                else:
+                    for cind in range(clabel[1]):
+                        self.ordered_regs.append((clabel[0], cind))
         self.img_regs = {bit: ind for ind, bit in
                          enumerate(self.ordered_regs)}
         self.img_width = len(self.img_regs)


### PR DESCRIPTION
Fix #767

### Summary

This commit adds a new kwarg parameter to the latex drawer
reverse_qubits which gives users an option to reverse the order qubits
are displayed. Currently the bit order increases downward with the q_0
bit being displayed at the top. When the reverse_qubit option is set to
True the order is reversed and q_N is at the top and the order
decreases.

### Details and comments

Related to #693

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


