### PR TITLE
Fix random_state from returning nan

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,7 @@ Fixed
 - Use case insensitive matching when comparing premium account URLs. (#1102)
 - Fixed AerJob status when the submitted Job is in a PENDING state. (#1215)
 - Add fallback for when CPU count can't be determined (#1214)
+- Fix random_state from returning nan (#1258)
 
 Removed
 -------

--- a/qiskit/quantum_info/states/_states.py
+++ b/qiskit/quantum_info/states/_states.py
@@ -48,7 +48,9 @@ def random_state(num):
     Returns:
         ndarray:  state(2**num) a random quantum state.
     """
-    x = np.random.random(1 << num)+0.00000001
+    # Random array over interval (0, 1]
+    x = np.random.random(1 << num)
+    x += x == 0
     x = -np.log(x)
     sumx = sum(x)
     phases = np.random.random(1 << num)*2.0*np.pi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `random_state` function from `qiskit.quanutm_info.states` starts by generating a random array on the interval (0,1]. This PR is fixes cases where values > 1 were actually being generated which caused the function to return `numpy.nan`.

Fixes #1247

