### PR TITLE
Add support to qobj_to_circuits for qobj without qasm

### DIFF
--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -6,7 +6,22 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Helper function for converting qobj to a list of circuits"""
-from qiskit._quantumcircuit import QuantumCircuit
+
+from qiskit import _classicalregister as cr
+from qiskit import _quantumcircuit as qc
+from qiskit import _quantumregister as qr
+
+def _get_registers(reg_list, constructor):
+    registers = {}
+    for bits in reg_list:
+        if bits[0] not in registers:
+            registers[bits[0]] = [bits[1]]
+        else:
+            registers[bits[0]].append(bits[1])
+    out_list = []
+    for reg in registers:
+        out_list.append(constructor(len(registers[reg]), name=reg))
+    return out_list
 
 
 def qobj_to_circuits(qobj):
@@ -23,8 +38,35 @@ def qobj_to_circuits(qobj):
         for x in qobj.experiments:
             if hasattr(x.header, 'compiled_circuit_qasm'):
                 circuits.append(
-                    QuantumCircuit.from_qasm_str(x.header.compiled_circuit_qasm))
+                    qc.QuantumCircuit.from_qasm_str(
+                        x.header.compiled_circuit_qasm))
+            else:
+                quantum_registers = _get_registers(x.header.qubit_labels,
+                                                   qr.QuantumRegister)
+                classical_registers = _get_registers(x.header.clbit_labels,
+                                                     cr.ClassicalRegister)
+                circuit = qc.QuantumCircuit(*quantum_registers,
+                                            *classical_registers,
+                                            name=x.header.name)
+                qreg_dict = {}
+                creg_dict = {}
+                for reg in quantum_registers:
+                    qreg_dict[reg.name] = reg
+                for reg in classical_registers:
+                    creg_dict[reg.name] = reg
+                for i in x.instructions:
+                    instr_method = getattr(circuit, i.name)
+                    qubits = []
+                    for qubit in i.qubits:
+                        qubit_label = x.header.qubit_labels[qubit]
+                        qubits.append(
+                            qreg_dict[qubit_label[0]][qubit_label[1]])
+                    clbits = []
+                    for clbit in i.memory:
+                        clbit_label = x.header.clbit_labels[clbit]
+                        clbits.append(
+                            creg_dict[clbit_label[0]][clbit_label[1]])
+                    instr_method(*qubits, *clbits, *i.params)
+                circuits.append(circuit)
         return circuits
-    # TODO(mtreinish): add support for converting a qobj if the qasm isn't
-    # embedded in the header
     return None

--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -12,19 +12,6 @@ from qiskit import _quantumcircuit as qc
 from qiskit import _quantumregister as qr
 
 
-def _get_registers(reg_list, constructor):
-    registers = {}
-    for bits in reg_list:
-        if bits[0] not in registers:
-            registers[bits[0]] = [bits[1]]
-        else:
-            registers[bits[0]].append(bits[1])
-    out_list = []
-    for reg in registers:
-        out_list.append(constructor(len(registers[reg]), name=reg))
-    return out_list
-
-
 def qobj_to_circuits(qobj):
     """Return a list of QuantumCircuit object(s) from a qobj
 
@@ -37,37 +24,34 @@ def qobj_to_circuits(qobj):
     if qobj.experiments:
         circuits = []
         for x in qobj.experiments:
