### PR TITLE
Skipping the `test_online_qasm_simulator_two_registers` intermitent test

### DIFF
--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -10,6 +10,7 @@
 """Test IBMQ online qasm simulator.
 TODO: Must expand tests. Re-evaluate after Aer."""
 
+from unittest import skip
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import transpiler
 from qiskit import IBMQ
@@ -75,6 +76,9 @@ class TestIbmqQasmSimulator(QiskitTestCase):
         self.assertDictAlmostEqual(counts1, target1, threshold)
         self.assertDictAlmostEqual(counts2, target2, threshold)
 
+    # TODO: Investigate why this test is failing in master:
+    # https://github.com/Qiskit/qiskit-terra/issues/1016
+    @skip('Intermitent failure, see: https://github.com/Qiskit/qiskit-terra/issues/1016 ')
     @requires_qe_access
     def test_online_qasm_simulator_two_registers(self, qe_token, qe_url):
         """Test online_qasm_simulator_two_registers.


### PR DESCRIPTION
### Summary
Related to #1016, this PR skips the test although it does not solve the problem.


