### PR TITLE
Remove .parameters() and .calibration() (now .properties())

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -96,6 +96,8 @@ Removed
   `qiskit.tools.visualization.plot_histogram`, and
   `qiskit.tools.visualization.plot_bloch_vector` you will now need to ensure
   you manually install and configure matplotlib independently.
+- ``backend.parameters()`` and ``backend.calibration()`` have been fully
+  deprecated, in favour of ``backend.properties()`` (#1305).
 
 
 Fixed

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -10,7 +10,6 @@
 To create add-on backend modules subclass the Backend class in this module.
 Doing so requires that the required backend interface is implemented.
 """
-import warnings
 from abc import ABC, abstractmethod
 
 from qiskit._qiskiterror import QISKitError
@@ -49,18 +48,6 @@ class BaseBackend(ABC):
     def configuration(self):
         """Return backend configuration"""
         return self._configuration
-
-    def calibration(self):
-        """Return backend calibration"""
-        warnings.warn("Backends will no longer return a calibration dictionary,"
-                      "use backend.properties() instead.", DeprecationWarning)
-        return {}
-
-    def parameters(self):
-        """Return backend parameters"""
-        warnings.warn("Backends will no longer return a parameters dictionary, "
-                      "use backend.properties() instead.", DeprecationWarning)
-        return {}
 
     def properties(self):
         """Return backend properties"""

--- a/qiskit/backends/ibmq/api/ibmqconnector.py
+++ b/qiskit/backends/ibmq/api/ibmqconnector.py
@@ -754,65 +754,6 @@ class IBMQConnector(object):
 
         return ret
 
-    def backend_calibration(self, backend='ibmqx4', hub=None,
-                            access_token=None, user_id=None):
-        """
-        Get the calibration of a real chip
-        """
-        if access_token:
-            self.req.credential.set_token(access_token)
-        if user_id:
-            self.req.credential.set_user_id(user_id)
-        if not self.check_credentials():
-            raise CredentialsError('credentials invalid')
-
-        backend_type = self._check_backend(backend, 'calibration')
-
-        if not backend_type:
-            raise BadBackendError(backend)
-
-        if backend_type in self.__names_backend_simulator:
-            ret = {}
-            return ret
-
-        url = get_backend_stats_url(self.config, backend_type, hub)
-
-        ret = self.req.get(url + '/calibration')
-        if not bool(ret):
-            ret = {}
-        else:
-            ret["backend"] = backend_type
-        return ret
-
-    def backend_parameters(self, backend='ibmqx4', hub=None,
-                           access_token=None, user_id=None):
-        """
-        Get the parameters of calibration of a real chip
-        """
-        if access_token:
-            self.req.credential.set_token(access_token)
-        if user_id:
-            self.req.credential.set_user_id(user_id)
-        if not self.check_credentials():
-            raise CredentialsError('credentials invalid')
-
-        backend_type = self._check_backend(backend, 'calibration')
-
-        if not backend_type:
-            raise BadBackendError(backend)
-
-        if backend_type in self.__names_backend_simulator:
-            return {}
-
-        url = get_backend_stats_url(self.config, backend_type, hub)
-
-        ret = self.req.get(url + '/parameters')
-        if not bool(ret):
-            ret = {}
-        else:
-            ret["backend"] = backend_type
-        return ret
-
     def backend_properties(self, backend='ibmqx4', hub=None,
                            access_token=None, user_id=None):
         """

--- a/qiskit/backends/ibmq/api/ibmqconnector.py
+++ b/qiskit/backends/ibmq/api/ibmqconnector.py
@@ -19,28 +19,27 @@ logger = logging.getLogger(__name__)
 CLIENT_APPLICATION = 'qiskit-api-py'
 
 
-def get_job_url(config, hub, group, project):
+def get_job_url(config, hub=None, group=None, project=None):
     """
     Util method to get job url
     """
-    if (config is not None) and ('hub' in config) and (hub is None):
-        hub = config["hub"]
-    if (config is not None) and ('group' in config) and (group is None):
-        group = config["group"]
-    if (config is not None) and ('project' in config) and (project is None):
-        project = config["project"]
-    if (hub is not None) and (group is not None) and (project is not None):
-        return '/Network/{}/Groups/{}/Projects/{}/jobs'.format(hub, group, project)
+    hub = config.get('hub', hub)
+    group = config.get('group', group)
+    project = config.get('project', project)
+
+    if hub and group and project:
+        return '/Network/{}/Groups/{}/Projects/{}/jobs'.format(hub, group,
+                                                               project)
     return '/Jobs'
 
 
-def get_backend_stats_url(config, hub, backend_type):
+def get_backend_stats_url(config, backend_type, hub=None):
     """
     Util method to get backend stats url
     """
-    if (config is not None) and ('hub' in config) and (hub is None):
-        hub = config["hub"]
-    if hub is not None:
+    hub = config.get('hub', hub)
+
+    if hub:
         return '/Network/{}/devices/{}'.format(hub, backend_type)
     return '/Backends/{}'.format(backend_type)
 
@@ -49,14 +48,13 @@ def get_backend_url(config, hub, group, project):
     """
     Util method to get backend url
     """
-    if (config is not None) and ('hub' in config) and (hub is None):
-        hub = config["hub"]
-    if (config is not None) and ('group' in config) and (group is None):
-        group = config["group"]
-    if (config is not None) and ('project' in config) and (project is None):
-        project = config["project"]
-    if (hub is not None) and (group is not None) and (project is not None):
-        return '/Network/{}/Groups/{}/Projects/{}/devices'.format(hub, group, project)
+    hub = config.get('hub', hub)
+    group = config.get('group', group)
+    project = config.get('project', project)
+
+    if hub and group and project:
+        return '/Network/{}/Groups/{}/Projects/{}/devices'.format(hub, group,
+                                                                  project)
     return '/Backends'
 
 
@@ -264,11 +262,11 @@ class _Request(object):
             r".*registers exceed the number of qubits, "
             r"it can\'t be greater than (\d+).*")
 
