### PR TITLE
A star mapper pass

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -9,5 +9,5 @@
 
 from .cx_cancellation import CXCancellation
 from .fixed_point import FixedPoint
-from .group_gates import GroupGates
+from .group_gates import group_gates
 from .a_star_cx import AStarCX

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -9,3 +9,4 @@
 
 from .cx_cancellation import CXCancellation
 from .fixed_point import FixedPoint
+from .group_gates import GroupGates

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -7,30 +7,10 @@
 
 """Pass for minimizing the number of CX gates.
 """
+
 from qiskit.transpiler._basepasses import TransformationPass
 
-def JAGcoupling_list2dict(couplinglist):
-    """Convert coupling map list into dictionary.
 
-    Example list format: [[0, 1], [0, 2], [1, 2]]
-    Example dictionary format: {0: [1, 2], 1: [2]}
-
-    We do not do any checking of the input.
-
-    Return coupling map in dict format.
-    """
-    if not couplinglist:
-        return None
-    couplingdict = {}
-    for pair in couplinglist:
-        if pair[0] in couplingdict:
-            couplingdict[pair[0]].append(pair[1])
-        else:
-            couplingdict[pair[0]] = [pair[1]]
-    return couplingdict
-
-#JAG I would think this would be there from __init.py but ... (testing because GroupGates argument count error)
-#from .fixed_point import FixedPoint
 class AStarCX(TransformationPass):
     """Find cheapest cost (local optimization with lookahead) for CX gates."""
 
@@ -39,92 +19,138 @@ class AStarCX(TransformationPass):
         self.coupling_map = coupling_map
         self.gate_costs = gate_costs
 
-    def run(self, dag_circuit):
+    def run(self, dag):
         """
         Runs one pass A*-based algorithm to minimize CX Gate count.
         Note: Currently *chained* to Group_Gates because that routine
         does not yet take/return a DAG.
 
         Args:
-        dag_circuit (DAGCircuit): DAGCircuit object to be compiled.
+        dag (DAGCircuit): DAGCircuit object to be compiled.
         coupling_circuit (list): Coupling map for device topology.
                                  A coupling map of None corresponds an
                                  all-to-all connected topology.
         gate_costs (dict) : dictionary of gate names and costs.
 
         Returns:
-        A modified DAGCircuit object that satisfies an input coupling_map
-        and has as low a gate_cost as possible.
+            DAGCircuit: Transformed DAG.  A modified DAGCircuit object
+            that satisfies an input coupling_map and has as low a gate_cost
+            as possible.
         """
         from qiskit.transpiler.passes.group_gates import GroupGates
         from qiskit.transpiler.passes.a_star_mapper import a_star_mapper
         from qiskit.transpiler.passes import post_mapping_optimization
         from qiskit.dagcircuit import DAGCircuit
-        #import time
+
+        # import time
 
         import copy
-        from qiskit.mapper import Coupling
+        from qiskit.mapper import Coupling, coupling_list2dict
         from qiskit import qasm, unroll
-        import networkx as nx
-        if self.gate_costs == None:
-            self.gate_costs = {'id': 0, 'u1': 0, 'measure': 0, 'reset': 0, 'barrier': 0, 'u2': 1, 'u3': 1, 'U': 1, 'cx': 10, 'CX': 10}
-        compiled_dag = copy.deepcopy(dag_circuit)
-        
+        # import networkx as nx
+
+        if self.gate_costs is None:
+            self.gate_costs = {
+                "id": 0,
+                "u1": 0,
+                "measure": 0,
+                "reset": 0,
+                "barrier": 0,
+                "u2": 1,
+                "u3": 1,
+                "U": 1,
+                "cx": 10,
+                "CX": 10,
+            }
+        compiled_dag = copy.deepcopy(dag)
+
         # temporary circuit to add all used gates to the available gate set
-        tmp_qasm = "OPENQASM 2.0;\n" + \
-                       "gate cx c,t { CX c,t; }\n" + \
-                       "gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }\n" + \
-                       "gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }\n" + \
-                       "gate u1(lambda) q { U(0,0,lambda) q; }\n" + \
-                       "qreg q[2];\n" + \
-                       "cx q[0], q[1];\n" + \
-                       "u3(0.1,0.4,0.7) q[0];\n" + \
-                       "u2(0.1,0.4) q[0]\n;" + \
-                       "u1(0.1) q[0];\n"
-        u = unroll.Unroller(qasm.Qasm(data=tmp_qasm).parse(),
-                            unroll.DAGBackend(["cx", "u3", "u2", "u1"]))
-        tmp_circuit = u.execute()
+        tmp_qasm = (
+            "OPENQASM 2.0;\n"
+            + "gate cx c,t { CX c,t; }\n"
+            + "gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }\n"
+            + "gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }\n"
+            + "gate u1(lambda) q { U(0,0,lambda) q; }\n"
+            + "qreg q[2];\n"
+            + "cx q[0], q[1];\n"
+            + "u3(0.1,0.4,0.7) q[0];\n"
+            + "u2(0.1,0.4) q[0]\n;"
+            + "u1(0.1) q[0];\n"
+        )
+        unrolled = unroll.Unroller(
+            qasm.Qasm(data=tmp_qasm).parse(),
+            unroll.DAGBackend(["cx", "u3", "u2", "u1"]),
+        )
+        tmp_circuit = unrolled.execute()
 
         # prepare empty circuit for the result
         empty_dag = DAGCircuit()
-        # JAG
-        coupling = Coupling(JAGcoupling_list2dict(self.coupling_map))
-        #Note: Works with a single register named 'q' (not with 'q0' for example)
-        empty_dag.add_qreg('q', coupling.size())
+        print(self.coupling_map)
+        coupling = Coupling(coupling_list2dict(self.coupling_map))
+        print(coupling)
+        print(coupling_list2dict(self.coupling_map))
+        # Note: Works with a single register named 'q' (not with 'q0' for example)
+        empty_dag.add_qreg("q", coupling.size())
         for k, v in sorted(compiled_dag.cregs.items()):
             empty_dag.add_creg(k, v)
 
         empty_dag.basis = compiled_dag._make_union_basis(tmp_circuit)
-        empty_dag.gates = compiled_dag._make_union_gates(tmp_circuit) 
+        empty_dag.gates = compiled_dag._make_union_gates(tmp_circuit)
         grouped_gates = GroupGates.group_gates(compiled_dag)
-        # call mapper (based on an A* search) to satisfy the constraints for CNOTs given by the coupling_map 
-        compiled_dag = a_star_mapper.a_star_mapper(copy.deepcopy(grouped_gates), JAGcoupling_list2dict(self.coupling_map), coupling.size(), copy.deepcopy(empty_dag))
+        # call mapper (based on an A* search) to satisfy the constraints for CNOTs
+        # given by the coupling_map
+        compiled_dag = a_star_mapper.a_star_mapper(
+            copy.deepcopy(grouped_gates),
+            coupling_list2dict(self.coupling_map),
+            coupling.size(),
+            copy.deepcopy(empty_dag),
+        )
         grouped_gates_compiled = GroupGates.group_gates(compiled_dag)
 
-        # estimate the cost of the mapped circuit: the number of groups as well as the cost regarding to gate_costs   
+        # estimate the cost of the mapped circuit:
+        # the number of groups as well as the cost regarding to gate_costs
         min_groups = grouped_gates_compiled.order()
         min_cost = 0
-        for op, count in compiled_dag.count_ops().items():
-            min_cost += count * self.gate_costs[op]
-        # Repeat the mapping procedure 9 times and take the result with minimum groups/cost. Each call may yield a different result, since the mapper is implemented with a certain non-determinism. In fact, in the priority queue used for implementing the A* algorithm, the entries are a pair of the priority and a pointer to an object holding th mapping infomation (as second criterion). Thus, it is uncertain which node is expanded first if two nodes have the same priority (it depends on the value of the pointer). However, this non-determinism allows to find different solution by repeatedly calling the mapper.
-        for i in range(9):
-            result = a_star_mapper.a_star_mapper(copy.deepcopy(grouped_gates), JAGcoupling_list2dict(self.coupling_map), coupling.size(), copy.deepcopy(empty_dag))
+        for operator, count in compiled_dag.count_ops().items():
+            min_cost += count * self.gate_costs[operator]
+        # Repeat the mapping procedure 9 times and take the result with minimum groups/cost.
+        # Each call may yield a different result, since the mapper is implemented with a certain
+        # non-determinism. In fact, in the priority queue used for implementing the A* algorithm,
+        # the entries are a pair of the priority and a pointer to an object holding th mapping
+        # infomation (as second criterion). Thus, it is uncertain which node is expanded first
+        # if two nodes have the same priority (it depends on the value of the pointer). However,
+        # this non-determinism allows to find different solution by repeatedly calling the mapper.
+        for _ in range(9):
+            result = a_star_mapper.a_star_mapper(
+                copy.deepcopy(grouped_gates),
+                coupling_list2dict(self.coupling_map),
+                coupling.size(),
+                copy.deepcopy(empty_dag),
+            )
             grouped_gates_result = GroupGates.group_gates(result)
 
             groups = grouped_gates_result.order()
             cost = 0
-            for op, count in result.count_ops().items():
-                cost += count * self.gate_costs[op]
-            # take the solution with fewer groups (fewer cost if the number of groups is equal) 
+            for operator, count in result.count_ops().items():
+                cost += count * self.gate_costs[operator]
+            # take the solution with fewer groups (fewer cost if the number of groups is equal)
             if groups < min_groups or (groups == min_groups and cost < min_cost):
                 min_groups = groups
                 min_cost = cost
                 compiled_dag = result
                 grouped_gates_compiled = grouped_gates_result
 
-        # post-mapping optimization: build 4x4 matrix for gate groups and decompose them using KAK decomposition.
-        # Moreover, subsequent single qubit gates are optimized 
-        compiled_dag = post_mapping_optimization.optimize_gate_groups(grouped_gates_compiled, coupling.get_edges(), copy.deepcopy(empty_dag), self.gate_costs)
-       
-        return compiled_dag        
+        # post-mapping optimization: build 4x4 matrix for gate groups and decompose them
+        # using KAK decomposition.  Moreover, subsequent single qubit gates are optimized.
+        print("Calling post mapping optimization at end")
+        compiled_dag = post_mapping_optimization.optimize_gate_groups(
+            grouped_gates_compiled,
+            coupling.get_edges(),
+            copy.deepcopy(empty_dag),
+            self.gate_costs,
+        )
+
+        return compiled_dag
+
+
 # -*- coding: utf-8 -*-

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -85,10 +85,7 @@ class AStarCX(TransformationPass):
 
         # prepare empty circuit for the result
         empty_dag = DAGCircuit()
-        print(self.coupling_map)
         coupling = Coupling(coupling_list2dict(self.coupling_map))
-        print(coupling)
-        print(coupling_list2dict(self.coupling_map))
         # Note: Works with a single register named 'q' (not with 'q0' for example)
         empty_dag.add_qreg("q", coupling.size())
         for k, v in sorted(compiled_dag.cregs.items()):
@@ -142,7 +139,6 @@ class AStarCX(TransformationPass):
 
         # post-mapping optimization: build 4x4 matrix for gate groups and decompose them
         # using KAK decomposition.  Moreover, subsequent single qubit gates are optimized.
