### PR TITLE
fix BasicAer sampling bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,12 @@ Changed
 - The snapshot instruction now takes ``label`` and ``snap_type`` instead of
   ``slot`` (#1615).
 
+Fixed
+-----
+
+- Fixed a bug with measurement sampling optimization in BasicAer
+  qasm_simulator (#1624).
+
 Removed
 -------
 

--- a/qiskit/providers/builtinsimulators/qasm_simulator.py
+++ b/qiskit/providers/builtinsimulators/qasm_simulator.py
@@ -206,8 +206,8 @@ class QasmSimulatorPy(BaseBackend):
         memory = []
         for sample in samples:
             classical_state = self._classical_state
-            for qubit, cbit in measure_params:
-                qubit_outcome = int((sample & (1 << qubit)) >> qubit)
+            for count, (qubit, cbit) in enumerate(sorted(measure_params)):
+                qubit_outcome = int((sample & (1 << count)) >> count)
                 bit = 1 << cbit
                 classical_state = (classical_state & (~bit)) | (qubit_outcome << cbit)
             value = bin(classical_state)[2:]

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -22,7 +22,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.providers.ibmq import least_busy
 from .._mockutils import FakeBackend
 from ..common import QiskitTestCase
-from ..common import requires_qe_access, requires_cpp_simulator
+from ..common import requires_qe_access
 
 
 class TestCompiler(QiskitTestCase):
@@ -472,13 +472,12 @@ class TestCompiler(QiskitTestCase):
         threshold = 0.05 * shots
         self.assertDictAlmostEqual(counts, target, threshold)
 
-    @requires_cpp_simulator
     def test_example_swap_bits(self):
         """Test a toy example swapping a set bit around.
 
         Uses the mapper. Pass if results are correct.
         """
-        backend = qiskit.Aer.get_backend('qasm_simulator')
+        backend = qiskit.BasicAer.get_backend('qasm_simulator')
         coupling_map = [[0, 1], [0, 8], [1, 2], [1, 9], [2, 3], [2, 10],
                         [3, 4], [3, 11], [4, 5], [4, 12], [5, 6], [5, 13],
                         [6, 7], [6, 14], [7, 15], [8, 9], [9, 10], [10, 11],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1583 

A bug in the BasicAer qasm_simulator caused measurement sampling to behave incorrectly when more qubits existed than being measured.

This fix also allows us to use BasicAer in the one remaining test in `test_compiler`. So now the only tests using the legacy_simulator are the ones living in `test/python/old_aer_integration_test`. So we just need to move those out of Terra and then #1621 can be closed.