### PR TITLE
Remove duplicated code from QasmSimulatorPy

### DIFF
--- a/qiskit/backends/aer/_simulatortools.py
+++ b/qiskit/backends/aer/_simulatortools.py
@@ -15,8 +15,8 @@ Functions
 """
 
 from string import ascii_uppercase, ascii_lowercase
+
 import numpy as np
-from sympy import Matrix, pi, E, I, cos, sin, N, sympify
 
 from qiskit import QISKitError
 
@@ -42,7 +42,7 @@ def index1(b, i, k):
 
 
 def index2(b1, i1, b2, i2, k):
-    """Magic index1 function.
+    """Magic index2 function.
 
     Takes a bitstring k and inserts bits b1 as the i1th bit
     and b2 as the i2th bit
@@ -157,52 +157,3 @@ def einsum_matmul_index(gate_indices, number_of_qubits):
            "{tens_lin}{tens_r}->{tens_lout}{tens_r}".format(tens_lin=idx_left_in,
                                                             tens_lout=idx_left_out,
                                                             tens_r=idx_right)
-
-
-# Functions used by the sympy simulators.
-
-def regulate(theta):
-    """
-    Return the regulated symbolic representation of `theta`::
-        * if it has a representation close enough to `pi` transformations,
-            return that representation (for example, `3.14` -> `sympy.pi`).
-        * otherwise, return a sympified representation of theta (for example,
-            `1.23` ->  `sympy.Float(1.23)`).
-
-    See also `UGateGeneric`.
-
-    Args:
-        theta (float or sympy.Basic): the float value (e.g., 3.14) or the
-            symbolic value (e.g., pi)
-
-    Returns:
-        sympy.Basic: the sympy-regulated representation of `theta`
-    """
-    error_margin = 0.01
-    targets = [pi, pi/2, pi * 2, pi / 4]
-
-    for t in targets:
-        if abs(N(theta - t)) < error_margin:
-            return t
-
-    return sympify(theta)
-
-
-def compute_ugate_matrix(parameters):
-    """Compute the matrix associated with a parameterized U gate.
-
-    Args:
-        parameters (list[float]): parameters carried by the U gate
-    Returns:
-        sympy.Matrix: the matrix associated with a parameterized U gate
-    """
-    theta = regulate(parameters[0])
-    phi = regulate(parameters[1])
-    lamb = regulate(parameters[2])
-
-    left_up = cos(theta/2)
-    right_up = (-E**(I*lamb)) * sin(theta/2)
-    left_down = (E**(I*phi)) * sin(theta/2)
-    right_down = (E**(I*(phi + lamb))) * cos(theta/2)
-
-    return Matrix([[left_up, right_up], [left_down, right_down]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `_index1` and `_index2` functions appear to now be used as static methods of `QasmSimulatorPy` in `qasm_simulator_py.py` so their definitions in `_simulartools.py` are never used and should be removed.

In addition there is a minor typo in the docstring of `_index2` which can be corrected.

Fixes #1171