### PR TITLE
Fix simulator instruction handling for qobj_to_circuit()

### DIFF
--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -51,7 +51,10 @@ def qobj_to_circuits(qobj):
                     clbit_label = x.header.clbit_labels[clbit]
                     clbits.append(
                         creg_dict[clbit_label[0]][clbit_label[1]])
-                instr_method(*i.params, *qubits, *clbits)
+                if i.name in ['snapshot', 'save', 'load', 'noise']:
+                    instr_method(*i.params)
+                else:
+                    instr_method(*i.params, *qubits, *clbits)
             circuits.append(circuit)
         return circuits
     return None

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -74,6 +74,19 @@ class TestQobjToCircuits(QiskitTestCase):
         self.assertEqual(circuit_to_dag(out_circuit[0]),
                          circuit_to_dag(circuit_b))
 
+    def test_qobj_to_circuit_with_sim_instructions(self):
+        backend = Aer.get_backend('qasm_simulator_py')
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(3)
+        circuit = QuantumCircuit(qr, cr)
+        circuit.ccx(qr[0], qr[1], qr[2])
+        circuit.snapshot(1)
+        circuit.measure(qr, cr)
+        dag = circuit_to_dag(circuit)
+        qobj_in = compile(circuit, backend, pass_manager=PassManager())
+        out_circuit = qobj_to_circuits(qobj_in)
+        self.assertEqual(circuit_to_dag(out_circuit[0]), dag)
+
     def test_qobj_to_circuits_with_nothing(self):
         """Verify that qobj_to_circuits returns None without any data."""
         qobj = Qobj('abc123', {}, {}, {})

--- a/test/python/converters/test_qobj_2_circuits.py
+++ b/test/python/converters/test_qobj_2_circuits.py
@@ -75,6 +75,7 @@ class TestQobjToCircuits(QiskitTestCase):
                          circuit_to_dag(circuit_b))
 
     def test_qobj_to_circuit_with_sim_instructions(self):
+        """Check qobj_to_circuit result with asimulator instruction."""
         backend = Aer.get_backend('qasm_simulator_py')
         qr = QuantumRegister(3)
         cr = ClassicalRegister(3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since moving the qobj_to_circuit() function from parsing the qasm in the
header any qobj with a simulator instruction hasn't worked. This is
because the function naively assumed that any instruction in the qobj
wouldn't have parameters defined that were not used by the QuantumCircuit
method. So it would always pass the list of all parameters, qargs, and
cargs assuming that to always be correct. However for the simulator
instructions snapshot, save, load, and noise the QuantumCircuit
instruction methods for those only want the slot (or switch for noise),
but the qobj has a qargs defined. This commit fixes this by special
casing the simulator instructions and only using the parameters required
by the instruction methods.

### Details and comments