### PR TITLE
Remove the test `test_simulator_online_size`

### DIFF
--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -11,13 +11,12 @@
 
 import os
 import unittest
-from sys import version_info, float_info
+from sys import version_info
 
 import numpy as np
 
 from qiskit import (ClassicalRegister, QISKitError, QuantumCircuit,
                     QuantumRegister, QuantumProgram, Result)
-from qiskit.backends import JobTimeoutError
 from qiskit.qobj import Qobj
 from qiskit.tools import file_io
 from .common import requires_qe_access, QiskitTestCase, Path
@@ -1123,25 +1122,6 @@ class TestQuantumProgram(QiskitTestCase):
         target = {'0': shots / 2, '1': shots / 2}
         threshold = 0.04 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
-
-    @requires_qe_access
-    def test_simulator_online_size(self, qe_token, qe_url):
-        """Test test_simulator_online_size.
-
-        If all correct should return the data.
-        """
-        backend_name = 'ibmq_qasm_simulator'
-        q_program = QuantumProgram()
-        qr = q_program.create_quantum_register("q", 1)
-        cr = q_program.create_classical_register("c", 1)
-        qc = q_program.create_circuit("qc", [qr], [cr])
-        qc.h(qr)
-        qc.measure(qr, cr)
-        shots = 1
-        q_program.set_api(qe_token, qe_url)
-        with self.assertRaises(JobTimeoutError):
-            q_program.execute(['qc'], backend=backend_name, shots=shots,
-                              max_credits=3, seed=73846087, timeout=float_info.min)
 
     @requires_qe_access
     def test_execute_several_circuits_simulator_online(self, qe_token, qe_url):

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -1132,8 +1132,8 @@ class TestQuantumProgram(QiskitTestCase):
         """
         backend_name = 'ibmq_qasm_simulator'
         q_program = QuantumProgram()
-        qr = q_program.create_quantum_register("q", 31)
-        cr = q_program.create_classical_register("c", 31)
+        qr = q_program.create_quantum_register("q", 1)
+        cr = q_program.create_classical_register("c", 1)
         qc = q_program.create_circuit("qc", [qr], [cr])
         qc.h(qr)
         qc.measure(qr, cr)

--- a/test/python/test_quantumprogram.py
+++ b/test/python/test_quantumprogram.py
@@ -11,7 +11,7 @@
 
 import os
 import unittest
-from sys import version_info
+from sys import version_info, float_info
 
 import numpy as np
 
@@ -1141,7 +1141,7 @@ class TestQuantumProgram(QiskitTestCase):
         q_program.set_api(qe_token, qe_url)
         with self.assertRaises(JobTimeoutError):
             q_program.execute(['qc'], backend=backend_name, shots=shots,
-                              max_credits=3, seed=73846087)
+                              max_credits=3, seed=73846087, timeout=float_info.min)
 
     @requires_qe_access
     def test_execute_several_circuits_simulator_online(self, qe_token, qe_url):


### PR DESCRIPTION
Fixes #791 

### Summary

This PR improves the way that the timeout in `test_simulator_online_size` is checked.

### Details and comments

There are two key changes in this PR. The first one is adding `timeout=float_info.min` as an argument of `q_program.execute`. This will warranty that a timeout is triggered. The second change is the simplification of the program since there is no need to send a big program to trigger the timeout.

The checking time is reduced from:
```
test_simulator_online_size (test.python.test_quantumprogram.TestQuantumProgram)
Test test_simulator_online_size. ... ok

----------------------------------------------------------------------
Ran 1 test in 60.914s
```
to
```
test_simulator_online_size (test.python.test_quantumprogram.TestQuantumProgram)
Test test_simulator_online_size. ... ok

----------------------------------------------------------------------
Ran 1 test in 2.702s
```