### PR TITLE
Fix test_ibmq_qobj simulator usage

### DIFF
--- a/test/python/ibmq/test_ibmq_qobj.py
+++ b/test/python/ibmq/test_ibmq_qobj.py
@@ -38,7 +38,7 @@ class TestIBMQQobj(JobTestCase):
                           "testing Qobj capabilities.")
 
         IBMQ.enable_account(self._qe_token, self._qe_url)
-        self._local_backend = Aer.get_backend('local_qasm_simulator')
+        self._local_backend = Aer.get_backend('qasm_simulator_py')
         self._remote_backend = IBMQ.get_backend(self._testing_device)
         self.log.info('Remote backend: %s', self._remote_backend.name())
         self.log.info('Local backend: %s', self._local_backend.name())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Update the name of the simulator used by `test_ibmq_qobj` during the setup phase, in order to make `master` pass after #1303 .


### Details and comments