-        print("Calling post mapping optimization at end")
         compiled_dag = post_mapping_optimization.optimize_gate_groups(
             grouped_gates_compiled,
             coupling.get_edges(),

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -114,9 +114,9 @@ class AStarCX(TransformationPass):
         min_cost = 0
         for operator, count in compiled_dag.count_ops().items():
             min_cost += count * self.gate_costs[operator]
-        #Allow 30 seconds for this optimization or 1000 iterations (max)/9 more min.
-        #The optimization is probabilistic, so a little more time can yield a better
-        #solution, a shorter run-time, and a higher-fidelity result on real HW.
+        # Allow 30 seconds for this optimization or 1000 iterations (max)/9 more min.
+        # The optimization is probabilistic, so a little more time can yield a better
+        # solution, a shorter run-time, and a higher-fidelity result on real HW.
         stop = timer()
         elapsed = stop - start
         reps = int(30/elapsed)

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -56,9 +56,9 @@ class AStarCX(TransformationPass):
         A modified DAGCircuit object that satisfies an input coupling_map
         and has as low a gate_cost as possible.
         """
-        from group_gates import GroupGates
-        from a_star_mapper import a_star_mapper
-        import post_mapping_optimization
+        from qiskit.transpiler.passes.group_gates import GroupGates
+        from qiskit.transpiler.passes.a_star_mapper import a_star_mapper
+        from qiskit.transpiler.passes import post_mapping_optimization
         from qiskit.dagcircuit import DAGCircuit
         #import time
 

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -39,7 +39,7 @@ class AStarCX(TransformationPass):
         """
         from qiskit.transpiler.passes.group_gates import GroupGates
         from qiskit.transpiler.passes.a_star_mapper import a_star_mapper
-        from qiskit.transpiler.passes import post_mapping_optimization
+        from qiskit.transpiler.passes.post_mapping_optimization import optimize_gate_groups
         from qiskit.dagcircuit import DAGCircuit
 
         # import time
@@ -139,7 +139,7 @@ class AStarCX(TransformationPass):
 
         # post-mapping optimization: build 4x4 matrix for gate groups and decompose them
         # using KAK decomposition.  Moreover, subsequent single qubit gates are optimized.
-        compiled_dag = post_mapping_optimization.optimize_gate_groups(
+        compiled_dag = optimize_gate_groups(
             grouped_gates_compiled,
             coupling.get_edges(),
             copy.deepcopy(empty_dag),

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Pass for minimizing the number of CX gates.
+"""
+from qiskit.transpiler._basepasses import TransformationPass
+
+def JAGcoupling_list2dict(couplinglist):
+    """Convert coupling map list into dictionary.
+
+    Example list format: [[0, 1], [0, 2], [1, 2]]
+    Example dictionary format: {0: [1, 2], 1: [2]}
+
+    We do not do any checking of the input.
+
+    Return coupling map in dict format.
+    """
+    if not couplinglist:
+        return None
+    couplingdict = {}
+    for pair in couplinglist:
+        if pair[0] in couplingdict:
+            couplingdict[pair[0]].append(pair[1])
+        else:
+            couplingdict[pair[0]] = [pair[1]]
+    return couplingdict
+
+#JAG I would think this would be there from __init.py but ... (testing because GroupGates argument count error)
+#from .fixed_point import FixedPoint
+class AStarCX(TransformationPass):
+    """Find cheapest cost (local optimization with lookahead) for CX gates."""
+
+    def __init__(self, coupling_map=None, gate_costs=None):
+        super().__init__()
+        self.coupling_map = coupling_map
+        self.gate_costs = gate_costs
+
+    def run(self, dag_circuit):
+        """
+        Runs one pass A*-based algorithm to minimize CX Gate count.
+        Note: Currently *chained* to Group_Gates because that routine
+        does not yet take/return a DAG.
+
+        Args:
+        dag_circuit (DAGCircuit): DAGCircuit object to be compiled.
+        coupling_circuit (list): Coupling map for device topology.
+                                 A coupling map of None corresponds an
+                                 all-to-all connected topology.
+        gate_costs (dict) : dictionary of gate names and costs.
+
+        Returns:
+        A modified DAGCircuit object that satisfies an input coupling_map
+        and has as low a gate_cost as possible.
+        """
+        from group_gates import GroupGates
+        from a_star_mapper import a_star_mapper
+        import post_mapping_optimization
+        from qiskit.dagcircuit import DAGCircuit
+        #import time
+
+        import copy
+        from qiskit.mapper import Coupling
+        from qiskit import qasm, unroll
+        import networkx as nx
+        if self.gate_costs == None:
+            self.gate_costs = {'id': 0, 'u1': 0, 'measure': 0, 'reset': 0, 'barrier': 0, 'u2': 1, 'u3': 1, 'U': 1, 'cx': 10, 'CX': 10}
+        compiled_dag = copy.deepcopy(dag_circuit)
+        
+        # temporary circuit to add all used gates to the available gate set
+        tmp_qasm = "OPENQASM 2.0;\n" + \
+                       "gate cx c,t { CX c,t; }\n" + \
+                       "gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }\n" + \
+                       "gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }\n" + \
+                       "gate u1(lambda) q { U(0,0,lambda) q; }\n" + \
+                       "qreg q[2];\n" + \
+                       "cx q[0], q[1];\n" + \
+                       "u3(0.1,0.4,0.7) q[0];\n" + \
+                       "u2(0.1,0.4) q[0]\n;" + \
+                       "u1(0.1) q[0];\n"
+        u = unroll.Unroller(qasm.Qasm(data=tmp_qasm).parse(),
+                            unroll.DAGBackend(["cx", "u3", "u2", "u1"]))
+        tmp_circuit = u.execute()
+
+        # prepare empty circuit for the result
+        empty_dag = DAGCircuit()
+        # JAG
+        coupling = Coupling(JAGcoupling_list2dict(self.coupling_map))
+        #Note: Works with a single register named 'q' (not with 'q0' for example)
+        empty_dag.add_qreg('q', coupling.size())
+        for k, v in sorted(compiled_dag.cregs.items()):
+            empty_dag.add_creg(k, v)
+
+        empty_dag.basis = compiled_dag._make_union_basis(tmp_circuit)
+        empty_dag.gates = compiled_dag._make_union_gates(tmp_circuit) 
+        grouped_gates = GroupGates.group_gates(compiled_dag)
+        # call mapper (based on an A* search) to satisfy the constraints for CNOTs given by the coupling_map 
+        compiled_dag = a_star_mapper.a_star_mapper(copy.deepcopy(grouped_gates), JAGcoupling_list2dict(self.coupling_map), coupling.size(), copy.deepcopy(empty_dag))
+        grouped_gates_compiled = GroupGates.group_gates(compiled_dag)
+
+        # estimate the cost of the mapped circuit: the number of groups as well as the cost regarding to gate_costs   
+        min_groups = grouped_gates_compiled.order()
+        min_cost = 0
+        for op, count in compiled_dag.count_ops().items():
+            min_cost += count * self.gate_costs[op]
+        # Repeat the mapping procedure 9 times and take the result with minimum groups/cost. Each call may yield a different result, since the mapper is implemented with a certain non-determinism. In fact, in the priority queue used for implementing the A* algorithm, the entries are a pair of the priority and a pointer to an object holding th mapping infomation (as second criterion). Thus, it is uncertain which node is expanded first if two nodes have the same priority (it depends on the value of the pointer). However, this non-determinism allows to find different solution by repeatedly calling the mapper.
+        for i in range(9):
+            result = a_star_mapper.a_star_mapper(copy.deepcopy(grouped_gates), JAGcoupling_list2dict(self.coupling_map), coupling.size(), copy.deepcopy(empty_dag))
+            grouped_gates_result = GroupGates.group_gates(result)
+
+            groups = grouped_gates_result.order()
+            cost = 0
+            for op, count in result.count_ops().items():
+                cost += count * self.gate_costs[op]
+            # take the solution with fewer groups (fewer cost if the number of groups is equal) 
+            if groups < min_groups or (groups == min_groups and cost < min_cost):
+                min_groups = groups
+                min_cost = cost
+                compiled_dag = result
+                grouped_gates_compiled = grouped_gates_result
+
+        # post-mapping optimization: build 4x4 matrix for gate groups and decompose them using KAK decomposition.
+        # Moreover, subsequent single qubit gates are optimized 
+        compiled_dag = post_mapping_optimization.optimize_gate_groups(grouped_gates_compiled, coupling.get_edges(), copy.deepcopy(empty_dag), self.gate_costs)
+       
+        return compiled_dag        
+# -*- coding: utf-8 -*-

--- a/qiskit/transpiler/passes/a_star_cx.py
+++ b/qiskit/transpiler/passes/a_star_cx.py
@@ -8,6 +8,7 @@
 """Pass for minimizing the number of CX gates.
 """
 
+# Competition winning entry
 from qiskit.transpiler._basepasses import TransformationPass
 
 
@@ -120,9 +121,9 @@ class AStarCX(TransformationPass):
         stop = timer()
         elapsed = stop - start
         reps = int(30/elapsed)
-        if(reps < 9):
+        if reps < 9:
             reps = 9
-        if(reps > 1000):
+        if reps > 1000:
             reps = 1000
         # Repeat the mapping procedure 9 times and take the result with minimum groups/cost.
         # Each call may yield a different result, since the mapper is implemented with a certain

--- a/qiskit/transpiler/passes/a_star_mapper/__init__.py
+++ b/qiskit/transpiler/passes/a_star_mapper/__init__.py
@@ -5,9 +5,3 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Utils for transpiler."""
-
-from .cx_cancellation import CXCancellation
-from .fixed_point import FixedPoint
-from .group_gates import GroupGates
-from .a_star_cx import AStarCX

--- a/qiskit/transpiler/passes/a_star_mapper/__init__.py
+++ b/qiskit/transpiler/passes/a_star_mapper/__init__.py
@@ -4,4 +4,3 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
-

--- a/qiskit/transpiler/passes/a_star_mapper/a_star_mapper.pyx
+++ b/qiskit/transpiler/passes/a_star_mapper/a_star_mapper.pyx
@@ -1,0 +1,516 @@
+from libcpp.queue cimport queue, priority_queue
+from libcpp.set cimport set
+from libcpp.pair cimport pair
+from libc.stdlib cimport malloc, free
+from libcpp.vector cimport vector
+from libc.string cimport memcpy
+from libcpp.utility cimport pair
+from libcpp cimport bool
+from libc.stdio cimport *
+from libc.limits cimport INT_MAX
+from libc.stdint cimport uintptr_t
+cimport cython
+
+# breadth-first search algorithm to find minimal distances between physical qubits
+cdef int bfs(int start, int** dist, set[pair[int, int] ]& coupling_graph):
+    cdef queue[int] q
+    cdef set[int] visited
+    cdef int v
+    cdef pair[int, int] edge
+
+    visited.insert(start)
+    q.push(start)
+    dist[start][start] = 0
+
+    while not q.empty(): 
+        v = q.front()
+        q.pop();
+        for edge in coupling_graph:
+            if edge.first == v and visited.find(edge.second) == visited.end():
+                visited.insert(edge.second)
+                q.push(edge.second)
+                dist[start][edge.second] = dist[start][v] + 1
+            elif edge.second == v and visited.find(edge.first) == visited.end():
+                visited.insert(edge.first)
+                q.push(edge.first)
+                dist[start][edge.first] = dist[start][v] + 1
+
+
+# define class for nodes in the A* search
+cdef cppclass a_star_node_mapper:
+    int cost_fixed # fixed cost of the current permutation
+    int cost_heur  # heuristic cost of the current permutation
+    int *locations # location (i.e. pysical qubit) of a logical qubit
+    int *qubits    # logical qubits that are mapped to the physical ones 
+    bool is_goal   # true if the node is a goal node
+    vector[pair[int, int]] swaps # a sequence of swap operations that have been applied 
+
+# A* search algorithm to find a sequence of swap gates such that at least one gate in gates can be applied
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef a_star_node_mapper* a_star_search(set[pair[int, int]]& gates, int* map, int* loc, int** dist, int nqubits, set[pair[int, int] ]& coupling_graph, set[pair[int, int]]& free_swaps) except + :
+    cdef priority_queue[pair[int, uintptr_t]] q
+    cdef a_star_node_mapper* current
+    cdef a_star_node_mapper* new_node
+    cdef int tmp_qubit1, tmp_qubit2
+    cdef pair[int, int] g, edge
+    cdef set[int] used_qubits
+    cdef set[int] interacted_qubits
+
+    # determine all qubits that occur in a 2-qubit gate that can be applied
+    for g in gates:
+        used_qubits.insert(g.first)
+        used_qubits.insert(g.second)
+
+    # create a new node representing the current mapping
+    current = new a_star_node_mapper()
+    current.cost_fixed = 0
+    current.cost_heur = 0
+    current.qubits = <int*>malloc(nqubits * sizeof(int))
+    current.locations = <int*>malloc(nqubits * sizeof(int))    
+    memcpy(current.qubits, map, sizeof(int) * nqubits)
+    memcpy(current.locations, loc, sizeof(int) * nqubits)
+    current.is_goal = False
+    current.swaps = vector[pair[int, int]]()
+
+    q.push(pair[int, uintptr_t](current.cost_fixed + current.cost_heur, <uintptr_t>current))
+
+    # perform A* search
+    while not (<a_star_node_mapper*>q.top().second).is_goal:
+        current = <a_star_node_mapper*> (q.top().second)
+        q.pop()
+
+        # determine all successor nodes (one for each SWAP gate that can be applied)
+        for edge in coupling_graph:
+            # apply only SWAP operations including at least one qubit in used_qubits 
+            if used_qubits.find(current.qubits[edge.first]) == used_qubits.end() and used_qubits.find(current.qubits[edge.second]) == used_qubits.end():
+                continue
+            # do not apply the same SWAP gate twice in a row
+            if current.swaps.size() > 0:
+                g = current.swaps[current.swaps.size()-1] 
+                if g.first == edge.first and g.second == edge.second:
+                    continue
+
+            # create a new node
+            new_node = new a_star_node_mapper()
+            new_node.qubits = <int*>malloc(nqubits * sizeof(int))
+            new_node.locations = <int*>malloc(nqubits * sizeof(int))    
+            new_node.swaps = current.swaps
+            new_node.swaps.push_back(edge)
+
+            # initialize the new node with the mapping of the current node 
+            memcpy(new_node.qubits, current.qubits, sizeof(int) * nqubits)
+            memcpy(new_node.locations, current.locations, sizeof(int) * nqubits)
+      
+            # update mapping of the qubits resulting from adding a SWAP gate
+            tmp_qubit1 = new_node.qubits[edge.first]
+            tmp_qubit2 = new_node.qubits[edge.second]
+            new_node.qubits[edge.first] = tmp_qubit2
+            new_node.qubits[edge.second] = tmp_qubit1
+
+            if tmp_qubit1 != -1:
+                new_node.locations[tmp_qubit1] = edge.second
+            if tmp_qubit2 != -1:
+                new_node.locations[tmp_qubit2] = edge.first
+
+            # determine fixed cost of new node
+            interacted_qubits.clear()
+            new_node.cost_fixed = 0
+            for edge in new_node.swaps:
+                # only add the cost of a swap gate if it is not "free"
+                if interacted_qubits.find(edge.first) != interacted_qubits.end() or interacted_qubits.find(edge.first) != interacted_qubits.end() or free_swaps.find(edge) == free_swaps.end():
+                    new_node.cost_fixed += 1
+                interacted_qubits.insert(edge.first)
+                interacted_qubits.insert(edge.second)
+
+            new_node.is_goal = False 
+            new_node.cost_heur = 0 
+
+            # Check wheter a goal state is reached (i.e. whether any gate can be applied) and determine heuristic cost
+            for g in gates:
+                if dist[new_node.locations[g.first]][new_node.locations[g.second]] == 1:
+                    new_node.is_goal = True
+                # estimate remaining cost (the heuristic is not necessarily admissible and, hence, may yield to sub-optimal local solutions) 
+                new_node.cost_heur += dist[new_node.locations[g.first]][new_node.locations[g.second]] - 1
+
+            # add new node to the queue
+            q.push(pair[int, uintptr_t](INT_MAX - (new_node.cost_fixed + new_node.cost_heur), <uintptr_t>new_node))
+
+        # delete current node
+        free(current.locations)
+        free(current.qubits)
+        del(current)
+    
+    current = <a_star_node_mapper*>(q.top().second)
+    q.pop()
+
+    # clean up
+    while not q.empty():
+        new_node = <a_star_node_mapper*>(q.top().second)
+        free(new_node.locations)
+        free(new_node.qubits)
+        del(new_node)
+        q.pop()
+
+    return current
+        
+# function to rewrite gates with the current mapping and add them to the compiled circuit
+cdef add_rewritten_gates(gates_original, int* locations, compiled_circuit):
+    qubit_names = compiled_circuit.get_qubits()    
+    for g in gates_original:
+        qargs_new = []
+        for qarg in g['qargs']:
+            qargs_new += [('q', locations[qubit_names.index(qarg)])]
+        g['qargs'] = qargs_new
+        compiled_circuit.apply_operation_back(g['name'], qargs_new, g['cargs'], g['params'], g['condition'])
+    return compiled_circuit            
+
+
+# define class for nodes in the A* search
+cdef cppclass a_star_node_initial_mapping:
+    int cost_fixed # fixed cost of the current permutation
+    int cost_heur  # heuristic cost of the current permutation
+    int *locations # location (i.e. pysical qubit) of a logical qubit
+    int *qubits    # logical qubits that are mapped to the physical ones
+    vector[pair[int, int]] remaining_gates # vector holding the initial gates that have to be mapped to an edge of the coupling map
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef a_star_node_initial_mapping* find_initial_permutation(int nqubits, set[pair[int, int]] initial_gates, int* first_interaction, int** dist, set[pair[int, int]] coupling_graph):
+    cdef priority_queue[pair[int, uintptr_t]] q
+    cdef a_star_node_initial_mapping* current
+    cdef a_star_node_initial_mapping* new_node
+    cdef int i, j, k, min_dist
+    cdef bool mappingOK
+    cdef pair[int, int] gate, edge
+
+    # create a new node representing the initial mapping (none of the qubits is mapped yet)
+    current = new a_star_node_initial_mapping()
+    current.cost_fixed = 0
+    current.cost_heur = 0
+    current.locations = <int*>malloc(nqubits * sizeof(int))
+    current.qubits = <int*>malloc(nqubits * sizeof(int))
+    for i in range(nqubits):
+        current.locations[i] = -1
+        current.qubits[i] = -1
+    for gate in initial_gates:
+        current.remaining_gates.push_back(gate)
+    
+    q.push(pair[int, uintptr_t](current.cost_fixed + current.cost_heur, <uintptr_t>current))
+
+    # perform A* search
+    while (<a_star_node_initial_mapping*>q.top().second).remaining_gates.size() != 0:
+        current = <a_star_node_initial_mapping*> (q.top().second)
+        q.pop()
+        gate = current.remaining_gates.back()
+        current.remaining_gates.pop_back()
+
+        # determine all successor nodes (a gate group acting on a pair of qubits can be applied to any edge in the coupling map)
+        # we enforce mapping these groups to an edge in the coupling map in order to avoid SWAPs before appliying the first gate
+        for edge in coupling_graph:
+            if current.qubits[edge.first] != -1 or current.qubits[edge.second] != -1:
+                continue
+
+            # create a new node
+            new_node = new a_star_node_initial_mapping()
+            new_node.locations = <int*>malloc(nqubits * sizeof(int))    
+            new_node.qubits = <int*>malloc(nqubits * sizeof(int))    
+
+            # initialize the new node with the mapping of the current node 
+            memcpy(new_node.locations, current.locations, sizeof(int) * nqubits)
+            memcpy(new_node.qubits, current.qubits, sizeof(int) * nqubits)
+
+            new_node.remaining_gates = current.remaining_gates
+
+            new_node.qubits[edge.first] = gate.first       
+            new_node.locations[gate.first] = edge.first
+
+            new_node.qubits[edge.second] = gate.second       
+            new_node.locations[gate.second] = edge.second
+            
+            new_node.cost_fixed = current.cost_fixed
+            new_node.cost_heur = 0
+            if first_interaction[gate.first] != -1 and new_node.locations[first_interaction[gate.first]] != -1:
+                new_node.cost_fixed += dist[new_node.locations[gate.first]][new_node.locations[first_interaction[gate.first]]]
+            else:
+                min_dist = nqubits
+                for k in range(0, nqubits):
+                    if new_node.qubits[k] == -1:
+                        min_dist = min(min_dist, dist[new_node.locations[gate.first]][k])
+                new_node.cost_heur += min_dist
+            if first_interaction[gate.second] != -1 and new_node.locations[first_interaction[gate.second]] != -1:
+                new_node.cost_fixed += dist[new_node.locations[gate.second]][new_node.locations[first_interaction[gate.second]]]
+            else:
+                min_dist = nqubits
+                for k in range(0, nqubits):
+                    if new_node.qubits[k] == -1:
+                        min_dist = min(min_dist, dist[new_node.locations[gate.second]][k])
+                new_node.cost_heur += min_dist
+
+            q.push(pair[int, uintptr_t](INT_MAX - (new_node.cost_fixed + new_node.cost_heur), <uintptr_t>new_node))
+
+
+            # create a second new node (since there are two qubits involved) 
+            new_node = new a_star_node_initial_mapping()
+            new_node.locations = <int*>malloc(nqubits * sizeof(int))    
+            new_node.qubits = <int*>malloc(nqubits * sizeof(int))    
+
+            # initialize the new node with the mapping of the current node 
+            memcpy(new_node.locations, current.locations, sizeof(int) * nqubits)
+            memcpy(new_node.qubits, current.qubits, sizeof(int) * nqubits)
+
+            new_node.remaining_gates = current.remaining_gates
+
+            new_node.qubits[edge.second] = gate.first       
+            new_node.locations[gate.first] = edge.second
+
+            new_node.qubits[edge.first] = gate.second       
+            new_node.locations[gate.second] = edge.first
+            
+            new_node.cost_fixed = current.cost_fixed
+            new_node.cost_heur = 0
+            if first_interaction[gate.first] != -1 and new_node.locations[first_interaction[gate.first]] != -1:
+                new_node.cost_fixed += dist[new_node.locations[gate.first]][new_node.locations[first_interaction[gate.first]]]
+            else:
+                min_dist = nqubits
+                for k in range(0, nqubits):
+                    if new_node.qubits[k] == -1:
+                        min_dist = min(min_dist, dist[new_node.locations[gate.first]][k])
+                new_node.cost_heur += min_dist
+            if first_interaction[gate.second] != -1 and new_node.locations[first_interaction[gate.second]] != -1:
+                new_node.cost_fixed += dist[new_node.locations[gate.second]][new_node.locations[first_interaction[gate.second]]]
+            else:
+                min_dist = nqubits
+                for k in range(0, nqubits):
+                    if new_node.qubits[k] == -1:
+                        min_dist = min(min_dist, dist[new_node.locations[gate.second]][k])
+                new_node.cost_heur += min_dist
+
+            q.push(pair[int, uintptr_t](INT_MAX - (new_node.cost_fixed + new_node.cost_heur*<int>1), <uintptr_t>new_node))    
+
+        # delete current node  
+        free(current.locations)
+        free(current.qubits)
+        del(current)
+           
+    current = <a_star_node_initial_mapping*>(q.top().second)
+    q.pop()
+
+    # clean up
+    while not q.empty():
+        new_node = <a_star_node_initial_mapping*>(q.top().second)
+        free(new_node.locations)
+        free(new_node.qubits)
+        del(new_node)
+        q.pop()
+    return current
+    
+
+# main method for performing the mapping algorithm
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def a_star_mapper(grouped_gates, coupling_map, int nqubits, empty_circuit):
+    compiled_circuit = empty_circuit
+ 
+    # Switch to C/C++ for performance reasons
+
+    cdef int** dist = <int**>malloc(nqubits * sizeof(int*))
+    cdef int i,j
+    cdef vector[pair[int, int]] applied_gates
+
+    # allocate 2-dimensional array for the distance between two physical qubits
+    for i in range(nqubits):
+        dist[i] = <int*>malloc(nqubits * sizeof(int))
+
+    # translate the coupling_map to a C++ set of pairs
+    cdef set[pair[int, int] ] coupling_graph    
+    for key, value in coupling_map.items():
+        for v in value:
+            coupling_graph.insert((key, v))
+
+    # determine the minimal distances between two qubits    
+    for i in range(nqubits):
+        bfs(i,dist,coupling_graph)
+
+    
+    # allocate arrays for the mapping of the qubits
+    # locations[q1] for a logical qubit q1 gives the physical qubit that q1 is mapped to
+    # qubits[Q1] for a physical qubit Q1 gives the logaic qubit that is mapped to Q1 
+    cdef int *locations = <int*>malloc(nqubits * sizeof(int))
+    cdef int *qubits = <int*>malloc(nqubits * sizeof(int))
+    # start with a mapping that is initially empty (none of the logical qubits is mapped to a physical one)
+    for i in range(0, nqubits):
+        locations[i] = -1
+        qubits[i] = -1
+
+    cdef int q0, q1, ii, iii
+
+    cdef a_star_node_initial_mapping* init_perm
+    cdef set[pair[int, int]] initial_gates
+    cdef int* first_interaction
+    # search for "best initial mapping" (regarding a certain heuristic) using an A* search algorithm. This is only feasable for a small number of qubits
+    if nqubits <= 8:
+        first_interaction = <int*>malloc(nqubits * sizeof(int))
+
+        for i in range(0, nqubits):
+            first_interaction[i] = -1
+
+        for node in grouped_gates.nodes:
+            degree = grouped_gates.in_degree(node)
+            if degree == 0:
+                if len(grouped_gates.node[node]['qubits']) == 2:
+                    q0 = grouped_gates.node[node]['qubits'][0]
+                    q1 = grouped_gates.node[node]['qubits'][1]
+                    # the mapping for all gates in the first layer shall be satified
+                    initial_gates.insert(pair[int, int](q0, q1))
+                    # determine the qubit with which q0 and q1 interact next  
+                    for succ in grouped_gates.successors(node):
+                        if q0 == grouped_gates.node[succ]['qubits'][0]:
+                            first_interaction[grouped_gates.node[succ]['qubits'][1]] = q0
+                        elif q0 == grouped_gates.node[succ]['qubits'][1]:
+                            first_interaction[grouped_gates.node[succ]['qubits'][0]] = q0
+                        elif q1 == grouped_gates.node[succ]['qubits'][0]:
+                            first_interaction[grouped_gates.node[succ]['qubits'][1]] = q1
+                        elif q1 == grouped_gates.node[succ]['qubits'][1]:
+                            first_interaction[grouped_gates.node[succ]['qubits'][0]] = q1
+
+        # call an A* algorithm to determe the best initial mapping    
+        init_perm = find_initial_permutation(nqubits, initial_gates, first_interaction, dist, coupling_graph)
+
+        free(locations)
+        locations = init_perm.locations
+        free(qubits)
+        qubits = init_perm.qubits
+        free(first_interaction)
+        del(init_perm)
+
+    cdef set[pair[int, int]] applicable_gates
+    cdef a_star_node_mapper* result
+
+    cdef set[int] used_qubits
+    cdef set[pair[int,int]] free_swaps
+
+    # conduct the mapping of the circuit
+    while grouped_gates.order() > 0:
+        # add all gates that can be directly applied to the circuit
+        while True:
+            applicable_gates.clear()
+            nodes_to_remove = []
+            for node in grouped_gates.nodes:
+                degree = grouped_gates.in_degree(node)
+                if degree == 0:
+                    if len(grouped_gates.node[node]['qubits']) != 2:
+                        # add measurement and barrier gates to the compiled circuit
+                        for q in grouped_gates.node[node]['qubits']:
+                            for qq in range(nqubits):
+                                if locations[qq] == -1:
+                                    locations[qq] = q
+                                    qubits[q] = qq
+                                    break
+                        compiled_circuit = add_rewritten_gates(grouped_gates.node[node]['gates'], locations, compiled_circuit)
+                        nodes_to_remove += [node]
+                    else:
+                        # map all yet unmapped qubits that occur in gates that can be applied
+
+                        q0 = grouped_gates.node[node]['qubits'][0]
+                        q1 = grouped_gates.node[node]['qubits'][1]
+
+                        if locations[q0] == -1 and locations[q1] == -1:
+                            # case: both qubits are not yet mapped
+                            min_dist = nqubits
+                            min_q1 = -1
+                            min_q2 = -1
+                            # find best initial mapping 
+                            for ii in range(nqubits):
+                                for iii in range(ii+1, nqubits):
+                                    if qubits[ii] == -1 and qubits[iii] == -1 and dist[ii][iii] < min_dist:
+                                        min_dist = dist[ii][iii]
+                                        min_q1 = ii
+                                        min_q2 = iii
+                            locations[q0] = min_q1
+                            locations[q1] = min_q2
+                            qubits[min_q1] = q0
+                            qubits[min_q2] = q1                                        
+                        elif locations[q0] == -1:
+                            # case: only q0 is not yet mapped 
+                            min_dist = nqubits
+                            min_q1 = -1
+                            # find best initial mapping 
+                            for ii in range(nqubits):
+                                if qubits[ii] == -1 and dist[ii][locations[q1]] < min_dist:
+                                    min_dist = dist[ii][locations[q1]]
+                                    min_q1 = ii
+                            locations[q0] = min_q1
+                            qubits[min_q1] = q0
+                        elif locations[q1] == -1:
+                            # case: only q1 is not yet mapped 
+                            min_dist = nqubits
+                            min_q1 = -1
+                            # find best initial mapping 
+                            for ii in range(nqubits):
+                                if qubits[ii] == -1 and dist[ii][locations[q0]] < min_dist:
+                                    min_dist = dist[ii][locations[q0]]
+                                    min_q1 = ii
+                            locations[q1] = min_q1
+                            qubits[min_q1] = q1
+
+                        # gates with a distance of 1 can be directly applied
+                        if dist[locations[q0]][locations[q1]] == 1:
+                            compiled_circuit = add_rewritten_gates(grouped_gates.node[node]['gates'], locations, compiled_circuit)
+                            if coupling_graph.find(pair[int, int](locations[q0], locations[q1])) != coupling_graph.end():
+                                applied_gates.push_back(pair[int, int](locations[q0], locations[q1]))
+                            else:
+                                applied_gates.push_back(pair[int, int](locations[q1], locations[q0]))
+
+                            # remove nodes representing the added gates
+                            nodes_to_remove += [node]
+                        else:
+                            # gates with a distance greater than 1 can potentially be applied (after fixing the mapping)
+                            applicable_gates.insert((q0, q1))
+            if len(nodes_to_remove) == 0:
+                break
+            else:
+                grouped_gates.remove_nodes_from(nodes_to_remove)
+        
+        # check whether all gates have been successfully applied 
+        if len(applicable_gates) == 0:
+            break
+
+        # determine which SWAPs can be applied for "free". A SWAP on qubits q0 and q1 does not cost anything if the group of gates between q0 and q1 have been directly applied before it. This assumption is justified by the post-processing we use and can be included in the heuristic of the search algorithm.
+        used_qubits.clear()
+        free_swaps.clear()
+        for i in range(applied_gates.size()-1,-1,-1):
+            if used_qubits.find(applied_gates[i].first) == used_qubits.end() and used_qubits.find(applied_gates[i].second) == used_qubits.end():
+                free_swaps.insert(applied_gates[i])
+            used_qubits.insert(applied_gates[i].first)
+            used_qubits.insert(applied_gates[i].second)
+    
+
+        # Apply A* to find a permutation such that further gates can be applied
+        result = a_star_search(applicable_gates, qubits, locations, dist, nqubits, coupling_graph, free_swaps)
+
+        # update current mapping
+        free(locations)
+        free(qubits)
+        locations = result.locations
+        qubits = result.qubits
+
+        # add SWAPs to the compiled circuit to modify the current the mapping
+        for swap in result.swaps:
+            compiled_circuit.apply_operation_back('cx', [('q',swap.first), ('q',swap.second)])
+            compiled_circuit.apply_operation_back('cx', [('q',swap.second), ('q',swap.first)])
+            compiled_circuit.apply_operation_back('cx', [('q',swap.first), ('q',swap.second)])
+
+            applied_gates.push_back(swap)
+
+
+        del(result)
+
+    # clean up
+    free(locations)
+    free(qubits)
+    for i in range(nqubits):
+        free(dist[i])
+    free(dist)
+
+    return compiled_circuit

--- a/qiskit/transpiler/passes/a_star_mapper/a_star_mapper.pyx
+++ b/qiskit/transpiler/passes/a_star_mapper/a_star_mapper.pyx
@@ -476,7 +476,9 @@ def a_star_mapper(grouped_gates, coupling_map, int nqubits, empty_circuit):
         if len(applicable_gates) == 0:
             break
 
-        # determine which SWAPs can be applied for "free". A SWAP on qubits q0 and q1 does not cost anything if the group of gates between q0 and q1 have been directly applied before it. This assumption is justified by the post-processing we use and can be included in the heuristic of the search algorithm.
+        # determine which SWAPs can be applied for "free". A SWAP on qubits q0 and q1 does not cost anything if the group 
+        # of gates between q0 and q1 have been directly applied before it. This assumption is justified by the post-processing 
+        # we use and can be included in the heuristic of the search algorithm.
         used_qubits.clear()
         free_swaps.clear()
         for i in range(applied_gates.size()-1,-1,-1):

--- a/qiskit/transpiler/passes/a_star_mapper/setup.py
+++ b/qiskit/transpiler/passes/a_star_mapper/setup.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+"""The A-star Mapper
+"""
+
+DOCLINES = __doc__.split('\n')
+
+CLASSIFIERS = """\
+Development Status :: 4 - Beta
+Intended Audience :: Science/Research
+License :: BSD
+Programming Language :: Python :: 3
+Topic :: Scientific/Engineering
+Operating System :: MacOS
+Operating System :: POSIX
+Operating System :: Unix
+Operating System :: Microsoft :: Windows
+"""
+
+# import statements
+import os
+import sys
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
+
+# all information about QuTiP goes here
+MAJOR = 0
+MINOR = 1
+MICRO = 0
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+REQUIRES = ['cython (>=0.28)']
+INSTALL_REQUIRES = ['cython>=0.28']
+PACKAGES = ['a_star_mapper']
+PACKAGE_DATA = {}
+
+INCLUDE_DIRS = []
+HEADERS = []
+NAME = "a_star_mapper"
+AUTHOR = ("")
+AUTHOR_EMAIL = ("")
+LICENSE = "BSD"
+DESCRIPTION = DOCLINES[0]
+LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
+KEYWORDS = "cython"
+CLASSIFIERS = [_f for _f in CLASSIFIERS.split('\n') if _f]
+PLATFORMS = ["Linux", "Mac OSX", "Unix", "Windows"]
+EXT_MODULES = []
+_compiler_flags = []
+_link_args = []
+
+# Add Cython extensions here
+cy_exts = ['a_star_mapper']
+
+# If on Win
+if sys.platform == 'win32':
+    _compiler_flags += ['/w', '/Ox']
+# Everything else
+else:
+    _compiler_flags += ['-w', '-O3', '-march=native', '-funroll-loops']
+    if sys.platform == 'darwin':
+        _compiler_flags.append('-mmacosx-version-min=10.9')
+        _link_args.append('-mmacosx-version-min=10.9')
+
+
+# Add Cython files
+for ext in cy_exts:
+    _mod = Extension(ext,
+            sources = [ext+'.pyx'],
+            include_dirs = INCLUDE_DIRS,
+            extra_compile_args=_compiler_flags,
+            extra_link_args=_link_args,
+            language='c++')
+    EXT_MODULES.append(_mod)
+
+# Remove -Wstrict-prototypes from cflags
+import distutils.sysconfig
+cfg_vars = distutils.sysconfig.get_config_vars()
+if "CFLAGS" in cfg_vars:
+    cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
+
+
+# Setup commands go here
+setup(
+    name = NAME,
+    version = VERSION,
+    packages = PACKAGES,
+    include_package_data=True,
+    include_dirs = INCLUDE_DIRS,
+    headers = HEADERS,
+    ext_modules = cythonize(EXT_MODULES),
+    cmdclass = {'build_ext': build_ext},
+    author = AUTHOR,
+    author_email = AUTHOR_EMAIL,
+    license = LICENSE,
+    description = DESCRIPTION,
+    long_description = LONG_DESCRIPTION,
+    keywords = KEYWORDS,
+    classifiers = CLASSIFIERS,
+    platforms = PLATFORMS,
+    requires = REQUIRES,
+    package_data = PACKAGE_DATA,
+    zip_safe = False,
+    install_requires=INSTALL_REQUIRES
+)

--- a/qiskit/transpiler/passes/a_star_mapper/setup.py
+++ b/qiskit/transpiler/passes/a_star_mapper/setup.py
@@ -2,7 +2,16 @@
 """The A-star Mapper
 """
 
-DOCLINES = __doc__.split('\n')
+# import statements
+# import os
+import sys
+import distutils.sysconfig
+from setuptools import setup, Extension
+from Cython.Build import cythonize
+from Cython.Distutils import build_ext
+
+
+DOCLINES = __doc__.split("\n")
 
 CLASSIFIERS = """\
 Development Status :: 4 - Beta
@@ -16,89 +25,83 @@ Operating System :: Unix
 Operating System :: Microsoft :: Windows
 """
 
-# import statements
-import os
-import sys
-from setuptools import setup, Extension
-from Cython.Build import cythonize
-from Cython.Distutils import build_ext
-
-# all information about QuTiP goes here
 MAJOR = 0
 MINOR = 1
 MICRO = 0
-VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
-REQUIRES = ['cython (>=0.28)']
-INSTALL_REQUIRES = ['cython>=0.28']
-PACKAGES = ['a_star_mapper']
+VERSION = "%d.%d.%d" % (MAJOR, MINOR, MICRO)
+REQUIRES = ["cython (>=0.28)"]
+INSTALL_REQUIRES = ["cython>=0.28"]
+PACKAGES = ["a_star_mapper"]
 PACKAGE_DATA = {}
 
 INCLUDE_DIRS = []
 HEADERS = []
 NAME = "a_star_mapper"
-AUTHOR = ("")
-AUTHOR_EMAIL = ("")
+AUTHOR = ""
+AUTHOR_EMAIL = ""
 LICENSE = "BSD"
 DESCRIPTION = DOCLINES[0]
 LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
 KEYWORDS = "cython"
-CLASSIFIERS = [_f for _f in CLASSIFIERS.split('\n') if _f]
+CLASSIFIERS = [_f for _f in CLASSIFIERS.split("\n") if _f]
 PLATFORMS = ["Linux", "Mac OSX", "Unix", "Windows"]
 EXT_MODULES = []
-_compiler_flags = []
-_link_args = []
+COMPILER_FLAGS = []
+LINK_ARGS = []
 
 # Add Cython extensions here
-cy_exts = ['a_star_mapper']
+CY_EXTS = ["a_star_mapper"]
 
 # If on Win
-if sys.platform == 'win32':
-    _compiler_flags += ['/w', '/Ox']
+if sys.platform == "win32":
+    COMPILER_FLAGS += ["/w", "/Ox"]
 # Everything else
 else:
-    _compiler_flags += ['-w', '-O3', '-march=native', '-funroll-loops']
-    if sys.platform == 'darwin':
-        _compiler_flags.append('-mmacosx-version-min=10.9')
-        _link_args.append('-mmacosx-version-min=10.9')
+    COMPILER_FLAGS += ["-w", "-O3", "-march=native", "-funroll-loops"]
+    if sys.platform == "darwin":
+        COMPILER_FLAGS.append("-mmacosx-version-min=10.9")
+        LINK_ARGS.append("-mmacosx-version-min=10.9")
 
 
 # Add Cython files
-for ext in cy_exts:
-    _mod = Extension(ext,
-            sources = [ext+'.pyx'],
-            include_dirs = INCLUDE_DIRS,
-            extra_compile_args=_compiler_flags,
-            extra_link_args=_link_args,
-            language='c++')
+for ext in CY_EXTS:
+    _mod = Extension(
+        ext,
+        sources=[ext + ".pyx"],
+        include_dirs=INCLUDE_DIRS,
+        extra_compile_args=COMPILER_FLAGS,
+        extra_link_args=LINK_ARGS,
+        language="c++",
+    )
     EXT_MODULES.append(_mod)
 
 # Remove -Wstrict-prototypes from cflags
-import distutils.sysconfig
-cfg_vars = distutils.sysconfig.get_config_vars()
-if "CFLAGS" in cfg_vars:
-    cfg_vars["CFLAGS"] = cfg_vars["CFLAGS"].replace("-Wstrict-prototypes", "")
+
+CFG_VARS = distutils.sysconfig.get_config_vars()
+if "CFLAGS" in CFG_VARS:
+    CFG_VARS["CFLAGS"] = CFG_VARS["CFLAGS"].replace("-Wstrict-prototypes", "")
 
 
 # Setup commands go here
 setup(
-    name = NAME,
-    version = VERSION,
-    packages = PACKAGES,
+    name=NAME,
+    version=VERSION,
+    packages=PACKAGES,
     include_package_data=True,
-    include_dirs = INCLUDE_DIRS,
-    headers = HEADERS,
-    ext_modules = cythonize(EXT_MODULES),
-    cmdclass = {'build_ext': build_ext},
-    author = AUTHOR,
-    author_email = AUTHOR_EMAIL,
-    license = LICENSE,
-    description = DESCRIPTION,
-    long_description = LONG_DESCRIPTION,
-    keywords = KEYWORDS,
-    classifiers = CLASSIFIERS,
-    platforms = PLATFORMS,
-    requires = REQUIRES,
-    package_data = PACKAGE_DATA,
-    zip_safe = False,
-    install_requires=INSTALL_REQUIRES
+    include_dirs=INCLUDE_DIRS,
+    headers=HEADERS,
+    ext_modules=cythonize(EXT_MODULES),
+    cmdclass={"build_ext": build_ext},
+    author=AUTHOR,
+    author_email=AUTHOR_EMAIL,
+    license=LICENSE,
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
+    keywords=KEYWORDS,
+    classifiers=CLASSIFIERS,
+    platforms=PLATFORMS,
+    requires=REQUIRES,
+    package_data=PACKAGE_DATA,
+    zip_safe=False,
+    install_requires=INSTALL_REQUIRES,
 )

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -17,33 +17,8 @@
 def group_gates(compiled_dag):
     """Group consecutive runs of gates on a qubit pair."""
 
-#    def __init__(self):
-#        pass
-
-    #def __init__(self, coupling_map=None, gate_costs=None):
-    #    self.coupling_map = coupling_map
-    #    self.gate_costs = gate_costs
-
-#def run(self, dag):
-#    """
-#    sweep dag in a greedy fashion and gather gates operating on the same pair,
-#    and terminate when a branch out of that pair is encountered.
-
-#    Args:
-#        dag (DAGCircuit): DAGCircuit object to be compiled (Note: was DiGraph - not MultiDiGraph)
-#    """
-
-#JAGdef group_gates(compiled_dag):
-#def group_gates(self, compiled_dag):
-#def group_gates(compiled_dag):
-#    """
-#    Group all gate that are applied to two certain qubits (if possible) in a greedy fashion
-#    return a graph holding the grouped gates.
-#    """
-
     import networkx as nx
 
-    #compiled_dag = dag
     gates = nx.topological_sort(compiled_dag.multi_graph)
     nqubits = compiled_dag.width()
 

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -9,7 +9,10 @@
 """
 from collections import defaultdict
 from qiskit.transpiler import AnalysisPass
-# Our goal is to turn this into an analysis pass.  At present this class is only used by a_star_cx.py
+
+# This will be turned into an analysis pass.  At present this class is only used by a_star_cx.py
+
+
 class GroupGates(AnalysisPass):
     """Group consecutive runs of gates on a qubit pair."""
 
@@ -25,15 +28,16 @@ class GroupGates(AnalysisPass):
             dag: directed acyclic graph (Note: DiGraph instead of MultiDiGraph)
         """
 
-# group all gate that are applied to two certain qubits (if possible) in a greedy fashion
-# return a graph holding the grouped gates
+    # group all gate that are applied to two certain qubits (if possible) in a greedy fashion
+    # return a graph holding the grouped gates
     def group_gates(compiled_dag):
 
         import networkx as nx
+
         gates = nx.topological_sort(compiled_dag.multi_graph)
         nqubits = compiled_dag.width()
 
-        single_qubit_gates = [ [] for i in range(nqubits) ]
+        single_qubit_gates = [[] for i in range(nqubits)]
         last_index = [-1] * nqubits
 
         nnodes = 0
@@ -42,19 +46,23 @@ class GroupGates(AnalysisPass):
         counter = 0
         for i in gates:
             nd = compiled_dag.multi_graph.node[i]
-            if nd['type'] != 'op':
+            if nd["type"] != "op":
                 continue
-            if nd['name'] == 'u3' or nd['name'] == 'u2' or nd['name'] == 'u1':
-                qubit = qubit_names.index(nd['qargs'][0])
+            if nd["name"] == "u3" or nd["name"] == "u2" or nd["name"] == "u1":
+                qubit = qubit_names.index(nd["qargs"][0])
                 if last_index[qubit] == -1:
                     single_qubit_gates[qubit] += [nd]
                 else:
-                    graph.node[last_index[qubit]]['gates'] += [nd]
-            elif nd['name'] == 'cx':
-                q1 = qubit_names.index(nd['qargs'][0])
-                q2 = qubit_names.index(nd['qargs'][1])
+                    graph.node[last_index[qubit]]["gates"] += [nd]
+            elif nd["name"] == "cx":
+                q1 = qubit_names.index(nd["qargs"][0])
+                q2 = qubit_names.index(nd["qargs"][1])
                 if last_index[q1] == -1 and last_index[q2] == -1:
-                    graph.add_node(nnodes, gates=single_qubit_gates[q1] + single_qubit_gates[q2] + [nd], qubits=(q1,q2))
+                    graph.add_node(
+                        nnodes,
+                        gates=single_qubit_gates[q1] + single_qubit_gates[q2] + [nd],
+                        qubits=(q1, q2),
+                    )
                     counter += 1
                     single_qubit_gates[q1] = []
                     single_qubit_gates[q2] = []
@@ -62,74 +70,85 @@ class GroupGates(AnalysisPass):
                     last_index[q2] = nnodes
                     nnodes += 1
                 elif last_index[q1] == -1:
-                    graph.add_node(nnodes, gates=single_qubit_gates[q1] + [nd], qubits=(q1,q2))
-                    counter += 1                
+                    graph.add_node(
+                        nnodes, gates=single_qubit_gates[q1] + [nd], qubits=(q1, q2)
+                    )
+                    counter += 1
                     graph.add_edge(last_index[q2], nnodes)
                     single_qubit_gates[q1] = []
                     last_index[q1] = nnodes
                     last_index[q2] = nnodes
                     nnodes += 1
                 elif last_index[q2] == -1:
-                    graph.add_node(nnodes, gates=single_qubit_gates[q2] + [nd], qubits=(q1,q2))
-                    counter += 1                
+                    graph.add_node(
+                        nnodes, gates=single_qubit_gates[q2] + [nd], qubits=(q1, q2)
+                    )
+                    counter += 1
                     graph.add_edge(last_index[q1], nnodes)
                     single_qubit_gates[q2] = []
                     last_index[q1] = nnodes
                     last_index[q2] = nnodes
                     nnodes += 1
-                else: 
-                    if last_index[q2] == last_index[q1] and len(graph.node[last_index[q2]]['qubits']) != nqubits:
-                        graph.node[last_index[q1]]['gates'] += [nd]
-                    else: 
-                        graph.add_node(nnodes, gates=[nd], qubits=(q1,q2))
-                        counter += 1                    
-                        graph.add_edge(last_index[q1], nnodes)                    
+                else:
+                    if (
+                        last_index[q2] == last_index[q1]
+                        and len(graph.node[last_index[q2]]["qubits"]) != nqubits
+                    ):
+                        graph.node[last_index[q1]]["gates"] += [nd]
+                    else:
+                        graph.add_node(nnodes, gates=[nd], qubits=(q1, q2))
+                        counter += 1
+                        graph.add_edge(last_index[q1], nnodes)
                         graph.add_edge(last_index[q2], nnodes)
                         last_index[q1] = nnodes
                         last_index[q2] = nnodes
                         nnodes += 1
-            elif nd['name'] == 'barrier':
+            elif nd["name"] == "barrier":
                 for i in range(len(single_qubit_gates)):
                     if single_qubit_gates[i] != []:
-                        graph.add_node(nnodes, gates=single_qubit_gates[i], qubits=tuple([i]))
-                        counter += 1                    
+                        graph.add_node(
+                            nnodes, gates=single_qubit_gates[i], qubits=tuple([i])
+                        )
+                        counter += 1
                         last_index[i] = nnodes
                         single_qubit_gates[i] = []
                         nnodes += 1
-                graph.add_node(nnodes, gates=[nd], qubits=tuple(range(0,nqubits)))
-                counter += 1            
+                graph.add_node(nnodes, gates=[nd], qubits=tuple(range(0, nqubits)))
+                counter += 1
                 for i in range(nqubits):
                     graph.add_edge(last_index[i], nnodes)
                     last_index[i] = nnodes
-                nnodes += 1                       
-            elif nd['name'] == 'measure':
-                qubit = qubit_names.index(nd['qargs'][0])
+                nnodes += 1
+            elif nd["name"] == "measure":
+                qubit = qubit_names.index(nd["qargs"][0])
                 if single_qubit_gates[qubit] != []:
-                    graph.add_node(nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit]))
-                    counter += 1                
+                    graph.add_node(
+                        nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit])
+                    )
+                    counter += 1
                     last_index[qubit] = nnodes
                     single_qubit_gates[qubit] = []
                     nnodes += 1
                 graph.add_node(nnodes, gates=[nd], qubits=tuple([qubit]))
