### PR TITLE
[WIP] Use nbconvert as a library in test_notebooks

### DIFF
--- a/test/python/notebooks/test_jupyter.ipynb
+++ b/test/python/notebooks/test_jupyter.ipynb
@@ -11,12 +11,7 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
-    "import sys\n",
-    "import time\n",
-    "cwd = os.getcwd()\n",
-    "qiskit_dir = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(cwd))))\n",
-    "sys.path.append(qiskit_dir)"
+    "import time"
    ]
   },
   {


### PR DESCRIPTION
Invoke the jupyter `nbconvert` tooling as a Python library instead of
invoking it as a separate process during `test_notebooks`.
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

(to be expanded)



### Details and comments


