### PR TITLE
Add models and schema for backend objects and Results

### DIFF
--- a/qiskit/backends/models/__init__.py
+++ b/qiskit/backends/models/__init__.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Qiskit schema-conformant objects used by the backends and providers."""
+
+from .backendconfiguration import BackendConfiguration
+from .backendproperties import BackendProperties
+from .backendstatus import BackendStatus
+from .jobstatus import JobStatus

--- a/qiskit/backends/models/backendconfiguration.py
+++ b/qiskit/backends/models/backendconfiguration.py
@@ -86,7 +86,6 @@ class GateConfig(BaseModel):
         self.parameters = parameters
         self.qasm_def = qasm_def
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)
 
 
@@ -120,5 +119,4 @@ class BackendConfiguration(BaseModel):
         self.conditional = conditional
         self.open_pulse = open_pulse
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)

--- a/qiskit/backends/models/backendconfiguration.py
+++ b/qiskit/backends/models/backendconfiguration.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Model and schema for backend configuration."""
+
+from marshmallow.fields import Boolean, DateTime, Integer, List, Nested, String
+from marshmallow.validate import Equal, Length, OneOf, Range, Regexp
+
+from qiskit.validation import BaseModel, BaseSchema, bind_schema
+from qiskit.validation.validate import Or
+
+
+class GateConfigSchema(BaseSchema):
+    """Schema for GateConfig."""
+
+    # Required properties.
+    name = String(required=True)
+    parameters = List(String(), required=True)
+    qasm_def = String(required=True)
+
+    # Optional properties.
+    coupling_map = List(List(Integer(),
+                             validate=Length(min=1)),
+                        validate=Length(min=1))
+    latency_map = List(List(Integer(validate=OneOf([0, 1])),
+                            validate=Length(min=1)),
+                       validate=Length(min=1))
+    conditional = Boolean()
+    description = String()
+
+
+class BackendConfigurationSchema(BaseSchema):
+    """Schema for BackendConfiguration."""
+
+    # Required properties.
+    backend_name = String(required=True)
+    backend_version = String(required=True,
+                             validate=Regexp("[0-9]+.[0-9]+.[0-9]+$"))
+    n_qubits = Integer(required=True,
+                       validate=Or([Equal(-1), Range(min=1)]))
+    basis_gates = List(String(), required=True,
+                       validate=Length(min=1))
+    gates = Nested(GateConfigSchema, required=True, many=True)
+    local = Boolean(required=True)
+    simulator = Boolean(required=True)
+    conditional = Boolean(required=True)
+    open_pulse = Boolean(required=True, validate=Equal(False))
+
+    # Optional properties.
+    sample_name = String()
+    coupling_map = List(List(Integer(),
+                             validate=Length(min=1)),
+                        validate=Length(min=1))
+    n_registers = Integer(validate=Range(min=1))
+    register_map = List(List(Integer(validate=OneOf([0, 1])),
+                             validate=Length(min=1)),
+                        validate=Length(min=1))
+    configurable = Boolean()
+    credits_required = Boolean()
+    online_date = DateTime()
+    display_name = String()
+    description = String()
+    tags = List(String())
+
+
+@bind_schema(GateConfigSchema)
+class GateConfig(BaseModel):
+    """Model for GateConfig.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``GateConfigSchema``.
+
+    Attributes:
+        name (str): the gate name as it will be referred to in QASM.
+        parameters (list[str]): variable names for the gate parameters (if any).
+        qasm_def (str): definition of this gate in terms of QASM primitives U
+            and CX.
+    """
+
+    def __init__(self, name, parameters, qasm_def, **kwargs):
+        self.name = name
+        self.parameters = parameters
+        self.qasm_def = qasm_def
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)
+
+
+@bind_schema(BackendConfigurationSchema)
+class BackendConfiguration(BaseModel):
+    """Model for BackendConfiguration.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``BackendConfigurationSchema``.
+    Attributes:
+        backend_name (str): backend name.
+        backend_version (str): backend version in the form X.Y.Z.
+        n_qubits (int): number of qubits.
+        basis_gates (list[str]): list of basis gates names on the backend.
+        gates (GateConfig): list of basis gates on the backend.
+        local (bool): backend is local or remote.
+        simulator (bool): backend is a simulator.
+        conditional (bool): backend supports conditional operations.
+        open_pulse (bool): backend supports open pulse.
+    """
+
+    def __init__(self, backend_name, backend_version, n_qubits, basis_gates,
+                 gates, local, simulator, conditional, open_pulse, **kwargs):
+        self.backend_name = backend_name
+        self.backend_version = backend_version
+        self.n_qubits = n_qubits
+        self.basis_gates = basis_gates
+        self.gates = gates
+        self.local = local
+        self.simulator = simulator
+        self.conditional = conditional
+        self.open_pulse = open_pulse
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)

