### PR TITLE
Update python simulators to match qiskit-aer simulator

### DIFF
--- a/qiskit/backends/builtinsimulators/_simulatortools.py
+++ b/qiskit/backends/builtinsimulators/_simulatortools.py
@@ -15,50 +15,8 @@ Functions
 """
 
 from string import ascii_uppercase, ascii_lowercase
-
 import numpy as np
-
 from qiskit import QiskitError
-
-
-def index1(b, i, k):
-    """Magic index1 function.
-
-    Takes a bitstring k and inserts bit b as the ith bit,
-    shifting bits >= i over to make room.
-    """
-    retval = k
-    lowbits = k & ((1 << i) - 1)  # get the low i bits
-
-    retval >>= i
-    retval <<= 1
-
-    retval |= b
-
-    retval <<= i
-    retval |= lowbits
-
-    return retval
-
-
-def index2(b1, i1, b2, i2, k):
-    """Magic index2 function.
-
-    Takes a bitstring k and inserts bits b1 as the i1th bit
-    and b2 as the i2th bit
-    """
-    if i1 == i2:
-        raise QiskitError("can't insert two bits to same place")
-
-    if i1 > i2:
-        # insert as (i1-1)th bit, will be shifted left 1 by next line
-        retval = index1(b1, i1-1, k)
-        retval = index1(b2, i2, retval)
-    else:  # i2>i1
-        # insert as (i2-1)th bit, will be shifted left 1 by next line
-        retval = index1(b2, i2-1, k)
-        retval = index1(b1, i1, retval)
-    return retval
 
 
 def single_gate_params(gate, params=None):
@@ -75,7 +33,7 @@ def single_gate_params(gate, params=None):
     if gate == 'U' or gate == 'u3':
         return params[0], params[1], params[2]
     elif gate == 'u2':
-        return np.pi/2, params[0], params[1]
+        return np.pi / 2, params[0], params[1]
     elif gate == 'u1':
         return 0, 0, params[0]
     elif gate == 'id':
@@ -97,14 +55,22 @@ def single_gate_matrix(gate, params=None):
     # This a is a probable a FIXME since it might show bugs in the simulator.
     (theta, phi, lam) = map(float, single_gate_params(gate, params))
 
-    return np.array([[np.cos(theta/2),
-                      -np.exp(1j*lam)*np.sin(theta/2)],
-                     [np.exp(1j*phi)*np.sin(theta/2),
-                      np.exp(1j*phi+1j*lam)*np.cos(theta/2)]])
+    return np.array([[np.cos(theta / 2),
+                      -np.exp(1j * lam) * np.sin(theta / 2)],
+                     [np.exp(1j * phi) * np.sin(theta / 2),
+                      np.exp(1j * phi + 1j * lam) * np.cos(theta / 2)]])
+
+
+def cx_gate_matrix():
+    """Get the matrix for a controlled-NOT gate."""
+    return np.array([[1, 0, 0, 0],
+                     [0, 0, 0, 1],
+                     [0, 0, 1, 0],
+                     [0, 1, 0, 0]], dtype=complex)
 
 
 def einsum_matmul_index(gate_indices, number_of_qubits):
-    """Return the index string for Numpy.eignsum matrix multiplication.
+    """Return the index string for Numpy.eignsum matrix-matrix multiplication.
 
     The returned indices are to perform a matrix multiplication A.B where
     the matrix A is an M-qubit matrix, matrix B is an N-qubit matrix, and
@@ -118,6 +84,65 @@ def einsum_matmul_index(gate_indices, number_of_qubits):
 
     Returns:
         str: An indices string for the Numpy.einsum function.
+    """
+
+    mat_l, mat_r, tens_lin, tens_lout = _einsum_matmul_index_helper(gate_indices,
+                                                                    number_of_qubits)
+
+    # Right indices for the N-qubit input and output tensor
+    tens_r = ascii_uppercase[:number_of_qubits]
+
+    # Combine indices into matrix multiplication string format
+    # for numpy.einsum function
+    return "{mat_l}{mat_r}, ".format(mat_l=mat_l, mat_r=mat_r) + \
+           "{tens_lin}{tens_r}->{tens_lout}{tens_r}".format(tens_lin=tens_lin,
+                                                            tens_lout=tens_lout,
+                                                            tens_r=tens_r)
+
+
+def einsum_vecmul_index(gate_indices, number_of_qubits):
+    """Return the index string for Numpy.eignsum matrix-vector multiplication.
+
+    The returned indices are to perform a matrix multiplication A.v where
+    the matrix A is an M-qubit matrix, vector v is an N-qubit vector, and
+    M <= N, and identity matrices are implied on the subsystems where A has no
+    support on v.
+
+    Args:
+        gate_indices (list[int]): the indices of the right matrix subsystems
+                                  to contract with the left matrix.
+        number_of_qubits (int): the total number of qubits for the right matrix.
+
+    Returns:
+        str: An indices string for the Numpy.einsum function.
+    """
+
+    mat_l, mat_r, tens_lin, tens_lout = _einsum_matmul_index_helper(gate_indices,
+                                                                    number_of_qubits)
+
+    # Combine indices into matrix multiplication string format
+    # for numpy.einsum function
+    return "{mat_l}{mat_r}, ".format(mat_l=mat_l, mat_r=mat_r) + \
+           "{tens_lin}->{tens_lout}".format(tens_lin=tens_lin,
+                                            tens_lout=tens_lout)
+
+
+def _einsum_matmul_index_helper(gate_indices, number_of_qubits):
+    """Return the index string for Numpy.eignsum matrix multiplication.
+
+    The returned indices are to perform a matrix multiplication A.v where
+    the matrix A is an M-qubit matrix, matrix v is an N-qubit vector, and
+    M <= N, and identity matrices are implied on the subsystems where A has no
+    support on v.
+
+    Args:
+        gate_indices (list[int]): the indices of the right matrix subsystems
+                                   to contract with the left matrix.
+        number_of_qubits (int): the total number of qubits for the right matrix.
+
+    Returns:
+        tuple: (mat_left, mat_right, tens_in, tens_out) of index strings for
+        that may be combined into a Numpy.einsum function string.
 
     Raises:
         QiskitError: if the total number of qubits plus the number of
@@ -131,14 +156,11 @@ def einsum_matmul_index(gate_indices, number_of_qubits):
     if len(gate_indices) + number_of_qubits > 26:
         raise QiskitError("Total number of free indexes limited to 26")
 
-    # Right indices for the N-qubit input and output tensor
-    idx_right = ascii_uppercase[:number_of_qubits]
+    # Indicies for N-qubit input tensor
+    tens_in = ascii_lowercase[:number_of_qubits]
 
-    # Left ndicies for N-qubit input tensor
-    idx_left_in = ascii_lowercase[:number_of_qubits]
-
-    # Left indices for the N-qubit output tensor
-    idx_left_out = list(idx_left_in)
+    # Indices for the N-qubit output tensor
+    tens_out = list(tens_in)
 
     # Left and right indices for the M-qubit multiplying tensor
     mat_left = ""
@@ -147,13 +169,10 @@ def einsum_matmul_index(gate_indices, number_of_qubits):
     # Update left indices for mat and output
     for pos, idx in enumerate(reversed(gate_indices)):
         mat_left += ascii_lowercase[-1 - pos]
-        mat_right += idx_left_in[-1 - idx]
-        idx_left_out[-1 - idx] = ascii_lowercase[-1 - pos]
-    idx_left_out = "".join(idx_left_out)
+        mat_right += tens_in[-1 - idx]
+        tens_out[-1 - idx] = ascii_lowercase[-1 - pos]
+    tens_out = "".join(tens_out)
 
     # Combine indices into matrix multiplication string format
     # for numpy.einsum function
-    return "{mat_l}{mat_r}, ".format(mat_l=mat_left, mat_r=mat_right) + \
-           "{tens_lin}{tens_r}->{tens_lout}{tens_r}".format(tens_lin=idx_left_in,
-                                                            tens_lout=idx_left_out,
-                                                            tens_r=idx_right)
+    return mat_left, mat_right, tens_in, tens_out

--- a/qiskit/backends/builtinsimulators/qasm_simulator.py
+++ b/qiskit/backends/builtinsimulators/qasm_simulator.py
@@ -6,6 +6,7 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 # pylint: disable=invalid-name
+# pylint: disable=arguments-differ
 
 """Contains a (slow) python simulator.
 
