### PR TITLE
Ensure local simulators pass the qobj headers

### DIFF
--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -22,10 +22,9 @@ from math import log2
 import numpy as np
 from qiskit._util import local_hardware_info
 from qiskit.backends.models import BackendConfiguration, BackendProperties
-from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
-from qiskit.qobj import qobj_to_dict
+from qiskit.result import Result
 
 logger = logging.getLogger(__name__)
 
@@ -110,12 +109,10 @@ class QasmSimulator(BaseBackend):
 
     def _run_job(self, job_id, qobj):
         self._validate(qobj)
-        result = run(qobj, self._configuration.exe)
+        qobj_dict = qobj.as_dict()
+        result = run(qobj_dict, self._configuration.exe)
         result['job_id'] = job_id
-        copy_qasm_from_qobj_into_result(qobj, result)
-        result['header'] = qobj.header.as_dict()
-
-        return result_from_old_style_dict(result)
+        return Result.from_dict(result)
 
     def _validate(self, qobj):
         for experiment in qobj.experiments:
@@ -198,68 +195,19 @@ class CliffordSimulator(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
+        qobj_dict = qobj.as_dict()
         self._validate()
         # set backend to Clifford simulator
-        qobj.config.simulator = 'clifford'
-
-        result = run(qobj, self._configuration.exe)
+        if 'config' in qobj_dict:
+            qobj_dict['config']['simulator'] = 'clifford'
+        else:
+            qobj_dict['config'] = {'simulator': 'clifford'}
+        result = run(qobj_dict, self._configuration.exe)
         result['job_id'] = job_id
-        copy_qasm_from_qobj_into_result(qobj, result)
-        result['header'] = qobj.header.as_dict()
-
-        return result_from_old_style_dict(result)
+        return Result.from_dict(result)
 
     def _validate(self):
         return
-
-
-class QASMSimulatorEncoder(json.JSONEncoder):
-    """
-    JSON encoder for NumPy arrays and complex numbers.
-
-    This functions as the standard JSON Encoder but adds support
-    for encoding:
-
-        * complex numbers z as lists [z.real, z.imag]
-        * ndarrays as nested lists.
-    """
-
-    # pylint: disable=method-hidden,arguments-differ
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, complex):
-            return [obj.real, obj.imag]
-        return json.JSONEncoder.default(self, obj)
-
-
-class QASMSimulatorDecoder(json.JSONDecoder):
-    """
-    JSON decoder for the output from C++ qasm_simulator.
-
-    This converts complex vectors and matrices into numpy arrays
-    for the following keys.
-    """
-    def __init__(self, *args, **kwargs):
-        json.JSONDecoder.__init__(self, object_hook=self.object_hook, *args, **kwargs)
-
-    # pylint: disable=method-hidden
-    def object_hook(self, obj):
-        """Special decoding rules for simulator output."""
-
-        for key in ['U_error', 'density_matrix']:
-            # JSON is a complex matrix
-            if key in obj and isinstance(obj[key], list):
-                tmp = np.array(obj[key])
-                obj[key] = tmp[::, ::, 0] + 1j * tmp[::, ::, 1]
-        for key in ['statevector', 'inner_products']:
-            # JSON is a list of complex vectors
-            if key in obj:
-                for j in range(len(obj[key])):
-                    if isinstance(obj[key][j], list):
-                        tmp = np.array(obj[key][j])
-                        obj[key][j] = tmp[::, 0] + 1j * tmp[::, 1]
-        return obj
 
 
 def run(qobj, executable):