--- a/qiskit/backends/models/backendproperties.py
+++ b/qiskit/backends/models/backendproperties.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Model and schema for backend configuration."""
+
+from marshmallow.fields import DateTime, List, Nested, Number, String
+from marshmallow.validate import Length, Regexp
+
+from qiskit.validation import BaseModel, BaseSchema, bind_schema
+
+
+class NduvSchema(BaseSchema):
+    """Schema for name-date-unit-value."""
+
+    # Required properties.
+    date = DateTime(required=True)
+    name = String(required=True)
+    unit = String(required=True)
+    value = Number(required=True)
+
+
+class GateSchema(BaseSchema):
+    """Schema for Gate."""
+
+    # Required properties.
+    qubits = List(Number(), required=True,
+                  validate=Length(min=1))
+    gate = String(required=True)
+    parameters = Nested(NduvSchema, required=True, many=True)
+
+
+class BackendPropertiesSchema(BaseSchema):
+    """Schema for BackendProperties."""
+
+    # Required properties.
+    backend_name = String(required=True)
+    backend_version = String(required=True,
+                             validate=Regexp("[0-9]+.[0-9]+.[0-9]+$"))
+    last_update_date = DateTime(required=True)
+    qubits = List(Nested(NduvSchema, many=True), required=True,
+                  validate=Length(min=1))
+    gates = Nested(GateSchema, required=True, many=True)
+    general = Nested(NduvSchema, required=True, many=True)
+
+
+@bind_schema(NduvSchema)
+class Nduv(BaseModel):
+    """Model for name-date-unit-value.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``NduvSchema``.
+
+    Attributes:
+        date (datetime): date.
+        name (str): name.
+        unit (str): unit.
+        value (Number): value.
+    """
+
+    def __init__(self, date, name, unit, value, **kwargs):
+        self.date = date
+        self.name = name
+        self.unit = unit
+        self.value = value
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)
+
+
+@bind_schema(GateSchema)
+class Gate(BaseModel):
+    """Model for Gate.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``GateSchema``.
+
+    Attributes:
+        qubits (list[Number]): qubits.
+        gate (str): gate.
+        parameters (Nduv): parameters.
+    """
+
+    def __init__(self, qubits, gate, parameters, **kwargs):
+        self.qubits = qubits
+        self.gate = gate
+        self.parameters = parameters
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)
+
+
+@bind_schema(BackendPropertiesSchema)
+class BackendProperties(BaseModel):
+    """Model for BackendProperties.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``BackendPropertiesSchema``.
+
+    Attributes:
+        backend_name (str): backend name.
+        backend_version (str): backend version in the form X.Y.Z.
+        last_update_date (datetime): last date/time that a property was updated.
+        qubits (list[list[Nduv]]): system qubit parameters.
+        gates (list[Gate]): system gate parameters.
+        general (list[Nduv]): general parameters.
+    """
+
+    def __init__(self, backend_name, backend_version, last_update_date,
+                 qubits, gates, general, **kwargs):
+        self.backend_name = backend_name
+        self.backend_version = backend_version
+        self.last_update_date = last_update_date
+        self.qubits = qubits
+        self.gates = gates
+        self.general = general
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)

--- a/qiskit/backends/models/backendproperties.py
+++ b/qiskit/backends/models/backendproperties.py
@@ -67,7 +67,6 @@ class Nduv(BaseModel):
         self.unit = unit
         self.value = value
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)
 
 
@@ -89,7 +88,6 @@ class Gate(BaseModel):
         self.gate = gate
         self.parameters = parameters
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)
 
 
@@ -117,5 +115,5 @@ class BackendProperties(BaseModel):
         self.qubits = qubits
         self.gates = gates
         self.general = general
-        kwargs.update(self.__dict__)
+
         super().__init__(**kwargs)

--- a/qiskit/backends/models/backendstatus.py
+++ b/qiskit/backends/models/backendstatus.py
@@ -49,5 +49,4 @@ class BackendStatus(BaseModel):
         self.pending_jobs = pending_jobs
         self.status_msg = status_msg
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)

--- a/qiskit/backends/models/backendstatus.py
+++ b/qiskit/backends/models/backendstatus.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Model and schema for backend status."""
+
+from marshmallow.fields import Boolean, Integer, String
+from marshmallow.validate import Range, Regexp
+
+from qiskit.validation import BaseModel, BaseSchema, bind_schema
+
+
+class BackendStatusSchema(BaseSchema):
+    """Schema for BackendStatus."""
+
+    # Required properties.
+    backend_name = String(required=True)
+    backend_version = String(required=True,
+                             validate=Regexp("[0-9]+.[0-9]+.[0-9]+$"))
+    operational = Boolean(required=True)
+    pending_jobs = Integer(required=True,
+                           validate=Range(min=0))
+    status_msg = String(required=True)
+
+
+@bind_schema(BackendStatusSchema)
+class BackendStatus(BaseModel):
+    """Model for BackendStatus.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``BackendStatusSchema``.
+
+    Attributes:
+        backend_name (str): backend name.
+        backend_version (str): backend version in the form X.Y.Z.
+        operational (bool): backend operational and accepting jobs.
+        pending_jobs (int): number of pending jobs on the backend.
+        status_msg (str): status message.
+    """
+
+    def __init__(self, backend_name, backend_version, operational,
+                 pending_jobs, status_msg, **kwargs):
+        self.backend_name = backend_name
+        self.backend_version = backend_version
+        self.operational = operational
+        self.pending_jobs = pending_jobs
+        self.status_msg = status_msg
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)