-    def check_token(self, respond):
+    def check_token(self, response):
         """
         Check is the user's token is valid
         """
-        if respond.status_code == 401:
+        if response.status_code == 401:
             self.credential.obtain_token(config=self.config)
             return False
         return True
@@ -285,18 +283,18 @@ class _Request(object):
                   self.credential.get_token() + params)
         retries = self.retries
         while retries > 0:
-            respond = requests.post(url, data=data, headers=headers,
-                                    verify=self.verify, **self.extra_args)
-            if not self.check_token(respond):
-                respond = requests.post(url, data=data, headers=headers,
-                                        verify=self.verify,
-                                        **self.extra_args)
+            response = requests.post(url, data=data, headers=headers,
+                                     verify=self.verify, **self.extra_args)
+            if not self.check_token(response):
+                response = requests.post(url, data=data, headers=headers,
+                                         verify=self.verify,
+                                         **self.extra_args)
 
-            if self._response_good(respond):
+            if self._response_good(response):
                 if self.result:
                     return self.result
                 elif retries < 2:
-                    return respond.json()
+                    return response.json()
                 else:
                     retries -= 1
             else:
@@ -319,17 +317,17 @@ class _Request(object):
                   self.credential.get_token() + params)
         retries = self.retries
         while retries > 0:
-            respond = requests.put(url, data=data, headers=headers,
-                                   verify=self.verify, **self.extra_args)
-            if not self.check_token(respond):
-                respond = requests.put(url, data=data, headers=headers,
-                                       verify=self.verify,
-                                       **self.extra_args)
-            if self._response_good(respond):
+            response = requests.put(url, data=data, headers=headers,
+                                    verify=self.verify, **self.extra_args)
+            if not self.check_token(response):
+                response = requests.put(url, data=data, headers=headers,
+                                        verify=self.verify,
+                                        **self.extra_args)
+            if self._response_good(response):
                 if self.result:
                     return self.result
                 elif retries < 2:
-                    return respond.json()
+                    return response.json()
                 else:
                     retries -= 1
             else:
@@ -353,16 +351,16 @@ class _Request(object):
         retries = self.retries
         headers = {'x-qx-client-application': self.client_application}
         while retries > 0:  # Repeat until no error
-            respond = requests.get(url, verify=self.verify, headers=headers,
-                                   **self.extra_args)
-            if not self.check_token(respond):
-                respond = requests.get(url, verify=self.verify,
-                                       headers=headers, **self.extra_args)
-            if self._response_good(respond):
+            response = requests.get(url, verify=self.verify, headers=headers,
+                                    **self.extra_args)
+            if not self.check_token(response):
+                response = requests.get(url, verify=self.verify,
+                                        headers=headers, **self.extra_args)
+            if self._response_good(response):
                 if self.result:
                     return self.result
                 elif retries < 2:
-                    return respond.json()
+                    return response.json()
                 else:
                     retries -= 1
             else:
@@ -372,11 +370,11 @@ class _Request(object):
         raise ApiError(usr_msg='Failed to get proper ' +
                        'response from backend.')
 
