### PR TITLE
Added empty __init__.py to transpiler/passes/mapping

### DIFF
--- a/qiskit/transpiler/passes/mapping/basic_mapper.py
+++ b/qiskit/transpiler/passes/mapping/basic_mapper.py
@@ -33,7 +33,6 @@ class BasicMapper(TransformationPass):
         Maps a DAGCircuit onto a `coupling_map` using swap gates.
         Args:
             coupling_map (Coupling): Directed graph represented a coupling map.
-            swap_gate (Type):  Default: SwapGate. The Gate class that defines a swap gate.
             initial_layout (Layout): initial layout of qubits in mapping
         """
         super().__init__()

--- a/qiskit/transpiler/passes/mapping/direction_mapper.py
+++ b/qiskit/transpiler/passes/mapping/direction_mapper.py
@@ -45,8 +45,12 @@ class DirectionMapper(TransformationPass):
         Flips the cx nodes to match the directed coupling map.
         Args:
             dag (DAGCircuit): DAG to map.
+        Returns:
+            DAGCircuit: The rearranged dag for the coupling map
+
         Raises:
-            TranspilerError: If the `dag` cannot be mapped just by flipping the cx nodes.
+            MapperError: If the circuit cannot be mapped just by flipping the
+                         cx nodes.
         """
         new_dag = DAGCircuit()
 

--- a/qiskit/transpiler/passes/mapping/unroller.py
+++ b/qiskit/transpiler/passes/mapping/unroller.py
@@ -7,11 +7,9 @@
 
 """Pass for unrolling a circuit to a given basis."""
 
-import copy
 import networkx as nx
 
 from qiskit.circuit import QuantumRegister, ClassicalRegister
-from qiskit.transpiler._transpilererror import TranspilerError
 from qiskit.transpiler._basepasses import TransformationPass
 
 


### PR DESCRIPTION
Without `__init__.py` file, Python does not consider this directory a package and it is not packaged when setup.py is ran, resulting in an error when trying to use this Qiskit package.