### PR TITLE
Remove some DeprecationWarnings in test suite

### DIFF
--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -199,9 +199,9 @@ def vectorize(density_matrix, method='col'):
         if len(density_matrix) != 2**num:
             raise Exception('Input state must be n-qubit state')
         if method == 'pauli_weights':
-            pgroup = pauli_group(num, case=0)
+            pgroup = pauli_group(num, case='weight')
         else:
-            pgroup = pauli_group(num, case=1)
+            pgroup = pauli_group(num, case='tensor')
         vals = [np.trace(np.dot(p.to_matrix(), density_matrix))
                 for p in pgroup]
         return np.array(vals)
@@ -239,9 +239,9 @@ def devectorize(vectorized_mat, method='col'):
         if dimension != 2 ** num_qubits:
             raise Exception('Input state must be n-qubit state')
         if method == 'pauli_weights':
-            pgroup = pauli_group(num_qubits, case=0)
+            pgroup = pauli_group(num_qubits, case='weight')
         else:
-            pgroup = pauli_group(num_qubits, case=1)
+            pgroup = pauli_group(num_qubits, case='tensor')
         pbasis = np.array([p.to_matrix() for p in pgroup]) / 2 ** num_qubits
         return np.tensordot(vectorized_mat, pbasis, axes=1)
     return None
@@ -272,6 +272,11 @@ def choi_to_rauli(choi, order=1):
     Returns:
         np.array: A superoperator in the Pauli basis.
     """
+    if order == 0:
+        order = 'weight'
+    elif order == 1:
+        order = 'tensor'
+
     # get number of qubits'
     num_qubits = int(np.log2(np.sqrt(len(choi))))
     pgp = pauli_group(num_qubits, case=order)

--- a/test/python/tools/visualization/test_visualization.py
+++ b/test/python/tools/visualization/test_visualization.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=missing-docstring
-
 """Tests for visualization tools."""
 
 import os

--- a/test/python/tools/visualization/test_visualization.py
+++ b/test/python/tools/visualization/test_visualization.py
@@ -11,11 +11,11 @@
 
 import os
 import random
-from inspect import signature
 import unittest
+from inspect import signature
+
 import qiskit
-from qiskit.tools.visualization import (_utils, generate_latex_source,
-                                        circuit_drawer)
+from qiskit.tools.visualization import _utils, circuit_drawer
 from ...common import QiskitTestCase
 
 

--- a/test/python/tools/visualization/test_visualization.py
+++ b/test/python/tools/visualization/test_visualization.py
@@ -14,7 +14,8 @@ import random
 from inspect import signature
 import unittest
 import qiskit
-from qiskit.tools.visualization import _utils, generate_latex_source
+from qiskit.tools.visualization import (_utils, generate_latex_source,
+                                        circuit_drawer)
 from ...common import QiskitTestCase
 
 
@@ -72,7 +73,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         filename = self._get_resource_path('test_tiny.tex')
         qc = self.random_circuit(1, 1, 1)
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):
@@ -83,7 +84,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         filename = self._get_resource_path('test_normal.tex')
         qc = self.random_circuit(5, 5, 3)
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):
@@ -94,7 +95,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         filename = self._get_resource_path('test_wide.tex')
         qc = self.random_circuit(100, 1, 1)
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):
@@ -105,7 +106,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         filename = self._get_resource_path('test_deep.tex')
         qc = self.random_circuit(1, 100, 1)
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):
@@ -116,7 +117,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         filename = self._get_resource_path('test_huge.tex')
         qc = self.random_circuit(40, 40, 1)
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):
@@ -145,7 +146,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
         qc.x(qr[2]).c_if(cr, 2)
         qc.measure(qr[2], cr[2])
         try:
-            generate_latex_source(qc, filename)
+            circuit_drawer(qc, filename=filename, output='latex_source')
             self.assertNotEqual(os.path.exists(filename), False)
         finally:
             if os.path.exists(filename):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Remove some `DeprecationWarnings` when running the test suite. There are still some of them that are expected:

`test/python/test_result.py`: two warnings due to using result addition, to be removed when the deprecation is completed.

`test/python/ibmq/test_registration.py`: one warning when using duplicate credentials (expected, as the test is actually checking for that feature).

### Details and comments


