### PR TITLE
Import commonly used visualizations by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,14 +64,10 @@ stage_osx: &stage_osx
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install gcc@6
       brew link --overwrite gcc@6
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-      bash miniconda.sh -b -p $HOME/miniconda
-      export PATH="$HOME/miniconda/bin:$PATH"
-      hash -r
-      conda config --set always_yes yes --set changeps1 no
-      conda create -q -n test-environment python=3.6.5
-      source activate test-environment
-      conda install matplotlib
+      brew upgrade pyenv
+      pyenv install 3.6.5
+      virtualenv --python ~/.pyenv/versions/3.6.5/bin/python venv
+      source venv/bin/activate
     fi
 
 stage_osx_python3_7: &stage_osx_python3_7
@@ -83,16 +79,12 @@ stage_osx_python3_7: &stage_osx_python3_7
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install gcc@6
       brew link --overwrite gcc@6
+      brew upgrade pyenv
       brew install freetype
       brew install pkg-config
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-      bash miniconda.sh -b -p $HOME/miniconda
-      export PATH="$HOME/miniconda/bin:$PATH"
-      hash -r
-      conda config --set always_yes yes --set changeps1 no
-      conda create -q -n test-environment python=3.7.0
-      source activate test-environment
-      conda install matplotlib
+      pyenv install 3.7.0
+      virtualenv --python ~/.pyenv/versions/3.7.0/bin/python venv
+      source venv/bin/activate
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,13 @@ stage_osx: &stage_osx
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install gcc@6
       brew link --overwrite gcc@6
-      brew upgrade pyenv
-      PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.6.5
-      virtualenv --python ~/.pyenv/versions/3.6.5/bin/python venv
-      source venv/bin/activate
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+      bash miniconda.sh -b -p $HOME/miniconda
+      export PATH="$HOME/miniconda/bin:$PATH"
+      hash -r
+      conda config --set always_yes yes --set changeps1 no
+      conda create -q -n test-environment python=3.6.5
+      source activate test-environment
     fi
 
 stage_osx_python3_7: &stage_osx_python3_7
@@ -79,12 +82,15 @@ stage_osx_python3_7: &stage_osx_python3_7
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew install gcc@6
       brew link --overwrite gcc@6
-      brew upgrade pyenv
       brew install freetype
       brew install pkg-config
-      PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.7.0
-      virtualenv --python ~/.pyenv/versions/3.7.0/bin/python venv
-      source venv/bin/activate
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+      bash miniconda.sh -b -p $HOME/miniconda
+      export PATH="$HOME/miniconda/bin:$PATH"
+      hash -r
+      conda config --set always_yes yes --set changeps1 no
+      conda create -q -n test-environment python=3.7.0
+      source activate test-environment
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ stage_osx: &stage_osx
       brew install gcc@6
       brew link --overwrite gcc@6
       brew upgrade pyenv
-      pyenv install 3.6.5
+      PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.6.5
       virtualenv --python ~/.pyenv/versions/3.6.5/bin/python venv
       source venv/bin/activate
     fi
@@ -82,7 +82,7 @@ stage_osx_python3_7: &stage_osx_python3_7
       brew upgrade pyenv
       brew install freetype
       brew install pkg-config
-      pyenv install 3.7.0
+      PYTHON_CONFIGURE_OPTS="--enable-framework" pyenv install 3.7.0
       virtualenv --python ~/.pyenv/versions/3.7.0/bin/python venv
       source venv/bin/activate
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ stage_osx: &stage_osx
       conda config --set always_yes yes --set changeps1 no
       conda create -q -n test-environment python=3.6.5
       source activate test-environment
+      conda install matplotlib
     fi
 
 stage_osx_python3_7: &stage_osx_python3_7
@@ -91,6 +92,7 @@ stage_osx_python3_7: &stage_osx_python3_7
       conda config --set always_yes yes --set changeps1 no
       conda create -q -n test-environment python=3.7.0
       source activate test-environment
+      conda install matplotlib
     fi
 
 stage_linux_no_compile: &stage_linux_no_compile

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -39,7 +39,7 @@ import qiskit.extensions.quantum_initializer
 try:
     from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
 except ImportError as expt:
-    QISKitError(expt)
+    pass
 
 # Allow extending this namespace. Please note that currently this line needs
 # to be placed *before* the wrapper imports.

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -33,6 +33,9 @@ from .result import Result
 import qiskit.extensions.standard
 import qiskit.extensions.quantum_initializer
 
+# Import circuit drawing methods by default
+from qiskit.tools.visualization import circuit_drawer
+
 # Allow extending this namespace. Please note that currently this line needs
 # to be placed *before* the wrapper imports.
 __path__ = pkgutil.extend_path(__path__, __name__)

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -34,7 +34,12 @@ import qiskit.extensions.standard
 import qiskit.extensions.quantum_initializer
 
 # Import circuit drawing methods by default
-from qiskit.tools.visualization import circuit_drawer
+# This is wrapped in a try because the Travis tests fail due to non-framework
+# Python build since using pyenv
+try:
+    from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
+except ImportError as expt:
+    QISKitError(expt)
 
 # Allow extending this namespace. Please note that currently this line needs
 # to be placed *before* the wrapper imports.

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -38,8 +38,8 @@ import qiskit.extensions.quantum_initializer
 # Python build since using pyenv
 try:
     from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
-except ImportError as expt:
-    pass
+except (ImportError, RuntimeError) as expt:
+    print("Error: {0}".format(expt))
 
 # Allow extending this namespace. Please note that currently this line needs
 # to be placed *before* the wrapper imports.

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -31,7 +31,9 @@ from PIL import Image, ImageChops
 from matplotlib import get_backend as get_matplotlib_backend, \
     patches as patches, pyplot as plt
 
-from qiskit import QuantumCircuit, QISKitError, load_qasm_file
+from qiskit._quantumcircuit import QuantumCircuit
+from qiskit._qiskiterror import QISKitError
+from qiskit.wrapper import load_qasm_file
 from qiskit.qasm import Qasm
 from qiskit.unroll import Unroller, JsonBackend
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
From an usability point of view, it should be easier to use the `circuit_drawer` and `plot_histogram` functions.  Especially given that they are used in the very first intro notebook.


### Details and comments
This PR makes the `circuit_drawer` and `plot_histogram` functions available at import.