--- a/qiskit/backends/models/jobstatus.py
+++ b/qiskit/backends/models/jobstatus.py
@@ -41,5 +41,4 @@ class JobStatus(BaseModel):
         self.status = status
         self.status_msg = status_msg
 
-        kwargs.update(self.__dict__)
         super().__init__(**kwargs)

--- a/qiskit/backends/models/jobstatus.py
+++ b/qiskit/backends/models/jobstatus.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Model and schema for job status."""
+
+from marshmallow.fields import String
+from marshmallow.validate import OneOf
+
+from qiskit.validation import BaseModel, BaseSchema, bind_schema
+
+
+class JobStatusSchema(BaseSchema):
+    """Schema for JobStatus."""
+
+    # Required properties.
+    job_id = String(required=True)
+    status = String(required=True,
+                    validate=OneOf(['DONE', 'QUEUED', 'CANCELLED', 'RUNNING', 'ERROR']))
+    status_msg = String(required=True)
+
+
+@bind_schema(JobStatusSchema)
+class JobStatus(BaseModel):
+    """Model for JobStatus.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``JobStatusSchema``.
+
+    Attributes:
+        job_id (str): backend job_id.
+        status (str): status of the job.
+        status_msg (str): status message.
+    """
+
+    def __init__(self, job_id, status, status_msg, **kwargs):
+        self.job_id = job_id
+        self.status = status
+        self.status_msg = status_msg
+
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -55,9 +55,10 @@ class BaseSchema(Schema):
         Unknown fields are added with no processing at all.
 
         Args:
-            valid_data (dict): data collected and returned by ``dump()``.
-            original_data (object): object passed to ``dump()`` in the first
-            place.
+            valid_data (dict or list): data collected and returned by ``dump()``.
+            many (bool): if True, data and original_data are a list.
+            original_data (object or list): object passed to ``dump()`` in the
+                first place.
 
         Returns:
             dict: the same ``valid_data`` extended with the unknown attributes.
@@ -83,8 +84,10 @@ class BaseSchema(Schema):
         Unknown fields are added with no processing at all.
 
         Args:
-            valid_data (dict): validated data returned by ``load()``.
-            original_data (dict): data passed to ``load()`` in the first place.
+            valid_data (dict or list): validated data returned by ``load()``.
+            many (bool): if True, data and original_data are a list.
+            original_data (dict or list): data passed to ``load()`` in the
+                first place.
 
         Returns:
             dict: the same ``valid_data`` extended with the unknown attributes.

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -172,28 +172,32 @@ class _SchemaBinder:
             field.fail('type', input=value, type=value.__class__.__name__)
 
         if not field.many:
-            value = [value]
+            values = [value]
+        else:
+            values = value
 
-        for v in value:
+        for v in values:
             if not isinstance(v, field.schema.model_cls):
                 raise ValidationError(
                     'Not a valid type for {}.'.format(field.__class__.__name__),
                     data=data)
-        return data
+        return value
 
     @staticmethod
     def _overridden_basepolyfield_deserialize(field, value, _, data):
         """Helper for minimal validation of fields.BasePolyField."""
         if not field.many:
-            value = [value]
+            values = [value]
+        else:
+            values = value
 
-        for v in value:
+        for v in values:
             schema = field.serialization_schema_selector(v, data)
             if not schema:
                 raise ValidationError(
                     'Not a valid type for {}.'.format(field.__class__.__name__),
                     data=data)
-        return data
+        return value
 
     @staticmethod
     def _overridden_field_deserialize(field, value, attr, data):

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -69,8 +69,8 @@ class BaseSchema(Schema):
             valid_data[key] = getattr(original_data, key)
         return valid_data
 
-    @post_load(pass_original=True)
-    def load_additional_data(self, valid_data, original_data):
+    @post_load(pass_original=True, pass_many=True)
+    def load_additional_data(self, valid_data, many, original_data):
         """Include unknown fields after load.
 
         Unknown fields are added with no processing at all.