-                counter += 1            
+                counter += 1
                 if last_index[qubit] != -1:
                     graph.add_edge(last_index[qubit], nnodes)
                 last_index[qubit] = nnodes
                 nnodes += 1
             else:
-                raise Exception('Unexpected operation in circuit!')
+                raise Exception("Unexpected operation in circuit!")
 
         for qubit in range(0, nqubits):
             if single_qubit_gates[qubit] != []:
-                graph.add_node(nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit]))
-                counter += 1            
+                graph.add_node(
+                    nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit])
+                )
+                counter += 1
                 last_index[qubit] = nnodes
                 single_qubit_gates[qubit] = []
                 nnodes += 1
 
         return graph
 
+
 # -*- coding: utf-8 -*-
-
-
-

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -30,7 +30,7 @@ def group_gates(compiled_dag):
 #    and terminate when a branch out of that pair is encountered.
 
 #    Args:
-#        dag (DAGCircuit): DAGCircuit object to be compiled (Note: was DiGraph instead of MultiDiGraph)
+#        dag (DAGCircuit): DAGCircuit object to be compiled (Note: was DiGraph - not MultiDiGraph)
 #    """
 
 #JAGdef group_gates(compiled_dag):

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Pass for grouping runs of two qubit gates and returning another graph with larger nodes.
+"""
+from collections import defaultdict
+from qiskit.transpiler import AnalysisPass
+# Our goal is to turn this into an analysis pass.  At present this class is only used by a_star_cx.py
+class GroupGates(AnalysisPass):
+    """Group consecutive runs of gates on a qubit pair."""
+
+    def __init__(self):
+        pass
+
+    def run(self, dag):
+        """
+        sweep dag in a greedy fashion and gather gates operating on the same pair,
+        and terminate when a branch out of that pair is encountered.
+
+        Args:
+            dag: directed acyclic graph (Note: DiGraph instead of MultiDiGraph)
+        """
+
+# group all gate that are applied to two certain qubits (if possible) in a greedy fashion
+# return a graph holding the grouped gates
+    def group_gates(compiled_dag):
+
+        import networkx as nx
+        gates = nx.topological_sort(compiled_dag.multi_graph)
+        nqubits = compiled_dag.width()
+
+        single_qubit_gates = [ [] for i in range(nqubits) ]
+        last_index = [-1] * nqubits
+
+        nnodes = 0
+        graph = nx.DiGraph()
+        qubit_names = sorted(compiled_dag.get_qubits())
+        counter = 0
+        for i in gates:
+            nd = compiled_dag.multi_graph.node[i]
+            if nd['type'] != 'op':
+                continue
+            if nd['name'] == 'u3' or nd['name'] == 'u2' or nd['name'] == 'u1':
+                qubit = qubit_names.index(nd['qargs'][0])
+                if last_index[qubit] == -1:
+                    single_qubit_gates[qubit] += [nd]
+                else:
+                    graph.node[last_index[qubit]]['gates'] += [nd]
+            elif nd['name'] == 'cx':
+                q1 = qubit_names.index(nd['qargs'][0])
+                q2 = qubit_names.index(nd['qargs'][1])
+                if last_index[q1] == -1 and last_index[q2] == -1:
+                    graph.add_node(nnodes, gates=single_qubit_gates[q1] + single_qubit_gates[q2] + [nd], qubits=(q1,q2))
+                    counter += 1
+                    single_qubit_gates[q1] = []
+                    single_qubit_gates[q2] = []
+                    last_index[q1] = nnodes
+                    last_index[q2] = nnodes
+                    nnodes += 1
+                elif last_index[q1] == -1:
+                    graph.add_node(nnodes, gates=single_qubit_gates[q1] + [nd], qubits=(q1,q2))
+                    counter += 1                
+                    graph.add_edge(last_index[q2], nnodes)
+                    single_qubit_gates[q1] = []
+                    last_index[q1] = nnodes
+                    last_index[q2] = nnodes
+                    nnodes += 1
+                elif last_index[q2] == -1:
+                    graph.add_node(nnodes, gates=single_qubit_gates[q2] + [nd], qubits=(q1,q2))
+                    counter += 1                
+                    graph.add_edge(last_index[q1], nnodes)
+                    single_qubit_gates[q2] = []
+                    last_index[q1] = nnodes
+                    last_index[q2] = nnodes
+                    nnodes += 1
+                else: 
+                    if last_index[q2] == last_index[q1] and len(graph.node[last_index[q2]]['qubits']) != nqubits:
+                        graph.node[last_index[q1]]['gates'] += [nd]
+                    else: 
+                        graph.add_node(nnodes, gates=[nd], qubits=(q1,q2))
+                        counter += 1                    
+                        graph.add_edge(last_index[q1], nnodes)                    
+                        graph.add_edge(last_index[q2], nnodes)
+                        last_index[q1] = nnodes
+                        last_index[q2] = nnodes
+                        nnodes += 1
+            elif nd['name'] == 'barrier':
+                for i in range(len(single_qubit_gates)):
+                    if single_qubit_gates[i] != []:
+                        graph.add_node(nnodes, gates=single_qubit_gates[i], qubits=tuple([i]))
+                        counter += 1                    
+                        last_index[i] = nnodes
+                        single_qubit_gates[i] = []
+                        nnodes += 1
+                graph.add_node(nnodes, gates=[nd], qubits=tuple(range(0,nqubits)))
+                counter += 1            
+                for i in range(nqubits):
+                    graph.add_edge(last_index[i], nnodes)
+                    last_index[i] = nnodes
+                nnodes += 1                       
+            elif nd['name'] == 'measure':
+                qubit = qubit_names.index(nd['qargs'][0])
+                if single_qubit_gates[qubit] != []:
+                    graph.add_node(nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit]))
+                    counter += 1                
+                    last_index[qubit] = nnodes
+                    single_qubit_gates[qubit] = []
+                    nnodes += 1
+                graph.add_node(nnodes, gates=[nd], qubits=tuple([qubit]))
+                counter += 1            
+                if last_index[qubit] != -1:
+                    graph.add_edge(last_index[qubit], nnodes)
+                last_index[qubit] = nnodes
+                nnodes += 1
+            else:
+                raise Exception('Unexpected operation in circuit!')
+
+        for qubit in range(0, nqubits):
+            if single_qubit_gates[qubit] != []:
+                graph.add_node(nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit]))
+                counter += 1            
+                last_index[qubit] = nnodes
+                single_qubit_gates[qubit] = []
+                nnodes += 1
+
+        return graph
+
+# -*- coding: utf-8 -*-
+
+
+

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -8,138 +8,127 @@
 """Pass for grouping runs of two qubit gates and returning another graph with larger nodes.
 """
 # from collections import defaultdict
-from qiskit.transpiler import AnalysisPass
+#from qiskit.transpiler import AnalysisPass
 
 # This will be turned into an analysis pass.  At present this class is only used by a_star_cx.py
 
 
-class GroupGates(AnalysisPass):
+#class GroupGates(AnalysisPass):
+def group_gates(compiled_dag):
     """Group consecutive runs of gates on a qubit pair."""
 
-    def __init__(self):
-        pass
+#    def __init__(self):
+#        pass
 
-    def run(self, dag):
-        """
-        sweep dag in a greedy fashion and gather gates operating on the same pair,
-        and terminate when a branch out of that pair is encountered.
+    #def __init__(self, coupling_map=None, gate_costs=None):
+    #    self.coupling_map = coupling_map
+    #    self.gate_costs = gate_costs
 
