### PR TITLE
Fixing AerJob::status() method to deal with Python's Future

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ Fixed
 - Fixed horizontal spacing when drawing barriers before CCNOT gates in latex
   circuit plots (#1051)
 - Use case insensitive matching when comparing premium account URLs. (#1102)
+- Fixed AerJob status when the submitted Job is in a PENDING state. (#1215)
 
 Removed
 -------

--- a/qiskit/backends/aer/aerjob.py
+++ b/qiskit/backends/aer/aerjob.py
@@ -114,8 +114,12 @@ class AerJob(BaseJob):
         elif self._future.done():
             _status = JobStatus.DONE if self._future.exception() is None else JobStatus.ERROR
         else:
-            raise JobError('Unexpected behavior of {0}'.format(
-                self.__class__.__name__))
+            # Note: There is an undocumented Future state: PENDING, that seems to show up when
+            # the job is enqueued, waiting for someone to pick it up. We need to deal with this
+            # state but there's no public API for it, so we are assuming that if the job is not
+            # in any of the previous states, is PENDING, ergo INITIALIZING for us.
+            _status = JobStatus.INITIALIZING
+
         return _status
 
     def backend_name(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
AerJobs are local Jobs, backed by Python's concurrent `Futures`. We were not dealing correctly with an
undocumented Future state: `PENDING`, that happens when a Job is enqueued (in an internal `Executor` queue) and waiting for some worker to take it and run it.

### Details and comments
Fixes #1203 and unblocks #975


