### PR TITLE
Sanitize url in error and warnings

### DIFF
--- a/qiskit/backends/ibmq/api/ibmqconnector.py
+++ b/qiskit/backends/ibmq/api/ibmqconnector.py
@@ -381,8 +381,7 @@ class _Request(object):
         Returns:
            str: The sanitized url
         """
-        parts = parse.urlparse(url).path.split('/')
-        return '/'.join(parts[-3:])
+        return parse.urlparse(url).path
 
     def _response_good(self, response):
         """check response

--- a/qiskit/backends/ibmq/api/ibmqconnector.py
+++ b/qiskit/backends/ibmq/api/ibmqconnector.py
@@ -391,7 +391,7 @@ class _Request(object):
         Args:
             url (str): The url to sanitize
 
-        returns:
+        Returns:
            str: The sanitized url
         """
         parts = parse.urlparse(url).path.split('/')
@@ -410,7 +410,7 @@ class _Request(object):
             ApiError: response isn't formatted properly.
         """
 
-        url = _sanitize_url(respond.url)
+        url = self._sanitize_url(response.url)
 
         if response.status_code != requests.codes.ok:
             logger.warning('Got a %s code response to %s: %s',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently when we encounter an error response we log a message (or raise
an exception) saying we hit a failure response code. In that message it
contains the full url which potentially includes the access token. This
is a potential security issue because we don't want to log the token
accidentally somewhere. While there is a ttl on that token and it's
going to expire, there is still a chance someone could use that
information to gain access to the system. This commit addresses this
potential issue by stripping any query info from the logged url and
also only logging the relative api path relative to the actions being
invoked. This is all that should be needed to understand and
report/debug a failure encountered while making requests to the api.

### Details and comments

This is a mirror of https://github.com/Qiskit/qiskit-api-py/pull/72 which didn't merge before we copied the library into qiskit-terra.

