### PR TITLE
Increase mapper identity_wire_map size to coupling.size() (#1426).

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -489,7 +489,7 @@ class DAGCircuit:
         add_regs = set()
         reg_frag_chk = {}
         for v in keyregs.values():
-            reg_frag_chk[v] = {j: False for j in range(len(keyregs))}
+            reg_frag_chk[v] = {j: False for j in range(len(v))}
         for k in edge_map.keys():
             if k[0].name in keyregs:
                 reg_frag_chk[k[0]][k[1]] = True

--- a/qiskit/mapper/_mapping.py
+++ b/qiskit/mapper/_mapping.py
@@ -183,9 +183,6 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials,
 
     logger.debug("layer_permutation: gates = %s", pprint.pformat(gates))
 
-    # Find layout maximum index
-    layout_max_index = max(map(lambda x: x[1] + 1, layout.values()))
-
     # Can we already apply the gates?
     dist = sum([coupling.distance(layout[g[0]][1], layout[g[1]][1]) for g in gates])
     logger.debug("layer_permutation: dist = %s", dist)
@@ -240,7 +237,7 @@ def layer_permutation(layer_partition, layout, qubit_subset, coupling, trials,
 
         # Identity wire-map for composing the circuits
         q = QuantumRegister(coupling.size(), 'q')
-        identity_wire_map = {(q, j): (q, j) for j in range(layout_max_index)}
+        identity_wire_map = {(q, j): (q, j) for j in range(coupling.size())}
 
         while d < 2 * n + 1:
             # Set of available qubits
@@ -402,12 +399,11 @@ def swap_mapper_layer_update(i, first_layer, best_layout, best_d,
     Return DAGCircuit object to append to the output DAGCircuit.
     """
     layout = best_layout
-    layout_max_index = max(map(lambda x: x[1] + 1, layout.values()))
     dagcircuit_output = DAGCircuit()
     dagcircuit_output.add_qreg(QuantumRegister(coupling_graph.size(), "q"))
     # Identity wire-map for composing the circuits
     q = QuantumRegister(coupling_graph.size(), 'q')
-    identity_wire_map = {(q, j): (q, j) for j in range(layout_max_index)}
+    identity_wire_map = {(q, j): (q, j) for j in range(coupling_graph.size())}
 
     # If this is the first layer with multi-qubit gates,
     # output all layers up to this point and ignore any
@@ -493,7 +489,6 @@ def swap_mapper(circuit_graph, coupling_graph,
 
     # Find swap circuit to preceed to each layer of input circuit
     layout = initial_layout.copy()
-    layout_max_index = max(map(lambda x: x[1] + 1, layout.values()))
 
     # Construct an empty DAGCircuit with one qreg "q"
     # and the same set of cregs as the input circuit
@@ -508,7 +503,7 @@ def swap_mapper(circuit_graph, coupling_graph,
     # we are building
     identity_wire_map = {}
     q = QuantumRegister(coupling_graph.size(), 'q')
-    for j in range(layout_max_index):
+    for j in range(coupling_graph.size()):
         identity_wire_map[(q, j)] = (q, j)
     for creg in circuit_graph.cregs.values():
         for j in range(creg.size):

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -318,8 +318,6 @@ class TestMapper(QiskitTestCase):
         qobj2 = compile(circ2, backend)
         self.assertIsInstance(qobj2, Qobj)
 
-    @unittest.skip("Temporary skipping")
-    # skipping temporarily due to mapping wire fragment bug.
     def test_move_measurements(self):
         """Measurements applied AFTER swap mapping.
         """

--- a/test/python/test_reordering.py
+++ b/test/python/test_reordering.py
@@ -50,8 +50,6 @@ class TestBitReordering(QiskitTestCase):
         threshold = 0.1 * shots
         self.assertDictAlmostEqual(counts_real, counts_sim, threshold)
 
-    @unittest.skip("Temporary skipping")
-    # skipping temporarily due to mapping wire fragment bug.
     @slow_test
     @requires_qe_access
     def test_multi_register_reordering(self, qe_token, qe_url):

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -361,8 +361,6 @@ class TestCompiler(QiskitTestCase):
             circuits = None
         self.assertIsInstance(circuits, QuantumCircuit)
 
-    @unittest.skip("Temporary skipping")
-    # skipping temporarily due to mapping wire fragment bug.
     def test_mapping_multi_qreg(self):
         """Test mapping works for multiple qregs.
         """

--- a/test/python/transpiler/test_basic_mapper.py
+++ b/test/python/transpiler/test_basic_mapper.py
@@ -296,23 +296,23 @@ class TestBasicMapper(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
-    @unittest.expectedFailure
-    # TODO It seems to be a problem in compose_back
     def test_swap_between_qregs(self):
         """ Adding a swap affecting different qregs
-         qr0_0:-------
+        virtual  physical
+         qr0_0:    [0] -------
 
-         qr1_0:--(+)--
-                  |
-         qr1_1:---.---
+         qr1_0:    [1] --(+)--
+                          |
+         qr1_1:    [2] ---.---
 
          Coupling map: [1]--[0]--[2]
 
-         qr0_0:--X--.---
-                 |  |
-         qr1_0:--|-(+)--
-                 |
-         qr1_1:--X------
+        virtual  physical
+         qr0_0:    [0] --X-(+)--
+                         |  |
+         qr1_0:    [1] --X--|---
+                            |
+         qr1_1:    [2] -----.---
 
         """
         coupling = Coupling({0: [1, 2]})
@@ -325,8 +325,8 @@ class TestBasicMapper(QiskitTestCase):
         dag = circuit_to_dag(circuit)
 
         expected = QuantumCircuit(qr0, qr1)
-        expected.swap(qr1[1], qr0[0])
-        expected.cx(qr1[1], qr0[0])
+        expected.swap(qr1[0], qr0[0])
+        expected.cx(qr0[0], qr1[1])
 
         pass_ = BasicMapper(coupling)
         after = pass_.run(dag)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Attempts to address failing tests in #1426 by increasing size of identity_wire_map to the number of physical qubits in the device.


### Details and comments


