### PR TITLE
Replace backend.calibration & backend.parameters with backend.properties

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,8 @@ Deprecated
 - The ``number_to_keep`` kwarg on the ``plot_histogram()`` function is now
   deprecated. A field of the same name should be used in the ``option``
   dictionary kwarg instead. (#866)
+- Breaking change: ``backend.properties()`` instead of ``backend.calibration()``
+  and ``backend.parameters()`` (#870)
 
 Removed
 -------

--- a/examples/python/using_qiskit_core_level_1.py
+++ b/examples/python/using_qiskit_core_level_1.py
@@ -53,10 +53,8 @@ try:
     my_backend = get_backend(my_backend_name)
     print("(Local QASM Simulator configuration) ")
     pprint.pprint(my_backend.configuration())
-    print("(Local QASM Simulator calibration) ")
-    pprint.pprint(my_backend.calibration())
-    print("(Local QASM Simulator parameters) ")
-    pprint.pprint(my_backend.parameters())
+    print("(Local QASM Simulator properties) ")
+    pprint.pprint(my_backend.properties())
 
 
     # Compiling the job
@@ -89,12 +87,10 @@ try:
 
         my_backend = get_backend(least_busy_device)
 
-        print("(with Configuration) ")
+        print("(with configuration) ")
         pprint.pprint(my_backend.configuration())
-        print("(with calibration) ")
-        pprint.pprint(my_backend.calibration())
-        print("(with parameters) ")
-        pprint.pprint(my_backend.parameters())
+        print("(with properties) ")
+        pprint.pprint(my_backend.properties())
 
         # Compiling the job
         # I want to make it so the compile is only done once and the needing

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -43,8 +43,8 @@ __path__ = pkgutil.extend_path(__path__, __name__)
 __path__ = pkgutil.extend_path(__path__, __name__)
 
 from .wrapper._wrapper import (
-    available_backends, local_backends, remote_backends,
-    get_backend, compile, execute, register, unregister,
+    available_backends, get_backend,
+    compile, execute, register, unregister,
     registered_providers, load_qasm_string, load_qasm_file, least_busy,
     store_credentials)
 

--- a/qiskit/_register.py
+++ b/qiskit/_register.py
@@ -11,7 +11,6 @@ Base register reference object.
 import re
 import logging
 import itertools
-import warnings
 
 from ._qiskiterror import QISKitError, QISKitIndexError
 

--- a/qiskit/_register.py
+++ b/qiskit/_register.py
@@ -28,20 +28,7 @@ class Register(object):
 
     def __init__(self, size, name=None):
         """Create a new generic register.
-
-        .. deprecated:: 0.5
-            The `name` parameter will be optional in upcoming versions (>0.5.0)
-            and the order of the parameters will change (`size`, `name`)
-            instead of (`name`, `size`).
         """
-
-        if isinstance(size, str):
-            warnings.warn(
-                "name will be optional in upcoming versions (>0.5.0) "
-                "and order will be size, name.", DeprecationWarning)
-            name_temp = size
-            size = name
-            name = name_temp
 
         if name is None:
             name = '%s%i' % (self.prefix, next(self.instances_counter))

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -145,20 +145,22 @@ class AvailableToOperationalDict(UserDict):
 
         return super(AvailableToOperationalDict, self).__getitem__(key)
 
+
 def _dict_merge(dct, merge_dct):
-    """ 
-    TEMPORARY method for merging backend.calibration & backend.parameters 
+    """
+    TEMPORARY method for merging backend.calibration & backend.parameters
     into backend.properties.
 
     Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
     updating only top-level keys, dict_merge recurses down into dicts nested
     to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
     ``dct``.
-    :param dct: dict onto which the merge is executed
-    :param merge_dct: dct merged into dct
-    :return: None
+
+    Args:
+        dct (dict): the dictionary to merge into
+        merge_dct (dict): the dictionary to merge
     """
-    for k, v in merge_dct.items():
+    for k, _ in merge_dct.items():
         if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], dict)):
             _dict_merge(dct[k], merge_dct[k])
         elif (k in dct and isinstance(dct[k], list) and isinstance(merge_dct[k], list)):

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -145,6 +145,28 @@ class AvailableToOperationalDict(UserDict):
 
         return super(AvailableToOperationalDict, self).__getitem__(key)
 
+def _dict_merge(dct, merge_dct):
+    """ 
+    TEMPORARY method for merging backend.calibration & backend.parameters 
+    into backend.properties.
+
+    Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
+    updating only top-level keys, dict_merge recurses down into dicts nested
+    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
+    ``dct``.
+    :param dct: dict onto which the merge is executed
+    :param merge_dct: dct merged into dct
+    :return: None
+    """
+    for k, v in merge_dct.items():
+        if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], dict)):
+            _dict_merge(dct[k], merge_dct[k])
+        elif (k in dct and isinstance(dct[k], list) and isinstance(merge_dct[k], list)):
+            for i in range(len(dct[k])):
+                _dict_merge(dct[k][i], merge_dct[k][i])
+        else:
+            dct[k] = merge_dct[k]
+
 
 def _parse_ibmq_credentials(url, hub=None, group=None, project=None):
     """Converts old Q network credentials to new url only

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -50,18 +50,14 @@ class BaseBackend(ABC):
 
     def calibration(self):
         """Return backend calibration"""
-        warnings.warn(
-                "Backends will no longer return a calibration dictionary,"
-                "use backend.properties() instead.",
-                DeprecationWarning)
+        warnings.warn("Backends will no longer return a calibration dictionary,"
+                      "use backend.properties() instead.", DeprecationWarning)
         return {}
 
     def parameters(self):
         """Return backend parameters"""
-        warnings.warn(
-                "Backends will no longer return a parameters dictionary, "
-                "use backend.properties() instead.",
-                DeprecationWarning)
+        warnings.warn("Backends will no longer return a parameters dictionary, "
+                      "use backend.properties() instead.", DeprecationWarning)
         return {}
 
     def properties(self):

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -10,6 +10,7 @@
 To create add-on backend modules subclass the Backend class in this module.
 Doing so requires that the required backend interface is implemented.
 """
+import warnings
 from abc import ABC, abstractmethod
 
 from qiskit._qiskiterror import QISKitError
@@ -49,10 +50,22 @@ class BaseBackend(ABC):
 
     def calibration(self):
         """Return backend calibration"""
+        warnings.warn(
+                "Backends will no longer return a calibration dictionary,"
+                "use backend.properties() instead.",
+                DeprecationWarning)
         return {}
 
     def parameters(self):
         """Return backend parameters"""
+        warnings.warn(
+                "Backends will no longer return a parameters dictionary, "
+                "use backend.properties() instead.",
+                DeprecationWarning)
+        return {}
+
+    def properties(self):
+        """Return backend properties"""
         return {}
 
     def status(self):

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -105,15 +105,8 @@ class IBMQBackend(BaseBackend):
 
         :deprecated: will be removed after 0.7
         """
-<<<<<<< HEAD
         warnings.warn("Backends will no longer return a parameters dictionary, "
                       "use backend.properties() instead.", DeprecationWarning)
-=======
-        warnings.warn(
-                "Backends will no longer return a parameters dictionary, "
-                "use backend.properties() instead.",
-                DeprecationWarning)
->>>>>>> update examples and tests
 
         try:
             backend_name = self.name()
@@ -144,8 +137,6 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If properties for the backend can't be found.
         """
-<<<<<<< HEAD
-<<<<<<< HEAD
         # FIXME: make this an actual call to _api.backend_properties
         # for now this api endpoint does not exist.
         warnings.simplefilter("ignore")
@@ -155,19 +146,6 @@ class IBMQBackend(BaseBackend):
         properties = calibration
         warnings.simplefilter("default")
         return properties
-=======
-        # FIXME: make this an actual call to api for getting properties
-        # for now this api endpoint does not exist.
-        return {**self.calibration(), **self.parameters()}
->>>>>>> adding backend.properties and deprecating calibration/parameters
-=======
-        # FIXME: make this an actual call to _api.backend_properties
-        # for now this api endpoint does not exist.
-        warnings.simplefilter("ignore")
-        properties = {**self.calibration(), **self.parameters()}
-        warnings.simplefilter("default")
-        return properties
->>>>>>> update examples and tests
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -68,14 +68,16 @@ class IBMQBackend(BaseBackend):
             dict: The calibration of the backend.
 
         Raises:
-            LookupError: If a configuration for the backend can't be found.
+            LookupError: If a calibration for the backend can't be found.
+
+        :deprecated: will be removed after 0.6
         """
         try:
-            backend_name = self.configuration()['name']
+            backend_name = self.name()
             calibrations = self._api.backend_calibration(backend_name)
             # FIXME a hack to remove calibration data that is none.
             # Needs to be fixed in api
-            if backend_name in ('ibmq_qasm_simulator', 'ibmqx_qasm_simulator'):
+            if backend_name == 'ibmq_qasm_simulator':
                 calibrations = {}
         except Exception as ex:
             raise LookupError(
@@ -96,9 +98,11 @@ class IBMQBackend(BaseBackend):
 
         Raises:
             LookupError: If parameters for the backend can't be found.
+
+        :deprecated: will be removed after 0.6
         """
         try:
-            backend_name = self.configuration()['name']
+            backend_name = self.name()
             parameters = self._api.backend_parameters(backend_name)
             # FIXME a hack to remove parameters data that is none.
             # Needs to be fixed in api
@@ -114,6 +118,21 @@ class IBMQBackend(BaseBackend):
             parameters_edit[new_key] = vals
 
         return parameters_edit
+
+    def properties(self):
+        """Return the online backend properties.
+
+        The return is via QX API call.
+
+        Returns:
+            dict: The properties of the backend.
+
+        Raises:
+            LookupError: If properties for the backend can't be found.
+        """
+        # FIXME: make this an actual call to api for getting properties
+        # for now this api endpoint does not exist.
+        return {**self.calibration(), **self.parameters()}
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -137,6 +137,7 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If properties for the backend can't be found.
         """
+<<<<<<< HEAD
         # FIXME: make this an actual call to _api.backend_properties
         # for now this api endpoint does not exist.
         warnings.simplefilter("ignore")
@@ -146,6 +147,11 @@ class IBMQBackend(BaseBackend):
         properties = calibration
         warnings.simplefilter("default")
         return properties
+=======
+        # FIXME: make this an actual call to api for getting properties
+        # for now this api endpoint does not exist.
+        return {**self.calibration(), **self.parameters()}
+>>>>>>> adding backend.properties and deprecating calibration/parameters
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -73,10 +73,8 @@ class IBMQBackend(BaseBackend):
 
         :deprecated: will be removed after 0.7
         """
-        warnings.warn(
-                "Backends will no longer return a calibration dictionary, "
-                "use backend.properties() instead.",
-                DeprecationWarning)
+        warnings.warn("Backends will no longer return a calibration dictionary, "
+                      "use backend.properties() instead.", DeprecationWarning)
 
         try:
             backend_name = self.name()
@@ -107,10 +105,8 @@ class IBMQBackend(BaseBackend):
 
         :deprecated: will be removed after 0.7
         """
-        warnings.warn(
-                "Backends will no longer return a parameters dictionary, "
-                "use backend.properties() instead.",
-                DeprecationWarning)
+        warnings.warn("Backends will no longer return a parameters dictionary, "
+                      "use backend.properties() instead.", DeprecationWarning)
 
         try:
             backend_name = self.name()

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -105,8 +105,15 @@ class IBMQBackend(BaseBackend):
 
         :deprecated: will be removed after 0.7
         """
+<<<<<<< HEAD
         warnings.warn("Backends will no longer return a parameters dictionary, "
                       "use backend.properties() instead.", DeprecationWarning)
+=======
+        warnings.warn(
+                "Backends will no longer return a parameters dictionary, "
+                "use backend.properties() instead.",
+                DeprecationWarning)
+>>>>>>> update examples and tests
 
         try:
             backend_name = self.name()
@@ -138,6 +145,7 @@ class IBMQBackend(BaseBackend):
             LookupError: If properties for the backend can't be found.
         """
 <<<<<<< HEAD
+<<<<<<< HEAD
         # FIXME: make this an actual call to _api.backend_properties
         # for now this api endpoint does not exist.
         warnings.simplefilter("ignore")
@@ -152,6 +160,14 @@ class IBMQBackend(BaseBackend):
         # for now this api endpoint does not exist.
         return {**self.calibration(), **self.parameters()}
 >>>>>>> adding backend.properties and deprecating calibration/parameters
+=======
+        # FIXME: make this an actual call to _api.backend_properties
+        # for now this api endpoint does not exist.
+        warnings.simplefilter("ignore")
+        properties = {**self.calibration(), **self.parameters()}
+        warnings.simplefilter("default")
+        return properties
+>>>>>>> update examples and tests
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -9,6 +9,7 @@
 
 This module is used for connecting to the Quantum Experience.
 """
+import warnings
 import logging
 
 from IBMQuantumExperience import ApiError
@@ -70,8 +71,13 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If a calibration for the backend can't be found.
 
-        :deprecated: will be removed after 0.6
+        :deprecated: will be removed after 0.7
         """
+        warnings.warn(
+                "Backends will no longer return a calibration dictionary, "
+                "use backend.properties() instead.",
+                DeprecationWarning)
+
         try:
             backend_name = self.name()
             calibrations = self._api.backend_calibration(backend_name)
@@ -99,8 +105,13 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If parameters for the backend can't be found.
 
-        :deprecated: will be removed after 0.6
+        :deprecated: will be removed after 0.7
         """
+        warnings.warn(
+                "Backends will no longer return a parameters dictionary, "
+                "use backend.properties() instead.",
+                DeprecationWarning)
+
         try:
             backend_name = self.name()
             parameters = self._api.backend_parameters(backend_name)
@@ -130,9 +141,12 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If properties for the backend can't be found.
         """
-        # FIXME: make this an actual call to api for getting properties
+        # FIXME: make this an actual call to _api.backend_properties
         # for now this api endpoint does not exist.
-        return {**self.calibration(), **self.parameters()}
+        warnings.simplefilter("ignore")
+        properties = {**self.calibration(), **self.parameters()}
+        warnings.simplefilter("default")
+        return properties
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -14,7 +14,7 @@ import logging
 
 from IBMQuantumExperience import ApiError
 from qiskit import QISKitError
-from qiskit._util import _camel_case_to_snake_case, AvailableToOperationalDict
+from qiskit._util import _camel_case_to_snake_case, AvailableToOperationalDict, _dict_merge
 from qiskit.backends import BaseBackend
 from qiskit.backends.ibmq.ibmqjob import IBMQJob, IBMQJobPreQobj
 from qiskit.backends import JobStatus
@@ -140,7 +140,10 @@ class IBMQBackend(BaseBackend):
         # FIXME: make this an actual call to _api.backend_properties
         # for now this api endpoint does not exist.
         warnings.simplefilter("ignore")
-        properties = {**self.calibration(), **self.parameters()}
+        calibration = self.calibration()
+        parameters = self.parameters()
+        _dict_merge(calibration, parameters)
+        properties = calibration
         warnings.simplefilter("default")
         return properties
 

--- a/qiskit/backends/local/qasm_simulator_py.py
+++ b/qiskit/backends/local/qasm_simulator_py.py
@@ -397,11 +397,6 @@ class QasmSimulatorPy(BaseBackend):
             'counts': self._format_result(counts, cl_reg_index, cl_reg_nbits),
             'snapshots': self._snapshots
         }
-        if self._shots == 1:
-            # TODO: deprecated -- remove in v0.6
-            data['statevector'] = self._statevector
-            data['quantum_state'] = self._statevector
-            data['classical_state'] = self._classical_state
         end = time.time()
         return {'name': circuit.header.name,
                 'seed': seed,

--- a/qiskit/schemas/backend_status_schema.json
+++ b/qiskit/schemas/backend_status_schema.json
@@ -5,11 +5,22 @@
     "version": "1.0.0",
     "type": "object",
     "required": [
+        "backend_name",
+        "backend_version",
         "operational",
         "pending_jobs",
         "status_msg"
     ],
     "properties": {
+        "backend_name": {
+            "type": "string",
+            "description": "Backend name"
+        },
+        "backend_version": {
+            "description": "Backend version in the form X.X.X",
+            "pattern": "[0-9]+.[0-9]+.[0-9]+$",
+            "type": "string"
+        },
         "operational": {
             "type": "boolean",
             "description": "Backend operational and accepting jobs (true/false)"

--- a/qiskit/schemas/examples/backend_status_example.json
+++ b/qiskit/schemas/examples/backend_status_example.json
@@ -1,4 +1,6 @@
 {
+    "backend_name": "ibmqx5",
+    "backend_version": "1.1.1",
     "operational": false,
     "pending_jobs": 10,
     "status_msg": "Paused for recalibration"

--- a/qiskit/wrapper/__init__.py
+++ b/qiskit/wrapper/__init__.py
@@ -15,7 +15,7 @@ scenarios and flows: for more advanced usage, it is encouraged to instead
 refer to the documentation of each component and use them separately.
 """
 
-from ._wrapper import (available_backends, local_backends, remote_backends,
-                       get_backend, compile, execute, register, unregister,
+from ._wrapper import (available_backends, get_backend,
+                       compile, execute, register, unregister,
                        registered_providers, load_qasm_string, load_qasm_file,
                        least_busy, store_credentials, qobj_to_circuits)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -8,7 +8,6 @@
 """Helper module for simplified QISKit usage."""
 
 import logging
-import warnings
 from copy import deepcopy
 import uuid
 from qiskit._qiskiterror import QISKitError

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -191,42 +191,6 @@ def available_backends(filters=None, compact=True):
     return sorted(backend_names)
 
 
-def local_backends(compact=True):
-    """
-    Return the available local backends.
-
-    Args:
-        compact (bool): only report alias names. this is usually shorter, any several
-        backends usually share the same alias.
-
-    Returns:
-        list[str]: the names of the available remote backends.
-    """
-    warnings.warn(
-        "local_backends() will be deprecated in upcoming versions (>0.5). "
-        "using filters instead is recommended (i.e. available_backends({'local': True}).",
-        DeprecationWarning)
-    return available_backends({'local': True}, compact=compact)
-
-
-def remote_backends(compact=True):
-    """
-    Return the available remote backends.
-
-    Args:
-        compact (bool): only report alias names. this is usually shorter, any several
-        backends usually share the same alias.
-
-    Returns:
-        list[str]: the names of the available remote backends.
-    """
-    warnings.warn(
-        "remote_backends() will be deprecated in upcoming versions (>0.5). "
-        "using filters instead is recommended (i.e. available_backends({'local': False}).",
-        DeprecationWarning)
-    return available_backends({'local': False}, compact=compact)
-
-
 def least_busy(names):
     """
     Return the least busy available backend for those that

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -154,53 +154,22 @@ class TestBackends(QiskitTestCase):
                 schema = json.load(schema_file)
             jsonschema.validate(configuration, schema)
 
-    def test_local_backend_calibration(self):
-        """Test backend calibration.
-
-        If all correct should pass the vaildation.
-        """
-        local_provider = LocalProvider()
-        local_backends = local_provider.available_backends()
-        for backend in local_backends:
-            calibration = backend.calibration()
-            # FIXME test against schema and decide what calibration
-            # is for a simulator
-            self.assertEqual(len(calibration), 0)
-
-    @requires_qe_access
-    def test_remote_backend_calibration(self, qe_token, qe_url):
-        """Test backend calibration.
+    def test_local_backend_properties(self):
+        """Test backend properties.
 
         If all correct should pass the validation.
         """
-        ibmq_provider = IBMQProvider(qe_token, qe_url)
-        remotes = ibmq_provider.available_backends()
-        remotes = remove_backends_from_list(remotes)
-        for backend in remotes:
-            calibration = backend.calibration()
-            # FIXME test against schema and decide what calibration
-            # is for a simulator
-            if backend.configuration()['simulator']:
-                self.assertEqual(len(calibration), 0)
-            else:
-                self.assertEqual(len(calibration), 4)
-
-    def test_local_backend_parameters(self):
-        """Test backend parameters.
-
-        If all correct should pass the vaildation.
-        """
         local_provider = LocalProvider()
         local_backends = local_provider.available_backends()
         for backend in local_backends:
-            parameters = backend.parameters()
-            # FIXME test against schema and decide what parameters
+            properties = backend.properties()
+            # FIXME test against schema and decide what properties
             # is for a simulator
-            self.assertEqual(len(parameters), 0)
+            self.assertEqual(len(properties), 0)
 
     @requires_qe_access
-    def test_remote_backend_parameters(self, qe_token, qe_url):
-        """Test backend parameters.
+    def test_remote_backend_properties(self, qe_token, qe_url):
+        """Test backend properties.
 
         If all correct should pass the validation.
         """
@@ -209,13 +178,13 @@ class TestBackends(QiskitTestCase):
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
             self.log.info(backend.name())
-            parameters = backend.parameters()
-            # FIXME test against schema and decide what parameters
+            properties = backend.properties()
+            # FIXME test against schema and decide what properties
             # is for a simulator
             if backend.configuration()['simulator']:
-                self.assertEqual(len(parameters), 0)
+                self.assertEqual(len(properties), 0)
             else:
-                self.assertTrue(all(key in parameters for key in (
+                self.assertTrue(all(key in properties for key in (
                     'last_update_date',
                     'qubits',
                     'backend')))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Fix #778 

### Summary
One major inconsistency between the defined spec/schemas and the current qiskit API is the methods `backend.calibration` and `backend.parameters`. The data returned from these should just be combined and returned via `backend.properties`.
The API doesn't have this endpoint yet, so this is a temporary hack in Qiskit to make the API consistent for 0.6 Should fix (along with a bunch of other FIXMEs) when the API finally gets updated.

The PR also does the following cleanups:
- Fixes a bug in the status schema that did not report backend name and version, like other backend calls.
- Fully remove some deprecated stuff (and messages) from `_register.py` and `qasm_simulator_py`

### Details and comments