-            if hasattr(x.header, 'compiled_circuit_qasm'):
-                circuits.append(
-                    qc.QuantumCircuit.from_qasm_str(
-                        x.header.compiled_circuit_qasm))
-            else:
-                quantum_registers = _get_registers(x.header.qubit_labels,
-                                                   qr.QuantumRegister)
-                classical_registers = _get_registers(x.header.clbit_labels,
-                                                     cr.ClassicalRegister)
-                circuit = qc.QuantumCircuit(*quantum_registers,
-                                            *classical_registers,
-                                            name=x.header.name)
-                qreg_dict = {}
-                creg_dict = {}
-                for reg in quantum_registers:
-                    qreg_dict[reg.name] = reg
-                for reg in classical_registers:
-                    creg_dict[reg.name] = reg
-                for i in x.instructions:
-                    instr_method = getattr(circuit, i.name)
-                    qubits = []
-                    for qubit in i.qubits:
-                        qubit_label = x.header.qubit_labels[qubit]
-                        qubits.append(
-                            qreg_dict[qubit_label[0]][qubit_label[1]])
-                    clbits = []
-                    for clbit in i.memory:
-                        clbit_label = x.header.clbit_labels[clbit]
-                        clbits.append(
-                            creg_dict[clbit_label[0]][clbit_label[1]])
-                    instr_method(*qubits, *clbits, *i.params)
-                circuits.append(circuit)
+            quantum_registers = [
+                qr.QuantumRegister(
+                    i[1], name=i[0]) for i in x.header.qreg_sizes]
+            classical_registers = [
+                cr.ClassicalRegister(
+                    i[1], name=i[0]) for i in x.header.creg_sizes]
+            circuit = qc.QuantumCircuit(*quantum_registers,
+                                        *classical_registers,
+                                        name=x.header.name)
+            qreg_dict = {}
+            creg_dict = {}
+            for reg in quantum_registers:
+                qreg_dict[reg.name] = reg
+            for reg in classical_registers:
+                creg_dict[reg.name] = reg
+            for i in x.instructions:
+                instr_method = getattr(circuit, i.name)
+                qubits = []
+                for qubit in i.qubits:
+                    qubit_label = x.header.qubit_labels[qubit]
+                    qubits.append(
+                        qreg_dict[qubit_label[0]][qubit_label[1]])
+                clbits = []
+                for clbit in i.memory:
+                    clbit_label = x.header.clbit_labels[clbit]
+                    clbits.append(
+                        creg_dict[clbit_label[0]][clbit_label[1]])
+                instr_method(*qubits, *clbits, *i.params)
+            circuits.append(circuit)
         return circuits
     return None

--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -11,6 +11,7 @@ from qiskit import _classicalregister as cr
 from qiskit import _quantumcircuit as qc
 from qiskit import _quantumregister as qr
 
+
 def _get_registers(reg_list, constructor):
     registers = {}
     for bits in reg_list:

--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -51,7 +51,7 @@ def qobj_to_circuits(qobj):
                     clbit_label = x.header.clbit_labels[clbit]
                     clbits.append(
                         creg_dict[clbit_label[0]][clbit_label[1]])
-                instr_method(*qubits, *clbits, *i.params)
+                instr_method(*i.params, *qubits, *clbits)
             circuits.append(circuit)
         return circuits
     return None

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -56,6 +56,23 @@ class TestQobjToCircuits(QiskitTestCase):
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
+    def test_qobj_to_circuit_with_parameters(self):
+        backend = Aer.get_backend('qasm_simulator_py')
+        qreg1 = QuantumRegister(2)
+        qreg2 = QuantumRegister(3)
+        creg1 = ClassicalRegister(2)
+        creg2 = ClassicalRegister(2)
+        circuit_b = QuantumCircuit(qreg1, qreg2, creg1, creg2)
+        circuit_b.x(qreg1)
+        circuit_b.h(qreg2)
+        circuit_b.u2(0.2, 0.57, qreg2[1])
+        circuit_b.measure(qreg1, creg1)
+        circuit_b.measure(qreg2[0], creg2[1])
+        qobj = compile(circuit_b, backend, pass_manager=PassManager())
+        out_circuit = qobj_to_circuits(qobj)
+        self.assertEqual(circuit_to_dag(out_circuit[0]),
+                         circuit_to_dag(circuit_b))
+
     def test_qobj_to_circuits_with_nothing(self):
         """Verify that qobj_to_circuits returns None without any data."""
         qobj = Qobj('abc123', {}, {}, {})

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -57,6 +57,7 @@ class TestQobjToCircuits(QiskitTestCase):
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
     def test_qobj_to_circuit_with_parameters(self):
