### PR TITLE
result.get_memory()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,9 @@ Added
   `size()`, `depth()`, `width()`, `count_ops()`, `num_tensor_factors()` (#1285)
 - New `plot_bloch_multivector()` to plot Bloch vectors from a tensored state
   vector or density matrix. (#1359)
+- Per-shot measurement results are available in simulators and select devices.
+  Request them by setting ``memory=True`` in ``compile()``/``execute()``,
+  and retrieve them from ``result.get_memory()`` (#1385).
 
 Changed
 """""""

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -105,6 +105,7 @@ class QasmSimulatorPy(BaseBackend):
         self._number_of_cbits = 0
         self._number_of_qubits = 0
         self._shots = 0
+        self._memory = False
         self._qobj_config = None
 
     def _add_qasm_single(self, gate, qubit):

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -239,6 +239,7 @@ class QasmSimulatorPy(BaseBackend):
         self._validate(qobj)
         result_list = []
         self._shots = qobj.config.shots
+        self._memory = qobj.config.memory
         self._qobj_config = qobj.config
         start = time.time()
 
@@ -359,9 +360,11 @@ class QasmSimulatorPy(BaseBackend):
 
         data = {
             'counts': dict(Counter(outcomes)),
-            'memory': outcomes,
             'snapshots': self._snapshots
         }
+        if self._memory:
+            data['memory'] = outcomes
+
         end = time.time()
         return {'name': experiment.header.name,
                 'seed': seed,

--- a/qiskit/converters/circuits_to_qobj.py
+++ b/qiskit/converters/circuits_to_qobj.py
@@ -15,7 +15,7 @@ from qiskit._quantumcircuit import QuantumCircuit
 
 def circuits_to_qobj(circuits, backend_name, config=None, shots=1024,
                      max_credits=10, qobj_id=None, basis_gates=None, coupling_map=None,
-                     seed=None):
+                     seed=None, memory=False):
     """Convert a list of circuits into a qobj.
 
     Args:
@@ -28,6 +28,7 @@ def circuits_to_qobj(circuits, backend_name, config=None, shots=1024,
         basis_gates (list[str])): basis gates for the experiment
         coupling_map (list): coupling map (perhaps custom) to target in mapping
         seed (int): random seed for simulators
+        memory (bool): if True, per-shot measurement bitstrings are returned as well
 
     Returns:
         Qobj: the Qobj to be run on the backends
@@ -40,7 +41,8 @@ def circuits_to_qobj(circuits, backend_name, config=None, shots=1024,
     qobj_config = deepcopy(config or {})
     qobj_config.update({'shots': shots,
                         'max_credits': max_credits,
-                        'memory_slots': 0})
+                        'memory_slots': 0,
+                        'memory': memory})
 
     qobj = Qobj(qobj_id=qobj_id or str(uuid.uuid4()),
                 config=QobjConfig(**qobj_config),

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -10,7 +10,8 @@
 import warnings
 from qiskit import QiskitError, QuantumCircuit
 from qiskit.validation.base import BaseModel, bind_schema
-from .postprocess import format_counts, format_statevector, format_unitary
+from .postprocess import (format_counts, format_statevector,
+                          format_unitary, format_memory)
 from .models import ResultSchema
 
 
@@ -94,6 +95,31 @@ class Result(BaseModel):
         except (KeyError, TypeError):
             raise QiskitError('No data for circuit "{0}"'.format(circuit))
 
+    def get_memory(self, circuit=None):
+        """Get the sequence of memory states (readouts) for each shot
+        The data from the experiment is a list of format
+        ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
+
+        Args:
+            circuit (str or QuantumCircuit or int or None): the index of the
+                experiment, as specified by ``data()``.
+
+        Returns:
+            List[str]: the list of each outcome, formatted according to
+                registers in circuit.
+
+        Raises:
+            QiskitError: if there is no memory data for the circuit.
+        """
+        try:
+            header = self._get_experiment(circuit).header.to_dict()
+            memory_list = []
+            for memory in self.data(circuit)['memory']:
+                memory_list.append(format_memory(memory, header))
+            return memory_list
+        except KeyError:
+            raise QiskitError('No memory for circuit "{0}".'.format(circuit))
+
     def get_counts(self, circuit=None):
         """Get the histogram data of an experiment.
 
@@ -158,27 +184,6 @@ class Result(BaseModel):
                                   decimals=decimals)
         except KeyError:
             raise QiskitError('No unitary for circuit "{0}"'.format(circuit))
-
-    def get_memory(self, circuit=None):
-        """Get the sequence of memory states (readouts) for each shot
-        The data from the experiment is a list of format
-        ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
-
-        Args:
-            circuit (str or QuantumCircuit or int or None): the index of the
-                experiment, as specified by ``data()``.
-
-        Returns:
-            List[str]: the list of each outcome, formatted according to
-                registers in circuit.
-
-        Raises:
-            QISKitError: if there is no memory data for the circuit.
-        """
-        try:
-            return self._get_experiment(circuit).data.memory
-        except KeyError:
-            raise QISKitError('No memory data for circuit "{0}".'.format(circuit))
 
     def _get_experiment(self, key=None):
         """Return a single experiment result from a given key.

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -159,6 +159,27 @@ class Result(BaseModel):
         except KeyError:
             raise QiskitError('No unitary for circuit "{0}"'.format(circuit))
 
+    def get_memory(self, circuit=None):
+        """Get the sequence of memory states (readouts) for each shot
+        The data from the experiment is a list of format
+        ['00000', '01000', '10100', '10100', '11101', '11100', '00101', ..., '01010']
+
+        Args:
+            circuit (str or QuantumCircuit or int or None): the index of the
+                experiment, as specified by ``data()``.
+
+        Returns:
+            List[str]: the list of each outcome, formatted according to
+                registers in circuit.
+
+        Raises:
+            QISKitError: if there is no memory data for the circuit.
+        """
+        try:
+            return self._get_experiment(circuit).data.memory
+        except KeyError:
+            raise QISKitError('No memory data for circuit "{0}".'.format(circuit))
+
     def _get_experiment(self, key=None):
         """Return a single experiment result from a given key.
 

--- a/qiskit/tools/_compiler.py
+++ b/qiskit/tools/_compiler.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def compile(circuits, backend,
             config=None, basis_gates=None, coupling_map=None, initial_layout=None,
             shots=1024, max_credits=10, seed=None, qobj_id=None,
-            skip_transpiler=False, seed_mapper=None, pass_manager=None):
+            skip_transpiler=False, seed_mapper=None, pass_manager=None, memory=False):
     """Compile a list of circuits into a qobj.
 
     Args:
@@ -37,10 +37,14 @@ def compile(circuits, backend,
         seed_mapper (int): random seed for swapper mapper
         qobj_id (int): identifier for the generated qobj
         pass_manager (PassManager): a pass manger for the transpiler pipeline
+        memory (bool): if True, per-shot measurement bitstrings are returned as well
         skip_transpiler (bool): DEPRECATED skip transpiler and create qobj directly
 
     Returns:
         Qobj: the qobj to be run on the backends
+
+    Raises:
+        QiskitError: if the desired options are not supported by backend
     """
     if skip_transpiler:  # empty pass manager which does nothing
         pass_manager = PassManager()
@@ -60,7 +64,7 @@ def compile(circuits, backend,
     qobj = circuits_to_qobj(circuits, backend_name=backend.name(),
                             config=config, shots=shots, max_credits=max_credits,
                             qobj_id=qobj_id, basis_gates=basis_gates,
-                            coupling_map=coupling_map, seed=seed)
+                            coupling_map=coupling_map, seed=seed, memory=memory)
 
     return qobj
 
@@ -68,7 +72,7 @@ def compile(circuits, backend,
 def execute(circuits, backend, config=None, basis_gates=None, coupling_map=None,
             initial_layout=None, shots=1024, max_credits=10, seed=None,
             qobj_id=None, skip_transpiler=False, seed_mapper=None, pass_manager=None,
-            **kwargs):
+            memory=False, **kwargs):
     """Executes a set of circuits.
 
     Args:
@@ -84,6 +88,7 @@ def execute(circuits, backend, config=None, basis_gates=None, coupling_map=None,
         seed_mapper (int): random seed for swapper mapper
         qobj_id (int): identifier for the generated qobj
         pass_manager (PassManager): a pass manger for the transpiler pipeline
+        memory (bool): if True, per-shot measurement bitstrings are returned as well.
         skip_transpiler (bool): DEPRECATED skip transpiler and create qobj directly
         kwargs: extra arguments used by AER for running configurable backends.
                 Refer to the backend documentation for details on these arguments
@@ -100,6 +105,6 @@ def execute(circuits, backend, config=None, basis_gates=None, coupling_map=None,
     qobj = compile(circuits, backend,
                    config, basis_gates, coupling_map, initial_layout,
                    shots, max_credits, seed, qobj_id,
-                   skip_transpiler, seed_mapper, pass_manager)
+                   skip_transpiler, seed_mapper, pass_manager, memory)
 
     return backend.run(qobj, **kwargs)

--- a/qiskit/tools/_compiler.py
+++ b/qiskit/tools/_compiler.py
@@ -12,6 +12,7 @@ import logging
 from qiskit import transpiler
 from qiskit.transpiler._passmanager import PassManager
 from qiskit.converters import circuits_to_qobj
+from qiskit import QiskitError
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +47,11 @@ def compile(circuits, backend,
         warnings.warn('The skip_transpiler option has been deprecated. '
                       'Please pass an empty PassManager() instance instead',
                       DeprecationWarning)
+
+    backend_memory = getattr(backend.configuration(), 'memory', False)
+    if memory and not backend_memory:
+        raise QiskitError("Backend %s only returns total counts, not single-shot memory." %
+                          backend.name())
 
     circuits = transpiler.transpile(circuits, backend, basis_gates, coupling_map, initial_layout,
                                     seed_mapper, pass_manager)

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -432,6 +432,27 @@ class TestAerQasmSimulator(QiskitTestCase):
             self.assertAlmostEqual(fidelity, 1.0, places=10,
                                    msg=name + ' snapshot fidelity')
 
+    def test_memory(self):
+        q = QuantumRegister(4, 'q')
+        c0 = ClassicalRegister(2, 'c0')
+        c1 = ClassicalRegister(2, 'c1')
+        circ = QuantumCircuit(q, c0, c1)
+        circ.h(q[0])
+        circ.cx(q[0], q[1])
+        circ.x(q[3])
+        circ.measure(q[0], c0[0])
+        circ.measure(q[1], c0[1])
+        circ.measure(q[2], c1[0])
+        circ.measure(q[3], c1[1])
+
+        shots = 50
+        qobj = compile(circ, backend=self.backend, shots=shots, memory=True)
+        result = self.backend.run(qobj).result()
+        memory = result.get_memory()
+        self.assertEqual(len(memory), shots)
+        for mem in memory:
+            self.assertIn(mem, ['10 00', '10 11'])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/python/aer/test_qasm_simulator.py
+++ b/test/python/aer/test_qasm_simulator.py
@@ -433,17 +433,17 @@ class TestAerQasmSimulator(QiskitTestCase):
                                    msg=name + ' snapshot fidelity')
 
     def test_memory(self):
-        q = QuantumRegister(4, 'q')
-        c0 = ClassicalRegister(2, 'c0')
-        c1 = ClassicalRegister(2, 'c1')
-        circ = QuantumCircuit(q, c0, c1)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.x(q[3])
-        circ.measure(q[0], c0[0])
-        circ.measure(q[1], c0[1])
-        circ.measure(q[2], c1[0])
-        circ.measure(q[3], c1[1])
+        qr = QuantumRegister(4, 'qr')
+        cr0 = ClassicalRegister(2, 'cr0')
+        cr1 = ClassicalRegister(2, 'cr1')
+        circ = QuantumCircuit(qr, cr0, cr1)
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.x(qr[3])
+        circ.measure(qr[0], cr0[0])
+        circ.measure(qr[1], cr0[1])
+        circ.measure(qr[2], cr1[0])
+        circ.measure(qr[3], cr1[1])
 
         shots = 50
         qobj = compile(circ, backend=self.backend, shots=shots, memory=True)

--- a/test/python/aer/test_qasm_simulator_py.py
+++ b/test/python/aer/test_qasm_simulator_py.py
@@ -129,17 +129,17 @@ class TestAerQasmSimulatorPy(QiskitTestCase):
         self.assertLess(error, 0.05)
 
     def test_memory(self):
-        q = QuantumRegister(4, 'q')
-        c0 = ClassicalRegister(2, 'c0')
-        c1 = ClassicalRegister(2, 'c1')
-        circ = QuantumCircuit(q, c0, c1)
-        circ.h(q[0])
-        circ.cx(q[0], q[1])
-        circ.x(q[3])
-        circ.measure(q[0], c0[0])
-        circ.measure(q[1], c0[1])
-        circ.measure(q[2], c1[0])
-        circ.measure(q[3], c1[1])
+        qr = QuantumRegister(4, 'qr')
+        cr0 = ClassicalRegister(2, 'cr0')
+        cr1 = ClassicalRegister(2, 'cr1')
+        circ = QuantumCircuit(qr, cr0, cr1)
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.x(qr[3])
+        circ.measure(qr[0], cr0[0])
+        circ.measure(qr[1], cr0[1])
+        circ.measure(qr[2], cr1[0])
+        circ.measure(qr[3], cr1[1])
 
         shots = 50
         qobj = compile(circ, backend=self.backend, shots=shots, memory=True)

--- a/test/python/aer/test_qasm_simulator_py.py
+++ b/test/python/aer/test_qasm_simulator_py.py
@@ -106,7 +106,6 @@ class TestAerQasmSimulatorPy(QiskitTestCase):
         qobj = compile(circuit, backend=self.backend, shots=shots, seed=self.seed)
         results = self.backend.run(qobj).result()
         data = results.get_counts('teleport')
-        print(data)
         alice = {
             '00': data['0 0 0'] + data['1 0 0'],
             '01': data['0 1 0'] + data['1 1 0'],
@@ -128,6 +127,27 @@ class TestAerQasmSimulatorPy(QiskitTestCase):
         error = abs(alice_ratio - bob_ratio) / alice_ratio
         self.log.info('test_teleport: relative error = %s', error)
         self.assertLess(error, 0.05)
+
+    def test_memory(self):
+        q = QuantumRegister(4, 'q')
+        c0 = ClassicalRegister(2, 'c0')
+        c1 = ClassicalRegister(2, 'c1')
+        circ = QuantumCircuit(q, c0, c1)
+        circ.h(q[0])
+        circ.cx(q[0], q[1])
+        circ.x(q[3])
+        circ.measure(q[0], c0[0])
+        circ.measure(q[1], c0[1])
+        circ.measure(q[2], c1[0])
+        circ.measure(q[3], c1[1])
+
+        shots = 50
+        qobj = compile(circ, backend=self.backend, shots=shots, memory=True)
+        result = self.backend.run(qobj).result()
+        memory = result.get_memory()
+        self.assertEqual(len(memory), shots)
+        for mem in memory:
+            self.assertIn(mem, ['10 00', '10 11'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1063
This PR supports reading per-shot measurements, in a new field of the result.data called memory. This information is accessible via result.get_memory().

The Aer.QasmSimulator() and Aer.QasmSimulatorPy() do this in #1373. The devices are being modified separately to do this. However, backends may continue to just return counts, if they choose.