@@ -84,9 +84,16 @@ class BaseSchema(Schema):
 
         Inspired by https://github.com/marshmallow-code/marshmallow/pull/595.
         """
-        additional_keys = set(original_data) - set(valid_data)
-        for key in additional_keys:
-            valid_data[key] = original_data[key]
+        if many:
+            for i, _ in enumerate(valid_data):
+                additional_keys = set(original_data[i]) - set(valid_data[i])
+                for key in additional_keys:
+                    valid_data[i][key] = original_data[i][key]
+        else:
+            additional_keys = set(original_data) - set(valid_data)
+            for key in additional_keys:
+                valid_data[key] = original_data[key]
+
         return valid_data
 
     @post_load
@@ -290,4 +297,15 @@ def bind_schema(schema):
 
 class BaseModel(SimpleNamespace):
     """Base class for Models for validated Qiskit classes."""
+    pass
+
+
+class ObjSchema(BaseSchema):
+    """Generic object schema."""
+    pass
+
+
+@bind_schema(ObjSchema)
+class Obj(BaseModel):
+    """Generic object in a Model."""
     pass

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -295,9 +295,23 @@ def bind_schema(schema):
     return _SchemaBinder(schema)
 
 
+def _base_model_from_kwargs(cls, kwargs):
+    """Helper for BaseModel.__reduce__, expanding kwargs."""
+    return cls(**kwargs)
+
+
 class BaseModel(SimpleNamespace):
     """Base class for Models for validated Qiskit classes."""
-    pass
+    def __reduce__(self):
+        """Custom __reduce__ for allowing pickling and unpickling.
+
+        Customize the reduction in order to allow serialization, as the
+        BaseModels need to be pickled during the use of futures by the backends.
+        Instead of returning the class, a helper is used in order to pass the
+        arguments as **kwargs, as it is needed by SimpleNamespace and the
+        standard __reduce__ only allows passing args as a tuple.
+        """
+        return _base_model_from_kwargs, (self.__class__, self.__dict__)
 
 
 class ObjSchema(BaseSchema):

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -48,8 +48,8 @@ class BaseSchema(Schema):
 
     model_cls = SimpleNamespace
 
-    @post_dump(pass_original=True)
-    def dump_additional_data(self, valid_data, original_data):
+    @post_dump(pass_original=True, pass_many=True)
+    def dump_additional_data(self, valid_data, many, original_data):
         """Include unknown fields after dumping.
 
         Unknown fields are added with no processing at all.
