### PR TITLE
Restoring header fields in _reorder_bits

### DIFF
--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -516,7 +516,7 @@ def _reorder_bits(job_data):
         job_data (dict): dict with the bare contents of the API.get_job request.
 
     Raises:
-            JobError: raised if the creg sizes don't add up in result header.
+        JobError: raised if the creg sizes don't add up in result header.
     """
     for circuit_result in job_data['qasms']:
         if 'metadata' in circuit_result:
@@ -526,7 +526,7 @@ def _reorder_bits(job_data):
                            ' bits: bits may be out of order')
             return
         # device_qubit -> device_clbit (how it should have been)
-        measure_dict = {op['qubits'][0]: op['memory'][0]
+        measure_dict = {op['qubits'][0]: op['clbits'][0]
                         for op in circ['operations']
                         if op['name'] == 'measure'}
         counts_dict_new = {}
@@ -543,13 +543,13 @@ def _reorder_bits(job_data):
             reordered_bits.reverse()
 
             # only keep the clbits specified by circuit, not everything on device
-            num_clbits = circ['header']['memory_slots']
+            num_clbits = circ['header']['number_of_clbits']
             compact_key = reordered_bits[-num_clbits:]
             compact_key = "".join([b if b != 'x' else '0'
                                    for b in compact_key])
 
             # insert spaces to signify different classical registers
-            cregs = circ['header']['creg_sizes']
+            cregs = circ['header']['clbit_labels']
             if sum([creg[1] for creg in cregs]) != num_clbits:
                 raise JobError("creg sizes don't add up in result header.")
             creg_begin_pos = []

--- a/test/python/ibmq/test_ibmqjob.py
+++ b/test/python/ibmq/test_ibmqjob.py
@@ -23,10 +23,9 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import IBMQ
 from qiskit import compile
 from qiskit.backends import JobStatus, JobError
-from qiskit.backends.ibmq.ibmqbackend import IBMQBackendError, DeprecatedFormatJobError
-from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from qiskit.backends.ibmq import least_busy
-
+from qiskit.backends.ibmq.ibmqbackend import IBMQBackendError
+from qiskit.backends.ibmq.ibmqjob import IBMQJob
 from ..common import requires_qe_access, JobTestCase, slow_test
 
 
@@ -259,11 +258,7 @@ class TestIBMQJob(JobTestCase):
         qobj = compile(self._qc, backend)
         job = backend.run(qobj)
 
-        try:
-            rjob = backend.retrieve_job(job.job_id())
-        except DeprecatedFormatJobError as err:
-            self.skipTest(err.message)
-
+        rjob = backend.retrieve_job(job.job_id())
         self.assertTrue(job.job_id() == rjob.job_id())
         self.assertTrue(job.result().get_counts() == rjob.result().get_counts())
 


### PR DESCRIPTION
Fix #1372 

This PR fixes the root cause for master failing allowing users to retrieve their jobs prior to 0.7. It also displays a deprecation warning encouraging the user to save the results from old jobs or resend with the latest version.