### PR TITLE
Add remove_all_accounts() function to the ibmqprovider

### DIFF
--- a/qiskit/backends/ibmq/credentials/_configrc.py
+++ b/qiskit/backends/ibmq/credentials/_configrc.py
@@ -152,3 +152,21 @@ def remove_credentials(credentials, filename=None):
         raise QISKitError('The account "%s" does not exist in the '
                           'configuration file')
     write_qiskit_rc(stored_credentials, filename)
+
+def remove_all_credentials(filename=None):
+    """Remove all credentials from qiskitrc.
+
+    Args:
+        filename (str): full path to the qiskitrc file. If `None`, the default
+            location is used (`HOME/.qiskit/qiskitrc`)
+
+    Raises:
+        FileNotFoundError: If the qiskitrc file can't be found
+    """
+
+    filename = filename or DEFAULT_QISKITRC_FILE
+    if not os.path.isfile(filename):
+        raise FileNotFoundError(
+            "Specified qiskitrc, %s, can't be found" % filename)
+    # Write an empty file
+    open(filename, 'w').close()

--- a/qiskit/backends/ibmq/credentials/_configrc.py
+++ b/qiskit/backends/ibmq/credentials/_configrc.py
@@ -152,22 +152,3 @@ def remove_credentials(credentials, filename=None):
         raise QISKitError('The account "%s" does not exist in the '
                           'configuration file')
     write_qiskit_rc(stored_credentials, filename)
-
-
-def remove_all_credentials(filename=None):
-    """Remove all credentials from qiskitrc.
-
-    Args:
-        filename (str): full path to the qiskitrc file. If `None`, the default
-            location is used (`HOME/.qiskit/qiskitrc`)
-
-    Raises:
-        FileNotFoundError: If the qiskitrc file can't be found
-    """
-
-    filename = filename or DEFAULT_QISKITRC_FILE
-    if not os.path.isfile(filename):
-        raise FileNotFoundError(
-            "Specified qiskitrc, %s, can't be found" % filename)
-    # Write an empty file
-    open(filename, 'w').close()

--- a/qiskit/backends/ibmq/credentials/_configrc.py
+++ b/qiskit/backends/ibmq/credentials/_configrc.py
@@ -153,6 +153,7 @@ def remove_credentials(credentials, filename=None):
                           'configuration file')
     write_qiskit_rc(stored_credentials, filename)
 
+
 def remove_all_credentials(filename=None):
     """Remove all credentials from qiskitrc.
 

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 from qiskit.backends import BaseProvider
 
-from .credentials._configrc import remove_credentials, remove_all_credentials
+from .credentials._configrc import remove_credentials
 from .credentials import (Credentials,
                           read_credentials_from_qiskitrc, store_credentials, discover_credentials)
 from .ibmqaccounterror import IBMQAccountError
@@ -149,15 +149,12 @@ class IBMQProvider(BaseProvider):
         if not removed:
             raise IBMQAccountError('Unable to find credentials')
 
-    def remove_all_accounts(self, delete=True):
-        """Remove all accounts from this session and optionally from disk.
-
-        Args:
-            delete (bool): If true remove the accounts from disk
-        """
-        if delete:
-            remove_all_credentials()
-        self._accounts = OrderedDict()
+    def remove_accounts(self):
+        """Remove all accounts from this session and optionally from disk."""
+        current_creds = self._accounts.copy()
+        for creds in current_creds:
+            self.remove_account(current_creds[creds].credentials.token,
+                                current_creds[creds].credentials.url)
 
     def use_account(self, token, url=QE_URL, **kwargs):
         """Authenticate against IBMQ during this session.

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -222,7 +222,7 @@ class IBMQProvider(BaseProvider):
             credentials (Credentials): set of credentials.
 
         Returns:
-            eBMQSingleProvider: new single-account provider.
+            IBMQSingleProvider: new single-account provider.
 
         Raises:
             IBMQAccountError: if the provider could not be appended.

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 from qiskit.backends import BaseProvider
 
