### PR TITLE
Fix conditional drawing in latex and mpl

### DIFF
--- a/qiskit/tools/visualization/_latex.py
+++ b/qiskit/tools/visualization/_latex.py
@@ -241,8 +241,8 @@ class QCircuitImage(object):
                 if len(qarglist) == 1:
                     pos_1 = self.img_regs[(qarglist[0][0],
                                            qarglist[0][1])]
-                    if 'conditional' in op:
-                        mask = int(op['conditional']['mask'], 16)
+                    if 'condition' in op and op['condition']:
+                        mask = self._get_mask(op['condition'][0])
                         cl_reg = self.clbit_list[self._ffs(mask)]
                         if_reg = cl_reg[0]
                         pos_2 = self.img_regs[cl_reg]
@@ -266,8 +266,8 @@ class QCircuitImage(object):
                     pos_1 = self.img_regs[(qarglist[0][0], qarglist[0][1])]
                     pos_2 = self.img_regs[(qarglist[1][0], qarglist[1][1])]
 
-                    if 'conditional' in op:
-                        mask = int(op['conditional']['mask'], 16)
+                    if 'condition' in op and op['condition']:
+                        mask = self._get_mask(op['condition'][0])
                         cl_reg = self.clbit_list[self._ffs(mask)]
                         if_reg = cl_reg[0]
                         pos_3 = self.img_regs[(if_reg, 0)]
@@ -322,8 +322,8 @@ class QCircuitImage(object):
                     pos_2 = self.img_regs[(qarglist[1][0], qarglist[1][1])]
                     pos_3 = self.img_regs[(qarglist[2][0], qarglist[2][1])]
 
-                    if 'conditional' in op:
-                        mask = int(op['conditional']['mask'], 16)
+                    if 'condition' in op and op['condition']:
+                        mask = self._get_mask(op['condition'][0])
                         cl_reg = self.clbit_list[self._ffs(mask)]
                         if_reg = cl_reg[0]
                         pos_4 = self.img_regs[(if_reg, 0)]
@@ -371,7 +371,7 @@ class QCircuitImage(object):
             elif op['name'] == "measure":
                 if len(op['cargs']) != 1 or len(op['qargs']) != 1:
                     raise _error.VisualizationError("bad operation record")
-                if 'conditional' in op:
+                if 'condition' in op and op['condition']:
                     raise _error.VisualizationError(
                         'conditional measures currently not supported.')
                 qindex = self._get_qubit_index(op['qargs'][0])
@@ -402,7 +402,7 @@ class QCircuitImage(object):
                 if columns not in max_column_width:
                     max_column_width[columns] = 0
             elif op['name'] == "reset":
-                if 'conditional' in op:
+                if 'conditional' in op and op['condition']:
                     raise _error.VisualizationError(
                         'conditional reset currently not supported.')
                 qindex = self._get_qubit_index(op['qargs'][0])
@@ -529,6 +529,13 @@ class QCircuitImage(object):
                 count += size
         raise ValueError('qubit index lies outside range of qubit registers')
 
