### PR TITLE
Update backend.properties to None for simulators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,7 +70,7 @@ Changed
   updated methods include:
     - ``backend.status()``(#1301).
     - ``backend.configuration()`` (and ``__init__``) (#1323).
-    - ``backend.properties()`` (#1331).
+    - ``backend.properties()``, returning ``None`` for sims (#1331, #1401).
     - ``qiskit.Result`` (#1360).
 - ``backend.provider()`` is now a method instead of a property (#1312).
 - Remove local backend (Aer) fallback (#1303)

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -21,7 +21,7 @@ import platform
 from math import log2
 import numpy as np
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
@@ -84,23 +84,6 @@ class QasmSimulator(BaseBackend):
         except StopIteration:
             raise FileNotFoundError('Simulator executable not found (using %s)' %
                                     getattr(self._configuration, 'exe', 'default locations'))
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a qobj on the backend."""
@@ -165,23 +148,6 @@ class CliffordSimulator(BaseBackend):
         except StopIteration:
             raise FileNotFoundError('Simulator executable not found (using %s)' %
                                     getattr(self._configuration, 'exe', 'default locations'))
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a Qobj on the backend.

--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -21,7 +21,7 @@ import platform
 from math import log2
 import numpy as np
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
 from qiskit.result import Result

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -79,12 +79,13 @@ from collections import Counter
 from math import log2
 import numpy as np
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
 from ._simulatorerror import SimulatorError
 from ._simulatortools import index2, single_gate_matrix
+
 logger = logging.getLogger(__name__)
 
 
@@ -122,23 +123,6 @@ class QasmSimulatorPy(BaseBackend):
         self._number_of_qubits = 0
         self._shots = 0
         self._qobj_config = None
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def _add_qasm_single(self, gate, qubit):
         """Apply an arbitrary 1-qubit operator to a qubit.

--- a/qiskit/backends/aer/qasm_simulator_py.py
+++ b/qiskit/backends/aer/qasm_simulator_py.py
@@ -31,7 +31,7 @@ from collections import Counter
 import numpy as np
 
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.result import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob

--- a/qiskit/backends/aer/statevector_simulator.py
+++ b/qiskit/backends/aer/statevector_simulator.py
@@ -15,7 +15,7 @@ import logging
 import uuid
 from math import log2
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.qobj import QobjInstruction
 from .qasm_simulator import QasmSimulator
 from ._simulatorerror import SimulatorError
@@ -49,23 +49,6 @@ class StatevectorSimulator(QasmSimulator):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run a qobj on the the backend."""

--- a/qiskit/backends/aer/statevector_simulator_py.py
+++ b/qiskit/backends/aer/statevector_simulator_py.py
@@ -24,7 +24,7 @@ from math import log2
 from qiskit._util import local_hardware_info
 from qiskit.backends.aer.aerjob import AerJob
 from qiskit.backends.aer._simulatorerror import SimulatorError
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.qobj import QobjInstruction
 from .qasm_simulator_py import QasmSimulatorPy
 
@@ -54,23 +54,6 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def run(self, qobj):
         """Run qobj asynchronously.

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -86,7 +86,7 @@ import time
 from math import log2, sqrt
 import numpy as np
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.result._utils import copy_qasm_from_qobj_into_result, result_from_old_style_dict
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
@@ -127,23 +127,6 @@ class UnitarySimulatorPy(BaseBackend):
         # Define attributes inside __init__.
         self._unitary_state = None
         self._number_of_qubits = 0
-
-    def properties(self):
-        """Return backend properties"""
-        properties = {
-            'backend_name': self.name(),
-            'backend_version': self.configuration().backend_version,
-            'last_update_date': '2000-01-01 00:00:00Z',
-            'qubits': [[{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                         'unit': 'TODO', 'value': 0}]],
-            'gates': [{'qubits': [0], 'gate': 'TODO',
-                       'parameters':
-                           [{'name': 'TODO', 'date': '2000-01-01 00:00:00Z',
-                             'unit': 'TODO', 'value': 0}]}],
-            'general': []
-        }
-
-        return BackendProperties.from_dict(properties)
 
     def _add_unitary_single(self, gate, qubit):
         """Apply the single-qubit gate.

--- a/qiskit/backends/aer/unitary_simulator_py.py
+++ b/qiskit/backends/aer/unitary_simulator_py.py
@@ -25,7 +25,7 @@ import time
 from math import log2, sqrt
 import numpy as np
 from qiskit._util import local_hardware_info
-from qiskit.backends.models import BackendConfiguration, BackendProperties
+from qiskit.backends.models import BackendConfiguration
 from qiskit.backends import BaseBackend
 from qiskit.backends.aer.aerjob import AerJob
 from qiskit.result import Result

--- a/qiskit/backends/basebackend.py
+++ b/qiskit/backends/basebackend.py
@@ -51,14 +51,14 @@ class BaseBackend(ABC):
         """
         return self._configuration
 
-    @abstractmethod
     def properties(self):
         """Return backend properties.
 
         Returns:
-            BackendProperties: the configuration for the backend.
+            BackendProperties: the configuration for the backend. If the backend
+            does not support properties, it returns ``None``.
         """
-        pass
+        return None
 
     def provider(self):
         """Return the backend Provider.

--- a/qiskit/backends/ibmq/ibmqbackend.py
+++ b/qiskit/backends/ibmq/ibmqbackend.py
@@ -66,8 +66,12 @@ class IBMQBackend(BaseBackend):
         The return is via QX API call.
 
         Returns:
-            dict: The properties of the backend.
+            BackendProperties: The properties of the backend. If the backend
+            is a simulator, it returns ``None``.
         """
+        if self.configuration().simulator:
+            return None
+
         api_properties = self._api.backend_properties(self.name())
 
         return BackendProperties.from_dict(api_properties)
@@ -76,7 +80,7 @@ class IBMQBackend(BaseBackend):
         """Return the online backend status.
 
         Returns:
-            dict: The status of the backend.
+            BackendStatus: The status of the backend.
 
         Raises:
             LookupError: If status for the backend can't be found.

--- a/test/python/test_backends.py
+++ b/test/python/test_backends.py
@@ -133,15 +133,10 @@ class TestBackends(QiskitTestCase):
 
         If all correct should pass the validation.
         """
-        schema_path = self._get_resource_path(
-            'backend_properties_schema.json', path=Path.SCHEMAS)
-        with open(schema_path, 'r') as schema_file:
-            schema = json.load(schema_file)
-
         aer_backends = Aer.backends()
         for backend in aer_backends:
             properties = backend.properties()
-            jsonschema.validate(properties.to_dict(), schema)
+            self.assertEqual(properties, None)
 
     @requires_qe_access
     def test_remote_backend_properties(self, qe_token, qe_url):
@@ -158,4 +153,7 @@ class TestBackends(QiskitTestCase):
         remotes = IBMQ.backends(simulator=False)
         for backend in remotes:
             properties = backend.properties()
-            jsonschema.validate(properties.to_dict(), schema)
+            if backend.configuration().simulator:
+                self.assertEqual(properties, None)
+            else:
+                jsonschema.validate(properties.to_dict(), schema)


### PR DESCRIPTION
As per conversations, update the `backend.properties()` methods for local and remote
simulators, so they return `None`, adjusting the `BaseBackend` method
accordingly.

Addresses partly #1332.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


