### PR TITLE
Fix a small typo in cpp qasm simulator README

### DIFF
--- a/src/qasm-simulator-cpp/README.md
+++ b/src/qasm-simulator-cpp/README.md
@@ -55,7 +55,7 @@ The following packages are required for building:
 Installing these dependencies for MacOS, Ubuntu or RHEL can be achieved by using the `build_dependencies.sh` script. This may be invoved from the command line by running
 
 ```bash
-> make depends
+> make depend
 ```
 
 This script installs the following platform specific dependencies:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This commit fixes a small typo in the readme for the cpp qasm simulator.
The doc refers to the 'depends' make target. However the actual target
name is 'depend' (no 's').

### Details and comments

Fixes #1122