### PR TITLE
warning instead of error for double loading

### DIFF
--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -7,6 +7,7 @@
 
 """Provider for remote IBMQ backends with admin features."""
 
+import warnings
 from collections import OrderedDict
 
 from qiskit.backends import BaseProvider
@@ -95,7 +96,7 @@ class IBMQProvider(BaseProvider):
                 * verify (bool): If False, ignores SSL certificates errors
 
         Raises:
-            IBMQAccountError: if the credentials are already in use.
+            IBMQAccountError: if the credentials are already stored.
         """
         credentials = Credentials(token, url, **kwargs)
 
@@ -199,8 +200,7 @@ class IBMQProvider(BaseProvider):
         3. in the `qiskitrc` configuration file
 
         Raises:
-            IBMQAccountError: if attempting to load previously loaded accounts,
-                    or if no credentials can be found.
+            IBMQAccountError: if no credentials can be found.
         """
         # Special handling of the credentials filters.
         credentials_filter = {}
@@ -223,14 +223,12 @@ class IBMQProvider(BaseProvider):
 
         Returns:
             IBMQSingleProvider: new single-account provider.
-
-        Raises:
-            IBMQAccountError: if the provider could not be appended.
         """
         # Check if duplicated credentials are already in use. By convention,
         # we assume (hub, group, project) is always unique.
         if credentials.unique_id() in self._accounts.keys():
-            raise IBMQAccountError('Credentials are already in use')
+            warnings.warn('Credentials are already in use.',
+                          DeprecationWarning)
 
         single_provider = IBMQSingleProvider(credentials, self)
         self._accounts[credentials.unique_id()] = single_provider

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -94,9 +94,6 @@ class IBMQProvider(BaseProvider):
             **kwargs (dict):
                 * proxies (dict): Proxy configuration for the API.
                 * verify (bool): If False, ignores SSL certificates errors
-
-        Raises:
-            IBMQAccountError: if the credentials are already stored.
         """
         credentials = Credentials(token, url, **kwargs)
 
@@ -105,12 +102,12 @@ class IBMQProvider(BaseProvider):
         stored_credentials = read_credentials_from_qiskitrc()
 
         if credentials.unique_id() in stored_credentials.keys():
-            raise IBMQAccountError('Credentials are already stored')
+            warnings.warn('Credentials are already stored')
+        else:
+            self._append_account(credentials)
 
-        self._append_account(credentials)
-
-        # Store the credentials back to disk.
-        store_credentials(credentials)
+            # Store the credentials back to disk.
+            store_credentials(credentials)
 
     def remove_account(self, token, url=QE_URL, **kwargs):
         """Remove an account from the session and from disk.
@@ -200,7 +197,7 @@ class IBMQProvider(BaseProvider):
         3. in the `qiskitrc` configuration file
 
         Raises:
-            IBMQAccountError: if no credentials can be found.
+            IBMQAccountError: if no credentials are found.
         """
         # Special handling of the credentials filters.
         credentials_filter = {}
@@ -227,8 +224,7 @@ class IBMQProvider(BaseProvider):
         # Check if duplicated credentials are already in use. By convention,
         # we assume (hub, group, project) is always unique.
         if credentials.unique_id() in self._accounts.keys():
-            warnings.warn('Credentials are already in use.',
-                          DeprecationWarning)
+            warnings.warn('Credentials are already in use.')
 
         single_provider = IBMQSingleProvider(credentials, self)
         self._accounts[credentials.unique_id()] = single_provider

--- a/test/python/test_registration.py
+++ b/test/python/test_registration.py
@@ -67,9 +67,6 @@ class TestIBMQAccounts(QiskitTestCase):
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.use_account('QISKITRC_TOKEN')
 
-            with self.assertRaises(QISKitError):
-                qiskit.IBMQ.use_account('QISKITRC_TOKEN')
-
             self.assertEqual(len(qiskit.IBMQ._accounts), 1)
 
     def test_store_credentials(self):
@@ -105,10 +102,6 @@ class TestIBMQAccounts(QiskitTestCase):
         """Test store the same credentials twice."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.add_account('QISKITRC_TOKEN')
-
-            with self.assertRaises(QISKitError):
-                # Note they are considered the same, as they have the same url.
-                qiskit.IBMQ.use_account('QISKITRC_TOKEN2')
 
             # Compare the session accounts with the ones stored in file.
             loaded_accounts = read_credentials_from_qiskitrc()

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -65,6 +65,7 @@ class TestWrapper(QiskitTestCase):
             qiskit.wrapper.register(qe_token, qe_url)
         self.assertCountEqual(initial_providers, registered_providers())
 
+    @requires_qe_access
     def test_register_bad_credentials(self):
         """Test registering a provider with bad credentials."""
         initial_providers = registered_providers()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Emit warning instead of raise exception when trying to add the same account twice (to disk or to session). It will just skip without doing anything (because it's not really an error).

fixes #961 



### Details and comments


