### PR TITLE
Fix incorrect conda download link in install docs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -14,7 +14,7 @@ To use Qiskit you'll need to have installed at least
 is also recommended for interacting with
 `tutorials`_.
 
-For this reason we recommend installing `Anaconda 3 <https://www.continuum.io/downloads>`__
+For this reason we recommend installing `Anaconda 3 <https://www.anaconda.com/download/>`__
 python distribution, which already comes with all these dependencies pre-installed.
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a small issue in the install docs pointing to the
incorrect location to download the anaconda python distribution. This
corrects the link which was either a typo or has changed since the link
was first added.

### Details and comments

Fixes #1123