### PR TITLE
Sphinx docstring cleanup, and include qiskit.tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ coverage:
 doc:
 	export PYTHONPATH=$(PWD); \
 	for LANGUAGE in "." "de" "ja"; do \
-		better-apidoc -f -o doc/$$LANGUAGE/_autodoc --no-toc --private --maxdepth=5 --separate --templates=doc/_templates/better-apidoc qiskit qiskit/tools qiskit/wrapper/jupyter "qiskit/extensions/standard/[a-z]*"; \
+		better-apidoc -f -o doc/$$LANGUAGE/_autodoc --no-toc --private --maxdepth=5 --separate --templates=doc/_templates/better-apidoc qiskit "qiskit/extensions/standard/[a-z]*"; \
 		sphinx-autogen -t doc/_templates doc/$$LANGUAGE/_autodoc/*; \
 		make -C doc -e BUILDDIR="_build/$$LANGUAGE" -e SOURCEDIR="./$$LANGUAGE" html; \
 	done

--- a/doc/theme/static/themeExt.js
+++ b/doc/theme/static/themeExt.js
@@ -18,9 +18,14 @@ $(function() {
             const $linkWrapper = $('<span class="link-wrapper"></span>');
             const $link = $li.children('a').addClass('ibm-type-b-tight');
             const $div = $('<div class="item"></div>');
-            const text = $link[0].text.split('.');
-            if(text.length > 2) {
-                $link[0].text = text[text.length - 1];
+            text = '';
+            if($link[0].text.indexOf('qiskit.') !== -1){
+                  text = $link[0].text.split('.');
+                  if (text.length > 1) {
+                      $link[0].text = text[text.length - 1];
+                  }
+            } else {
+                  text = $link[0].text;
             }
             const isCurrent = $li.hasClass('current');
             const isActive = $li.hasClass('current') && $link.hasClass('mdl-color-text--primary')

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -40,11 +40,14 @@ class Measure(Instruction):
 
 def measure(self, qubit, cbit):
     """Measure quantum bit into classical bit (tuples).
-     Args:
+
+    Args:
         qubit (QuantumRegister|tuple): quantum register
         cbit (ClassicalRegister|tuple): classical register
+
     Returns:
         qiskit.Instruction: the attached measure instruction.
+
     Raises:
         QiskitError: if qubit is not in this circuit or bad format;
             if cbit is not in this circuit or not creg.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -313,9 +313,9 @@ class QuantumCircuit(object):
             scale (float): scale of image to draw (shrink if < 1)
             filename (str): file path to save image to
             style (dict or str): dictionary of style or file name of style
-                                 file. You can refer to the
-                                 :ref:`Style Dict Doc <style-dict-doc>` for
-                                 more information on the contents.
+                file. You can refer to the
+                :ref:`Style Dict Doc <style-dict-doc>` for more information
+                on the contents.
             output (str): Select the output method to use for drawing the
                 circuit. Valid choices are `text`, `latex`, `latex_source`,
                 `mpl`.
@@ -327,17 +327,19 @@ class QuantumCircuit(object):
                 registers for the output visualization.
             plot_barriers (bool): Enable/disable drawing barriers in the output
                 circuit. Defaults to True.
+
         Returns:
-            PIL.Image: (output `latex`) an in-memory representation of the
-                image of the circuit diagram.
-            matplotlib.figure: (output `mpl`) a matplotlib figure object for
-                the circuit diagram.
-            String: (output `latex_source`). The LaTeX source code.
-            TextDrawing: (output `text`). A drawing that can be printed as
-                ascii art
+            PIL.Image or matplotlib.figure or str or TextDrawing:
+                * PIL.Image: (output `latex`) an in-memory representation of the
+                  image of the circuit diagram.
+                * matplotlib.figure: (output `mpl`) a matplotlib figure object
+                  for the circuit diagram.
+                * str: (output `latex_source`). The LaTeX source code.
+                * TextDrawing: (output `text`). A drawing that can be printed as
+                  ascii art
+
         Raises:
             VisualizationError: when an invalid output method is selected
-
         """
         from qiskit.tools import visualization
         return visualization.circuit_drawer(self, scale=scale,

--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -155,19 +155,21 @@ class Layout(dict):
         self[right] = temp
 
     def combine_into_edge_map(self, another_layout):
-        """ Combines self and another_layout into an "edge map". For example
+        """ Combines self and another_layout into an "edge map".
+
+        For example::
 
               self       another_layout  resulting edge map
            qr_1 -> 0        0 <- q_2         qr_1 -> q_2
            qr_2 -> 2        2 <- q_1         qr_2 -> q_1
            qr_3 -> 3        3 <- q_0         qr_3 -> q_0
 
-           The edge map is used to compose dags via, for example, compose_back.
+        The edge map is used to compose dags via, for example, compose_back.
 
         Args:
             another_layout (Layout): The other layout to combine.
         Returns:
-            Dict: A "edge map".
+            dict: A "edge map".
         Raises:
             LayoutError: another_layout can be bigger than self, but not smaller. Otherwise, raises.
         """

--- a/qiskit/providers/builtinsimulators/qasm_simulator.py
+++ b/qiskit/providers/builtinsimulators/qasm_simulator.py
@@ -16,6 +16,7 @@ to run on the simulator. It is exponential in the number of qubits.
 The simulator is run using
 
 .. code-block:: python
+
     QasmSimulatorPy().run(qobj)
 
 Where the input is a Qobj object and the output is a SimulatorsJob object, which can
@@ -369,10 +370,11 @@ class QasmSimulatorPy(BaseBackend):
             zero state. This size of this vector must be correct for the number
             of qubits in all experiments in the qobj.
 
-            Example:
-            backend_options = {
-                "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
-            }
+            Example::
+
+                backend_options = {
+                    "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+                }
         """
         self._set_options(qobj_config=qobj.config,
                           backend_options=backend_options)

--- a/qiskit/providers/builtinsimulators/simulatorsjob.py
+++ b/qiskit/providers/builtinsimulators/simulatorsjob.py
@@ -99,7 +99,7 @@ class SimulatorsJob(BaseJob):
         """Gets the status of the job by querying the Python's future
 
         Returns:
-            JobStatus: The current JobStatus
+            qiskit.providers.JobStatus: The current JobStatus
 
         Raises:
             JobError: If the future is in unexpected state

--- a/qiskit/providers/builtinsimulators/statevector_simulator.py
+++ b/qiskit/providers/builtinsimulators/statevector_simulator.py
@@ -100,7 +100,8 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         Returns:
             SimulatorsJob: derived from BaseJob
 
-        Additional Information:
+        Additional Information::
+
             backend_options: Is a dict of options for the backend. It may contain
                 * "initial_statevector": vector_like
                 * "chop_threshold": double
@@ -114,11 +115,12 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
             setting small values to zero in the output statevector. The default
             value is 1e-15.
 
-            Example:
-            backend_options = {
-                "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
-                "chop_threshold": 1e-15
-            }
+            Example::
+
+                backend_options = {
+                    "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+                    "chop_threshold": 1e-15
+                }
         """
         return super().run(qobj, backend_options=backend_options)
 

--- a/qiskit/providers/builtinsimulators/unitary_simulator.py
+++ b/qiskit/providers/builtinsimulators/unitary_simulator.py
@@ -221,7 +221,8 @@ class UnitarySimulatorPy(BaseBackend):
         Returns:
             SimulatorsJob: derived from BaseJob
 
-        Additional Information:
+        Additional Information::
+
             backend_options: Is a dict of options for the backend. It may contain
                 * "initial_unitary": matrix_like
                 * "chop_threshold": double
@@ -235,14 +236,15 @@ class UnitarySimulatorPy(BaseBackend):
             setting small values to zero in the output unitary. The default
             value is 1e-15.
 
-            Example:
-            backend_options = {
-                "initial_unitary": np.array([[1, 0, 0, 0],
-                                             [0, 0, 0, 1],
-                                             [0, 0, 1, 0],
-                                             [0, 1, 0, 0]])
-                "chop_threshold": 1e-15
-            }
+            Example::
+
+                backend_options = {
+                    "initial_unitary": np.array([[1, 0, 0, 0],
+                                                 [0, 0, 0, 1],
+                                                 [0, 0, 1, 0],
+                                                 [0, 1, 0, 0]])
+                    "chop_threshold": 1e-15
+                }
         """
         self._set_options(qobj_config=qobj.config,
                           backend_options=backend_options)
@@ -286,8 +288,8 @@ class UnitarySimulatorPy(BaseBackend):
             experiment (QobjExperiment): experiment from qobj experiments list
 
         Returns:
-            dict: A dictionary of results.
             dict: A result dictionary which looks something like::
+
                 {
                 "name": name of this experiment (obtained from qobj.experiment header)
                 "seed": random seed used for simulation

--- a/qiskit/providers/ibmq/ibmqbackend.py
+++ b/qiskit/providers/ibmq/ibmqbackend.py
@@ -101,8 +101,9 @@ class IBMQBackend(BaseBackend):
         Args:
             limit (int): number of jobs to retrieve
             skip (int): starting index of retrieval
-            status (None or JobStatus or str): only get jobs with this status,
-                where status is e.g. `JobStatus.RUNNING` or `'RUNNING'`
+            status (None or qiskit.providers.JobStatus or str): only get jobs
+                with this status, where status is e.g. `JobStatus.RUNNING` or
+                `'RUNNING'`
             db_filter (dict): `loopback-based filter
                 <https://loopback.io/doc/en/lb2/Querying-data.html>`_.
                 This is an interface to a database ``where`` filter. Some

--- a/qiskit/providers/ibmq/ibmqjob.py
+++ b/qiskit/providers/ibmq/ibmqjob.py
@@ -93,11 +93,10 @@ class IBMQJob(BaseJob):
         except JobError as ex:
             print("Something wrong happened!: {}".format(ex))
 
-
     Both methods can raise if something ath the API level happens that prevent
     Qiskit from determining the status of the job.
 
-    .. NOTE::
+    Note:
         When querying the API for getting the status, two kinds of errors are
         possible. The most severe is the one preventing Qiskit from getting a
         response from the backend. This can be caused by a network failure or a
@@ -133,7 +132,7 @@ class IBMQJob(BaseJob):
         Notes:
             It is mandatory to pass either ``qobj`` or ``job_id``. Passing a ``qobj``
             will ignore ``job_id`` and will create an instance to be submitted to the
-            API server for job creation. Passing only a `job_id`will create an instance
+            API server for job creation. Passing only a `job_id` will create an instance
             representing an already-created job retrieved from the API server.
         """
         super().__init__(backend, job_id)
@@ -250,7 +249,7 @@ class IBMQJob(BaseJob):
         """Query the API to update the status.
 
         Returns:
-            JobStatus: The status of the job, once updated.
+            qiskit.providers.JobStatus: The status of the job, once updated.
 
         Raises:
             JobError: if there was an exception in the future being executed
@@ -440,9 +439,7 @@ class IBMQJob(BaseJob):
 
 
 class IBMQJobPreQobj(IBMQJob):
-    """
-    Subclass of IBMQJob for handling pre-qobj jobs.
-    """
+    """Subclass of IBMQJob for handling pre-qobj jobs."""
 
     def _submit_callback(self):
         """Submit old style qasms job to IBM-Q. Can remove when all devices

--- a/qiskit/quantum_info/operators/_measures.py
+++ b/qiskit/quantum_info/operators/_measures.py
@@ -19,7 +19,8 @@ def process_fidelity(channel1, channel2):
     """Return the process fidelity between two quantum channels.
 
     Currently the input must be a unitary (until we decide on the channel)
-    For a unitary channels the process fidelity is given by
+    For a unitary channels the process fidelity is given by::
+
         F_p(U, U) = abs(Tr[ U^dagger U ])^2/d^2
 
     Args:

--- a/qiskit/quantum_info/states/_measures.py
+++ b/qiskit/quantum_info/states/_measures.py
@@ -21,11 +21,16 @@ def state_fidelity(state1, state2):
     """Return the state fidelity between two quantum states.
 
     Either input may be a state vector, or a density matrix. The state
-    fidelity (F) for two density matrices is defined as:
+    fidelity (F) for two density matrices is defined as::
+
         F(rho1, rho2) = Tr[sqrt(sqrt(rho1).rho2.sqrt(rho1))] ^ 2
-    For a pure state and mixed state the fidelity is given by
+
+    For a pure state and mixed state the fidelity is given by::
+
         F(|psi1>, rho2) = <psi1|rho2|psi1>
-    For two pure states the fidelity is given by
+
+    For two pure states the fidelity is given by::
+
         F(|psi1>, |psi2>) = |<psi1|psi2>|^2
 
     Args:

--- a/qiskit/transpiler/_passmanager.py
+++ b/qiskit/transpiler/_passmanager.py
@@ -78,13 +78,16 @@ class PassManager():
             ignore_requires (bool): ignore the requires need of passes. Default: False
             max_iteration (int): max number of iterations of passes. Default: 1000
             flow_controller_conditions (kwargs): See add_flow_controller(): Dictionary of
-                control flow plugins. Default:
-                do_while (callable property_set -> boolean): The passes repeat until the
-                   callable returns False.
-                   Default: lambda x: False # i.e. passes run once
-                condition (callable property_set -> boolean): The passes run only if the
-                   callable returns True.
-                   Default: lambda x: True # i.e. passes run
+            control flow plugins. Default:
+
+                * do_while (callable property_set -> boolean): The passes repeat until the
+                  callable returns False.
+                  Default: `lambda x: False # i.e. passes run once`
+
+                * condition (callable property_set -> boolean): The passes run only if the
+                  callable returns True.
+                  Default: `lambda x: True # i.e. passes run`
+
         Raises:
             TranspilerError: if a pass in passes is not a proper pass.
         """
@@ -215,11 +218,12 @@ class FlowController():
     def controller_factory(cls, passes, options, **partial_controller):
         """
         Constructs a flow controller based on the partially evaluated controller arguments.
+
         Args:
             passes (list[BasePass]): passes to add to the flow controller.
             options (dict): PassManager options.
             **partial_controller (dict): Partially evaluated controller arguments in the form
-                                         {name:partial}
+                `{name:partial}`
 
         Raises:
             TranspilerError: When partial_controller is not well-formed.

--- a/qiskit/transpiler/passes/decompose.py
+++ b/qiskit/transpiler/passes/decompose.py
@@ -18,13 +18,14 @@ class Decompose(TransformationPass):
     def __init__(self, gate=None):
         """
         Args:
-            gate (Gate): Gate to decompose.
+            gate (qiskit.circuit.gate.Gate): Gate to decompose.
         """
         super().__init__()
         self.gate = gate
 
     def run(self, dag):
         """Expand a given gate into its decomposition.
+
         Args:
             dag(DAGCircuit): input dag
         Returns:

--- a/qiskit/transpiler/passes/mapping/cx_direction.py
+++ b/qiskit/transpiler/passes/mapping/cx_direction.py
@@ -22,7 +22,8 @@ class CXDirection(TransformationPass):
      Rearranges the direction of the cx nodes to make the circuit
      compatible with the directed coupling map.
 
-     It uses this equivalence:
+     It uses this equivalence::
+
         ---(+)---      --[H]---.---[H]--
             |      =           |
         ----.----      --[H]--(+)--[H]--

--- a/qiskit/transpiler/passes/mapping/unroller.py
+++ b/qiskit/transpiler/passes/mapping/unroller.py
@@ -19,7 +19,7 @@ class Unroller(TransformationPass):
     def __init__(self, basis=None):
         """
         Args:
-            basis (list[Gate]): Target basis gates to unroll to.
+            basis (list[qiskit.circuit.gate.Gate]): Target basis gates to unroll to.
         """
         super().__init__()
         self.basis = basis or []

--- a/qiskit/validation/fields/polymorphic.py
+++ b/qiskit/validation/fields/polymorphic.py
@@ -29,7 +29,7 @@ class BasePolyField(PolyField, ModelTypeValidator):
 
      Args:
         choices (dict or iterable): iterable or dict containing the schema
-            instances and the information needed for performing disambiguation.
+        instances and the information needed for performing disambiguation.
         many (bool): whether the field is a collection of objects.
         metadata (dict): the same keyword arguments that ``PolyField`` receives.
     """

--- a/qiskit/validation/validate.py
+++ b/qiskit/validation/validate.py
@@ -18,6 +18,7 @@ class Or(Validator):
     any of those validators pass.
 
     Examples:
+
         wheels = Integer(validate=Or(Equal(4), Equal(2)))
     """
 
@@ -47,12 +48,14 @@ class PatternProperties(Validator):
     conform to any of the specified validators in the mapping, and its value
     has the specified type.
 
-    Examples:
+    Examples::
+
         counts = Nested(
             SomeSchema,
             validate=PatternProperties(
                 {Regexp('^0x([0-9A-Fa-f])+$'): Integer(),
                  Regexp('OTHER_THING'): String()})
+
     """
 
     def __init__(self, pattern_properties):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Remove most of the sphinx warnings produced during `make doc`, which involves tweaking a bunch of docstrings, as part of the release dance.
* Fix a rendering issue with the TOC, where some sections where not shown with the right name.
* More importantly, **include `qiskit.tools` in the documentation.** Previously it was not included as it was a non-essential package, but now it has grown in scope and includes relevant functionality (ie. compiler, events, visualization). Please note that the warnings for `qiskit.tools` have *not* been fixed.


### Details and comments

Ideally we should followup with cleaning the warnings for `qiskit.tools` and indentation fixes for the changelog and release notes (not included to avoid conflicts with the work in #1456 )

