### PR TITLE
Avoid consuming results during `.retrieve_job()` and `.jobs()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Changed
 -------
 
 - Evolved pass-based transpiler to support advanced functionality (#1060)
+- Avoid consuming results during `.retrieve_job()` and `.jobs()` (#1082).
 
 Deprecated
 ----------

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -242,14 +242,14 @@ class IBMQBackend(BaseBackend):
             elif status == JobStatus.ERROR:
                 this_filter = {'status': {'regexp': '^ERROR'}}
             else:
-                raise IBMQBackendValueError('unrecongized value for "status" keyword '
+                raise IBMQBackendValueError('unrecognized value for "status" keyword '
                                             'in job filter')
             api_filter.update(this_filter)
         if db_filter:
-            # status takes precendence over db_filter for same keys
+            # status takes precedence over db_filter for same keys
             api_filter = {**db_filter, **api_filter}
-        job_info_list = self._api.get_jobs(limit=limit, skip=skip,
-                                           filter=api_filter)
+        job_info_list = self._api.get_status_jobs(limit=limit, skip=skip,
+                                                  filter=api_filter)
         job_list = []
         for job_info in job_info_list:
             job_class = _job_class_from_job_response(job_info)
@@ -272,7 +272,7 @@ class IBMQBackend(BaseBackend):
             IBMQBackendError: if retrieval failed
         """
         try:
-            job_info = self._api.get_job(job_id)
+            job_info = self._api.get_status_job(job_id)
             if 'error' in job_info:
                 raise IBMQBackendError('Failed to get job "{}": {}'
                                        .format(job_id, job_info['error']))

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -255,7 +255,8 @@ class IBMQBackend(BaseBackend):
             job_class = _job_class_from_job_response(job_info)
             is_device = not bool(self._configuration.get('simulator'))
             job = job_class(self, job_info.get('id'), self._api, is_device,
-                            creation_date=job_info.get('creationDate'))
+                            creation_date=job_info.get('creationDate'),
+                            api_status=job_info.get('status'))
             job_list.append(job)
         return job_list
 
@@ -282,7 +283,8 @@ class IBMQBackend(BaseBackend):
         job_class = _job_class_from_job_response(job_info)
         is_device = not bool(self._configuration.get('simulator'))
         job = job_class(self, job_info.get('id'), self._api, is_device,
-                        creation_date=job_info.get('creationDate'))
+                        creation_date=job_info.get('creationDate'),
+                        api_status=job_info.get('status'))
         return job
 
     def __repr__(self):

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -115,19 +115,21 @@ class IBMQJob(BaseJob):
     _executor = futures.ThreadPoolExecutor()
 
     def __init__(self, backend, job_id, api, is_device, qobj=None,
-                 creation_date=None, **kwargs):
+                 creation_date=None, api_status=None, **kwargs):
         """IBMQJob init function.
+
         We can instantiate jobs from two sources: A QObj, and an already submitted job returned by
         the API servers.
 
         Args:
+            backend (str): The backend instance used to run this job.
+            job_id (str): The job ID of an already submitted job. Pass `None`
+                if you are creating a new one.
             api (IBMQuantumExperience): IBM Q API
             is_device (bool): whether backend is a real device  # TODO: remove this after Qobj
             qobj (Qobj): The Quantum Object. See notes below
-            job_id (String): The job ID of an already submitted job. Pass `None`
-            if you are creating a new one.
-            creation_date(String): When the job was run.
-            backend (str): The backend instance used to run this job.
+            creation_date (str): When the job was run.
+            api_status (str): `status` field directly from the API response.
             kwargs (dict): You can pass `backend_name` to this function although
                 it has been deprecated.
 
@@ -161,13 +163,25 @@ class IBMQJob(BaseJob):
         self._future_captured_exception = None
         self._api = api
         self._backend = backend
-        self._status = JobStatus.INITIALIZING
-        # In case of not providing a qobj, it assumes job_id has been provided
-        # and query the API for updating the status.
-        if qobj is None:
-            self.status()
-        self._queue_position = None
         self._cancelled = False
+        self._status = JobStatus.INITIALIZING
+        # In case of not providing a `qobj`, it is assumed the job already
+        # exists in the API (with `job_id`).
+        if qobj is None:
+            # Some API calls (`get_status_jobs`, `get_status_job`) provide
+            # enough information to recreate the `Job`. If that is the case, try
+            # to make use of that information during instantiation, as
+            # `self.status()` involves an extra call to the API.
+            if api_status == 'VALIDATING':
+                self._status = JobStatus.VALIDATING
+            elif api_status == 'COMPLETED':
+                self._status = JobStatus.DONE
+            elif api_status == 'CANCELLED':
+                self._status = JobStatus.CANCELLED
+                self._cancelled = True
+            else:
+                self.status()
+        self._queue_position = None
         self._is_device = is_device
 
         def current_utc_time():

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -278,7 +278,7 @@ class IBMQJob(BaseJob):
             # TODO: See result values
             api_job = self._api.get_status_job(self._job_id)
             if 'status' not in api_job:
-                raise JobError('get_job didn\'t return status: %s' %
+                raise JobError('get_status_job didn\'t return status: %s' %
                                pprint.pformat(api_job))
         # pylint: disable=broad-except
         except Exception as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema>=2.6,<2.7
-IBMQuantumExperience>=2.0.3
+IBMQuantumExperience>=2.0.4
 matplotlib>=2.1
 networkx>=2.0
 numpy>=1.13

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools.dist import Distribution
 
 requirements = [
     "jsonschema>=2.6,<2.7",
-    "IBMQuantumExperience>=2.0.3",
+    "IBMQuantumExperience>=2.0.4",
     "matplotlib>=2.1",
     "networkx>=2.0",
     "numpy>=1.13",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1065 

Make use of new functionality in the API (bumped to 2.0.4) in order to fetch only "informational" fields of a job during 
```
backend.jobs()
backend.retrieve_job()
```
which in turn avoids fetching the results until the user explicitly calls

```
job.result()
```
 (alleviating the problem of inadvertently deleting them).

Additionally, reduce a bit the number of API calls made by those methods, as in some cases it is no longer needed to call `.status()` internally during instantiation.


### Details and comments

@jaygambetta : note  #1065 was initially asking for a new method - with this PR the fix is a bit different: the user is free to use the list of `Job`s directly and pick from any attribute of them (so in practice, hopefully you have all the metadata needed, and decent guarantees that the jobs will not be deleted).

