### PR TITLE
Reintroduce the external addons through namespaces

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -33,7 +33,7 @@ from .result import Result
 import qiskit.extensions.standard
 import qiskit.extensions.quantum_initializer
 
-# Allow extending this namespace. Please note that currently this import needs
+# Allow extending this namespace. Please note that currently this line needs
 # to be placed *before* the wrapper imports.
 __path__ = pkgutil.extend_path(__path__, __name__)
 

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -11,6 +11,7 @@
 """Main QISKit public functionality."""
 
 import os
+import pkgutil
 
 # First, check for required Python and API version
 from . import _util
@@ -25,13 +26,16 @@ from ._instruction import Instruction
 from ._instructionset import InstructionSet
 from ._reset import Reset
 from ._measure import Measure
+from .result import Result
 
 # The qiskit.extensions.x imports needs to be placed here due to the
 # mechanism for adding gates dynamically.
 import qiskit.extensions.standard
 import qiskit.extensions.quantum_initializer
 
-from .result import Result
+# Allow extending this namespace. Please note that currently this import needs
+# to be placed *before* the wrapper imports.
+__path__ = pkgutil.extend_path(__path__, __name__)
 
 from .wrapper._wrapper import (
     available_backends, local_backends, remote_backends,

--- a/qiskit/backends/__init__.py
+++ b/qiskit/backends/__init__.py
@@ -6,9 +6,15 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Utilities for using backends."""
+
+import pkgutil
+
 from .basebackend import BaseBackend
 from .baseprovider import BaseProvider
 from .basejob import BaseJob
 from .jobstatus import JobStatus
 from .joberror import JobError
 from .jobtimeouterror import JobTimeoutError
+
+# Allow extending this namespace.
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -25,17 +25,20 @@ def _qiskit_supported_providers():
     """
     supported_providers = [LocalProvider]
 
-    # Add Qiskit-supported backends (sympy, projectq).
+    # Add Qiskit-supported backends.
     try:
         from qiskit.backends.sympy import SympyProvider
-
         supported_providers.append(SympyProvider)
     except ImportError:
         pass
     try:
         from qiskit.backends.projectq import ProjectQProvider
-
         supported_providers.append(ProjectQProvider)
+    except ImportError:
+        pass
+    try:
+        from qiskit.backends.jku import JKUProvider
+        supported_providers.append(JKUProvider)
     except ImportError:
         pass
 
@@ -50,7 +53,8 @@ class DefaultQISKitProvider(BaseProvider):
         super().__init__()
 
         # List of providers.
-        self.providers = [cls() for cls in _qiskit_supported_providers()]
+        self.providers = [provider_class() for provider_class
+                          in _qiskit_supported_providers()]
 
     def get_backend(self, name):
         name = self.resolve_backend_name(name)

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -17,6 +17,31 @@ from qiskit.backends.local.localprovider import LocalProvider
 logger = logging.getLogger(__name__)
 
 
+def _qiskit_supported_providers():
+    """Get the providers supported by the Qiskit team.
+
+    Returns:
+        list[class]: list of provider classes.
+    """
+    supported_providers = [LocalProvider]
+
+    # Add Qiskit-supported backends (sympy, projectq).
+    try:
+        from qiskit.backends.sympy import SympyProvider
+
+        supported_providers.append(SympyProvider)
+    except ImportError:
+        pass
+    try:
+        from qiskit.backends.projectq import ProjectQProvider
+
+        supported_providers.append(ProjectQProvider)
+    except ImportError:
+        pass
+
+    return supported_providers
+
+
 class DefaultQISKitProvider(BaseProvider):
     """
     Meta-provider that aggregates several providers.
@@ -25,7 +50,7 @@ class DefaultQISKitProvider(BaseProvider):
         super().__init__()
 
         # List of providers.
-        self.providers = [LocalProvider()]
+        self.providers = [cls() for cls in _qiskit_supported_providers()]
 
     def get_backend(self, name):
         name = self.resolve_backend_name(name)

--- a/qiskit/wrapper/defaultqiskitprovider.py
+++ b/qiskit/wrapper/defaultqiskitprovider.py
@@ -26,6 +26,8 @@ def _qiskit_supported_providers():
     supported_providers = [LocalProvider]
 
     # Add Qiskit-supported backends.
+    # TODO: once the backends are available as packages, they will not need to
+    # be imported conditionally.
     try:
         from qiskit.backends.sympy import SympyProvider
         supported_providers.append(SympyProvider)

--- a/test/python/_test_options.py
+++ b/test/python/_test_options.py
@@ -11,7 +11,6 @@ import os
 import logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(format='Testing: %(message)s')
 
 
 def get_test_options(option_var='QISKIT_TESTS'):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
See #699.

### Summary

Changes needed for reintroducing the sympy, projectq and jku backends as addons for 0.6. The implementation is based on the upcoming packaging structure and actually serve as the first tentative step - this PR:
* makes `qiskit.backends` "extensible"
* adds the providers to the `DefaultQISKitProvider` set if they are available (as the assumption is that they are official addons maintained by the Qiskit team)

and will be accompanied by PRs on each backend repositories that rename their modules.

After this PR, the only related change left in this repository will be to add them to the dependency list - this will need to be done probably closer to the release  (as the packages will need to be in pip, a bit of a chicken-and-egg style).

### Details and comments