@@ -21,7 +22,7 @@ Where the input is a Qobj object and the output is a SimulatorsJob object, which
 later be queried for the Result object. The result will contain a 'memory' data
 field, which is a result of measurements for each shot.
 """
-import random
+
 import uuid
 import time
 import logging
@@ -36,7 +37,9 @@ from qiskit.result import Result
 from qiskit.backends import BaseBackend
 from qiskit.backends.builtinsimulators.simulatorsjob import SimulatorsJob
 from ._simulatorerror import SimulatorError
-from ._simulatortools import single_gate_matrix, index2
+from ._simulatortools import single_gate_matrix
+from ._simulatortools import cx_gate_matrix
+from ._simulatortools import einsum_vecmul_index
 
 logger = logging.getLogger(__name__)
 
@@ -44,10 +47,12 @@ logger = logging.getLogger(__name__)
 class QasmSimulatorPy(BaseBackend):
     """Python implementation of a qasm simulator."""
 
+    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
         'backend_version': '2.0.0',
-        'n_qubits': int(log2(local_hardware_info()['memory'] * (1024**3)/16)),
+        'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
         'local': True,
@@ -56,7 +61,7 @@ class QasmSimulatorPy(BaseBackend):
         'memory': True,
         'max_shots': 65536,
         'description': 'A python simulator for qasm experiments',
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'snapshot'],
+        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id'],
         'gates': [
             {
                 'name': 'u1',
@@ -82,146 +87,283 @@ class QasmSimulatorPy(BaseBackend):
                 'name': 'id',
                 'parameters': ['a'],
                 'qasm_def': 'gate id a { U(0,0,0) a; }'
-            },
-            {
-                'name': 'snapshot',
-                'parameters': ['slot'],
-                'qasm_def': 'gate snapshot(slot) q { TODO }'
             }
         ]
     }
+
+    DEFAULT_OPTIONS = {
+        "initial_statevector": None,
+        "chop_threshold": 1e-15
+    }
+
+    # Class level variable to return the final state at the end of simulation
+    # This should be set to True for the statevector simulator
+    SHOW_FINAL_STATE = False
 
     def __init__(self, configuration=None, provider=None):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
 
-        self._local_random = random.Random()
-
         # Define attributes in __init__.
+        self._local_random = np.random.RandomState()
         self._classical_state = 0
         self._statevector = 0
-        self._snapshots = {}
         self._number_of_cbits = 0
         self._number_of_qubits = 0
         self._shots = 0
         self._memory = False
+        self._initial_statevector = self.DEFAULT_OPTIONS["initial_statevector"]
+        self._chop_threshold = self.DEFAULT_OPTIONS["chop_threshold"]
         self._qobj_config = None
+        # TEMP
+        self._sample_measure = False
 
-    def _add_qasm_single(self, gate, qubit):
-        """Apply an arbitrary 1-qubit operator to a qubit.
+    def _add_unitary_single(self, gate, qubit):
+        """Apply an arbitrary 1-qubit unitary matrix.
 
-        Gate is the single qubit applied.
-        qubit is the qubit the gate is applied to.
+        Args:
+            gate (matrix_like): a single qubit gate matrix
+            qubit (int): the qubit to apply gate to
         """
-        psi = self._statevector
-        bit = 1 << qubit
-        for k1 in range(0, 1 << self._number_of_qubits, 1 << (qubit+1)):
-            for k2 in range(0, 1 << qubit, 1):
-                k = k1 | k2
-                cache0 = psi[k]
-                cache1 = psi[k | bit]
-                psi[k] = gate[0, 0] * cache0 + gate[0, 1] * cache1
-                psi[k | bit] = gate[1, 0] * cache0 + gate[1, 1] * cache1
+        # Compute einsum index string for 1-qubit matrix multiplication
+        indexes = einsum_vecmul_index([qubit], self._number_of_qubits)
+        # Convert to complex rank-2 tensor
+        gate_tensor = np.array(gate, dtype=complex)
+        # Apply matrix multiplication
+        self._statevector = np.einsum(indexes, gate_tensor,
+                                      self._statevector,
+                                      dtype=complex,
+                                      casting='no')
 
-    def _add_qasm_cx(self, q0, q1):
-        """Optimized ideal CX on two qubits.
+    def _add_unitary_two(self, gate, qubit0, qubit1):
+        """Apply a two-qubit unitary matrix.
 
-        q0 is the first qubit (control) counts from 0.
-        q1 is the second qubit (target).
+        Args:
+            gate (matrix_like): a the two-qubit gate matrix
+            qubit0 (int): gate qubit-0
+            qubit1 (int): gate qubit-1
         """
-        psi = self._statevector
-        for k in range(0, 1 << (self._number_of_qubits - 2)):
-            # first bit is control, second is target
-            ind1 = index2(1, q0, 0, q1, k)
-            # swap target if control is 1
-            ind3 = index2(1, q0, 1, q1, k)
-            cache0 = psi[ind1]
-            cache1 = psi[ind3]
-            psi[ind3] = cache0
-            psi[ind1] = cache1
+        # Compute einsum index string for 1-qubit matrix multiplication
+        indexes = einsum_vecmul_index([qubit0, qubit1], self._number_of_qubits)
+        # Convert to complex rank-4 tensor
+        gate_tensor = np.reshape(np.array(gate, dtype=complex), 4 * [2])
+        # Apply matrix multiplication
+        self._statevector = np.einsum(indexes, gate_tensor,
+                                      self._statevector,
+                                      dtype=complex,
+                                      casting='no')
 
-    def _add_qasm_decision(self, qubit):
-        """Apply the decision of measurement/reset qubit gate.
+    def _get_measure_outcome(self, qubit):
+        """Simulate the outcome of measurement of a qubit.
 
-        qubit is the qubit that is measured/reset
+        Args:
+            qubit (int): the qubit to measure
+
+        Return:
+            tuple: pair (outcome, probability) where outcome is '0' or '1' and
+            probability is the probability of the returned outcome.
         """
