### PR TITLE
Use integers in properties.gates.qubits

### DIFF
--- a/qiskit/backends/models/backendproperties.py
+++ b/qiskit/backends/models/backendproperties.py
@@ -10,7 +10,7 @@
 from marshmallow.validate import Length, Regexp
 
 from qiskit.validation import BaseModel, BaseSchema, bind_schema
-from qiskit.validation.fields import DateTime, List, Nested, Number, String
+from qiskit.validation.fields import DateTime, List, Nested, Number, String, Integer
 
 
 class NduvSchema(BaseSchema):
@@ -27,7 +27,7 @@ class GateSchema(BaseSchema):
     """Schema for Gate."""
 
     # Required properties.
-    qubits = List(Number(), required=True,
+    qubits = List(Integer(), required=True,
                   validate=Length(min=1))
     gate = String(required=True)
     parameters = Nested(NduvSchema, required=True, many=True,

--- a/qiskit/schemas/backend_properties_schema.json
+++ b/qiskit/schemas/backend_properties_schema.json
@@ -18,7 +18,7 @@
                 },
                 "qubits": {
                     "items": {
-                        "type": "number"
+                        "type": "integer"
                     },
                     "minItems": 1,
                     "type": "array"


### PR DESCRIPTION
Use `integer` instead of `number` in the schema for BackendProperties
(`BackendProperties.gates[x].qubits`).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


