### PR TITLE
Start circuit count at zero

### DIFF
--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -51,9 +51,9 @@ class QuantumCircuit(object):
         Raises:
             QISKitError: if the circuit name, if given, is not valid.
         """
-        self._increment_instances()
         if name is None:
             name = self.cls_prefix() + str(self.cls_instances())
+        self._increment_instances()
 
         if not isinstance(name, str):
             raise QISKitError("The circuit name should be a string "


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The default circuit name is the circuit prefix with an integer which
increments every time a new circuit is created. However this circuit
count starts at 1 instead of 0 because we were incrementing this before
referencing the value in the circuit object constructor. This commit
fixes the issue by moving this to after we pull the value for the
default name. This will make the default name counts consistent with
standard indexing in python.

### Details and comments

Fixes #1078
