### PR TITLE
Fix clifford simulator run for qobj

### DIFF
--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -23,6 +23,7 @@ import numpy as np
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
+from qiskit.qobj import Qobj
 from qiskit.qobj import qobj_to_dict
 
 logger = logging.getLogger(__name__)
@@ -146,13 +147,18 @@ class CliffordSimulator(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
+        if isinstance(qobj, Qobj):
+            qobj_dict = qobj.as_dict()
+        else:
+            qobj_dict = qobj
         self._validate()
         # set backend to Clifford simulator
-        if 'config' in qobj:
-            qobj['config']['simulator'] = 'clifford'
+        if 'config' in qobj_dict:
+            qobj_dict['config']['simulator'] = 'clifford'
         else:
-            qobj['config'] = {'simulator': 'clifford'}
+            qobj_dict['config'] = {'simulator': 'clifford'}
 
+        qobj = Qobj.from_dict(qobj_dict)
         result = run(qobj, self._configuration['exe'])
         result['job_id'] = job_id
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The qobj conversion for the clifford simulator was incorrectly treating
a qobj object as a dict and trying to access it like one. This commit
fixes this by converting an input qobj object into a dict, performing
the transforms and then making a new qobj from that dict to pass to
run().

### Details and comments

Fixes #1119

