### PR TITLE
Fix deprecation warnings for abc on Python 3.7

### DIFF
--- a/qiskit/validation/fields/containers.py
+++ b/qiskit/validation/fields/containers.py
@@ -7,7 +7,7 @@
 
 """Container fields that represent nested/collections of schemas or types."""
 
-from collections import Iterable
+from collections.abc import Iterable
 
 from marshmallow import fields as _fields
 from marshmallow.utils import is_collection

--- a/qiskit/validation/fields/polymorphic.py
+++ b/qiskit/validation/fields/polymorphic.py
@@ -7,7 +7,7 @@
 
 """Polymorphic fields that represent one of several schemas or types."""
 
-from collections import Iterable
+from collections.abc import Iterable
 from functools import partial
 
 from marshmallow.utils import is_collection


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When running on Python 3.7 importing things from 'collections.abc' via
just 'collections' raises a deprecation warning because it'll be
removed in python 3.8. This commit fixes this by updating the imports
to not use the alias.

### Details and comments