-    def _response_good(self, respond):
+    def _response_good(self, response):
         """check response
 
         Args:
-            respond (requests.Response): HTTP response.
+            response (requests.Response): HTTP response.
 
         Returns:
             bool: True if the response is good, else False.
@@ -384,44 +382,44 @@ class _Request(object):
         Raises:
             ApiError: response isn't formatted properly.
         """
-        if respond.status_code != requests.codes.ok:
+        if response.status_code != requests.codes.ok:
             logger.warning('Got a %s code response to %s: %s',
-                           respond.status_code,
-                           respond.url,
-                           respond.text)
-            if respond.status_code in self.errors_not_retry:
+                           response.status_code,
+                           response.url,
+                           response.text)
+            if response.status_code in self.errors_not_retry:
                 raise ApiError(usr_msg='Got a {} code response to {}: {}'.format(
-                    respond.status_code,
-                    respond.url,
-                    respond.text))
+                    response.status_code,
+                    response.url,
+                    response.text))
             else:
-                return self._parse_response(respond)
+                return self._parse_response(response)
         try:
-            if str(respond.headers['content-type']).startswith("text/html;"):
-                self.result = respond.text
+            if str(response.headers['content-type']).startswith("text/html;"):
+                self.result = response.text
                 return True
             else:
-                self.result = respond.json()
+                self.result = response.json()
         except (json.JSONDecodeError, ValueError):
             usr_msg = 'device server returned unexpected http response'
-            dev_msg = usr_msg + ': ' + respond.text
+            dev_msg = usr_msg + ': ' + response.text
             raise ApiError(usr_msg=usr_msg, dev_msg=dev_msg)
         if not isinstance(self.result, (list, dict)):
             msg = ('JSON not a list or dict: url: {0},'
                    'status: {1}, reason: {2}, text: {3}')
             raise ApiError(
-                usr_msg=msg.format(respond.url,
-                                   respond.status_code,
-                                   respond.reason, respond.text))
+                usr_msg=msg.format(response.url,
+                                   response.status_code,
+                                   response.reason, response.text))
         if ('error' not in self.result or
                 ('status' not in self.result['error'] or
                  self.result['error']['status'] != 400)):
             return True
 
-        logger.warning("Got a 400 code JSON response to %s", respond.url)
+        logger.warning("Got a 400 code JSON response to %s", response.url)
         return False
 
-    def _parse_response(self, respond):
+    def _parse_response(self, response):
         """parse text of response for HTTP errors
 
         This parses the text of the response to decide whether to
@@ -429,7 +427,7 @@ class _Request(object):
         detects an exception condition.
 
         Args:
-            respond (Response): requests.Response object
+            response (Response): requests.Response object
 
         Returns:
             bool: False if the request should be retried, True
@@ -439,7 +437,7 @@ class _Request(object):
             RegisterSizeError: if invalid device register size.
         """
         # convert error messages into exceptions
-        mobj = self._max_qubit_error_re.match(respond.text)
+        mobj = self._max_qubit_error_re.match(response.text)
         if mobj:
             raise RegisterSizeError(
                 'device register size must be <= {}'.format(mobj.group(1)))
@@ -574,15 +572,11 @@ class IBMQConnector(object):
         if user_id:
             self.req.credential.set_user_id(user_id)
         if not self.check_credentials():
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Not credentials valid"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Not credentials valid'}
         if not id_job:
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Job ID not specified"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Job ID not specified'}
 
         url = get_job_url(self.config, hub, group, project)
 
@@ -646,15 +640,11 @@ class IBMQConnector(object):
         if user_id:
             self.req.credential.set_user_id(user_id)
         if not self.check_credentials():
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Not credentials valid"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Not credentials valid'}
         if not id_job:
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Job ID not specified"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Job ID not specified'}
 
         url = get_job_url(self.config, hub, group, project)
 
@@ -711,15 +701,11 @@ class IBMQConnector(object):
         if user_id:
             self.req.credential.set_user_id(user_id)
         if not self.check_credentials():
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Not credentials valid"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Not credentials valid'}
         if not id_job:
-            respond = {}
-            respond["status"] = 'Error'
-            respond["error"] = "Job ID not specified"
-            return respond
+            return {'status': 'Error',
+                    'error': 'Job ID not specified'}
 
         url = get_job_url(self.config, hub, group, project)
 
@@ -756,7 +742,8 @@ class IBMQConnector(object):
 
         return ret
 
