### PR TITLE
Introducing a TypedDict field enabling fine control on the format of keys and values

### DIFF
--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -30,7 +30,7 @@ from marshmallow import ValidationError
 from marshmallow import Schema, post_dump, post_load, fields
 from marshmallow.utils import is_collection
 
-from .fields import BasePolyField, ByType
+from .fields import BasePolyField, ByType, TypedDict
 
 
 class BaseSchema(Schema):
@@ -178,7 +178,7 @@ class _SchemaBinder:
                 field._deserialize = partial(self._overridden_nested_deserialize, field)
             elif isinstance(field, BasePolyField):
                 field._deserialize = partial(self._overridden_basepolyfield_deserialize, field)
-            elif not isinstance(field, (fields.Number, fields.String, ByType)):
+            elif not isinstance(field, (fields.Number, fields.String, ByType, TypedDict)):
                 field._deserialize = partial(self._overridden_field_deserialize, field)
         return shallow_schema
 

--- a/qiskit/validation/result.py
+++ b/qiskit/validation/result.py
@@ -10,21 +10,20 @@
 TODO: Note this file is temporary, and will be removed before 0.7, replacing
       qiskit.qobj.result and qiskit.result.
 """
-
 from marshmallow.fields import Boolean, DateTime, Integer, List, Nested, Raw, String
 from marshmallow.validate import Length, OneOf, Regexp, Range
 
 from qiskit.validation.base import BaseModel, BaseSchema, ObjSchema, bind_schema
-from qiskit.validation.fields import Complex, ByType
-from qiskit.validation.validate import PatternProperties
+from qiskit.validation.fields import Complex, ByType, TypedDict
 
 
 class ExperimentResultDataSchema(BaseSchema):
     """Schema for ExperimentResultData."""
 
-    counts = Nested(ObjSchema,
-                    validate=PatternProperties(
-                        {Regexp('^0x([0-9A-Fa-f])+$'): Integer()}))
+    counts = TypedDict(
+        key_type=String(validate=Regexp('^0x([0-9A-Fa-f])+$')),
+        value_type=Integer()
+    ),
     snapshots = Nested(ObjSchema)
     memory = List(Raw(),
                   validate=Length(min=1))


### PR DESCRIPTION
Following the discussion in #1277, this is an alternative implementation for the `counts` field as per https://github.com/Qiskit/qiskit-terra/pull/1277#discussion_r234129837

My main motivation behind this alternative is that the `counts` value is a real dictionary, not an instance of an arbitrary class.

In my opinion, schemas should be used to represent instances of classes with a known property layout while dictionaries are variable collections of keys and values. This is similar to how we use a [custom field](https://github.com/Qiskit/qiskit-terra/blob/4c5be2b3c426f3233ad2cb615c3c94d82db5a987/qiskit/validation/fields.py#L193-L223) to model a complex number.