### PR TITLE
Respect plotbarrier style setting for latex circuit drawers

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1325,15 +1325,16 @@ class QCircuitImage(object):
                     raise QISKitError('Error during Latex building: %s' %
                                       str(e))
             elif op['name'] == "barrier":
-                qarglist = [self.qubit_list[i] for i in op['qubits']]
-                if self._style.reverse:
-                    qarglist = list(reversed(qarglist))
-                if aliases is not None:
-                    qarglist = map(lambda x: aliases[x], qarglist)
-                start = self.img_regs[(qarglist[0][0],
-                                       qarglist[0][1])]
-                span = len(op['qubits']) - 1
-                self._latex[start][columns] += " \\barrier{" + str(span) + "}"
+                if self._style.barrier:
+                    qarglist = [self.qubit_list[i] for i in op['qubits']]
+                    if self._style.reverse:
+                        qarglist = list(reversed(qarglist))
+                    if aliases is not None:
+                        qarglist = map(lambda x: aliases[x], qarglist)
+                    start = self.img_regs[(qarglist[0][0],
+                                           qarglist[0][1])]
+                    span = len(op['qubits']) - 1
+                    self._latex[start][columns] += " \\barrier{" + str(span) + "}"
             else:
                 assert False, "bad node data"
 

--- a/qiskit/tools/visualization/_qcstyle.py
+++ b/qiskit/tools/visualization/_qcstyle.py
@@ -64,7 +64,7 @@ class QCStyle:
         self.pimode = False
         self.fold = 20
         self.bundle = False
-        self.barrier = False
+        self.barrier = True
         self.index = False
         self.compress = True
         self.figwidth = -1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support to the latex circuit drawers (output 'latex'
and 'latex_source') for respecting the plotbarrier style config setting.
However, to maintain backwards compatibility for the latex drawer the
default style has to change from false to true.

### Details and comments

Partially addresses #1099

