### PR TITLE
Restore qiskit.qiskiterror

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,12 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+Changed
+-------
+
+- The ``Exception`` subclasses have been moved to an ``.exceptions`` module
+  within each package (for example, ``qiskit.exceptions.QiskitError``). (#1600).
+
 
 `0.7.0`_ - 2018-12-19
 =====================

--- a/qiskit/qiskiterror.py
+++ b/qiskit/qiskiterror.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Exception for errors raised by Qiskit.
+
+Note: this module will be deprecated in Terra 0.7+. Please import the exceptions
+from the `qiskit.exceptions` module instead.
+"""
+
+# pylint: disable=unused-import
+
+from .exceptions import QISKitError
+from .exceptions import QiskitError


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1600, `qiskit.qiskiterror` (the module) was renamed to `qiskit.exceptions` - and it seems we have dependencies using that import directly (as opposed to importing from qiskit - sorry aer guys! :grin: ).

This PR restores the module, making it a soft import of the real `qiskit.exceptions` module, along with a note in the CHANGELOG.


### Details and comments


