### PR TITLE
Revert "Add debug logging to occasionally failing tests"

### DIFF
--- a/qiskit/unrollers/_jsonbackend.py
+++ b/qiskit/unrollers/_jsonbackend.py
@@ -67,7 +67,7 @@ class JsonBackend(UnrollerBackend):
 
         self.creg = None
         self.cval = None
-        self.gates = {}
+        self.gates = OrderedDict()
         if basis:
             self.basis = basis.copy()
         else:

--- a/qiskit/unrollers/_jsonbackend.py
+++ b/qiskit/unrollers/_jsonbackend.py
@@ -67,7 +67,7 @@ class JsonBackend(UnrollerBackend):
 
         self.creg = None
         self.cval = None
-        self.gates = OrderedDict()
+        self.gates = {}
         if basis:
             self.basis = basis.copy()
         else:

--- a/test/python/common.py
+++ b/test/python/common.py
@@ -43,7 +43,6 @@ class QiskitTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(QiskitTestCase, cls).setUpClass()
         cls.moduleName = os.path.splitext(inspect.getfile(cls))[0]
         cls.log = logging.getLogger(cls.__name__)
         # Determines if the TestCase is using IBMQ credentials.
@@ -78,7 +77,6 @@ class QiskitTestCase(unittest.TestCase):
 
         IBMQ._accounts.clear()
         Aer._backends = Aer._verify_aer_backends()
-        super(QiskitTestCase, self).tearDown()
 
     @staticmethod
     def _get_resource_path(filename, path=Path.TEST):

--- a/test/python/ibmq/test_ibmq_qasm_simulator.py
+++ b/test/python/ibmq/test_ibmq_qasm_simulator.py
@@ -10,12 +10,6 @@
 """Test IBMQ online qasm simulator.
 TODO: Must expand tests. Re-evaluate after Aer."""
 
-import logging
-import unittest
-
-import fixtures
-import testtools
-
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 # pylint: disable=redefined-builtin
 from qiskit import compile
@@ -23,26 +17,8 @@ from qiskit import IBMQ
 from ..common import requires_qe_access, QiskitTestCase
 
 
-LOG = logging.getLogger(__name__)
-
-
-class TestIbmqQasmSimulator(QiskitTestCase, testtools.TestCase):
+class TestIbmqQasmSimulator(QiskitTestCase):
     """Test IBM Q Qasm Simulator."""
-
-    @classmethod
-    def setUpClass(cls):
-        super(TestIbmqQasmSimulator, cls).setUpClass()
-        cls.orig_method = unittest.SkipTest
-        unittest.SkipTest = testtools.TestCase.skipException
-
-    @classmethod
-    def tearDownClass(cls):
-        unittest.SkipTest = cls.orig_method
-        super(TestIbmqQasmSimulator, cls).tearDownClass()
-
-    def setUp(self):
-        super(TestIbmqQasmSimulator, self).setUp()
-        self.useFixture(fixtures.LoggerFixture())
 
     @requires_qe_access
     def test_execute_one_circuit_simulator_online(self, qe_token, qe_url):
@@ -127,12 +103,6 @@ class TestIbmqQasmSimulator(QiskitTestCase, testtools.TestCase):
         qcr2.measure(qr2[1], cr2[1])
         shots = 1024
         qobj = compile([qcr1, qcr2], backend, seed=8458, shots=shots, seed_mapper=88434)
-        qobj_exp = qobj.experiments[0]
-        LOG.warning(qobj_exp.header.qubit_labels)
-        LOG.warning(qobj_exp.header.compiled_circuit_qasm)
-        LOG.warning(qobj_exp.header.clbit_labels)
-        for i in qobj_exp.instructions:
-            LOG.warning(i)
         job = backend.run(qobj)
         result = job.result()
         result1 = result.get_counts(qcr1)

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -9,10 +9,7 @@
 
 """Tests for the wrapper functionality."""
 
-import logging
-
-import fixtures
-import testtools
+import unittest
 
 import qiskit.wrapper
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
@@ -20,15 +17,12 @@ from qiskit import Aer
 from qiskit import compile
 
 from qiskit.qobj import Qobj
+from .common import QiskitTestCase
 
-LOG = logging.getLogger(__name__)
 
-
-class TestWrapper(testtools.TestCase):
+class TestWrapper(QiskitTestCase):
     """Wrapper test case."""
     def setUp(self):
-        super(TestWrapper, self).setUp()
-        self.useFixture(fixtures.LoggerFixture())
         qr = QuantumRegister(3)
         cr = ClassicalRegister(3)
         self.circuit = QuantumCircuit(qr, cr)
@@ -56,17 +50,13 @@ class TestWrapper(testtools.TestCase):
         circuit_b.measure(qreg2[0], creg2[1])
         qobj = compile([self.circuit, circuit_b], backend, skip_transpiler=True)
         qasm_list = [x.qasm() for x in qiskit.wrapper.qobj_to_circuits(qobj)]
-        LOG.warning(qasm_list[1])
-        qobj_exp = qobj.experiments[1]
-        LOG.warning(str(qobj_exp.header.qubit_labels))
-        LOG.warning(str(qobj_exp.header.compiled_circuit_qasm))
-        LOG.warning(str(qobj_exp.header.clbit_labels))
-        for i in qobj_exp.instructions:
-            LOG.warning(str(i))
-        LOG.warning(circuit_b.qasm())
         self.assertEqual(qasm_list, [self.circuit.qasm(), circuit_b.qasm()])
 
     def test_qobj_to_circuits_with_qobj_no_qasm(self):
         """Verify that qobj_to_circuits returns None without QASM."""
         qobj = Qobj('abc123', {}, {}, {})
         self.assertIsNone(qiskit.wrapper.qobj_to_circuits(qobj))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Reverts Qiskit/qiskit-terra#1309 (via the github interface button - let's see how it goes, seems to be creating a branch in the main repo).

As #1309 was a temporary solution for trying to find a bug finally fixed by #1314 (hopefully), I'm creating the revert PR in the hopes of being able to introduce the underlying feature (easy access to logs and extra-information from travis and CIs) later in a more controlled way, as part of the post-0.7 CI revamp.
