### PR TITLE
Fix horizontal barrier offset before ccnot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ The format is based on `Keep a Changelog`_.
 Changed
 -------
 
+Fixed
+-----
+- Fixed horizontal spacing when drawing barriers before CCNOT gates in latex
+  circuit plots (#1051)
 
 `0.6.0`_ - 2018-10-04
 =====================

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1178,6 +1178,16 @@ class QCircuitImage(object):
                                     is_occupied[j] = True
                                 break
 
+                        prev_column = [x[columns - 1] for x in self._latex]
+                        for item, prev_entry in enumerate(prev_column):
+                            if 'barrier' in prev_entry:
+                                span = re.search('barrier{(.*)}', prev_entry)
+                                if span and (
+                                        item + int(span.group(1))) - pos_1 >= 0:
+                                    self._latex[
+                                        item][columns - 1] = prev_entry.replace(
+                                            '\\barrier{', '\\barrier[-0.65em]{')
+
                         gap = pos_4 - bottom
                         for i in range(self.cregs[if_reg]):
                             if if_value[i] == '1':
@@ -1214,6 +1224,17 @@ class QCircuitImage(object):
                                 for j in range(top, bottom + 1):
                                     is_occupied[j] = True
                                 break
+
+                        prev_column = [x[columns - 1] for x in self._latex]
+                        for item, prev_entry in enumerate(prev_column):
+                            if 'barrier' in prev_entry:
+                                span = re.search('barrier{(.*)}', prev_entry)
+                                if span and (
+                                        item + int(
+                                            span.group(1))) - pos_1 in temp:
+                                    self._latex[
+                                        item][columns - 1] = prev_entry.replace(
+                                            '\\barrier{', '\\barrier[-0.65em]{')
 
                         if nm == "ccx":
                             self._latex[pos_1][columns] = "\\ctrl{" + str(pos_2 - pos_1) + "}"

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1182,8 +1182,8 @@ class QCircuitImage(object):
                         for item, prev_entry in enumerate(prev_column):
                             if 'barrier' in prev_entry:
                                 span = re.search('barrier{(.*)}', prev_entry)
-                                if span and (
-                                        item + int(span.group(1))) - pos_1 >= 0:
+                                if span and any(i in temp for i in range(
+                                        item, int(span.group(1)))):
                                     self._latex[
                                         item][columns - 1] = prev_entry.replace(
                                             '\\barrier{', '\\barrier[-0.65em]{')
@@ -1229,9 +1229,8 @@ class QCircuitImage(object):
                         for item, prev_entry in enumerate(prev_column):
                             if 'barrier' in prev_entry:
                                 span = re.search('barrier{(.*)}', prev_entry)
-                                if span and (
-                                        item + int(
-                                            span.group(1))) - pos_1 in temp:
+                                if span and any(i in temp for i in range(
+                                        item, int(span.group(1)))):
                                     self._latex[
                                         item][columns - 1] = prev_entry.replace(
                                             '\\barrier{', '\\barrier[-0.65em]{')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If there is a barrier right before a ccnot in a circuit it requires a
modified horizontal offset for the barrier because of the spacing
between the elements. This commit fixes this by modifying offset when
drawing a ccnot if there is a barrier on overlapping rows in the
circuit.

### Details and comments