-        probability_zero = 0
-        random_number = self._local_random.random()
-        for ii in range(1 << self._number_of_qubits):
-            if ii & (1 << qubit) == 0:
-                probability_zero += np.abs(self._statevector[ii])**2
-        if random_number <= probability_zero:
-            outcome = '0'
-            norm = np.sqrt(probability_zero)
-        else:
-            outcome = '1'
-            norm = np.sqrt(1-probability_zero)
-        return (outcome, norm)
+        # Axis for numpy.sum to compute probabilities
+        axis = list(range(self._number_of_qubits))
+        axis.remove(self._number_of_qubits - 1 - qubit)
+        probabilities = np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis))
+        # Compute einsum index string for 1-qubit matrix multiplication
+        random_number = self._local_random.rand()
+        if random_number < probabilities[0]:
+            return '0', probabilities[0]
+        # Else outcome was '1'
+        return '1', probabilities[1]
+
+    def _add_sample_measure(self, measure_params, num_samples):
+        """Generate memory samples from current statevector.
+
+        Args:
+            measure_params (list): List of (qubit, clbit) values for
+                                   measure instructions to sample.
+            num_samples (int): The number of memory samples to generate.
+
+        Returns:
+            list: A list of memory values in hex format.
+        """
+        # Get unique qubits that are actually measured
+        measured_qubits = list(set([qubit for qubit, clbit in measure_params]))
+        num_measured = len(measured_qubits)
+        # Axis for numpy.sum to compute probabilities
+        axis = list(range(self._number_of_qubits))
+        for qubit in reversed(measured_qubits):
+            # Remove from largest qubit to smallest so list position is correct
+            # with respect to position from end of the list
+            axis.remove(self._number_of_qubits - 1 - qubit)
+        probabilities = np.reshape(np.sum(np.abs(self._statevector) ** 2,
+                                          axis=tuple(axis)),
+                                   2 ** num_measured)
+        # Generate samples on measured qubits
+        samples = self._local_random.choice(range(2 ** num_measured),
+                                            num_samples, p=probabilities)
+        # Convert to bit-strings
+        memory = []
+        for sample in samples:
+            classical_state = self._classical_state
+            for qubit, cbit in measure_params:
+                qubit_outcome = int((sample & (1 << qubit)) >> qubit)
+                bit = 1 << cbit
+                classical_state = (classical_state & (~bit)) | (qubit_outcome << cbit)
+            value = bin(classical_state)[2:]
+            memory.append(hex(int(value, 2)))
+        return memory
 
     def _add_qasm_measure(self, qubit, cbit):
-        """Apply the measurement qubit gate.
+        """Apply a measure instruction to a qubit.
 
-        qubit is the qubit measured.
-        cbit is the classical bit the measurement is assigned to.
+        Args:
+            qubit (int): qubit is the qubit measured.
+            cbit (int): is the classical bit to store outcome in.
         """
-        outcome, norm = self._add_qasm_decision(qubit)
-        for ii in range(1 << self._number_of_qubits):
-            # update quantum state
-            if (ii >> qubit) & 1 == int(outcome):
-                self._statevector[ii] = self._statevector[ii]/norm
-            else:
-                self._statevector[ii] = 0
+        # get measure outcome
+        outcome, probability = self._get_measure_outcome(qubit)
         # update classical state
         bit = 1 << cbit
         self._classical_state = (self._classical_state & (~bit)) | (int(outcome) << cbit)
+        # update quantum state
+        if outcome == '0':
+            update_diag = [[1 / np.sqrt(probability), 0], [0, 0]]
+        else:
+            update_diag = [[0, 0], [0, 1 / np.sqrt(probability)]]
+        # update classical state
+        self._add_unitary_single(update_diag, qubit)
 
     def _add_qasm_reset(self, qubit):
-        """Apply the reset to the qubit.
-
-        This is done by doing a measurement and if 0 do nothing and
-        if 1 flip the qubit.
-
-        qubit is the qubit that is reset.
-        """
-        # TODO: slow, refactor later
-        outcome, norm = self._add_qasm_decision(qubit)
-        temp = np.copy(self._statevector)
-        self._statevector.fill(0.0)
-        # measurement
-        for ii in range(1 << self._number_of_qubits):
-            if (ii >> qubit) & 1 == int(outcome):
-                temp[ii] = temp[ii]/norm
-            else:
-                temp[ii] = 0
-        # reset
-        if outcome == '1':
-            for ii in range(1 << self._number_of_qubits):
-                iip = (~ (1 << qubit)) & ii  # bit number qubit set to zero
-                self._statevector[iip] += temp[ii]
-        else:
-            self._statevector = temp
-
-    def _add_qasm_snapshot(self, slot):
-        """Snapshot instruction to record simulator's internal representation
-        of quantum statevector.
+        """Apply a reset instruction to a qubit.
 
         Args:
-            slot (string): a label to identify the recorded snapshot.
-        """
-        self._snapshots.setdefault(str(slot),
-                                   {}).setdefault("statevector",
-                                                  []).append(np.copy(self._statevector))
+            qubit (int): the qubit being rest
 
-    def run(self, qobj):
+        This is done by doing a simulating a measurement
+        outcome and projecting onto the outcome state while
+        renormalizing.
+        """
+        # get measure outcome
+        outcome, probability = self._get_measure_outcome(qubit)
+        # update quantum state
+        if outcome == '0':
+            update = [[1 / np.sqrt(probability), 0], [0, 0]]
+            self._add_unitary_single(update, qubit)
+        else:
+            update = [[0, 1 / np.sqrt(probability)], [0, 0]]
+            self._add_unitary_single(update, qubit)
+
+    def _validate_initial_statevector(self):
+        """Validate an initial statevector"""
+        # If initial statevector isn't set we don't need to validate
+        if self._initial_statevector is None:
+            return
+        # Check statevector is correct length for number of qubits
+        length = len(self._initial_statevector)
+        required_dim = 2 ** self._number_of_qubits
+        if length != required_dim:
+            raise SimulatorError('initial statevector is incorrect length: ' +
+                                 '{} != {}'.format(length, required_dim))
+
+    def _set_options(self, backend_options=None):
+        """Set the backend options for all experiments in a qobj"""
+        # Reset default options
+        self._initial_statevector = self.DEFAULT_OPTIONS["initial_statevector"]
+        self._chop_threshold = self.DEFAULT_OPTIONS["chop_threshold"]
+        # Replace with custom options
+        if backend_options is not None:
+            if 'chop_threshold' in backend_options:
+                self._chop_threshold = backend_options['chop_threshold']
+            if 'initial_statevector' in backend_options:
+                self._initial_statevector = np.array(backend_options['initial_statevector'],
+                                                     dtype=complex)
+                # Check the initial statevector is normalized
+                norm = np.linalg.norm(self._initial_statevector)
+                if round(norm, 12) != 1:
+                    raise SimulatorError('initial statevector is not normalized: ' +
+                                         'norm {} != 1'.format(norm))
+
+    def _initialize_statevector(self):
+        """Set the initial statevector for simulation"""
+        if self._initial_statevector is None:
+            # Set to default state of all qubits in |0>
+            self._statevector = np.zeros(2 ** self._number_of_qubits,
+                                         dtype=complex)
+            self._statevector[0] = 1
+        else:
+            self._statevector = self._initial_statevector.copy()
+        # Reshape to rank-N tensor
+        self._statevector = np.reshape(self._statevector,
+                                       self._number_of_qubits * [2])
+
+    def _get_statevector(self):
+        """Return the current statevector in JSON Result spec format"""
+        vec = np.reshape(self._statevector, 2 ** self._number_of_qubits)
+        # Expand complex numbers
+        vec = np.stack([vec.real, vec.imag], axis=1)
+        # Truncate small values
+        vec[abs(vec) < self._chop_threshold] = 0.0
+        return vec
+
+    def _validate_measure_sampling(self, experiment):
+        """Determine if measure sampling is allowed for an experiment
+
+        Args:
+            experiment (QobjExperiment): a qobj experiment.
+        """
+
+        # Check for config flag
+        if hasattr(experiment.config, 'allows_measure_sampling'):
+            self._sample_measure = experiment.config.allows_measure_sampling
+        # If flag isn't found do a simple test to see if a circuit contains
+        # no reset instructions, and no gates instructions after
+        # the first measure.
+        else:
+            measure_flag = False
+            for instruction in experiment.instructions:
+                # If circuit contains reset operations we cannot sample
+                if instruction.name == "reset":
+                    self._sample_measure = False
+                    return
+                # If circuit contains a measure option then we can
+                # sample only if all following operations are measures
+                if measure_flag:
+                    # If we find a non-measure instruction
+                    # we cannot do measure sampling
+                    if instruction.name not in ["measure", "barrier", "id", "u0"]:
+                        self._sample_measure = False
+                        return
+                elif instruction.name == "measure":
+                    measure_flag = True
+            # If we made it to the end of the circuit without returning
+            # measure sampling is allowed
+            self._sample_measure = True
+
+    def run(self, qobj, backend_options=None):
         """Run qobj asynchronously.
 
         Args:
             qobj (Qobj): payload of the experiment
