### PR TITLE
Stop overloading backend_name in statevector simluators

### DIFF
--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -56,8 +56,6 @@ class StatevectorSimulator(QasmSimulator):
                 QobjInstruction(name='snapshot', params=[final_state_key])
             )
         result = super()._run_job(job_id, qobj)
-        # Replace backend name with current backend
-        result.backend_name = self.name
         # Extract final state snapshot and move to 'statevector' data field
         for experiment_result in result.results.values():
             snapshots = experiment_result.snapshots

--- a/qiskit/backends/aer/statevector_simulator_py.py
+++ b/qiskit/backends/aer/statevector_simulator_py.py
@@ -70,8 +70,6 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
                 QobjInstruction(name='snapshot', params=[final_state_key])
             )
         result = super()._run_job(job_id, qobj)
-        # Replace backend name with current backend
-        result.backend_name = self.name
         # Extract final state snapshot and move to 'statevector' data field
         for experiment_result in result.results.values():
             snapshots = experiment_result.snapshots

--- a/test/python/test_result.py
+++ b/test/python/test_result.py
@@ -120,47 +120,5 @@ class TestQiskitResult(QiskitTestCase):
         self.assertIsNot(new_result, result2)
 
 
-class TestResultConsistency(QiskitTestCase):
-    """Test consistency of qiskit.Results API across all backends."""
-
-    def test_add_aer(self):
-        """Test combining results on all Aer backends."""
-        qr = qiskit.QuantumRegister(1)
-        cr = qiskit.ClassicalRegister(1)
-        qc1 = qiskit.QuantumCircuit(qr, cr, name='qc1')
-        qc1.h(qr[0])
-        qc2 = qiskit.QuantumCircuit(qr, cr, name='qc2')
-        qc2.x(qr[0])
-        for backend in qiskit.Aer.backends():
-            with self.subTest(backend=backend.name()):
-                result_a = qiskit.execute(qc1, backend).result()
-                result_b = qiskit.execute(qc2, backend).result()
-                res = result_a + result_b
-                self.assertEqual(str(res), 'COMPLETED')
-                self.assertIsNot(res, result_a)
-                self.assertIsNot(res, result_b)
-
-    @requires_qe_access
-    def test_add_ibmq(self, qe_token, qe_url):
-        """Test combining results on all IBMQ backends."""
-        qiskit.IBMQ.enable_account(qe_token, qe_url)
-        qr = qiskit.QuantumRegister(1)
-        cr = qiskit.ClassicalRegister(1)
-        qc1 = qiskit.QuantumCircuit(qr, cr, name='qc1')
-        qc1.h(qr[0])
-        qc1.measure(qr, cr)
-        qc2 = qiskit.QuantumCircuit(qr, cr, name='qc2')
-        qc2.x(qr[0])
-        qc2.measure(qr, cr)
-        for backend in qiskit.IBMQ.backends():
-            with self.subTest(backend=backend.name()):
-                result_a = qiskit.execute(qc1, backend).result()
-                result_b = qiskit.execute(qc2, backend).result()
-                res = result_a + result_b
-                self.assertEqual(str(res), 'COMPLETED')
-                self.assertIsNot(res, result_a)
-                self.assertIsNot(res, result_b)
-
-
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue when using the statevector simulators where
accessing the backend_name attribute of a results object would return a
bound method instead of the actual string for the backend name. This was
caused by the statevector simulators were overloading the backend_name
property of its parent classes with a pointer to the name() method. If
this was necessary it should have overloaded the value and called name()
instead of setting the method as backend_name. However this isn't even
necessary because backend_name is assigned automatically already. So
this commit just removes the unnecessary overloads.

### Details and comments

Fixes #1116 