### PR TITLE
Immediately set job magic status value

### DIFF
--- a/qiskit/wrapper/jupyter/jupyter_magics.py
+++ b/qiskit/wrapper/jupyter/jupyter_magics.py
@@ -81,6 +81,7 @@ class StatusMagic(Magics):
             job_status = job_var.status()
             job_status_name = job_status.name
             job_status_msg = job_status.value
+            status.value = header % (job_status_msg)
             while job_status_name not in ['DONE', 'CANCELLED']:
                 time.sleep(args.interval)
                 job_status = job_var.status()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Previously there was a delay of length `interval` in the `qiskit_job_status` magic before it output to screen if the job status was not done.  This fixes that.


### Details and comments


