### PR TITLE
Make qasm_simulator always return valid results

### DIFF
--- a/qiskit/backends/aer/qasm_simulator.py
+++ b/qiskit/backends/aer/qasm_simulator.py
@@ -96,6 +96,15 @@ class QasmSimulator(BaseBackend):
         qobj_dict = qobj.as_dict()
         result = run(qobj_dict, self._configuration.exe)
         result['job_id'] = job_id
+
+        # Ensure that the required results fields are present, even if the
+        # job failed.
+        result['results'] = result.get('results', [])
+        result['qobj_id'] = result.get('qobj_id', 'unavailable')
+        result['backend_name'] = result.get('backend_name', self.name())
+        result['backend_version'] = result.get('backend_version',
+                                               self.configuration().backend_version)
+
         return Result.from_dict(result)
 
     def _validate(self, qobj):
@@ -171,6 +180,15 @@ class CliffordSimulator(BaseBackend):
             qobj_dict['config'] = {'simulator': 'clifford'}
         result = run(qobj_dict, self._configuration.exe)
         result['job_id'] = job_id
+
+        # Ensure that the required results fields are present, even if the
+        # job failed.
+        result['results'] = result.get('results', [])
+        result['qobj_id'] = result.get('qobj_id', 'unavailable')
+        result['backend_name'] = result.get('backend_name', self.name())
+        result['backend_version'] = result.get('backend_version',
+                                               self.configuration().backend_version)
+
         return Result.from_dict(result)
 
     def _validate(self):
@@ -199,11 +217,10 @@ def run(qobj, executable):
                          cerr.decode())
         sim_output = json.loads(cout.decode())
         return sim_output
-
     except FileNotFoundError:
         msg = "ERROR: Simulator exe not found at: %s" % executable
         logger.error(msg)
-        return {"status": msg, "success": False}
+        return {'status': msg, 'success': False}
 
 
 def cx_error_matrix(cal_error, zz_error):


### PR DESCRIPTION
Revise `qasm_simulator` in order to return schema-conformant results
even if the execution was not successful.

This is part of a concern well spotted by @chriseclectic - even if a job fails, its `.results()` should be returned, and in turn need to conform to the results schema. If that is not the case, potential errors in the simulator were "swallowed" by the `ValidationError` resulting of not conforming to the schema.

The other simulators have not been updated as it seems they are not constructing non-schema results for unsuccessful runs - for the online backends, full Qobj support should take care of the issue.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


