### PR TITLE
require ipywidgets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sympy>=1.3
 pillow>=4.2.1
 psutil>=5
 nxpd>=0.2
+ipywidgets>=7.4.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
After #1231 ipywidgets is a requirement of Qiskit (it is imported with `from qiskit import *`).
I don't quite like this, as Qiskit should work without jupyter notebooks.

I'm adding this fix here temporarily. I think the `job_monitor` and `progress_bar` should be removed from `qiskit.tools.__init__`, and it should be further documented that the job monitor/backend monitor only work with `ipywidgets v7.4.2+`.


### Details and comments