+            backend_options (dict): backend options
 
         Returns:
             SimulatorsJob: derived from BaseJob
+
+        Additional Information:
+            backend_options: Is a dict of options for the backend. It may contain
+                * "initial_statevector": vector_like
+
+            The "initial_statevector" option specifies a custom initial
+            initial statevector for the simulator to be used instead of the all
+            zero state. This size of this vector must be correct for the number
+            of qubits in all experiments in the qobj.
+
+            Example:
+            backend_options = {
+                "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+            }
         """
+        self._set_options(backend_options)
         job_id = str(uuid.uuid4())
         job = SimulatorsJob(self, job_id, self._run_job, qobj)
         job.submit()
@@ -243,7 +385,6 @@ class QasmSimulatorPy(BaseBackend):
         self._memory = qobj.config.memory
         self._qobj_config = qobj.config
         start = time.time()
-
         for experiment in qobj.experiments:
             result_list.append(self.run_experiment(experiment))
         end = time.time()
@@ -274,12 +415,8 @@ class QasmSimulatorPy(BaseBackend):
                 "shots": number of shots used in the simulation
                 "data":
                     {
+                    "counts": {'0x9: 5, ...},
                     "memory": ['0x9', '0xF', '0x1D', ..., '0x9']
-                    "snapshots":
-                            {
-                            '1': [0.7, 0, 0, 0.7],
-                            '2': [0.5, 0.5, 0.5, 0.5]
-                            }
                     },
                 "status": status string for the simulation
                 "success": boolean
@@ -288,27 +425,41 @@ class QasmSimulatorPy(BaseBackend):
         Raises:
             SimulatorError: if an error occurred.
         """
+        start = time.time()
         self._number_of_qubits = experiment.config.n_qubits
         self._number_of_cbits = experiment.config.memory_slots
         self._statevector = 0
         self._classical_state = 0
-        self._snapshots = {}
-
+        self._sample_measure = False
+        # Validate the dimension of initial statevector if set
+        self._validate_initial_statevector()
         # Get the seed looking in circuit, qobj, and then random.
-        if hasattr(experiment, 'config') and hasattr(experiment.config, 'seed'):
+        if hasattr(experiment.config, 'seed'):
             seed = experiment.config.seed
         elif hasattr(self._qobj_config, 'seed'):
             seed = self._qobj_config.seed
         else:
-            seed = random.getrandbits(32)
+            # For compatibility on Windows force dyte to be int32
+            # and set the maximum value to be (2 ** 31) - 1
+            seed = np.random.randint(2147483647, dtype='int32')
         self._local_random.seed(seed)
-        outcomes = []
+        # Check if measure sampling is supported for current circuit
+        self._validate_measure_sampling(experiment)
 
-        start = time.time()
-        for _ in range(self._shots):
-            self._statevector = np.zeros(1 << self._number_of_qubits,
-                                         dtype=complex)
-            self._statevector[0] = 1
+        # List of final counts for all shots
+        memory = []
+        # Check if we can sample measurements, if so we only perform 1 shot
+        # and sample all outcomes from the final state vector
+        if self._sample_measure:
+            shots = 1
+            # Store (qubit, cbit) pairs for all measure ops in circuit to
+            # be sampled
+            measure_sample_ops = []
+        else:
+            shots = self._shots
+        for _ in range(shots):
+            self._initialize_statevector()
+            # Initialize classical memory to all 0
             self._classical_state = 0
             for operation in experiment.instructions:
                 if getattr(operation, 'conditional', None):
@@ -325,19 +476,15 @@ class QasmSimulatorPy(BaseBackend):
                     params = getattr(operation, 'params', None)
                     qubit = operation.qubits[0]
                     gate = single_gate_matrix(operation.name, params)
-                    self._add_qasm_single(gate, qubit)
+                    self._add_unitary_single(gate, qubit)
                 # Check if CX gate
                 elif operation.name in ('id', 'u0'):
                     pass
                 elif operation.name in ('CX', 'cx'):
                     qubit0 = operation.qubits[0]
                     qubit1 = operation.qubits[1]
-                    self._add_qasm_cx(qubit0, qubit1)
-                # Check if measure
-                elif operation.name == 'measure':
-                    qubit = operation.qubits[0]
-                    cbit = operation.memory[0]
-                    self._add_qasm_measure(qubit, cbit)
+                    gate = cx_gate_matrix()
+                    self._add_unitary_two(gate, qubit0, qubit1)
                 # Check if reset
                 elif operation.name == 'reset':
                     qubit = operation.qubits[0]
@@ -345,27 +492,45 @@ class QasmSimulatorPy(BaseBackend):
                 # Check if barrier
                 elif operation.name == 'barrier':
                     pass
-                # Check if snapshot command
-                elif operation.name == 'snapshot':
-                    params = operation.params
-                    self._add_qasm_snapshot(params[0])
+                # Check if measure
+                elif operation.name == 'measure':
+                    qubit = operation.qubits[0]
+                    cbit = operation.memory[0]
+                    if self._sample_measure:
+                        # If sampling measurements record the qubit and cbit
+                        # for this measurement for later sampling
+                        measure_sample_ops.append((qubit, cbit))
+                    else:
+                        # If not sampling perform measurement as normal
+                        self._add_qasm_measure(qubit, cbit)
                 else:
                     backend = self.name()
                     err_msg = '{0} encountered unrecognized operation "{1}"'
-                    raise SimulatorError(err_msg.format(backend,
-                                                        operation.name))
-            # Turn classical_state (int) into bit string and pad zero for unused cbits
-            outcome = bin(self._classical_state)[2:]
-            # Return a compact hexadecimal
-            outcomes.append(hex(int(outcome, 2)))
+                    raise SimulatorError(err_msg.format(backend, operation.name))
 
-        data = {
-            'counts': dict(Counter(outcomes)),
-            'snapshots': self._snapshots
-        }
+            # Add final creg data to memory list
+            if self._number_of_cbits > 0:
+                if self._sample_measure:
+                    # If sampling we generate all shot samples from the final statevector
+                    memory = self._add_sample_measure(measure_sample_ops, self._shots)
+                else:
+                    # Turn classical_state (int) into bit string and pad zero for unused cbits
+                    outcome = bin(self._classical_state)[2:]
+                    memory.append(hex(int(outcome, 2)))
+
+        # Add data
+        data = {'counts': dict(Counter(memory))}
+        # Optionally add memory list
         if self._memory:
-            data['memory'] = outcomes
-
+            data['memory'] = memory
+        # Optionally add final statevector
+        if self.SHOW_FINAL_STATE:
+            data['statevector'] = self._get_statevector()
+            # Remove empty counts and memory for statevector simulator
+            if not data['counts']:
+                data.pop('counts')
+            if 'memory' in data and not data['memory']:
+                data.pop('memory')
         end = time.time()
         return {'name': experiment.header.name,
                 'seed': seed,
@@ -373,13 +538,22 @@ class QasmSimulatorPy(BaseBackend):
                 'data': data,
                 'status': 'DONE',
                 'success': True,
-                'time_taken': (end-start),
+                'time_taken': (end - start),
                 'header': experiment.header.as_dict()}
 
     def _validate(self, qobj):
+        """Semantic validations of the qobj which cannot be done via schemas."""
+        n_qubits = qobj.config.n_qubits
+        max_qubits = self.configuration().n_qubits
+        if n_qubits > max_qubits:
+            raise SimulatorError('Number of qubits {} '.format(n_qubits) +
+                                 'is greater than maximum ({}) '.format(max_qubits) +
+                                 'for "{}".'.format(self.name()))
         for experiment in qobj.experiments:
-            if 'measure' not in [op.name for
-                                 op in experiment.instructions]:
-                logger.warning("no measurements in circuit '%s', "
-                               "classical register will remain all zeros.",
-                               experiment.header.name)
+            name = experiment.header.name
+            if experiment.config.memory_slots == 0:
+                logger.warning('No classical registers in circuit "%s", ' +
+                               'counts will be empty.', name)
+            elif 'measure' not in [op.name for op in experiment.instructions]:
+                logger.warning('No measurements in circuit "%s", ' +
+                               'classical register will remain all zeros.', name)

--- a/qiskit/backends/builtinsimulators/statevector_simulator.py
+++ b/qiskit/backends/builtinsimulators/statevector_simulator.py
@@ -6,6 +6,7 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 # pylint: disable=invalid-name
+# pylint: disable=arguments-differ
 
 """Contains a (slow) python statevector simulator.
 
@@ -18,8 +19,8 @@ The input is a qobj dictionary and the output is a Result object.
 
 The input qobj to this simulator has no shots, no measures, no reset, no noise.
 """
+
 import logging
-import uuid
 from math import log2
 from qiskit._util import local_hardware_info
 from qiskit.backends.builtinsimulators.simulatorsjob import SimulatorsJob
@@ -34,16 +35,18 @@ logger = logging.getLogger(__name__)
 class StatevectorSimulatorPy(QasmSimulatorPy):
     """Python statevector simulator."""
 
+    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
         'backend_version': '1.0.0',
-        'n_qubits': int(log2(local_hardware_info()['memory'] * (1024**3)/16)),
+        'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
         'local': True,
-        'conditional': False,
+        'conditional': True,
         'open_pulse': False,
-        'memory': False,
+        'memory': True,
         'max_shots': 65536,
         'description': 'A Python statevector simulator for qobj files',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'snapshot'],
