### PR TITLE
Fix for 0.6 backend names in API

### DIFF
--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -21,12 +21,7 @@ from qiskit.backends import JobStatus
 # imports. Once fixed, their place should be `ibmqprovider.py`.
 
 # Dict with the form {'new_name': 'previous_name'}
-ALIASED_BACKEND_NAMES = {
-    'ibmq_5_yorktown': 'ibmqx2',
-    'ibmq_5_tenerife': 'ibmqx4',
-    'ibmq_16_rueschlikon': 'ibmqx5',
-    'ibmq_20_austin': 'QS1_1'
-}
+ALIASED_BACKEND_NAMES = {}
 
 # Dict with the form {'previous_name': 'new_name'}
 ALIASED_BACKEND_NAMES_REVERSED = {name: alias for alias, name in

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -55,7 +55,11 @@ class IBMQProvider(BaseProvider):
         return {
             'ibmqx_qasm_simulator': 'ibmq_qasm_simulator',
             'ibmqx_hpc_qasm_simulator': 'ibmq_qasm_simulator',
-            'real': 'ibmqx1'
+            'real': 'ibmqx1',
+            'ibmqx2': 'ibmq_5_yorktown',
+            'ibmqx4': 'ibmq_5_tenerife',
+            'ibmqx5': 'ibmq_16_rueschlikon',
+            'QS1_1': 'ibmq_20_austin',
             }
 
     def aliased_backend_names(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-IBMQuantumExperience>=1.9.6
+IBMQuantumExperience>=2.0.4
 matplotlib>=2.1
 networkx>=2.0
 numpy>=1.13


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is a fix for the switch to city names as the default names for the backends, as introduced in qiskit 0.6.  This PR will not work until the `IBMQuantumExperience` is at version `2.0.4+`.


### Details and comments


