### PR TITLE
Tests revealed a couple of bugs in the codebase.

### DIFF
--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -184,12 +184,6 @@ class IBMQJob(BaseJob):
         self._wait_for_submission()
         try:
             this_result = self._wait_for_job(timeout=timeout, wait=wait)
-        except JobTimeoutError as err:
-            # A timeout error retrieving the results does not imply the job
-            # is failing. The job can be still running. This is why we are not
-            # throwing an exception here.
-            return Result({'id': self._id, 'status': 'ERROR',
-                           'result': str(err)})
         except ApiError as api_err:
             raise JobError(str(api_err))
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -184,7 +184,7 @@ class IBMQJob(BaseJob):
         self._wait_for_submission()
         try:
             this_result = self._wait_for_job(timeout=timeout, wait=wait)
-        except TimeoutError as err:
+        except JobTimeoutError as err:
             # A timeout error retrieving the results does not imply the job
             # is failing. The job can be still running. This is why we are not
             # throwing an exception here.

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -14,10 +14,11 @@ import unittest
 import time
 from contextlib import suppress
 from IBMQuantumExperience import ApiError
+from qiskit import QISKitError
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from qiskit.backends.ibmq.ibmqjob import API_FINAL_STATES
-from qiskit.backends import JobError, JobTimeoutError
+from qiskit.backends import JobError
 from .common import JobTestCase
 from ._mockutils import new_fake_qobj
 
@@ -221,10 +222,10 @@ class TestIBMQJobStates(JobTestCase):
         job = self.run_with_api(NonQueuedAPI())
 
         self.wait_for_initialization(job)
-        # We never make the API status to progress so it is stuck on RUNNING
-        with self.assertRaises(JobTimeoutError):
-            job.result(timeout=0.2)
-
+        result = job.result(timeout=0.2)
+        # TODO: This is inconsistent, the timeout prevents Qiskit from knowing
+        # the exact state of the job so it should raise.
+        self.assertRaises(QISKitError, result.get_data)
         self.assertEqual(job.status(), JobStatus.RUNNING)
 
     def test_cancel_while_initializing_fails(self):

--- a/test/python/test_ibmqjob_states.py
+++ b/test/python/test_ibmqjob_states.py
@@ -14,11 +14,10 @@ import unittest
 import time
 from contextlib import suppress
 from IBMQuantumExperience import ApiError
-from qiskit import QISKitError
 from qiskit.backends.jobstatus import JobStatus
 from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from qiskit.backends.ibmq.ibmqjob import API_FINAL_STATES
-from qiskit.backends import JobError
+from qiskit.backends import JobError, JobTimeoutError
 from .common import JobTestCase
 from ._mockutils import new_fake_qobj
 
@@ -222,11 +221,8 @@ class TestIBMQJobStates(JobTestCase):
         job = self.run_with_api(NonQueuedAPI())
 
         self.wait_for_initialization(job)
-        result = job.result(timeout=0.2)
-        # TODO: This is inconsistent, the timeout prevents Qiskit from knowing
-        # the exact state of the job so it should raise.
-        self.assertRaises(QISKitError, result.get_data)
-        self.assertEqual(job.status(), JobStatus.RUNNING)
+        with self.assertRaises(JobTimeoutError):
+            job.result(timeout=0.2)
 
     def test_cancel_while_initializing_fails(self):
         job = self.run_with_api(CancellableAPI())

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     QuantumRegister, QuantumProgram, Result)
+from qiskit.backends import JobTimeoutError
 from qiskit.qobj import Qobj
 from qiskit.tools import file_io
 from .common import requires_qe_access, QiskitTestCase, Path
@@ -1138,9 +1139,9 @@ class TestQuantumProgram(QiskitTestCase):
         qc.measure(qr, cr)
         shots = 1
         q_program.set_api(qe_token, qe_url)
-        result = q_program.execute(['qc'], backend=backend_name, shots=shots,
-                                   max_credits=3, seed=73846087)
-        self.assertRaises(QISKitError, result.get_data, 'qc')
+        with self.assertRaises(JobTimeoutError):
+            q_program.execute(['qc'], backend=backend_name, shots=shots,
+                              max_credits=3, seed=73846087)
 
     @requires_qe_access
     def test_execute_several_circuits_simulator_online(self, qe_token, qe_url):


### PR DESCRIPTION
Fix #780

One related to the simplification of the Job API. It is now raising JobTimeoutError instead of TimeoutError and we forgot to update a reference. It also evidentiates an inconsistency in the way we treat exceptions.

The other was related to a new update in the IBMQuantumExperience library. Now some server errors raise an ApiError that was not captured before.

