### PR TITLE
Fix reversed width and height options in plot_histogram

### DIFF
--- a/qiskit/tools/visualization/_counts_visualization.py
+++ b/qiskit/tools/visualization/_counts_visualization.py
@@ -61,7 +61,7 @@ def plot_histogram(data, number_to_keep=False, legend=None, options=None):
                                  (len(legend), len(data)))
 
     if 'height' in options and 'width' in options:
-        _, ax = plt.subplots(figsize=(options['height'], options['width']))
+        _, ax = plt.subplots(figsize=(options['width'], options['height']))
     else:
         _, ax = plt.subplots()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The options `width` and `height` in `plot_histogram` were passed to `figsize` in the wrong order.  This fixes that.


### Details and comments


