### PR TITLE
Fix links to languages in sphinx docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -37,9 +37,9 @@
         <a href="https://qiskit.org/aqua">Aqua</a>
       </nav>
       <nav class="second">
-        <a href="/qiskit-terra/doc/_build/html/index.html">English</a>
-          <a href="/qiskit-terra/doc/_build/ja/html/index.html">Japanese</a>
-          <a href="/qiskit-terra/doc/_build/de/html/index.html">German</a>
+        <a href="/documentation/{{ pagename }}{{ file_suffix }}">English</a> /
+        <a href="/documentation/de/{{ pagename }}{{ file_suffix }}">German</a> /
+        <a href="/documentation/ja/{{ pagename }}{{ file_suffix }}">Japanese</a>
         <a class="external" href="https://qiskit.org/vscode">Tools</a>
         <a class="external" href="https://qiskit.org/fun">Fun</a>
       </nav>


### PR DESCRIPTION
Small follow-up to #1133, fixing the links to the different languages of the sphinx documentation, to avoid 404s when the release is made.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


