### PR TITLE
Removing snapshots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,6 +134,7 @@ Removed
   ``.from_dict()`` directly (#1360).
 - The ``qiskit.Result`` class method for ``len()`` and indexing have been
   removed, along with the functions that perform post-processing (#1351).
+- The ``get_snapshots`` from the ``result object.
 
 `0.6.0`_ - 2018-10-04
 ^^^^^^^^^^^^^^^^^^^^^

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -141,64 +141,6 @@ class Result(BaseModel):
         except KeyError:
             raise QISKitError('No unitary for circuit "{0}"'.format(circuit))
 
-    def get_snapshots(self, circuit=None):
-        """Get snapshots recorded during the run of an experiment.
-
-        Args:
-            circuit (str or QuantumCircuit or int or None): the index of the
-                experiment, as specified by ``data()``.
-
-        Returns:
-            dict[slot: dict[str: array]]: dictionary where the keys are the
-                requested snapshot slots, and the values are a dictionary of
-                the snapshots themselves.
-
-        Raises:
-            QISKitError: if there are no snapshots for the experiment.
-        """
-        try:
-            return self._get_experiment(circuit).data.snapshots.to_dict()
-        except KeyError:
-            raise QISKitError('No snapshots for circuit "{0}"'.format(circuit))
-
-    def get_snapshot(self, slot=None, circuit=None):
-        """Get snapshot at a specific slot of an experiment.
-
-        Args:
-            slot (str): snapshot slot to retrieve. If None and there is only one
-                slot, return that one.
-            circuit (str or QuantumCircuit or int or None): the index of the
-                experiment, as specified by ``data()``.
-
-        Returns:
-            dict[slot: dict[str: array]]: list of 2^n_qubits complex amplitudes.
-
-        Raises:
-            QISKitError: if there is no snapshot at all, or in this slot
-        """
-        try:
-            snapshots_dict = self.get_snapshots(circuit)
-
-            if slot is None:
-                slots = list(snapshots_dict.keys())
-                if len(slots) == 1:
-                    slot = slots[0]
-                else:
-                    raise QISKitError("You have to select a slot when there "
-                                      "is more than one available")
-            snapshot_dict = snapshots_dict[slot]
-
-            snapshot_types = list(snapshot_dict.keys())
-            if len(snapshot_types) == 1:
-                snapshot_list = snapshot_dict[snapshot_types[0]]
-                if len(snapshot_list) == 1:
-                    return snapshot_list[0]
-                return snapshot_list
-            return snapshot_dict
-        except KeyError:
-            raise QISKitError('No snapshot at slot {0} for '
-                              'circuit "{1}"'.format(slot, circuit))
-
     def _get_experiment(self, key=None):
         """Return an experiment from a given key.
 

--- a/test/python/aer/test_extensions_simulator.py
+++ b/test/python/aer/test_extensions_simulator.py
@@ -59,9 +59,9 @@ class TestExtensionsSimulator(QiskitTestCase):
 
         sim = Aer.get_backend('statevector_simulator')
         result = execute(circuit, sim).result()
-        snapshot = result.get_snapshot(slot='3')
+        snapshot = result.data(0)['snapshots']['3']['statevector']
         target = [0.70710678 + 0.j, 0. + 0.j, 0. + 0.j, 0.70710678 + 0.j]
-        fidelity = state_fidelity(snapshot, target)
+        fidelity = state_fidelity(snapshot[0], target)
         self.assertGreater(
             fidelity, self._desired_fidelity,
             "snapshot has low fidelity{0:.2g}.".format(fidelity))

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -177,7 +177,7 @@ class TestAerQasmSimulator(QiskitTestCase):
                 self.assertDictAlmostEqual(counts, expected_counts,
                                            threshold, msg=name + 'counts')
             # Check snapshot
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
             self.assertEqual(len(snapshots['0']), 3,
@@ -211,7 +211,7 @@ class TestAerQasmSimulator(QiskitTestCase):
         }
 
         for name in sampled_measurements:
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             # Check snapshot keys
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
@@ -239,7 +239,7 @@ class TestAerQasmSimulator(QiskitTestCase):
         }
         for name in expected_data:
             # Check snapshot is |0> state
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
             self.assertEqual(len(snapshots['0']), 1,
@@ -256,7 +256,7 @@ class TestAerQasmSimulator(QiskitTestCase):
             qobj = Qobj.from_dict(json.load(file))
         result = self.backend.run(qobj).result()
 
-        snapshots = result.get_snapshots('save_command')
+        snapshots = result.data('save_command')['snapshots']
         self.assertEqual(set(snapshots), {'0', '1', '10', '11'},
                          msg='snapshot keys')
         state0 = snapshots['0']['statevector'][0]
@@ -356,7 +356,7 @@ class TestAerQasmSimulator(QiskitTestCase):
 
         for name in expected_data:
             # Check snapshot
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
             self.assertEqual(len(snapshots['0']), 1,
@@ -413,7 +413,7 @@ class TestAerQasmSimulator(QiskitTestCase):
 
         for name in expected_data:
             # Check snapshot
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
             self.assertEqual(len(snapshots['0']), 1,
@@ -442,7 +442,7 @@ class TestAerQasmSimulator(QiskitTestCase):
 
         for name in expected_data:
             # Check snapshot
-            snapshots = result.get_snapshots(name)
+            snapshots = result.data(name)['snapshots']
             self.assertEqual(set(snapshots), {'0'},
                              msg=name + ' snapshot keys')
             self.assertEqual(len(snapshots['0']), 1,

--- a/test/python/aer/test_simulator_interfaces.py
+++ b/test/python/aer/test_simulator_interfaces.py
@@ -61,7 +61,6 @@ class TestCrossSimulation(QiskitTestCase):
         counts_py = result_py.get_counts()
         self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.05)
 
-
     def test_qasm_reset_measure(self):
         """counts from a qasm program with measure and reset in the middle"""
         qr = qiskit.QuantumRegister(3)

--- a/test/python/aer/test_simulator_interfaces.py
+++ b/test/python/aer/test_simulator_interfaces.py
@@ -61,32 +61,6 @@ class TestCrossSimulation(QiskitTestCase):
         counts_py = result_py.get_counts()
         self.assertDictAlmostEqual(counts_cpp, counts_py, shots*0.05)
 
-    def test_qasm_snapshot(self):
-        """snapshot a circuit at multiple places"""
-        qr = qiskit.QuantumRegister(3)
-        cr = qiskit.ClassicalRegister(3)
-        circuit = qiskit.QuantumCircuit(qr, cr)
-        circuit.h(qr[0])
-        circuit.cx(qr[0], qr[1])
-        circuit.snapshot(1)
-        circuit.ccx(qr[0], qr[1], qr[2])
-        circuit.snapshot(2)
-        circuit.reset(qr)
-        circuit.snapshot(3)
-        circuit.measure(qr, cr)
-
-        sim_cpp = Aer.get_backend('qasm_simulator')
-        sim_py = Aer.get_backend('qasm_simulator_py')
-        result_cpp = execute(circuit, sim_cpp, shots=2).result()
-        result_py = execute(circuit, sim_py, shots=2).result()
-        snapshots_cpp = result_cpp.get_snapshots()
-        snapshots_py = result_py.get_snapshots()
-        self.assertEqual(snapshots_cpp.keys(), snapshots_py.keys())
-        snapshot_cpp_1 = result_cpp.get_snapshot(slot='1')
-        snapshot_py_1 = result_py.get_snapshot(slot='1')
-        self.assertEqual(len(snapshot_cpp_1), len(snapshot_py_1))
-        fidelity = state_fidelity(snapshot_cpp_1[0], snapshot_py_1[0])
-        self.assertGreater(fidelity, self._desired_fidelity)
 
     def test_qasm_reset_measure(self):
         """counts from a qasm program with measure and reset in the middle"""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -15,7 +15,7 @@ from qiskit import execute
 from qiskit import QISKitError
 from qiskit.quantum_info import state_fidelity
 
-from ..common import QiskitTestCase, bin_to_hex_keys
+from ..common import QiskitTestCase, bin_to_hex_keys, requires_cpp_simulator
 
 
 class TestCircuitOperations(QiskitTestCase):
@@ -73,6 +73,7 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertRaises(QISKitError, qc1.__add__, qc2)
         self.assertRaises(QISKitError, qc1.__add__, qcr3)
 
+    @requires_cpp_simulator
     def test_combine_circuit_extension_instructions(self):
         """Test combining circuits containing barrier, initializer, snapshot
         """
@@ -86,10 +87,10 @@ class TestCircuitOperations(QiskitTestCase):
         qc2.snapshot(slot='1')
         qc2.measure(qr, cr)
         new_circuit = qc1 + qc2
-        backend = Aer.get_backend('qasm_simulator_py')
+        backend = Aer.get_backend('qasm_simulator')
         shots = 1024
         result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
-        snapshot_vectors = result.get_snapshot()
+        snapshot_vectors = result.data(0)['snapshots']['1']['statevector']
         fidelity = state_fidelity(snapshot_vectors[0], desired_vector)
         self.assertGreater(fidelity, 0.99)
 
@@ -150,6 +151,7 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertRaises(QISKitError, qc1.__iadd__, qc2)
         self.assertRaises(QISKitError, qc1.__iadd__, qcr3)
 
+    @requires_cpp_simulator
     def test_extend_circuit_extension_instructions(self):
         """Test extending circuits containing barrier, initializer, snapshot
         """
@@ -167,7 +169,7 @@ class TestCircuitOperations(QiskitTestCase):
         shots = 1024
         result = execute(qc1, backend=backend, shots=shots, seed=78).result()
 
-        snapshot_vectors = result.get_snapshot('1')
+        snapshot_vectors = result.data(0)['snapshots']['1']['statevector']
         fidelity = state_fidelity(snapshot_vectors[0], desired_vector)
         self.assertGreater(fidelity, 0.99)
 

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -206,5 +206,6 @@ class TestDagEquivalence(QiskitTestCase):
 
         self.assertNotEqual(self.dag1, dag2)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In this pull request we are removing from results get_snapshot. The snapshots are still possible using results.data(circuit)[‘snapshot’] and if we need a method for making this simpler we will add this to analyzation and it can be configured to the snapshots the users wants. 