### PR TITLE
Add latex barrier drawing to changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,8 @@ Changed
 - When ``plot_histogram()`` or ``plot_state()`` are called from a jupyter
   notebook if there is network connectivity the interactive plots will be used
   by default (#862, #866)
+- Add support for drawing circuit barriers to the latex circuit drawer. This
+  requires having the LaTeX qcircuit package version >=2.6.0 installed (#764)
 
 Deprecated
 ----------

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -261,6 +261,8 @@ def latex_circuit_drawer(circuit,
                          style=None):
     """Draw a quantum circuit based on latex (Qcircuit package)
 
+    Requires version >=2.6.0 of the qcircuit LaTeX package.
+
     Args:
         circuit (QuantumCircuit): a quantum circuit
         basis (str): comma separated list of gates


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This commit adds a note about the latex drawer supporting barriers now,
it also highlights that you need to have the latest version of the latex
qcircuit package installed to use it.

### Details and comments

Related to #934 