### PR TITLE
update qobj examples

### DIFF
--- a/qiskit/schemas/examples/qobj_openqasm_example.json
+++ b/qiskit/schemas/examples/qobj_openqasm_example.json
@@ -7,14 +7,14 @@
         "backend_name": "ibmqx2"},
     "config": {
         "shots": 1024,
-        "memory_slots": 3
+        "memory_slots": 1
         },
     "experiments": [
         {
         "header": {
-            "memory_slots": 3,
+            "memory_slots": 1,
             "n_qubits": 3,
-            "clbit_labels": [["c1", 0],null,null],
+            "clbit_labels": [["c1", 0]],
             "qubit_labels": [null,["q", 0],["q",1]]
             },
         "config": {},
@@ -33,7 +33,7 @@
         "header": {
             "memory_slots": 3,
             "n_qubits": 3,
-            "clbit_labels": [["c1", 0],null,null],
+            "clbit_labels": [["c1", 0]],
             "qubit_labels": [null,["q", 0],["q",1]]
             },
         "config": {},

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -251,15 +251,15 @@
         },
         "openqasm_instructions": {
             "oneOf": [
-                { 
+                {
                     "properties": {
                         "name": {"not": {
-                            "enum": ["u3", "U", "id", "h", "s", "sdg", "t", "tdg", "x", "y", "z", 
-                            "u1", "u0", "rx", "ry", "rz", "u2", "cx", "CX", "cy", "cz", "ch", 
-                            "swap", "cu1", "crz", "rzz", "cu3", "ccx", "cswap", "snapshot", 
+                            "enum": ["u3", "U", "id", "h", "s", "sdg", "t", "tdg", "x", "y", "z",
+                            "u1", "u0", "rx", "ry", "rz", "u2", "cx", "CX", "cy", "cz", "ch",
+                            "swap", "cu1", "crz", "rzz", "cu3", "ccx", "cswap", "snapshot",
                             "reset", "barrier", "bfunc", "copy", "measure"]
                             },
-                            "type": "string"                            
+                            "type": "string"
                             }
                     }
                 },
@@ -690,7 +690,18 @@
             "properties": {
                 "config": {
                     "description": "Configuration options that apply to specific experiments in this qobj. Overwrites qobj level configuration.",
-                    "properties": {},
+                    "properties": {
+                        "memory_slots": {
+                            "description": "Total number of (slow) measurement slots used in this experiment.",
+                            "minimum": 0,
+                            "type": "integer"
+                        },
+                        "n_qubits": {
+                            "description": "Total number of qubits used in this experiment.",
+                            "minimum": 1,
+                            "type": "integer"
+                        }                        
+                    },
                     "title": "Experiment level configuration",
                     "type": "object"
                 },
@@ -701,41 +712,68 @@
                             "description": "Experiment name.",
                             "type": "string"
                         },
-                        "n_qubits": {
-                            "description": "Number of backend qubits for converting back to OpenQasm registers",
-                            "type": "number"
-                        },
                         "memory_slots": {
-                            "description": "Number of backend memory slots",
-                            "type": "number"
+                            "description": "Total number of (slow) measurement slots used in this experiment.",
+                            "minimum": 1,
+                            "type": "integer"
+                        },                        
+                        "n_qubits": {
+                            "description": "Total number of qubits used in this experiment.",
+                            "minimum": 1,                            
+                            "type": "integer"
                         },
-                        "clbit_labels": {
-                            "description": "A list of length memory_slots (from backend.configuration or in this header), where each element is either [creg_name, n] to identify the corresponding memory slot as the n-th element of creg creg_name, or null to identify that the corresponding memory slot has no corresponding creg",
-                            "items": [
-                                {
-                                    "items": [
-                                        {
-                                            "minLength": 1,
-                                            "title": "clreg",
-                                            "type": "string"
-                                        },
-                                        {
-                                            "description": "The register slot of the clreg",
-                                            "minimum": 0,
-                                            "title": "size",
-                                            "type": "integer"
-                                        }
-                                    ],
-                                    "maxItems": 2,
-                                    "minItems": 2,
-                                    "type": [
-                                        "array",
-                                        "null"
-                                    ]
-                                }
-                            ],
+                        "qreg_sizes": {
+                            "description": "A list of [qreg_name, size], to identify the QASM quantum registers and their size, where the most significant register appears first, and the least significant register last.",
+                            "items":
+                            {
+                                "items": [
+                                    {
+                                        "minLength": 1,
+                                        "title": "qreg",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "size of corresponding quantum register",
+                                        "minimum": 1,
+                                        "title": "qreg size",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": [
+                                    "array"
+                                ]
+                            },
+                            "minItems": 1,
+                            "title": "List of quantum registers and their sizes.",
+                            "type": "array"
+                        },
+                        "creg_sizes": {
+                            "description": "A list of [creg_name, size], to identify the QASM classical registers and their size, where the most significant register appears first, and the least significant register last.",
+                            "items":
+                            {
+                                "items": [
+                                    {
+                                        "minLength": 1,
+                                        "title": "creg",
+                                        "type": "string"
+                                    },
+                                    {
+                                        "description": "size of corresponding classical register",
+                                        "minimum": 1,
+                                        "title": "creg size",
+                                        "type": "integer"
+                                    }
+                                ],
+                                "maxItems": 2,
+                                "minItems": 2,
+                                "type": [
+                                    "array"
+                                ]
+                            },
                             "minItems": 0,
-                            "title": "Map physical clbits to register_slots (for QASM)",
+                            "title": "List of classical registers and their sizes.",
                             "type": "array"
                         },
                         "qubit_labels": {
@@ -748,9 +786,9 @@
                                         "type": "string"
                                     },
                                     {
-                                        "description": "The qubit number within the qreg",
+                                        "description": "The qubit index within the qreg",
                                         "minimum": 0,
-                                        "title": "qubit number",
+                                        "title": "qubit index",
                                         "type": "integer"
                                     }
                                 ],
@@ -761,12 +799,44 @@
                                     "null"
                                 ]
                             },
-                            "minItems": 0,
+                            "minItems": 1,
                             "title": "Map physical qubits to qregs (for QASM)",
+                            "type": "array"
+                        },
+                        "clbit_labels": {
+                            "description": "A list of length memory_slots, where each element is [creg_name, n] to identify the corresponding memory slot as the n-th element of creg creg_name.",
+                            "items": [
+                                {
+                                    "items": [
+                                        {
+                                            "minLength": 1,
+                                            "title": "creg",
+                                            "type": "string"
+                                        },
+                                        {
+                                            "description": "The clbit index within creg",
+                                            "minimum": 0,
+                                            "title": "clbit index",
+                                            "type": "integer"
+                                        }
+                                    ],
+                                    "maxItems": 2,
+                                    "minItems": 2,
+                                    "type": [
+                                        "array"
+                                    ]
+                                }
+                            ],
+                            "minItems": 0,
+                            "title": "Map physical clbits to register_slots (for QASM)",
                             "type": "array"
                         }
                     },
-                    "type": "object"
+                    "type": "object",
+                    "_constraints": [
+                        "sum(x[1] for x in qreg_sizes) == n_qubits",
+                        "sum(x[1] for x in creg_sizes) == memory_slots"
+                    ]
                 },
                 "instructions": {
                     "description": "List of experiment instructions.",
@@ -798,10 +868,15 @@
                             "type": "integer"
                         },
                         "memory_slots": {
-                            "description": "The number of measurement slots in the classical memory on the backend.",
+                            "description": "The number of (slow) measurement slots requested on the backend, equivalent to the max of memory_slot requested by individual experiments.",
                             "minimum": 0,
                             "type": "integer"
                         },
+                        "n_qubits": {
+                            "description": "The number of qubits requested on the backend, equivalent to the max of n_qubits requested by individual experiments.",
+                            "minimum": 1,
+                            "type": "integer"
+                        },                        
                         "seed": {
                             "default": 1,
                             "type": "integer"
@@ -810,11 +885,10 @@
                             "description": "Number of repetitions of each experiment",
                             "minimum": 1,
                             "type": "integer"
-                        }
+                        }                        
                     },
                     "required": [
-                        "shots",
-                        "memory_slots"
+                        "shots"
                     ],
                     "title": "Qobj-level configuration",
                     "type": "object"

