### PR TITLE
Add setuptools extras for installing matplotlib

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -34,6 +34,20 @@ This will install the latest stable release, along with all the dependencies.
     to cleanly separate Qiskit from other applications and improve your experience.
 
 
+Install with visualization dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are optional dependencies that are required to use all the visualization
+functions included in Qiskit Terra. You can install these at the same time by
+running:
+
+.. code:: sh
+
+   pip install qiskit[visualization]
+
+which will install qiskit and all the visualization dependencies.
+
+
 Setup with an environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -120,5 +120,8 @@ setup(
     cmdclass={
         'build': QasmSimulatorCppBuild,
     },
-    distclass=BinaryDistribution
+    distclass=BinaryDistribution,
+    extra_requires={
+        'visualization': ['matplotlib>=2.1']
+    }
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a setuptools extras [1] entry for optionally installing
matplotlib. This enables users to just run:
'pip install qiskt[visualization]' and instlal qiskit and the
visualization dependencies in one command. Right now this is only
matplotlib, but it will likely also include nxpd too in the near future.

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

### Details and comments