-    def backend_calibration(self, backend='ibmqx4', hub=None, access_token=None, user_id=None):
+    def backend_calibration(self, backend='ibmqx4', hub=None,
+                            access_token=None, user_id=None):
         """
         Get the calibration of a real chip
         """
@@ -776,7 +763,7 @@ class IBMQConnector(object):
             ret = {}
             return ret
 
-        url = get_backend_stats_url(self.config, hub, backend_type)
+        url = get_backend_stats_url(self.config, backend_type, hub)
 
         ret = self.req.get(url + '/calibration')
         if not bool(ret):
@@ -785,7 +772,8 @@ class IBMQConnector(object):
             ret["backend"] = backend_type
         return ret
 
-    def backend_parameters(self, backend='ibmqx4', hub=None, access_token=None, user_id=None):
+    def backend_parameters(self, backend='ibmqx4', hub=None,
+                           access_token=None, user_id=None):
         """
         Get the parameters of calibration of a real chip
         """
@@ -805,7 +793,7 @@ class IBMQConnector(object):
             ret = {}
             return ret
 
-        url = get_backend_stats_url(self.config, hub, backend_type)
+        url = get_backend_stats_url(self.config, backend_type, hub)
 
         ret = self.req.get(url + '/parameters')
         if not bool(ret):
@@ -873,7 +861,7 @@ class BadBackendError(ApiError):
         Args:
             backend (str): name of backend.
         """
-        usr_msg = ('Could not find backend "{0}" available.').format(backend)
+        usr_msg = 'Could not find backend "{0}" available.'.format(backend)
         dev_msg = ('Backend "{0}" does not exist. Please use '
                    'available_backends to see options').format(backend)
         ApiError.__init__(self, usr_msg=usr_msg,

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -9,7 +9,6 @@
 
 This module is used for connecting to the Quantum Experience.
 """
-import warnings
 import logging
 
 from qiskit import QISKitError
@@ -67,72 +66,6 @@ class IBMQBackend(BaseBackend):
         job = job_class(self, None, self._api, not self.configuration()['simulator'], qobj=qobj)
         job.submit()
         return job
-
-    def calibration(self):
-        """Return the online backend calibrations.
-
-        The return is via QX API call.
-
-        Returns:
-            dict: The calibration of the backend.
-
-        Raises:
-            LookupError: If a calibration for the backend can't be found.
-
-        :deprecated: will be removed after 0.7
-        """
-        warnings.warn("Backends will no longer return a calibration dictionary, "
-                      "use backend.properties() instead.", DeprecationWarning)
-
-        try:
-            backend_name = self.name()
-            calibrations = self._api.backend_calibration(backend_name)
-            # FIXME a hack to remove calibration data that is none.
-            # Needs to be fixed in api
-            if backend_name == 'ibmq_qasm_simulator':
-                calibrations = {}
-        except Exception as ex:
-            raise LookupError(
-                "Couldn't get backend calibration: {0}".format(ex))
-
-        calibrations_edit = {}
-        for key, vals in calibrations.items():
-            new_key = _camel_case_to_snake_case(key)
-            calibrations_edit[new_key] = vals
-
-        return calibrations_edit
-
-    def parameters(self):
-        """Return the online backend parameters.
-
-        Returns:
-            dict: The parameters of the backend.
-
-        Raises:
-            LookupError: If parameters for the backend can't be found.
-
-        :deprecated: will be removed after 0.7
-        """
-        warnings.warn("Backends will no longer return a parameters dictionary, "
-                      "use backend.properties() instead.", DeprecationWarning)
-
-        try:
-            backend_name = self.name()
-            parameters = self._api.backend_parameters(backend_name)
-            # FIXME a hack to remove parameters data that is none.
-            # Needs to be fixed in api
-            if backend_name == 'ibmq_qasm_simulator':
-                parameters = {}
-        except Exception as ex:
-            raise LookupError(
-                "Couldn't get backend parameters: {0}".format(ex))
-
-        parameters_edit = {}
-        for key, vals in parameters.items():
-            new_key = _camel_case_to_snake_case(key)
-            parameters_edit[new_key] = vals
-
-        return parameters_edit
 
     def properties(self):
         """Return the online backend properties.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -145,15 +145,16 @@ class IBMQBackend(BaseBackend):
         Raises:
             LookupError: If properties for the backend can't be found.
         """