--- a/test/python/qobj/cpp_conditionals.json
+++ b/test/python/qobj/cpp_conditionals.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 2,
         "seed": 1
     },
     "header": {
@@ -15,8 +16,8 @@
             "header": {
                 "name": "single creg (c0=0)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 2,
+                "memory_slots": 1,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -51,8 +52,8 @@
             "header": {
                 "name": "single creg (c0=1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 2,
+                "memory_slots": 1,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -87,8 +88,8 @@
             "header": {
                 "name": "two creg (c1=0)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -123,8 +124,8 @@
             "header": {
                 "name": "two creg (c1=1)",
                 "clbit_labels": [["c0", 1], ["c1", 1]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_measure_opt.json
+++ b/test/python/qobj/cpp_measure_opt.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 2000,
         "memory_slots": 2,
+        "n_qubits": 2,
         "seed": 1,
         "data" : ["density_matrix", "probabilities"]
     },
@@ -16,8 +17,8 @@
             "header": {
                 "name": "measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -30,8 +31,8 @@
             "header": {
                 "name": "x0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -45,8 +46,8 @@
             "header": {
                 "name": "x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -60,8 +61,8 @@
             "header": {
                 "name": "x0 x1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -76,8 +77,8 @@
             "header": {
                 "name": "y0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -91,8 +92,8 @@
             "header": {
                 "name": "y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -106,8 +107,8 @@
             "header": {
                 "name": "y0 y1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -122,8 +123,8 @@
             "header": {
                 "name": "h0 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -137,8 +138,8 @@
             "header": {
                 "name": "h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -152,8 +153,8 @@
             "header": {
                 "name": "h0 h1 measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [
@@ -168,8 +169,8 @@
             "header": {
                 "name": "bell measure (opt)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 2,
+                "memory_slots": 2,
+                "n_qubits": 2,
                 "qubit_labels": [["q", 0], ["q", 1]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_measure_opt_flag.json
+++ b/test/python/qobj/cpp_measure_opt_flag.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 5,
         "memory_slots": 2,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "measure (sampled)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -27,8 +28,8 @@
             "header": {
                 "name": "trivial (sampled)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -45,8 +46,8 @@
             "header": {
                 "name": "reset1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -60,8 +61,8 @@
             "header": {
                 "name": "reset2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -75,8 +76,8 @@
             "header": {
                 "name": "reset3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -90,8 +91,8 @@
             "header": {
                 "name": "gate1 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -104,8 +105,8 @@
             "header": {
                 "name": "gate2 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -118,8 +119,8 @@
             "header": {
                 "name": "gate3 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -133,8 +134,8 @@
             "header": {
                 "name": "gate4 (shots)",
                 "clbit_labels": [["c", 2]],
-                "number_of_clbits": 2,
-                "number_of_qubits": 1,
+                "memory_slots": 2,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_reset.json
+++ b/test/python/qobj/cpp_reset.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -33,8 +34,8 @@
             "header": {
                 "name": "x reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -54,8 +55,8 @@
             "header": {
                 "name": "y reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -75,8 +76,8 @@
             "header": {
                 "name": "h reset",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_save_load.json
+++ b/test/python/qobj/cpp_save_load.json
@@ -4,6 +4,7 @@
     "schema_version": "1.0.0",
     "config": {
         "shots": 1,
+        "n_qubits": 1,
         "memory_slots": 1,
         "seed": 1
     },
@@ -13,8 +14,8 @@
             "header": {
                 "name": "save_command",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_single_qubit_gates.json
+++ b/test/python/qobj/cpp_single_qubit_gates.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 1,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
             "header": {
                 "name": "snapshot",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -32,8 +33,8 @@
             "header": {
                 "name": "id(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -52,8 +53,8 @@
             "header": {
                 "name": "id(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -72,8 +73,8 @@
             "header": {
                 "name": "id(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -93,8 +94,8 @@
             "header": {
                 "name": "id(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -115,8 +116,8 @@
             "header": {
                 "name": "x(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -137,8 +138,8 @@
             "header": {
                 "name": "x(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -159,8 +160,8 @@
             "header": {
                 "name": "x(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -181,8 +182,8 @@
             "header": {
                 "name": "y(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -203,8 +204,8 @@
             "header": {
                 "name": "y(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -225,8 +226,8 @@
             "header": {
                 "name": "y(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -247,8 +248,8 @@
             "header": {
                 "name": "h(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -269,8 +270,8 @@
             "header": {
                 "name": "h(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -291,8 +292,8 @@
             "header": {
                 "name": "h(u2)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -313,8 +314,8 @@
             "header": {
                 "name": "h(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -335,8 +336,8 @@
             "header": {
                 "name": "h(direct) z(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -358,8 +359,8 @@
             "header": {
                 "name": "h(direct) z(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -381,8 +382,8 @@
             "header": {
                 "name": "h(direct) z(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -404,8 +405,8 @@
             "header": {
                 "name": "h(direct) z(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -427,8 +428,8 @@
             "header": {
                 "name": "h(direct) s(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -450,8 +451,8 @@
             "header": {
                 "name": "h(direct) s(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -473,8 +474,8 @@
             "header": {
                 "name": "h(direct) s(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -496,8 +497,8 @@
             "header": {
                 "name": "h(direct) s(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -519,8 +520,8 @@
             "header": {
                 "name": "h(direct) sdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -542,8 +543,8 @@
             "header": {
                 "name": "h(direct) sdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -565,8 +566,8 @@
             "header": {
                 "name": "h(direct) sdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -588,8 +589,8 @@
             "header": {
                 "name": "h(direct) sdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -611,8 +612,8 @@
             "header": {
                 "name": "h(direct) t(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -634,8 +635,8 @@
             "header": {
                 "name": "h(direct) t(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -657,8 +658,8 @@
             "header": {
                 "name": "h(direct) t(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -680,8 +681,8 @@
             "header": {
                 "name": "h(direct) t(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -703,8 +704,8 @@
             "header": {
                 "name": "h(direct) tdg(U)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -726,8 +727,8 @@
             "header": {
                 "name": "h(direct) tdg(u3)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -749,8 +750,8 @@
             "header": {
                 "name": "h(direct) tdg(u1)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [
@@ -772,8 +773,8 @@
             "header": {
                 "name": "h(direct) tdg(direct)",
                 "clbit_labels": [["c0", 1]],
-                "number_of_clbits": 1,
-                "number_of_qubits": 1,
+                "memory_slots": 1,
+                "n_qubits": 1,
                 "qubit_labels": [["q", 0]]
             },
             "instructions": [

--- a/test/python/qobj/cpp_two_qubit_gates.json
+++ b/test/python/qobj/cpp_two_qubit_gates.json
@@ -5,6 +5,7 @@
     "config": {
         "shots": 1,
         "memory_slots": 1,
+        "n_qubits": 2,
         "seed": 1
     },
     "header": {"backend_name": "qasm_simulator"},
@@ -13,8 +14,8 @@
                 "header": {
                     "name": "h0 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -35,8 +36,8 @@
                 "header": {
                     "name": "h0 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -57,8 +58,8 @@
                 "header": {
                     "name": "h1 CX01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -79,8 +80,8 @@
                 "header": {
                     "name": "h1 CX10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -101,8 +102,8 @@
                 "header": {
                     "name": "h0 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -123,8 +124,8 @@
                 "header": {
                     "name": "h0 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -145,8 +146,8 @@
                 "header": {
                     "name": "h1 cx01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -167,8 +168,8 @@
                 "header": {
                     "name": "h1 cx10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -189,8 +190,8 @@
                 "header": {
                     "name": "h0 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -211,8 +212,8 @@
                 "header": {
                     "name": "h0 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -233,8 +234,8 @@
                 "header": {
                     "name": "h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -255,8 +256,8 @@
                 "header": {
                     "name": "h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -277,8 +278,8 @@
                 "header": {
                     "name": "h0 h1 cz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -300,8 +301,8 @@
                 "header": {
                     "name": "h0 h1 cz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -323,8 +324,8 @@
                 "header": {
                     "name": "h0 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -345,8 +346,8 @@
                 "header": {
                     "name": "h0 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -367,8 +368,8 @@
                 "header": {
                     "name": "h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -389,8 +390,8 @@
                 "header": {
                     "name": "h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -411,8 +412,8 @@
                 "header": {
                     "name": "h0 h1 rzz01",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [
@@ -434,8 +435,8 @@
                 "header": {
                     "name": "h0 h1 rzz10",
                     "clbit_labels": [["c0", 1]],
-                    "number_of_clbits": 1,
-                    "number_of_qubits": 2,
+                    "memory_slots": 1,
+                    "n_qubits": 2,
                     "qubit_labels": [["q", 0], ["q", 1]]
                 },
                 "instructions": [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This is another follow up to #1373, making the header changes propagated elsewhere. Mostly in qobj examples. This commit may actually belong to #1373, whatever @diego-plan9 decides. 

**Fixes #1066**, **Fixes #1087**

Collectively these commits make some progress in making the various local simulators conform to the specs (in parsing qobj, and reporting result). 

- Qiskit now puts `memory_slots` and `n_qubits` in the `config` of each single experiment. Although the schema has them as optional, the simulators do need it. This ensures that none of the backends use the info in `header` to conduct the experiment, only the `config` and `instructions`.

- The qobj header of each experiment now contains `n_qubits`, `memory_slots`, `clbit_labels`, `qubit_labels`, `clreg_sizes`, `qureg_sizes`, which are helpful for reconstructing the result according to the original circuit specs. The schema and the rest of the codebase have been updated accordingly.



