### PR TITLE
Fix test_remote_simulator usage of providers

### DIFF
--- a/test/python/test_remote_simulator.py
+++ b/test/python/test_remote_simulator.py
@@ -13,10 +13,9 @@
 
 import os
 import unittest
-from qiskit import (ClassicalRegister, QuantumCircuit, QuantumRegister,
-                    get_backend, compile)
+from qiskit import (ClassicalRegister, QuantumCircuit, QuantumRegister, compile)
 
-from qiskit.backends.ibmq import IBMQProvider
+from qiskit import IBMQ, Aer
 from qiskit.qasm import pi
 from .common import requires_qe_access, JobTestCase, slow_test
 
@@ -38,9 +37,9 @@ class TestBackendQobj(JobTestCase):
             self.skipTest("No credentials or testing device available for "
                           "testing Qobj capabilities.")
 
-        self._remote_provider = IBMQProvider(self._qe_token, self._qe_url)
-        self._local_backend = get_backend('local_qasm_simulator')
-        self._remote_backend = self._remote_provider.get_backend(self._testing_device)
+        IBMQ.use_account(self._qe_token, self._qe_url)
+        self._local_backend = Aer.get_backend('local_qasm_simulator')
+        self._remote_backend = IBMQ.get_backend(self._testing_device)
         self.log.info('Remote backend: %s', self._remote_backend.name())
         self.log.info('Local backend: %s', self._local_backend.name())
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Quick fix for the `master` tests, as it seems that due the high pace of the weekend, they are not passing since #950:

https://travis-ci.org/Qiskit/qiskit-terra/builds/435083330?utm_source=github_status&utm_medium=notification

This changes `test_remote_simulator.py` setup(), as it was instantiating a provider manually with the previous syntax, resulting in a failure - and it was hard to catch as these tests are only run when pushing to master, and require the specific environment variables to access the device.


### Details and comments