-        # FIXME: make this an actual call to _api.backend_properties
-        # for now this api endpoint does not exist.
-        warnings.simplefilter("ignore")
-        calibration = self.calibration()
-        parameters = self.parameters()
-        _dict_merge(calibration, parameters)
-        properties = calibration
-        warnings.simplefilter("default")
-        return properties
+        properties = self._api.backend_properties(self.name())
+
+        # Convert the properties to snake_case.
+        # TODO: ideally should be handled at the API level.
+        properties_edit = {}
+        for key, val in properties.items():
+            new_key = _camel_case_to_snake_case(key)
+            properties_edit[new_key] = val
+
+        return properties_edit
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -244,27 +244,3 @@ def _job_class_from_job_response(job_response):
 def _job_class_from_backend_support(backend):
     support_qobj = backend.configuration().get('allow_q_object')
     return IBMQJob if support_qobj else IBMQJobPreQobj
-
-
-def _dict_merge(dct, merge_dct):
-    """
-    TEMPORARY method for merging backend.calibration & backend.parameters
-    into backend.properties.
-
-    Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
-    updating only top-level keys, dict_merge recurses down into dicts nested
-    to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
-    ``dct``.
-
-    Args:
-        dct (dict): the dictionary to merge into
-        merge_dct (dict): the dictionary to merge
-    """
-    for k, _ in merge_dct.items():
-        if k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], dict):
-            _dict_merge(dct[k], merge_dct[k])
-        elif k in dct and isinstance(dct[k], list) and isinstance(merge_dct[k], list):
-            for i in range(len(dct[k])):
-                _dict_merge(dct[k][i], merge_dct[k][i])
-        else:
-            dct[k] = merge_dct[k]

--- a/test/python/ibmq/test_ibmq_connector.py
+++ b/test/python/ibmq/test_ibmq_connector.py
@@ -117,6 +117,18 @@ class TestIBMQConnector(QiskitTestCase):
         self.assertIsNotNone(parameters)
 
     @requires_qe_access
+    def test_api_backend_properties(self, qe_token, qe_url):
+        """
+        Check the properties of calibration of a real chip
+        """
+        backend_name = ('ibmq_20_tokyo'
+                        if self.using_ibmq_credentials else 'ibmqx4')
+        api = self._get_api(qe_token, qe_url)
+
+        properties = api.backend_properties(backend_name)
+        self.assertIsNotNone(properties)
+
+    @requires_qe_access
     def test_api_backends_available(self, qe_token, qe_url):
         """
         Check the backends available

--- a/test/python/ibmq/test_ibmq_connector.py
+++ b/test/python/ibmq/test_ibmq_connector.py
@@ -95,28 +95,6 @@ class TestIBMQConnector(QiskitTestCase):
         self.assertIsNotNone(is_available['available'])
 
     @requires_qe_access
-    def test_api_backend_calibration(self, qe_token, qe_url):
-        """
-        Check the calibration of a real chip
-        """
-        backend_name = ('ibmq_20_tokyo'
-                        if self.using_ibmq_credentials else 'ibmqx4')
-        api = self._get_api(qe_token, qe_url)
-        calibration = api.backend_calibration(backend_name)
-        self.assertIsNotNone(calibration)
-
-    @requires_qe_access
-    def test_api_backend_parameters(self, qe_token, qe_url):
-        """
-        Check the parameters of calibration of a real chip
-        """
-        backend_name = ('ibmq_20_tokyo'
-                        if self.using_ibmq_credentials else 'ibmqx4')
-        api = self._get_api(qe_token, qe_url)
-        parameters = api.backend_parameters(backend_name)
-        self.assertIsNotNone(parameters)
-
-    @requires_qe_access
     def test_api_backend_properties(self, qe_token, qe_url):
         """
         Check the properties of calibration of a real chip

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -166,4 +166,4 @@ class TestBackends(QiskitTestCase):
                 self.assertTrue(all(key in properties for key in (
                     'last_update_date',
                     'qubits',
-                    'backend')))
+                    'backend_name')))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove the `.calibration()` and `.parameters()` methods (that were marked as deprecated in 0.6) from:
* BaseBackend
* IBMQBackend
* related methods from IBMQConnector

This includes adding `IBMQConnector.backend_properties()` method, based on the original code of the unpublished branch "feature/qiskit_requirement" of `qiskit-api-py` (commit 3791601) with some additional tweaks.

For testing, the most relevant test is `test/python/test_backends.py::TestBackends::test_remote_backend_properties` (which as usual will not be run until merging) - running it manually against QX and IBMQ seemed to work.

Please note that this PR does **not** deal with the schema for the `backend_properties` - which currently seems to be quite a way off from the expected one (to be addressed in subsequent PRs).

### Details and comments


