### PR TITLE
Log stdout and stderr on test_notebook failure

### DIFF
--- a/test/python/test_notebooks.py
+++ b/test/python/test_notebooks.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=redefined-builtin
-
 """Tests for the wrapper functionality."""
 
 import os
@@ -16,23 +14,27 @@ import tempfile
 from .common import QiskitTestCase
 
 
-def _exec_notebook(path):
-    with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
-        args = ["jupyter", "nbconvert", "--to", "notebook", "--execute",
-                "--ExecutePreprocessor.timeout=1000",
-                "--output", fout.name, path]
-        subprocess.check_call(args)
-
-
 class TestJupyter(QiskitTestCase):
     """Notebooks test case."""
     def setUp(self):
         self.path = os.path.dirname(os.path.realpath(__file__))
 
+    def _exec_notebook(self, path):
+        with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
+            args = ["jupyter", "nbconvert", "--to", "notebook", "--execute",
+                    "--ExecutePreprocessor.timeout=1000",
+                    "--output", fout.name, path]
+            proc = subprocess.Popen(args, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+            out, err = proc.communicate()
+            error_msg = ("jupyter nbconvert exited with a non-zero code.\n"
+                         "STDOUT: %s\nSTDERR: %s" % (out, err))
+            self.assertEqual(0, proc.returncode, error_msg)
+
     @unittest.skipIf(os.getenv('APPVEYOR', None), 'Cannot make temp file in Appveyor.')
     def test_jupyter(self):
         "Test Jupyter functionality"
-        _exec_notebook(self.path+'/notebooks/test_jupyter.ipynb')
+        self._exec_notebook(self.path + '/notebooks/test_jupyter.ipynb')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds additional output to the test_notebook test. This test
module operates by subprocessing out and calling jupyter nbconvert to
run a notebook. However, when the test fails and the jupyter command
exits with a non-zero return code there is no debugging information in
logged. It just says the return code, which normally isn't enough to fix
an issue. This commit changes our error messaging by printing the
contents of stdout and stderr from subprocess in the error message when
jupyter returns a non-zero return code. This should aid in debugging
when the test fails.

### Details and comments


