### PR TITLE
Updated  property Backend Configuration schema and example to reflect spec.

### DIFF
--- a/qiskit/schemas/backend_configuration_schema.json
+++ b/qiskit/schemas/backend_configuration_schema.json
@@ -169,10 +169,11 @@
                     "description": "The backend supports openPulse (true/false)"},
                 "n_uchannels": {
                     "type": "integer",
-                    "description": "Number of additional control channels", 
+                    "description": "Number of additional control channels",
                     "minimum": 0},
                 "hamiltonian": {
                     "type": "object",
+                    "required": ["h_latex"],
                     "description": "Hamiltonian of the backend",
                     "properties": {
                         "h_latex": {
@@ -183,7 +184,14 @@
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "The Hamiltonian in machine readable form"
-                            }
+                          },
+                        "vars": {
+                              "type": "object",
+                              "description": "Variables in the h_str"},
+                        "osc": {
+                            "type": "object",
+                            "description": "Number of levels for each oscillator mode"}
+                          }
                         }
                     },
                 "u_channel_lo": {
@@ -219,11 +227,11 @@
                     "items": {"type": "array", "minItems": 2, "maxItems": 2, "items": {"type": "number"}}},
                 "dt": {
                     "type": "number",
-                    "description": "Time discretization for the drive and U channels", 
+                    "description": "Time discretization for the drive and U channels",
                     "minimum": 0},
                 "dtm": {
                     "type": "number",
-                    "description": "Time discretization for the measurement channels", 
+                    "description": "Time discretization for the measurement channels",
                     "minimum": 0},
                 "rep_rates": {
                     "type": "array",
@@ -267,6 +275,5 @@
     "properties": {
                 "open_pulse": {"enum": [ false ]}
                 }}]}
-                ]           
+                ]
 }
-

--- a/qiskit/schemas/backend_configuration_schema.json
+++ b/qiskit/schemas/backend_configuration_schema.json
@@ -192,8 +192,7 @@
                             "type": "object",
                             "description": "Number of levels for each oscillator mode"}
                           }
-                        }
-                    },
+                        },
                 "u_channel_lo": {
                     "type": "array",
                     "minItems": 0,

--- a/qiskit/schemas/examples/backend_configuration_openpulse_example.json
+++ b/qiskit/schemas/examples/backend_configuration_openpulse_example.json
@@ -36,18 +36,11 @@
     "tags": ["credits_required","readable_hamiltonian","all_meas"],
     "n_uchannels": 2,
     "hamiltonian": {
-        "type": "object",
-        "required": ["h_latex"],
         "properties": {
             "h_latex": "H = \\sum_{i}^{N} D_i(t) \\sigma_i^{X} +\\sum_{i}^{N} 2\\pi \\nu_i \\sigma_i^{+}\\sigma_i^{-}",
             "h_str": ["__SUM[i,0,N,_X{i}_||_D{i}_]","__SUM[i,0,N,2*pi*_v{i}_*_O{i}_]"],
-            "vars": {
-                "type": "object",
-                "description": "Variables in the h_str"},
-            "osc": {
-                "type": "object",
-                "description": "Number of levels for each oscillator mode"}
-            }
+            "vars": {},
+            "osc": {}
         },
     "u_channel_lo": [[{"q": 0, "scale": [0,1]}],[{"q": 1, "scale": [1.0,0]}, {"q": 2, "scale": [-1.0,0]}]],
     "meas_levels": [0,1,2],

--- a/qiskit/schemas/examples/backend_configuration_openpulse_example.json
+++ b/qiskit/schemas/examples/backend_configuration_openpulse_example.json
@@ -36,11 +36,10 @@
     "tags": ["credits_required","readable_hamiltonian","all_meas"],
     "n_uchannels": 2,
     "hamiltonian": {
-        "properties": {
-            "h_latex": "H = \\sum_{i}^{N} D_i(t) \\sigma_i^{X} +\\sum_{i}^{N} 2\\pi \\nu_i \\sigma_i^{+}\\sigma_i^{-}",
-            "h_str": ["__SUM[i,0,N,_X{i}_||_D{i}_]","__SUM[i,0,N,2*pi*_v{i}_*_O{i}_]"],
-            "vars": {},
-            "osc": {}
+        "h_latex": "H = \\sum_{i}^{N} D_i(t) \\sigma_i^{X} +\\sum_{i}^{N} 2\\pi \\nu_i \\sigma_i^{+}\\sigma_i^{-}",
+        "h_str": ["__SUM[i,0,N,_X{i}_||_D{i}_]","__SUM[i,0,N,2*pi*_v{i}_*_O{i}_]"],
+        "vars": {},
+        "osc": {}
         },
     "u_channel_lo": [[{"q": 0, "scale": [0,1]}],[{"q": 1, "scale": [1.0,0]}, {"q": 2, "scale": [-1.0,0]}]],
     "meas_levels": [0,1,2],


### PR DESCRIPTION
I believe the vars and osc definitions were accidentally added to the example.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix #787. Moved schema definition from example to the schema. Updated example with empty `vars` and `osc` field. 

### Details and comments


