### PR TITLE
Guarantee order of registers in DAGCircuit

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -74,10 +74,10 @@ class DAGCircuit:
         self.multi_graph = nx.MultiDiGraph()
 
         # Map of qregs to sizes
-        self.qregs = {}
+        self.qregs = OrderedDict()
 
         # Map of cregs to sizes
-        self.cregs = {}
+        self.cregs = OrderedDict()
 
         # Map of user defined gates to ast nodes defining them
         self.gates = {}


### PR DESCRIPTION
### Summary

Use `OrderedDict`s for `DAGCircuit.qregs` and `DAGCircuit.cregs` in
order to ensure that they are traversed always in the same order (which
should be the order of creation).

### Details and comments

This is an attempt to fix the problem we have been experiencing in `master` recently, and intermittently in local tests:
```
1: ======================================================================
1: FAIL: test_online_qasm_simulator_two_registers (python.ibmq.test_ibmq_qasm_simulator.TestIbmqQasmSimulator)
1: Test online_qasm_simulator_two_registers.
1: ----------------------------------------------------------------------
1: Traceback (most recent call last):
1:   File "/home/travis/build/Qiskit/qiskit-terra/test/python/common.py", line 373, in _wrapper
1:     return decorated_func(self, *args, **kwargs)
1:   File "/home/travis/build/Qiskit/qiskit-terra/test/python/ibmq/test_ibmq_qasm_simulator.py", line 109, in test_online_qasm_simulator_two_registers
1:     self.assertEqual(result1, {'00 01': 1024})
1: AssertionError: {'01 00': 1024} != {'00 01': 1024}
1: - {'01 00': 1024}
1: ?     ---
1: 
1: + {'00 01': 1024}
1: ?    +++
1: 
1: 
1: ----------------------------------------------------------------------
```

It seems to boil down to the list of instructions obtained by the `DagUnroller(JsonBackend)` not being deterministic - the registers stored in the DAG could be traversed in different order, and as a result the generated instructions could have different indices for the registers (as, `JsonBackend._qubit_order`, `JsonBackend._qubit_order_internal`, and the analogous for classical registers were not guaranteed to be populated in always the same order).

This seems to have rippled up in the `test/python/ibmq/test_ibmq_qasm_simulator.py::TestIbmqQasmSimulator::test_online_qasm_simulator_two_registers`  test - for the failing runs, the last measures would alternatively be using different registers than the one expected by the assertion.

Thanks a lot to @hitomitak for the help debugging the issue!
