### PR TITLE
fix middle measurements moving to the end

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -122,6 +122,8 @@ Fixed
   AerJob usage (#1125)
 - Fixed an edge case when connection checks would raise an unhandled exception
   (#1226)
+- Fixed a bug where the transpiler moved middle-of-circuit measurements to the
+  end (#1334)
 
 Removed
 """""""

--- a/examples/python/teleport.py
+++ b/examples/python/teleport.py
@@ -63,11 +63,6 @@ initial_layout = {("q", 0): ("q", 0), ("q", 1): ("q", 1),
 qobj = compile(qc, backend=backend, coupling_map=None, shots=1024, initial_layout=initial_layout)
 job = backend.run(qobj)
 qobj_exp = qobj.experiments[0]
-print(qobj_exp.header.qubit_labels)
-print(qobj_exp.header.compiled_circuit_qasm)
-print(qobj_exp.header.clbit_labels)
-for i in qobj_exp.instructions:
-            print(i)
 
 result = job.result()
 print(result)
@@ -76,12 +71,7 @@ print(result.get_counts(qc))
 # Second version: mapped to 2x8 array coupling graph
 qobj = compile(qc, backend=backend, coupling_map=coupling_map, shots=1024,initial_layout=initial_layout)
 qobj_exp = qobj.experiments[0]
-print(qobj_exp.header.qubit_labels)
 qobj_exp.header.compiled_circuit_qasm = ""
-print(qobj_exp.header.compiled_circuit_qasm)
-print(qobj_exp.header.clbit_labels)
-for i in qobj_exp.instructions:
-            print(i)
 job = backend.run(qobj)
 result = job.result()
 print(result)

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -850,7 +850,8 @@ def remove_last_measurements(dag_circuit, perform_remove=True):
 
     for idx in meas_nodes:
         _, succ_map = dag_circuit._make_pred_succ_maps(idx)
-        if len(succ_map) == 2:
+        if len(succ_map) == 2 and all([dag_circuit.multi_graph.node[n]["type"] == "out"
+                                       for n in succ_map.values()]):
             # All succesors of the measurement are outputs, one for qubit and one for cbit
             # (As opposed to more gates being applied), and it is safe to remove the
             # measurement node and add it back after the swap mapper is done.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1289 

The output of `examples/python/teleport.py` now looks correct:
```
COMPLETED
{'0 0 0': 257, '0 0 1': 254, '0 1 0': 233, '0 1 1': 256, '1 0 0': 7, '1 0 1': 3, '1 1 0': 7, '1 1 1': 7}
COMPLETED
{'0 0 0': 277, '0 0 1': 246, '0 1 0': 235, '0 1 1': 252, '1 0 0': 5, '1 0 1': 2, '1 1 0': 4, '1 1 1': 3}
```

Thanks to @kdk for finding the source of the bug.