@@ -277,14 +225,13 @@ def run(qobj, executable):
     try:
         with subprocess.Popen([executable, '-'],
                               stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
-            cin = json.dumps(qobj_to_dict(qobj, version='0.0.1'),
-                             cls=QASMSimulatorEncoder).encode()
+            cin = json.dumps(qobj).encode()
             cout, cerr = proc.communicate(cin)
         if cerr:
             logger.error('ERROR: Simulator encountered a runtime error: %s',
                          cerr.decode())
         sim_output = cout.decode()
-        return json.loads(sim_output, cls=QASMSimulatorDecoder)
+        return json.loads(sim_output)
 
     except FileNotFoundError:
         msg = "ERROR: Simulator exe not found at: %s" % executable

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -108,6 +108,7 @@ class QasmSimulator(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
+        """Run a Qobj on the backend."""
         self._validate(qobj)
         qobj_dict = qobj.as_dict()
         result = run(qobj_dict, self._configuration.exe)

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -25,7 +25,6 @@ from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
-from qiskit.qobj import Qobj
 from qiskit.qobj import qobj_to_dict
 
 logger = logging.getLogger(__name__)
@@ -114,6 +113,7 @@ class QasmSimulator(BaseBackend):
         result = run(qobj, self._configuration.exe)
         result['job_id'] = job_id
         copy_qasm_from_qobj_into_result(qobj, result)
+        result['header'] = qobj.header.as_dict()
 
         return result_from_old_style_dict(result)
 
@@ -198,20 +198,14 @@ class CliffordSimulator(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
-        if isinstance(qobj, Qobj):
-            qobj_dict = qobj.as_dict()
-        else:
-            qobj_dict = qobj
         self._validate()
         # set backend to Clifford simulator
-        if 'config' in qobj_dict:
-            qobj_dict['config']['simulator'] = 'clifford'
-        else:
-            qobj_dict['config'] = {'simulator': 'clifford'}
+        qobj.config.simulator = 'clifford'
 
-        qobj = Qobj.from_dict(qobj_dict)
         result = run(qobj, self._configuration.exe)
         result['job_id'] = job_id
+        copy_qasm_from_qobj_into_result(qobj, result)
+        result['header'] = qobj.header.as_dict()
 
         return result_from_old_style_dict(result)
 

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -231,8 +231,8 @@ def run(qobj, executable):
         if cerr:
             logger.error('ERROR: Simulator encountered a runtime error: %s',
                          cerr.decode())
-        sim_output = cout.decode()
-        return json.loads(sim_output)
+        sim_output = json.loads(cout.decode())
+        return sim_output
 
     except FileNotFoundError:
         msg = "ERROR: Simulator exe not found at: %s" % executable

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -279,8 +279,8 @@ class QasmSimulatorPy(BaseBackend):
         self._snapshots = {}
 
         # Get the seed looking in circuit, qobj, and then random.
-        if hasattr(circuit, 'config') and hasattr(circuit.config, 'seed'):
-            seed = circuit.config.seed
+        if hasattr(experiment, 'config') and hasattr(experiment.config, 'seed'):
+            seed = experiment.config.seed
         elif hasattr(self._qobj_config, 'seed'):
             seed = self._qobj_config.seed
         else:

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -9,82 +9,35 @@
 
 """Contains a (slow) python simulator.
 
-It simulates a qasm quantum circuit that has been compiled to run on the
-simulator. It is exponential in the number of qubits.
-
-We advise using the c++ simulator or online simulator for larger size systems.
-
-The input is a qobj dictionary
-
-and the output is a Results object
-
-    results['data']["counts"] where this is dict {"0000" : 454}
+It simulates a qasm quantum circuit (an experiment) that has been compiled
+to run on the simulator. It is exponential in the number of qubits.
 
 The simulator is run using
 
 .. code-block:: python
+    QasmSimulatorPy().run(qobj)
 
-    QasmSimulatorPy(compiled_circuit,shots,seed).run().
-
-.. code-block:: guess
-
-       compiled_circuit =
-       {
-        "header": {
-        "number_of_qubits": 2, // int
-        "number_of_clbits": 2, // int
-        "qubit_labels": [["q", 0], ["v", 0]], // list[list[string, int]]
-        "clbit_labels": [["c", 2]], // list[list[string, int]]
-        }
-        "operations": // list[map]
-           [
-               {
-                   "name": , // required -- string
-                   "params": , // optional -- list[double]
-                   "qubits": , // required -- list[int]
-                   "clbits": , // optional -- list[int]
-                   "conditional":  // optional -- map
-                       {
-                           "type": , // string
-                           "mask": , // hex string
-                           "val":  , // bhex string
-                       }
-               },
-           ]
-       }
-
-.. code-block:: python
-
-       result =
-               {
-               'data': {
-                        'statevector': array([ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]),
-                        'classical_state': 0
-                        'counts': {'0000': 1}
-                        'snapshots': { '0': {'statevector': array([1.+0.j,  0.+0.j,
-                                                                     0.+0.j,  0.+0.j])}}
-                        }
-                   }
-               'time_taken': 0.002
-               'status': 'DONE'
-               }
-
+Where the input is a Qobj object and the output is a AerJob object, which can
+later be queried for the Result object. The result will contain a 'memory' data
+field, which is a result of measurements for each shot.
 """
 import random
 import uuid
 import time
 import logging
-from collections import Counter
 
 from math import log2
+from collections import Counter
 import numpy as np
+
 from qiskit._util import local_hardware_info
 from qiskit.backends.models import BackendConfiguration, BackendProperties
-from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
+from qiskit.result import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
 from ._simulatorerror import SimulatorError
-from ._simulatortools import index2, single_gate_matrix
+from ._simulatortools import single_gate_matrix, index2
+
 logger = logging.getLogger(__name__)
 
 
@@ -211,7 +164,7 @@ class QasmSimulatorPy(BaseBackend):
     def _add_qasm_reset(self, qubit):
         """Apply the reset to the qubit.
 
-        This is done by doing a measruement and if 0 do nothing and
+        This is done by doing a measurement and if 0 do nothing and
         if 1 flip the qubit.
 
         qubit is the qubit that is reset.
@@ -238,7 +191,8 @@ class QasmSimulatorPy(BaseBackend):
         """Snapshot instruction to record simulator's internal representation
         of quantum statevector.
 
-        slot is a string indicating a snapshot slot label.
+        Args:
+            slot (string): a label to identify the recorded snapshot.
         """
         self._snapshots.setdefault(str(slot),
                                    {}).setdefault("statevector",
@@ -248,7 +202,7 @@ class QasmSimulatorPy(BaseBackend):
         """Run qobj asynchronously.
 
         Args:
-            qobj (dict): job description
+            qobj (Qobj): payload of the experiment
 
         Returns:
             AerJob: derived from BaseJob
@@ -259,61 +213,70 @@ class QasmSimulatorPy(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
-        """Run circuits in qobj"""
+        """Run experiments in qobj
+
+        Args:
+            job_id (str): unique id for the job.
+            qobj (Qobj): job description
+
+        Returns:
+            Result: Result object
+        """
         self._validate(qobj)
         result_list = []
         self._shots = qobj.config.shots
         self._qobj_config = qobj.config
         start = time.time()
 
-        for circuit in qobj.experiments:
-            result_list.append(self.run_circuit(circuit))
+        for experiment in qobj.experiments:
+            result_list.append(self.run_experiment(experiment))
         end = time.time()
-        result = {'backend': self.name(),
-                  'id': qobj.qobj_id,
+        result = {'backend_name': self.name(),
+                  'backend_version': self._configuration.backend_version,
+                  'qobj_id': qobj.qobj_id,
                   'job_id': job_id,
-                  'result': result_list,
+                  'results': result_list,
                   'status': 'COMPLETED',
                   'success': True,
                   'time_taken': (end - start),
                   'header': qobj.header.as_dict()}
 
-        copy_qasm_from_qobj_into_result(qobj, result)
+        return Result.from_dict(result)
 
-        return result_from_old_style_dict(result)
-
-    def run_circuit(self, circuit):
-        """Run a circuit and return a single Result.
+    def run_experiment(self, experiment):
+        """Run an experiment (circuit) and return a single experiment result.
 
         Args:
-            circuit (QobjExperiment): experiment from qobj experiments list
+            experiment (QobjExperiment): experiment from qobj experiments list
 
         Returns:
-            dict: A dictionary of results which looks something like::
+             dict: A result dictionary which looks something like::
 
                 {
+                "name": name of this experiment (obtained from qobj.experiment header)
+                "seed": random seed used for simulation
+                "shots": number of shots used in the simulation
                 "data":
-                    {  #### DATA CAN BE A DIFFERENT DICTIONARY FOR EACH BACKEND ####
-                    "counts": {'00000': XXXX, '00001': XXXXX},
-                    "time"  : xx.xxxxxxxx
+                    {
+                    "memory": ['0x9', '0xF', '0x1D', ..., '0x9']
+                    "snapshots":
+                            {
+                            '1': [0.7, 0, 0, 0.7],
+                            '2': [0.5, 0.5, 0.5, 0.5]
+                            }
                     },
-                "status": --status (string)--
+                "status": status string for the simulation
+                "success": boolean
+                "time_taken": simulation time of this single experiment
                 }
         Raises:
             SimulatorError: if an error occurred.
         """
-        self._number_of_qubits = circuit.header.number_of_qubits
-        self._number_of_cbits = circuit.header.number_of_clbits
+        self._number_of_qubits = experiment.config.n_qubits
+        self._number_of_cbits = experiment.config.memory_slots
         self._statevector = 0
         self._classical_state = 0
         self._snapshots = {}
-        cl_reg_index = []  # starting bit index of classical register
-        cl_reg_nbits = []  # number of bits in classical register
-        cbit_index = 0
-        for cl_reg in circuit.header.clbit_labels:
-            cl_reg_nbits.append(cl_reg[1])
-            cl_reg_index.append(cbit_index)
-            cbit_index += cl_reg[1]
 
         # Get the seed looking in circuit, qobj, and then random.
         if hasattr(circuit, 'config') and hasattr(circuit.config, 'seed'):
@@ -331,7 +294,7 @@ class QasmSimulatorPy(BaseBackend):
                                          dtype=complex)
             self._statevector[0] = 1
             self._classical_state = 0
-            for operation in circuit.instructions:
+            for operation in experiment.instructions:
                 if getattr(operation, 'conditional', None):
                     mask = int(operation.conditional.mask, 16)
                     if mask > 0:
@@ -357,7 +320,7 @@ class QasmSimulatorPy(BaseBackend):
                 # Check if measure
                 elif operation.name == 'measure':
                     qubit = operation.qubits[0]
-                    cbit = operation.clbits[0]
+                    cbit = operation.memory[0]
                     self._add_qasm_measure(qubit, cbit)
                 # Check if reset
                 elif operation.name == 'reset':
@@ -375,23 +338,25 @@ class QasmSimulatorPy(BaseBackend):
                     err_msg = '{0} encountered unrecognized operation "{1}"'
                     raise SimulatorError(err_msg.format(backend,
                                                         operation.name))
-            # Turn classical_state (int) into bit string
-            outcomes.append(bin(self._classical_state)[2:].zfill(
-                self._number_of_cbits))
-        # Return the results
-        counts = dict(Counter(outcomes))
+            # Turn classical_state (int) into bit string and pad zero for unused cbits
+            outcome = bin(self._classical_state)[2:]
+            # Return a compact hexadecimal
+            outcomes.append(hex(int(outcome, 2)))
+
         data = {
-            'counts': self._format_result(counts, cl_reg_index, cl_reg_nbits),
+            'counts': dict(Counter(outcomes)),
+            'memory': outcomes,
             'snapshots': self._snapshots
         }
         end = time.time()
-        return {'name': circuit.header.name,
+        return {'name': experiment.header.name,
                 'seed': seed,
                 'shots': self._shots,
                 'data': data,
                 'status': 'DONE',
                 'success': True,
-                'time_taken': (end-start)}
+                'time_taken': (end-start),
+                'header': experiment.header.as_dict()}
 
     def _validate(self, qobj):
         for experiment in qobj.experiments:
@@ -400,26 +365,3 @@ class QasmSimulatorPy(BaseBackend):
                 logger.warning("no measurements in circuit '%s', "
                                "classical register will remain all zeros.",
                                experiment.header.name)
-
-    def _format_result(self, counts, cl_reg_index, cl_reg_nbits):
-        """Format the result bit string.
-
-        This formats the result bit strings such that spaces are inserted
-        at register divisions.
-
-        Args:
-            counts (dict): dictionary of counts e.g. {'1111': 1000, '0000':5}
-            cl_reg_index (list): starting bit index of classical register
-            cl_reg_nbits (list): total amount of bits in classical register
-        Returns:
-            dict: spaces inserted into dictionary keys at register boundaries.
-        """
-        fcounts = {}
-        for key, value in counts.items():
-            if cl_reg_nbits:
-                new_key = [key[-cl_reg_nbits[0]:]]
-                for index, nbits in zip(cl_reg_index[1:],
-                                        cl_reg_nbits[1:]):
-                    new_key.insert(0, key[-(index+nbits):-index])
-                fcounts[' '.join(new_key)] = value
-        return fcounts

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -275,7 +275,8 @@ class QasmSimulatorPy(BaseBackend):
                   'result': result_list,
                   'status': 'COMPLETED',
                   'success': True,
-                  'time_taken': (end - start)}
+                  'time_taken': (end - start),
+                  'header': qobj.header.as_dict()}
 
         copy_qasm_from_qobj_into_result(qobj, result)
 

--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -14,6 +14,7 @@ Interface to C++ quantum circuit simulator with realistic noise.
 import logging
 import uuid
 from math import log2
+from numpy import array
 from qiskit._util import local_hardware_info
 from qiskit.backends.models import BackendConfiguration, BackendProperties
 from qiskit.qobj import QobjInstruction
@@ -95,6 +96,7 @@ class StatevectorSimulator(QasmSimulator):
                 final_state_key = str(final_state_key)
             # Pop off final snapshot added above
             final_state = snapshots['statevector'].pop(final_state_key)[0]
+            final_state = array([v[0] + 1j * v[1] for v in final_state], dtype=complex)
             # Add final state to results data
             experiment_result.data.statevector = final_state
             # Remove snapshot dict if empty

--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -91,11 +91,10 @@ class StatevectorSimulator(QasmSimulator):
         # Extract final state snapshot and move to 'statevector' data field
         for experiment_result in result.results:
             snapshots = experiment_result.data.snapshots.to_dict()
-            if str(final_state_key) in snapshots:
+            if str(final_state_key) in snapshots['statevector']:
                 final_state_key = str(final_state_key)
             # Pop off final snapshot added above
-            final_state = snapshots.pop(final_state_key, None)
-            final_state = final_state['statevector'][0]
+            final_state = snapshots['statevector'].pop(final_state_key)[0]
             # Add final state to results data
             experiment_result.data.statevector = final_state
             # Remove snapshot dict if empty

--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -68,7 +68,7 @@ class StatevectorSimulator(QasmSimulator):
         return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
-        """Run a qobj on the the backend."""
+        """Run a qobj on the backend."""
         job_id = str(uuid.uuid4())
         aer_job = AerJob(self, job_id, self._run_job, qobj)
         aer_job.submit()

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -220,7 +220,8 @@ class UnitarySimulatorPy(BaseBackend):
                   'result': result_list,
                   'status': 'COMPLETED',
                   'success': True,
-                  'time_taken': (end - start)}
+                  'time_taken': (end - start),
+                  'header': qobj.header.as_dict()}
         copy_qasm_from_qobj_into_result(qobj, result)
 
         return result_from_old_style_dict(result)

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -254,8 +254,8 @@ class UnitarySimulatorPy(BaseBackend):
                 logger.info("unitary simulator only supports 1 shot. "
                             "Setting shots=1 for circuit %s.", experiment.name)
                 experiment.config.shots = 1
-            for op in experiment.instructions:
-                if op.name in ['measure', 'reset']:
+            for operation in experiment.instructions:
+                if operation.name in ['measure', 'reset']:
                     raise SimulatorError(
                         "In circuit {}: unitary simulator does not support "
                         "measure or reset.".format(experiment.header.name))

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -10,75 +10,14 @@
 It simulates a unitary of a quantum circuit that has been compiled to run on
 the simulator. It is exponential in the number of qubits.
 
-The input is the circuit object and the output is the same circuit object with
-a result field added results['data']['unitary'] where the unitary is
-a 2**n x 2**n complex numpy array representing the unitary matrix.
+.. code-block:: python
 
+    UnitarySimulator().run(qobj)
 
-The input is
-
-    compiled_circuit object
-
-and the output is the results object
-
-The simulator is run using
-
-    UnitarySimulatorPy(compiled_circuit).run().
-
-In the qasm, key operations with type 'measure' and 'reset' are dropped.
-
-Internal circuit_object::
-
-    compiled_circuit =
-    {
-     "header": {
-     "number_of_qubits": 2, // int
-     "number_of_clbits": 2, // int
-     "qubit_labels": [["q", 0], ["v", 0]], // list[list[string, int]]
-     "clbit_labels": [["c", 2]], // list[list[string, int]]
-     }
-     "operations": // list[map]
-        [
-            {
-                "name": , // required -- string
-                "params": , // optional -- list[double]
-                "qubits": , // required -- list[int]
-                "clbits": , //optional -- list[int]
-                "conditional":  // optional -- map
-                    {
-                        "type": , // string
-                        "mask": , // hex string
-                        "val":  , // bhex string
-                    }
-            },
-        ]
-    }
-
-returned results object::
-
-    result =
-            {
-            'data':
-                {
-                'unitary': np.array([[ 0.70710678 +0.00000000e+00j
-                                     0.70710678 -8.65956056e-17j
-                                     0.00000000 +0.00000000e+00j
-                                     0.00000000 +0.00000000e+00j]
-                                   [ 0.00000000 +0.00000000e+00j
-                                     0.00000000 +0.00000000e+00j
-                                     0.70710678 +0.00000000e+00j
-                                     -0.70710678 +8.65956056e-17j]
-                                   [ 0.00000000 +0.00000000e+00j
-                                     0.00000000 +0.00000000e+00j
-                                     0.70710678 +0.00000000e+00j
-                                     0.70710678 -8.65956056e-17j]
-                                   [ 0.70710678 +0.00000000e+00j
-                                    -0.70710678 +8.65956056e-17j
-                                     0.00000000 +0.00000000e+00j
-                                     0.00000000 +0.00000000e+00j]
-                }
-            'state': 'DONE'
-            }
+Where the input is a Qobj object and the output is a AerJob object, which can
+later be queried for the Result object. The result will contain a 'unitary'
+data field, which is a 2**n x 2**n complex numpy array representing the
+circuit's unitary matrix.
 """
 import logging
 import uuid
@@ -87,10 +26,10 @@ from math import log2, sqrt
 import numpy as np
 from qiskit._util import local_hardware_info
 from qiskit.backends.models import BackendConfiguration, BackendProperties
-from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
-from qiskit import QiskitError
+from qiskit.result import Result
+from ._simulatorerror import SimulatorError
 from ._simulatortools import single_gate_matrix, einsum_matmul_index
 
 logger = logging.getLogger(__name__)
@@ -201,51 +140,70 @@ class UnitarySimulatorPy(BaseBackend):
         return aer_job
 
     def _run_job(self, job_id, qobj):
-        """Run qobj. This is a blocking call.
+        """Run experiments in qobj.
 
         Args:
             job_id (str): unique id for the job.
             qobj (Qobj): job description
+
         Returns:
             Result: Result object
         """
+        self._validate(qobj)
         result_list = []
         start = time.time()
-        for circuit in qobj.experiments:
-            result_list.append(self.run_circuit(circuit))
+        for experiment in qobj.experiments:
+            result_list.append(self.run_experiment(experiment))
         end = time.time()
-        result = {'backend': self.name(),
-                  'id': qobj.qobj_id,
+        result = {'backend_name': self.name(),
+                  'backend_version': self._configuration.backend_version,
+                  'qobj_id': qobj.qobj_id,
                   'job_id': job_id,
-                  'result': result_list,
+                  'results': result_list,
                   'status': 'COMPLETED',
                   'success': True,
                   'time_taken': (end - start),
                   'header': qobj.header.as_dict()}
-        copy_qasm_from_qobj_into_result(qobj, result)
 
-        return result_from_old_style_dict(result)
+        return Result.from_dict(result)
 
-    def run_circuit(self, circuit):
-        """Apply the single-qubit gate.
+    def run_experiment(self, experiment):
+        """Run an experiment (circuit) and return a single experiment result.
 
         Args:
-            circuit (QobjExperiment): experiment from qobj experiments list
+            experiment (QobjExperiment): experiment from qobj experiments list
 
         Returns:
             dict: A dictionary of results.
+            dict: A result dictionary which looks something like::
+                {
+                "name": name of this experiment (obtained from qobj.experiment header)
+                "seed": random seed used for simulation
+                "shots": number of shots used in the simulation
+                "data":
+                    {
+                    "unitary": [[0.2, 0.6, j+0.1, 0.2j],
+                                [0, 0.9+j, 0.5, 0.7],
+                                [-j, -0.1, -3.14, 0],
+                                [0, 0, 0.5j, j-0.5]]
+                    },
+                "status": status string for the simulation
+                "success": boolean
+                "time taken": simulation time of this single experiment
+                }
 
         Raises:
-            QiskitError: if the number of qubits in the circuit is greater than 24.
+            SimulatorError: if the number of qubits in the circuit is greater than 24.
             Note that the practical qubit limit is much lower than 24.
         """
-        self._number_of_qubits = circuit.header.number_of_qubits
+        self._number_of_qubits = experiment.header.n_qubits
         if self._number_of_qubits > 24:
-            raise QiskitError("np.einsum implementation limits unitary_simulator_py" +
-                              " to 24 qubit circuits.")
+            raise SimulatorError("np.einsum implementation limits unitary_simulator_py" +
+                                 " to 24 qubit circuits.")
         result = {
             'data': {},
-            'name': circuit.header.name
+            'name': experiment.header.name,
+            'header': experiment.header.as_dict()
         }
 
         # Initialize unitary as rank 2*N tensor
@@ -253,7 +211,7 @@ class UnitarySimulatorPy(BaseBackend):
                                                 dtype=complex),
                                          self._number_of_qubits * [2, 2])
 
-        for operation in circuit.instructions:
+        for operation in experiment.instructions:
             if operation.name in ('U', 'u1', 'u2', 'u3'):
                 params = getattr(operation, 'params', None)
                 qubit = operation.qubits[0]
@@ -267,12 +225,6 @@ class UnitarySimulatorPy(BaseBackend):
                 gate = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0],
                                  [0, 1, 0, 0]])
                 self._add_unitary_two(gate, qubit0, qubit1)
-            elif operation.name == 'measure':
-                logger.info('Warning have dropped measure from unitary '
-                            'simulator')
-            elif operation.name == 'reset':
-                logger.info('Warning have dropped reset from unitary '
-                            'simulator')
             elif operation.name == 'barrier':
                 pass
             else:
@@ -286,3 +238,24 @@ class UnitarySimulatorPy(BaseBackend):
         result['success'] = True
         result['shots'] = 1
         return result
+
+    def _validate(self, qobj):
+        """Semantic validations of the qobj which cannot be done via schemas.
+        Some of these may later move to backend schemas.
+        1. No shots
+        2. No measurements in the middle
+        """
+        if qobj.config.shots != 1:
+            logger.info("unitary simulator only supports 1 shot. "
+                        "Setting shots=1.")
+            qobj.config.shots = 1
+        for experiment in qobj.experiments:
+            if getattr(experiment.config, 'shots', 1) != 1:
+                logger.info("unitary simulator only supports 1 shot. "
+                            "Setting shots=1 for circuit %s.", experiment.name)
+                experiment.config.shots = 1
+            for op in experiment.instructions:
+                if op.name in ['measure', 'reset']:
+                    raise SimulatorError(
+                        "In circuit {}: unitary simulator does not support "
+                        "measure or reset.".format(experiment.header.name))

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -527,7 +527,8 @@ class IBMQJobPreQobj(IBMQJob):
             'used_credits': job_response.get('usedCredits'),
             'result': experiment_results,
             'backend_name': self.backend().name(),
-            'success': job_response['status'] == 'COMPLETED'
+            'success': job_response['status'] == 'COMPLETED',
+            'header': self._qobj_payload.get('header', {})
         })
 
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -503,7 +503,9 @@ class IBMQJobPreQobj(IBMQJob):
 
     def _result_from_job_response(self, job_response):
         if self._is_device:
