### PR TITLE
Remove finalstate snapshot added to qobj in statevector sim

### DIFF
--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -57,6 +57,9 @@ class StatevectorSimulator(QasmSimulator):
                                 label='MISSING', type='MISSING')
             )
         result = super()._run_job(job_id, qobj)
+        # Remove added snapshot from qobj
+        for experiment in qobj.experiments:
+            del experiment.instructions[-1]
         # Extract final state snapshot and move to 'statevector' data field
         for experiment_result in result.results.values():
             snapshots = experiment_result.snapshots

--- a/qiskit/backends/aer/statevector_simulator_py.py
+++ b/qiskit/backends/aer/statevector_simulator_py.py
@@ -71,6 +71,9 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
                                 label='MISSING', type='MISSING')
             )
         result = super()._run_job(job_id, qobj)
+        # Remove added snapshot from qobj
+        for experiment in qobj.experiments:
+            del experiment.instructions[-1]
         # Extract final state snapshot and move to 'statevector' data field
         for experiment_result in result.results.values():
             snapshots = experiment_result.snapshots


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #1112 by cleaning up the final state snapshot added to the qobj by the statevector simulator backends.

### Details and comments


