### PR TITLE
Fix import of visualization tools

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -37,6 +37,12 @@ import qiskit.extensions.quantum_initializer
 # to be placed *before* the wrapper imports or any non-import code.
 __path__ = pkgutil.extend_path(__path__, __name__)
 
+from .wrapper._wrapper import (
+    available_backends, local_backends, remote_backends,
+    get_backend, compile, execute, register, unregister,
+    registered_providers, load_qasm_string, load_qasm_file, least_busy,
+    store_credentials)
+
 # Import circuit drawing methods by default
 # This is wrapped in a try because the Travis tests fail due to non-framework
 # Python build since using pyenv
@@ -44,12 +50,6 @@ try:
     from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
 except (ImportError, RuntimeError) as expt:
     print("Error: {0}".format(expt))
-
-from .wrapper._wrapper import (
-    available_backends, local_backends, remote_backends,
-    get_backend, compile, execute, register, unregister,
-    registered_providers, load_qasm_string, load_qasm_file, least_busy,
-    store_credentials)
 
 # Import the wrapper, to make it available when doing "import qiskit".
 from . import wrapper

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -31,7 +31,9 @@ from PIL import Image, ImageChops
 from matplotlib import get_backend as get_matplotlib_backend, \
     patches as patches, pyplot as plt
 
-from qiskit import QuantumCircuit, QISKitError, load_qasm_file
+from qiskit._qiskiterror import QISKitError
+from qiskit._quantumcircuit import QuantumCircuit
+from qiskit.wrapper import load_qasm_file
 
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler import transpile


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Fixes #889 

### Summary

Fixes #889 by changing the imports in `qiskit.tools.visualization._circuit_visualization.py`.  Also moved the import in the `__init__.py`, although this is not strictly necessary once the  correct imports are done.


### Details and comments


