### PR TITLE
Remove unused options from iplot_histogram docstring

### DIFF
--- a/qiskit/tools/visualization/interactive/_iplot_histogram.py
+++ b/qiskit/tools/visualization/interactive/_iplot_histogram.py
@@ -64,12 +64,9 @@ def iplot_histogram(data, number_to_keep=False, options=None, legend=None):
             legend (list): A list of strings to use for labels of the data.
                 The number of entries must match the length of data.
             options (dict): Representation settings containing
-                    - width (integer): graph horizontal size
-                    - height (integer): graph vertical size
                     - slider (bool): activate slider
                     - number_to_keep (integer): groups max values
                     - show_legend (bool): show legend of graph content
-                    - sort (string): Could be 'asc' or 'desc'
         Raises:
             VisualizationError: When legend is provided and the length doesn't
                 match the input data.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit removes 3 options, height, width, and sort which are not
actually used anywhere. This should remove confusion because setting
them won't do anything.

### Details and comments