@@ -64,9 +64,16 @@ class BaseSchema(Schema):
 
         Inspired by https://github.com/marshmallow-code/marshmallow/pull/595.
         """
-        additional_keys = set(original_data.__dict__) - set(valid_data)
-        for key in additional_keys:
-            valid_data[key] = getattr(original_data, key)
+        if many:
+            for i, _ in enumerate(valid_data):
+                additional_keys = set(original_data[i].__dict__) - set(valid_data[i])
+                for key in additional_keys:
+                    valid_data[i][key] = getattr(original_data[i], key)
+        else:
+            additional_keys = set(original_data.__dict__) - set(valid_data)
+            for key in additional_keys:
+                valid_data[key] = getattr(original_data, key)
+
         return valid_data
 
     @post_load(pass_original=True, pass_many=True)

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -30,7 +30,7 @@ from marshmallow import ValidationError
 from marshmallow import Schema, post_dump, post_load, fields
 from marshmallow.utils import is_collection
 
-from .fields import BasePolyField
+from .fields import BasePolyField, ByType
 
 
 class BaseSchema(Schema):
@@ -161,7 +161,7 @@ class _SchemaBinder:
                 field._deserialize = partial(self._overridden_nested_deserialize, field)
             elif isinstance(field, BasePolyField):
                 field._deserialize = partial(self._overridden_basepolyfield_deserialize, field)
-            elif not isinstance(field, (fields.Number, fields.String)):
+            elif not isinstance(field, (fields.Number, fields.String, ByType)):
                 field._deserialize = partial(self._overridden_field_deserialize, field)
         return shallow_schema
 

--- a/qiskit/validation/fields.py
+++ b/qiskit/validation/fields.py
@@ -164,7 +164,7 @@ class ByType(fields.Field):
     """
 
     default_error_messages = {
-        'invalid': 'Not a valid type.'
+        'invalid': 'Value {value} does not fit any of the types {types}.'
     }
 
     def __init__(self, choices, *args, **kwargs):
@@ -178,7 +178,7 @@ class ByType(fields.Field):
             except ValidationError:
                 pass
 
-        self.fail('invalid')
+        self.fail('invalid', value=value, types=self.choices)
 
     def _deserialize(self, value, attr, data):
         for field in self.choices:
@@ -187,7 +187,7 @@ class ByType(fields.Field):
             except ValidationError:
                 pass
 
-        self.fail('invalid')
+        self.fail('invalid', value=value, types=self.choices)
 
 
 class Complex(fields.Field):
@@ -195,11 +195,11 @@ class Complex(fields.Field):
 
     Field for parsing complex numbers:
     * deserializes to Python's `complex`.