-        Args:
-            dag: directed acyclic graph (Note: DiGraph instead of MultiDiGraph)
-        """
+#def run(self, dag):
+#    """
+#    sweep dag in a greedy fashion and gather gates operating on the same pair,
+#    and terminate when a branch out of that pair is encountered.
 
-    #JAGdef group_gates(compiled_dag):
-    def group_gates(self, compiled_dag):
-        """
-        Group all gate that are applied to two certain qubits (if possible) in a greedy fashion
-        return a graph holding the grouped gates.
-        """
+#    Args:
+#        dag (DAGCircuit): DAGCircuit object to be compiled (Note: was DiGraph instead of MultiDiGraph)
+#    """
 
-        import networkx as nx
+#JAGdef group_gates(compiled_dag):
+#def group_gates(self, compiled_dag):
+#def group_gates(compiled_dag):
+#    """
+#    Group all gate that are applied to two certain qubits (if possible) in a greedy fashion
+#    return a graph holding the grouped gates.
+#    """
 
-        gates = nx.topological_sort(compiled_dag.multi_graph)
-        nqubits = compiled_dag.width()
+    import networkx as nx
 
-        single_qubit_gates = [[] for i in range(nqubits)]
-        last_index = [-1] * nqubits
+    #compiled_dag = dag
+    gates = nx.topological_sort(compiled_dag.multi_graph)
+    nqubits = compiled_dag.width()
 