-from .credentials._configrc import remove_credentials
+from .credentials._configrc import remove_credentials, remove_all_credentials
 from .credentials import (Credentials,
                           read_credentials_from_qiskitrc, store_credentials, discover_credentials)
 from .ibmqaccounterror import IBMQAccountError
@@ -149,6 +149,16 @@ class IBMQProvider(BaseProvider):
         if not removed:
             raise IBMQAccountError('Unable to find credentials')
 
+    def remove_all_accounts(self, delete=True):
+        """Remove all accounts from this session and optionally from disk.
+
+        Args:
+            delete (bool): If true remove the accounts from disk
+        """
+        if delete:
+            remove_all_credentials()
+        self._accounts = OrderedDict()
+
     def use_account(self, token, url=QE_URL, **kwargs):
         """Authenticate against IBMQ during this session.
 
@@ -215,7 +225,7 @@ class IBMQProvider(BaseProvider):
             credentials (Credentials): set of credentials.
 
         Returns:
-            IBMQSingleProvider: new single-account provider.
+            eBMQSingleProvider: new single-account provider.
 
         Raises:
             IBMQAccountError: if the provider could not be appended.

--- a/test/python/test_registration.py
+++ b/test/python/test_registration.py
@@ -134,38 +134,25 @@ class TestIBMQAccounts(QiskitTestCase):
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 
-    def test_remove_all_accounts(self):
+    def test_remove_accounts(self):
         """Test removing all accounts from session."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.add_account('QISKITRC_TOKEN')
             qiskit.IBMQ.add_account('QISKITRC_TOKEN',
                                     url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
-            qiskit.IBMQ.remove_all_accounts()
+            qiskit.IBMQ.remove_accounts()
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
 
-    def test_remove_all_accounts_from_disk(self):
+    def test_remove_accounts_from_disk(self):
         """Test removing all account from disk."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.add_account('QISKITRC_TOKEN')
             qiskit.IBMQ.add_account('QISKITRC_TOKEN',
                                     url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
             self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
-            qiskit.IBMQ._accounts.clear()
-            qiskit.IBMQ.remove_all_accounts()
+            qiskit.IBMQ.remove_accounts()
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
-
-    def test_remove_all_accounts_not_from_disk(self):
-        """Test removing an account from disk."""
-        with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
-            self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
-            qiskit.IBMQ._accounts.clear()
-            qiskit.IBMQ.remove_all_accounts(delete=False)
-            self.assertEqual(len(qiskit.IBMQ._accounts), 0)
-            self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
 
 
 # TODO: NamedTemporaryFiles do not support name in Windows

--- a/test/python/test_registration.py
+++ b/test/python/test_registration.py
@@ -134,6 +134,39 @@ class TestIBMQAccounts(QiskitTestCase):
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 
+    def test_remove_all_accounts(self):
+        """Test removing all accounts from session."""
+        with custom_qiskitrc(), mock_ibmq_provider():
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
+                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            qiskit.IBMQ.remove_all_accounts()
+            self.assertEqual(len(qiskit.IBMQ._accounts), 0)
+
+    def test_remove_all_accounts_from_disk(self):
+        """Test removing all account from disk."""
+        with custom_qiskitrc(), mock_ibmq_provider():
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
+                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
+            qiskit.IBMQ._accounts.clear()
+            qiskit.IBMQ.remove_all_accounts()
+            self.assertEqual(len(qiskit.IBMQ._accounts), 0)
+            self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
+
+    def test_remove_all_accounts_not_from_disk(self):
+        """Test removing an account from disk."""
+        with custom_qiskitrc(), mock_ibmq_provider():
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
+                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
+            qiskit.IBMQ._accounts.clear()
+            qiskit.IBMQ.remove_all_accounts(delete=False)
+            self.assertEqual(len(qiskit.IBMQ._accounts), 0)
+            self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
+
 
 # TODO: NamedTemporaryFiles do not support name in Windows
 @skipIf(os.name == 'nt', 'Test not supported in Windows')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a function to remove all accounts from the ibmqprovider
and optionally the qiskitrc. Previously there was only a function to
remove a single which got a bit tedious if you wanted to flush
everything. This fixes that by giving a single point to delete all
accounts.

### Details and comments

Fixes #958 
