### PR TITLE
fix snapshot insertion so qobj doesnt break when running statevector sim

### DIFF
--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -53,7 +53,8 @@ class StatevectorSimulator(QasmSimulator):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction(name='snapshot', params=[final_state_key])
+                QobjInstruction(name='snapshot', params=[final_state_key],
+                                label='MISSING', type='MISSING')
             )
         result = super()._run_job(job_id, qobj)
         # Replace backend name with current backend

--- a/qiskit/backends/aer/statevector_simulator_py.py
+++ b/qiskit/backends/aer/statevector_simulator_py.py
@@ -67,7 +67,8 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         # Add final snapshots to circuits
         for experiment in qobj.experiments:
             experiment.instructions.append(
-                QobjInstruction(name='snapshot', params=[final_state_key])
+                QobjInstruction(name='snapshot', params=[final_state_key],
+                                label='MISSING', type='MISSING')
             )
         result = super()._run_job(job_id, qobj)
         # Replace backend name with current backend


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Partial fix for #1112 

This PR follows [the hack introduced in #807](https://github.com/Qiskit/qiskit-terra/blob/02200d2cdbbc5057062c35f9002463db7795cdf0/qiskit/unroll/_dagunroller.py#L198) to make snapshot instructions pass the schema. 
Here I add the same hack to 2 other places where snapshots are used.

This will make the bug in #1112 go away, but the problem is deeper, having to do with the relationship between statevector_simulator and qasm_simulator in general, and removing places where qobj is hacked. I will thus keep that issue open.

