### PR TITLE
Switch _get_instructions() function to use a circuit

### DIFF
--- a/qiskit/tools/visualization/_utils.py
+++ b/qiskit/tools/visualization/_utils.py
@@ -9,6 +9,8 @@
 
 import PIL
 
+from qiskit import dagcircuit
+
 
 def _trim(image):
     """Trim a PIL image and remove white space."""
@@ -21,18 +23,20 @@ def _trim(image):
     return image
 
 
-def _get_instructions(dag, reversebits=False):
+def _get_instructions(circuit, reversebits=False):
     """
-    Given a dag, return a tuple (qregs, cregs, ops) where
+    Given a circuit, return a tuple (qregs, cregs, ops) where
     qregs and cregs are the name of the quantum and classical
     registers in order (based on reversebits) and ops is a list
     of DAG nodes which type is "operation".
     Args:
-        dag (DAGCircuit): From where the information is extracted.
-        reversebits (bool): If true the order of the bits in the registers is reversed.
+        circuit (QuantumCircuit): From where the information is extracted.
+        reversebits (bool): If true the order of the bits in the registers is
+            reversed.
     Returns:
         Tuple(list,list,list): To be consumed by the visualizer directly.
     """
+    dag = dagcircuit.DAGCircuit.fromQuantumCircuit(circuit, expand_gates=False)
     ops = []
     qregs = []
     cregs = []

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -158,34 +158,24 @@ class TestVisualizationUtils(QiskitTestCase):
     the need to be check if the interface or their result changes."""
 
     def setUp(self):
-        qubit1_0 = ('qr1', 0)
-        qubit1_1 = ('qr1', 1)
-        clbit1_0 = ('cr1', 0)
-        clbit1_1 = ('cr1', 1)
-        qubit2_0 = ('qr2', 0)
-        qubit2_1 = ('qr2', 1)
-        clbit2_0 = ('cr2', 0)
-        clbit2_1 = ('cr2', 1)
+        qreg_a = qiskit.QuantumRegister(2, 'qr1')
+        qreg_b = qiskit.QuantumRegister(2, 'qr2')
+        creg_a = qiskit.ClassicalRegister(2, 'cr1')
+        creg_b = qiskit.ClassicalRegister(2, 'cr2')
 
-        self.dag = qiskit.dagcircuit.DAGCircuit()
-        self.dag.add_basis_element('cx', 2)
-        self.dag.add_basis_element('measure', 1, number_classical=1, number_parameters=0)
-        self.dag.add_qreg(qiskit.QuantumRegister(2, "qr1"))
-        self.dag.add_creg(qiskit.ClassicalRegister(2, "cr1"))
-        self.dag.add_qreg(qiskit.QuantumRegister(2, "qr2"))
-        self.dag.add_creg(qiskit.ClassicalRegister(2, "cr2"))
-        self.dag.apply_operation_back('cx', [qubit1_0, qubit1_1], [], [])
-        self.dag.apply_operation_back('measure', [qubit1_0], [clbit1_0], [])
-        self.dag.apply_operation_back('cx', [qubit1_1, qubit1_0], [], [])
-        self.dag.apply_operation_back('measure', [qubit1_1], [clbit1_1], [])
-        self.dag.apply_operation_back('cx', [qubit2_0, qubit2_1], [], [])
-        self.dag.apply_operation_back('measure', [qubit2_0], [clbit2_0], [])
-        self.dag.apply_operation_back('cx', [qubit2_1, qubit2_0], [], [])
-        self.dag.apply_operation_back('measure', [qubit2_1], [clbit2_1], [])
+        self.circuit = qiskit.QuantumCircuit(qreg_a, qreg_b, creg_a, creg_b)
+        self.circuit.cx(qreg_b[0], qreg_b[1])
+        self.circuit.measure(qreg_b[0], creg_b[0])
+        self.circuit.cx(qreg_b[1], qreg_b[0])
+        self.circuit.measure(qreg_b[1], creg_b[1])
+        self.circuit.cx(qreg_a[0], qreg_a[1])
+        self.circuit.measure(qreg_a[0], creg_a[0])
+        self.circuit.cx(qreg_a[1], qreg_a[0])
+        self.circuit.measure(qreg_a[1], creg_a[1])
 
     def test_get_instructions(self):
         """ _get_instructions without reversebits """
-        (qregs, cregs, ops) = _utils._get_instructions(self.dag)
+        (qregs, cregs, ops) = _utils._get_instructions(self.circuit)
         self.assertEqual([('qr2', 1), ('qr2', 0), ('qr1', 1), ('qr1', 0)], qregs)
         self.assertEqual([('cr2', 1), ('cr2', 0), ('cr1', 1), ('cr1', 0)], cregs)
         self.assertEqual(['cx', 'measure', 'cx', 'measure', 'cx', 'measure', 'cx', 'measure'],
@@ -204,9 +194,23 @@ class TestVisualizationUtils(QiskitTestCase):
 
     def test_get_instructions_reversebits(self):
         """ _get_instructions with reversebits=True """
-        (qregs, cregs, _) = _utils._get_instructions(self.dag, reversebits=True)
+        (qregs, cregs, ops) = _utils._get_instructions(self.circuit, reversebits=True)
         self.assertEqual([('qr1', 0), ('qr1', 1), ('qr2', 0), ('qr2', 1)], qregs)
         self.assertEqual([('cr1', 0), ('cr1', 1), ('cr2', 0), ('cr2', 1)], cregs)
+        self.assertEqual(['cx', 'measure', 'cx', 'measure', 'cx', 'measure', 'cx', 'measure'],
+                         [op['name'] for op in ops])
+        self.assertEqual([[('qr2', 0), ('qr2', 1)],
+                          [('qr2', 0)],
+                          [('qr2', 1), ('qr2', 0)],
+                          [('qr2', 1)],
+                          [('qr1', 0), ('qr1', 1)],
+                          [('qr1', 0)],
+                          [('qr1', 1), ('qr1', 0)],
+                          [('qr1', 1)]],
+                         [op['qargs'] for op in ops])
+        self.assertEqual([[], [('cr2', 0)], [], [('cr2', 1)], [], [('cr1', 0)], [], [('cr1', 1)]],
+                         [op['cargs'] for op in ops])
+
 
 
 if __name__ == '__main__':

--- a/test/python/test_visualization.py
+++ b/test/python/test_visualization.py
@@ -212,6 +212,5 @@ class TestVisualizationUtils(QiskitTestCase):
                          [op['cargs'] for op in ops])
 
 
-
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The _get_instructions() helper function was operating a level too low,
it should take a circuit in and return the iterators needed for drawing
the circuit. Each of the drawer backends deal with a circuit and
converting to a dag prior to getting the instructions adds unnecessary
complexity to the circuit_drawers. We also can isolate handling that in
one place in the helper function so if/when we change our relationship
between dags and circuits we have a single place to fix.

### Details and comments


