### PR TITLE
runtime matplotlib import

### DIFF
--- a/qiskit/tools/qcvv/fitters.py
+++ b/qiskit/tools/qcvv/fitters.py
@@ -52,6 +52,8 @@ def plot_coherence(xdata, ydata, std_error, fit, fit_function, xunit, exp_str,
         xunit
         exp_str
         qubit_label
+    Raises:
+        ImportError: If matplotlib is not installed.
     """
     if not HAS_MATPLOTLIB:
         raise ImportError('The function plot_coherence needs matplotlib. '
@@ -132,6 +134,9 @@ def plot_rb_data(xdata, ydatas, yavg, yerr, fit, survival_prob, ax=None,
         survival_prob (callable): function that computes survival probability
         ax (Axes or None): plot axis (if passed in)
         show_plt (bool): display the plot.
+
+    Raises:
+        ImportError: If matplotlib is not installed.
     """
     # pylint: disable=invalid-name
 

--- a/qiskit/tools/qcvv/fitters.py
+++ b/qiskit/tools/qcvv/fitters.py
@@ -10,26 +10,32 @@ Basic plotting methods using matplotlib.
 
 These include methods to plot Bloch vectors, histograms, and quantum spheres.
 """
-import matplotlib.pyplot as plt
+
 import numpy as np
+
+try:
+    from matplotlib import pyplot as plt
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 
 def exp_fit_fun(x, a, tau, c):
     """Function used to fit the exponential decay."""
     # pylint: disable=invalid-name
-    return a * np.exp(-x/tau) + c
+    return a * np.exp(-x / tau) + c
 
 
 def osc_fit_fun(x, a, tau, f, phi, c):
     """Function used to fit the decay cosine."""
     # pylint: disable=invalid-name
-    return a * np.exp(-x/tau)*np.cos(2*np.pi*f*x+phi) + c
+    return a * np.exp(-x / tau) * np.cos(2 * np.pi * f * x + phi) + c
 
 
 def rb_fit_fun(x, a, alpha, b):
     """Function used to fit rb."""
     # pylint: disable=invalid-name
-    return a * alpha**x + b
+    return a * alpha ** x + b
 
 
 # Functions used by randomized benchmarking.
@@ -47,6 +53,9 @@ def plot_coherence(xdata, ydata, std_error, fit, fit_function, xunit, exp_str,
         exp_str
         qubit_label
     """
+    if not HAS_MATPLOTLIB:
+        raise ImportError('The function plot_coherence needs matplotlib. '
+                          'Run "pip install matplotlib" before.')
     plt.errorbar(xdata, ydata, std_error, marker='.',
                  markersize=9, c='b', linestyle='')
     plt.plot(xdata, fit_function(xdata, *fit), c='r', linestyle='--',
@@ -98,11 +107,11 @@ def rb_epc(fit, rb_pattern):
         for qubit in patterns:
             fitalpha = fit['q%d' % qubit]['fit'][1]
             fitalphaerr = fit['q%d' % qubit]['fiterr'][1]
-            nrb = 2**len(patterns)
+            nrb = 2 ** len(patterns)
 
             fit['q%d' % qubit]['fit_calcs'] = {}
-            fit['q%d' % qubit]['fit_calcs']['epc'] = [(nrb-1)/nrb*(1-fitalpha),
-                                                      fitalphaerr/fitalpha]
+            fit['q%d' % qubit]['fit_calcs']['epc'] = [(nrb - 1) / nrb * (1 - fitalpha),
+                                                      fitalphaerr / fitalpha]
             fit['q%d' % qubit]['fit_calcs']['epc'][1] *= fit['q%d' % qubit]['fit_calcs']['epc'][0]
 
     return fit
@@ -125,6 +134,10 @@ def plot_rb_data(xdata, ydatas, yavg, yerr, fit, survival_prob, ax=None,
         show_plt (bool): display the plot.
     """
     # pylint: disable=invalid-name
+
+    if not HAS_MATPLOTLIB:
+        raise ImportError('The function plot_rb_data needs matplotlib. '
+                          'Run "pip install matplotlib" before.')
     if ax is None:
         plt.figure()
         ax = plt.gca()

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -33,19 +33,16 @@ if HAS_MATPLOTLIB:
 
 else:
 
-    MSG = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
-
+    _MSG = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
 
     def plot_bloch_vector(*_, **__):
         """ Dummy plot_bloch_vector."""
-        raise ImportError(MSG % "plot_bloch_vector")
-
+        raise ImportError(_MSG % "plot_bloch_vector")
 
     def plot_state(*_, **__):
         """ Dummy plot_state."""
-        raise ImportError(MSG % "plot_state")
-
+        raise ImportError(_MSG % "plot_state")
 
     def plot_histogram(*_, **__):
         """ Dummy plot_histogram."""
-        raise ImportError(MSG % "plot_histogram")
+        raise ImportError(_MSG % "plot_histogram")

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -12,8 +12,10 @@ from qiskit._util import _has_connection
 from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source, \
     latex_circuit_drawer, matplotlib_circuit_drawer, _text_circuit_drawer, qx_color_scheme
 from ._error import VisualizationError
+from ._matplotlib import HAS_MATPLOTLIB
+from ._dag_visualization import dag_drawer
 
-try:
+if HAS_MATPLOTLIB:
     from ._state_visualization import plot_bloch_vector
 
     if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
@@ -29,9 +31,7 @@ try:
         from ._state_visualization import plot_state
         from ._counts_visualization import plot_histogram
 
-    HAS_MATPLOTLIB = True
-
-except ImportError:
+else:
 
     MSG = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
 
@@ -49,8 +49,3 @@ except ImportError:
     def plot_histogram(*_, **__):
         """ Dummy plot_histogram."""
         raise ImportError(MSG % "plot_histogram")
-
-
-    HAS_MATPLOTLIB = False
-
-from ._dag_visualization import dag_drawer

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -9,22 +9,45 @@
 
 import sys
 from qiskit._util import _has_connection
-from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source,\
+from ._circuit_visualization import circuit_drawer, plot_circuit, generate_latex_source, \
     latex_circuit_drawer, matplotlib_circuit_drawer, _text_circuit_drawer, qx_color_scheme
 from ._error import VisualizationError
-from ._state_visualization import plot_bloch_vector
-from ._dag_visualization import dag_drawer
 
+try:
+    from ._state_visualization import plot_bloch_vector
 
-if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
-    if _has_connection('https://qvisualization.mybluemix.net/', 443):
-        from .interactive._iplot_state import iplot_state as plot_state
-        from .interactive._iplot_histogram import iplot_histogram as \
-            plot_histogram
+    if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+        if _has_connection('https://qvisualization.mybluemix.net/', 443):
+            from .interactive._iplot_state import iplot_state as plot_state
+            from .interactive._iplot_histogram import iplot_histogram as \
+                plot_histogram
+        else:
+            from ._state_visualization import plot_state
+            from ._counts_visualization import plot_histogram
+
     else:
         from ._state_visualization import plot_state
         from ._counts_visualization import plot_histogram
 
-else:
-    from ._state_visualization import plot_state
-    from ._counts_visualization import plot_histogram
+    HAS_MATPLOTLIB = True
+
+except ImportError:
+
+    message = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
+
+
+    def plot_bloch_vector(*_, **__):
+        raise ImportError(message % "plot_bloch_vector")
+
+
+    def plot_state(*_, **__):
+        raise ImportError(message % "plot_state")
+
+
+    def plot_histogram(*_, **__):
+        raise ImportError(message % "plot_histogram")
+
+
+    HAS_MATPLOTLIB = False
+
+from ._dag_visualization import dag_drawer

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -33,19 +33,22 @@ try:
 
 except ImportError:
 
-    message = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
+    MSG = 'The function %s needs matplotlib. Run "pip install matplotlib" before.'
 
 
     def plot_bloch_vector(*_, **__):
-        raise ImportError(message % "plot_bloch_vector")
+        """ Dummy plot_bloch_vector."""
+        raise ImportError(MSG % "plot_bloch_vector")
 
 
     def plot_state(*_, **__):
-        raise ImportError(message % "plot_state")
+        """ Dummy plot_state."""
+        raise ImportError(MSG % "plot_state")
 
 
     def plot_histogram(*_, **__):
-        raise ImportError(message % "plot_histogram")
+        """ Dummy plot_histogram."""
+        raise ImportError(MSG % "plot_histogram")
 
 
     HAS_MATPLOTLIB = False

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -220,7 +220,7 @@ def circuit_drawer(circuit,
         try:
             image = _latex_circuit_drawer(circuit, basis, scale, filename, style)
         except (OSError, subprocess.CalledProcessError, FileNotFoundError):
-            if HAS_MATPLOTLIB:
+            if _matplotlib.HAS_MATPLOTLIB:
                 image = _matplotlib_circuit_drawer(circuit, basis, scale, filename,
                                                    style)
             else:

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -25,10 +25,16 @@ from PIL import Image
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.tools.visualization import _error
 from qiskit.tools.visualization import _latex
-from qiskit.tools.visualization import _matplotlib
 from qiskit.tools.visualization import _text
 from qiskit.tools.visualization import _utils
 from qiskit.transpiler import transpile_dag
+
+
+try:
+  from qiskit.tools.visualization import _matplotlib # pylint: disable=g-import-not-at-top
+  HAS_MATPLOTLIB = True
+except ImportError:
+  HAS_MATPLOTLIB = False
 
 logger = logging.getLogger(__name__)
 
@@ -219,8 +225,12 @@ def circuit_drawer(circuit,
         try:
             image = _latex_circuit_drawer(circuit, basis, scale, filename, style)
         except (OSError, subprocess.CalledProcessError, FileNotFoundError):
-            image = _matplotlib_circuit_drawer(circuit, basis, scale, filename,
+            if HAS_MATPLOTLIB:
+                image = _matplotlib_circuit_drawer(circuit, basis, scale, filename,
                                                style)
+            else:
+                raise ImportError('The default output needs matplotlib. '
+                                  'Run "pip install matplotlib" before.')
     else:
         if output == 'text':
             return _text_circuit_drawer(circuit, filename=filename, basis=basis,

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -28,13 +28,7 @@ from qiskit.tools.visualization import _latex
 from qiskit.tools.visualization import _text
 from qiskit.tools.visualization import _utils
 from qiskit.transpiler import transpile_dag
-
-try:
-    from qiskit.tools.visualization import _matplotlib
-
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
+from qiskit.tools.visualization import _matplotlib
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -29,12 +29,12 @@ from qiskit.tools.visualization import _text
 from qiskit.tools.visualization import _utils
 from qiskit.transpiler import transpile_dag
 
-
 try:
-  from qiskit.tools.visualization import _matplotlib # pylint: disable=g-import-not-at-top
-  HAS_MATPLOTLIB = True
+    from qiskit.tools.visualization import _matplotlib
+
+    HAS_MATPLOTLIB = True
 except ImportError:
-  HAS_MATPLOTLIB = False
+    HAS_MATPLOTLIB = False
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +112,7 @@ def circuit_drawer(circuit,
         TextDrawing: (output `text`). A drawing that can be printed as ascii art
     Raises:
         VisualizationError: when an invalid output method is selected
+        ImportError: when the output methods requieres non-installed libraries.
 
     .. _style-dict-doc:
 
@@ -227,7 +228,7 @@ def circuit_drawer(circuit,
         except (OSError, subprocess.CalledProcessError, FileNotFoundError):
             if HAS_MATPLOTLIB:
                 image = _matplotlib_circuit_drawer(circuit, basis, scale, filename,
-                                               style)
+                                                   style)
             else:
                 raise ImportError('The default output needs matplotlib. '
                                   'Run "pip install matplotlib" before.')

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -19,7 +19,8 @@ import math
 import numpy as np
 
 try:
-    import matplotlib
+    from matplotlib import patches
+    from matplotlib import pyplot as plt
     HAS_MATPLOTLIB = True
 except ImportError:
     HAS_MATPLOTLIB = False

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -17,8 +17,12 @@ import logging
 import math
 
 import numpy as np
-from matplotlib import patches
-from matplotlib import pyplot as plt
+
+try:
+    import matplotlib
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
 
 from qiskit import dagcircuit
 from qiskit import transpiler
@@ -91,6 +95,10 @@ class MatplotlibDrawer:
                        'cx,cy,cz,ch,crz,cu1,cu3,swap,ccx,cswap',
                  scale=1.0, style=None, plot_barriers=True,
                  reverse_bits=False):
+
+        if not HAS_MATPLOTLIB:
+            raise ImportError('The class MatplotlibDrawer needs matplotlib. '
+                              'Run "pip install matplotlib" before.')
 
         self._ast = None
         self._basis = basis

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,3 +11,4 @@ jupyter
 ipywidgets
 stestr>=2.0.0
 sphinx_materialdesign_theme
+matplotlib>=2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 jsonschema>=2.6,<2.7
 marshmallow>=2.16.3,<3
 marshmallow_polyfield>=3.2,<4
-matplotlib>=2.1
 networkx>=2.2
 numpy>=1.13
 ply>=3.10

--- a/test/python/test_circuit_text_drawer.py
+++ b/test/python/test_circuit_text_drawer.py
@@ -15,20 +15,10 @@ from codecs import encode
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from .common import QiskitTestCase
 
-try:
-    from qiskit.tools.visualization import _text as elements
-    from qiskit.tools.visualization import _text_circuit_drawer
-
-    VALID_MATPLOTLIB = True
-except (RuntimeError, ImportError):
-    # Under some combinations (travis osx vms, or headless configurations)
-    # matplotlib might not be fully, raising:
-    # RuntimeError: Python is not installed as a framework.
-    # when importing. If that is the case, the full test is skipped.
-    VALID_MATPLOTLIB = False
+from qiskit.tools.visualization import _text as elements
+from qiskit.tools.visualization import _text_circuit_drawer
 
 
-@unittest.skipUnless(VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestTextDrawerElement(QiskitTestCase):
     """ Draw each element"""
 
@@ -110,7 +100,6 @@ class TestTextDrawerElement(QiskitTestCase):
         self.assertEqual(amount_of_lines, 2)
 
 
-@unittest.skipUnless(VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestTextDrawerGatesInCircuit(QiskitTestCase):
     """ Gate by gate checks in different settings."""
 

--- a/test/python/test_circuit_text_drawer.py
+++ b/test/python/test_circuit_text_drawer.py
@@ -13,10 +13,9 @@ import unittest
 from math import pi
 from codecs import encode
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from .common import QiskitTestCase
-
 from qiskit.tools.visualization import _text as elements
 from qiskit.tools.visualization import _text_circuit_drawer
+from .common import QiskitTestCase
 
 
 class TestTextDrawerElement(QiskitTestCase):

--- a/test/python/test_qcvv_fitters.py
+++ b/test/python/test_qcvv_fitters.py
@@ -12,19 +12,9 @@ import unittest
 import numpy as np
 
 from .common import QiskitTestCase
-
-try:
-    from qiskit.tools.qcvv import fitters
-    VALID_MATPLOTLIB = True
-except (RuntimeError, ImportError):
-    # Under some combinations (travis osx vms, or headless configurations)
-    # matplotlib might not be fully, raising:
-    # RuntimeError: Python is not installed as a framework.
-    # when importing. If that is the case, the full test is skipped.
-    VALID_MATPLOTLIB = False
+from qiskit.tools.qcvv import fitters
 
 
-@unittest.skipUnless(VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestQCVVFitters(QiskitTestCase):
     """Tests for functions in qiskit.tools.qcvv.fitters."""
 

--- a/test/python/test_qcvv_fitters.py
+++ b/test/python/test_qcvv_fitters.py
@@ -7,12 +7,10 @@
 
 """Test qiskit.tools.qcvv.fitters."""
 
-import unittest
-
 import numpy as np
 
-from .common import QiskitTestCase
 from qiskit.tools.qcvv import fitters
+from .common import QiskitTestCase
 
 
 class TestQCVVFitters(QiskitTestCase):

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -15,21 +15,9 @@ from inspect import signature
 import unittest
 import qiskit
 from .common import QiskitTestCase
-
-try:
-    from qiskit.tools.visualization import generate_latex_source
-    from qiskit.tools.visualization import _utils
-
-    VALID_MATPLOTLIB = True
-except (RuntimeError, ImportError):
-    # Under some combinations (travis osx vms, or headless configurations)
-    # matplotlib might not be fully, raising:
-    # RuntimeError: Python is not installed as a framework.
-    # when importing. If that is the case, the full test is skipped.
-    VALID_MATPLOTLIB = False
+from qiskit.tools.visualization import _utils, generate_latex_source
 
 
-@unittest.skipIf(not VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestLatexSourceGenerator(QiskitTestCase):
     """QISKit latex source generator tests."""
 
@@ -164,7 +152,6 @@ class TestLatexSourceGenerator(QiskitTestCase):
                 os.remove(filename)
 
 
-@unittest.skipIf(not VALID_MATPLOTLIB, 'osx matplotlib backend not available')
 class TestVisualizationUtils(QiskitTestCase):
     """ Tests for visualizer utilities.
     Since the utilities in qiskit/tools/visualization/_utils.py are used by several visualizers

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -14,8 +14,8 @@ import random
 from inspect import signature
 import unittest
 import qiskit
-from .common import QiskitTestCase
 from qiskit.tools.visualization import _utils, generate_latex_source
+from .common import QiskitTestCase
 
 
 class TestLatexSourceGenerator(QiskitTestCase):

--- a/test/python/test_visualization_output.py
+++ b/test/python/test_visualization_output.py
@@ -27,6 +27,7 @@ def _path_to_diagram_reference(filename):
 def _this_directory():
     return os.path.dirname(os.path.abspath(__file__))
 
+
 class TestVisualizationImplementation(QiskitTestCase):
     """Visual accuracy of visualization tools outputs tests."""
 

--- a/test/python/test_visualization_output.py
+++ b/test/python/test_visualization_output.py
@@ -15,9 +15,9 @@ import unittest
 from codecs import encode
 from math import pi
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from .common import QiskitTestCase
 from qiskit.tools.visualization import HAS_MATPLOTLIB, latex_circuit_drawer, \
     matplotlib_circuit_drawer, circuit_drawer
+from .common import QiskitTestCase
 
 
 def _path_to_diagram_reference(filename):

--- a/test/python/test_visualization_output.py
+++ b/test/python/test_visualization_output.py
@@ -16,19 +16,8 @@ from codecs import encode
 from math import pi
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from .common import QiskitTestCase
-
-try:
-    from qiskit.tools.visualization import (latex_circuit_drawer,
-                                            matplotlib_circuit_drawer,
-                                            circuit_drawer)
-
-    VALID_MATPLOTLIB = True
-except (RuntimeError, ImportError):
-    # Under some combinations (travis osx vms, or headless configurations)
-    # matplotlib might not be fully, raising:
-    # RuntimeError: Python is not installed as a framework.
-    # when importing. If that is the case, the full test is skipped.
-    VALID_MATPLOTLIB = False
+from qiskit.tools.visualization import HAS_MATPLOTLIB, latex_circuit_drawer, \
+    matplotlib_circuit_drawer, circuit_drawer
 
 
 def _path_to_diagram_reference(filename):
@@ -38,8 +27,6 @@ def _path_to_diagram_reference(filename):
 def _this_directory():
     return os.path.dirname(os.path.abspath(__file__))
 
-
-@unittest.skipIf(not VALID_MATPLOTLIB, 'matplotlib not available.')
 class TestVisualizationImplementation(QiskitTestCase):
     """Visual accuracy of visualization tools outputs tests."""
 
@@ -100,6 +87,7 @@ class TestVisualizationImplementation(QiskitTestCase):
 
     # TODO: Enable for refactoring purposes and enable by default when we can
     # decide if the backend is available or not.
+    @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_matplotlib_drawer(self):
         filename = self._get_resource_path('current_matplot.png')
@@ -123,7 +111,7 @@ class TestVisualizationImplementation(QiskitTestCase):
         """Checks if both file are the same."""
         self.assertTrue(os.path.exists(current))
         self.assertTrue(os.path.exists(expected))
-        with open(current, "r", encoding='cp437') as cur,\
+        with open(current, "r", encoding='cp437') as cur, \
                 open(expected, "r", encoding='cp437') as exp:
             self.assertEqual(cur.read(), exp.read())
 


### PR DESCRIPTION
Fixes #1275

As discussed #911, this PR makes matplotlib optional:
 - `import qiskit` does not import matplotlib.
 - The module `qiskit.tools.visualization` has a  `HAS_MATPLOTLIB` constant to query if matplotlib is installed. Test using matplot lib should check for this to skip or not.
 - When a function that requires matplotlib is called and matplotlib is not installed (or python is not running as a framework in osx) a `ImportError` exception is raised with instructions to pip install matplotlib. Because this only happens when effective use occurs, more tests can be executed without matplotlib now.
 - The use of `VALID_MATPLOTLIB` in the tests was removed.
- The line `matplotlib>=2.1` was moved from `requirements.txt` to `requirements-dev.txt`

Example without matplotlib:
```
>>> from qiskit.tools.visualization import circuit_drawer, HAS_MATPLOTLIB
>>> circuit_drawer(circuit, output='text')
 <qiskit.tools.visualization._text.TextDrawing at 0x10eb8cef0>
>>> circuit_drawer(circuit, output='mpl')
ImportError: The class MatplotlibDrawer needs matplotlib. Run "pip install matplotlib" before.
>>> HAS_MATPLOTLIB
  False
```

Example with matplotlib:
```
>>> from qiskit.tools.visualization import circuit_drawer, HAS_MATPLOTLIB
>>> circuit_drawer(circuit, output='text')
 <qiskit.tools.visualization._text.TextDrawing at 0x11ea05ef0>
>>> circuit_drawer(circuit, output='mpl')
 <Figure size 334.444x443.139 with 1 Axes>
>>> HAS_MATPLOTLIB
  True
```
