### PR TITLE
Properly check if connection can be established for importing interactive visualizations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -60,16 +60,17 @@ Removed
 
 Fixed
 -----
-- Fixed ``get_ran_qasm`` methods on ``Result`` instances (#688)
-- Fixed ``probabilities_ket`` computation in C++ simulator. (#580)
+- Fixed ``get_ran_qasm`` methods on ``Result`` instances (#688).
+- Fixed ``probabilities_ket`` computation in C++ simulator (#580).
 - Fixed bug in the definition of ``cswap`` gate and its test (#685).
-- Fixed the examples to be compatible with version 0.5+ (#672)
+- Fixed the examples to be compatible with version 0.5+ (#672).
 - Fixed swap mapper using qubits after measurement (#691).
 - Fixed error in cpp simulator for 3+ qubit operations (#698).
 - Fixed issue with combining or extending circuits that contain CompositeGate (#710).
 - Fixed the random unitary generation from the Haar measure (#760).
-- Fixed the issue with control lines spanning through several classical registers. (#762).
-- Fixed visualizations crashing when using simulator extensions (#885)
+- Fixed the issue with control lines spanning through several classical registers (#762).
+- Fixed visualizations crashing when using simulator extensions (#885).
+- Fixed check for network connection when loading interactive visualizations (#892).
 
 `0.5.6`_ - 2018-07-06
 =====================

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -13,6 +13,7 @@ import logging
 import re
 import sys
 import warnings
+import socket
 from collections import UserDict
 
 API_NAME = 'IBMQuantumExperience'
@@ -157,3 +158,26 @@ def _parse_ibmq_credentials(url, hub=None, group=None, project=None):
             "0.6+. Please use the new URL format provided in the q-console.",
             DeprecationWarning)
     return url
+
+
+def _has_connection(hostname, port):
+    """Checks to see if internet connection exists to host
+    via specified port
+
+    Args:
+        hostname (str): Hostname to connect to.
+        port (int): Port to connect to
+
+    Returns:
+        bool: Has connection or not
+
+    Raises:
+        gaierror: No connection established.
+    """
+    try:
+        host = socket.gethostbyname(hostname)
+        socket.create_connection((host, port), 2)
+        return True
+    except socket.gaierror:
+        pass
+    return False

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -8,7 +8,7 @@
 """Main QISKit visualization methods."""
 
 import sys
-
+from qiskit._util import _has_connection
 from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source,\
     latex_circuit_drawer, matplotlib_circuit_drawer, qx_color_scheme
 from ._error import VisualizationError
@@ -16,9 +16,7 @@ from ._state_visualization import plot_bloch_vector
 
 
 if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
-    import requests
-    if requests.get(
-            'https://qvisualization.mybluemix.net/').status_code == 200:
+    if _has_connection('https://qvisualization.mybluemix.net/', 443):
         from .interactive._iplot_state import iplot_state as plot_state
         from .interactive._iplot_histogram import iplot_histogram as \
             plot_histogram

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 jsonschema>=2.6,<2.7
-requests>=2.19.0
 IBMQuantumExperience>=2.0.1
 matplotlib>=2.1
 networkx>=2.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Fix #895

### Summary
As pointed out by @chriseclectic , loading qiskit with no internet connection results in a `ConnectionError` because the interactive visualizations max out the number of attempts to look for the needed host url.  Here we replace the previous check with on that gracefully exits if no connection can be established.


### Details and comments


