### PR TITLE
measure() clearer message for args types cohesion check

### DIFF
--- a/qiskit/_measure.py
+++ b/qiskit/_measure.py
@@ -8,6 +8,8 @@
 """
 Quantum measurement in the computational basis.
 """
+from qiskit import QISKitError
+
 from ._instruction import Instruction
 from ._instructionset import InstructionSet
 from ._quantumcircuit import QuantumCircuit
@@ -38,20 +40,30 @@ class Measure(Instruction):
 
 def measure(self, qubit, cbit):
     """Measure quantum bit into classical bit (tuples).
-
+     Args:
+        qubit (QuantumRegister|tuple): quantum register
+        cbit (ClassicalRegister|tuple): classical register
     Returns:
         qiskit.Instruction: the attached measure instruction.
-
     Raises:
         QISKitError: if qubit is not in this circuit or bad format;
             if cbit is not in this circuit or not creg.
     """
-    if isinstance(qubit, QuantumRegister) and \
-       isinstance(cbit, ClassicalRegister) and len(qubit) == len(cbit):
+    if isinstance(qubit, QuantumRegister) and isinstance(cbit, ClassicalRegister) \
+            and len(qubit) == len(cbit):
         instructions = InstructionSet()
         for i in range(qubit.size):
             instructions.add(self.measure((qubit, i), (cbit, i)))
         return instructions
+    elif isinstance(qubit, QuantumRegister) and isinstance(cbit, ClassicalRegister) and len(
+            qubit) != len(cbit):
+        raise QISKitError("qubit (%s) and cbit (%s) should have the same length"
+                          % (len(qubit), len(cbit)))
+    elif not (isinstance(qubit, tuple) and isinstance(cbit, tuple)):
+        raise QISKitError(
+            "Both qubit <%s> and cbit <%s> should be Registers or formated as tuples. "
+            "Hint: You can use subscript eg. cbit[0] to convert it into tuple."
+            % (type(qubit).__name__, type(cbit).__name__))
 
     self._check_qubit(qubit)
     self._check_creg(cbit[0])

--- a/qiskit/_quantumcircuit.py
+++ b/qiskit/_quantumcircuit.py
@@ -272,7 +272,7 @@ class QuantumCircuit(object):
     def _check_creg(self, register):
         """Raise exception if r is not in this circuit or not creg."""
         if not isinstance(register, ClassicalRegister):
-            raise QISKitError("expected classical register")
+            raise QISKitError("Expected ClassicalRegister, but %s given" % type(register))
         if not self.has_register(register):
             raise QISKitError(
                 "register '%s' not in this circuit" %

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -179,3 +179,24 @@ class TestCircuitOperations(QiskitTestCase):
         target = {'00': shots/4, '01': shots/4, '10': shots/4, '11': shots/4}
         threshold = 0.04 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
+
+    def test_measure_args_type_cohesion(self):
+        """Test for proper args types for measure function.
+        """
+        quantum_reg = QuantumRegister(2)
+        classical_reg_0 = ClassicalRegister(1)
+        classical_reg_1 = ClassicalRegister(1)
+        quantum_circuit = QuantumCircuit(quantum_reg, classical_reg_0, classical_reg_1)
+        quantum_circuit.h(quantum_reg)
+
+        with self.assertRaises(QISKitError) as ctx:
+            quantum_circuit.measure(quantum_reg, classical_reg_1)
+        self.assertEqual(ctx.exception.message,
+                         'qubit (2) and cbit (1) should have the same length')
+
+        with self.assertRaises(QISKitError) as ctx:
+            quantum_circuit.measure(quantum_reg[1], classical_reg_1)
+        self.assertEqual(ctx.exception.message, 'Both qubit <tuple> and cbit <ClassicalRegister> '
+                                                'should be Registers or formated as tuples. Hint: '
+                                                'You can use subscript eg. cbit[0] to '
+                                                'convert it into tuple.')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added better control for args type for the measure() function, to eliminate the common usage problem described in https://github.com/Qiskit/qiskit-terra/issues/915