-        nnodes = 0
-        graph = nx.DiGraph()
-        qubit_names = sorted(compiled_dag.get_qubits())
-        counter = 0
-        for i in gates:
-            node_i = compiled_dag.multi_graph.node[i]
-            if node_i["type"] != "op":
-                continue
-            if node_i["name"] == "u3" or node_i["name"] == "u2" or node_i["name"] == "u1":
-                qubit = qubit_names.index(node_i["qargs"][0])
-                if last_index[qubit] == -1:
-                    single_qubit_gates[qubit] += [node_i]
-                else:
-                    graph.node[last_index[qubit]]["gates"] += [node_i]
-            elif node_i["name"] == "cx":
-                q_1 = qubit_names.index(node_i["qargs"][0])
-                q_2 = qubit_names.index(node_i["qargs"][1])
-                if last_index[q_1] == -1 and last_index[q_2] == -1:
-                    graph.add_node(
-                        nnodes,
-                        gates=single_qubit_gates[q_1] + single_qubit_gates[q_2] + [node_i],
-                        qubits=(q_1, q_2),
-                    )
-                    counter += 1
-                    single_qubit_gates[q_1] = []
-                    single_qubit_gates[q_2] = []
-                    last_index[q_1] = nnodes
-                    last_index[q_2] = nnodes
-                    nnodes += 1
-                elif last_index[q_1] == -1:
-                    graph.add_node(
-                        nnodes, gates=single_qubit_gates[q_1] + [node_i], qubits=(q_1, q_2)
-                    )
-                    counter += 1
-                    graph.add_edge(last_index[q_2], nnodes)
-                    single_qubit_gates[q_1] = []
-                    last_index[q_1] = nnodes
-                    last_index[q_2] = nnodes
-                    nnodes += 1
-                elif last_index[q_2] == -1:
-                    graph.add_node(
-                        nnodes, gates=single_qubit_gates[q_2] + [node_i], qubits=(q_1, q_2)
-                    )
-                    counter += 1
-                    graph.add_edge(last_index[q_1], nnodes)
-                    single_qubit_gates[q_2] = []
-                    last_index[q_1] = nnodes
-                    last_index[q_2] = nnodes
-                    nnodes += 1
-                else:
-                    if (last_index[q_2] == last_index[q_1]
-                            and len(graph.node[last_index[q_2]]["qubits"]) != nqubits):
-                        graph.node[last_index[q_1]]["gates"] += [node_i]
-                    else:
-                        graph.add_node(nnodes, gates=[node_i], qubits=(q_1, q_2))
-                        counter += 1
-                        graph.add_edge(last_index[q_1], nnodes)
-                        graph.add_edge(last_index[q_2], nnodes)
-                        last_index[q_1] = nnodes
-                        last_index[q_2] = nnodes
-                        nnodes += 1
-            elif node_i["name"] == "barrier":
-                for i_inner in range(len(single_qubit_gates)):
-                    if single_qubit_gates[i_inner] != []:
-                        graph.add_node(
-                            nnodes, gates=single_qubit_gates[i_inner], qubits=tuple([i_inner])
-                        )
-                        counter += 1
-                        last_index[i_inner] = nnodes
-                        single_qubit_gates[i_inner] = []
-                        nnodes += 1
-                graph.add_node(nnodes, gates=[node_i], qubits=tuple(range(0, nqubits)))
+    single_qubit_gates = [[] for i in range(nqubits)]
+    last_index = [-1] * nqubits
+
+    nnodes = 0
+    graph = nx.DiGraph()
+    qubit_names = sorted(compiled_dag.get_qubits())
+    counter = 0
+    for i in gates:
+        node_i = compiled_dag.multi_graph.node[i]
+        if node_i["type"] != "op":
+            continue
+        if node_i["name"] == "u3" or node_i["name"] == "u2" or node_i["name"] == "u1":
+            qubit = qubit_names.index(node_i["qargs"][0])
+            if last_index[qubit] == -1:
+                single_qubit_gates[qubit] += [node_i]
+            else:
+                graph.node[last_index[qubit]]["gates"] += [node_i]
+        elif node_i["name"] == "cx":
+            q_1 = qubit_names.index(node_i["qargs"][0])
+            q_2 = qubit_names.index(node_i["qargs"][1])
+            if last_index[q_1] == -1 and last_index[q_2] == -1:
+                graph.add_node(
+                    nnodes,
+                    gates=single_qubit_gates[q_1] + single_qubit_gates[q_2] + [node_i],
+                    qubits=(q_1, q_2),
+                )
                 counter += 1
-                for i_inner in range(nqubits):
-                    graph.add_edge(last_index[i_inner], nnodes)
-                    last_index[i_inner] = nnodes
+                single_qubit_gates[q_1] = []
+                single_qubit_gates[q_2] = []
+                last_index[q_1] = nnodes
+                last_index[q_2] = nnodes
                 nnodes += 1
-            elif node_i["name"] == "measure":
-                qubit = qubit_names.index(node_i["qargs"][0])
-                if single_qubit_gates[qubit] != []:
-                    graph.add_node(
-                        nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit])
-                    )
-                    counter += 1
-                    last_index[qubit] = nnodes
-                    single_qubit_gates[qubit] = []
-                    nnodes += 1
-                graph.add_node(nnodes, gates=[node_i], qubits=tuple([qubit]))
+            elif last_index[q_1] == -1:
+                graph.add_node(
+                    nnodes, gates=single_qubit_gates[q_1] + [node_i], qubits=(q_1, q_2)
+                )
                 counter += 1
-                if last_index[qubit] != -1:
-                    graph.add_edge(last_index[qubit], nnodes)
-                last_index[qubit] = nnodes
+                graph.add_edge(last_index[q_2], nnodes)
+                single_qubit_gates[q_1] = []
+                last_index[q_1] = nnodes
+                last_index[q_2] = nnodes
+                nnodes += 1
+            elif last_index[q_2] == -1:
+                graph.add_node(
+                    nnodes, gates=single_qubit_gates[q_2] + [node_i], qubits=(q_1, q_2)
+                )
+                counter += 1
+                graph.add_edge(last_index[q_1], nnodes)
+                single_qubit_gates[q_2] = []
+                last_index[q_1] = nnodes
+                last_index[q_2] = nnodes
                 nnodes += 1
             else:
-                raise Exception("Unexpected operation in circuit!")
-
-        for qubit in range(0, nqubits):
+                if (last_index[q_2] == last_index[q_1]
+                        and len(graph.node[last_index[q_2]]["qubits"]) != nqubits):
+                    graph.node[last_index[q_1]]["gates"] += [node_i]
+                else:
+                    graph.add_node(nnodes, gates=[node_i], qubits=(q_1, q_2))
+                    counter += 1
+                    graph.add_edge(last_index[q_1], nnodes)
+                    graph.add_edge(last_index[q_2], nnodes)
+                    last_index[q_1] = nnodes
+                    last_index[q_2] = nnodes
+                    nnodes += 1
+        elif node_i["name"] == "barrier":
+            for i_inner in range(len(single_qubit_gates)):
+                if single_qubit_gates[i_inner] != []:
+                    graph.add_node(
+                        nnodes, gates=single_qubit_gates[i_inner], qubits=tuple([i_inner])
+                    )
+                    counter += 1
+                    last_index[i_inner] = nnodes
+                    single_qubit_gates[i_inner] = []
+                    nnodes += 1
+            graph.add_node(nnodes, gates=[node_i], qubits=tuple(range(0, nqubits)))
+            counter += 1
+            for i_inner in range(nqubits):
+                graph.add_edge(last_index[i_inner], nnodes)
+                last_index[i_inner] = nnodes
+            nnodes += 1
+        elif node_i["name"] == "measure":
+            qubit = qubit_names.index(node_i["qargs"][0])
             if single_qubit_gates[qubit] != []:
                 graph.add_node(
                     nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit])
@@ -148,8 +137,26 @@ class GroupGates(AnalysisPass):
                 last_index[qubit] = nnodes
                 single_qubit_gates[qubit] = []
                 nnodes += 1
+            graph.add_node(nnodes, gates=[node_i], qubits=tuple([qubit]))
+            counter += 1
+            if last_index[qubit] != -1:
+                graph.add_edge(last_index[qubit], nnodes)
+            last_index[qubit] = nnodes
+            nnodes += 1
+        else:
+            raise Exception("Unexpected operation in circuit!")
 
-        return graph
+    for qubit in range(0, nqubits):
+        if single_qubit_gates[qubit] != []:
+            graph.add_node(
+                nnodes, gates=single_qubit_gates[qubit], qubits=tuple([qubit])
+            )
+            counter += 1
+            last_index[qubit] = nnodes
+            single_qubit_gates[qubit] = []
+            nnodes += 1
+
+    return graph
 
 
 # -*- coding: utf-8 -*-

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -28,7 +28,8 @@ class GroupGates(AnalysisPass):
             dag: directed acyclic graph (Note: DiGraph instead of MultiDiGraph)
         """
 
-    def group_gates(compiled_dag):
+    #JAGdef group_gates(compiled_dag):
+    def group_gates(self, compiled_dag):
         """
         Group all gate that are applied to two certain qubits (if possible) in a greedy fashion
         return a graph holding the grouped gates.
@@ -104,20 +105,20 @@ class GroupGates(AnalysisPass):
                         last_index[q_2] = nnodes
                         nnodes += 1
             elif node_i["name"] == "barrier":
-                for i in range(len(single_qubit_gates)):
-                    if single_qubit_gates[i] != []:
+                for i_inner in range(len(single_qubit_gates)):
+                    if single_qubit_gates[i_inner] != []:
                         graph.add_node(
-                            nnodes, gates=single_qubit_gates[i], qubits=tuple([i])
+                            nnodes, gates=single_qubit_gates[i_inner], qubits=tuple([i_inner])
                         )
                         counter += 1
