### PR TITLE
Update backend.properties() to use BackendProperties

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -71,6 +71,7 @@ disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax
     protected-access,   # disabled as we don't follow the public vs private
                         # convention strictly
     duplicate-code,     # disabled as it is too verbose
+    redundant-returns-doc, # for @abstractmethod, it cannot interpret "pass"
     # disable the "too-many/few-..." refactoring hints
     too-many-lines, too-many-branches, too-many-locals, too-many-nested-blocks,
     too-many-statements, too-many-instance-attributes, too-many-arguments,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,7 @@ Changed
   updated methods include:
     - ``backend.status()``(#1301).
     - ``backend.configuration()`` (and ``__init__``) (#1323).
+    - ``backend.properties()`` (#1331).
 - ``backend.provider()`` is now a method instead of a property (#1312).
 - Remove local backend (Aer) fallback (#1303)
 

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -20,7 +20,7 @@ import platform
 
 import numpy as np
 
-from qiskit.backends.models import BackendConfiguration
+from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
@@ -81,6 +81,23 @@ class QasmSimulator(BaseBackend):
         except StopIteration:
             raise FileNotFoundError('Simulator executable not found (using %s)' %
                                     getattr(self._configuration, 'exe', 'default locations'))
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a qobj on the backend."""
@@ -144,6 +161,23 @@ class CliffordSimulator(BaseBackend):
         except StopIteration:
             raise FileNotFoundError('Simulator executable not found (using %s)' %
                                     getattr(self._configuration, 'exe', 'default locations'))
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a Qobj on the backend.

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -78,7 +78,7 @@ from collections import Counter
 
 import numpy as np
 
-from qiskit.backends.models import BackendConfiguration
+from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
@@ -119,6 +119,23 @@ class QasmSimulatorPy(BaseBackend):
         self._number_of_qubits = 0
         self._shots = 0
         self._qobj_config = None
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def _add_qasm_single(self, gate, qubit):
         """Apply an arbitrary 1-qubit operator to a qubit.

--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -14,7 +14,7 @@ Interface to C++ quantum circuit simulator with realistic noise.
 import logging
 import uuid
 
-from qiskit.backends.models import BackendConfiguration
+from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.qobj import QobjInstruction
 from .qasm_simulator import QasmSimulator
 from ._simulatorerror import SimulatorError
@@ -46,6 +46,23 @@ class StatevectorSimulator(QasmSimulator):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a qobj on the the backend."""

--- a/qiskit/backends/aer/statevector_simulator_py.py
+++ b/qiskit/backends/aer/statevector_simulator_py.py
@@ -23,7 +23,7 @@ import uuid
 
 from qiskit.backends.aer.aerjob import AerJob
 from qiskit.backends.aer._simulatorerror import SimulatorError
-from qiskit.backends.models import BackendConfiguration
+from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.qobj import QobjInstruction
 from .qasm_simulator_py import QasmSimulatorPy
 
@@ -51,6 +51,23 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run qobj asynchronously.

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -86,7 +86,7 @@ import time
 
 import numpy as np
 
-from qiskit.backends.models import BackendConfiguration
+from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
@@ -125,6 +125,23 @@ class UnitarySimulatorPy(BaseBackend):
         # Define attributes inside __init__.
         self._unitary_state = None
         self._number_of_qubits = 0
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def _add_unitary_single(self, gate, qubit):
         """Apply the single-qubit gate.

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -47,13 +47,18 @@ class BaseBackend(ABC):
         """Return the backend configuration.
 
         Returns:
-            BackendConfiguration: the configuration fot the backend.
+            BackendConfiguration: the configuration for the backend.
         """
         return self._configuration
 
+    @abstractmethod
     def properties(self):
-        """Return backend properties"""
-        return {}
+        """Return backend properties.
+
+        Returns:
+            BackendProperties: the configuration for the backend.
+        """
+        pass
 
     def provider(self):
         """Return the backend Provider.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -14,9 +14,8 @@ import logging
 from marshmallow import ValidationError
 
 from qiskit import QISKitError
-from qiskit._util import _camel_case_to_snake_case
 from qiskit.backends import BaseBackend, JobStatus
-from qiskit.backends.models import BackendStatus
+from qiskit.backends.models import BackendStatus, BackendProperties
 
 from .api import ApiError
 from .ibmqjob import IBMQJob, IBMQJobPreQobj
@@ -68,20 +67,10 @@ class IBMQBackend(BaseBackend):
 
         Returns:
             dict: The properties of the backend.
-
-        Raises:
-            LookupError: If properties for the backend can't be found.
         """
-        properties = self._api.backend_properties(self.name())
+        api_properties = self._api.backend_properties(self.name())
 
-        # Convert the properties to snake_case.
-        # TODO: ideally should be handled at the API level.
-        properties_edit = {}
-        for key, val in properties.items():
-            new_key = _camel_case_to_snake_case(key)
-            properties_edit[new_key] = val
-
-        return properties_edit
+        return BackendProperties.from_dict(api_properties)
 
     def status(self):
         """Return the online backend status.

--- a/qiskit/backends/models/backendproperties.py
+++ b/qiskit/backends/models/backendproperties.py
@@ -30,7 +30,8 @@ class GateSchema(BaseSchema):
     qubits = List(Number(), required=True,
                   validate=Length(min=1))
     gate = String(required=True)
-    parameters = Nested(NduvSchema, required=True, many=True)
+    parameters = Nested(NduvSchema, required=True, many=True,
+                        validate=Length(min=1))
 
 
 class BackendPropertiesSchema(BaseSchema):
@@ -41,9 +42,11 @@ class BackendPropertiesSchema(BaseSchema):
     backend_version = String(required=True,
                              validate=Regexp("[0-9]+.[0-9]+.[0-9]+$"))
     last_update_date = DateTime(required=True)
-    qubits = List(Nested(NduvSchema, many=True), required=True,
+    qubits = List(Nested(NduvSchema, many=True,
+                         validate=Length(min=1)), required=True,
                   validate=Length(min=1))
-    gates = Nested(GateSchema, required=True, many=True)
+    gates = Nested(GateSchema, required=True, many=True,
+                   validate=Length(min=1))
     general = Nested(NduvSchema, required=True, many=True)
 
 

--- a/test/python/_mockutils.py
+++ b/test/python/_mockutils.py
@@ -22,6 +22,7 @@ import time
 from qiskit import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends import BaseJob
+from qiskit.backends.models import BackendProperties
 from qiskit.qobj import Qobj, QobjItem, QobjConfig, QobjHeader, QobjInstruction
 from qiskit.qobj import QobjExperiment, QobjExperimentHeader
 from qiskit.backends.jobstatus import JobStatus
@@ -66,6 +67,23 @@ class DummySimulator(BaseBackend):
         """
         super().__init__(configuration or self.DEFAULT_CONFIGURATION.copy())
         self.time_alive = time_alive
+
+    def properties(self):
+        """Return backend properties"""
+        properties = {
+            'backend_name': self.name(),
+            'backend_version': self.configuration().backend_version,
+            'last_update_date': '2000-01-01 00:00:00Z',
+            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                         'unit': 'TODO', 'value': 0}]],
+            'gates': [{'qubits': [0], 'gate': 'TODO',
+                       'parameters':
+                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
+                             'unit': 'TODO', 'value': 0}]}],
+            'general': []
+        }
+
+        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         job_id = str(uuid.uuid4())

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -150,17 +150,13 @@ class TestBackends(QiskitTestCase):
 
         If all correct should pass the validation.
         """
+        schema_path = self._get_resource_path(
+            'backend_properties_schema.json', path=Path.SCHEMAS)
+        with open(schema_path, 'r') as schema_file:
+            schema = json.load(schema_file)
+
         IBMQ.enable_account(qe_token, qe_url)
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:
-            self.log.info(backend.name())
             properties = backend.properties()
-            # FIXME test against schema and decide what properties
-            # is for a simulator
-            if backend.configuration().simulator:
-                self.assertEqual(len(properties), 0)
-            else:
-                self.assertTrue(all(key in properties for key in (
-                    'last_update_date',
-                    'qubits',
-                    'backend_name')))
+            jsonschema.validate(properties.to_dict(), schema)

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -134,12 +134,15 @@ class TestBackends(QiskitTestCase):
 
         If all correct should pass the validation.
         """
