### PR TITLE
Pinning to matplotlib < 3 to avoid incompatibility issues.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jsonschema>=2.6,<2.7
 IBMQuantumExperience>=2.0.3
-matplotlib>=2.1
+matplotlib>=2.1,<3
 networkx>=2.0
 numpy>=1.13
 ply>=3.10


### PR DESCRIPTION
Fix #920 

New matplotlib 3.0 version breaks backwards compatibility by raising
an ImportError when Python is not installed as a framework in MacOS X.
This PR pins Matplotlib to versions under 3.0 since it is the fastest
way to ensure we are not introducing breaking changes in visualization
tools given the proximity of the new release.


