### PR TITLE
Set fixed hash seed for travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ stage_linux: &stage_linux
   dist: trusty
   language: python
   python: 3.5
-  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-5 -D ENABLE_TARGETS_QA=False -D WHEEL_TAG=-pmanylinux1_x86_64 -D STATIC_LINKING=True"
+  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-5 -D ENABLE_TARGETS_QA=False -D WHEEL_TAG=-pmanylinux1_x86_64 -D STATIC_LINKING=True" PYTHONHASHSEED=42
   addons:
     apt:
       sources:
@@ -56,7 +56,7 @@ stage_osx: &stage_osx
   os: osx
   osx_image: xcode9.2
   language: generic
-  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-6 -D ENABLE_TARGETS_QA=False -D STATIC_LINKING=True"
+  env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-6 -D ENABLE_TARGETS_QA=False -D STATIC_LINKING=True" PYTHONHASHSEED=42
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.
@@ -90,7 +90,7 @@ stage_osx_python3_7: &stage_osx_python3_7
 stage_linux_no_compile: &stage_linux_no_compile
   <<: *stage_linux
   addons: false
-  env: CMAKE_FLAGS="-D ENABLE_TARGETS_NON_PYTHON=False"
+  env: CMAKE_FLAGS="-D ENABLE_TARGETS_NON_PYTHON=False" PYTHONHASHSEED=42
 
 
 # Other aliases: for convenience, keeping the "jobs" matrix defined later on
@@ -179,7 +179,7 @@ jobs:
       <<: *stage_linux
       if: branch = master and repo = Qiskit/qiskit-terra and type = push
       python: 3.6
-      env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-5 -D ENABLE_TARGETS_QA=False -D WHEEL_TAG=-pmanylinux1_x86_64 -D STATIC_LINKING=True" USE_ALTERNATE_ENV_CREDENTIALS=True
+      env: CMAKE_FLAGS="-D CMAKE_CXX_COMPILER=g++-5 -D ENABLE_TARGETS_QA=False -D WHEEL_TAG=-pmanylinux1_x86_64 -D STATIC_LINKING=True" USE_ALTERNATE_ENV_CREDENTIALS=True PYTHONHASHSEED=42
 
     # "deploy" stage.
     ###########################################################################


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We've been seeing a spike in failures related to the randomness in
simulator results. (for example see #1223 ) Since there will always be
some randomness in the results to limit the variability this sets a
fixed hash seed for all the travis jobs to try and limit the variability
of the results, and make things more consistent.

### Details and comments


