### PR TITLE
[WIP] Enable efficient validation of models without adhoc solutions for container fields.

### DIFF
--- a/qiskit/validation/utils.py
+++ b/qiskit/validation/utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Collection of utilities, helpers and special values to use with
+marshmallow."""
+
+from traceback import StackSummary, walk_stack
+
+
+class _ValidModel:
+    """Represents a valid model."""
+
+    def __bool__(self):
+        return True
+
+    def __repr__(self):
+        return '<qiskit.validation.valid_model>'
+
+
+VALID_MODEL = _ValidModel()
+
+
+def is_validating():
+    """Check if execution is in the middle of a model validation.
+
+    This function _climbs_ the stacktrace in the search of a local flag
+    indicating the execution is in the middle of a model validation.
+    """
+    this_traceback = walk_stack(None)
+    frames = StackSummary.extract(this_traceback, capture_locals=True)
+    for frame in frames:
+        if frame.locals.get('__is_validating__', False):
+            return True
+
+    return False

--- a/test/python/test_validation.py
+++ b/test/python/test_validation.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from marshmallow import fields, ValidationError
 
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema
-from qiskit.validation.fields import TryFrom, ByAttribute, ByType
+from qiskit.validation.fields import TryFrom, ByAttribute, ByType, StrictString
 from .common import QiskitTestCase
 
 
@@ -21,14 +21,14 @@ from .common import QiskitTestCase
 
 class PersonSchema(BaseSchema):
     """Example Person schema."""
-    name = fields.String(required=True)
+    name = StrictString(required=True)
     birth_date = fields.Date()
     email = fields.Email()
 
 
 class BookSchema(BaseSchema):
     """Example Book schema."""
-    title = fields.String(required=True)
+    title = StrictString(required=True)
     date = fields.Date()
     author = fields.Nested(PersonSchema, required=True)
 


### PR DESCRIPTION
In Qiskit, we want validation of the data structures that we send and
receive to and from our backends. To do it, we use Marshmallow, a validation
library.

Marshmallow does not have the concept of validation, since the method for validating
schemas is simply loading a Python dict and checking for the existence of errors,
discarding the data.

This PR includes a hack[1] to signal we are in the middle of a validation and then uses
the strategy explained in [2] below to orchestrate "load" and "dump" to work together and
save unnecessary validations.

---
[1] Assuming that Marshmallow loading is a **synchronous** operation, the
`qiskit.validation.utils.is_validation` helper functions pass through the stacktrace
inpecting the locals of each function until finding a special name `__is_validating__`
set to True. That variable is used locally in the `_validate` method of models.

[2] During validation, we know there will be two stages, one for "dumping", and another
for "loading". While the dumping stage, our schemas' "dump" methods could serialize into
a special value with no nested fields. Then, during the loading stage, the "load" method
could recognize these special values and bypass inner validation.