### PR TITLE
Add documentation for graphviz external requirement

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,8 @@ The format is based on `Keep a Changelog`_.
 Added
 -----
 
-- Added DAG visualizer (#1059)
+- Added DAG visualizer which requires `Graphivz <https://www.graphviz.org/>`_
+  (#1059)
 - Added a ASCII art circuit visualizer (#909)
 
 Changed

--- a/qiskit/tools/visualization/_dag_visualization.py
+++ b/qiskit/tools/visualization/_dag_visualization.py
@@ -21,6 +21,12 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
     """Plot the directed acyclic graph (dag) to represent operation dependencies
     in a quantum circuit.
 
+    Note this function leverages
+    `pydot <https://github.com/erocarrera/pydot>`_ (via
+    `nxpd <https://github.com/chebee7i/nxpd`_) to generate the graph, which
+    means that having `Graphviz <https://www.graphviz.org/>`_ installed on your
+    system is required for this to work.
+
     Args:
         dag (DAGCircuit): The dag to draw.
         scale (float): scaling factor


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The dag visualizations require that graphviz be installed to function
because they leverage pydot via nxpd. However this was not documented or
noted in the docstring or release notes. This commit updates those
accordingly to document this.

### Details and comments

Fixes #1093
