### PR TITLE
ENH: Adaptive job status check interval

### DIFF
--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -22,7 +22,8 @@ from qiskit.tools.events.progressbar import TextProgressBar
 from .progressbar import HTMLProgressBar
 
 
-def _html_checker(job_var, interval, status, header):
+def _html_checker(job_var, interval, status, header,
+                  _interval_set=False):
     """Internal function that updates the status
     of a HTML job monitor.
 
@@ -31,6 +32,7 @@ def _html_checker(job_var, interval, status, header):
         interval (int): The status check interval
         status (widget): HTML ipywidget for output ot screen
         header (str): String representing HTML code for status.
+        _interval_set (bool): Was interval set by user?
     """
     job_status = job_var.status()
     job_status_name = job_status.name
@@ -45,7 +47,12 @@ def _html_checker(job_var, interval, status, header):
             break
         else:
             if job_status_name == 'QUEUED':
-                job_status_msg += ' (%s)' % job_var._queue_position
+                job_status_msg += ' (%s)' % job_var.queue_position()
+                if not _interval_set:
+                    interval = max(job_var.queue_position(), 2)
+            else:
+                if not _interval_set:
+                    interval = 2
             status.value = header % (job_status_msg)
 
     status.value = header % (job_status_msg)
@@ -61,13 +68,20 @@ class StatusMagic(Magics):
         '-i',
         '--interval',
         type=float,
-        default=2,
+        default=None,
         help='Interval for status check.'
     )
     def qiskit_job_status(self, line='', cell=None):
         """A Jupyter magic function to check the status of a Qiskit job instance.
         """
         args = magic_arguments.parse_argstring(self.qiskit_job_status, line)
+
+        if args.interval is None:
+            args.interval = 2
+            _interval_set = False
+        else:
+            _interval_set = True
+
         # Split cell lines to get LHS variables
         cell_lines = cell.split('\n')
         line_vars = []
@@ -127,7 +141,8 @@ class StatusMagic(Magics):
                 value=header % job_var.status().value)
 
             thread = threading.Thread(target=_html_checker, args=(job_var, args.interval,
-                                                                  status, header))
+                                                                  status, header,
+                                                                  _interval_set))
             thread.start()
             job_checkers.append(status)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
For long device queues, it is possible to check the status of a job more times than is allowed on the IBM network.  Here, the job status check interval is made adaptive, where the interval between checks is determined by queue position.


### Details and comments


