### PR TITLE
Fix bug in Jupyter status magic

### DIFF
--- a/qiskit/wrapper/jupyter/jupyter_magics.py
+++ b/qiskit/wrapper/jupyter/jupyter_magics.py
@@ -75,7 +75,9 @@ class StatusMagic(Magics):
                 "Cell must contain at least one variable of BaseJob type.")
 
         def _checker(job_var, status, header):
-            job_status_name = job_var.status().name
+            job_status = job_var.status()
+            job_status_name = job_status.name
+            job_status_msg = job_status.value
             while job_status_name not in ['DONE', 'CANCELLED']:
                 time.sleep(args.interval)
                 job_status = job_var.status()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As pointed out by @ajavadia, the Jupyter job status magic could have an undefined variable when using a simulator that reports done before the magic enters its loop.  This fixes that error.


### Details and comments


