### PR TITLE
Fix setting parallel flag at init

### DIFF
--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -6,7 +6,7 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Utils for transpiler."""
-
+import os
 from ._passmanager import PassManager
 from ._transpilererror import TranspilerError
 
@@ -15,3 +15,6 @@ from ._transpiler import compile, transpile
 
 from ._parallel import parallel_map
 from ._progressbar import TextProgressBar
+
+# Set parallel ennvironmental variable
+os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'

--- a/qiskit/transpiler/_parallel.py
+++ b/qiskit/transpiler/_parallel.py
@@ -53,9 +53,6 @@ from ._progressbar import BaseProgressBar
 # Number of local physical cpus
 CPU_COUNT = local_hardware_info()['cpus']
 
-# Set parallel ennvironmental variable
-os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
-
 
 def parallel_map(task, values, task_args=tuple(), task_kwargs={},  # pylint: disable=W0102
                  num_processes=CPU_COUNT):

--- a/test/python/test_parallel.py
+++ b/test/python/test_parallel.py
@@ -6,7 +6,7 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Tests for qiskit/_util.py"""
-
+import os
 import time
 from qiskit.transpiler._receiver import receiver as rec
 from qiskit.transpiler._parallel import parallel_map
@@ -24,6 +24,11 @@ def _parfunc(x):
 class TestParallel(QiskitTestCase):
     """A class for testing parallel_map functionality.
     """
+
+    def test_parallel_env_falg(self):
+        """Verify parallel env flag is set """
+        self.assertEqual(os.getenv('QISKIT_IN_PARALLEL', None), 'FALSE')
+
     def test_parallel(self):
         """Test parallel_map """
         ans = parallel_map(_parfunc, list(range(10)))

--- a/test/python/test_parallel.py
+++ b/test/python/test_parallel.py
@@ -25,7 +25,7 @@ class TestParallel(QiskitTestCase):
     """A class for testing parallel_map functionality.
     """
 
-    def test_parallel_env_falg(self):
+    def test_parallel_env_flag(self):
         """Verify parallel env flag is set """
         self.assertEqual(os.getenv('QISKIT_IN_PARALLEL', None), 'FALSE')
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
After moving all the parallel tools to the `transpiler` the env var flag was not being set at init, and therefore using `parallel_map` directly would not use multiple processes.  This fixes that.


### Details and comments


