### PR TITLE
Convert mpl drawer to use _utils.get_instructions()

### DIFF
--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -132,10 +132,8 @@ class MatplotlibDrawer:
                             labelleft=False, labelright=False)
 
     def parse_circuit(self, circuit):
-        dag_circuit = dagcircuit.DAGCircuit.fromQuantumCircuit(
-            circuit, expand_gates=False)
         qregs, cregs, ops = _utils._get_instructions(
-            dag_circuit, reversebits=self.reverse_bits)
+            circuit, reversebits=self.reverse_bits)
         self._registers(cregs, qregs)
         self._ops = ops
 

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
-from qiskit import dagcircuit
 from qiskit.tools.visualization import _error
 from qiskit.tools.visualization import _qcstyle
 from qiskit.tools.visualization import _utils

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -406,22 +406,6 @@ class MatplotlibDrawer:
                     }
                 self._cond['n_lines'] += 1
                 idx += 1
-        # reverse bit order
-        if self.reverse_bits:
-            self._reverse_bits(self._qreg_dict)
-            self._reverse_bits(self._creg_dict)
-
-    def _reverse_bits(self, target_dict):
-        coord = {}
-        # grouping
-        for dict_ in target_dict.values():
-            if dict_['group'] not in coord:
-                coord[dict_['group']] = [dict_['y']]
-            else:
-                coord[dict_['group']].insert(0, dict_['y'])
-        # reverse bit order
-        for key in target_dict.keys():
-            target_dict[key]['y'] = coord[target_dict[key]['group']].pop(0)
 
     def _draw_regs_sub(self, n_fold, feedline_l=False, feedline_r=False):
         # quantum register


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit converts the matplotlib drawer to use the
_utils.get_instructions() function instead of using the transpiler. This
allows us to remove our dependency on the transpiler for circuit
visualization and also makes our bit ordering consistent with the
documented ordering.

### Details and comments

Fixes #1272 
