### PR TITLE
Move aliased and deprecated functions to private

### DIFF
--- a/qiskit/backends/aer/aerprovider.py
+++ b/qiskit/backends/aer/aerprovider.py
@@ -53,7 +53,7 @@ class AerProvider(BaseProvider):
             try:
                 resolved_name = resolve_backend_name(
                     name, backends,
-                    self.deprecated_backend_names(),
+                    self._deprecated_backend_names(),
                     {},
                     self._alternative_py_backend_names()
                 )
@@ -74,7 +74,7 @@ class AerProvider(BaseProvider):
             try:
                 resolved_name = resolve_backend_name(
                     name, backends,
-                    self.deprecated_backend_names(),
+                    self._deprecated_backend_names(),
                     {},
                     self._alternative_py_backend_names()
                 )
@@ -86,7 +86,7 @@ class AerProvider(BaseProvider):
         return filter_backends(backends, filters=filters, **kwargs)
 
     @staticmethod
-    def deprecated_backend_names():
+    def _deprecated_backend_names():
         """Returns deprecated backend names."""
         return {
             'local_qasm_simulator_cpp': 'qasm_simulator',

--- a/qiskit/backends/ibmq/ibmqprovider.py
+++ b/qiskit/backends/ibmq/ibmqprovider.py
@@ -66,8 +66,8 @@ class IBMQProvider(BaseProvider):
 
         # Special handling of the `name` parameter, to support alias resolution.
         if name:
-            aliases = self.aliased_backend_names()
-            aliases.update(self.deprecated_backend_names())
+            aliases = self._aliased_backend_names()
+            aliases.update(self._deprecated_backend_names())
             name = aliases.get(name, name)
 
         # Aggregate the list of filtered backends.
@@ -79,7 +79,7 @@ class IBMQProvider(BaseProvider):
         return backends
 
     @staticmethod
-    def deprecated_backend_names():
+    def _deprecated_backend_names():
         """Returns deprecated backend names."""
         return {
             'ibmqx_qasm_simulator': 'ibmq_qasm_simulator',
@@ -88,7 +88,7 @@ class IBMQProvider(BaseProvider):
             }
 
     @staticmethod
-    def aliased_backend_names():
+    def _aliased_backend_names():
         """Returns aliased backend names."""
         return {
             'ibmq_5_yorktown': 'ibmqx2',

--- a/test/python/test_backend_name_resolution.py
+++ b/test/python/test_backend_name_resolution.py
@@ -26,7 +26,7 @@ class TestBackendNameResolution(QiskitTestCase):
     def test_deprecated(self):
         """Test that deprecated names map the same backends as the new names.
         """
-        deprecated_names = Aer.deprecated_backend_names()
+        deprecated_names = Aer._deprecated_backend_names()
 
         for oldname, newname in deprecated_names.items():
             if (newname == 'qasm_simulator' or
@@ -48,7 +48,7 @@ class TestBackendNameResolution(QiskitTestCase):
         """Test that display names of devices map the same backends as the
         regular names."""
         IBMQ.enable_account(qe_token, qe_url)
-        aliased_names = IBMQ.aliased_backend_names()
+        aliased_names = IBMQ._aliased_backend_names()
 
         for display_name, backend_name in aliased_names.items():
             with self.subTest(display_name=display_name,


### PR DESCRIPTION
Move the `deprecated_backend_names` and `aliased_backend_names` to
private.

Part of #1046.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


