### PR TITLE
Fix label when drawing registers in mpl

### DIFF
--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -363,9 +363,9 @@ class MatplotlibDrawer:
         # quantum register
         for ii, reg in enumerate(self._qreg):
             if len(self._qreg) > 1:
-                label = '${}_{{{}}}$'.format(reg.name, reg.index)
+                label = '${}_{{{}}}$'.format(reg.name.name, reg.index)
             else:
-                label = '${}$'.format(reg.name)
+                label = '${}$'.format(reg.name.name)
             pos = -ii
             self._qreg_dict[ii] = {
                 'y': pos,
@@ -384,7 +384,7 @@ class MatplotlibDrawer:
                     self._creg, n_creg)):
                 pos = y_off - idx
                 if self._style.bundle:
-                    label = '${}$'.format(reg.name)
+                    label = '${}$'.format(reg.name.name)
                     self._creg_dict[ii] = {
                         'y': pos,
                         'label': label,
@@ -394,7 +394,7 @@ class MatplotlibDrawer:
                     if not (not nreg or reg.name != nreg.name):
                         continue
                 else:
-                    label = '${}_{{{}}}$'.format(reg.name, reg.index)
+                    label = '${}_{{{}}}$'.format(reg.name.name, reg.index)
                     self._creg_dict[ii] = {
                         'y': pos,
                         'label': label,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When we migrated to using the dag the labels for bits in mpl drawings
were broken because we started passing around a Register object instead
of just a string. This commit fixes the issue by pulling the actual
string label for the register instead of an object.

### Details and comments

Fixes #1449 