### PR TITLE
Update docs around Result.get_snapshot removal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -134,7 +134,9 @@ Removed
   ``.from_dict()`` directly (#1360).
 - The ``qiskit.Result`` class method for ``len()`` and indexing have been
   removed, along with the functions that perform post-processing (#1351).
-- The ``get_snapshots`` from the ``result object.
+- The ``get_snapshot()`` and ``get_snapshots()`` method from the ``Result``
+  class has been removed. Instead you can access the snapshots in a Result
+  using ``Result.data()['snapshots']``.
 
 `0.6.0`_ - 2018-10-04
 ^^^^^^^^^^^^^^^^^^^^^

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -80,7 +80,7 @@ class Result(BaseModel):
             [[0.5+0j, 0-1j], ...] the value returned will be
             [[[0.5, 0], [0, -1]], ...].
 
-            The simulator backends also have an optional key 'snapshot' which
+            The simulator backends also have an optional key 'snapshots' which
             returns a dict of snapshots specified by the simulator backend.
             The value is of the form dict[slot: dict[str: array]]
             where the keys are the requested snapshot slots, and the values are


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit just makes some small tweaks to the changelog entry for the
removal of Result.get_snapshot() and the docstring for Result.data()
(which is the alternative to getting snapshots post removal). Hopefully
this will make it a bit clearer moving forward on how to access
snapshots in a result object.

### Details and comments


