### PR TITLE
rework IBMQ account adminstration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Added
 - Added decorator to check for C++ simulator availability (#662)
 - It is possible to cancel jobs in non comercial backends (#687)
 - Introduced new `qiskit.IBMQ` provider, with centralized handling of IBMQ
-  credentials (qiskitrc file, environment variables). (#547, #948)
+  credentials (qiskitrc file, environment variables). (#547, #948, #1000)
 - Add OpenMP parallelization for Apple builds of the cpp simulator (#698).
 - Add parallelization utilities (#701)
 - Parallelize transpilation (#701)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ COMPLETED
 This script is available [here](examples/python/hello_quantum.py), where we also show how to
 run the same program on a real quantum computer.
 
-### Executing your code on a real Quantum chip
+### Executing your code on a real quantum chip
 
 You can also use Qiskit to execute your code on a
 [real quantum chip](https://github.com/Qiskit/ibmqx-backend-information).
@@ -129,22 +129,22 @@ your IBM Q Experience account:
 
 2. Get an API token from the IBM Q Experience website under _My Account > Advanced > API Token_. This API token allows you to execute your programs with the IBM Q Experience backends. See: [Example](doc/example_real_backend.rst).
 
-3. We are now going to add the necessary credentials to QISKit. Take your token
+3. We are now going to add the necessary credentials to Qiskit. Take your token
    from step 2, here called `MY_API_TOKEN`, and pass it to the
-   `IBMQ.add_account()` function:
+   `IBMQ.save_account()` function:
 
    ```python
    from qiskit import IBMQ
 
-   IBMQ.add_account('MY_API_TOKEN')
+   IBMQ.save_account('MY_API_TOKEN')
     ```
 
 4. If you have access to the IBM Q Network features, you also need to pass the
-   url listed on your IBM Q account page to `store_credentials`.
+   url listed on your IBM Q account page to `save_account`.
 
-After calling `IBMQ.add_account()`, your credentials will be stored into disk.
-Once they are stored, Qiskit will automatically load and use them in your program
-via:
+After calling `IBMQ.save_account()`, your credentials will be stored into disk.
+Once they are stored, at any point in the future you can load and use them
+in your program simply via:
 
 ```python
 from qiskit import IBMQ
@@ -185,7 +185,7 @@ at these resources:
   for additional information and examples of QASM code
 * **[IBM Quantum Experience Composer](https://quantumexperience.ng.bluemix.net/qx/editor)**,
   a GUI for interacting with real and simulated quantum computers
-* **[QISkit Python API](https://github.com/Qiskit/qiskit-api-py)**, an API to use the IBM Quantum
+* **[Qiskit Python API](https://github.com/Qiskit/qiskit-api-py)**, an API to use the IBM Quantum
   Experience in Python
 
 Qiskit was originally developed by researchers and developers on the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -76,19 +76,19 @@ To store your information, simply run:
 
     from qiskit import IBMQ
 
-    IBMQ.add_account('MY_API_TOKEN')
+    IBMQ.save_account('MY_API_TOKEN')
 
 
 where `MY_API_TOKEN` should be replaced with your token.
 
 If you are on the IBM Q network, you must also pass the `url` 
-argument found on your q-console account page to `IBMQ.add_account()`:
+argument found on your q-console account page to `IBMQ.save_account()`:
 
 .. code:: python
 
     from qiskit import IBMQ
 
-    IBMQ.add_account('MY_API_TOKEN', url='https://...')
+    IBMQ.save_account('MY_API_TOKEN', url='https://...')
 
 
 3.1.2 Load API credentials from environment variables
@@ -177,14 +177,14 @@ precedence over the environment variables or the credentials stored in disk.
 
 In more complex scenarios or for users that need finer control over multiple
 accounts, please note that you can pass the API token and the other parameters
-directly to the ``IBMQ.use_account()`` function, which will ignore the automatic
+directly to the ``IBMQ.enable_account()`` function, which will ignore the automatic
 loading of the credentials and use the arguments directly. For example:
 
 .. code:: python
 
     from qiskit import IBMQ
 
-    IBMQ.use_account('MY_API_TOKEN', url='https://my.url')
+    IBMQ.enable_account('MY_API_TOKEN', url='https://my.url')
 
 will try to authenticate using ``MY_API_TOKEN`` and the specified URL,
 regardless of the configuration stored in the config file, the environment

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -69,22 +69,26 @@ Please check the :ref:`0.5 release notes <quantum-program-0-5>` and the
 IBM Q Authentication and ``Qconfig.py``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The managing of credentials for authenticating when using the QE backends has
+The managing of credentials for authenticating when using the QX backends has
 been expanded, and there are new options that can be used for convenience:
 
-1. store your credentials in disk once, and automatically load them in future
+1. save your credentials in disk once, and automatically load them in future
    sessions. This provides a one-off mechanism::
 
      from qiskit import IBMQ
-     IBQM.add_account('MY_API_TOKEN')
+     IBQM.save_account('MY_API_TOKEN', 'MY_API_URL')
 
-   afterwards, your credentials can be automatically read from disk by invoking
+   afterwards, your credentials can be automatically loaded from disk by invoking
    :meth:`~qiskit.backends.ibmq.IBMQ.load_accounts`::
 
      from qiskit import IBMQ
      IBMQ.load_accounts()
 
-2. use environment variables. If ``QE_TOKEN`` and ``QE_URL`` is set, the
+   or you can load only specific accounts if you only want to use those in a session::
+   
+     IBMQ.load_accounts(project='MY_PROJECT')
+
+2. use environment variables. If ``QX_TOKEN`` and ``QX_URL`` is set, the
    ``IBMQ.load_accounts()`` call will automatically load the credentials from
    them.
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -120,7 +120,7 @@ And for listing and using remote backends::
 
   from qiskit import IBMQ
 
-  IBMQ.use_account('MY_API_TOKEN')
+  IBMQ.enable_account('MY_API_TOKEN')
   5_qubit_devices = IBMQ.backends(simulator=True, n_qubits=5)
   ibmqx4 = IBMQ.get_backend('ibmqx4')
 

--- a/doc/releases.rst
+++ b/doc/releases.rst
@@ -88,7 +88,7 @@ been expanded, and there are new options that can be used for convenience:
    
      IBMQ.load_accounts(project='MY_PROJECT')
 
-2. use environment variables. If ``QX_TOKEN`` and ``QX_URL`` is set, the
+2. use environment variables. If ``QE_TOKEN`` and ``QE_URL`` is set, the
    ``IBMQ.load_accounts()`` call will automatically load the credentials from
    them.
 

--- a/examples/python/ghz.py
+++ b/examples/python/ghz.py
@@ -39,7 +39,7 @@ for i in range(5):
 ###############################################################
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/examples/python/hello_quantum.py
+++ b/examples/python/hello_quantum.py
@@ -11,7 +11,7 @@ from qiskit.backends.ibmq import least_busy
 # Authenticate for access to remote backends
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/examples/python/qft.py
+++ b/examples/python/qft.py
@@ -72,7 +72,7 @@ print(qft5.qasm())
 ###############################################################
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/examples/python/using_qiskit_terra_level_0.py
+++ b/examples/python/using_qiskit_terra_level_0.py
@@ -26,7 +26,7 @@ from qiskit.backends.ibmq import least_busy
 
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/examples/python/using_qiskit_terra_level_1.py
+++ b/examples/python/using_qiskit_terra_level_1.py
@@ -26,7 +26,7 @@ from qiskit.backends.ibmq import least_busy
 
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/examples/python/using_qiskit_terra_level_2.py
+++ b/examples/python/using_qiskit_terra_level_2.py
@@ -20,7 +20,7 @@ from qiskit import IBMQ, qobj_to_circuits
 
 try:
     import Qconfig
-    IBMQ.use_account(Qconfig.APItoken, Qconfig.config['url'])
+    IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
 except:
     print("""WARNING: There's no connection with the API for remote backends.
              Have you initialized a Qconfig.py file with your personal token?

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -80,8 +80,27 @@ class IBMQProvider(BaseProvider):
             'ibmq_20_austin': 'QS1_1'
             }
 
-    def add_account(self, token, url=QE_URL, **kwargs):
-        """Authenticate against IBMQ and store the account for future use.
+    def use_account(self, token, url=QE_URL, **kwargs):
+        """Authenticate and use one IBMQ account during this session.
+
+        Login into Quantum Experience or IBMQ using the provided credentials,
+        adding the account to the current session. The account is not stored
+        in disk.
+
+        Args:
+            token (str): Quantum Experience or IBM Q API token.
+            url (str): URL for Quantum Experience or IBM Q (for IBM Q,
+                including the hub, group and project in the URL).
+            **kwargs (dict):
+                * proxies (dict): Proxy configuration for the API.
+                * verify (bool): If False, ignores SSL certificates errors
+        """
+        credentials = Credentials(token, url, **kwargs)
+
+        self._append_account(credentials)
+
+    def save_account(self, token, url=QE_URL, **kwargs):
+        """Authenticate against IBMQ and save the account to disk for future use.
 
         Login into Quantum Experience or IBMQ using the provided credentials,
         adding the account to the current session. The account is stored in
@@ -102,75 +121,12 @@ class IBMQProvider(BaseProvider):
         stored_credentials = read_credentials_from_qiskitrc()
 
         if credentials.unique_id() in stored_credentials.keys():
-            warnings.warn('Credentials are already stored')
+            warnings.warn('Credentials are already stored.')
         else:
-            self._append_account(credentials)
-
-            # Store the credentials back to disk.
             store_credentials(credentials)
 
-    def remove_account(self, token, url=QE_URL, **kwargs):
-        """Remove an account from the session and from disk.
-
-        Args:
-            token (str): Quantum Experience or IBM Q API token.
-            url (str): URL for Quantum Experience or IBM Q (for IBM Q,
-                including the hub, group and project in the URL).
-            **kwargs (dict):
-                * proxies (dict): Proxy configuration for the API.
-                * verify (bool): If False, ignores SSL certificates errors
-
-        Raises:
-            IBMQAccountError: if the credentials could not be removed.
-        """
-        removed = False
-        credentials = Credentials(token, url, **kwargs)
-
-        # Check if the credentials are already stored in session or disk. By
-        # convention, we assume (hub, group, project) is always unique.
-        stored_credentials = read_credentials_from_qiskitrc()
-
-        # Try to remove from session.
-        if credentials.unique_id() in self._accounts.keys():
-            del self._accounts[credentials.unique_id()]
-            removed = True
-
-        # Try to remove from disk.
-        if credentials.unique_id() in stored_credentials.keys():
-            remove_credentials(credentials)
-            removed = True
-
-        if not removed:
-            raise IBMQAccountError('Unable to find credentials')
-
-    def remove_accounts(self):
-        """Remove all accounts from this session and optionally from disk."""
-        current_creds = self._accounts.copy()
-        for creds in current_creds:
-            self.remove_account(current_creds[creds].credentials.token,
-                                current_creds[creds].credentials.url)
-
-    def use_account(self, token, url=QE_URL, **kwargs):
-        """Authenticate against IBMQ during this session.
-
-        Login into Quantum Experience or IBMQ using the provided credentials,
-        adding the account to the current session. The account is not stored
-        in disk.
-
-        Args:
-            token (str): Quantum Experience or IBM Q API token.
-            url (str): URL for Quantum Experience or IBM Q (for IBM Q,
-                including the hub, group and project in the URL).
-            **kwargs (dict):
-                * proxies (dict): Proxy configuration for the API.
-                * verify (bool): If False, ignores SSL certificates errors
-        """
-        credentials = Credentials(token, url, **kwargs)
-
-        self._append_account(credentials)
-
-    def list_accounts(self):
-        """List all accounts currently stored in the session.
+    def active_accounts(self):
+        """List all accounts currently in the session.
 
         Returns:
             list[dict]: a list with information about the accounts currently
@@ -185,8 +141,26 @@ class IBMQProvider(BaseProvider):
 
         return information
 
+    def stored_accounts(self):
+        """List all accounts stored to disk.
+
+        Returns:
+            list[dict]: a list with information about the accounts stored
+                on disk.
+        """
+        information = []
+        stored_creds = read_credentials_from_qiskitrc()
+        for creds in stored_creds:
+            information.append({
+                'token': stored_creds[creds].token,
+                'url': stored_creds[creds].url
+            })
+
+        return information
+
     def load_accounts(self, **kwargs):
-        """Load IBMQ accounts found in the system, subject to optional filtering.
+        """Load IBMQ accounts found in the system into current session,
+        subject to optional filtering.
 
         Automatically load the accounts found in the system. This method
         looks for credentials in the following locations, in order, and
@@ -210,7 +184,65 @@ class IBMQProvider(BaseProvider):
                 self._append_account(credentials)
 
         if not self._accounts:
-            raise IBMQAccountError('No IBMQ credentials found.')
+            raise IBMQAccountError('No IBMQ credentials found on disk.')
+
+    def disable_accounts(self, **kwargs):
+        """Disable accounts in the current session, subject to optional filtering.
+
+        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
+        If no filter is passed, all accounts in the current session will be disabled.
+
+        Raises:
+            IBMQAccountError: if no account matched the filter.
+        """
+        disabled = False
+
+        # Special handling of the credentials filters.
+        credentials_filter = {}
+        for key in ['token', 'url', 'hub', 'group', 'project']:
+            if key in kwargs:
+                credentials_filter[key] = kwargs.pop(key)
+
+        # Try to remove from session.
+        current_creds = self._accounts.copy()
+        for creds in current_creds:
+            credentials = Credentials(current_creds[creds].credentials.token,
+                                      current_creds[creds].credentials.url)
+            if self._match_all(credentials, credentials_filter):
+                del self._accounts[credentials.unique_id()]
+                disabled = True
+
+        if not disabled:
+            raise IBMQAccountError('No matching account to disable in current session.')
+
+    def delete_accounts(self, **kwargs):
+        """Delete saved accounts from disk, subject to optional filtering.
+
+        The filter kwargs can be `token`, `url`, `hub`, `group`, `project`.
+        If no filter is passed, all accounts will be deleted from disk.
+
+        Raises:
+            IBMQAccountError: if no account matched the filter.
+        """
+        deleted = False
+
+        # Special handling of the credentials filters.
+        credentials_filter = {}
+        for key in ['token', 'url', 'hub', 'group', 'project']:
+            if key in kwargs:
+                credentials_filter[key] = kwargs.pop(key)
+
+        # Try to delete from disk.
+        stored_creds = read_credentials_from_qiskitrc()
+        for creds in stored_creds:
+            credentials = Credentials(stored_creds[creds].token,
+                                      stored_creds[creds].url)
+            if self._match_all(credentials, credentials_filter):
+                remove_credentials(credentials)
+                deleted = True
+
+        if not deleted:
+            raise IBMQAccountError('No matching account to delete from disk.')
 
     def _append_account(self, credentials):
         """Append an account with the specified credentials to the session.

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -251,10 +251,7 @@ class IBMQProvider(BaseProvider):
             if key in filter_dict:
                 credentials_filter[key] = filter_dict.pop(key)
 
-        if self._match_all(credentials, credentials_filter):
-            return True
-        else:
-            return False
+        return self._match_all(credentials, credentials_filter)
 
     def _match_all(self, obj, criteria):
         """Return True if all items in criteria matches items in obj."""

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -37,13 +37,22 @@ class IBMQProvider(BaseProvider):
         self._accounts = OrderedDict()
 
     def backends(self, name=None, filters=None, **kwargs):
+        """Return all backends accessible via IBMQ provider, subject to optional filtering.
+
+        Args:
+            name (str): backend name to filter by
+            filters (callable): more complex filters, such as lambda functions
+                e.g. IBMQ.backends(filters=lambda b: b.congiguration['n_qubits'] > 5)
+            kwargs: simple filters specifying a true/false criteria in the
+                backend configuration or backend status or provider credentials
+                e.g. IBMQ.backends(n_qubits=5, operational=True, hub='internal')
+
+        Raises:
+            IBMQAccountError: if no account matched the filter.
+        """
         # pylint: disable=arguments-differ
 
         # Special handling of the credentials filters.
-        credentials_filter = {}
-        for key in ['token', 'url', 'hub', 'group', 'project']:
-            if key in kwargs:
-                credentials_filter[key] = kwargs.pop(key)
         providers = [provider for provider in self._accounts.values() if
                      self._credentials_match_filter(provider.credentials, kwargs)]
 

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -47,6 +47,9 @@ class IBMQProvider(BaseProvider):
                 backend configuration or backend status or provider credentials
                 e.g. IBMQ.backends(n_qubits=5, operational=True, hub='internal')
 
+        Returns:
+            list[IBMQBackend]: list of backends available that match the filter
+
         Raises:
             IBMQAccountError: if no account matched the filter.
         """

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -55,12 +55,14 @@ class IBMQProvider(BaseProvider):
         """
         # pylint: disable=arguments-differ
 
-        # Special handling of the credentials filters: match, then prune from kwargs
-        providers = [provider for provider in self._accounts.values() if
-                     self._credentials_match_filter(provider.credentials, kwargs)]
+        # Special handling of the credentials filters: match and prune from kwargs
+        credentials_filter = {}
         for key in ['token', 'url', 'hub', 'group', 'project', 'proxies', 'verify']:
             if key in kwargs:
-                kwargs.pop(key)
+                credentials_filter[key] = kwargs.pop(key)
+        providers = [provider for provider in self._accounts.values() if
+                     self._credentials_match_filter(provider.credentials,
+                                                    credentials_filter)]
 
         # Special handling of the `name` parameter, to support alias resolution.
         if name:

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -53,7 +53,7 @@ def register(*args, provider_class=None, **kwargs):
 
     .. deprecated:: 0.6+
         After 0.6, this function is deprecated. Please use the methods in
-        `qiskit.IBMQ` instead (`use_account()`) for using IBMQ
+        `qiskit.IBMQ` instead (`enable_account()`) for using IBMQ
         accounts. For custom `Provider`s, please instantiate them directly.
     """
     if provider_class:
@@ -64,11 +64,11 @@ def register(*args, provider_class=None, **kwargs):
         return provider_class(*args, **kwargs)
     else:
         warnings.warn('register() will be deprecated after 0.6. Please use the '
-                      'qiskit.IBMQ.use_account() method instead.',
+                      'qiskit.IBMQ.enable_account() method instead.',
                       DeprecationWarning)
 
     try:
-        provider = IBMQ.use_account(*args, **kwargs)
+        provider = IBMQ.enable_account(*args, **kwargs)
     except Exception as ex:
         raise QISKitError("Couldn't instantiate provider! Error: {0}".format(ex))
 
@@ -91,11 +91,11 @@ def unregister(provider):
 
     .. deprecated:: 0.6+
         After 0.6, this function is deprecated. Please use the methods in
-        `qiskit.IBMQ` instead (`remove_account()`).
+        `qiskit.IBMQ` instead (`disable_account()`).
     """
     # pylint: disable=unused-argument
     warnings.warn('unregister() will be deprecated after 0.6. Please use the '
-                  'qiskit.IBMQ.remove_account() method instead.',
+                  'qiskit.IBMQ.disable_account() method instead.',
                   DeprecationWarning)
 
 
@@ -104,12 +104,12 @@ def registered_providers():
 
     .. deprecated:: 0.6+
         After 0.6, this function is deprecated. Please use the methods in
-        `qiskit.IBMQ` instead (`list_accounts()`).
+        `qiskit.IBMQ` instead (`active_accounts()`).
     """
     warnings.warn('registered_providers() will be deprecated after 0.6. Please '
-                  'use the qiskit.IBMQ.list_accounts() method instead.',
+                  'use the qiskit.IBMQ.active_accounts() method instead.',
                   DeprecationWarning)
-    return IBMQ.list_accounts()
+    return IBMQ.active_accounts()
 
 
 # Functions for inspecting and retrieving backends.

--- a/test/python/aer/test_simulator_interfaces.py
+++ b/test/python/aer/test_simulator_interfaces.py
@@ -44,7 +44,7 @@ class TestCrossSimulation(QiskitTestCase):
     @requires_qe_access
     def test_qasm(self, qe_token, qe_url):
         """counts from a GHZ state"""
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)
         circuit = qiskit.QuantumCircuit(qr, cr)
@@ -96,7 +96,7 @@ class TestCrossSimulation(QiskitTestCase):
     @requires_qe_access
     def test_qasm_reset_measure(self, qe_token, qe_url):
         """counts from a qasm program with measure and reset in the middle"""
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)
         circuit = qiskit.QuantumCircuit(qr, cr)

--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -25,7 +25,7 @@ class TestIbmqQasmSimulator(QiskitTestCase):
 
         If all correct should return correct counts.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qr = QuantumRegister(1)
@@ -48,7 +48,7 @@ class TestIbmqQasmSimulator(QiskitTestCase):
 
         If all correct should return correct counts.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qr = QuantumRegister(2)
@@ -81,7 +81,7 @@ class TestIbmqQasmSimulator(QiskitTestCase):
 
         If all correct should return correct counts.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qr1 = QuantumRegister(2)

--- a/test/python/ibmq/test_ibmq_qobj.py
+++ b/test/python/ibmq/test_ibmq_qobj.py
@@ -9,7 +9,7 @@
 # pylint: disable=redefined-builtin
 # pylint: disable=too-many-function-args
 
-"""IBMQ Remote Simulator Tests"""
+"""IBMQ Remote Backend Qobj Tests"""
 
 import os
 import unittest
@@ -17,10 +17,10 @@ from qiskit import (ClassicalRegister, QuantumCircuit, QuantumRegister, compile)
 
 from qiskit import IBMQ, Aer
 from qiskit.qasm import pi
-from .common import requires_qe_access, JobTestCase, slow_test
+from ..common import requires_qe_access, JobTestCase, slow_test
 
 
-class TestBackendQobj(JobTestCase):
+class TestIBMQQobj(JobTestCase):
     """Qiskit backend qobj test. Compares remote simulator as
        configured in environment variables 'IBMQ_QOBJ_DEVICE',
        'IBMQ_TOKEN' and 'IBMQ_QOBJ_URL' against local simulator
@@ -37,7 +37,7 @@ class TestBackendQobj(JobTestCase):
             self.skipTest("No credentials or testing device available for "
                           "testing Qobj capabilities.")
 
-        IBMQ.use_account(self._qe_token, self._qe_url)
+        IBMQ.enable_account(self._qe_token, self._qe_url)
         self._local_backend = Aer.get_backend('local_qasm_simulator')
         self._remote_backend = IBMQ.get_backend(self._testing_device)
         self.log.info('Remote backend: %s', self._remote_backend.name())

--- a/test/python/ibmq/test_ibmqjob.py
+++ b/test/python/ibmq/test_ibmqjob.py
@@ -39,7 +39,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_run_simulator(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qr = QuantumRegister(2, 'q')
@@ -77,7 +77,7 @@ class TestIBMQJob(JobTestCase):
     @slow_test
     @requires_qe_access
     def test_run_device(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends(simulator=False)
 
         self.log.info('devices: %s', [b.name() for b in backends])
@@ -108,7 +108,7 @@ class TestIBMQJob(JobTestCase):
     def test_run_async_simulator(self, qe_token, qe_url):
         IBMQJob._executor = futures.ThreadPoolExecutor(max_workers=2)
 
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         self.log.info('submitting to backend %s', backend.name())
@@ -157,7 +157,7 @@ class TestIBMQJob(JobTestCase):
     @slow_test
     @requires_qe_access
     def test_run_async_device(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends(simulator=False)
         backend = least_busy(backends)
 
@@ -205,7 +205,7 @@ class TestIBMQJob(JobTestCase):
     @slow_test
     @requires_qe_access
     def test_cancel(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend_name = ('ibmq_20_tokyo'
                         if self.using_ibmq_credentials else 'ibmqx4')
         backend = IBMQ.get_backend(backend_name)
@@ -219,7 +219,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_job_id(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qobj = transpiler.compile(self._qc, backend)
@@ -229,7 +229,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_get_backend_name(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qobj = transpiler.compile(self._qc, backend)
@@ -238,7 +238,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_get_jobs_from_backend(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = least_busy(IBMQ.backends())
 
         start_time = time.time()
@@ -252,7 +252,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_retrieve_job(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qobj = transpiler.compile(self._qc, backend)
@@ -263,7 +263,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_retrieve_job_error(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends(simulator=False)
         backend = least_busy(backends)
 
@@ -271,7 +271,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_get_jobs_filter_job_status(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends(simulator=False)
         backend = least_busy(backends)
 
@@ -285,7 +285,7 @@ class TestIBMQJob(JobTestCase):
     def test_get_jobs_filter_counts(self, qe_token, qe_url):
         # TODO: consider generalizing backend name
         # TODO: this tests depends on the previous executions of the user
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         my_filter = {'backend.name': 'ibmq_qasm_simulator',
@@ -308,7 +308,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_get_jobs_filter_date(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends(simulator=False)
         backend = least_busy(backends)
 
@@ -321,7 +321,7 @@ class TestIBMQJob(JobTestCase):
 
     @requires_qe_access
     def test_double_submit_fails(self, qe_token, qe_url):
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backend = IBMQ.get_backend('ibmq_qasm_simulator')
 
         qobj = transpiler.compile(self._qc, backend)
@@ -343,7 +343,7 @@ class TestQObjectBasedIBMQJob(JobTestCase):
             self.skipTest('No credentials or testing device available for '
                           'testing Qobj capabilities.')
 
-        IBMQ.use_account(self._qe_token, self._qe_url)
+        IBMQ.enable_account(self._qe_token, self._qe_url)
         self._backend = IBMQ.get_backend(self._testing_device)
 
         self._qc = _bell_circuit()

--- a/test/python/ibmq/test_registration.py
+++ b/test/python/ibmq/test_registration.py
@@ -23,7 +23,7 @@ from qiskit.backends.ibmq.credentials import (
 from qiskit.backends.ibmq.credentials._environ import VARIABLES_MAP
 from qiskit.backends.ibmq.ibmqprovider import QE_URL
 from qiskit.backends.ibmq.ibmqsingleprovider import IBMQSingleProvider
-from .common import QiskitTestCase
+from ..common import QiskitTestCase
 
 
 IBMQ_TEMPLATE = 'https://localhost/api/Hubs/{}/Groups/{}/Projects/{}'
@@ -33,11 +33,11 @@ IBMQ_TEMPLATE = 'https://localhost/api/Hubs/{}/Groups/{}/Projects/{}'
 @skipIf(os.name == 'nt', 'Test not supported in Windows')
 class TestIBMQAccounts(QiskitTestCase):
     """Tests for the IBMQ account handling."""
-    def test_use_credentials(self):
-        """Test using one account."""
+    def test_enable_account(self):
+        """Test enabling one account."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN', url='someurl',
-                                    proxies={'http': 'foo'})
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN', url='someurl',
+                                       proxies={'http': 'foo'})
 
             # Compare the session accounts with the ones stored in file.
             loaded_accounts = read_credentials_from_qiskitrc()
@@ -48,102 +48,98 @@ class TestIBMQAccounts(QiskitTestCase):
             self.assertEqual('someurl', provider.credentials.url)
             self.assertEqual({'http': 'foo'}, provider.credentials.proxies)
 
-    def test_use_multiple_credentials(self):
-        """Test using multiple accounts, combining QE and IBMQ."""
+    def test_enable_multiple_accounts(self):
+        """Test enabling multiple accounts, combining QX and IBMQ."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'X'))
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN',
+                                       url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN',
+                                       url=IBMQ_TEMPLATE.format('a', 'b', 'X'))
 
             # Compare the session accounts with the ones stored in file.
             loaded_accounts = read_credentials_from_qiskitrc()
             self.assertEqual(loaded_accounts, {})
             self.assertEqual(len(qiskit.IBMQ._accounts), 3)
 
-    def test_use_duplicate_credentials(self):
-        """Test using the same credentials twice."""
+    def test_enable_duplicate_accounts(self):
+        """Test enabling the same credentials twice."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
 
             self.assertEqual(len(qiskit.IBMQ._accounts), 1)
 
-    def test_store_credentials(self):
-        """Test storing one account."""
+    def test_save_account(self):
+        """Test saving one account."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN', url=QE_URL,
-                                    proxies={'http': 'foo'})
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN', url=QE_URL,
+                                     proxies={'http': 'foo'})
 
             # Compare the session accounts with the ones stored in file.
-            loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertEqual(qiskit.IBMQ._accounts.keys(), loaded_accounts.keys())
-            self.assertEqual(list(qiskit.IBMQ._accounts.values())[0].credentials,
-                             list(loaded_accounts.values())[0])
+            stored_accounts = read_credentials_from_qiskitrc()
+            self.assertEqual(len(stored_accounts.keys()), 1)
 
-    def test_store_multiple_credentials(self):
-        """Test storing several accounts, combining QE and IBMQ"""
+    def test_save_multiple_accounts(self):
+        """Test saving several accounts, combining QX and IBMQ"""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'X'))
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN',
+                                     url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN',
+                                     url=IBMQ_TEMPLATE.format('a', 'b', 'X'))
 
             # Compare the session accounts with the ones stored in file.
-            loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertEqual(qiskit.IBMQ._accounts.keys(), loaded_accounts.keys())
-            self.assertEqual(len(loaded_accounts), 3)
+            stored_accounts = read_credentials_from_qiskitrc()
+            self.assertEqual(len(stored_accounts), 3)
             for account_name, provider in qiskit.IBMQ._accounts.items():
                 self.assertEqual(provider.credentials,
-                                 loaded_accounts[account_name])
+                                 stored_accounts[account_name])
 
-    def test_store_duplicate_credentials(self):
-        """Test store the same credentials twice."""
+    def test_save_duplicate_accounts(self):
+        """Test saving the same credentials twice."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN')
 
             # Compare the session accounts with the ones stored in file.
-            loaded_accounts = read_credentials_from_qiskitrc()
-            self.assertEqual(len(qiskit.IBMQ._accounts), 1)
-            self.assertEqual(len(loaded_accounts), 1)
+            stored_accounts = read_credentials_from_qiskitrc()
+            self.assertEqual(len(stored_accounts), 1)
 
-    def test_remove_account(self):
-        """Test removing an account from session."""
-        with mock_ibmq_provider():
-            qiskit.IBMQ.use_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.remove_account('QISKITRC_TOKEN')
+    def test_disable_accounts(self):
+        """Test disabling an account in a session."""
+        with custom_qiskitrc(), mock_ibmq_provider():
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.disable_accounts('QISKITRC_TOKEN')
 
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
 
-    def test_remove_account_from_disk(self):
-        """Test removing an account from disk."""
+    def test_delete_accounts(self):
+        """Test deleting an account from disk."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN')
             self.assertEqual(len(read_credentials_from_qiskitrc()), 1)
 
             qiskit.IBMQ._accounts.clear()
-            qiskit.IBMQ.remove_account('QISKITRC_TOKEN')
-            self.assertEqual(len(qiskit.IBMQ._accounts), 0)
+            qiskit.IBMQ.delete_accounts(token='QISKITRC_TOKEN')
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 
-    def test_remove_accounts(self):
-        """Test removing all accounts from session."""
+    def test_disable_accounts(self):
+        """Test disabling all accounts from session."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
-            qiskit.IBMQ.remove_accounts()
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.enable_account('QISKITRC_TOKEN',
+                                       url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            qiskit.IBMQ.disable_accounts()
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
 
-    def test_remove_accounts_from_disk(self):
-        """Test removing all account from disk."""
+    def test_delete_accounts(self):
+        """Test deleting all accounts from disk."""
         with custom_qiskitrc(), mock_ibmq_provider():
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.add_account('QISKITRC_TOKEN',
-                                    url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN')
+            qiskit.IBMQ.save_account('QISKITRC_TOKEN',
+                                     url=IBMQ_TEMPLATE.format('a', 'b', 'c'))
             self.assertEqual(len(read_credentials_from_qiskitrc()), 2)
-            qiskit.IBMQ.remove_accounts()
+            qiskit.IBMQ.delete_accounts()
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 

--- a/test/python/ibmq/test_registration.py
+++ b/test/python/ibmq/test_registration.py
@@ -109,7 +109,7 @@ class TestIBMQAccounts(QiskitTestCase):
         """Test disabling an account in a session."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
-            qiskit.IBMQ.disable_accounts('QISKITRC_TOKEN')
+            qiskit.IBMQ.disable_accounts(token='QISKITRC_TOKEN')
 
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
 
@@ -123,7 +123,7 @@ class TestIBMQAccounts(QiskitTestCase):
             qiskit.IBMQ.delete_accounts(token='QISKITRC_TOKEN')
             self.assertEqual(len(read_credentials_from_qiskitrc()), 0)
 
-    def test_disable_accounts(self):
+    def test_disable_all_accounts(self):
         """Test disabling all accounts from session."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.enable_account('QISKITRC_TOKEN')
@@ -132,7 +132,7 @@ class TestIBMQAccounts(QiskitTestCase):
             qiskit.IBMQ.disable_accounts()
             self.assertEqual(len(qiskit.IBMQ._accounts), 0)
 
-    def test_delete_accounts(self):
+    def test_delete_all_accounts(self):
         """Test deleting all accounts from disk."""
         with custom_qiskitrc(), mock_ibmq_provider():
             qiskit.IBMQ.save_account('QISKITRC_TOKEN')

--- a/test/python/test_backend_name_resolution.py
+++ b/test/python/test_backend_name_resolution.py
@@ -46,7 +46,7 @@ class TestBackendNameResolution(QiskitTestCase):
     def test_aliases(self, qe_token, qe_url):
         """Test that display names of devices map the same backends as the
         regular names."""
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         aliased_names = IBMQ.aliased_backend_names()
 
         for display_name, backend_name in aliased_names.items():

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -41,7 +41,7 @@ class TestBackends(QiskitTestCase):
 
         If all correct some should exists.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends()
         self.assertTrue(len(remotes) > 0)
 
@@ -51,7 +51,7 @@ class TestBackends(QiskitTestCase):
 
         If all correct some should exists.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         self.assertTrue(remotes)
 
@@ -61,7 +61,7 @@ class TestBackends(QiskitTestCase):
 
         If all correct some should exists.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=True)
         self.assertTrue(remotes)
 
@@ -99,7 +99,7 @@ class TestBackends(QiskitTestCase):
         # FIXME: reintroduce in 0.6
         self.skipTest('Skipping due to available vs operational')
 
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends()
         remotes = remove_backends_from_list(remotes)
         for backend in remotes:
@@ -132,7 +132,7 @@ class TestBackends(QiskitTestCase):
 
         If all correct should pass the validation.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:
             configuration = backend.configuration()
@@ -160,7 +160,7 @@ class TestBackends(QiskitTestCase):
 
         If all correct should pass the validation.
         """
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:
             self.log.info(backend.name())

--- a/test/python/test_compiler.py
+++ b/test/python/test_compiler.py
@@ -165,7 +165,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = least_busy(qiskit.IBMQ.backends())
 
         qubit_reg = QuantumRegister(2, name='q')
@@ -186,7 +186,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = least_busy(qiskit.IBMQ.backends())
 
         qubit_reg = QuantumRegister(2, name='q')
@@ -208,7 +208,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
         qubit_reg = QuantumRegister(2, name='q')
@@ -228,7 +228,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
         qubit_reg = QuantumRegister(2, name='q')
@@ -250,7 +250,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
         qubit_reg = QuantumRegister(2)
@@ -270,7 +270,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
 
         qubit_reg = QuantumRegister(2)

--- a/test/python/test_filter_backends.py
+++ b/test/python/test_filter_backends.py
@@ -20,14 +20,14 @@ class TestBackendFilters(QiskitTestCase):
         """Test filtering by configuration properties"""
         n_qubits = 20 if self.using_ibmq_credentials else 5
 
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         filtered_backends = IBMQ.backends(n_qubits=n_qubits, local=False)
         self.assertTrue(filtered_backends)
 
     @requires_qe_access
     def test_filter_status_dict(self, qe_token, qe_url):
         """Test filtering by dictionary of mixed status/configuration properties"""
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         filtered_backends = IBMQ.backends(
             operational=True,  # from status
             local=False, simulator=True)  # from configuration
@@ -37,7 +37,7 @@ class TestBackendFilters(QiskitTestCase):
     @requires_qe_access
     def test_filter_config_callable(self, qe_token, qe_url):
         """Test filtering by lambda function on configuration properties"""
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         filtered_backends = IBMQ.backends(
             filters=lambda x: (not x.configuration()['simulator']
                                and x.configuration()['n_qubits'] > 5))
@@ -46,7 +46,7 @@ class TestBackendFilters(QiskitTestCase):
     @requires_qe_access
     def test_filter_least_busy(self, qe_token, qe_url):
         """Test filtering by least busy function"""
-        IBMQ.use_account(qe_token, qe_url)
+        IBMQ.enable_account(qe_token, qe_url)
         backends = IBMQ.backends()
         filtered_backends = least_busy(backends)
         self.assertTrue(filtered_backends)

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -90,7 +90,7 @@ class TestBitReordering(QiskitTestCase):
     def _get_backends(self, qe_token, qe_url):
         sim_backend = qiskit.Aer.get_backend('qasm_simulator')
         try:
-            qiskit.IBMQ.use_account(qe_token, qe_url)
+            qiskit.IBMQ.enable_account(qe_token, qe_url)
             real_backends = qiskit.IBMQ.backends(simulator=False)
             real_backend = least_busy(real_backends)
         except Exception:

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -41,7 +41,7 @@ class TestQiskitResult(QiskitTestCase):
     @requires_qe_access
     def test_ibmq_result_fields(self, qe_token, qe_url):
         """Test components of a result from a remote simulator."""
-        qiskit.IBMQ.use_account(qe_token, qe_url)
+        qiskit.IBMQ.enable_account(qe_token, qe_url)
         remote_backend = qiskit.IBMQ.get_backend(local=False, simulator=True)
         remote_result = qiskit.execute(self._qc1, remote_backend).result()
         self.assertEqual(remote_result.backend_name, remote_backend.name())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
**PR #1000!**

Fixes #980 
Fixes #1001 

The IBMQ account adminstration has been changed a bit. Here is how it works now.

```python
enable_account(token, url) # add to current session
disable_accounts(**kwargs)  #remove from current session
save_account(token, url) #save to disk
delete_accounts(**kwargs) #delete from disk
load_accounts(**kwargs) #load into session
active_accounts() # list all accounts active in this session
stored_accounts() # list all accounts saved to disk
```

Example usage:
```python
from qiskit import *
import Qconfig
import QconfigCore

# start fresh. delete any accounts on disk
IBMQ.delete_accounts()
# verify that there are no accounts stored now
IBMQ.stored_accounts()

# enable an account (useful for one-off use, or if you don't want to save to disk)
IBMQ.enable_account(Qconfig.APItoken, Qconfig.config['url'])
# you see that specific account enabled for use
IBMQ.active_accounts()

# and its backends are available
IBMQ.backends()

# disable that account (so we go back to no accounts active)
IBMQ.disable_accounts(token=Qconfig.APItoken, url=Qconfig.config['url'])

# save two accounts: a public and a premium
import Qconfig
import QconfigCore
IBMQ.save_account(Qconfig.APItoken, Qconfig.config['url'])
IBMQ.save_account(QconfigCore.APItoken, QconfigCore.config['url'])

# now they should show up as present on disk
IBMQ.stored_accounts()

# but no account active in current session yet
IBMQ.active_accounts()

# so IBMQ can't see any backends yet
IBMQ.backends()

# now load up every account stored to disk
IBMQ.load_accounts()

# backends from two different accounts available for use
IBMQ.backends()

# now if you want to work with backends of a single account,
# you can do so via backend filtering
IBMQ.backends(name='ibmq_qasm_simulator', group=None)

# but you can also just disable account in the current session
IBMQ.disable_accounts(project='qiskit-core')

# so now only one account is active
IBMQ.active_accounts()

# and only that account's backends are available
IBMQ.backends()

# or from the start just load up that account you're interested in
IBMQ.disable_accounts()
IBMQ.load_accounts(project='qiskit-core')
IBMQ.backends()
```


