### PR TITLE
Fix/complete deprecations 0.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -158,6 +158,8 @@ Removed
 - The ``get_snapshot()`` and ``get_snapshots()`` method from the ``Result``
   class has been removed. Instead you can access the snapshots in a Result
   using ``Result.data()['snapshots']``.
+- Completed the deprecation of ``job.backend_name()``, ``job.id()``, and the
+  ``backend_name`` parameter in its constructor.
 
 `0.6.0`_ - 2018-10-04
 ^^^^^^^^^^^^^^^^^^^^^

--- a/qiskit/backends/aer/aerjob.py
+++ b/qiskit/backends/aer/aerjob.py
@@ -7,7 +7,6 @@
 
 """This module implements the job class used for AerBackend objects."""
 
-import warnings
 from concurrent import futures
 import logging
 import sys

--- a/qiskit/backends/aer/aerjob.py
+++ b/qiskit/backends/aer/aerjob.py
@@ -122,18 +122,6 @@ class AerJob(BaseJob):
 
         return _status
 
-    def backend_name(self):
-        """
-        Return the name of the backend used for this job.
-
-        .. deprecated:: 0.6+
-            After 0.6, this function is deprecated. Please use
-            `job.backend().name()` instead.
-        """
-        warnings.warn('The use of `job.backend_name()` is deprecated, use '
-                      '`job.backend().name()` instead.', DeprecationWarning)
-        return self._backend.name()
-
     def backend(self):
         """Return the instance of the backend used for this job."""
         return self._backend

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -348,18 +348,6 @@ class IBMQJob(BaseJob):
         self._wait_for_submission()
         return self._job_id
 
-    def backend_name(self):
-        """
-        Return backend name used for this job.
-
-        .. deprecated:: 0.6+
-            After 0.6, this function is deprecated. Please use
-            `job.backend().name()` instead.
-        """
-        warnings.warn('The use of `job.backend_name()` is deprecated, '
-                      'use `job.backend().name()` instead', DeprecationWarning)
-        return self.backend().name()
-
     def submit(self):
         """Submit job to IBM-Q.
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -12,7 +12,6 @@ IBM Q Experience.
 """
 
 from concurrent import futures
-import warnings
 import time
 import logging
 import pprint
@@ -114,7 +113,7 @@ class IBMQJob(BaseJob):
     _executor = futures.ThreadPoolExecutor()
 
     def __init__(self, backend, job_id, api, is_device, qobj=None,
-                 creation_date=None, api_status=None, **kwargs):
+                 creation_date=None, api_status=None):
         """IBMQJob init function.
 
         We can instantiate jobs from two sources: A QObj, and an already submitted job returned by

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -129,8 +129,6 @@ class IBMQJob(BaseJob):
             qobj (Qobj): The Quantum Object. See notes below
             creation_date (str): When the job was run.
             api_status (str): `status` field directly from the API response.
-            kwargs (dict): You can pass `backend_name` to this function although
-                it has been deprecated.
 
         Notes:
             It is mandatory to pass either ``qobj`` or ``job_id``. Passing a ``qobj``
@@ -138,11 +136,6 @@ class IBMQJob(BaseJob):
             API server for job creation. Passing only a `job_id`will create an instance
             representing an already-created job retrieved from the API server.
         """
-        if 'backend_name' in kwargs:
-            warnings.warn('Passing the parameter `backend_name` is deprecated, '
-                          'pass the `backend` parameter with the instance of '
-                          'the backend running the job.', DeprecationWarning)
-
         super().__init__(backend, job_id)
         self._job_data = None
 

--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -317,21 +317,6 @@ class IBMQJob(BaseJob):
         """
         return self._creation_date
 
-    # pylint: disable=invalid-name
-    def id(self):
-        """Return backend determined id.
-
-        If the Id is not set because the job is already initializing, this call
-        will block until we have an Id.
-
-        .. deprecated:: 0.6+
-            After 0.6, this function is deprecated. Please use
-            `job.job_id()` instead.
-        """
-        warnings.warn('The method `job.id()` is deprecated, use '
-                      '``job.job_id()`` instead.', DeprecationWarning)
-        return self.job_id()
-
     def job_id(self):
         """Return backend determined id.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Complete the deprecation of some items that were deprecated in 0.6:
* `AerJob.backend_name()`
* `IBMQJob.backend_name()`
* `backend_name` as `IBMQJob.__init__` parameter
* `IBMQJob.id()`



### Details and comments