-    * serializes to a tuple of 2 decimals `(real, imaginary)`
+    * serializes to a tuple of 2 decimals `(float, imaginary)`
     """
 
     default_error_messages = {
-        'invalid': 'Not a valid complex number.',
+        'invalid': '{input} cannot be parsed as a complex number.',
         'format': '"{input}" cannot be formatted as complex number.',
     }
 
@@ -216,8 +216,8 @@ class Complex(fields.Field):
 
     def _deserialize(self, value, attr, data):
         if not is_collection(value) or len(value) != 2:
-            self.fail('invalid')
+            self.fail('invalid', input=value)
         try:
             return complex(*value)
         except (ValueError, TypeError):
-            self.fail('invalid')
+            self.fail('invalid', input=value)

--- a/qiskit/validation/fields.py
+++ b/qiskit/validation/fields.py
@@ -159,6 +159,8 @@ class ByType(fields.Field):
 
     Args:
         choices (list[Field]): list of accepted `Fields` instances.
+        *args (tuple): args for Field.
+        **kwargs (dict): kwargs for Field.
     """
 
     default_error_messages = {

--- a/qiskit/validation/result.py
+++ b/qiskit/validation/result.py
@@ -5,7 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Schema and Model for schema-conformant Results."""
+"""Schema and Model for schema-conformant Results.
+
+TODO: Note this file is temporary, and will be removed before 0.7, replacing
+      qiskit.qobj.result and qiskit.result.
+"""
 
 from marshmallow.fields import Boolean, DateTime, Integer, List, Nested, Raw, String
 from marshmallow.validate import Length, OneOf, Regexp, Range
@@ -16,6 +20,8 @@ from qiskit.validation.validate import PatternProperties
 
 
 class ExperimentResultDataSchema(BaseSchema):
+    """Schema for ExperimentResultData."""
+
     counts = Nested(ObjSchema,
                     validate=PatternProperties(
                         {Regexp('^0x([0-9A-Fa-f])+$'): Integer()}))
@@ -31,6 +37,8 @@ class ExperimentResultDataSchema(BaseSchema):
 
 
 class ExperimentResultSchema(BaseSchema):
+    """Schema for ExperimentResult."""
+
     # Required fields.
     shots = ByType([Integer(), List(Integer(validate=Range(min=1)),
                                     validate=Length(equal=2))],
@@ -46,6 +54,8 @@ class ExperimentResultSchema(BaseSchema):
 
 
 class ResultSchema(BaseSchema):
+    """Schema for Result."""
+
     # Required fields.
     backend_name = String(required=True)
     backend_version = String(required=True,
@@ -63,14 +73,61 @@ class ResultSchema(BaseSchema):
 
 @bind_schema(ExperimentResultDataSchema)
 class ExperimentResultData(BaseModel):
+    """Model for ExperimentResultData.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check
+    ``ExperimentResultDataSchema``.
+    """
     pass
 
 
 @bind_schema(ExperimentResultSchema)
 class ExperimentResult(BaseModel):
-    pass
+    """Model for ExperimentResult.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``ExperimentResultSchema``.
+
+    Attributes:
+        shots (int or tuple): the starting and ending shot for this data.
+        success (bool): if true, we can trust results for this experiment.
+        data (ExperimentResultData): results information.
+    """
+
+    def __init__(self, shots, success, data, **kwargs):
+        self.shots = shots
+        self.success = success
+        self.data = data
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)
 
 
 @bind_schema(ResultSchema)
 class Result(BaseModel):
-    pass
+    """Model for Results.
+
+    Please note that this class only describes the required fields. For the
+    full description of the model, please check ``ResultSchema``.
+
+    Attributes:
+        backend_name (str): backend name.
+        backend_version (str): backend version, in the form X.Y.Z.
+        qobj_id (str): user-generated Qobj id.
+        job_id (str): unique execution id from the backend.
+        success (bool): True if complete input qobj executed correctly. (Implies
+            each experiment success)
+        results (ExperimentResult): corresponding results for array of
+            experiments of the input qobj
+    """
+
+    def __init__(self, backend_name, backend_version, qobj_id, job_id, success,
+                 results, **kwargs):
+        self.backend_name = backend_name
+        self.backend_version = backend_version
+        self.qobj_id = qobj_id
+        self.job_id = job_id
+        self.success = success
+        self.results = results
+        kwargs.update(self.__dict__)
+        super().__init__(**kwargs)

--- a/qiskit/validation/result.py
+++ b/qiskit/validation/result.py
@@ -99,7 +99,7 @@ class ExperimentResult(BaseModel):
         self.shots = shots
         self.success = success
         self.data = data
-        kwargs.update(self.__dict__)
+
         super().__init__(**kwargs)
 
 
@@ -129,5 +129,5 @@ class Result(BaseModel):
         self.job_id = job_id
         self.success = success
         self.results = results
-        kwargs.update(self.__dict__)
+
         super().__init__(**kwargs)

--- a/qiskit/validation/result.py
+++ b/qiskit/validation/result.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Schema and Model for schema-conformant Results."""
+
+from marshmallow.fields import Boolean, DateTime, Integer, List, Nested, Raw, String
+from marshmallow.validate import Length, OneOf, Regexp, Range
+
+from qiskit.validation.base import BaseModel, BaseSchema, ObjSchema, bind_schema
+from qiskit.validation.fields import Complex, ByType
+from qiskit.validation.validate import PatternProperties
+
+
+class ExperimentResultDataSchema(BaseSchema):
+    counts = Nested(ObjSchema,
+                    validate=PatternProperties(
+                        {Regexp('^0x([0-9A-Fa-f])+$'): Integer()}))
+    snapshots = Nested(ObjSchema)
+    memory = List(Raw(),
+                  validate=Length(min=1))
+    statevector = List(List(Complex(),
+                            validate=Length(min=1)))
+    unitary = List(List(List(Complex(),
+                             validate=Length(min=1)),
+                        validate=Length(min=1)),
+                   validate=Length(min=1))
+
+
+class ExperimentResultSchema(BaseSchema):
+    # Required fields.
+    shots = ByType([Integer(), List(Integer(validate=Range(min=1)),
+                                    validate=Length(equal=2))],
+                   required=True)
+    success = Boolean(required=True)
+    data = Nested(ExperimentResultDataSchema, required=True)
+
+    # Optional fields.
+    status = String()
+    seed = Integer()
+    meas_return = String(validate=OneOf(['single', 'avg']))
+    header = Nested(ObjSchema)
+
+
+class ResultSchema(BaseSchema):
+    # Required fields.
+    backend_name = String(required=True)
+    backend_version = String(required=True,
+                             validate=Regexp('[0-9]+.[0-9]+.[0-9]+$'))
+    qobj_id = String(required=True)
+    job_id = String(required=True)
+    success = Boolean(required=True)
+    results = Nested(ExperimentResultSchema, required=True, many=True)
+
+    # Optional fields.
+    date = DateTime()
+    status = String()
+    header = Nested(ObjSchema)
+
+
+@bind_schema(ExperimentResultDataSchema)
+class ExperimentResultData(BaseModel):
+    pass
+
+
+@bind_schema(ExperimentResultSchema)
+class ExperimentResult(BaseModel):
+    pass
+
+
+@bind_schema(ResultSchema)
+class Result(BaseModel):
+    pass

--- a/qiskit/validation/validate.py
+++ b/qiskit/validation/validate.py
@@ -11,6 +11,33 @@ from marshmallow import ValidationError
 from marshmallow.validate import Validator
 
 
+class Or(Validator):
+    """Validate using a boolean "or" against a list of Validators.
+
+    This validator accepts a list of other ``Validators``, and returns True if
+    any of those validators pass.
+
+    Examples:
+        wheels = Integer(validate=Or(Equal(4), Equal(2)))
+    """
+
+    def __init__(self, validators):
+        """
+        Args:
+            validators (list[Validator]): list of Validators.
+        """
+        self.validators = validators
+
+    def __call__(self, value):
+        for validator in self.validators:
+            try:
+                return validator(value)
+            except ValidationError:
+                pass
+
+        raise ValidationError('nope')
+
+
 class PatternProperties(Validator):
     """Validate the keys and values of an object, disallowing additional ones.
 
@@ -26,6 +53,7 @@ class PatternProperties(Validator):
                 {Regexp('^0x([0-9A-Fa-f])+$'): Integer(),
                  Regexp('OTHER_THING'): String()})
     """
+
     def __init__(self, pattern_properties):
         """
         Args:

--- a/qiskit/validation/validate.py
+++ b/qiskit/validation/validate.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Validators for Qiskit validated classes."""
+
+from marshmallow import ValidationError
+from marshmallow.validate import Validator
+
+
+class PatternProperties(Validator):
+    """Validate the keys and values of an object, disallowing additional ones.
+
+    This validator is a combination of the jsonschema `patternProperties` and
+    `additionalProperties == False`. It enforces that the keys of an object
+    conform to any of the specified validators in the mapping, and its value
+    has the specified type.
+
+    Examples:
+        counts = Nested(
+            SomeSchema,
+            validate=PatternProperties(
+                {Regexp('^0x([0-9A-Fa-f])+$'): Integer(),
+                 Regexp('OTHER_THING'): String()})
+    """
+    def __init__(self, pattern_properties):
+        """
+        Args:
+            pattern_properties (dict[Validator: Field]): dictionary of the
+                valid mappings.
+        """
+        self.pattern_properties = pattern_properties
+
+    def __call__(self, value):
+        errors = {}
+        for key, value_ in value.__dict__.items():
+            # Attempt to validate the keys against any field.
+            field = None
+            for validator, candidate in self.pattern_properties.items():
+                try:
+                    validator(key)
+                    field = candidate
+                except ValidationError as ex:
+                    errors[key] = ex.messages
+
+            # Attempt to validate the contents.
+            if field:
+                errors.pop(key, None)
+                try:
+                    field.deserialize(value_)
+                except ValidationError as ex:
+                    errors[key] = ex.messages
+
+        if errors:
+            raise ValidationError(errors)
+
+        return value

--- a/qiskit/validation/validate.py
+++ b/qiskit/validation/validate.py
@@ -35,7 +35,8 @@ class Or(Validator):
             except ValidationError:
                 pass
 
-        raise ValidationError('nope')
+        raise ValidationError('Data could not be validated against any '
+                              'validator')
 
 
 class PatternProperties(Validator):

--- a/test/python/test_schemas.py
+++ b/test/python/test_schemas.py
@@ -13,6 +13,7 @@ import os
 from qiskit._schema_validation import (validate_json_against_schema,
                                        _get_validator)
 from qiskit import __path__ as qiskit_path
+from qiskit.validation.result import Result
 from .common import QiskitTestCase
 
 
@@ -66,6 +67,11 @@ class TestSchemaExamples(QiskitTestCase):
 
                             validate_json_against_schema(example,
                                                          schema_name, msg)
+                        # TODO: temporary quick check for validating examples
+                        # using the qiskit.validation-based Result.
+                        if schema_name == 'result':
+                            _ = Result.from_dict(example)
+
 
     def test_schemas_are_valid(self):
         """Validate that schemas are valid jsonschema"""

--- a/test/python/test_schemas.py
+++ b/test/python/test_schemas.py
@@ -13,6 +13,8 @@ import os
 from qiskit._schema_validation import (validate_json_against_schema,
                                        _get_validator)
 from qiskit import __path__ as qiskit_path
+from qiskit.backends.models import (BackendConfiguration, BackendProperties,
+                                    BackendStatus, JobStatus)
 from qiskit.validation.result import Result
 from .common import QiskitTestCase
 
@@ -69,9 +71,14 @@ class TestSchemaExamples(QiskitTestCase):
                                                          schema_name, msg)
                         # TODO: temporary quick check for validating examples
                         # using the qiskit.validation-based Result.