-            _reorder_bits(job_response)
+            # TODO: temporarily disabled for #1373, reenable before 0.7.
+            # _reorder_bits(job_response)
+            pass
 
         experiment_results = []
         for circuit_result in job_response['qasms']:

--- a/qiskit/qobj/_qobj.py
+++ b/qiskit/qobj/_qobj.py
@@ -62,6 +62,8 @@ class QobjItem(SimpleNamespace):
             return float(obj.evalf())
         if isinstance(obj, numpy.ndarray):
             return obj.tolist()
+        if isinstance(obj, complex):
+            return [obj.real, obj.imag]
         return obj
 
     @classmethod

--- a/qiskit/result/_utils.py
+++ b/qiskit/result/_utils.py
@@ -75,7 +75,7 @@ def copy_qasm_from_qobj_into_result(qobj_, result):
 
 
 def _find_experiment_result(result, name):
-    for experiment_result in result['result']:
+    for experiment_result in result['results']:
         if experiment_result['name'] == name:
             return experiment_result
 

--- a/qiskit/result/_utils.py
+++ b/qiskit/result/_utils.py
@@ -52,28 +52,6 @@ def result_from_old_style_dict(result_dict):
     return Result.from_dict(result_dict)
 
 
-def copy_qasm_from_qobj_into_result(qobj_, result):
-    """Copy QASMs belonging to the Qobj experiment into a Result.
-
-    Find the QASMs belonging to the Qobj experiments and copy them
-    into the corresponding result entries.
-
-    Args:
-        qobj_ (qobj): Qobj
-        result (qiskit.Result): Result (modified in-place).
-    """
-    for experiment in qobj_.experiments:
-        name = experiment.header.name
-        qasm = getattr(experiment.header, 'compiled_circuit_qasm', None)
-        experiment_result = _find_experiment_result(result, name)
-        if qasm and experiment_result:
-            experiment_result['compiled_circuit_qasm'] = qasm
-
-        # TODO: passing the header to the results should be done at a higher
-        # level. This ensures result[x].header.name is present, for results.
-        experiment_result['header'] = experiment.header.as_dict()
-
-
 def _find_experiment_result(result, name):
     for experiment_result in result['results']:
         if experiment_result['name'] == name:

--- a/qiskit/schemas/examples/qobj_openqasm_example.json
+++ b/qiskit/schemas/examples/qobj_openqasm_example.json
@@ -7,14 +7,14 @@
         "backend_name": "ibmqx2"},
     "config": {
         "shots": 1024,
-        "memory_slots": 3
+        "memory_slots": 1
         },
     "experiments": [
         {
         "header": {
-            "memory_slots": 3,
+            "memory_slots": 1,
             "n_qubits": 3,
-            "clbit_labels": [["c1", 0],null,null],
+            "clbit_labels": [["c1", 0]],
             "qubit_labels": [null,["q", 0],["q",1]]
             },
         "config": {},
@@ -33,7 +33,7 @@
         "header": {
             "memory_slots": 3,
             "n_qubits": 3,
-            "clbit_labels": [["c1", 0],null,null],
+            "clbit_labels": [["c1", 0]],
             "qubit_labels": [null,["q", 0],["q",1]]
             },
         "config": {},

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -714,7 +714,7 @@
                         },
                         "memory_slots": {
                             "description": "Total number of (slow) measurement slots used in this experiment.",
-                            "minimum": 1,
+                            "minimum": 0,
                             "type": "integer"
                         },                        
                         "n_qubits": {

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -745,7 +745,7 @@
                                     "array"
                                 ]
                             },
-                            "minItems": 1,
+                            "minItems": 0,
                             "title": "List of quantum registers and their sizes.",
                             "type": "array"
                         },
