### PR TITLE
Fix main __init__ py instruction order

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -33,6 +33,10 @@ from .result import Result
 import qiskit.extensions.standard
 import qiskit.extensions.quantum_initializer
 
+# Allow extending this namespace. Please note that currently this line needs
+# to be placed *before* the wrapper imports or any non-import code.
+__path__ = pkgutil.extend_path(__path__, __name__)
+
 # Import circuit drawing methods by default
 # This is wrapped in a try because the Travis tests fail due to non-framework
 # Python build since using pyenv
@@ -40,10 +44,6 @@ try:
     from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
 except (ImportError, RuntimeError) as expt:
     print("Error: {0}".format(expt))
-
-# Allow extending this namespace. Please note that currently this line needs
-# to be placed *before* the wrapper imports.
-__path__ = pkgutil.extend_path(__path__, __name__)
 
 from .wrapper._wrapper import (
     available_backends, local_backends, remote_backends,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix an issue with the addon reintegration at #699  caused during #874, as the expansion is not performed in the right order due to the introduction of an extra code block.

Moving forward, we should really think deeply the need for making functions available in the top-level namespace via imports, as the modularization of `terra` is still not ideal and `qiskit/__init__.py` is central to the project and modifications have a number of non-trivial implications - and we should also keep an eye on the upcoming uber-qiskit reorganization.


### Details and comments