@@ -81,53 +84,45 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         ]
     }
 
+    # Override base class value to return the final state vector
+    SHOW_FINAL_STATE = True
+
     def __init__(self, configuration=None, provider=None):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
 
-    def run(self, qobj):
+    def run(self, qobj, backend_options=None):
         """Run qobj asynchronously.
 
         Args:
-            qobj (dict): job description
+            qobj (Qobj): payload of the experiment
+            backend_options (dict): backend options
 
         Returns:
             SimulatorsJob: derived from BaseJob
-        """
-        job_id = str(uuid.uuid4())
-        job = SimulatorsJob(self, job_id, self._run_job, qobj)
-        job.submit()
-        return job
 
-    def _run_job(self, job_id, qobj):
-        """Run a Qobj on the backend."""
-        self._validate(qobj)
-        final_state_key = 32767  # Internal key for final state snapshot
-        # Add final snapshots to circuits
-        for experiment in qobj.experiments:
-            experiment.instructions.append(
-                QobjInstruction(name='snapshot', params=[final_state_key],
-                                label='MISSING', type='MISSING')
-            )
-        result = super()._run_job(job_id, qobj)
-        # Remove added snapshot from qobj
-        for experiment in qobj.experiments:
-            del experiment.instructions[-1]
-        # Extract final state snapshot and move to 'statevector' data field
-        for experiment_result in result.results:
-            snapshots = experiment_result.data.snapshots.to_dict()
-            if str(final_state_key) in snapshots:
-                final_state_key = str(final_state_key)
-            # Pop off final snapshot added above
-            final_state = snapshots.pop(final_state_key, None)
-            final_state = final_state['statevector'][0]
-            # Add final state to results data
-            experiment_result.data.statevector = final_state
-            # Remove snapshot dict if empty
-            if snapshots == {}:
-                delattr(experiment_result.data, 'snapshots')
-        return result
+        Additional Information:
+            backend_options: Is a dict of options for the backend. It may contain
+                * "initial_statevector": vector_like
+                * "chop_threshold": double
+
+            The "initial_statevector" option specifies a custom initial
+            initial statevector for the simulator to be used instead of the all
+            zero state. This size of this vector must be correct for the number
+            of qubits in all experiments in the qobj.
+
+            The "chop_threshold" option specifies a trunctation value for
+            setting small values to zero in the output statevector. The default
+            value is 1e-15.
+
+            Example:
+            backend_options = {
+                "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+                "chop_threshold": 1e-15
+            }
+        """
+        return super().run(qobj, backend_options=backend_options)
 
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas.
@@ -136,17 +131,20 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         1. No shots
         2. No measurements in the middle
         """
+        n_qubits = qobj.config.n_qubits
+        max_qubits = self.configuration().n_qubits
+        if n_qubits > max_qubits:
+            raise SimulatorError('Number of qubits {} '.format(n_qubits) +
+                                 'is greater than maximum ({}) '.format(max_qubits) +
+                                 'for "{}".'.format(self.name()))
         if qobj.config.shots != 1:
-            logger.info("statevector simulator only supports 1 shot. "
-                        "Setting shots=1.")
+            logger.info('"%s" only supports 1 shot. Setting shots=1.',
+                        self.name())
             qobj.config.shots = 1
         for experiment in qobj.experiments:
