### PR TITLE
Fix depreciation warning when getting results from ibmqjob

### DIFF
--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -516,7 +516,7 @@ class IBMQJobPreQobj(IBMQJob):
             'status': job_response['status'],
             'used_credits': job_response.get('usedCredits'),
             'result': experiment_results,
-            'backend_name': self.backend_name(),
+            'backend_name': self.backend().name(),
             'success': job_response['status'] == 'DONE'
         }, [circuit_result['name'] for circuit_result in job_response['qasms']])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
There was a depreciation warning when grabbing results from a ibmq job.  This fixes that.


### Details and comments


