### PR TITLE
Make to_dict and from_dict more discoverable, adjust converter tests

### DIFF
--- a/test/python/converters/__init__.py
+++ b/test/python/converters/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Tests for the converters."""

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -7,7 +7,7 @@
 
 # pylint: disable=redefined-builtin
 
-"""Tests for the wrapper functionality."""
+"""Tests for the converters."""
 
 import unittest
 
@@ -17,14 +17,13 @@ from qiskit import Aer
 from qiskit import compile
 
 from qiskit.qobj import Qobj
-from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler import PassManager
 from qiskit.converters import circuit_to_dag
 from ..common import QiskitTestCase
 
 
-class TestQobj2Circuits(QiskitTestCase):
-    """Wrapper test case."""
+class TestQobjToCircuits(QiskitTestCase):
+    """Test Qobj to Circuits."""
 
     def setUp(self):
         qr = QuantumRegister(3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

 Move the `to_dict()` and `from_dict()` methods directly to the
    `BaseModel` instead of appending them at decoration time, for ease of
    usage and aiding discovery.

Adjust the converter tests as a followup to #1410, caught while testing.

### Details and comments