+    def _get_mask(self, creg_name):
+        mask = 0
+        for index, cbit in enumerate(self.clbit_list):
+            if creg_name == cbit[0]:
+                mask |= (1 << index)
+        return mask
+
     def _build_latex_array(self, aliases=None):
         """Returns an array of strings containing \\LaTeX for this circuit.
 
@@ -551,12 +558,12 @@ class QCircuitImage(object):
             qregdata = self.qregs
 
         for _, op in enumerate(self.ops):
-            if 'conditional' in op:
-                mask = int(op['conditional']['mask'], 16)
+            if 'condition' in op and op['condition']:
+                mask = self._get_mask(op['condition'][0])
                 cl_reg = self.clbit_list[self._ffs(mask)]
                 if_reg = cl_reg[0]
                 pos_2 = self.img_regs[cl_reg]
-                if_value = format(int(op['conditional']['val'], 16),
+                if_value = format(op['condition'][1],
                                   'b').zfill(self.cregs[if_reg])[::-1]
             if op['name'] not in ['measure', 'barrier', 'snapshot', 'load',
                                   'save', 'noise']:
@@ -567,8 +574,8 @@ class QCircuitImage(object):
                 if len(qarglist) == 1:
                     pos_1 = self.img_regs[(qarglist[0][0],
                                            qarglist[0][1])]
-                    if 'conditional' in op:
-                        mask = int(op['conditional']['mask'], 16)
+                    if 'condition' in op and op['condition']:
+                        mask = self._get_mask(op['condition'][0])
                         cl_reg = self.clbit_list[self._ffs(mask)]
                         if_reg = cl_reg[0]
                         pos_2 = self.img_regs[cl_reg]
@@ -691,7 +698,7 @@ class QCircuitImage(object):
                     pos_1 = self.img_regs[(qarglist[0][0], qarglist[0][1])]
                     pos_2 = self.img_regs[(qarglist[1][0], qarglist[1][1])]
 
-                    if 'conditional' in op:
+                    if 'condition' in op and op['condition']:
                         pos_3 = self.img_regs[(if_reg, 0)]
                         temp = [pos_1, pos_2, pos_3]
                         temp.sort(key=int)
@@ -829,7 +836,7 @@ class QCircuitImage(object):
                     pos_2 = self.img_regs[(qarglist[1][0], qarglist[1][1])]
                     pos_3 = self.img_regs[(qarglist[2][0], qarglist[2][1])]
 
-                    if 'conditional' in op:
+                    if 'condition' in op and op['condition']:
                         pos_4 = self.img_regs[(if_reg, 0)]
 
                         temp = [pos_1, pos_2, pos_3, pos_4]
@@ -928,7 +935,7 @@ class QCircuitImage(object):
                         or len(op['qargs']) != 1
                         or op['params']):
                     raise _error.VisualizationError("bad operation record")
-                if 'conditional' in op:
+                if 'condition' in op and op['condition']:
                     raise _error.VisualizationError(
                         "If controlled measures currently not supported.")
 

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -517,7 +517,8 @@ class MatplotlibDrawer:
             if not _barriers['group']:
                 this_anc = max([q_anchors[ii].get_index() for ii in q_idxs])
                 while True:
-                    if op['name'] in _force_next or 'conditional' in op.keys() or \
+                    if op['name'] in _force_next or (
+                            'condition' in op.keys() and op['condition']) or \
                             not self._style.compress:
                         occupied = self._qreg_dict.keys()
                     else:
@@ -554,16 +555,19 @@ class MatplotlibDrawer:
             else:
                 param = None
             # conditional gate
-            if 'conditional' in op.keys():
+            if 'condition' in op.keys() and op['condition']:
                 c_xy = [c_anchors[ii].plot_coord(this_anc, gw) for
                         ii in self._creg_dict]
+                mask = 0
+                for index, cbit in enumerate(self._creg):
+                    if cbit.name == op['condition'][0]:
+                        mask |= (1 << index)
+                val = op['condition'][1]
                 # cbit list to consider
                 fmt_c = '{{:0{}b}}'.format(len(c_xy))
-                mask = int(op['conditional']['mask'], 16)
                 cmask = list(fmt_c.format(mask))[::-1]
                 # value
                 fmt_v = '{{:0{}b}}'.format(cmask.count('1'))
-                val = int(op['conditional']['val'], 16)
                 vlist = list(fmt_v.format(val))[::-1]
                 # plot conditionals
                 v_ind = 0
@@ -578,7 +582,7 @@ class MatplotlibDrawer:
                             xy_plot.append(xy)
                         v_ind += 1
                 creg_b = sorted(xy_plot, key=lambda xy: xy[1])[0]
-                self._subtext(creg_b, op['conditional']['val'])
+                self._subtext(creg_b, hex(val))
                 self._line(qreg_t, creg_b, lc=self._style.cc,
                            ls=self._style.cline)
             #


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The patches that switched the circuit drawers away from using the
transpiler and switching to the circuit/dag changed the format we were
passing conditionals to the drawers. Instead of getting a bitmask and a
value we now get the register name and the value. Additionally the field
in the instruction changed from 'conditional' to 'condition', and
defaults to None instead of not being present. However none of these
changes were reflected in the migration patches #1278 and #1276. This
commit corrects the behavior for conditionals by updated the checks and
just generating the bitmask for conditionals.

### Details and comments

Fixes #1318