+        schema_path = self._get_resource_path(
+            'backend_properties_schema.json', path=Path.SCHEMAS)
+        with open(schema_path, 'r') as schema_file:
+            schema = json.load(schema_file)
+
         aer_backends = Aer.backends()
         for backend in aer_backends:
             properties = backend.properties()
-            # FIXME test against schema and decide what properties
-            # is for a simulator
-            self.assertEqual(len(properties), 0)
+            jsonschema.validate(properties.to_dict(), schema)
 
     @requires_qe_access
     def test_remote_backend_properties(self, qe_token, qe_url):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Related issues:
#996 - backend_properties_schema.json checkbox

### Summary

In a similar spirit to #1301 and #1323, update `backend.properties()` (base, aer, and ibmq) in order to return instances of `BackendProperties` that conform to the schemas instead of dicts.

For the local simulators, their properties have been composed trying to achieve minimal working ones, using placeholders - as the specs does not allow empty Properties. In particular, `qubits` and `gates` require at lease one element: they should be set to proper values in a follow-up PR.

For `IBMQBackend`, the changes involved moving the parsing and processing of the properties to the IBMQConnector, freeing up the layer above from those modifications. Please note that the processing included is meant to be temporary, and takes into account the format currently returned by the API for all QX and IBMQ current devices and sims. Ideally, the call will be replaced with a call to a new endpoint that needs no preprocessing before the 0.7 release.

The `IBMQBackend` simulators (both QX and IBMQ) API calls return an empty dict - in practice it means the `online_simulator.properties()` will return a `ValidationError` until 0.7.

### Details and comments

There are some potential follow-ups for this PR:

* all properties (for local sims) need to return meaningful `qubits` and `gates` attributes, as currently they return dummy values (as the specs requires at least 1 element in them). Alternatively, we should look if it makes sense to relax the schemas for the simulators.