+        """Check qobj_to_circuit result with a gate that uses parameters."""
         backend = Aer.get_backend('qasm_simulator_py')
         qreg1 = QuantumRegister(2)
         qreg2 = QuantumRegister(3)

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -94,6 +94,5 @@ class TestQobjToCircuits(QiskitTestCase):
                                     DAGCircuit.fromQuantumCircuit(circuit_b)])
 
 
-
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -56,10 +56,43 @@ class TestQobjToCircuits(QiskitTestCase):
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
-    def test_qobj_to_circuits_with_qobj_no_qasm(self):
-        """Verify that qobj_to_circuits returns None without QASM."""
+    def test_qobj_to_circuits_with_nothing(self):
+        """Verify that qobj_to_circuits returns None without any data."""
         qobj = Qobj('abc123', {}, {}, {})
         self.assertIsNone(qobj_to_circuits(qobj))
+
+    def test_qobj_to_circuits_single_no_qasm(self):
+        """Check that qobj_to_circuits's result matches the qobj ini."""
+        backend = Aer.get_backend('qasm_simulator_py')
+        qobj_in = compile(self.circuit, backend, pass_manager=PassManager())
+        for i in qobj_in.experiments:
+            del i.header.compiled_circuit_qasm
+        out_circuit = qobj_to_circuits(qobj_in)
+        self.assertEqual(DAGCircuit.fromQuantumCircuit(out_circuit[0]),
+                         self.dag)
+
+    def test_qobj_to_circuits_multiple_no_qasm(self):
+        """Check that qobj_to_circuits's result with multiple circuits"""
+        backend = Aer.get_backend('qasm_simulator_py')
+        qreg1 = QuantumRegister(2)
+        qreg2 = QuantumRegister(3)
+        creg1 = ClassicalRegister(2)
+        creg2 = ClassicalRegister(2)
+        circuit_b = QuantumCircuit(qreg1, qreg2, creg1, creg2)
+        circuit_b.x(qreg1)
+        circuit_b.h(qreg2)
+        circuit_b.measure(qreg1, creg1)
+        circuit_b.measure(qreg2[0], creg2[1])
+        qobj = compile([self.circuit, circuit_b], backend,
+                       pass_manager=PassManager())
+        for i in qobj.experiments:
+            del i.header.compiled_circuit_qasm
+
+        dag_list = [
+            DAGCircuit.fromQuantumCircuit(x) for x in qobj_to_circuits(qobj)]
+        self.assertEqual(dag_list, [self.dag,
+                                    DAGCircuit.fromQuantumCircuit(circuit_b)])
+
 
 
 if __name__ == '__main__':

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -68,8 +68,7 @@ class TestQobjToCircuits(QiskitTestCase):
         for i in qobj_in.experiments:
             del i.header.compiled_circuit_qasm
         out_circuit = qobj_to_circuits(qobj_in)
-        self.assertEqual(DAGCircuit.fromQuantumCircuit(out_circuit[0]),
-                         self.dag)
+        self.assertEqual(circuit_to_dag(out_circuit[0]), self.dag)
 
     def test_qobj_to_circuits_multiple_no_qasm(self):
         """Check that qobj_to_circuits's result with multiple circuits"""
@@ -88,10 +87,8 @@ class TestQobjToCircuits(QiskitTestCase):
         for i in qobj.experiments:
             del i.header.compiled_circuit_qasm
 
-        dag_list = [
-            DAGCircuit.fromQuantumCircuit(x) for x in qobj_to_circuits(qobj)]
-        self.assertEqual(dag_list, [self.dag,
-                                    DAGCircuit.fromQuantumCircuit(circuit_b)])
+        dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
+        self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support to the helper function in
qiskit.tools.qobj_to_circuits for creating circuits from a qobj without
compiled qasm in the header. It does this by looping over the Qobj
object to run the operations needed to construct the circuit objects
directly instead of just parsing qasm.

### Details and comments

Fixes #1407
