### PR TITLE
Fix barrier centering before measure on all qubits

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1257,10 +1257,16 @@ class QCircuitImage(object):
 
                 try:
                     self._latex[pos_1][columns] = "\\meter"
-                    prev_entry = self._latex[pos_1][columns - 1]
-                    if 'barrier' in prev_entry:
-                        self._latex[pos_1][columns - 1] = prev_entry.replace(
-                            '\\barrier{', '\\barrier[-1.15em]{')
+                    prev_column = [x[columns - 1] for x in self._latex]
+                    for item, prev_entry in enumerate(prev_column):
+                        if 'barrier' in prev_entry:
+                            span = re.search('barrier{(.*)}', prev_entry)
+                            if span and (
+                                    item + int(span.group(1))) - pos_1 >= 0:
+                                self._latex[
+                                    item][columns - 1] = prev_entry.replace(
+                                        '\\barrier{', '\\barrier[-1.15em]{')
+
                     self._latex[pos_2][columns] = \
                         "\\cw \\cwx[-" + str(pos_2 - pos_1) + "]"
                 except Exception as e:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue on drawing the barrier centering for all
qubits covered by a barrier when there is a measure after a gate. When
there is a gate followed immediately by a measure in the next column we
need to adjust the horizontal offset for the barrier because the box for
a measure is wider. However, prior to this commit we weren't accounting
for the downward span of the barrier being drawn, just the qubit/row
where the \barrier LaTeX call was made. This commit fixes the issue by
searching all the qubits/rows in the column before a measure and looking
for a \barrier. If a barrier is found and it's span covers the qubit/row
with the measure then we adjust the horizontal offset of that \barrier
command.

### Details and comments

Fixes #940
