### PR TITLE
Add documentation on the style input parameter

### DIFF
--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -79,11 +79,15 @@ def circuit_drawer(circuit,
         basis (str): the basis to unroll to prior to drawing
         scale (float): scale of image to draw (shrink if < 1)
         filename (str): file path to save image to
-        style (dict or str): dictionary of style or file name of style file
+        style (dict or str): dictionary of style or file name of style file.
+            This option is only used by the `mpl`, `latex`, and `latex_source`
+            output types. If a str is passed in that is the path to a json
+            file which contains that will be open, parsed, and then used just
+            as the input dict.
         output (str): Select the output method to use for drawing the circuit.
-            Valid choices are `text`, `latex`, `latex_source`, `mpl`. Note if one
-            is not specified it will use latex and if that fails fallback to
-            mpl. However this behavior is deprecated and in a future release
+            Valid choices are `text`, `latex`, `latex_source`, `mpl`. Note if
+            one is not specified it will use latex and if that fails fallback
+            to mpl. However this behavior is deprecated and in a future release
             the default will change.
         interactive (bool): when set true show the circuit in a new window
             (cannot inline in Jupyter). Note when used with the latex_source
@@ -94,9 +98,85 @@ def circuit_drawer(circuit,
                    the circuit diagram.
         String: (outputs `text` and `latex_source`). The ascii art or the LaTeX
                 source code.
-
     Raises:
         VisualizationError: when an invalid output method is selected
+
+    The style dict kwarg contains numerous options that define the style of the
+    output circuit visualization. While the style dict is used by the `mpl`,
+    `latex`, and `latex_source` outputs some options in that are only used
+    by the `mpl` output. These options are defined below, if it is only used by
+    the `mpl` output it is marked as such:
+
+        textcolor (str): The color code to use for text. Defaults to
+            `'#000000'` (`mpl` only)
+        subtextcolor (str): The color code to use for subtext. Defaults to
+            `'#000000'` (`mpl` only)
+        linecolor (str): The color code to use for lines. Defaults to
+            `'#000000'` (`mpl` only)
+        creglinecolor (str): The color code to use for classical register lines
+            `'#778899'`(`mpl` only)
+        gatetextcolor (str): The color code to use for gate text `'#000000'`
+            (`mpl` only)
+        gatefacecolor (str): The color code to use for gates. Defaults to
+            `'#ffffff'` (`mpl` only)
+        barrierfacecolor (str): The color code to use for barriers. Defaults to
+            `'#bdbdbd'` (`mpl` only)
+        backgroundcolor (str): The color code to use for the background.
+            Defaults to `'#ffffff'` (`mpl` only)
+        fontsize (int): The font size to use for text. Defaults to 13 (`mpl`
+            only)
+        subfontsize (int): The font size to use for subtext. Defatuls to 8
+            (`mpl` only)
+        displaytext (dict): A dictionary of the text to use for each element
+            type in the output visualization. The default values are:
+            {
+                'id': 'id',
+                'u0': 'U_0',
+                'u1': 'U_1',
+                'u2': 'U_2',
+                'u3': 'U_3',
+                'x': 'X',
+                'y': 'Y',
+                'z': 'Z',
+                'h': 'H',
+                's': 'S',
+                'sdg': 'S^\\dagger',
+                't': 'T',
+                'tdg': 'T^\\dagger',
+                'rx': 'R_x',
+                'ry': 'R_y',
+                'rz': 'R_z',
+                'reset': '\\left|0\\right\\rangle'
+            }
+            You must specify all the necessary values if using this. There is
+            no provision for passing an incomplete dict in. (`mpl` only)
+        displaycolor (dict): The color codes to use for each circuit element.
+            By default all values default to the value of `gatefacecolor` and
+            the keys are the same as `displaytext`. Also, just like
+            `displaytext` there is no provision for an incomplete dict passed
+            in. (`mpl` only)
+        latexdrawerstyle (bool): When set to True enable latex mode which will
+            draw gates like the `latex` output modes. (`mpl` only)
+        usepiformat (bool): When set to True use radians for output (`mpl`
+            only)
+        fold (int): The number of circuit elements to fold the circuit at.
+            Defaults to 20 (`mpl` only)
+        cregbundle (bool): If set True bundle classical registers (`mpl` only)
+        plotbarrier (bool): Enable/disable drawing barriers in the output
+            circuit. Defaults to True.
+        showindex (bool): If set True draw an index. (`mpl` only)
+        compress (bool): If set True draw a compressed circuit (`mpl` only)
+        figwidth (int): The maximum width (in inches) for the output figure.
+            (`mpl` only)
+        dpi (int): The DPI to use for the output image. Defaults to 150 (`mpl`
+            only)
+        margin (list): `mpl` only
+        creglinestyle (str): The style of line to use for classical registers.
+            Choices are `'solid'`, `'doublet'`, or any valid matplotlib
+            `linestyle` kwarg value. Defaults to `doublet`(`mpl` only)
+        reversebits (bool): When set to True reverse the bit order inside
+            registers for the output visualization.
+
     """
 
     im = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The style input dict for better or worse is our interface to adjust how
the latex and mpl backends draw circuits. However we never actually
included any documentation on the different parameters for the dict.
This commit fixes the oversight and adds documentation explaining in
detail how to use the kwarg, which keys are accepted in the input dict,
and the function of each value.

### Details and comments

