### PR TITLE
Respect reversed bit order for drawing barriers in latex

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -1435,6 +1435,8 @@ class QCircuitImage(object):
                                       str(e))
             elif op['name'] == "barrier":
                 qarglist = [self.qubit_list[i] for i in op['qubits']]
+                if self._style.reverse:
+                    qarglist = list(reversed(qarglist))
                 if aliases is not None:
                     qarglist = map(lambda x: aliases[x], qarglist)
                 start = self.img_regs[(qarglist[0][0],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue when drawing a circuit using the latex*
output methods and reversebits is enabled. The barriers were not using
the reversed bit order so it was drawing on the LSB instead of the MSB
(or vice versa) as the start of the barrier when reversed. This meant we
were incorrectly starting to draw the downward span at the bottom instead
of the top. To fix this we just reverse the bit order if reversebits is
set before we start drawing the barrier.

### Details and comments

Fixes #1099