-                        last_index[i] = nnodes
-                        single_qubit_gates[i] = []
+                        last_index[i_inner] = nnodes
+                        single_qubit_gates[i_inner] = []
                         nnodes += 1
                 graph.add_node(nnodes, gates=[node_i], qubits=tuple(range(0, nqubits)))
                 counter += 1
-                for i in range(nqubits):
-                    graph.add_edge(last_index[i], nnodes)
-                    last_index[i] = nnodes
+                for i_inner in range(nqubits):
+                    graph.add_edge(last_index[i_inner], nnodes)
+                    last_index[i_inner] = nnodes
                 nnodes += 1
             elif node_i["name"] == "measure":
                 qubit = qubit_names.index(node_i["qargs"][0])

--- a/qiskit/transpiler/passes/group_gates.py
+++ b/qiskit/transpiler/passes/group_gates.py
@@ -7,13 +7,10 @@
 
 """Pass for grouping runs of two qubit gates and returning another graph with larger nodes.
 """
-# from collections import defaultdict
-#from qiskit.transpiler import AnalysisPass
 
 # This will be turned into an analysis pass.  At present this class is only used by a_star_cx.py
 
 
-#class GroupGates(AnalysisPass):
 def group_gates(compiled_dag):
     """Group consecutive runs of gates on a qubit pair."""
 

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -1,48 +1,54 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+""" Methods to assist with compiling tasks.
 """
