### PR TITLE
Fix IBMQ.get_backends and IBMQ.backends for new backend names

### DIFF
--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -47,6 +47,12 @@ class IBMQProvider(BaseProvider):
         providers = [provider for provider in self._accounts.values() if
                      self._match_all(provider.credentials, credentials_filter)]
 
+        # Special handling of the `name` parameter, to support alias resolution.
+        if name:
+            aliases = self.aliased_backend_names()
+            aliases.update(self.deprecated_backend_names())
+            name = aliases.get(name, name)
+        
         # Aggregate the list of filtered backends.
         backends = []
         for provider in providers:

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -52,7 +52,7 @@ class IBMQProvider(BaseProvider):
             aliases = self.aliased_backend_names()
             aliases.update(self.deprecated_backend_names())
             name = aliases.get(name, name)
-        
+
         # Aggregate the list of filtered backends.
         backends = []
         for provider in providers:

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -47,12 +47,6 @@ class IBMQProvider(BaseProvider):
         providers = [provider for provider in self._accounts.values() if
                      self._match_all(provider.credentials, credentials_filter)]
 
-        # Special handling of the `name` parameter, to support alias resolution.
-        if name:
-            aliases = self.aliased_backend_names()
-            aliases.update(self.deprecated_backend_names())
-            name = aliases.get(name, name)
-
         # Aggregate the list of filtered backends.
         backends = []
         for provider in providers:
@@ -67,18 +61,17 @@ class IBMQProvider(BaseProvider):
         return {
             'ibmqx_qasm_simulator': 'ibmq_qasm_simulator',
             'ibmqx_hpc_qasm_simulator': 'ibmq_qasm_simulator',
-            'real': 'ibmqx1'
+            'real': 'ibmqx1',
+            'ibmqx2': 'ibmq_5_yorktown',
+            'ibmqx4': 'ibmq_5_tenerife',
+            'ibmqx5': 'ibmq_16_rueschlikon',
+            'QS1_1': 'ibmq_20_austin',
             }
 
     @staticmethod
     def aliased_backend_names():
         """Returns aliased backend names."""
-        return {
-            'ibmq_5_yorktown': 'ibmqx2',
-            'ibmq_5_tenerife': 'ibmqx4',
-            'ibmq_16_rueschlikon': 'ibmqx5',
-            'ibmq_20_austin': 'QS1_1'
-            }
+        return {}
 
     def add_account(self, token, url=QE_URL, **kwargs):
         """Authenticate against IBMQ and store the account for future use.

--- a/qiskit/backends/providerutils.py
+++ b/qiskit/backends/providerutils.py
@@ -8,7 +8,7 @@
 """Utilities for providers."""
 
 import logging
-
+import qiskit.backends.ibmq as _ibmq
 logger = logging.getLogger(__name__)
 
 
@@ -41,6 +41,10 @@ def filter_backends(backends, filters=None, **kwargs):
     status_filters = {}
     for key, value in kwargs.items():
         if all(key in backend.configuration() for backend in backends):
+            if key == 'name':
+                for _k, _v in _ibmq.IBMQ.aliased_backend_names().items():
+                    if value == _v:
+                        value = _k
             configuration_filters[key] = value
         else:
             status_filters[key] = value

--- a/qiskit/backends/providerutils.py
+++ b/qiskit/backends/providerutils.py
@@ -8,7 +8,7 @@
 """Utilities for providers."""
 
 import logging
-import qiskit.backends.ibmq as _ibmq
+
 logger = logging.getLogger(__name__)
 
 
@@ -41,14 +41,6 @@ def filter_backends(backends, filters=None, **kwargs):
     status_filters = {}
     for key, value in kwargs.items():
         if all(key in backend.configuration() for backend in backends):
-            if key == 'name':
-                try:
-                    value = resolve_backend_name(
-                        value, backends, {},
-                        _ibmq.IBMQ.deprecated_backend_names(),
-                        _ibmq.IBMQ.aliased_backend_names())
-                except LookupError:
-                    pass
             configuration_filters[key] = value
         else:
             status_filters[key] = value

--- a/qiskit/backends/providerutils.py
+++ b/qiskit/backends/providerutils.py
@@ -42,9 +42,13 @@ def filter_backends(backends, filters=None, **kwargs):
     for key, value in kwargs.items():
         if all(key in backend.configuration() for backend in backends):
             if key == 'name':
-                for _k, _v in _ibmq.IBMQ.aliased_backend_names().items():
-                    if value == _v:
-                        value = _k
+                try:
+                    value = resolve_backend_name(
+                        value, backends, {},
+                        _ibmq.IBMQ.deprecated_backend_names(),
+                        _ibmq.IBMQ.aliased_backend_names())
+                except LookupError:
+                    pass
             configuration_filters[key] = value
         else:
             status_filters[key] = value
@@ -89,7 +93,6 @@ def resolve_backend_name(name, backends, grouped, deprecated, aliased):
     """
     resolved_name = ""
     available = [backend.name() for backend in backends]
-
     if name in available:
         resolved_name = name
     elif name in grouped:

--- a/test/python/test_backend_name_resolution.py
+++ b/test/python/test_backend_name_resolution.py
@@ -78,6 +78,20 @@ class TestBackendNameResolution(QiskitTestCase):
         """Test a failing backend lookup."""
         self.assertRaises(LookupError, Aer.get_backend, 'bad_name')
 
+    @requires_qe_access
+    def test_get_backends(self, qe_token, qe_url):
+        """Test that one can get_backends from backends using city
+        and qx formats (if available)"""
+        IBMQ.use_account(qe_token, qe_url)
+        backends = IBMQ.backends()
+        dep_backend_names = IBMQ.deprecated_backend_names()
+        for back in backends:
+            test_back = IBMQ.get_backend(back.name())
+            self.assertEqual(test_back, back)
+            if back.name() in dep_backend_names.keys():
+                dep_back = IBMQ.get_backend(dep_backend_names[back.name()])
+                self.assertEqual(test_back, dep_back)
+
 
 class TestAerBackendNames(QiskitTestCase):
     """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The default IBMQ backend names were changed to their city names, causing `IBMQ.get_backend` and `IBMQ.backend('name')` to fail with backend not found.  This fixes that by moving the qx names to depreciated, this making aliased names an empty dict.  This also includes a test for explicitly getting both city and qx backends if they are in the depreciated names list.


### Details and comments