+            name = experiment.header.name
             if getattr(experiment.config, 'shots', 1) != 1:
-                logger.info("statevector simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", experiment.name)
+                logger.info('"{}" only supports 1 shot. ' +
+                            'Setting shots=1 for circuit "{}".',
+                            self.name(), name)
                 experiment.config.shots = 1
-            for op in experiment.instructions:
-                if op.name in ['measure', 'reset']:
-                    raise SimulatorError(
-                        "In circuit {}: statevector simulator does not support "
-                        "measure or reset.".format(experiment.header.name))

--- a/qiskit/backends/builtinsimulators/statevector_simulator.py
+++ b/qiskit/backends/builtinsimulators/statevector_simulator.py
@@ -23,10 +23,8 @@ The input qobj to this simulator has no shots, no measures, no reset, no noise.
 import logging
 from math import log2
 from qiskit._util import local_hardware_info
-from qiskit.backends.builtinsimulators.simulatorsjob import SimulatorsJob
 from qiskit.backends.builtinsimulators._simulatorerror import SimulatorError
 from qiskit.backends.models import BackendConfiguration
-from qiskit.qobj import QobjInstruction
 from .qasm_simulator import QasmSimulatorPy
 
 logger = logging.getLogger(__name__)

--- a/qiskit/backends/builtinsimulators/unitary_simulator.py
+++ b/qiskit/backends/builtinsimulators/unitary_simulator.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+# pylint: disable=arguments-differ
+
 """Contains a Python simulator that returns the unitary of the circuit.
 
 It simulates a unitary of a quantum circuit that has been compiled to run on
@@ -30,7 +32,9 @@ from qiskit.backends import BaseBackend
 from qiskit.backends.builtinsimulators.simulatorsjob import SimulatorsJob
 from qiskit.result import Result
 from ._simulatorerror import SimulatorError
-from ._simulatortools import single_gate_matrix, einsum_matmul_index
+from ._simulatortools import single_gate_matrix
+from ._simulatortools import cx_gate_matrix
+from ._simulatortools import einsum_matmul_index
 
 logger = logging.getLogger(__name__)
 
@@ -42,12 +46,12 @@ logger = logging.getLogger(__name__)
 class UnitarySimulatorPy(BaseBackend):
     """Python implementation of a unitary simulator."""
 
-    max_qubits = int(log2(sqrt(local_hardware_info()['memory'] * (1024**3))/16))
+    MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': '1.0.0',
-        'n_qubits': max_qubits,
+        'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
         'local': True,
@@ -86,41 +90,44 @@ class UnitarySimulatorPy(BaseBackend):
         ]
     }
 
+    DEFAULT_OPTIONS = {
+        "initial_unitary": None,
+        "chop_threshold": 1e-15
+    }
+
     def __init__(self, configuration=None, provider=None):
         super().__init__(configuration=(configuration or
                                         BackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
 
         # Define attributes inside __init__.
-        self._unitary_state = None
+        self._unitary = None
         self._number_of_qubits = 0
+        self._initial_unitary = None
+        self._chop_threshold = 1e-15
 
     def _add_unitary_single(self, gate, qubit):
-        """Apply the single-qubit gate.
+        """Apply an arbitrary 1-qubit unitary matrix.
 
-        gate is the single-qubit gate.
-        qubit is the qubit to apply it on counts from 0 and order
-            is q_{n-1} ... otimes q_1 otimes q_0.
-        number_of_qubits is the number of qubits in the system.
+        Args:
+            gate (matrix_like): a single qubit gate matrix
+            qubit (int): the qubit to apply gate to
         """
         # Convert to complex rank-2 tensor
         gate_tensor = np.array(gate, dtype=complex)
         # Compute einsum index string for 1-qubit matrix multiplication
         indexes = einsum_matmul_index([qubit], self._number_of_qubits)
         # Apply matrix multiplication
-        self._unitary_state = np.einsum(indexes,
-                                        gate_tensor,
-                                        self._unitary_state,
-                                        dtype=complex,
-                                        casting='no')
+        self._unitary = np.einsum(indexes, gate_tensor, self._unitary,
+                                  dtype=complex, casting='no')
 
     def _add_unitary_two(self, gate, qubit0, qubit1):
-        """Apply the two-qubit gate.
+        """Apply a two-qubit unitary matrix.
 
-        gate is the two-qubit gate
-        qubit0 is the first qubit (control) counts from 0
-        qubit1 is the second qubit (target)
-        returns a complex numpy array
+        Args:
+            gate (matrix_like): a the two-qubit gate matrix
+            qubit0 (int): gate qubit-0
+            qubit1 (int): gate qubit-1
         """
 
         # Convert to complex rank-4 tensor
@@ -130,21 +137,97 @@ class UnitarySimulatorPy(BaseBackend):
         indexes = einsum_matmul_index([qubit0, qubit1], self._number_of_qubits)
 
         # Apply matrix multiplication
-        self._unitary_state = np.einsum(indexes,
-                                        gate_tensor,
-                                        self._unitary_state,
-                                        dtype=complex,
-                                        casting='no')
+        self._unitary = np.einsum(indexes, gate_tensor, self._unitary,
+                                  dtype=complex, casting='no')
 
-    def run(self, qobj):
+    def _validate_initial_unitary(self):
+        """Validate an initial unitary matrix"""
+        # If initial unitary isn't set we don't need to validate
+        if self._initial_unitary is None:
+            return
+        # Check unitary is correct length for number of qubits
+        shape = np.shape(self._initial_unitary)
+        required_shape = (2 ** self._number_of_qubits,
+                          2 ** self._number_of_qubits)
+        if shape != required_shape:
+            raise SimulatorError('initial unitary is incorrect shape: ' +
+                                 '{} != 2 ** {}'.format(shape, required_shape))
+
+    def _set_options(self, backend_options=None):
+        """Set the backend options for all experiments in a qobj"""
+        # Reset default options
+        self._initial_unitary = self.DEFAULT_OPTIONS["initial_unitary"]
+        self._chop_threshold = self.DEFAULT_OPTIONS["chop_threshold"]
+        # Replace with custom options
+        if backend_options is not None:
+            unitary = backend_options.get('initial_unitary')
+            if unitary is not None:
+                unitary = np.array(unitary, dtype=complex)
+                self._initial_unitary = unitary
+                # Check the initial unitary is actually unitary
+                shape = np.shape(unitary)
+                if len(shape) != 2 or shape[0] != shape[1]:
+                    raise SimulatorError("initial unitary is not a square matrix")
+                norm = np.linalg.norm(np.dot(unitary.T.conj(), unitary) - np.eye(len(unitary)))
+                if round(norm, 12) != 0:
+                    raise SimulatorError("initial unitary is not unitary")
+
+    def _initialize_unitary(self):
+        """Set the initial unitary for simulation"""
+        self._validate_initial_unitary()
+        if self._initial_unitary is None:
+            # Set to identity matrix
+            self._unitary = np.eye(2 ** self._number_of_qubits,
+                                   dtype=complex)
+        else:
+            self._unitary = self._initial_unitary.copy()
+        # Reshape to rank-N tensor
+        self._unitary = np.reshape(self._unitary,
+                                   self._number_of_qubits * [2, 2])
+
+    def _get_unitary(self):
+        """Return the current unitary in JSON Result spec format"""
+        unitary = np.reshape(self._unitary, 2 * [2 ** self._number_of_qubits])
+        # Expand complex numbers
+        unitary = np.stack((unitary.real, unitary.imag), axis=-1)
+        # Truncate small values
+        unitary[abs(unitary) < self._chop_threshold] = 0.0
+        return unitary
+
+    def run(self, qobj, backend_options=None):
         """Run qobj asynchronously.
 
         Args:
-            qobj (dict): job description
+            qobj (Qobj): payload of the experiment
+            backend_options (dict): backend options
 
         Returns:
             SimulatorsJob: derived from BaseJob
+
+        Additional Information:
+            backend_options: Is a dict of options for the backend. It may contain
+                * "initial_unitary": matrix_like
+                * "chop_threshold": double
+
+            The "initial_unitary" option specifies a custom initial unitary
+            matrix for the simulator to be used instead of the identity
+            matrix. This size of this matrix must be correct for the number
+            of qubits inall experiments in the qobj.
+
+            The "chop_threshold" option specifies a trunctation value for
+            setting small values to zero in the output unitary. The default
+            value is 1e-15.
+
+            Example:
+            backend_options = {
+                "initial_unitary": np.array([[1, 0, 0, 0],
+                                             [0, 0, 0, 1],
+                                             [0, 0, 1, 0],
+                                             [0, 1, 0, 0]])
+                "chop_threshold": 1e-15
+            }
         """
+        self._set_options(backend_options)
         job_id = str(uuid.uuid4())
         job = SimulatorsJob(self, job_id, self._run_job, qobj)
         job.submit()
@@ -193,10 +276,8 @@ class UnitarySimulatorPy(BaseBackend):
                 "shots": number of shots used in the simulation
                 "data":
                     {
-                    "unitary": [[0.2, 0.6, j+0.1, 0.2j],
-                                [0, 0.9+j, 0.5, 0.7],
-                                [-j, -0.1, -3.14, 0],
-                                [0, 0, 0.5j, j-0.5]]
+                    "unitary": [[[0.0, 0.0], [1.0, 0.0]],
+                                [[1.0, 0.0], [0.0, 0.0]]]
                     },
                 "status": status string for the simulation
                 "success": boolean
@@ -207,22 +288,15 @@ class UnitarySimulatorPy(BaseBackend):
             SimulatorError: if the number of qubits in the circuit is greater than 24.
             Note that the practical qubit limit is much lower than 24.
         """
+        start = time.time()
         self._number_of_qubits = experiment.header.n_qubits
-        if self._number_of_qubits > self.max_qubits:
-            raise SimulatorError("np.einsum implementation limits unitary_simulator" +
-                                 " to 24 qubit circuits.")
-        result = {
-            'data': {},
-            'name': experiment.header.name,
-            'header': experiment.header.as_dict()
-        }
 
-        # Initialize unitary as rank 2*N tensor
-        self._unitary_state = np.reshape(np.eye(2 ** self._number_of_qubits,
-                                                dtype=complex),
-                                         self._number_of_qubits * [2, 2])
+        # Validate the dimension of initial unitary if set
+        self._validate_initial_unitary()
+        self._initialize_unitary()
 
         for operation in experiment.instructions:
+            # Check if single  gate
             if operation.name in ('U', 'u1', 'u2', 'u3'):
                 params = getattr(operation, 'params', None)
                 qubit = operation.qubits[0]
@@ -230,25 +304,29 @@ class UnitarySimulatorPy(BaseBackend):
                 self._add_unitary_single(gate, qubit)
             elif operation.name in ('id', 'u0'):
                 pass
+            # Check if CX gate
             elif operation.name in ('CX', 'cx'):
                 qubit0 = operation.qubits[0]
                 qubit1 = operation.qubits[1]
-                gate = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0],
-                                 [0, 1, 0, 0]])
+                gate = cx_gate_matrix()
                 self._add_unitary_two(gate, qubit0, qubit1)
+            # Check if barrier
             elif operation.name == 'barrier':
                 pass
             else:
-                result['status'] = 'ERROR'
-                return result
-        # Reshape unitary rank-2n tensor back to a matrix
-        tmp = np.reshape(self._unitary_state, 2 * [2 ** self._number_of_qubits])
-        # Convert complex numbers to pair of (real, imag)
-        result['data']['unitary'] = np.stack((tmp.real, tmp.imag), axis=-1)
-        result['status'] = 'DONE'
-        result['success'] = True
-        result['shots'] = 1
-        return result
+                backend = self.name()
+                err_msg = '{0} encountered unrecognized operation "{1}"'
+                raise SimulatorError(err_msg.format(backend, operation.name))
+        # Add final state to data
+        data = {'unitary': self._get_unitary()}
+        end = time.time()
+        return {'name': experiment.header.name,
+                'shots': 1,
+                'data': data,
+                'status': 'DONE',
+                'success': True,
+                'time_taken': (end - start),
+                'header': experiment.header.as_dict()}
 
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas.
@@ -256,17 +334,25 @@ class UnitarySimulatorPy(BaseBackend):
         1. No shots
         2. No measurements in the middle
         """
+        n_qubits = qobj.config.n_qubits
+        max_qubits = self.configuration().n_qubits
+        if n_qubits > max_qubits:
+            raise SimulatorError('Number of qubits {} '.format(n_qubits) +
+                                 'is greater than maximum ({}) '.format(max_qubits) +
+                                 'for "{}".'.format(self.name()))
         if qobj.config.shots != 1:
-            logger.info("unitary simulator only supports 1 shot. "
-                        "Setting shots=1.")
+            logger.info('"%s" only supports 1 shot. Setting shots=1.',
+                        self.name())
             qobj.config.shots = 1
         for experiment in qobj.experiments:
+            name = experiment.header.name
             if getattr(experiment.config, 'shots', 1) != 1:
-                logger.info("unitary simulator only supports 1 shot. "
-                            "Setting shots=1 for circuit %s.", experiment.name)
+                logger.info('"%s" only supports 1 shot. ' +
+                            'Setting shots=1 for circuit "%s".',
+                            self.name(), name)
                 experiment.config.shots = 1
             for operation in experiment.instructions:
                 if operation.name in ['measure', 'reset']:
-                    raise SimulatorError(
-                        "In circuit {}: unitary simulator does not support "
-                        "measure or reset.".format(experiment.header.name))
+                    raise SimulatorError('Unsupported "%s" instruction "%s" ' +
+                                         'in circuit "%s" ', self.name(),
+                                         operation.name, name)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -12,10 +12,8 @@ from qiskit import Simulators, LegacySimulators
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import execute
 from qiskit import QiskitError
-from qiskit.quantum_info import state_fidelity
-from qiskit.result.postprocess import format_statevector
 
-from ..common import QiskitTestCase, requires_cpp_simulator
+from ..common import QiskitTestCase
 
 
 class TestCircuitOperations(QiskitTestCase):
@@ -73,33 +71,6 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertRaises(QiskitError, qc1.__add__, qc2)
         self.assertRaises(QiskitError, qc1.__add__, qcr3)
 
-    @requires_cpp_simulator
-    def test_combine_circuit_extension_instructions(self):
-        """Test combining circuits containing barrier, initializer, snapshot
-        """
-        qr = QuantumRegister(2)
-        cr = ClassicalRegister(2)
-        qc1 = QuantumCircuit(qr)
-        desired_vector = [0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j, 0.5 + 0.j]
-        qc1.initialize(desired_vector, qr)
-        qc1.barrier()
-        qc2 = QuantumCircuit(qr, cr)
-        qc2.snapshot(slot='1')
-        qc2.measure(qr, cr)
-        new_circuit = qc1 + qc2
-        backend = LegacySimulators.get_backend('qasm_simulator')
-        shots = 1024
-        result = execute(new_circuit, backend=backend, shots=shots, seed=78).result()
-        snapshot_vectors = result.data(0)['snapshots']['statevector']['1']
-        snapshot = format_statevector(snapshot_vectors[0])
-        fidelity = state_fidelity(snapshot, desired_vector)
-        self.assertGreater(fidelity, 0.99)
-
-        counts = result.get_counts()
-        target = {'00': shots/4, '01': shots/4, '10': shots/4, '11': shots/4}
-        threshold = 0.04 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
-
     def test_extend_circuit(self):
         """Test extending a circuit with same registers.
         """
@@ -151,33 +122,6 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertRaises(QiskitError, qc1.__iadd__, qc2)
         self.assertRaises(QiskitError, qc1.__iadd__, qcr3)
-
-    @requires_cpp_simulator
-    def test_extend_circuit_extension_instructions(self):
-        """Test extending circuits containing barrier, initializer, snapshot
-        """
-        qr = QuantumRegister(2)
-        cr = ClassicalRegister(2)
-        qc1 = QuantumCircuit(qr)
-        desired_vector = [0.5, 0.5, 0.5, 0.5]
-        qc1.initialize(desired_vector, qr)
-        qc1.barrier()
-        qc2 = QuantumCircuit(qr, cr)
-        qc2.snapshot(slot='1')
-        qc2.measure(qr, cr)
-        qc1 += qc2
-        backend = Simulators.get_backend('qasm_simulator')
-        shots = 1024
-        result = execute(qc1, backend=backend, shots=shots, seed=78).result()
-
-        snapshot_vectors = result.data(0)['snapshots']['1']['statevector']
-        fidelity = state_fidelity(snapshot_vectors[0], desired_vector)
-        self.assertGreater(fidelity, 0.99)
-
-        counts = result.get_counts()
-        target = {'00': shots/4, '01': shots/4, '10': shots/4, '11': shots/4}
-        threshold = 0.04 * shots
-        self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_measure_args_type_cohesion(self):
         """Test for proper args types for measure function.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -7,8 +7,8 @@
 
 
 """Test Qiskit's QuantumCircuit class."""