-Methods to assist with compiling tasks.
-"""
-import math
+
+# import math
 import numpy as np
 
 from qiskit.backends.aer._simulatortools import single_gate_matrix
 from qiskit.mapper._compiling import euler_angles_1q, simplify_U, two_qubit_kak
-
-# determine the cost of all gates in the group
-
+from qiskit.mapper._mapping import MapperError
 
 def cost_of_group(gates, gate_costs):
+    """determine the cost of all gates in the group"""
     cost = 0
-    for g in gates:
-        cost += gate_costs[g["name"]]
+    for gate in gates:
+        cost += gate_costs[gate["name"]]
     return cost
 
 
-# count the number of cx gates
 def count_cx_gates(gates):
+    """count the number of cx gates"""
     count = 0
-    for g in gates:
-        if g["name"].lower() == "cx":
+    for gate in gates:
+        if gate["name"].lower() == "cx":
             count += 1
     return count
 
 
-# optimize gates and add them to the compiled circuit
-def apply_gates(compiled_dag, gates, q0, q1):
+def apply_gates(compiled_dag, gates, qubit0, qubit1):
+    """optimize gates and add them to the compiled circuit"""
 
     from sympy import sympify
 
     # fix the direction of the CX gates
     gates_fixed = []
-    for g in gates:
-        if len(g["qargs"]) == 2:
-            if (g["qargs"][0][1], g["qargs"][1][1]) == (q1, q0):
+    for gate in gates:
+        if len(gate["qargs"]) == 2:
+            if (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit1, qubit0):
                 # swap the direction of the CNOT gate to satisfy constraints
                 # given by the coupling map
                 gates_fixed += [
                     {
                         "type": "op",
                         "name": "u2",
-                        "qargs": [("q", q0)],
+                        "qargs": [("q", qubit0)],
                         "cargs": [],
                         "params": [sympify(0), sympify(np.pi)],
                         "condition": None,
@@ -52,19 +58,19 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     {
                         "type": "op",
                         "name": "u2",
-                        "qargs": [("q", q1)],
+                        "qargs": [("q", qubit1)],
                         "cargs": [],
                         "params": [sympify(0), sympify(np.pi)],
                         "condition": None,
                     }
                 ]
-                g["qargs"] = [g["qargs"][1], g["qargs"][0]]
-                gates_fixed += [g]
+                gate["qargs"] = [gate["qargs"][1], gate["qargs"][0]]
+                gates_fixed += [gate]
                 gates_fixed += [
                     {
                         "type": "op",
                         "name": "u2",
-                        "qargs": [("q", q0)],
+                        "qargs": [("q", qubit0)],
                         "cargs": [],
                         "params": [sympify(0), sympify(np.pi)],
                         "condition": None,
@@ -74,33 +80,33 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     {
                         "type": "op",
                         "name": "u2",
-                        "qargs": [("q", q1)],
+                        "qargs": [("q", qubit1)],
                         "cargs": [],
                         "params": [sympify(0), sympify(np.pi)],
                         "condition": None,
                     }
                 ]
-            elif (g["qargs"][0][1], g["qargs"][1][1]) == (q0, q1):
-                gates_fixed += [g]
+            elif (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit0, qubit1):
+                gates_fixed += [gate]
         else:
-            gates_fixed += [g]
+            gates_fixed += [gate]
 
     # combine consecutive single qubit gates and simplify the result
-    u0 = np.identity(2)
+    u0_mat = np.identity(2)
     u0_gates = []
-    u1 = np.identity(2)
+    u1_mat = np.identity(2)
     u1_gates = []
-    for g in gates_fixed:
-        if g["name"] == "cx":
+    for gate in gates_fixed:
+        if gate["name"] == "cx":
             # add single qubit gates to the compiled circuit
-            if not np.array_equal(u0, np.identity(2)):
+            if not np.array_equal(u0_mat, np.identity(2)):
                 try:
-                    theta, phi, lamb, tmp = euler_angles_1q(u0)
-                    name, params, qasm = simplify_U(theta, phi, lamb)
+                    theta, phi, lamb, _ = euler_angles_1q(u0_mat)
+                    name, params, _ = simplify_U(theta, phi, lamb)
                     if name == "u3":
                         compiled_dag.apply_operation_back(
                             name,
-                            [("q", q0)],
+                            [("q", qubit0)],
                             [],
                             [
                                 sympify(params[0]),
@@ -112,35 +118,35 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     elif name == "u2":
                         compiled_dag.apply_operation_back(
                             name,
-                            [("q", q0)],
+                            [("q", qubit0)],
                             [],
                             [sympify(params[1]), sympify(params[2])],
                             None,
                         )
                     elif name == "u1":
                         compiled_dag.apply_operation_back(
-                            name, [("q", q0)], [], [sympify(params[2])], None
+                            name, [("q", qubit0)], [], [sympify(params[2])], None
                         )
-                except Exception as e:
+                except MapperError as _:
                     # fallback if decomposition provided by qiskit fails
-                    for gg in u0_gates:
+                    for inner_gate in u0_gates:
                         compiled_dag.apply_operation_back(
-                            gg["name"],
-                            gg["qargs"],
-                            gg["cargs"],
-                            gg["params"],
-                            gg["condition"],
+                            inner_gate["name"],
+                            inner_gate["qargs"],
+                            inner_gate["cargs"],
+                            inner_gate["params"],
+                            inner_gate["condition"],
                         )
-                u0 = np.identity(2)
+                u0_mat = np.identity(2)
                 u0_gates = []
-            if not np.array_equal(u1, np.identity(2)):
+            if not np.array_equal(u1_mat, np.identity(2)):
                 try:
-                    theta, phi, lamb, tmp = euler_angles_1q(u1)
-                    name, params, qasm = simplify_U(theta, phi, lamb)
+                    theta, phi, lamb, _ = euler_angles_1q(u1_mat)
+                    name, params, _ = simplify_U(theta, phi, lamb)
                     if name == "u3":
                         compiled_dag.apply_operation_back(
                             name,
-                            [("q", q1)],
+                            [("q", qubit1)],
                             [],
                             [
                                 sympify(params[0]),
@@ -152,49 +158,57 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     elif name == "u2":
                         compiled_dag.apply_operation_back(
                             name,
-                            [("q", q1)],
+                            [("q", qubit1)],
                             [],
                             [sympify(params[1]), sympify(params[2])],
                             None,
                         )
                     elif name == "u1":
                         compiled_dag.apply_operation_back(
-                            name, [("q", q1)], [], [sympify(params[2])], None
+                            name, [("q", qubit1)], [], [sympify(params[2])], None
                         )
-                except Exception as e:
+                except MapperError as _:
                     # fallback if decomposition provided by qiskit fails
-                    for gg in u1_gates:
+                    for inner_gate in u1_gates:
                         compiled_dag.apply_operation_back(
-                            gg["name"],
-                            gg["qargs"],
-                            gg["cargs"],
-                            gg["params"],
-                            gg["condition"],
+                            inner_gate["name"],
+                            inner_gate["qargs"],
+                            inner_gate["cargs"],
+                            inner_gate["params"],
+                            inner_gate["condition"],
                         )
-                u1 = np.identity(2)
+                u1_mat = np.identity(2)
                 u1_gates = []
             compiled_dag.apply_operation_back(
-                g["name"], g["qargs"], g["cargs"], g["params"], g["condition"]
+                gate["name"],
+                gate["qargs"],
+                gate["cargs"],
+                gate["params"],
+                gate["condition"],
             )
 
         else:
             # combine single gates
-            if g["qargs"][0][1] == q0:
-                u0 = np.dot(single_gate_matrix(g["name"], g["params"]), u0)
-                u0_gates += [g]
+            if gate["qargs"][0][1] == qubit0:
+                u0_mat = np.dot(
+                    single_gate_matrix(gate["name"], gate["params"]), u0_mat
+                )
+                u0_gates += [gate]
             else:
-                u1 = np.dot(single_gate_matrix(g["name"], g["params"]), u1)
-                u1_gates += [g]
+                u1_mat = np.dot(
+                    single_gate_matrix(gate["name"], gate["params"]), u1_mat
+                )
+                u1_gates += [gate]
 
     # add single qubit gates to the compiled circuit
-    if not np.array_equal(u0, np.identity(2)):
+    if not np.array_equal(u0_mat, np.identity(2)):
         try:
-            theta, phi, lamb, tmp = euler_angles_1q(u0)
-            name, params, qasm = simplify_U(theta, phi, lamb)
+            theta, phi, lamb, _ = euler_angles_1q(u0_mat)
+            name, params, _ = simplify_U(theta, phi, lamb)
             if name == "u3":
                 compiled_dag.apply_operation_back(
                     name,
-                    [("q", q0)],
+                    [("q", qubit0)],
                     [],
                     [sympify(params[0]), sympify(params[1]), sympify(params[2])],
                     None,
@@ -202,31 +216,35 @@ def apply_gates(compiled_dag, gates, q0, q1):
             elif name == "u2":
                 compiled_dag.apply_operation_back(
                     name,
-                    [("q", q0)],
+                    [("q", qubit0)],
                     [],
                     [sympify(params[1]), sympify(params[2])],
                     None,
                 )
             elif name == "u1":
                 compiled_dag.apply_operation_back(
-                    name, [("q", q0)], [], [sympify(params[2])], None
+                    name, [("q", qubit0)], [], [sympify(params[2])], None
                 )
-        except Exception as e:
+        except MapperError as _:
             # fallback if decomposition provided by qiskit fails
-            for gg in u0_gates:
+            for inner_gate in u0_gates:
                 compiled_dag.apply_operation_back(
-                    gg["name"], gg["qargs"], gg["cargs"], gg["params"], gg["condition"]
+                    inner_gate["name"],
+                    inner_gate["qargs"],
+                    inner_gate["cargs"],
+                    inner_gate["params"],
+                    inner_gate["condition"],
                 )
-        u0 = np.identity(2)
+        u0_mat = np.identity(2)
         u0_gates = []
-    if not np.array_equal(u1, np.identity(2)):
+    if not np.array_equal(u1_mat, np.identity(2)):
         try:
-            theta, phi, lamb, tmp = euler_angles_1q(u1)
-            name, params, qasm = simplify_U(theta, phi, lamb)
+            theta, phi, lamb, _ = euler_angles_1q(u1_mat)
+            name, params, _ = simplify_U(theta, phi, lamb)
             if name == "u3":
                 compiled_dag.apply_operation_back(
                     name,
-                    [("q", q1)],
+                    [("q", qubit1)],
                     [],
                     [sympify(params[0]), sympify(params[1]), sympify(params[2])],
                     None,
@@ -234,29 +252,33 @@ def apply_gates(compiled_dag, gates, q0, q1):
             elif name == "u2":
                 compiled_dag.apply_operation_back(
                     name,
-                    [("q", q1)],
+                    [("q", qubit1)],
                     [],
                     [sympify(params[1]), sympify(params[2])],
                     None,
                 )
             elif name == "u1":
                 compiled_dag.apply_operation_back(
-                    name, [("q", q1)], [], [sympify(params[2])], None
+                    name, [("q", qubit1)], [], [sympify(params[2])], None
                 )
-        except Exception as e:
+        except MapperError as _:
             # fallback if decomposition provided by qiskit fails
-            for gg in u1_gates:
+            for inner_gate in u1_gates:
                 compiled_dag.apply_operation_back(
-                    gg["name"], gg["qargs"], gg["cargs"], gg["params"], gg["condition"]
+                    inner_gate["name"],
+                    inner_gate["qargs"],
+                    inner_gate["cargs"],
+                    inner_gate["params"],
+                    inner_gate["condition"],
                 )
-        u1 = np.identity(2)
+        u1_mat = np.identity(2)
         u1_gates = []
     # return compiled circuit
     return compiled_dag
 
 
-# optimize groups of gates and add them to the compiled circuit
 def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
+    """ Optimize groups of gates and add them to the compiled circuit """
 
     from sympy import sympify
 
@@ -271,60 +293,62 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
         group = grouped_gates.node[index]
         if len(group["qubits"]) == 2:
             cost_before = cost_of_group(group["gates"], gate_costs)
-            q = [group["qubits"][0], group["qubits"][1]]
-            if (("q", q[0]), ("q", q[1])) in coupling_map:
-                q = [group["qubits"][0], group["qubits"][1]]
+            qubits = [group["qubits"][0], group["qubits"][1]]
+            if (("q", qubits[0]), ("q", qubits[1])) in coupling_map:
+                qubits = [group["qubits"][0], group["qubits"][1]]
             else:
-                if (("q", q[1]), ("q", q[0])) in coupling_map:
-                    q = [group["qubits"][1], group["qubits"][0]]
+                if (("q", qubits[1]), ("q", qubits[0])) in coupling_map:
+                    qubits = [group["qubits"][1], group["qubits"][0]]
 
             # estimate whether KAK decomposition (which is time intensive) will improve the result
             if count_cx_gates(group["gates"]) <= 3:
-                compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
+                compiled_dag = apply_gates(
+                    compiled_dag, group["gates"], qubits[0], qubits[1]
+                )
                 continue
 
-            U = np.identity(4)
+            u_mat = np.identity(4)
             cnot1 = np.array(
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]], dtype=complex
             )
             cnot2 = np.array(
                 [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=complex
             )
-            for g in group["gates"]:
-                if g["name"] == "cx":
-                    if g["qargs"][0][1] == q[0]:
-                        U = np.dot(cnot1, U)
+            for gate in group["gates"]:
+                if gate["name"] == "cx":
+                    if gate["qargs"][0][1] == qubits[0]:
+                        u_mat = np.dot(cnot1, u_mat)
                     else:
-                        U = np.dot(cnot2, U)
+                        u_mat = np.dot(cnot2, u_mat)
                 else:
-                    if g["qargs"][0][1] == q[0]:
-                        U = np.dot(
+                    if gate["qargs"][0][1] == qubits[0]:
+                        u_mat = np.dot(
                             np.kron(
-                                single_gate_matrix(g["name"], g["params"]),
+                                single_gate_matrix(gate["name"], gate["params"]),
                                 np.identity(2),
                             ),
-                            U,
+                            u_mat,
                         )
                     else:
-                        U = np.dot(
+                        u_mat = np.dot(
                             np.kron(
                                 np.identity(2),
-                                single_gate_matrix(g["name"], g["params"]),
+                                single_gate_matrix(gate["name"], gate["params"]),
                             ),
-                            U,
+                            u_mat,
                         )
 
             new_gates = []
             try:
-                for gate in two_qubit_kak(U):
-                    i0 = gate["args"][0]
+                for gate in two_qubit_kak(u_mat):
+                    i_0 = gate["args"][0]
                     if gate["name"] == "cx":
-                        i1 = gate["args"][1]
+                        i_1 = gate["args"][1]
                         new_gates += [
                             {
                                 "type": "op",
                                 "name": "cx",
-                                "qargs": [("q", q[i0]), ("q", q[i1])],
+                                "qargs": [("q", qubits[i_0]), ("q", qubits[i_1])],
                                 "cargs": [],
                                 "params": [],
                                 "condition": None,
@@ -335,7 +359,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                             {
                                 "type": "op",
                                 "name": "u1",
-                                "qargs": [("q", q[i0])],
+                                "qargs": [("q", qubits[i_0])],
                                 "cargs": [],
                                 "params": [sympify(gate["params"][2])],
                                 "condition": None,
@@ -346,7 +370,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                             {
                                 "type": "op",
                                 "name": "u2",
-                                "qargs": [("q", q[i0])],
+                                "qargs": [("q", qubits[i_0])],
                                 "cargs": [],
                                 "params": [
                                     sympify(gate["params"][1]),
@@ -360,7 +384,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                             {
                                 "type": "op",
                                 "name": "u3",
-                                "qargs": [("q", q[i0])],
+                                "qargs": [("q", qubits[i_0])],
                                 "cargs": [],
                                 "params": [
                                     sympify(gate["params"][0]),
@@ -373,20 +397,27 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
 
                 # determine cost
                 cost_after = cost_of_group(new_gates, gate_costs)
-            except Exception as e:
+            except Exception as _:
                 cost_after = cost_before + 1
-                pass
             if cost_after < cost_before:
                 # add gates in the decomposition
-                compiled_dag = apply_gates(compiled_dag, new_gates, q[0], q[1])
+                compiled_dag = apply_gates(
+                    compiled_dag, new_gates, qubits[0], qubits[1]
+                )
             else:
                 # add original gates
-                compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
+                compiled_dag = apply_gates(
+                    compiled_dag, group["gates"], qubits[0], qubits[1]
+                )
         else:
             # apply measurement gates and barrier gates without optimization
-            for g in group["gates"]:
+            for gate in group["gates"]:
                 compiled_dag.apply_operation_back(
-                    g["name"], g["qargs"], g["cargs"], g["params"], g["condition"]
+                    gate["name"],
+                    gate["qargs"],
+                    gate["cargs"],
+                    gate["params"],
+                    gate["condition"],
                 )
 
     return compiled_dag

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -34,9 +34,7 @@ def apply_gates(compiled_dag, gates, q0, q1):
     # fix the direction of the CX gates
     gates_fixed = []
     for g in gates:
-        print(g)
         if len(g["qargs"]) == 2:
-            print(g["qargs"][0][1], g["qargs"][1][1])
             if (g["qargs"][0][1], g["qargs"][1][1]) == (q1, q0):
                 # swap the direction of the CNOT gate to satisfy constraints
                 # given by the coupling map
@@ -275,22 +273,16 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
             cost_before = cost_of_group(group["gates"], gate_costs)
             q = [group["qubits"][0], group["qubits"][1]]
             if (("q", q[0]), ("q", q[1])) in coupling_map:
-                print("Right order IS present ... leaving: ", q)
                 q = [group["qubits"][0], group["qubits"][1]]
-                print("Right order IS present ... leaving: ", q)
             else:
                 if (("q", q[1]), ("q", q[0])) in coupling_map:
-                   print("Right order NOT present ... swapping: ", q)
                    q = [group["qubits"][1], group["qubits"][0]]
-                   print("Right order NOT present ... swapping: ", q)
 
             # estimate whether KAK decomposition (which is time intensive) will improve the result
             if count_cx_gates(group["gates"]) <= 3:
-                print("Less than or equal to 3 case")
                 compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
                 continue
 
-            print("Not less than or equal to 3 case")
             U = np.identity(4)
             cnot1 = np.array(
                 [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]], dtype=complex
@@ -386,11 +378,9 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                 pass
             if cost_after < cost_before:
                 # add gates in the decomposition
-                print("Apply gates cost_after was less")
                 compiled_dag = apply_gates(compiled_dag, new_gates, q[0], q[1])
             else:
                 # add original gates
-                print("Apply gates cost_after was NOT less")
                 compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
         else:
             # apply measurement gates and barrier gates without optimization

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -43,7 +43,7 @@ def apply_gates(compiled_dag, gates, qubit0, qubit1, coupling_map):
     for gate in gates:
         if len(gate["qargs"]) == 2:
             if (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit1, qubit0) and (
-                ("q", qubit1), ("q", qubit0)) not in coupling_map:
+            ("q", qubit1), ("q", qubit0)) not in coupling_map:
                 # swap the direction of the CNOT gate to satisfy constraints
                 # given by the coupling map
                 gates_fixed += [

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -1,0 +1,205 @@
+"""
+Methods to assist with compiling tasks.
+"""
+import math
+import numpy as np
+
+from qiskit.backends.aer._simulatortools import single_gate_matrix
+from qiskit.mapper._compiling import euler_angles_1q, simplify_U, two_qubit_kak
+
+# determine the cost of all gates in the group
+def cost_of_group(gates, gate_costs):
+    cost = 0
+    for g in gates:
+        cost += gate_costs[g['name']]
+    return cost
+
+# count the number of cx gates
+def count_cx_gates(gates):
+    count = 0
+    for g in gates:
+        if g['name'].lower() == 'cx':
+            count += 1
+    return count
+
+# optimize gates and add them to the compiled circuit 
+def apply_gates(compiled_dag, gates, q0, q1):
+
+    from sympy import sympify
+
+    # fix the direction of the CX gates
+    gates_fixed = []
+    for g in gates:
+        if len(g['qargs']) == 2:
+            if (g['qargs'][0][1], g['qargs'][1][1]) == (q1, q0):
+                # swap the direction of the CNOT gate to satisfy constraints given by the coupling map
+                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q0)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]             
+                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q1)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]             
+                g['qargs'] = [g['qargs'][1], g['qargs'][0]]
+                gates_fixed += [g]
+                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q0)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]
+                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q1)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]
+            elif (g['qargs'][0][1], g['qargs'][1][1]) == (q0, q1):
+                gates_fixed += [g]
+        else: 
+            gates_fixed += [g]
+
+    # combine consecutive single qubit gates and simplify the result
+    u0 = np.identity(2)
+    u0_gates = []
+    u1 = np.identity(2)
+    u1_gates = []
+    for g in gates_fixed:
+        if g["name"] == "cx":
+            # add single qubit gates to the compiled circuit
+            if not np.array_equal(u0, np.identity(2)):
+                try:
+                    theta, phi, lamb, tmp = euler_angles_1q(u0)
+                    name, params, qasm = simplify_U(theta, phi, lamb)
+                    if name == "u3":
+                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                    elif name == "u2":
+                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[1]), sympify(params[2])], None)    
+                    elif name == "u1":
+                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[2])], None)
+                except Exception as e:
+                    # fallback if decomposition provided by qiskit fails
+                    for gg in u0_gates:
+                        compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                u0 = np.identity(2)
+                u0_gates = []
+            if not np.array_equal(u1, np.identity(2)):
+                try:
+                    theta, phi, lamb, tmp = euler_angles_1q(u1)
+                    name, params, qasm = simplify_U(theta, phi, lamb)
+                    if name == "u3":
+                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                    elif name == "u2":
+                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[1]), sympify(params[2])], None)    
+                    elif name == "u1":
+                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[2])], None)
+                except Exception as e:
+                    # fallback if decomposition provided by qiskit fails
+                    for gg in u1_gates:
+                        compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                u1 = np.identity(2)
+                u1_gates = []
+            compiled_dag.apply_operation_back(g['name'], g['qargs'], g['cargs'], g['params'], g['condition'])
+
+        else:
+            # combine single gates
+            if g['qargs'][0][1] == q0:
+                u0 = np.dot(single_gate_matrix(g['name'], g['params']), u0)
+                u0_gates += [g]
+            else:
+                u1 = np.dot(single_gate_matrix(g['name'], g['params']), u1)
+                u1_gates += [g]
+
+    # add single qubit gates to the compiled circuit
+    if not np.array_equal(u0, np.identity(2)):
+        try:
+            theta, phi, lamb, tmp = euler_angles_1q(u0)
+            name, params, qasm = simplify_U(theta, phi, lamb)
+            if name == "u3":
+                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+            elif name == "u2":
+                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[1]), sympify(params[2])], None)    
+            elif name == "u1":
+                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[2])], None)
+        except Exception as e:
+            # fallback if decomposition provided by qiskit fails
+            for gg in u0_gates:
+                compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+        u0 = np.identity(2)
+        u0_gates = []
+    if not np.array_equal(u1, np.identity(2)):
+        try:
+            theta, phi, lamb, tmp = euler_angles_1q(u1)
+            name, params, qasm = simplify_U(theta, phi, lamb)
+            if name == "u3":
+                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+            elif name == "u2":
+                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[1]), sympify(params[2])], None)    
+            elif name == "u1":
+                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[2])], None)
+        except Exception as e:
+            # fallback if decomposition provided by qiskit fails
+            for gg in u1_gates:
+                compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+        u1 = np.identity(2)
+        u1_gates = []
+    # return compiled circuit
+    return compiled_dag 
+   
+
+# optimize groups of gates and add them to the compiled circuit
+def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
+
+    from sympy import sympify
+
+    compiled_dag = empty_dag
+
+    import networkx as nx
+
+    gate_groups = nx.topological_sort(grouped_gates)
+
+    # iterate over all gates in the group and build corresponding 4x4 unitary matrix
+    for index in gate_groups:
+        group = grouped_gates.node[index]
+        if len(group['qubits']) == 2:
+            cost_before = cost_of_group(group['gates'], gate_costs)
+            q = [group['qubits'][0], group['qubits'][1]]
+            if (('q', q[1]), ('q', q[0])) in coupling_map:
+                q = [group['qubits'][1], group['qubits'][0]]
+
+            # estimate whether KAK decomposition (which is time intensive) will improve the result
+            if count_cx_gates(group['gates']) <= 3:
+                compiled_dag = apply_gates(compiled_dag, group['gates'], q[0], q[1])
+                continue
+
+            U = np.identity(4)
+            cnot1 = np.array([[1,0,0,0],[0,1,0,0],[0,0,0,1],[0,0,1,0]], dtype=complex)            
+            cnot2 = np.array([[1,0,0,0],[0,0,0,1],[0,0,1,0],[0,1,0,0]], dtype=complex)
+            for g in group['gates']:
+                if g["name"] == "cx":
+                    if g['qargs'][0][1] == q[0]:
+                        U = np.dot(cnot1, U)
+                    else:
+                        U = np.dot(cnot2, U)
+                else:
+                    if g['qargs'][0][1] == q[0]:
+                        U = np.dot(np.kron(single_gate_matrix(g['name'], g['params']), np.identity(2)), U)
+                    else:
+                        U = np.dot(np.kron(np.identity(2), single_gate_matrix(g['name'], g['params'])), U)
+
+            new_gates = []
+            try:
+                for gate in two_qubit_kak(U):
+                    i0 = gate["args"][0]
+                    if gate["name"] == "cx":
+                        i1 = gate["args"][1]
+                        new_gates += [{'type': 'op', 'name': 'cx', 'qargs':[('q',q[i0]), ('q',q[i1])], 'cargs':[], 'params': [], 'condition': None  }] 
+                    elif gate["name"] == "u1":
+                        new_gates += [{'type': 'op', 'name': 'u1', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][2])], 'condition': None  }]
+                    elif gate["name"] == "u2":
+                        new_gates += [{'type': 'op', 'name': 'u2', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][1]), sympify(gate["params"][2])], 'condition': None  }]
+                    elif gate["name"] == "u3":
+                        new_gates += [{'type': 'op', 'name': 'u3', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][0]), sympify(gate["params"][1]),sympify(gate["params"][2])], 'condition': None  }]                
+
+                # determine cost 
+                cost_after = cost_of_group(new_gates, gate_costs)
+            except:
+                cost_after = cost_before+1
+                pass
+            if(cost_after < cost_before):
+                # add gates in the decomposition
+                compiled_dag = apply_gates(compiled_dag, new_gates, q[0], q[1])
+            else:
+                # add original gates
+                compiled_dag = apply_gates(compiled_dag, group['gates'], q[0], q[1])
+        else:
+            # apply measurement gates and barrier gates without optimization
+            for g in group['gates']:
+                compiled_dag.apply_operation_back(g['name'], g['qargs'], g['cargs'], g['params'], g['condition']) 
+        
+    return compiled_dag

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -274,8 +274,15 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
         if len(group["qubits"]) == 2:
             cost_before = cost_of_group(group["gates"], gate_costs)
             q = [group["qubits"][0], group["qubits"][1]]
-            if (("q", q[1]), ("q", q[0])) in coupling_map:
-                q = [group["qubits"][1], group["qubits"][0]]
+            if (("q", q[0]), ("q", q[1])) in coupling_map:
+                print("Right order IS present ... leaving: ", q)
+                q = [group["qubits"][0], group["qubits"][1]]
+                print("Right order IS present ... leaving: ", q)
+            else:
+                if (("q", q[1]), ("q", q[0])) in coupling_map:
+                   print("Right order NOT present ... swapping: ", q)
+                   q = [group["qubits"][1], group["qubits"][0]]
+                   print("Right order NOT present ... swapping: ", q)
 
             # estimate whether KAK decomposition (which is time intensive) will improve the result
             if count_cx_gates(group["gates"]) <= 3:

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -42,8 +42,8 @@ def apply_gates(compiled_dag, gates, qubit0, qubit1, coupling_map):
     gates_fixed = []
     for gate in gates:
         if len(gate["qargs"]) == 2:
-            if (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit1, qubit0) and (
-             ("q", qubit1), ("q", qubit0)) not in coupling_map:
+            if (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit1, qubit0) and \
+                (("q", qubit1), ("q", qubit0)) not in coupling_map:
                 # swap the direction of the CNOT gate to satisfy constraints
                 # given by the coupling map
                 gates_fixed += [

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -8,21 +8,25 @@ from qiskit.backends.aer._simulatortools import single_gate_matrix
 from qiskit.mapper._compiling import euler_angles_1q, simplify_U, two_qubit_kak
 
 # determine the cost of all gates in the group
+
+
 def cost_of_group(gates, gate_costs):
     cost = 0
     for g in gates:
-        cost += gate_costs[g['name']]
+        cost += gate_costs[g["name"]]
     return cost
+
 
 # count the number of cx gates
 def count_cx_gates(gates):
     count = 0
     for g in gates:
-        if g['name'].lower() == 'cx':
+        if g["name"].lower() == "cx":
             count += 1
     return count
 
-# optimize gates and add them to the compiled circuit 
+
+# optimize gates and add them to the compiled circuit
 def apply_gates(compiled_dag, gates, q0, q1):
 
     from sympy import sympify
@@ -30,18 +34,57 @@ def apply_gates(compiled_dag, gates, q0, q1):
     # fix the direction of the CX gates
     gates_fixed = []
     for g in gates:
-        if len(g['qargs']) == 2:
-            if (g['qargs'][0][1], g['qargs'][1][1]) == (q1, q0):
-                # swap the direction of the CNOT gate to satisfy constraints given by the coupling map
-                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q0)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]             
-                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q1)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]             
-                g['qargs'] = [g['qargs'][1], g['qargs'][0]]
+        print(g)
+        if len(g["qargs"]) == 2:
+            print(g["qargs"][0][1], g["qargs"][1][1])
+            if (g["qargs"][0][1], g["qargs"][1][1]) == (q1, q0):
+                # swap the direction of the CNOT gate to satisfy constraints
+                # given by the coupling map
+                gates_fixed += [
+                    {
+                        "type": "op",
+                        "name": "u2",
+                        "qargs": [("q", q0)],
+                        "cargs": [],
+                        "params": [sympify(0), sympify(np.pi)],
+                        "condition": None,
+                    }
+                ]
+                gates_fixed += [
+                    {
+                        "type": "op",
+                        "name": "u2",
+                        "qargs": [("q", q1)],
+                        "cargs": [],
+                        "params": [sympify(0), sympify(np.pi)],
+                        "condition": None,
+                    }
+                ]
+                g["qargs"] = [g["qargs"][1], g["qargs"][0]]
                 gates_fixed += [g]
-                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q0)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]
-                gates_fixed += [{'type': 'op', 'name': 'u2', 'qargs':[('q', q1)], 'cargs':[], 'params': [sympify(0), sympify(np.pi)], 'condition': None  }]
-            elif (g['qargs'][0][1], g['qargs'][1][1]) == (q0, q1):
+                gates_fixed += [
+                    {
+                        "type": "op",
+                        "name": "u2",
+                        "qargs": [("q", q0)],
+                        "cargs": [],
+                        "params": [sympify(0), sympify(np.pi)],
+                        "condition": None,
+                    }
+                ]
+                gates_fixed += [
+                    {
+                        "type": "op",
+                        "name": "u2",
+                        "qargs": [("q", q1)],
+                        "cargs": [],
+                        "params": [sympify(0), sympify(np.pi)],
+                        "condition": None,
+                    }
+                ]
+            elif (g["qargs"][0][1], g["qargs"][1][1]) == (q0, q1):
                 gates_fixed += [g]
-        else: 
+        else:
             gates_fixed += [g]
 
     # combine consecutive single qubit gates and simplify the result
@@ -57,15 +100,39 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     theta, phi, lamb, tmp = euler_angles_1q(u0)
                     name, params, qasm = simplify_U(theta, phi, lamb)
                     if name == "u3":
-                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                        compiled_dag.apply_operation_back(
+                            name,
+                            [("q", q0)],
+                            [],
+                            [
+                                sympify(params[0]),
+                                sympify(params[1]),
+                                sympify(params[2]),
+                            ],
+                            None,
+                        )
                     elif name == "u2":
-                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[1]), sympify(params[2])], None)    
+                        compiled_dag.apply_operation_back(
+                            name,
+                            [("q", q0)],
+                            [],
+                            [sympify(params[1]), sympify(params[2])],
+                            None,
+                        )
                     elif name == "u1":
-                        compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[2])], None)
+                        compiled_dag.apply_operation_back(
+                            name, [("q", q0)], [], [sympify(params[2])], None
+                        )
                 except Exception as e:
                     # fallback if decomposition provided by qiskit fails
                     for gg in u0_gates:
-                        compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                        compiled_dag.apply_operation_back(
+                            gg["name"],
+                            gg["qargs"],
+                            gg["cargs"],
+                            gg["params"],
+                            gg["condition"],
+                        )
                 u0 = np.identity(2)
                 u0_gates = []
             if not np.array_equal(u1, np.identity(2)):
@@ -73,26 +140,52 @@ def apply_gates(compiled_dag, gates, q0, q1):
                     theta, phi, lamb, tmp = euler_angles_1q(u1)
                     name, params, qasm = simplify_U(theta, phi, lamb)
                     if name == "u3":
-                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                        compiled_dag.apply_operation_back(
+                            name,
+                            [("q", q1)],
+                            [],
+                            [
+                                sympify(params[0]),
+                                sympify(params[1]),
+                                sympify(params[2]),
+                            ],
+                            None,
+                        )
                     elif name == "u2":
-                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[1]), sympify(params[2])], None)    
+                        compiled_dag.apply_operation_back(
+                            name,
+                            [("q", q1)],
+                            [],
+                            [sympify(params[1]), sympify(params[2])],
+                            None,
+                        )
                     elif name == "u1":
-                        compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[2])], None)
+                        compiled_dag.apply_operation_back(
+                            name, [("q", q1)], [], [sympify(params[2])], None
+                        )
                 except Exception as e:
                     # fallback if decomposition provided by qiskit fails
                     for gg in u1_gates:
-                        compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                        compiled_dag.apply_operation_back(
+                            gg["name"],
+                            gg["qargs"],
+                            gg["cargs"],
+                            gg["params"],
+                            gg["condition"],
+                        )
                 u1 = np.identity(2)
                 u1_gates = []
-            compiled_dag.apply_operation_back(g['name'], g['qargs'], g['cargs'], g['params'], g['condition'])
+            compiled_dag.apply_operation_back(
+                g["name"], g["qargs"], g["cargs"], g["params"], g["condition"]
+            )
 
         else:
             # combine single gates
-            if g['qargs'][0][1] == q0:
-                u0 = np.dot(single_gate_matrix(g['name'], g['params']), u0)
+            if g["qargs"][0][1] == q0:
+                u0 = np.dot(single_gate_matrix(g["name"], g["params"]), u0)
                 u0_gates += [g]
             else:
-                u1 = np.dot(single_gate_matrix(g['name'], g['params']), u1)
+                u1 = np.dot(single_gate_matrix(g["name"], g["params"]), u1)
                 u1_gates += [g]
 
     # add single qubit gates to the compiled circuit
@@ -101,15 +194,31 @@ def apply_gates(compiled_dag, gates, q0, q1):
             theta, phi, lamb, tmp = euler_angles_1q(u0)
             name, params, qasm = simplify_U(theta, phi, lamb)
             if name == "u3":
-                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                compiled_dag.apply_operation_back(
+                    name,
+                    [("q", q0)],
+                    [],
+                    [sympify(params[0]), sympify(params[1]), sympify(params[2])],
+                    None,
+                )
             elif name == "u2":
-                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[1]), sympify(params[2])], None)    
+                compiled_dag.apply_operation_back(
+                    name,
+                    [("q", q0)],
+                    [],
+                    [sympify(params[1]), sympify(params[2])],
+                    None,
+                )
             elif name == "u1":
-                compiled_dag.apply_operation_back(name, [('q', q0)], [], [sympify(params[2])], None)
+                compiled_dag.apply_operation_back(
+                    name, [("q", q0)], [], [sympify(params[2])], None
+                )
         except Exception as e:
             # fallback if decomposition provided by qiskit fails
             for gg in u0_gates:
-                compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                compiled_dag.apply_operation_back(
+                    gg["name"], gg["qargs"], gg["cargs"], gg["params"], gg["condition"]
+                )
         u0 = np.identity(2)
         u0_gates = []
     if not np.array_equal(u1, np.identity(2)):
@@ -117,20 +226,36 @@ def apply_gates(compiled_dag, gates, q0, q1):
             theta, phi, lamb, tmp = euler_angles_1q(u1)
             name, params, qasm = simplify_U(theta, phi, lamb)
             if name == "u3":
-                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[0]), sympify(params[1]), sympify(params[2])], None)
+                compiled_dag.apply_operation_back(
+                    name,
+                    [("q", q1)],
+                    [],
+                    [sympify(params[0]), sympify(params[1]), sympify(params[2])],
+                    None,
+                )
             elif name == "u2":
-                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[1]), sympify(params[2])], None)    
+                compiled_dag.apply_operation_back(
+                    name,
+                    [("q", q1)],
+                    [],
+                    [sympify(params[1]), sympify(params[2])],
+                    None,
+                )
             elif name == "u1":
-                compiled_dag.apply_operation_back(name, [('q', q1)], [], [sympify(params[2])], None)
+                compiled_dag.apply_operation_back(
+                    name, [("q", q1)], [], [sympify(params[2])], None
+                )
         except Exception as e:
             # fallback if decomposition provided by qiskit fails
             for gg in u1_gates:
-                compiled_dag.apply_operation_back(gg['name'], gg['qargs'], gg['cargs'], gg['params'], gg['condition'])              
+                compiled_dag.apply_operation_back(
+                    gg["name"], gg["qargs"], gg["cargs"], gg["params"], gg["condition"]
+                )
         u1 = np.identity(2)
         u1_gates = []
     # return compiled circuit
-    return compiled_dag 
-   
+    return compiled_dag
+
 
 # optimize groups of gates and add them to the compiled circuit
 def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
@@ -146,31 +271,49 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
     # iterate over all gates in the group and build corresponding 4x4 unitary matrix
     for index in gate_groups:
         group = grouped_gates.node[index]
-        if len(group['qubits']) == 2:
-            cost_before = cost_of_group(group['gates'], gate_costs)
-            q = [group['qubits'][0], group['qubits'][1]]
-            if (('q', q[1]), ('q', q[0])) in coupling_map:
-                q = [group['qubits'][1], group['qubits'][0]]
+        if len(group["qubits"]) == 2:
+            cost_before = cost_of_group(group["gates"], gate_costs)
+            q = [group["qubits"][0], group["qubits"][1]]
+            if (("q", q[1]), ("q", q[0])) in coupling_map:
+                q = [group["qubits"][1], group["qubits"][0]]
 
             # estimate whether KAK decomposition (which is time intensive) will improve the result
-            if count_cx_gates(group['gates']) <= 3:
-                compiled_dag = apply_gates(compiled_dag, group['gates'], q[0], q[1])
+            if count_cx_gates(group["gates"]) <= 3:
+                print("Less than or equal to 3 case")
+                compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
                 continue
 
+            print("Not less than or equal to 3 case")
             U = np.identity(4)
-            cnot1 = np.array([[1,0,0,0],[0,1,0,0],[0,0,0,1],[0,0,1,0]], dtype=complex)            
-            cnot2 = np.array([[1,0,0,0],[0,0,0,1],[0,0,1,0],[0,1,0,0]], dtype=complex)
-            for g in group['gates']:
+            cnot1 = np.array(
+                [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]], dtype=complex
+            )
+            cnot2 = np.array(
+                [[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [0, 1, 0, 0]], dtype=complex
+            )
+            for g in group["gates"]:
                 if g["name"] == "cx":
-                    if g['qargs'][0][1] == q[0]:
+                    if g["qargs"][0][1] == q[0]:
                         U = np.dot(cnot1, U)
                     else:
                         U = np.dot(cnot2, U)
                 else:
-                    if g['qargs'][0][1] == q[0]:
-                        U = np.dot(np.kron(single_gate_matrix(g['name'], g['params']), np.identity(2)), U)
+                    if g["qargs"][0][1] == q[0]:
+                        U = np.dot(
+                            np.kron(
+                                single_gate_matrix(g["name"], g["params"]),
+                                np.identity(2),
+                            ),
+                            U,
+                        )
                     else:
-                        U = np.dot(np.kron(np.identity(2), single_gate_matrix(g['name'], g['params'])), U)
+                        U = np.dot(
+                            np.kron(
+                                np.identity(2),
+                                single_gate_matrix(g["name"], g["params"]),
+                            ),
+                            U,
+                        )
 
             new_gates = []
             try:
@@ -178,28 +321,75 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                     i0 = gate["args"][0]
                     if gate["name"] == "cx":
                         i1 = gate["args"][1]
-                        new_gates += [{'type': 'op', 'name': 'cx', 'qargs':[('q',q[i0]), ('q',q[i1])], 'cargs':[], 'params': [], 'condition': None  }] 
+                        new_gates += [
+                            {
+                                "type": "op",
+                                "name": "cx",
+                                "qargs": [("q", q[i0]), ("q", q[i1])],
+                                "cargs": [],
+                                "params": [],
+                                "condition": None,
+                            }
+                        ]
                     elif gate["name"] == "u1":
-                        new_gates += [{'type': 'op', 'name': 'u1', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][2])], 'condition': None  }]
+                        new_gates += [
+                            {
+                                "type": "op",
+                                "name": "u1",
+                                "qargs": [("q", q[i0])],
+                                "cargs": [],
+                                "params": [sympify(gate["params"][2])],
+                                "condition": None,
+                            }
+                        ]
                     elif gate["name"] == "u2":
-                        new_gates += [{'type': 'op', 'name': 'u2', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][1]), sympify(gate["params"][2])], 'condition': None  }]
+                        new_gates += [
+                            {
+                                "type": "op",
+                                "name": "u2",
+                                "qargs": [("q", q[i0])],
+                                "cargs": [],
+                                "params": [
+                                    sympify(gate["params"][1]),
+                                    sympify(gate["params"][2]),
+                                ],
+                                "condition": None,
+                            }
+                        ]
                     elif gate["name"] == "u3":
-                        new_gates += [{'type': 'op', 'name': 'u3', 'qargs':[('q',q[i0])], 'cargs':[], 'params': [sympify(gate["params"][0]), sympify(gate["params"][1]),sympify(gate["params"][2])], 'condition': None  }]                
+                        new_gates += [
+                            {
+                                "type": "op",
+                                "name": "u3",
+                                "qargs": [("q", q[i0])],
+                                "cargs": [],
+                                "params": [
+                                    sympify(gate["params"][0]),
+                                    sympify(gate["params"][1]),
+                                    sympify(gate["params"][2]),
+                                ],
+                                "condition": None,
+                            }
+                        ]
 
-                # determine cost 
+                # determine cost
                 cost_after = cost_of_group(new_gates, gate_costs)
             except:
-                cost_after = cost_before+1
+                cost_after = cost_before + 1
                 pass
-            if(cost_after < cost_before):
+            if cost_after < cost_before:
                 # add gates in the decomposition
+                print("Apply gates cost_after was less")
                 compiled_dag = apply_gates(compiled_dag, new_gates, q[0], q[1])
             else:
                 # add original gates
-                compiled_dag = apply_gates(compiled_dag, group['gates'], q[0], q[1])
+                print("Apply gates cost_after was NOT less")
+                compiled_dag = apply_gates(compiled_dag, group["gates"], q[0], q[1])
         else:
             # apply measurement gates and barrier gates without optimization
-            for g in group['gates']:
-                compiled_dag.apply_operation_back(g['name'], g['qargs'], g['cargs'], g['params'], g['condition']) 
-        
+            for g in group["gates"]:
+                compiled_dag.apply_operation_back(
+                    g["name"], g["qargs"], g["cargs"], g["params"], g["condition"]
+                )
+
     return compiled_dag

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -6,6 +6,8 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """ Methods to assist with compiling tasks.
+    These functions are all used by a_star_mapper (Python, not Cython) in order to such things
+    as KAK refactoring, flip swaps to satisfy the coupling map, evaluate the cost of a circuit, etc.
 """
 
 # import math

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -43,7 +43,7 @@ def apply_gates(compiled_dag, gates, qubit0, qubit1, coupling_map):
     for gate in gates:
         if len(gate["qargs"]) == 2:
             if (gate["qargs"][0][1], gate["qargs"][1][1]) == (qubit1, qubit0) and (
-            ("q", qubit1), ("q", qubit0)) not in coupling_map:
+             ("q", qubit1), ("q", qubit0)) not in coupling_map:
                 # swap the direction of the CNOT gate to satisfy constraints
                 # given by the coupling map
                 gates_fixed += [

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -397,7 +397,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
 
                 # determine cost
                 cost_after = cost_of_group(new_gates, gate_costs)
-            except Exception as _:
+            except (MapperError, ValueError) as _:
                 cost_after = cost_before + 1
             if cost_after < cost_before:
                 # add gates in the decomposition

--- a/qiskit/transpiler/passes/post_mapping_optimization.py
+++ b/qiskit/transpiler/passes/post_mapping_optimization.py
@@ -276,7 +276,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
                 q = [group["qubits"][0], group["qubits"][1]]
             else:
                 if (("q", q[1]), ("q", q[0])) in coupling_map:
-                   q = [group["qubits"][1], group["qubits"][0]]
+                    q = [group["qubits"][1], group["qubits"][0]]
 
             # estimate whether KAK decomposition (which is time intensive) will improve the result
             if count_cx_gates(group["gates"]) <= 3:
@@ -373,7 +373,7 @@ def optimize_gate_groups(grouped_gates, coupling_map, empty_dag, gate_costs):
 
                 # determine cost
                 cost_after = cost_of_group(new_gates, gate_costs)
-            except:
+            except Exception as e:
                 cost_after = cost_before + 1
                 pass
             if cost_after < cost_before:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Adding the A* transpiler pass


### Details and comments
The A* transpiler pass is used to reduce the number of swap gates needed to implemented controls in a circuit.  This is done by breaking the circuit into phases and optimizing phases with lookahead.  The metric used for A* optimization is necessary circuit depth, using the connectivity map supplied.

