### PR TITLE
Text drawer's line_length defaults to shutil.get_terminal_size()

### DIFF
--- a/qiskit/tools/visualization/_text.py
+++ b/qiskit/tools/visualization/_text.py
@@ -10,6 +10,7 @@ A module for drawing circuits in ascii art or some other text representation
 """
 
 from itertools import groupby
+from shutil import get_terminal_size
 
 
 class DrawElement():
@@ -450,12 +451,18 @@ class TextDrawing():
         """
         Generates a list with lines. These lines form the text drawing.
         Args:
-            line_length (int): Optional. When given, breaks the circuit drawing to this length. This
-                               useful when the drawing does not fit in the console.
+            line_length (int): Optional. Breaks the circuit drawing to this length. This
+                               useful when the drawing does not fit in the console. If
+                               None (default), it will try to guess the console width using
+                               shutil.get_terminal_size(). If you don't want pagination
+                               at all, set line_length=-1.
 
         Returns:
             list: A list of lines with the text drawing.
         """
+        if line_length is None:
+            line_length, _ = get_terminal_size()
+
         noqubits = self.json_circuit['header']['number_of_qubits']
         layers = self.build_layers()
 
@@ -474,8 +481,8 @@ class TextDrawing():
 
             TextDrawing.normalize_width(layer)
 
-            if line_length is None:
-                # does not page
+            if line_length == -1:
+                # Do not use pagination (aka line breaking. aka ignore line_length).
                 layer_groups[-1].append(layer)
                 continue
 

--- a/test/python/test_circuit_text_drawer.py
+++ b/test/python/test_circuit_text_drawer.py
@@ -101,6 +101,15 @@ class TestTextDrawerElement(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
         self.assertEqual(_text_circuit_drawer(circuit, line_length=20), expected)
 
+    def test_text_no_pager(self):
+        """ The pager can be disable."""
+        qr = QuantumRegister(1, 'q')
+        circuit = QuantumCircuit(qr)
+        for _ in range(100):
+            circuit.h(qr[0])
+        amount_of_lines = _text_circuit_drawer(circuit, line_length=-1).count('\n')
+        self.assertEqual(amount_of_lines, 2)
+
 
 @unittest.skipUnless(VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestTextDrawerGatesInCircuit(QiskitTestCase):

--- a/test/python/test_visualization_output.py
+++ b/test/python/test_visualization_output.py
@@ -111,7 +111,7 @@ class TestVisualizationImplementation(QiskitTestCase):
     def test_text_drawer(self):
         filename = self._get_resource_path('current_textplot.txt')
         qc = self.sample_circuit()
-        output = circuit_drawer(qc, filename=filename, output="text")
+        output = circuit_drawer(qc, filename=filename, output="text", line_length=-1)
         self.assertFilesAreEqual(filename, self.text_reference)
         os.remove(filename)
         try:


### PR DESCRIPTION
Fixes #1192.

### Summary

As suggested by @mtreinish in #1192, this PR uses `shutil.get_terminal_size()` for the `line_length` option in text drawer. It also adds the option to set `line_length` to `-1` if the user does not want to break the lines in the drawing.