### PR TITLE
Update configuration.n_qubits model, disallow -1

### DIFF
--- a/qiskit/backends/models/backendconfiguration.py
+++ b/qiskit/backends/models/backendconfiguration.py
@@ -11,7 +11,6 @@ from marshmallow.fields import Boolean, DateTime, Integer, List, Nested, String
 from marshmallow.validate import Equal, Length, OneOf, Range, Regexp
 
 from qiskit.validation import BaseModel, BaseSchema, bind_schema
-from qiskit.validation.validate import Or
 
 
 class GateConfigSchema(BaseSchema):
@@ -40,8 +39,7 @@ class BackendConfigurationSchema(BaseSchema):
     backend_name = String(required=True)
     backend_version = String(required=True,
                              validate=Regexp("[0-9]+.[0-9]+.[0-9]+$"))
-    n_qubits = Integer(required=True,
-                       validate=Or([Equal(-1), Range(min=1)]))
+    n_qubits = Integer(required=True, validate=Range(min=1))
     basis_gates = List(String(), required=True,
                        validate=Length(min=1))
     gates = Nested(GateConfigSchema, required=True, many=True,


### PR DESCRIPTION
Update the `BackendConfiguration` model to adhere to the schemas,
disallowing `-1` for `n_qubits`.

This is a small fix  that makes that model be consistent with the change introduced in #1327 - which now can be added safely since #1369 landed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