-                        if schema_name == 'result':
-                            _ = Result.from_dict(example)
-
+                        obj_map = {'result': Result,
+                                   'backend_configuration': BackendConfiguration,
+                                   'backend_properties': BackendProperties,
+                                   'backend_status': BackendStatus,
+                                   'job_status': JobStatus}
+                        cls = obj_map.get(schema_name, None)
+                        if cls and 'openpulse' not in example_schema:
+                            _ = cls.from_dict(example)
 
     def test_schemas_are_valid(self):
         """Validate that schemas are valid jsonschema"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Follow-up to #1249, adding models and schemas for:
* BackendConfiguration
* BackendProperties
* BackendStatus
* JobStatus
* Results

along with the utilities needed for supporting their functionality (Fields, Validators, and tweaks and fixes for the base models).The models however have been tested against the existing `qiskit/schemas/examples` files by modifying the `test_schema.py` file.

By having these files in place, the rest of the work (updating the components needed for each schema, adjusting the simulators for conforming to it, working with results, etc) can hopefully be split more easily.

### Details and comments

Please note that the objects are not in use yet - will be tackled in subsequent PRS. Also, the location of some files and classes is still not set in stone (in particular, `qiskit.validation.result` will be removed, Jay!). No changes have been made to the schemas themselves, and the .json files have been used as a reference.

The schema files 