### PR TITLE
Remove deepcopy usage in dag_to_circuit

### DIFF
--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -43,6 +43,8 @@ def dag_to_circuit(dag):
                 name = 'u_base'
             elif n['op'].name == 'CX':
                 name = 'cx_base'
+            elif n['op'].name == 'id':
+                name = 'iden'
             else:
                 name = n['op'].name
 
@@ -55,7 +57,11 @@ def dag_to_circuit(dag):
             for clbit in n['cargs']:
                 clbits.append(cregs[clbit[0].name][clbit[1]])
             params = n['op'].param
-            result = instr_method(*params, *qubits, *clbits)
+
+            if name in ['snapshot', 'save', 'noise', 'load']:
+                result = instr_method(params[0])
+            else:
+                result = instr_method(*params, *qubits, *clbits)
             if 'condition' in n and n['condition']:
                 result.c_if(*n['condition'])
     return circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit attempts to improve the performance of dag_to_circuit by
removing the deepcopy usage. Instead this switches to  creating a
circuit object using the normal constructors while iterating over the
dag.


### Details and comments