### PR TITLE
Expand gates in circuit_drawer by default

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -349,7 +349,7 @@ def generate_latex_source(circuit, filename=None,
     Returns:
         str: Latex string appropriate for writing to file.
     """
-    dag_circuit = DAGCircuit.fromQuantumCircuit(circuit, expand_gates=False)
+    dag_circuit = DAGCircuit.fromQuantumCircuit(circuit)
     json_circuit = transpile(dag_circuit, basis_gates=basis, format='json')
     qcimg = QCircuitImage(json_circuit, scale, style=style)
     latex = qcimg.latex()


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix #946 by removing `expand_gates=False` in the conversion from circuit to DAG in `circuit_drawer`


### Details and comments
Fixes #946

