### PR TITLE
Add dag_drawer() visualizer

### DIFF
--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Main QISKit visualization methods."""
+"""Main Qiskit visualization methods."""
 
 import sys
 from qiskit._util import _has_connection
@@ -13,6 +13,7 @@ from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex
     latex_circuit_drawer, matplotlib_circuit_drawer, qx_color_scheme
 from ._error import VisualizationError
 from ._state_visualization import plot_bloch_vector
+from ._dag_visualization import dag_drawer
 
 
 if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):

--- a/qiskit/tools/visualization/_dag_visualization.py
+++ b/qiskit/tools/visualization/_dag_visualization.py
@@ -35,7 +35,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
     Raises:
         VisualizationError: when style is not recognized.
     """
-    G = copy.deepcopy(dag.multi_graph)
+    G = copy.deepcopy(dag.multi_graph)  # don't modify the original graph attributes
     G.graph['dpi'] = 100 * scale
 
     if style == 'plain':
@@ -58,13 +58,12 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
     else:
         raise VisualizationError("Unrecognized style for the dag_drawer.")
 
-    if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
-        show = 'ipynb'  # inline dot file visualization of graph
-        if filename:
-            show = False
-        return nxpd.draw(G, filename=filename, show=show)
+    show = nxpd.nxpdParams['show']
+    if filename:
+        show = False
+    elif ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+        show = 'ipynb'
     else:
         show = True
-        if filename:
-            show = False
-        nxpd.draw(G, filename=filename, show=show)
+
+    return nxpd.draw(G, filename=filename, show=show)

--- a/qiskit/tools/visualization/_dag_visualization.py
+++ b/qiskit/tools/visualization/_dag_visualization.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name
+
+"""
+Visualization function for DAG circuit representation.
+"""
+
+import sys
+import copy
+import nxpd
+from ._error import VisualizationError
+
+
+def dag_drawer(dag, scale=0.7, filename=None, style='color'):
+    """Plot the directed acyclic graph (dag) to represent operation dependencies
+    in a quantum circuit.
+
+    Args:
+        dag (DAGCircuit): The dag to draw.
+        scale (float): scaling factor
+        filename (str): file path to save image to (format inferred from name)
+        style (str): 'plain': B&W graph
+                     'color' (default): color input/output/op nodes
+
+    Returns:
+        Ipython.display.Image: if in Jupyter notebook and not saving to file,
+            otherwise None.
+
+    Raises:
+        VisualizationError: when style is not recognized.
+    """
+    G = copy.deepcopy(dag.multi_graph)
+    G.graph['dpi'] = 100 * scale
+
+    if style == 'plain':
+        pass
+    elif style == 'color':
+        for n in G.nodes:
+            G.nodes[n]['label'] = str(G.nodes[n]['name'])
+            if G.nodes[n]['type'] == 'op':
+                G.nodes[n]['color'] = 'blue'
+                G.nodes[n]['style'] = 'filled'
+                G.nodes[n]['fillcolor'] = 'lightblue'
+            if G.nodes[n]['type'] == 'in':
+                G.nodes[n]['color'] = 'black'
+                G.nodes[n]['style'] = 'filled'
+                G.nodes[n]['fillcolor'] = 'green'
+            if G.nodes[n]['type'] == 'out':
+                G.nodes[n]['color'] = 'black'
+                G.nodes[n]['style'] = 'filled'
+                G.nodes[n]['fillcolor'] = 'red'
+    else:
+        raise VisualizationError("Unrecognized style for the dag_drawer.")
+
+    if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+        show = 'ipynb'  # inline dot file visualization of graph
+        if filename:
+            show = False
+        return nxpd.draw(G, filename=filename, show=show)
+    else:
+        show = True
+        if filename:
+            show = False
+        nxpd.draw(G, filename=filename, show=show)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ scipy>=0.19,!=0.19.1
 sympy>=1.0
 pillow>=4.2.1
 psutil>=5
+nxpd>=0.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Fix #956 

A dag visualizer is important for developing transpiler passes. This PR introduces that. 

This is to be merged into the `transpiler` branch (i.e. not for 0.6). So no CHANGELOG here.

### Summary
```python
from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
from qiskit.tools.visualization import circuit_drawer
q = QuantumRegister(3)
c = ClassicalRegister(3)
circ = QuantumCircuit(q, c)
circ.h(q[0])
circ.cx(q[0], q[1])
circ.cx(q[0], q[1])
circ.u1(0.2, q[0])
circ.u2(0.2, 0.4, q[0])
circ.iden(q[0])
circ.ccx(q[0], q[1], q[2])
circuit_drawer(circ)
```
![image](https://user-images.githubusercontent.com/8622381/46165777-737c2e80-c25f-11e8-9697-cd2efb55961b.png)

```python
from qiskit.transpiler._transpiler import _circuits_2_dags
from qiskit.tools.visualization import dag_drawer
dag = _circuits_2_dags([circ])[0]
dag_drawer(dag)
```
![image](https://user-images.githubusercontent.com/8622381/46165762-69f2c680-c25f-11e8-9179-34478b6ef934.png)

# details
This adds a new dependency (`nxpd` package). This is simply the best way to go from a networkx graph to a pydot object that can be visualized with graphviz to look like a dependency graph. NetworkX's own graph visualizations do not serve our purpose.
