### PR TITLE
Update backend.status() to use BackendStatus

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,6 +63,8 @@ Changed
 - Speed up the Pauli class and extended its operators (#1271 #1166).
 - `IBMQ.save_account()` now takes an `overwrite` option to replace an existing
   account on disk. Default is False (#1295).
+- Backend and Provider methods defined in the specification use model objects
+  rather than dicts, along with validation against schemas (#1249, #1277).
 
 Deprecated
 """"""""""

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -13,8 +13,8 @@ Doing so requires that the required backend interface is implemented.
 import warnings
 from abc import ABC, abstractmethod
 
-from qiskit._qiskiterror import QISKitError
 import qiskit
+from .models import BackendStatus
 
 
 class BaseBackend(ABC):
@@ -37,7 +37,7 @@ class BaseBackend(ABC):
             QISKitError: if there is no name in the configuration
         """
         if 'name' not in configuration:
-            raise QISKitError('backend does not have a name.')
+            raise qiskit.QISKitError('backend does not have a name.')
         self._configuration = configuration
         self.provider = provider
 
@@ -67,14 +67,16 @@ class BaseBackend(ABC):
         return {}
 
     def status(self):
-        """Return backend status"""
-        return {'backend_name': self.name(),
-                #  Backend version in the form X.X.X
-                'backend_version': qiskit.__version__,
-                #  Backend operational and accepting jobs (true/false)
-                'operational': True,
-                'pending_jobs': 0,
-                'status_msg': ''}
+        """Return backend status.
+
+        Returns:
+            BackendStatus: the status of the backend.
+        """
+        return BackendStatus(backend_name=self.name(),
+                             backend_version=qiskit.__version__,
+                             operational=True,
+                             pending_jobs=0,
+                             status_msg='')
 
     def name(self):
         """Return backend name"""

--- a/qiskit/backends/ibmq/__init__.py
+++ b/qiskit/backends/ibmq/__init__.py
@@ -32,8 +32,7 @@ def least_busy(backends):
             either empty or none have attribute ``pending_jobs``
     """
     try:
-        return min([b for b in backends
-                    if b.status()['operational'] and 'pending_jobs' in b.status()],
-                   key=lambda b: b.status()['pending_jobs'])
+        return min([b for b in backends if b.status().operational],
+                   key=lambda b: b.status().pending_jobs)
     except (ValueError, TypeError):
         raise QISKitError("Can only find least_busy backend from a non-empty list.")

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -167,26 +167,7 @@ class IBMQBackend(BaseBackend):
             LookupError: If status for the backend can't be found.
             IBMQBackendError: If the status can't be formatted properly.
         """
-        base_status = super().status()
         api_status = self._api.backend_status(self.name())
-
-        # FIXME: these corrections need to be resolved at the API level
-        # - eventually it will.
-
-        # 'operational' needs to be present, not 'available'
-        if 'available' in api_status:
-            api_status['operational'] = api_status.pop('available')
-        # 'backend_name' addressed as 'backend'.
-        if 'backend' in api_status:
-            api_status['backend_name'] = api_status.pop('backend')
-        # 'pending_jobs' should be >= 0.
-        api_status['pending_jobs'] = max(api_status.get('pending_jobs', 0), 0)
-        # 'backend_version' needs to be present, and in the form X.Y.Z.
-        if 'backend_version' not in api_status:
-            api_status['backend_version'] = base_status.backend_version
-        # 'status_msg' needs to be present.
-        if 'status_msg' not in api_status:
-            api_status['status_msg'] = base_status.status_msg
 
         try:
             return BackendStatus.from_dict(api_status)

--- a/qiskit/backends/providerutils.py
+++ b/qiskit/backends/providerutils.py
@@ -54,7 +54,7 @@ def filter_backends(backends, filters=None, **kwargs):
     # each backend).
     if status_filters:
         backends = [b for b in backends if
-                    _match_all(b.status(), status_filters)]
+                    _match_all(b.status().to_dict(), status_filters)]
 
     # 3. Apply acceptor filter.
     backends = list(filter(filters, backends))

--- a/test/python/ibmq/test_ibmq_connector.py
+++ b/test/python/ibmq/test_ibmq_connector.py
@@ -92,7 +92,7 @@ class TestIBMQConnector(QiskitTestCase):
                         if self.using_ibmq_credentials else 'ibmqx4')
         api = self._get_api(qe_token, qe_url)
         is_available = api.backend_status(backend_name)
-        self.assertIsNotNone(is_available['available'])
+        self.assertIsNotNone(is_available['operational'])
 
     @requires_qe_access
     def test_api_backend_calibration(self, qe_token, qe_url):

--- a/test/python/ibmq/test_ibmq_qobj.py
+++ b/test/python/ibmq/test_ibmq_qobj.py
@@ -48,7 +48,7 @@ class TestIBMQQobj(JobTestCase):
     def test_operational(self):
         """Test if backend is operational.
         """
-        self.assertTrue(self._remote_backend.status()['operational'])
+        self.assertTrue(self._remote_backend.status().operational)
 
     @slow_test
     @requires_qe_access


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Related issues:
#996 - `backend_status_schema.json` checkbox
#1175 - fixes for `connector.backend_status()`


### Summary

Update the Base (used by Aer) and IBMQBackend `.status()` method in order to return instances of `BackendStatus`. This includes moving the `IBMQBackend.status()` property mangling one layer deeper, to `IBMQConnector.backend_status()`, making use of the original fixes of the unpublished branch "feature/qiskit_requirement" of `qiskit-api-py` (commit f55c5d9) along with additional fixes for the rest of the fields in the schema.

`test/python/test_backends.py` has also been adjusted in order to iterate through the backends, checking their `.status()`.

### Details and comments