-import qiskit.extensions.simulator  # pylint: disable=unused-import
-from qiskit import Simulators, LegacySimulators
+
+from qiskit import Simulators
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import execute
 from qiskit import QiskitError

--- a/test/python/simulators/test_qasm_simulator_py.py
+++ b/test/python/simulators/test_qasm_simulator_py.py
@@ -86,7 +86,7 @@ class TestBuiltinQasmSimulatorPy(QiskitTestCase):
         """test teleportation as in tutorials"""
         self.log.info('test_teleport')
         pi = np.pi
-        shots = 1000
+        shots = 2000
         qr = QuantumRegister(3, 'qr')
         cr0 = ClassicalRegister(1, 'cr0')
         cr1 = ClassicalRegister(1, 'cr1')

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -461,7 +461,7 @@ class TestCompiler(QiskitTestCase):
         bell_result = backend.run(bell_qobj).result()
         ghz_result = backend.run(ghz_qobj).result()
 
-        threshold = 0.04 * shots
+        threshold = 0.05 * shots
         counts_bell = bell_result.get_counts()
         target_bell = {'00000': shots / 2, '00011': shots / 2}
         self.assertDictAlmostEqual(counts_bell, target_bell, threshold)
@@ -486,7 +486,7 @@ class TestCompiler(QiskitTestCase):
         qc.measure(qr[0], cr[0])
         qc.measure(qr[1], cr[1])
         qc.measure(qr[2], cr[2])
-        shots = 1024
+        shots = 2048
         coupling_map = [[0, 1], [1, 2]]
         initial_layout = {("qr", 0): ("q", 0), ("qr", 1): ("q", 1),
                           ("qr", 2): ("q", 2)}
@@ -500,7 +500,7 @@ class TestCompiler(QiskitTestCase):
 
         counts = result.get_counts(qc)
         target = {'000': shots / 2, '111': shots / 2}
-        threshold = 0.04 * shots
+        threshold = 0.05 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
     @requires_cpp_simulator


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates Terra python simulators to match qiskit-aer C++ simulators for basic usage and options.

Improves speed of `QasmSimulatorPy` and `StatevectorSimulatorPy` by switching to using Numpy Einsum and adding measure sampling to QasmSimulatorPy


### Details and comments

* update `QasmSimulatorPy` to use `numpy.einsum`
* add measurement sampling to `QasmSimulatorPy`. Enabled by setting`"allows_measure_sampling": True` in qobj experiment config, or it can do a basic check that a circuit contains no resets, and no gates after the first measure.
* implements `StatevectorSimulatorPy` without snapshot hack
* removes snapshots from python simulators
* allows measure, reset, conditionals in single shot statevector simulator
* if circuit contains no creg `QasmSimulatorPy` returns empty count dictionary
* if circuit contains no creg `QasmSimulatorPy` return empty list for `memory=True` case
* adds basic `backend_options` from qiskit-aer C++ to terra python simulators:
  * set initial statevector for `QasmSimulatorPy` and `StatevectorSimulatorPy` with "initial_statevector"
  * set initial unitary for `UnitarySimulatorPy` with "initial_unitary
  * set chop threshold for output statevector and unitaries with "chop_threshold". Default value is `1e-15`.

### Performance comparison

Quick speed comparison on my laptop for a test circuit that makes an N-qubit GHZ state.

Time taken for 100 shots for 15-qubit GHZ state:
* new simulator (with sampling) ~ 0.18s
* new simulator (without sampling) ~ 3s
* old simulator is ~ 2 mins

Time taken for 1000 shots for 24-qubit GHZ state (maximum allowed qubit size for the simulator):
* new simulator (with sampling) ~ 16.5s
* old simualtor ~ fahgettaboudit

Code:
```python
import time
import qiskit
from qiskit import Aer, QuantumRegister, ClassicalRegister, QuantumCircuit

n_qubits = 15
qr = QuantumRegister(n_qubits, 'qr')
cr = ClassicalRegister(n_qubits, 'cr')
circ = QuantumCircuit(qr, cr, name='bell')
circ.h(qr[0])
for j in range(n_qubits - 1):
    circ.cx(qr[j], qr[j + 1])
circ.barrier(qr)
circ.measure(qr, cr)

shots = 100
sim = Aer.get_backend('qasm_simulator_py')
qobj = qiskit.compile(circ, sim, shots=shots)
start = time.time()
result = sim.run(qobj).result()
end = time.time()
print('Time:', end - start)
print('Counts:', result.get_counts(circ))
```