### PR TITLE
Fix/support old and new job

### DIFF
--- a/qiskit/backends/ibmq/ibmqjob.py
+++ b/qiskit/backends/ibmq/ibmqjob.py
@@ -526,7 +526,7 @@ def _reorder_bits(job_data):
                            ' bits: bits may be out of order')
             return
         # device_qubit -> device_clbit (how it should have been)
-        measure_dict = {op['qubits'][0]: op['clbits'][0]
+        measure_dict = {op['qubits'][0]: op.get('clbits', op.get('memory'))[0]
                         for op in circ['operations']
                         if op['name'] == 'measure'}
         counts_dict_new = {}
@@ -543,13 +543,15 @@ def _reorder_bits(job_data):
             reordered_bits.reverse()
 
             # only keep the clbits specified by circuit, not everything on device
-            num_clbits = circ['header']['number_of_clbits']
+            num_clbits = circ['header'].get('number_of_clbits',
+                                            circ['header'].get('memory_slots'))
             compact_key = reordered_bits[-num_clbits:]
             compact_key = "".join([b if b != 'x' else '0'
                                    for b in compact_key])
 
             # insert spaces to signify different classical registers
-            cregs = circ['header']['clbit_labels']
+            cregs = circ['header'].get('clbit_labels',
+                                       circ['header'].get('creg_sizes'))
             if sum([creg[1] for creg in cregs]) != num_clbits:
                 raise JobError("creg sizes don't add up in result header.")
             creg_begin_pos = []


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
#1481 attempted to restore the ability to retrieve jobs submitted using qiskit 0.6 and before. In doing so, it broke jobs submitted using qiskit 0.7 to non-qobj backends. 

Here I keep both abilities. So any scenario would work:
1- 0.7 job submitted to qobj backend
2- 0.7 job submitted to non-qobj backend
3- 0.6 jobs sumitted to non-qobj backend


### Details and comments


