### PR TITLE
Deprecate basis kwarg on circuit_drawer() function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,10 @@ Deprecated
    should be used. (#1055)
 - The current default output of ``circuit_drawer()`` (using latex and falling
    back on python) is deprecated and will be changed in the future. (#1055)
+- The ``basis`` kwarg for the ``circuit_drawer()`` function to provide an
+  alternative list of basis gates is deprecated and will be removed in the
+  future. Instead users should adjust the basis gates prior to visualizing
+  the circuit. (#1151)
 
 Fixed
 -----

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -50,8 +50,7 @@ def plot_circuit(circuit,
 
 
 def circuit_drawer(circuit,
-                   basis="id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
-                         "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap",
+                   basis=None,
                    scale=0.7,
                    filename=None,
                    style=None,
@@ -67,7 +66,10 @@ def circuit_drawer(circuit,
 
     Args:
         circuit (QuantumCircuit): the quantum circuit to draw
-        basis (str): the basis to unroll to prior to drawing
+        basis (str): the basis to unroll to prior to drawing. Defaults to
+            `"id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,cx,cy,cz,ch,crz,cu1,
+            cu3,swap,ccx,cswap"` This option is deprecated and will be removed
+            in the future.
         scale (float): scale of image to draw (shrink if < 1)
         filename (str): file path to save image to
         style (dict or str): dictionary of style or file name of style file.
@@ -169,6 +171,13 @@ def circuit_drawer(circuit,
             registers for the output visualization.
 
     """
+    if basis is None:
+        basis = ("id,u0,u1,u2,u3,x,y,z,h,s,sdg,t,tdg,rx,ry,rz,"
+                 "cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap")
+    else:
+        warnings.warn('The basis kwarg is deprecated and the circuit drawer '
+                      'function will not be able to adjust basis gates itself '
+                      'in a future release', DeprecationWarning)
 
     im = None
     if not output:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This commit deprecates the basis argument to the circuit_drawer()
function. This has always been out of scope for a tool to just visualize
the circuit, if you need to adjust the basis gates used to construct the
circuit that should be done outside the visualization layer. But, with
the discussion of removing the dependence on calling transpile() from
the circuit_drawer (see #1129) this becomes the first step to some
larger cleanups.

### Details and comments


