### PR TITLE
Trying to import Aer provider and adding the Aer element as a feature

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -42,6 +42,12 @@ from qiskit.backends.ibmq import IBMQ
 from qiskit.backends.builtinsimulators import Simulators
 from qiskit.backends.legacysimulators import LegacySimulators
 
+# Try to import the Aer provider if th Aer element is installed.
+try:
+    from qiskit.backends.aer import Aer
+except ImportError:
+    pass
+
 # TODO: Remove
 from .wrapper._wrapper import (load_qasm_string, load_qasm_file)
 

--- a/setup.py
+++ b/setup.py
@@ -90,12 +90,11 @@ class BinaryDistribution(Distribution):
 
 
 setup(
-    name="qiskit",
+    name="qiskit-terra",
     version="0.7.0",
     description="Software for developing quantum computing programs",
-    long_description="""Qiskit is a software development kit for writing
-        quantum computing experiments, programs, and applications. Works with
-        Python 3.5 and 3.6""",
+    long_description="""Terra provides the foundations for Qiskit. It allows the user to write 
+        quantum circuits easily, and takes care of the constraints of real hardware.""",
     url="https://github.com/Qiskit/qiskit-terra",
     author="Qiskit Development Team",
     author_email="qiskit@us.ibm.com",
@@ -122,6 +121,7 @@ setup(
     },
     distclass=BinaryDistribution,
     extra_requires={
-        'visualization': ['matplotlib>=2.1']
+        'visualization': ['matplotlib>=2.1'],
+        'native-simulators': ['qiskit-aer>=0.1']
     }
 )


### PR DESCRIPTION
Partially solves #1490 by:

* Trying to make `Aer` available in the `qiskit` root package.
* Changing the name of the package to `qiskit-terra`.
* Changing the description to align it with the repository description of the Terra element.
* Adding the Aer element as a feature dependency.

