### PR TITLE
Switch to iplot_state by default if env supports it

### DIFF
--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -7,7 +7,18 @@
 
 """Main QISKit visualization methods."""
 
+import sys
+
 from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source,\
     latex_circuit_drawer, matplotlib_circuit_drawer, qx_color_scheme
-from ._state_visualization import plot_state
 from ._counts_visualization import plot_histogram
+
+if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+    import requests
+    if requests.get(
+            'https://qvisualization.mybluemix.net/').status_code == 200:
+        from .interactive._iplot_state import iplot_state as plot_state
+    else:
+        from ._state_visualization import plot_state
+else:
+    from ._state_visualization import plot_state

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jsonschema>=2.6,<2.7
+requests>=2.19.0
 IBMQuantumExperience>=2.0.1
 matplotlib>=2.1
 networkx>=2.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the default graphing method to use the interactive
plot_state method if the environment conditions support it. There are 2
conditions when iplot_state can be used, the first is that things are
running inside jupyter, the second is that the environment has an
internet connection and can reach the js source needed for the
visualization. This will verify these 2 conditions by checking if the
ipykernel module is present and they trying to do an HTTP GET on
the url where the page is hosted to verify the plot function can do the
same.


### Details and comments

The requests library is used directly to perform the HTTP GET call so it
is added to the requirements.txt file in this commit. However this was
already an implicit requirement for qiskit-terra because it's what the
IBMQuantumExperience package uses for its HTTP client. This only adds it
to the requirements file because it is now directly called.

Fixes #806

