### PR TITLE
Make multiple load_account calls a warning no exception

### DIFF
--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -8,7 +8,7 @@
 """Provider for remote IBMQ backends with admin features."""
 
 from collections import OrderedDict
-
+import warnings
 from qiskit.backends import BaseProvider
 
 from .credentials._configrc import remove_credentials
@@ -200,7 +200,7 @@ class IBMQProvider(BaseProvider):
                 no credentials could be found.
         """
         if self._accounts:
-            raise IBMQAccountError('The account list is not empty')
+            warnings.warn('Can not load accounts. The account list is not empty')
 
         for credentials in discover_credentials().values():
             self._append_account(credentials)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Make multiple calls to `load_accounts` raise a warning and not an exception.


### Details and comments
Fixes #961 

