### PR TITLE
Handle simulator builtins in dag unroller

### DIFF
--- a/qiskit/unroll/_dagunroller.py
+++ b/qiskit/unroll/_dagunroller.py
@@ -78,11 +78,12 @@ class DagUnroller(object):
             gatedefs.append(Gate(children))
         # Walk through the DAG and examine each node
         builtins = ["U", "CX", "measure", "reset", "barrier"]
+        simulator_builtins = ['snapshot', 'save', 'load', 'noise']
         topological_sorted_list = list(nx.topological_sort(self.dag_circuit.multi_graph))
         for node in topological_sorted_list:
             current_node = self.dag_circuit.multi_graph.node[node]
             if current_node["type"] == "op" and \
-               current_node["name"] not in builtins + basis and \
+               current_node["name"] not in builtins + basis + simulator_builtins and \
                not self.dag_circuit.gates[current_node["name"]]["opaque"]:
                 subcircuit, wires = self._build_subcircuit(gatedefs,
                                                            basis,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the dag unroller when it encounters
simulator builtin instructions like snapshot(). It doesn't know what
those are so it assumes it's a gate. But since it's not a gate when it
tries to look that up it fails on a KeyError. This fixes that by having
a list of simulator builtins to check against and treats those like
other builtins (barrier, reset, etc).

### Details and comments

Fixes #1019
