### PR TITLE
Fix intermittent linter warning in qcvv.tomography

### DIFF
--- a/qiskit/tools/qcvv/tomography.py
+++ b/qiskit/tools/qcvv/tomography.py
@@ -562,12 +562,12 @@ def create_tomography_circuits(circuit, qreg, creg, tomoset):
             prep = QuantumCircuit(qreg, creg, name='tmp_prep')
             for qubit, op in conf['prep'].items():
                 tomoset['prep_basis'].prep_gate(prep, qreg[qubit], op)
-                prep.barrier(qreg[qubit])
+                prep.barrier(qreg[qubit])  # pylint: disable=no-member
             tmp = prep + tmp
         # Add measurement circuits
         meas = QuantumCircuit(qreg, creg, name='tmp_meas')
         for qubit, op in conf['meas'].items():
-            meas.barrier(qreg[qubit])
+            meas.barrier(qreg[qubit])  # pylint: disable=no-member
             tomoset['meas_basis'].meas_gate(meas, qreg[qubit], op)
             meas.measure(qreg[qubit], creg[qubit])
         tmp = tmp + meas
@@ -939,7 +939,7 @@ def build_wigner_circuits(circuit, phis, thetas, qubits,
         label += str(point)
         tmp_circ = QuantumCircuit(qreg, creg, name=label)
         for qubit, _ in enumerate(qubits):
-            tmp_circ.u3(thetas[qubit][point], 0,
+            tmp_circ.u3(thetas[qubit][point], 0,  # pylint: disable=no-member
                         phis[qubit][point], qreg[qubits[qubit]])
             tmp_circ.measure(qreg[qubits[qubit]], creg[qubits[qubit]])
         # Add to original circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Silent linter warnings in `qiskit/tools/qcvv/tomography.py` (the real credit is  @1ucian0 's!). Please note that these warnings are actually not shown when running under some configurations, and hint towards depending on the order `pylint` reads and parses the files or a similar issue, which in turn might be a symptom of other issue with the tomography module that should be investigated further.


### Details and comments


