### PR TITLE
Fully deprecate `BaseProvider.available backends()`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -85,19 +85,6 @@ Deprecated
   are deprecated, instead the `qiskit.tools.visualization.circuit_drawer()`
   kwargs ``plot_barriers`` and ``reverse_bits`` should be used instead. (#1180)
 
-
-Removed
-"""""""
-
-- ``matplotlib`` is no longer in the package requirements and is now an optional
-  dependency. In order to use any matplotlib based visualizations (which
-  includes the `qiskit.tools.visualization.circuit_drawer()` `mpl` output,
-  `qiskit.tools.visualization.plot_state`,
-  `qiskit.tools.visualization.plot_histogram`, and
-  `qiskit.tools.visualization.plot_bloch_vector` you will now need to ensure
-  you manually install and configure matplotlib independently.
-
-
 Fixed
 """""
 
@@ -113,7 +100,6 @@ Fixed
 - Fixed an edge case when connection checks would raise an unhandled exception
   (#1226)
 
-
 Removed
 """""""
 
@@ -121,6 +107,13 @@ Removed
 - Remove tools/apps (#1184).
 - Removed the dependency on `IBMQuantumExperience`, as it is now included
   in `qiskit.backends.IBMQ` (#1198).
+- ``matplotlib`` is no longer in the package requirements and is now an optional
+  dependency. In order to use any matplotlib based visualizations (which
+  includes the `qiskit.tools.visualization.circuit_drawer()` `mpl` output,
+  `qiskit.tools.visualization.plot_state`,
+  `qiskit.tools.visualization.plot_histogram`, and
+  `qiskit.tools.visualization.plot_bloch_vector` you will now need to ensure
+  you manually install and configure matplotlib independently.
 
 
 `0.6.0`_ - 2018-10-04

--- a/qiskit/backends/baseprovider.py
+++ b/qiskit/backends/baseprovider.py
@@ -23,19 +23,6 @@ class BaseProvider(ABC):
     def __init__(self, *args, **kwargs):
         pass
 
-    def available_backends(self, *args, **kwargs):
-        """Return the list of available backends.
-
-        Returns:
-            list[BaseBackend]: a list of backend instances available
-            from this provider.
-
-        .. deprecated:: 0.6+
-            After 0.6, this function is deprecated. Please use `.backends()`
-            instead.
-        """
-        return self.backends(*args, **kwargs)
-
     def get_backend(self, name=None, **kwargs):
         """Return a single backend matching the specified filtering.
 

--- a/test/python/_mockutils.py
+++ b/test/python/_mockutils.py
@@ -44,16 +44,6 @@ class DummyProvider(BaseProvider):
 
         super().__init__()
 
-    def available_backends(self, filters=None):
-        # pylint: disable=arguments-differ
-        backends = {DummySimulator.name: self._backend}
-
-        filters = filters or {}
-        for key, value in filters.items():
-            backends = {name: instance for name, instance in backends.items()
-                        if instance.configuration().get(key) == value}
-        return list(backends.values())
-
 
 class DummySimulator(BaseBackend):
     """ This is Dummy backend simulator just for testing purposes """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Complete the deprecation of `available_backends()` - which actually resulted in a tiny PR as the real functionality was removed during #1131.

In the process, a duplicated section of the changelog was removed (and no line added for this PR, as it was already present).

### Details and comments

Labelling this PR as `specs`, as it carries out the action mentioned in  https://github.com/Qiskit/qiskit-terra/issues/1047#issuecomment-435461710