### PR TITLE
Remove top level visualization imports

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -43,14 +43,6 @@ from .wrapper._wrapper import (
     registered_providers, load_qasm_string, load_qasm_file, least_busy,
     store_credentials)
 
-# Import circuit drawing methods by default
-# This is wrapped in a try because the Travis tests fail due to non-framework
-# Python build since using pyenv
-try:
-    from qiskit.tools.visualization import (circuit_drawer, plot_histogram)
-except (ImportError, RuntimeError) as expt:
-    print("Error: {0}".format(expt))
-
 # Import the wrapper, to make it available when doing "import qiskit".
 from . import wrapper
 


### PR DESCRIPTION
Fix #904  

Fixes issue where aqua GUI interface crashes for default OSX matplotlib backend.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


