### PR TITLE
Rename python circuit_drawer() backend to mpl

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -79,9 +79,9 @@ def circuit_drawer(circuit,
         filename (str): file path to save image to
         style (dict or str): dictionary of style or file name of style file
         output (str): Select the output method to use for drawing the circuit.
-            Valid choices are `latex`, `latex_source`, `python`. Note if one is
+            Valid choices are `latex`, `latex_source`, `mpl`. Note if one is
             not specified it will use latex and if that fails fallback to
-            python. However this behavior is deprecated and in a future release
+            mpl. However this behavior is deprecated and in a future release
             the default will change.
         interactive (bool): when set true show the circuit in a new window
             (cannot inline in Jupyter). Note when used with the latex_source
@@ -98,18 +98,18 @@ def circuit_drawer(circuit,
     if not output:
         warnings.warn('The current behavior for the default output will change'
                       ' in a future release. Instead of trying latex and '
-                      'falling back to python on failure it will just use '
-                      'python by default', DeprecationWarning)
+                      'falling back to mpl on failure it will just use '
+                      'mpl by default', DeprecationWarning)
         try:
             im = _latex_circuit_drawer(circuit, basis, scale, filename, style)
         except (OSError, subprocess.CalledProcessError):
             im = _matplotlib_circuit_drawer(circuit, basis, scale, filename,
                                             style)
     else:
-        if output not in ['latex', 'latex_source', 'python']:
+        if output not in ['latex', 'latex_source', 'mpl']:
             raise VisualizationError(
                 'Invalid output type %s selected. The only valid choices are '
-                'latex, latex_source, and python' % output)
+                'latex, latex_source, and mpl' % output)
         if output == 'latex':
             im = _latex_circuit_drawer(circuit, basis=basis, scale=scale,
                                        filename=filename, style=style)
@@ -117,7 +117,7 @@ def circuit_drawer(circuit,
             return _generate_latex_source(circuit, basis=basis,
                                           filename=filename, scale=scale,
                                           style=style)
-        elif output == 'python':
+        elif output == 'mpl':
             im = _matplotlib_circuit_drawer(circuit, basis=basis, scale=scale,
                                             filename=filename, style=style)
     if im and interactive:
@@ -1491,7 +1491,7 @@ def matplotlib_circuit_drawer(circuit,
     warnings.warn('The matplotlib_circuit_drawer() function is deprecated and '
                   'will be removed in a future release. Instead use the '
                   'circuit_drawer() function with the `output` kwarg set to '
-                  '`python`.', DeprecationWarning)
+                  '`mpl`.', DeprecationWarning)
     return _matplotlib_circuit_drawer(circuit, basis=basis, scale=scale,
                                       filename=filename, style=style)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The python backend name was a bit ambigious as to what it was. We only
used this originally because matplotlib was too long. This changes the
backend name to be mpl (the canonical short name for matplotlib) to
better describe what the backend is.

### Details and comments

Fixes #1076