@@ -777,7 +777,7 @@
                             "type": "array"
                         },
                         "qubit_labels": {
-                            "description": "A list of length n_qubits (from backend.configuration or in this header), where each element is either [qreg_name, n] to identify the corresponding physical qubit as the n-th qubit of qreg qreg_name, or null to identify that the corresponding physical qubit has no corresponding qreg",
+                            "description": "A list of length total physical qubits (from backend.configuration), where each element is either [qreg_name, n] to identify the corresponding physical qubit as the n-th qubit of qreg qreg_name, or null to identify that the corresponding physical qubit has no corresponding qreg",
                             "items": {
                                 "items": [
                                     {

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -251,15 +251,15 @@
         },
         "openqasm_instructions": {
             "oneOf": [
-                { 
+                {
                     "properties": {
                         "name": {"not": {
-                            "enum": ["u3", "U", "id", "h", "s", "sdg", "t", "tdg", "x", "y", "z", 
-                            "u1", "u0", "rx", "ry", "rz", "u2", "cx", "CX", "cy", "cz", "ch", 
-                            "swap", "cu1", "crz", "rzz", "cu3", "ccx", "cswap", "snapshot", 
+                            "enum": ["u3", "U", "id", "h", "s", "sdg", "t", "tdg", "x", "y", "z",
+                            "u1", "u0", "rx", "ry", "rz", "u2", "cx", "CX", "cy", "cz", "ch",
+                            "swap", "cu1", "crz", "rzz", "cu3", "ccx", "cswap", "snapshot",
                             "reset", "barrier", "bfunc", "copy", "measure"]
                             },
-                            "type": "string"                            
+                            "type": "string"
                             }
                     }
                 },
@@ -690,7 +690,18 @@
             "properties": {
                 "config": {
                     "description": "Configuration options that apply to specific experiments in this qobj. Overwrites qobj level configuration.",
-                    "properties": {},
+                    "properties": {
+                        "memory_slots": {
+                            "description": "Total number of (slow) measurement slots used in this experiment.",
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "n_qubits": {
+                            "description": "Total number of qubits used in this experiment.",
+                            "minimum": 1,
+                            "type": "integer"
+                        }                        
+                    },
                     "title": "Experiment level configuration",
                     "type": "object"
                 },
@@ -701,41 +712,68 @@
                             "description": "Experiment name.",
                             "type": "string"
                         },
-                        "n_qubits": {
-                            "description": "Number of backend qubits for converting back to OpenQasm registers",
-                            "type": "number"
-                        },
                         "memory_slots": {
-                            "description": "Number of backend memory slots",
-                            "type": "number"
+                            "description": "Total number of (slow) measurement slots used in this experiment.",
+                            "minimum": 1,
+                            "type": "integer"
+                        },                        
+                        "n_qubits": {
+                            "description": "Total number of qubits used in this experiment.",
+                            "minimum": 1,                            
+                            "type": "integer"
                         },
-                        "clbit_labels": {
-                            "description": "A list of length memory_slots (from backend.configuration or in this header), where each element is either [creg_name, n] to identify the corresponding memory slot as the n-th element of creg creg_name, or null to identify that the corresponding memory slot has no corresponding creg",
-                            "items": [
-                                {
-                                    "items": [
-                                        {
-                                            "minLength": 1,
-                                            "title": "clreg",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "description": "The register slot of the clreg",
-                                            "minimum": 0,
-                                            "title": "size",
-                                            "type": "integer"
-                                        }
-                                    ],
-                                    "maxItems": 2,
-                                    "minItems": 2,
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ]
-                                }
-                            ],
+                        "qreg_sizes": {
+                            "description": "A list of [qreg_name, size], to identify the QASM quantum registers and their size, where the most significant register appears first, and the least significant register last.",
+                            "items":
+                            {
+                                "items": [
+                                    {
+                                        "minLength": 1,
+                                        "title": "qreg",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "size of corresponding quantum register",
+                                        "minimum": 1,
+                                        "title": "qreg size",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": [
+                                    "array"
+                                ]
+                            },
+                            "minItems": 1,
+                            "title": "List of quantum registers and their sizes.",
+                            "type": "array"
+                        },
+                        "creg_sizes": {
+                            "description": "A list of [creg_name, size], to identify the QASM classical registers and their size, where the most significant register appears first, and the least significant register last.",
+                            "items":
+                            {
+                                "items": [
+                                    {
+                                        "minLength": 1,
+                                        "title": "creg",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "size of corresponding classical register",
+                                        "minimum": 1,
+                                        "title": "creg size",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": [
+                                    "array"
+                                ]
+                            },
                             "minItems": 0,
-                            "title": "Map physical clbits to register_slots (for QASM)",
+                            "title": "List of classical registers and their sizes.",
                             "type": "array"
                         },
                         "qubit_labels": {
@@ -748,9 +786,9 @@
                                         "type": "string"
                                     },
                                     {
-                                        "description": "The qubit number within the qreg",
+                                        "description": "The qubit index within the qreg",
                                         "minimum": 0,
-                                        "title": "qubit number",
+                                        "title": "qubit index",
                                         "type": "integer"
                                     }
                                 ],
@@ -761,12 +799,44 @@
                                     "null"
                                 ]
                             },
-                            "minItems": 0,
+                            "minItems": 1,
                             "title": "Map physical qubits to qregs (for QASM)",
+                            "type": "array"
+                        },
+                        "clbit_labels": {
+                            "description": "A list of length memory_slots, where each element is [creg_name, n] to identify the corresponding memory slot as the n-th element of creg creg_name.",
+                            "items": [
+                                {
+                                    "items": [
+                                        {
+                                            "minLength": 1,
+                                            "title": "creg",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "description": "The clbit index within creg",
+                                            "minimum": 0,
+                                            "title": "clbit index",
+                                            "type": "integer"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": [
+                                        "array"
+                                    ]
+                                }
+                            ],
+                            "minItems": 0,
+                            "title": "Map physical clbits to register_slots (for QASM)",
                             "type": "array"
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "_constraints": [
+                        "sum(x[1] for x in qreg_sizes) == n_qubits",
+                        "sum(x[1] for x in creg_sizes) == memory_slots"
+                    ]
                 },
                 "instructions": {
                     "description": "List of experiment instructions.",
@@ -798,10 +868,15 @@
                             "type": "integer"
                         },
                         "memory_slots": {
-                            "description": "The number of measurement slots in the classical memory on the backend.",
+                            "description": "The number of (slow) measurement slots requested on the backend, equivalent to the max of memory_slot requested by individual experiments.",
                             "minimum": 0,
                             "type": "integer"
                         },
+                        "n_qubits": {
+                            "description": "The number of qubits requested on the backend, equivalent to the max of n_qubits requested by individual experiments.",
+                            "minimum": 1,
+                            "type": "integer"
+                        },                        
                         "seed": {
                             "default": 1,
                             "type": "integer"
@@ -810,11 +885,10 @@
                             "description": "Number of repetitions of each experiment",
                             "minimum": 1,
                             "type": "integer"
-                        }
+                        }                        
                     },
                     "required": [
-                        "shots",
-                        "memory_slots"
+                        "shots"
                     ],
                     "title": "Qobj-level configuration",
                     "type": "object"

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -745,7 +745,7 @@
                                     "array"
                                 ]
                             },
-                            "minItems": 0,
+                            "minItems": 1,
                             "title": "List of quantum registers and their sizes.",
                             "type": "array"
                         },

--- a/qiskit/tools/_compiler.py
+++ b/qiskit/tools/_compiler.py
@@ -90,11 +90,6 @@ def circuits_to_qobj(circuits, backend_name, config=None, shots=1024,
     # Step 1: create the Qobj, with empty experiments.
     # Copy the configuration: the values in `config` have preference
     qobj_config = deepcopy(config or {})
-    # TODO: "memory_slots" is required by the qobj schema in the top-level
-    # qobj.config, and is user-defined. At the moment is set to the maximum
-    # number of *register* slots for the circuits, in order to have `measure`
-    # behave properly until the transition is over; and each circuit stores
-    # its memory_slots in its configuration.
     qobj_config.update({'shots': shots,
                         'max_credits': max_credits,
                         'memory_slots': 0})
@@ -115,14 +110,10 @@ def circuits_to_qobj(circuits, backend_name, config=None, shots=1024,
                                                        basis_gates,
                                                        coupling_map))
 
-    # Update the `memory_slots` value.
-    # TODO: remove when `memory_slots` can be provided by the user.
+    # Update the global `memory_slots` and `n_qubits` values.
     qobj.config.memory_slots = max(experiment.config.memory_slots for
                                    experiment in qobj.experiments)
 
-    # Update the `n_qubits` global value.
-    # TODO: num_qubits is not part of the qobj specification, but needed
-    # for the simulator.
     qobj.config.n_qubits = max(experiment.config.n_qubits for
                                experiment in qobj.experiments)
 
@@ -148,15 +139,9 @@ def _circuit_to_experiment(circuit, config=None, basis_gates=None,
     experiment = QobjExperiment.from_dict(json_circuit)
     # Step 3b: populate the Experiment configuration and header
     experiment.header.name = circuit.name
-    # TODO: place in header or config?
     experiment_config = deepcopy(config or {})
     experiment_config.update({
-        'coupling_map': coupling_map,
-        'basis_gates': basis_gates,
-        'layout': [[[i[0][0].name, i[0][1]], [i[1][0].name, i[1][1]]]
-                   for i in dag.layout] if dag.layout else [],
         'memory_slots': sum([creg.size for creg in dag.cregs.values()]),
-        # TODO: `n_qubits` is not part of the qobj spec, but needed for the simulator.
         'n_qubits': sum([qreg.size for qreg in dag.qregs.values()])
         })
     experiment.config = QobjItem(**experiment_config)

--- a/qiskit/tools/_compiler.py
+++ b/qiskit/tools/_compiler.py
@@ -47,7 +47,6 @@ def compile(circuits, backend,
 
     Raises:
         TranspilerError: in case of bad compile options, e.g. the hpc options.
-
     """
     pass_manager = None  # default pass manager which executes predetermined passes
     if skip_transpiler:  # empty pass manager which does nothing
@@ -133,6 +132,9 @@ def _circuit_to_experiment(circuit, config=None, basis_gates=None,
     Returns:
         Qobj: Qobj to be run on the backends
     """
+    # pylint: disable=unused-argument
+    #  TODO: if arguments are really unused, consider changing the signature
+
     dag = DAGCircuit.fromQuantumCircuit(circuit)
     json_circuit = DagUnroller(dag, JsonBackend(dag.basis)).execute()
     # Step 3a: create the Experiment based on json_circuit

--- a/qiskit/unrollers/_jsonbackend.py
+++ b/qiskit/unrollers/_jsonbackend.py
@@ -104,6 +104,9 @@ class JsonBackend(UnrollerBackend):
 
         qreg = QuantumRegister object
         """
+        self._qreg_sizes.append([qreg.name, qreg.size])
+
+        # order qubits from lower to higher index. backends will do little endian.
         for j in range(qreg.size):
             self._qubit_order.append([qreg.name, j])
             self._qubit_order_internal[(qreg.name, j)] = self._number_of_qubits + j
@@ -127,6 +130,7 @@ class JsonBackend(UnrollerBackend):
         # TODO: avoid rewriting the same data over and over
         self.circuit['header']['memory_slots'] = self._number_of_clbits
         self.circuit['header']['creg_sizes'] = self._creg_sizes
+        self.circuit['header']['clbit_labels'] = self._cbit_order
 
     def define_gate(self, name, gatedata):
         """Define a new quantum gate.

--- a/qiskit/unrollers/_jsonbackend.py
+++ b/qiskit/unrollers/_jsonbackend.py
@@ -12,11 +12,13 @@
 The input is a AST and a basis set and returns a json memory object::
 
     {
-     "header": {
-     "number_of_qubits": 2, // int
-     "number_of_clbits": 2, // int
-     "qubit_labels": [["q", 0], ["v", 0]], // list[list[string, int]]
-     "clbit_labels": [["c", 2]], // list[list[string, int]]
+      "header": {
+        "n_qubits": 2, // int
+        "memory_slots": 2, // int
+        "qubit_labels": [["q", 0], ["q", 1], null], // list[list[string, int] or null]
+        "clbit_labels": [["c", 0], ["c", 1]], // list[list[string, int]]
+        "qreg_sizes": [["q", 1], ["v", 1]], // list[list[string, int]]
+        "creg_sizes": [["c", 2]]  // list[list[string, int]]
      }
      "instructions": // list[map]
         [
@@ -56,13 +58,17 @@ class JsonBackend(UnrollerBackend):
         self.circuit = {}
         self.circuit['instructions'] = []
         self.circuit['header'] = {
-            'number_of_qubits': 0,
-            'number_of_clbits': 0,
+            'n_qubits': 0,
+            'memory_slots': 0,
             'qubit_labels': [],
-            'clbit_labels': []
+            'clbit_labels': [],
+            'qreg_sizes': [],
+            'creg_sizes': []
         }
         self._number_of_qubits = 0
-        self._number_of_cbits = 0
+        self._number_of_clbits = 0
+        self._qreg_sizes = []
+        self._creg_sizes = []
         self._qubit_order = []
         self._cbit_order = []
         self._qubit_order_internal = OrderedDict()
@@ -102,7 +108,9 @@ class JsonBackend(UnrollerBackend):
             self._qubit_order.append([qreg.name, j])
             self._qubit_order_internal[(qreg.name, j)] = self._number_of_qubits + j
         self._number_of_qubits += qreg.size
-        self.circuit['header']['number_of_qubits'] = self._number_of_qubits
+        # TODO: avoid rewriting the same data over and over
+        self.circuit['header']['n_qubits'] = self._number_of_qubits
+        self.circuit['header']['qreg_sizes'] = self._qreg_sizes
         self.circuit['header']['qubit_labels'] = self._qubit_order
 
     def new_creg(self, creg):
@@ -110,12 +118,15 @@ class JsonBackend(UnrollerBackend):
 
         creg = ClassicalRegister object
         """
-        self._cbit_order.append([creg.name, creg.size])
+        self._creg_sizes.append([creg.name, creg.size])
+        # order clbits from lower to higher index. backends will do little endian.
         for j in range(creg.size):
-            self._cbit_order_internal[(creg.name, j)] = self._number_of_cbits + j
-        self._number_of_cbits += creg.size
-        self.circuit['header']['number_of_clbits'] = self._number_of_cbits
-        self.circuit['header']['clbit_labels'] = self._cbit_order
+            self._cbit_order.append([creg.name, j])
+            self._cbit_order_internal[(creg.name, j)] = self._number_of_clbits + j
+        self._number_of_clbits += creg.size
+        # TODO: avoid rewriting the same data over and over
+        self.circuit['header']['memory_slots'] = self._number_of_clbits
+        self.circuit['header']['creg_sizes'] = self._creg_sizes
 
     def define_gate(self, name, gatedata):
         """Define a new quantum gate.
@@ -190,8 +201,7 @@ class JsonBackend(UnrollerBackend):
                 'params': list(map(lambda x: x.evalf(), op.param)),
                 'texparams': list(map(sympy.latex, op.param)),
                 'qubits': qubit_indices,
-                'clbits': clbit_indices,
-                'memory': clbit_indices.copy()
+                'memory': clbit_indices
             }
             if extra_fields is not None:
                 gate_instruction.update(extra_fields)

--- a/src/qasm-simulator-cpp/src/engines/base_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/base_engine.hpp
@@ -49,7 +49,7 @@ public:
   //============================================================================
 
   // Counts formatting
-  
+
   bool counts_show = true;       // Dislay the map of final creg bitstrings
   bool hex_counts = true;        // Return counts as hexadecimal strings
   bool counts_sort = true;       // Sort the map of bitstrings by occurrence
@@ -259,18 +259,20 @@ template <typename StateType>
 inline void from_json(const json_t &js, BaseEngine<StateType> &engine) {
   engine = BaseEngine<StateType>();
   std::vector<std::string> opts;
-  for (auto &o : js) {
-    to_lowercase(o);
-    string_trim(o);
-    // check options
-    if (o == "memory") {
-      engine.show_final_creg = true;
-    } else if (o == "bitstringcounts") {
-      engine.hex_counts = false;
-    } else if (o == "nosort") {
-      engine.counts_sort = false;
-    } else if (o == "hidesnapshots" || o == "hidesnapshots") {
+  if (JSON::get_value(opts, "data", js)) {
+    for (auto &o : opts) {
+      to_lowercase(o);
+      string_trim(o);
+      // check options
+      if (o == "memory") {
+        engine.show_final_creg = true;
+      } else if (o == "bitstringcounts") {
+        engine.hex_counts = false;
+      } else if (o == "nosort") {
+        engine.counts_sort = false;
+      } else if (o == "hidesnapshots" || o == "hidesnapshots") {
       engine.show_snapshots = false;
+      }
     }
   }
 

--- a/src/qasm-simulator-cpp/src/engines/base_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/base_engine.hpp
@@ -49,10 +49,10 @@ public:
   //============================================================================
 
   // Counts formatting
-  bool counts_show = true;     // Dislay the map of final creg bitstrings
-  bool counts_sort = true;     // Sort the map of bitstrings by occurrence
-  bool counts_space = true;    // Insert a space between named QISKIT cregs
-  bool counts_bits_h2l = true; // Display bitstring with least sig to right
+  
+  bool counts_show = true;       // Dislay the map of final creg bitstrings
+  bool hex_counts = true;        // Return counts as hexadecimal strings
+  bool counts_sort = true;       // Sort the map of bitstrings by occurrence
 
   // Return list of final bitstrings for all shots
   bool show_final_creg = false; // Display a list of all observed outcomes
@@ -130,7 +130,7 @@ public:
    */
   virtual void compute_results(const Circuit &circ, BaseBackend<StateType> *be);
 
-  void compute_counts(const reglist clbit_labels, const creg_t &creg);
+  void compute_counts(const creg_t &creg);
 };
 
 /*******************************************************************************
@@ -169,7 +169,7 @@ template <typename StateType>
 void BaseEngine<StateType>::compute_results(const Circuit &qasm,
                                             BaseBackend<StateType> *be) {
   // Compute counts
-  compute_counts(qasm.clbit_labels, be->access_creg());
+  compute_counts(be->access_creg());
 
   // Snapshots
   if (show_snapshots && be->access_snapshots().empty() == false) {
@@ -180,27 +180,20 @@ void BaseEngine<StateType>::compute_results(const Circuit &qasm,
 }
 
 template <typename StateType>
-void BaseEngine<StateType>::compute_counts(const reglist clbit_labels,
-                                           const creg_t &creg) {
+void BaseEngine<StateType>::compute_counts(const creg_t &creg) {
   if (counts_show || show_final_creg) {
+
+    // Convert reg to string
+    // Note reg is in order [c0, c1, c2]
+    // but bitstring is in order: c2c1c0
     std::string shotstr;
-    uint_t shift = 0;
-
-    for (const auto &reg : clbit_labels) {
-      uint_t sz = reg.second;
-      for (uint_t j = 0; j < sz; j++) {
-        shotstr += std::to_string(creg[shift + j]);
-      }
-      shift += sz;
-      if (counts_space)
-        shotstr += " "; // opt whitespace between named cregs
+    for (auto it = creg.crbegin(); it != creg.crend(); ++it) {
+      shotstr += std::to_string(*it);
     }
-    if (shotstr.empty() == false && counts_space)
-      shotstr.pop_back(); // remove last whitespace char
 
-    // reverse shot string to least significant bit to the right
-    if (counts_bits_h2l == true)
-      std::reverse(shotstr.begin(), shotstr.end());
+    // Convert to hexadecimal
+    if (hex_counts)
+      shotstr = bin2hex(shotstr, true);
 
     // add shot to shot map
     if (counts_show && shotstr.empty() == false)
@@ -247,18 +240,17 @@ inline void to_json(json_t &js, const BaseEngine<StateType> &engine) {
     js["counts"] = engine.counts;
 
   if (engine.show_final_creg && engine.output_creg.empty() == false)
-    js["classical_state"] = engine.output_creg;
+    js["memory"] = engine.output_creg;
 
   if (engine.show_snapshots && engine.snapshots.empty() == false) {
-
     try {
       // use try incase state class doesn't have json conversion method
       for (const auto& pair: engine.snapshots)
-        js["snapshots"][pair.first]["statevector"] = pair.second;
+        js["snapshots"]["statevector"][pair.first] = pair.second;
     } catch (std::exception &e) {
       // Leave message in output that type conversion failed
-      js["statevector"] =
-          "Error: Failed to convert state type to JSON";
+      js["snapshots"]["statevector"] =
+        "Error: Failed to convert state type to JSON";
     }
   }
 }
@@ -267,23 +259,18 @@ template <typename StateType>
 inline void from_json(const json_t &js, BaseEngine<StateType> &engine) {
   engine = BaseEngine<StateType>();
   std::vector<std::string> opts;
-  if (JSON::get_value(opts, "data", js)) {
-    for (auto &o : opts) {
-      to_lowercase(o);
-      string_trim(o);
-      // check options
-      if (o == "hidecounts")
-        engine.counts_show = false;
-      else if (o == "nospace")
-        engine.counts_space = false;
-      else if (o == "nosort")
-        engine.counts_sort = false;
-      else if (o == "reverse")
-        engine.counts_bits_h2l = false;
-      else if (o == "classicalstate" || o == "classicalstates")
-        engine.show_final_creg = true;
-      else if (o == "hidesnapshots" || o == "hidesnapshots")
-        engine.show_snapshots = false;
+  for (auto &o : js) {
+    to_lowercase(o);
+    string_trim(o);
+    // check options
+    if (o == "memory") {
+      engine.show_final_creg = true;
+    } else if (o == "bitstringcounts") {
+      engine.hex_counts = false;
+    } else if (o == "nosort") {
+      engine.counts_sort = false;
+    } else if (o == "hidesnapshots" || o == "hidesnapshots") {
+      engine.show_snapshots = false;
     }
   }
 

--- a/src/qasm-simulator-cpp/src/engines/base_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/base_engine.hpp
@@ -253,34 +253,20 @@ inline void to_json(json_t &js, const BaseEngine<StateType> &engine) {
         "Error: Failed to convert state type to JSON";
     }
   }
+  // check for edge case of null array and instead return empty object
+  if (js.is_null())
+    js = json_t::object();
 }
 
 template <typename StateType>
 inline void from_json(const json_t &js, BaseEngine<StateType> &engine) {
   engine = BaseEngine<StateType>();
-  std::vector<std::string> opts;
-  if (JSON::get_value(opts, "data", js)) {
-    for (auto &o : opts) {
-      to_lowercase(o);
-      string_trim(o);
-      // check options
-      if (o == "memory") {
-        engine.show_final_creg = true;
-      } else if (o == "bitstringcounts") {
-        engine.hex_counts = false;
-      } else if (o == "nosort") {
-        engine.counts_sort = false;
-      } else if (o == "hidesnapshots" || o == "hidesnapshots") {
-      engine.show_snapshots = false;
-      }
-    }
-  }
-
+  // Check for single shot memory
+  JSON::get_value(engine.show_final_creg, "memory", js);
   // parse initial state from JSON
   if (JSON::get_value(engine.initial_state, "initial_state", js)) {
     engine.initial_state_flag = true;
   }
-
 }
 
 //------------------------------------------------------------------------------

--- a/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
+++ b/src/qasm-simulator-cpp/src/engines/vector_engine.hpp
@@ -57,27 +57,6 @@ public:
   uint_t qudit_dim = 2;   // dimension of each qubit as qudit
   double epsilon = 1e-10; // Chop small numbers
 
-  bool show_snapshots_ket = false;           // show snapshots as ket-vector
-  bool show_snapshots_density = false;       // show snapshots as density matrix
-  bool show_snapshots_probs = false;         // show snapshots as probability vector
-  bool show_snapshots_probs_ket = false;     // show snapshots as probability ket-vector
-  bool show_snapshots_inner_product = false; // show inner product with snapshots
-  bool show_snapshots_overlaps = false;      // show overlaps with snapshots
-
-  std::vector<QubitVector> target_states; // vector of target states
-
-  //============================================================================
-  // Results / Data
-  //============================================================================
-
-  // Snapshots output data
-  std::map<std::string, std::vector<cket_t>> snapshots_ket;
-  std::map<std::string, cmatrix_t> snapshots_density;
-  std::map<std::string, rvector_t> snapshots_probs;
-  std::map<std::string, std::map<std::string, double>> snapshots_probs_ket;
-  std::map<std::string, std::vector<cvector_t>> snapshots_inprods;
-  std::map<std::string, rvector_t> snapshots_overlaps;
-
   //============================================================================
   // Methods
   //============================================================================
@@ -93,22 +72,10 @@ public:
   };
 
   // Compute results
-  void compute_results(const Circuit &circ, BaseBackend<QubitVector> *be) override;
   template<class T>
   void sample_counts(const Circuit &prog, BaseBackend<QubitVector> *be, uint_t nshots,
                      const std::vector<T> &probs, const std::vector<operation> &meas,
                      const std::vector<uint_t> &meas_qubits);
-  // Additional snapshot formatting
-  void snapshot_ketform(const std::map<std::string, QubitVector>& qreg_snapshots,
-                        const std::vector<uint_t> &labels);
-  void snapshot_density_matrix(const std::map<std::string, QubitVector>& qreg_snapshots);
-  void snapshot_probabilities(const std::map<std::string, QubitVector>& qreg_snapshots);
-  void snapshot_inner_products(const std::map<std::string, QubitVector>& qreg_snapshots);
-
-  // Convert a complex vector or ket to a real one
-  double get_probs(const complex_t &val) const;
-  rvector_t get_probs(const QubitVector &vec) const;
-  std::map<std::string, double> get_probs(const cket_t &ket) const;
 };
 
 /***************************************************************************/ /**
@@ -118,43 +85,7 @@ public:
   ******************************************************************************/
 
 void VectorEngine::add(const VectorEngine &eng) {
-
   BaseEngine<QubitVector>::add(eng);
-
-  /* Accumulated snapshot sdata */
-
-  // copy snapshots ket-maps
-  for (const auto &s: eng.snapshots_ket)
-    std::copy(s.second.begin(), s.second.end(),
-              back_inserter(snapshots_ket[s.first]));
-
-  // Add snapshots density
-  for (const auto &s : eng.snapshots_density) {
-    auto &rho = snapshots_density[s.first];
-    if (rho.size() == 0)
-      rho = s.second;
-    else
-      rho += s.second;
-  }
-
-  // Add snapshots probs
-  for (const auto &s : eng.snapshots_probs) {
-    snapshots_probs[s.first] += s.second;
-  }
-
-  // Add snapshots probs ket
-  for (const auto &s : eng.snapshots_probs_ket)
-    snapshots_probs_ket[s.first] += s.second;
-
-  // Add snapshots overlaps
-  for (const auto &s : eng.snapshots_overlaps)
-    snapshots_overlaps[s.first] += s.second;
-
-  // copy snapshots inner prods
-  for (const auto &s : eng.snapshots_inprods)
-    std::copy(s.second.begin(), s.second.end(),
-              back_inserter(snapshots_inprods[s.first]));
-
 }
 
 void VectorEngine::execute(const Circuit &prog, BaseBackend<QubitVector> *be,
@@ -179,7 +110,7 @@ void VectorEngine::execute(const Circuit &prog, BaseBackend<QubitVector> *be,
     be->initialize(prog);
     be->execute(not_meas);
 
-    VectorEngine::compute_results(prog, be);
+    BaseEngine<QubitVector>::compute_results(prog, be);
     // Clear creg results from shot without measurements
     counts.clear();
     output_creg.clear();
@@ -245,130 +176,10 @@ void VectorEngine::sample_counts(const Circuit &prog, BaseBackend<QubitVector> *
     for (const auto &op : meas)
       creg[op.clbits[0]] = outcomes[op.qubits[0]];
     // compute count based results
-    compute_counts(prog.clbit_labels, creg);
+    compute_counts(creg);
   }
 }
 
-//------------------------------------------------------------------------------
-
-void VectorEngine::snapshot_ketform(const std::map<std::string, QubitVector>& qreg_snapshots,
-                                    const std::vector<uint_t> &labels) {
-  if (show_snapshots_ket || show_snapshots_probs_ket) {
-    for (auto const &psi : qreg_snapshots) {
-      cket_t psi_ket = vec2ket(psi.second.vector(), qudit_dim, epsilon, labels);
-      // snapshots kets
-      if (show_snapshots_ket)
-        snapshots_ket[psi.first].push_back(psi_ket);
-      // snapshots probabilities (ket form)
-      if (show_snapshots_probs_ket) {
-        rket_t probs_ket;
-        for (const auto &val : psi_ket) {
-          probs_ket[val.first] = get_probs(val.second);
-        }
-        snapshots_probs_ket[psi.first] += probs_ket;
-      }
-    }
-  }
-}
-
-void VectorEngine::snapshot_density_matrix(const std::map<std::string, QubitVector>& qreg_snapshots) {
-  if (show_snapshots_density) {
-    for (auto const &psi : qreg_snapshots) {
-      cmatrix_t &rho = snapshots_density[psi.first];
-      if (rho.size() == 0)
-        rho = outer_product(psi.second.vector(), psi.second.vector());
-      else
-        rho = rho + outer_product(psi.second.vector(), psi.second.vector());
-    }
-  }
-}
-
-void VectorEngine::snapshot_probabilities(const std::map<std::string, QubitVector>& qreg_snapshots) {
-  if (show_snapshots_probs) {
-      for (auto const &psi : qreg_snapshots) {
-        auto &pr = snapshots_probs[psi.first];
-        if (pr.empty())
-          pr = get_probs(psi.second);
-        else
-          pr += get_probs(psi.second);
-      }
-    }
-}
-
-void VectorEngine::snapshot_inner_products(const std::map<std::string, QubitVector>& qreg_snapshots) {
-  if (target_states.empty() == false &&
-        (show_snapshots_inner_product || show_snapshots_overlaps)) {
-      for (auto const &psi : qreg_snapshots) {
-        // compute inner products
-        cvector_t inprods;
-        for (auto const &vec : target_states) {
-          // check correct size
-          if (vec.size() != psi.second.size()) {
-            std::stringstream msg;
-            msg << "error: target_state vector size \"" << vec.size()
-                << "\" should be \"" << psi.second.size() << "\"";
-            throw std::runtime_error(msg.str());
-          }
-          complex_t val = psi.second.inner_product(vec);
-          chop(val, epsilon);
-          inprods.push_back(val);
-        }
-
-        // add output inner products
-        if (show_snapshots_inner_product)
-          snapshots_inprods[psi.first].push_back(inprods);
-        // Add output overlaps (needs renormalizing at output)
-        if (show_snapshots_overlaps)
-          snapshots_overlaps[psi.first] += get_probs(inprods);
-      }
-    }
-}
-
-void VectorEngine::compute_results(const Circuit &qasm, BaseBackend<QubitVector> *be) {
-  // Run BaseEngine Counts
-  BaseEngine<QubitVector>::compute_results(qasm, be);
-
-  std::map<std::string, QubitVector> &qreg_snapshots = be->access_snapshots();
-
-  /* Snapshot quantum state output data */
-  if (snapshots.empty() == false) {
-
-    // String labels for ket form
-    std::vector<uint_t> ket_regs;
-    for (auto it = qasm.qubit_sizes.crbegin(); it != qasm.qubit_sizes.crend(); ++it)
-      ket_regs.push_back(it->second);
-    // Snapshot ket-form of state vector or probabilities
-    snapshot_ketform(qreg_snapshots, ket_regs);
-
-    // add density matrix (needs renormalizing after all shots)
-    snapshot_density_matrix(qreg_snapshots);
-
-    // add probs (needs renormalizing after all shots)
-    snapshot_probabilities(qreg_snapshots);
-
-    // Inner products
-    snapshot_inner_products(qreg_snapshots);
-  }
-}
-
-//------------------------------------------------------------------------------
-double VectorEngine::get_probs(const complex_t &val) const {
-  return std::real(std::conj(val) * val);
-}
-
-rvector_t VectorEngine::get_probs(const QubitVector &vec) const {
-  rvector_t ret;
-  for (const auto &elt : vec.vector())
-    ret.push_back(get_probs(elt));
-  return ret;
-}
-
-std::map<std::string, double> VectorEngine::get_probs(const cket_t &ket) const {
-  std::map<std::string, double> ret;
-  for (const auto &elt : ket)
-    ret[elt.first] = get_probs(elt.second);
-  return ret;
-}
 
 /***************************************************************************/ /**
   *
@@ -381,92 +192,13 @@ inline void to_json(json_t &js, const VectorEngine &eng) {
   // Get results from base class
   const BaseEngine<QubitVector> &base_eng = eng;
   to_json(js, base_eng);
-
-  // renormalization constant for average over shots
-  double renorm = 1. / eng.total_shots;
-
-  /* Additional snapshot output data */
-  // Snapshot skets
-  if (eng.show_snapshots_ket && eng.snapshots_ket.empty() == false) {
-    for (const auto& s: eng.snapshots_ket)
-        js["snapshots"][s.first]["quantum_state_ket"] = s.second;
-  }
-
-  // Snapshots density
-  if (eng.show_snapshots_density && eng.snapshots_density.empty() == false) {
-    for (const auto &s : eng.snapshots_density) {
-      auto rho = s.second * renorm;
-      chop(rho, eng.epsilon);
-      js["snapshots"][s.first]["density_matrix"] = rho;
-    }
-  }
-
-  // Snapshots probs
-  if (eng.show_snapshots_probs && eng.snapshots_probs.empty() == false) {
-    for (const auto &s : eng.snapshots_probs) {
-      auto val = s.second;
-      val *= renorm;
-      chop(val, eng.epsilon);
-      js["snapshots"][s.first]["probabilities"] = val;
-    }
-  }
-
-  // Snapshots probs ket
-  if (eng.show_snapshots_probs_ket && eng.snapshots_probs_ket.empty() == false) {
-    for (const auto &s : eng.snapshots_probs_ket) {
-      auto val = s.second;
-      val *= renorm;
-      chop(val, eng.epsilon);
-      js["snapshots"][s.first]["probabilities_ket"] = val;
-    }
-  }
-
-
-  // Snapshots inner products
-  if (eng.show_snapshots_inner_product && eng.snapshots_inprods.empty() == false) {
-    for (const auto &s : eng.snapshots_inprods) {
-      auto val = s.second;
-      chop(val, eng.epsilon);
-      js["snapshots"][s.first]["target_states_inner_product"] = val;
-    }
-  }
-
-  // Snapshots overlaps
-  if (eng.show_snapshots_overlaps && eng.snapshots_overlaps.empty() == false) {
-    for (const auto &s : eng.snapshots_overlaps) {
-      auto val = s.second;
-      val *= renorm;
-      chop(val, eng.epsilon);
-      js["snapshots"][s.first]["target_states_inner_overlaps"] = val;
-    }
-  }
 }
 
 inline void from_json(const json_t &js, VectorEngine &eng) {
   eng = VectorEngine();
   BaseEngine<QubitVector> &base_eng = eng;
   from_json(js, base_eng);
-  // Get output options
-  std::vector<std::string> opts;
-  if (JSON::get_value(opts, "data", js)) {
-    for (auto &o : opts) {
-      to_lowercase(o);
-      string_trim(o);
 
-      if (o == "quantumstateket" || o == "quantumstatesket")
-        eng.show_snapshots_ket = true;
-      else if (o == "densitymatrix")
-        eng.show_snapshots_density = true;
-      else if (o == "probabilities" || o == "probs")
-        eng.show_snapshots_probs = true;
-      else if (o == "probabilitiesket" || o == "probsket")
-        eng.show_snapshots_probs_ket = true;
-      else if (o == "targetstatesinnerproduct")
-        eng.show_snapshots_inner_product = true;
-      else if (o == "targetstatesoverlaps")
-        eng.show_snapshots_overlaps = true;
-    }
-  }
   // Get additional settings
   JSON::get_value(eng.epsilon, "chop", js);
   JSON::get_value(eng.qudit_dim, "qudit_dim", js);
@@ -474,14 +206,6 @@ inline void from_json(const json_t &js, VectorEngine &eng) {
   // renormalize state vector
   if (eng.initial_state_flag)
     eng.initial_state.renormalize();
-
-  // parse target states from JSON
-  bool renorm_target_states = true;
-  JSON::get_value(renorm_target_states, "renorm_target_states", js);
-  if (JSON::get_value(eng.target_states, "target_states", js) &&
-      renorm_target_states)
-    for (auto &qv : eng.target_states)
-      qv.renormalize();
 }
 
 //------------------------------------------------------------------------------

--- a/src/qasm-simulator-cpp/src/simulator.hpp
+++ b/src/qasm-simulator-cpp/src/simulator.hpp
@@ -55,9 +55,10 @@ using QV::omp_int_t;  // signed int for OpenMP 2.0 on msvc
 class Simulator {
 public:
   std::string id = "";                              // simulation id
-  std::string qobj_backend = "qasm_simulator_cpp"; // qobj backend specification
-  std::string simulator = "qasm_simulator_cpp";    // internally used simulator backend
+  std::string qobj_backend = "qasm_simulator"; // qobj backend specification
+  std::string simulator = "qasm_simulator";    // internally used simulator backend
   std::vector<Circuit> circuits;                   // QISKIT program
+  json_t header; // Input qobj header;
 
   // Multithreading Params
   uint_t max_memory_gb = 16;   // max memory to use
@@ -104,9 +105,9 @@ json_t Simulator::execute_json(){
   // Initialize output JSON
   std::chrono::time_point<myclock_t> start = myclock_t::now(); // start timer
   json_t ret;
-  ret["id"] = id;
-  ret["backend"] = qobj_backend;
-  ret["cpp_simulator_kernel"] = simulator;
+  ret["qobj_id"] = id;
+  ret["backend_name"] = qobj_backend;
+  ret["header"] = header;
 
   // Choose simulator and execute circuits
   try {
@@ -115,7 +116,7 @@ json_t Simulator::execute_json(){
       json_t circ_res;
 
       // Choose Simulator Backend
-      if (simulator == "clifford_simulator_cpp")
+      if (simulator == "clifford_simulator")
         circ_res = run_circuit<BaseEngine<Clifford>, CliffordBackend>(circ);
       else if (circ.noise.ideal)
         circ_res = run_circuit<VectorEngine, IdealBackend>(circ);
@@ -124,12 +125,14 @@ json_t Simulator::execute_json(){
 
       // Check results
       qobj_success &= circ_res["success"].get<bool>();
-      ret["result"].push_back(circ_res);
+      ret["results"].push_back(circ_res);
     }
     ret["time_taken"] =
         std::chrono::duration<double>(myclock_t::now() - start).count();
     ret["status"] = std::string("COMPLETED");
     ret["success"] = qobj_success;
+    ret["backend_version"] = std::string("0.0.0");
+    ret["job_id"] = std::string("TODO");
   } catch (std::exception &e) {
     ret["success"] = false;
     ret["status"] = std::string("ERROR: ") + e.what();
@@ -231,6 +234,7 @@ json_t Simulator::run_circuit(Circuit &circ) const {
 
 
     // Return results
+    ret["header"] = circ.header;
     ret["data"] = engine; // add engine output to return
     //if (simulator != "ideal" && JSON::check_key("noise_params", circ.config)) {
     if (simulator != "ideal" && backend.noise.ideal == false) {
@@ -259,7 +263,8 @@ void Simulator::load_qobj_json(const json_t &js) {
   try {
     if (check_qobj(js)) { // check valid qobj
 
-      JSON::get_value(id, "id", js);
+      JSON::get_value(id, "qobj_id", js);
+      JSON::get_value(header, "header", js);
 
       json_t config;
       JSON::get_value(config, "config", js);
@@ -270,32 +275,29 @@ void Simulator::load_qobj_json(const json_t &js) {
       JSON::get_value(max_threads_gate, "max_threads_gate", config);
 
       // Override with user simulator backend specification
-      JSON::get_value(qobj_backend, "backend", config);
+      JSON::get_value(qobj_backend, "simulator", config);
       simulator = qobj_backend; // copy backend info;
-      // look for custom override
-      JSON::get_value(simulator, "custom_simulator_kernel", config);
       to_lowercase(simulator); // convert to lowercase
       string_trim(simulator); // trim whitespace, '-', '_' characters
-
       if (simulator.find("clifford") != std::string::npos) {
-        simulator = "clifford_simulator_cpp";
+        simulator = "clifford_simulator";
       }
       else {
-        simulator = "qasm_simulator_cpp";
+        simulator = "qasm_simulator";
       }
 
       // Set simulator gateset
       gateset_t gateset;
-      if (simulator == "qasm_simulator_cpp") {
+      if (simulator == "qasm_simulator") {
         gateset = QubitBackend::gateset;
-      } else if (simulator == "clifford_simulator_cpp") {
+      } else if (simulator == "clifford_simulator") {
         gateset = CliffordBackend::gateset;
       } else {
         throw std::runtime_error(std::string("invalid simulator."));
       }
 
       // Load circuit instructions
-      const json_t &circs = js["circuits"];
+      const json_t &circs = js["experiments"];
       for (auto it = circs.cbegin(); it != circs.cend(); ++it) {
         circuits.push_back(Circuit(*it, config, gateset));
       }
@@ -311,21 +313,13 @@ void Simulator::load_qobj_json(const json_t &js) {
 
 //------------------------------------------------------------------------------
 bool Simulator::check_qobj(const json_t &qobj) {
-  std::vector<std::string> qobj_keys{"id", "circuits"}; // optional: "config"
-  std::vector<std::string> compiled_keys{"header", "operations"};
-  std::vector<std::string> header_keys{"clbit_labels", "number_of_clbits",
-                                       "number_of_qubits", "qubit_labels"};
+  std::vector<std::string> qobj_keys{"qobj_id", "experiments"}; // optional: "config"
+  std::vector<std::string> experiment_keys{"config", "instructions"};
 
   bool pass = JSON::check_keys(qobj_keys, qobj);
   if (pass) {
-    for (auto &c : qobj["circuits"]) {
-      pass &= JSON::check_key("compiled_circuit", c);
-      if (pass) {
-        pass &= JSON::check_keys(compiled_keys, c["compiled_circuit"]);
-        if (pass)
-          pass &=
-              JSON::check_keys(header_keys, c["compiled_circuit"]["header"]);
-      }
+    for (auto &c : qobj["experiments"]) {
+      pass &= JSON::check_keys(experiment_keys, c);
     }
   }
   return pass;

--- a/src/qasm-simulator-cpp/src/utilities/circuit.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/circuit.hpp
@@ -240,7 +240,7 @@ operation Circuit::parse_op(const json_t &node, const gateset_t &gs) {
     JSON::get_value(op.params, "params", node);
   }
   JSON::get_value(op.qubits, "qubits", node);
-  JSON::get_value(op.clbits, "clbits", node);
+  JSON::get_value(op.clbits, "memory", node);
 
   // Check op
   for (auto q : op.qubits)

--- a/src/qasm-simulator-cpp/src/utilities/misc.hpp
+++ b/src/qasm-simulator-cpp/src/utilities/misc.hpp
@@ -234,12 +234,19 @@ std::vector<uint_t> int2reg(uint_t n, uint_t base = 2);
 std::vector<uint_t> int2reg(uint_t n, uint_t base, uint_t minlen);
 
 /**
+ * Converts an bitstring to a hexadecimal string
+ * @param str: a bit string (with or without leading "0b")
+ * @param prefix: prefix output string with "0x" (default true)
+ * @return: a hexadecimal string
+ */
+std::string bin2hex(std::string str, bool prefix = true);
+
+/**
  * Write me
  * @param str
  * @param regs
  * @return
  */
-
 std::string format_bitstr(std::string str, const creg_t &regs);
 
 /**
@@ -744,6 +751,43 @@ std::vector<uint_t> hex2reg(std::string str) {
   } else {
     throw std::runtime_error(std::string("invalid hexadecimal"));
   }
+}
+
+//------------------------------------------------------------------------------
+// Convert hexadecimal string to bit-string
+//------------------------------------------------------------------------------
+std::string bin2hex(std::string str, bool prefix) {
+  // empty case
+  if (str.empty())
+    return std::string();
+
+  // If string starts with 0b prob prefix
+  if (str.size() > 1 && str.substr(0, 2) == "0b") {
+    str.erase(0, 2);
+  }
+
+  // We go via 64-bit integer conversion, so we process 64-bit chunks at
+  // a time
+  const size_t block = 64;
+  const size_t len = str.size();
+  const size_t chunks = len / block;
+  const size_t remain = len % block;
+
+  // initialize output string
+  std::string hex = (prefix) ? "0x" : "";
+
+  // Start with remain
+  std::stringstream ss;
+  ss << std::hex << std::stoull(str.substr(0, remain), nullptr, 2);
+  hex += ss.str();
+  for (size_t j=0; j < chunks; ++j) {
+    ss.str(std::string()); // clear string stream
+    ss << std::hex << std::stoull(str.substr(remain + j * block, block), nullptr, 2);
+    std::string part = ss.str();
+    part.insert(0, block - part.size(), '0'); // pad out zeros
+    hex += part;
+  }
+  return hex;
 }
 
 //------------------------------------------------------------------------------

--- a/test/python/aer/test_aer_simulators.py
+++ b/test/python/aer/test_aer_simulators.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+
+"""Tests for all aer simulators."""
+
+from qiskit import Aer, ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import compile  # pylint: disable=redefined-builtin
+from qiskit.qobj import QobjHeader
+
+from ..common import QiskitTestCase
+
+
+class TestAerSimulators(QiskitTestCase):
+    """Tests for all the Aer simulators."""
+
+    def setUp(self):
+        super().setUp()
+
+        self.backends = Aer.backends()
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(1)
+        self.qc1 = QuantumCircuit(qr, cr, name='circuit0')
+        self.qc1.h(qr[0])
+
+    def test_qobj_headers_in_result(self):
+        """Test that the qobj headers are passed onto the results."""
+        custom_qobj_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
+
+        for backend in Aer.backends():
+            with self.subTest(backend=backend):
+                qobj = compile(self.qc1, backend)
+
+                # Update the Qobj header.
+                qobj.header = QobjHeader.from_dict(custom_qobj_header)
+                # Update the Qobj.experiment header.
+                qobj.experiments[0].header.some_field = 'extra info'
+
+                result = backend.run(qobj).result()
+                self.assertEqual(result.header.to_dict(), custom_qobj_header)
+                self.assertEqual(result.results[0].header.some_field,
+                                 'extra info')

--- a/test/python/aer/test_extensions_simulator.py
+++ b/test/python/aer/test_extensions_simulator.py
@@ -10,6 +10,7 @@
 """Tests for verifying the correctness of simulator extension instructions."""
 
 import unittest
+import numpy as np
 import qiskit
 import qiskit.extensions.simulator
 from qiskit import Aer
@@ -59,9 +60,11 @@ class TestExtensionsSimulator(QiskitTestCase):
 
         sim = Aer.get_backend('statevector_simulator')
         result = execute(circuit, sim).result()
-        snapshot = result.data(0)['snapshots']['statevector']['3']
+        # TODO: rely on Result.get_statevector() postprocessing rather than manual
+        snapshots = result.data(0)['snapshots']['statevector']['3']
+        snapshot = np.array([v[0] + 1j * v[1] for v in snapshots[0]], dtype=complex)
         target = [0.70710678 + 0.j, 0. + 0.j, 0. + 0.j, 0.70710678 + 0.j]
-        fidelity = state_fidelity(snapshot[0], target)
+        fidelity = state_fidelity(snapshot, target)
         self.assertGreater(
             fidelity, self._desired_fidelity,
             "snapshot has low fidelity{0:.2g}.".format(fidelity))

--- a/test/python/aer/test_extensions_simulator.py
+++ b/test/python/aer/test_extensions_simulator.py
@@ -59,7 +59,7 @@ class TestExtensionsSimulator(QiskitTestCase):
 
         sim = Aer.get_backend('statevector_simulator')
         result = execute(circuit, sim).result()
-        snapshot = result.data(0)['snapshots']['3']['statevector']
+        snapshot = result.data(0)['snapshots']['statevector']['3']
         target = [0.70710678 + 0.j, 0. + 0.j, 0. + 0.j, 0.70710678 + 0.j]
         fidelity = state_fidelity(snapshot[0], target)
         self.assertGreater(

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -19,7 +19,9 @@ from qiskit.backends.aer.qasm_simulator import (QasmSimulator,
                                                 x90_error_matrix)
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.qobj import Qobj
-from ..common import QiskitTestCase, requires_cpp_simulator, bin_to_hex_keys
+from qiskit import compile
+from ..common import QiskitTestCase, Path
+from ..common import requires_cpp_simulator, bin_to_hex_keys
 
 
 class TestAerQasmSimulator(QiskitTestCase):
@@ -31,8 +33,10 @@ class TestAerQasmSimulator(QiskitTestCase):
     def setUp(self):
         self.backend = QasmSimulator()
 
-        qasm_filename = self._get_resource_path('qasm/example.qasm')
-        qc1 = QuantumCircuit.from_qasm_file(qasm_filename)
+        qasm_file_name = 'example.qasm'
+        qasm_file_path = self._get_resource_path(
+            'qasm/' + qasm_file_name, Path.TEST)
+        qc1 = QuantumCircuit.from_qasm_file(qasm_file_path)
 
         qr = QuantumRegister(2, 'q')
         cr = ClassicalRegister(2, 'c')

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -92,7 +92,7 @@ class TestAerQasmSimulator(QiskitTestCase):
         result = self.backend.run(self.qobj).result()
         shots = self.qobj.config.shots
         threshold = 0.04 * shots
-        counts = result.get_counts(self.qc2)
+        counts = result.get_counts(self.qc1)
         target = {'100 100': shots / 8, '011 011': shots / 8,
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -165,7 +165,7 @@ class TestAerQasmSimulator(QiskitTestCase):
             snapshots = result.data(name)['snapshots']['statevector']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
-            self.assertEqual(len(snapshots['0']), 3,
+            self.assertEqual(len(snapshots['0']), 1,
                              msg=name + ' snapshot length')
             state = self._to_complex_array(snapshots['0'][0])
             expected_state = expected_data[name]['statevector']

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -36,15 +36,15 @@ class TestAerQasmSimulator(QiskitTestCase):
         qasm_file_name = 'example.qasm'
         qasm_file_path = self._get_resource_path(
             'qasm/' + qasm_file_name, Path.TEST)
-        qc1 = QuantumCircuit.from_qasm_file(qasm_file_path)
+        self.qc1 = QuantumCircuit.from_qasm_file(qasm_file_path)
 
         qr = QuantumRegister(2, 'q')
         cr = ClassicalRegister(2, 'c')
-        qc2 = QuantumCircuit(qr, cr)
-        qc2.h(qr[0])
-        qc2.measure(qr[0], cr[0])
+        self.qc2 = QuantumCircuit(qr, cr)
+        self.qc2.h(qr[0])
+        self.qc2.measure(qr[0], cr[0])
 
-        self.qobj = compile([qc1, qc2], backend=self.backend,
+        self.qobj = compile([self.qc1, self.qc2], backend=self.backend,
                             shots=2000, seed=1111)
 
     def _to_complex_array(self, vec):
@@ -93,7 +93,7 @@ class TestAerQasmSimulator(QiskitTestCase):
         result = self.backend.run(self.qobj).result()
         shots = self.qobj.config.shots
         threshold = 0.04 * shots
-        counts = result.get_counts('test_circuit2')
+        counts = result.get_counts(self.qc2)
         target = {'100 100': shots / 8, '011 011': shots / 8,
                   '101 101': shots / 8, '111 111': shots / 8,
                   '000 000': shots / 8, '010 010': shots / 8,

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring,redefined-builtin
 
 import json
 import unittest
@@ -17,7 +17,6 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.backends.aer.qasm_simulator import (QasmSimulator,
                                                 cx_error_matrix,
                                                 x90_error_matrix)
-from qiskit.dagcircuit import DAGCircuit
 from qiskit.qobj import Qobj
 from qiskit import compile
 from ..common import QiskitTestCase, Path

--- a/test/python/aer/test_qasm_simulator_py.py
+++ b/test/python/aer/test_qasm_simulator_py.py
@@ -70,7 +70,6 @@ class TestAerQasmSimulatorPy(QiskitTestCase):
         circuit_if_false.measure(qr[0], cr[0])
         circuit_if_false.measure(qr[1], cr[1])
         circuit_if_false.measure(qr[2], cr[2])
-<<<<<<< HEAD
         qobj = compile([circuit_if_true, circuit_if_false],
                        backend=self.backend, shots=shots, seed=self.seed)
 
@@ -79,51 +78,6 @@ class TestAerQasmSimulatorPy(QiskitTestCase):
         counts_if_false = result.get_counts(circuit_if_false)
         self.assertEqual(counts_if_true, bin_to_hex_keys({'111': 100}))
         self.assertEqual(counts_if_false, bin_to_hex_keys({'001': 100}))
-=======
-        basis_gates = []  # unroll to base gates
-        unroller = unroll.Unroller(
-            qasm.Qasm(data=circuit_if_true.qasm()).parse(),
-            unroll.JsonBackend(basis_gates))
-        ucircuit_true = QobjExperiment.from_dict(unroller.execute())
-        unroller = unroll.Unroller(
-            qasm.Qasm(data=circuit_if_false.qasm()).parse(),
-            unroll.JsonBackend(basis_gates))
-        ucircuit_false = QobjExperiment.from_dict(unroller.execute())
-
-        # Customize the experiments and create the qobj.
-        ucircuit_true.config = QobjItem(coupling_map=None,
-                                        basis_gates='u1,u2,u3,cx,id',
-                                        layout=None,
-                                        n_qubits=max_qubits,
-                                        memory_slots=max_qubits)
-        ucircuit_true.header.name = 'test_if_true'
-        ucircuit_false.config = QobjItem(coupling_map=None,
-                                         basis_gates='u1,u2,u3,cx,id',
-                                         layout=None,
-                                         n_qubits=max_qubits,
-                                         memory_slots=max_qubits)
-        ucircuit_false.header.name = 'test_if_false'
-
-        qobj = Qobj(qobj_id='test_if_qobj',
-                    config=QobjConfig(max_credits=3,
-                                      shots=shots,
-                                      memory_slots=max_qubits),
-                    experiments=[ucircuit_true, ucircuit_false],
-                    header=QobjHeader(backend_name='qasm_simulator_py'))
-
-        result = QasmSimulatorPy().run(qobj).result()
-        result_if_true = result.data('test_if_true')
-        self.log.info('result_if_true circuit:')
-        self.log.info(circuit_if_true.qasm())
-        self.log.info('result_if_true=%s', result_if_true)
-
-        result_if_false = result.data('test_if_false')
-        self.log.info('result_if_false circuit:')
-        self.log.info(circuit_if_false.qasm())
-        self.log.info('result_if_false=%s', result_if_false)
-        self.assertTrue(result_if_true['counts'][hex(int('111', 2))] == 100)
-        self.assertTrue(result_if_false['counts'][hex(int('001', 2))] == 100)
->>>>>>> update qobj header and python simulators (#13)
 
     @unittest.skipIf(version_info.minor == 5,
                      "Due to gate ordering issues with Python 3.5 "

--- a/test/python/aer/test_simulator_interfaces.py
+++ b/test/python/aer/test_simulator_interfaces.py
@@ -59,7 +59,7 @@ class TestCrossSimulation(QiskitTestCase):
         result_py = execute(circuit, sim_py, shots=shots).result()
         counts_cpp = result_cpp.get_counts()
         counts_py = result_py.get_counts()
-        self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.05)
+        self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.08)
 
     def test_qasm_reset_measure(self):
         """counts from a qasm program with measure and reset in the middle"""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -7,7 +7,7 @@
 
 
 """Test Qiskit's QuantumCircuit class."""
-
+import numpy as np
 import qiskit.extensions.simulator  # pylint: disable=unused-import
 from qiskit import Aer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
@@ -80,7 +80,7 @@ class TestCircuitOperations(QiskitTestCase):
         qr = QuantumRegister(2)
         cr = ClassicalRegister(2)
         qc1 = QuantumCircuit(qr)
-        desired_vector = [0.5, 0.5, 0.5, 0.5]
+        desired_vector = [0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j]
         qc1.initialize(desired_vector, qr)
         qc1.barrier()
         qc2 = QuantumCircuit(qr, cr)
@@ -90,8 +90,9 @@ class TestCircuitOperations(QiskitTestCase):
         backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
-        snapshot_vectors = result.data(0)['snapshots']['1']['statevector']
-        fidelity = state_fidelity(snapshot_vectors[0], desired_vector)
+        snapshot_vectors = result.data(0)['snapshots']['statevector']['1']
+        snapshot = np.array([v[0] + 1j * v[1] for v in snapshot_vectors[0]], dtype=complex)
+        fidelity = state_fidelity(snapshot, desired_vector)
         self.assertGreater(fidelity, 0.99)
 
         counts = result.get_counts()

--- a/test/python/ibmq/test_ibmq_backends.py
+++ b/test/python/ibmq/test_ibmq_backends.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+
+"""Tests for all IBMQ backends."""
+
+from qiskit import IBMQ, ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import compile  # pylint: disable=redefined-builtin
+from qiskit.qobj import QobjHeader
+
+from ..common import QiskitTestCase, requires_qe_access, slow_test
+
+
+class TestIBMQBackends(QiskitTestCase):
+    """Tests for all the Aer simulators."""
+
+    def setUp(self):
+        super().setUp()
+
+        qr = QuantumRegister(1)
+        cr = ClassicalRegister(1)
+        self.qc1 = QuantumCircuit(qr, cr, name='circuit0')
+        self.qc1.h(qr[0])
+        self.qc1.measure(qr, cr)
+
+    @requires_qe_access
+    def test_qobj_headers_in_result_sims(self, qe_token, qe_url):
+        """Test that the qobj headers are passed onto the results for sims."""
+        IBMQ.enable_account(qe_token, qe_url)
+        backends = IBMQ.backends(simulator=True)
+
+        custom_qobj_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
+
+        for backend in backends:
+            with self.subTest(backend=backend):
+                qobj = compile(self.qc1, backend)
+
+                # Update the Qobj header.
+                qobj.header = QobjHeader.from_dict(custom_qobj_header)
+                # Update the Qobj.experiment header.
+                qobj.experiments[0].header.some_field = 'extra info'
+
+                result = backend.run(qobj).result()
+                self.assertEqual(result.header.to_dict(), custom_qobj_header)
+                self.assertEqual(result.results[0].header.some_field,
+                                 'extra info')
+
+    @slow_test
+    @requires_qe_access
+    def test_qobj_headers_in_result_devices(self, qe_token, qe_url):
+        """Test that the qobj headers are passed onto the results for sims."""
+        IBMQ.enable_account(qe_token, qe_url)
+        backends = IBMQ.backends(simulator=False)
+
+        custom_qobj_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
+
+        for backend in backends:
+            print(backend)
+            with self.subTest(backend=backend):
+                qobj = compile(self.qc1, backend)
+
+                # Update the Qobj header.
+                qobj.header = QobjHeader.from_dict(custom_qobj_header)
+                # Update the Qobj.experiment header.
+                qobj.experiments[0].header.some_field = 'extra info'
+
+                result = backend.run(qobj).result()
+                self.assertEqual(result.header.to_dict(), custom_qobj_header)
+                self.assertEqual(result.results[0].header.some_field,
+                                 'extra info')

--- a/test/python/ibmq/test_ibmq_backends.py
+++ b/test/python/ibmq/test_ibmq_backends.py
@@ -59,7 +59,6 @@ class TestIBMQBackends(QiskitTestCase):
         custom_qobj_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
 
         for backend in backends:
-            print(backend)
             with self.subTest(backend=backend):
                 qobj = compile(self.qc1, backend)
 

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 2,
         "seed": 1
     },
     "header": {
@@ -15,8 +16,8 @@
             "header": {
                 "name": "single creg (c0=0)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 2,
+                "memory_slots": 1,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -51,8 +52,8 @@
             "header": {
                 "name": "single creg (c0=1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 2,
+                "memory_slots": 1,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -87,8 +88,8 @@
             "header": {
                 "name": "two creg (c1=0)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -123,8 +124,8 @@
             "header": {
                 "name": "two creg (c1=1)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -16,9 +16,11 @@
             "header": {
                 "name": "single creg (c0=0)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 2
             },
             "instructions": [
                 {
@@ -52,9 +54,11 @@
             "header": {
                 "name": "single creg (c0=1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 2
             },
             "instructions": [
                 {
@@ -88,9 +92,11 @@
             "header": {
                 "name": "two creg (c1=0)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {
@@ -124,9 +130,11 @@
             "header": {
                 "name": "two creg (c1=1)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {
@@ -136,7 +144,7 @@
                 },
                 {
                     "name": "measure",
-                    "memory": [0],
+                    "memory": [1],
                     "params": [],
                     "qubits": [0],
                     "clbits": [1]

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 2000,
         "memory_slots": 2,
+        "n_qubits": 2,
         "seed": 1,
         "data" : ["density_matrix", "probabilities"]
     },
@@ -16,8 +17,8 @@
             "header": {
                 "name": "measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -30,8 +31,8 @@
             "header": {
                 "name": "x0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -45,8 +46,8 @@
             "header": {
                 "name": "x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -60,8 +61,8 @@
             "header": {
                 "name": "x0 x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -76,8 +77,8 @@
             "header": {
                 "name": "y0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -91,8 +92,8 @@
             "header": {
                 "name": "y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -106,8 +107,8 @@
             "header": {
                 "name": "y0 y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -122,8 +123,8 @@
             "header": {
                 "name": "h0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -137,8 +138,8 @@
             "header": {
                 "name": "h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -152,8 +153,8 @@
             "header": {
                 "name": "h0 h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -168,8 +169,8 @@
             "header": {
                 "name": "bell measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -17,9 +17,11 @@
             "header": {
                 "name": "measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -31,9 +33,11 @@
             "header": {
                 "name": "x0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "x", "qubits": [0]},
@@ -46,9 +50,11 @@
             "header": {
                 "name": "x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "x", "qubits": [1]},
@@ -61,9 +67,11 @@
             "header": {
                 "name": "x0 x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "x", "qubits": [0]},
@@ -77,9 +85,11 @@
             "header": {
                 "name": "y0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "y", "qubits": [0]},
@@ -92,9 +102,11 @@
             "header": {
                 "name": "y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "y", "qubits": [1]},
@@ -107,9 +119,11 @@
             "header": {
                 "name": "y0 y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "y", "qubits": [0]},
@@ -123,9 +137,11 @@
             "header": {
                 "name": "h0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -138,9 +154,11 @@
             "header": {
                 "name": "h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "h", "qubits": [1]},
@@ -153,9 +171,11 @@
             "header": {
                 "name": "h0 h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -169,9 +189,11 @@
             "header": {
                 "name": "bell measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 2
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},

--- a/test/python/qobj/cpp_measure_opt_flag.json
+++ b/test/python/qobj/cpp_measure_opt_flag.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 5,
         "memory_slots": 2,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "measure (sampled)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -27,8 +28,8 @@
             "header": {
                 "name": "trivial (sampled)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -45,8 +46,8 @@
             "header": {
                 "name": "reset1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -60,8 +61,8 @@
             "header": {
                 "name": "reset2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -75,8 +76,8 @@
             "header": {
                 "name": "reset3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -90,8 +91,8 @@
             "header": {
                 "name": "gate1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -104,8 +105,8 @@
             "header": {
                 "name": "gate2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -118,8 +119,8 @@
             "header": {
                 "name": "gate3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -133,8 +134,8 @@
             "header": {
                 "name": "gate4 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_measure_opt_flag.json
+++ b/test/python/qobj/cpp_measure_opt_flag.json
@@ -14,9 +14,11 @@
             "header": {
                 "name": "measure (sampled)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -28,9 +30,11 @@
             "header": {
                 "name": "trivial (sampled)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -46,9 +50,11 @@
             "header": {
                 "name": "reset1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "reset", "qubits": [0]},
@@ -61,9 +67,11 @@
             "header": {
                 "name": "reset2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -76,9 +84,11 @@
             "header": {
                 "name": "reset3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -91,9 +101,11 @@
             "header": {
                 "name": "gate1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "measure", "memory": [0], "params": [], "qubits": [0], "clbits": [0]},
@@ -105,9 +117,11 @@
             "header": {
                 "name": "gate2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "measure", "memory": [0], "params": [], "qubits": [0], "clbits": [0]},
@@ -119,9 +133,11 @@
             "header": {
                 "name": "gate3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -134,9 +150,11 @@
             "header": {
                 "name": "gate4 (shots)",
                 "clbit_labels": [["c", 2]],
-                "memory_slots": 2,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 2,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -33,8 +34,8 @@
             "header": {
                 "name": "x reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -54,8 +55,8 @@
             "header": {
                 "name": "y reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -75,8 +76,8 @@
             "header": {
                 "name": "h reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -14,9 +14,11 @@
             "header": {
                 "name": "reset",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "reset", "qubits": [0]},
@@ -34,9 +36,11 @@
             "header": {
                 "name": "x reset",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "x", "qubits": [0]},
@@ -55,9 +59,11 @@
             "header": {
                 "name": "y reset",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "y", "qubits": [0]},
@@ -76,9 +82,11 @@
             "header": {
                 "name": "h reset",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -4,6 +4,7 @@
     "schema_version": "1.0.0",
     "config": {
         "shots": 1,
+        "n_qubits": 1,
         "memory_slots": 1,
         "seed": 1
     },
@@ -13,8 +14,8 @@
             "header": {
                 "name": "save_command",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -14,9 +14,11 @@
             "header": {
                 "name": "save_command",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "save", "params": [0]},

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "snapshot",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -32,8 +33,8 @@
             "header": {
                 "name": "id(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -52,8 +53,8 @@
             "header": {
                 "name": "id(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -72,8 +73,8 @@
             "header": {
                 "name": "id(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -93,8 +94,8 @@
             "header": {
                 "name": "id(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -115,8 +116,8 @@
             "header": {
                 "name": "x(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -137,8 +138,8 @@
             "header": {
                 "name": "x(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -159,8 +160,8 @@
             "header": {
                 "name": "x(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -181,8 +182,8 @@
             "header": {
                 "name": "y(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -203,8 +204,8 @@
             "header": {
                 "name": "y(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -225,8 +226,8 @@
             "header": {
                 "name": "y(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -247,8 +248,8 @@
             "header": {
                 "name": "h(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -269,8 +270,8 @@
             "header": {
                 "name": "h(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -291,8 +292,8 @@
             "header": {
                 "name": "h(u2)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -313,8 +314,8 @@
             "header": {
                 "name": "h(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -335,8 +336,8 @@
             "header": {
                 "name": "h(direct) z(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -358,8 +359,8 @@
             "header": {
                 "name": "h(direct) z(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -381,8 +382,8 @@
             "header": {
                 "name": "h(direct) z(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -404,8 +405,8 @@
             "header": {
                 "name": "h(direct) z(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -427,8 +428,8 @@
             "header": {
                 "name": "h(direct) s(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -450,8 +451,8 @@
             "header": {
                 "name": "h(direct) s(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -473,8 +474,8 @@
             "header": {
                 "name": "h(direct) s(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -496,8 +497,8 @@
             "header": {
                 "name": "h(direct) s(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -519,8 +520,8 @@
             "header": {
                 "name": "h(direct) sdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -542,8 +543,8 @@
             "header": {
                 "name": "h(direct) sdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -565,8 +566,8 @@
             "header": {
                 "name": "h(direct) sdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -588,8 +589,8 @@
             "header": {
                 "name": "h(direct) sdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -611,8 +612,8 @@
             "header": {
                 "name": "h(direct) t(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -634,8 +635,8 @@
             "header": {
                 "name": "h(direct) t(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -657,8 +658,8 @@
             "header": {
                 "name": "h(direct) t(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -680,8 +681,8 @@
             "header": {
                 "name": "h(direct) t(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -703,8 +704,8 @@
             "header": {
                 "name": "h(direct) tdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -726,8 +727,8 @@
             "header": {
                 "name": "h(direct) tdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -749,8 +750,8 @@
             "header": {
                 "name": "h(direct) tdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -772,8 +773,8 @@
             "header": {
                 "name": "h(direct) tdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -14,9 +14,11 @@
             "header": {
                 "name": "snapshot",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "snapshot", "label": "", "type": "", "params": [0]},
@@ -33,9 +35,11 @@
             "header": {
                 "name": "id(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "U", "params": [0.0, 0.0, 0.0], "qubits": [0]},
@@ -53,9 +57,11 @@
             "header": {
                 "name": "id(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u3", "params": [0.0, 0.0, 0.0], "qubits": [0]},
@@ -73,9 +79,11 @@
             "header": {
                 "name": "id(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u1", "params": [0.0], "qubits": [0]},
@@ -94,9 +102,11 @@
             "header": {
                 "name": "id(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "id", "qubits": [0]},
@@ -116,9 +126,11 @@
             "header": {
                 "name": "x(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "U", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
@@ -138,9 +150,11 @@
             "header": {
                 "name": "x(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u3", "params": [3.14159265358979, 0.0, 3.14159265358979], "qubits": [0]},
@@ -160,9 +174,11 @@
             "header": {
                 "name": "x(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "x", "qubits": [0]},
@@ -182,9 +198,11 @@
             "header": {
                 "name": "y(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "U", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
@@ -200,13 +218,14 @@
 
         },
         {
-
             "header": {
                 "name": "y(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u3", "params": [3.14159265358979, 1.5707963267948966, 1.5707963267948966], "qubits": [0]},
@@ -226,9 +245,11 @@
             "header": {
                 "name": "y(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "y", "qubits": [0]},
@@ -248,9 +269,11 @@
             "header": {
                 "name": "h(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "U", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
@@ -270,9 +293,11 @@
             "header": {
                 "name": "h(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u3", "params": [1.5707963267948966, 0.0, 3.141592653589793], "qubits": [0]},
@@ -292,9 +317,11 @@
             "header": {
                 "name": "h(u2)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "u2", "params": [0.0, 3.141592653589793], "qubits": [0]},
@@ -314,9 +341,11 @@
             "header": {
                 "name": "h(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -336,9 +365,11 @@
             "header": {
                 "name": "h(direct) z(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -359,9 +390,11 @@
             "header": {
                 "name": "h(direct) z(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -382,9 +415,11 @@
             "header": {
                 "name": "h(direct) z(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -405,9 +440,11 @@
             "header": {
                 "name": "h(direct) z(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -428,9 +465,11 @@
             "header": {
                 "name": "h(direct) s(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -451,9 +490,11 @@
             "header": {
                 "name": "h(direct) s(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -474,9 +515,11 @@
             "header": {
                 "name": "h(direct) s(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -497,9 +540,11 @@
             "header": {
                 "name": "h(direct) s(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -520,9 +565,11 @@
             "header": {
                 "name": "h(direct) sdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -543,9 +590,11 @@
             "header": {
                 "name": "h(direct) sdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -566,9 +615,11 @@
             "header": {
                 "name": "h(direct) sdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -589,9 +640,11 @@
             "header": {
                 "name": "h(direct) sdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -612,9 +665,11 @@
             "header": {
                 "name": "h(direct) t(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -635,9 +690,11 @@
             "header": {
                 "name": "h(direct) t(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -658,9 +715,11 @@
             "header": {
                 "name": "h(direct) t(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -681,9 +740,11 @@
             "header": {
                 "name": "h(direct) t(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -704,9 +765,11 @@
             "header": {
                 "name": "h(direct) tdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -727,9 +790,11 @@
             "header": {
                 "name": "h(direct) tdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -750,9 +815,11 @@
             "header": {
                 "name": "h(direct) tdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},
@@ -773,9 +840,11 @@
             "header": {
                 "name": "h(direct) tdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "memory_slots": 1,
-                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
+            },
+            "config": {
+                "memory_slots": 1,
+                "n_qubits": 1
             },
             "instructions": [
                 {"name": "h", "qubits": [0]},

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 2,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
                 "header": {
                     "name": "h0 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -35,8 +36,8 @@
                 "header": {
                     "name": "h0 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -57,8 +58,8 @@
                 "header": {
                     "name": "h1 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -79,8 +80,8 @@
                 "header": {
                     "name": "h1 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -101,8 +102,8 @@
                 "header": {
                     "name": "h0 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -123,8 +124,8 @@
                 "header": {
                     "name": "h0 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -145,8 +146,8 @@
                 "header": {
                     "name": "h1 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -167,8 +168,8 @@
                 "header": {
                     "name": "h1 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -189,8 +190,8 @@
                 "header": {
                     "name": "h0 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -211,8 +212,8 @@
                 "header": {
                     "name": "h0 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -233,8 +234,8 @@
                 "header": {
                     "name": "h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -255,8 +256,8 @@
                 "header": {
                     "name": "h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -277,8 +278,8 @@
                 "header": {
                     "name": "h0 h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -300,8 +301,8 @@
                 "header": {
                     "name": "h0 h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -323,8 +324,8 @@
                 "header": {
                     "name": "h0 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -345,8 +346,8 @@
                 "header": {
                     "name": "h0 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -367,8 +368,8 @@
                 "header": {
                     "name": "h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -389,8 +390,8 @@
                 "header": {
                     "name": "h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -411,8 +412,8 @@
                 "header": {
                     "name": "h0 h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -434,8 +435,8 @@
                 "header": {
                     "name": "h0 h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -14,9 +14,11 @@
                 "header": {
                     "name": "h0 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -36,9 +38,11 @@
                 "header": {
                     "name": "h0 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -58,9 +62,11 @@
                 "header": {
                     "name": "h1 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -80,9 +86,11 @@
                 "header": {
                     "name": "h1 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -102,9 +110,11 @@
                 "header": {
                     "name": "h0 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -124,9 +134,11 @@
                 "header": {
                     "name": "h0 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -146,9 +158,11 @@
                 "header": {
                     "name": "h1 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -168,9 +182,11 @@
                 "header": {
                     "name": "h1 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -190,9 +206,11 @@
                 "header": {
                     "name": "h0 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -212,9 +230,11 @@
                 "header": {
                     "name": "h0 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -234,9 +254,11 @@
                 "header": {
                     "name": "h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -256,9 +278,11 @@
                 "header": {
                     "name": "h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -278,9 +302,11 @@
                 "header": {
                     "name": "h0 h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -301,9 +327,11 @@
                 "header": {
                     "name": "h0 h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -324,9 +352,11 @@
                 "header": {
                     "name": "h0 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -346,9 +376,11 @@
                 "header": {
                     "name": "h0 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -368,9 +400,11 @@
                 "header": {
                     "name": "h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -390,9 +424,11 @@
                 "header": {
                     "name": "h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [1]},
@@ -412,9 +448,11 @@
                 "header": {
                     "name": "h0 h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},
@@ -435,9 +473,11 @@
                 "header": {
                     "name": "h0 h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "memory_slots": 1,
-                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
+                },
+                "config": {
+                    "memory_slots": 1,
+                    "n_qubits": 2
                 },
                 "instructions": [
                     {"name": "h", "qubits": [0]},

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -401,9 +401,11 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qr, cr)
         qobj = compile(qc, backend)
         compiled_ops = qobj.experiments[0].instructions
+        original_cx_qubits = [[1, 2], [2, 3], [3, 4], [3, 14]]
         for operation in compiled_ops:
             if operation.name == 'cx':
                 self.assertIn(operation.qubits, backend.configuration().coupling_map)
+                self.assertIn(operation.qubits, original_cx_qubits)
 
     def test_compile_circuits_diff_registers(self):
         """Compile list of circuits with different qreg names.
@@ -560,25 +562,6 @@ class TestCompiler(QiskitTestCase):
         qlist = [qc for k in range(10)]
         qobj = compile(qlist, backend=backend)
         self.assertEqual(len(qobj.experiments), 10)
-
-    def test_already_matching(self):
-        """Map qubit i -> i if circuit is already compatible with topology.
-        """
-        backend = FakeBackend()
-        qr = QuantumRegister(16, 'qr')
-        cr = ClassicalRegister(4, 'cr')
-        qc = QuantumCircuit(qr, cr)
-        qc.h(qr)
-        qc.cx(qr[1], qr[0])
-        qc.cx(qr[6], qr[11])
-        qc.cx(qr[8], qr[7])
-        qc.measure(qr[1], cr[0])
-        qc.measure(qr[0], cr[1])
-        qc.measure(qr[6], cr[2])
-        qc.measure(qr[11], cr[3])
-        qobj = compile(qc, backend=backend)
-        for qubit_layout in qobj.experiments[0].config.layout:
-            self.assertEqual(qubit_layout[0][1], qubit_layout[1][1])
 
 
 if __name__ == '__main__':

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -141,7 +141,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        backend = qiskit.Aer.get_backend('qasm_simulator_py')
+        backend = qiskit.Aer.get_backend('qasm_simulator')
 
         qubit_reg = QuantumRegister(2)
         clbit_reg = ClassicalRegister(2)

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -141,7 +141,7 @@ class TestCompiler(QiskitTestCase):
 
         If all correct some should exists.
         """
-        backend = qiskit.Aer.get_backend('qasm_simulator')
+        backend = qiskit.Aer.get_backend('qasm_simulator_py')
 
         qubit_reg = QuantumRegister(2)
         clbit_reg = ClassicalRegister(2)


### PR DESCRIPTION
Revise the local simulators to ensure that the Qobj.header and the
Qobj.experiments[x].header are passed through and present in their
results.
Add a `test_qobj_headers_in_result` for verifying.

Also: Fixes #1066, Fixes #1087 

* Qiskit now puts memory_slots and n_qubits in the config of each single experiment. Although the schema has them as optional, the simulators do need it. This ensures that none of the backends use the info in header to conduct the experiment, only the config and instructions.

* The qobj header of each experiment now contains n_qubits, memory_slots, clbit_labels, qubit_labels, clreg_sizes, qureg_sizes, which are helpful for reconstructing the result according to the original circuit specs. The schema and the rest of the codebase have been updated accordingly.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #1365, tackling the first part (making sure the headers are present in the results).

### Details and comments


