### PR TITLE
expand qobj types for previous version too

### DIFF
--- a/examples/python/using_qiskit_terra_level_1.py
+++ b/examples/python/using_qiskit_terra_level_1.py
@@ -90,18 +90,18 @@ try:
     # See a list of available remote backends
     try:
         # Runing the job.
-        job_exp = least_busy_device.run(qobj)
+        exp_job = least_busy_device.run(qobj)
 
         lapse = 0
         interval = 10
-        while job_exp.status().name != 'DONE':
+        while exp_job.status().name != 'DONE':
             print('Status @ {} seconds'.format(interval * lapse))
-            print(job_exp.status())
+            print(exp_job.status())
             time.sleep(interval)
             lapse += 1
-        print(job_exp.status())
+        print(exp_job.status())
 
-        exp_result = job_exp.result()
+        exp_result = exp_job.result()
 
         # Show the results
         print("experiment: ", exp_result)

--- a/qiskit/qobj/_converter.py
+++ b/qiskit/qobj/_converter.py
@@ -10,6 +10,7 @@ import logging
 
 from qiskit import QISKitError
 from ._qobj import QOBJ_VERSION
+from ._qobj import QobjItem
 
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 def qobj_to_dict(qobj, version=QOBJ_VERSION):
     """Convert a Qobj to another version of the schema.
+    Convert all types to native python types.
 
     Args:
         qobj (Qobj): input Qobj.
@@ -31,7 +33,9 @@ def qobj_to_dict(qobj, version=QOBJ_VERSION):
     if version == QOBJ_VERSION:
         return qobj_to_dict_current_version(qobj)
     elif version == '0.0.1':
-        return qobj_to_dict_previous_version(qobj)
+        return_dict = qobj_to_dict_previous_version(qobj)
+        return {key: QobjItem._expand_item(value) for key, value
+                in return_dict.items()}
     else:
         raise QISKitError('Invalid target version for conversion.')
 

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -41,15 +41,16 @@ class QobjItem(SimpleNamespace):
 
     @classmethod
     def _expand_item(cls, obj):
+        # pylint: disable=too-many-return-statements
         """
         Return a valid representation of `obj` depending on its type.
         """
         if isinstance(obj, (list, tuple)):
             return [cls._expand_item(item) for item in obj]
-        if isinstance(obj, QobjItem):
-            return obj.as_dict()
         if isinstance(obj, dict):
             return {key: cls._expand_item(value) for key, value in obj.items()}
+        if isinstance(obj, QobjItem):
+            return obj.as_dict()
         if isinstance(obj, numpy.integer):
             return int(obj)
         if isinstance(obj, numpy.float):

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -48,6 +48,8 @@ class QobjItem(SimpleNamespace):
             return [cls._expand_item(item) for item in obj]
         if isinstance(obj, QobjItem):
             return obj.as_dict()
+        if isinstance(obj, dict):
+            return {key: cls._expand_item(value) for key, value in obj.items()}
         if isinstance(obj, numpy.integer):
             return int(obj)
         if isinstance(obj, numpy.float):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

The qobj converter was not expanding the types to native python types when doing conversion to old qobj format. This PR fixes that.

The context is that jobs compiled for IBMQ backends resulted in JSON decoding error when being run on Aer `qasm_simulator`.

An immediate consequence is that `example/using_qiskit_level_1.py` can now be run (i.e. compile once run twice).



