### PR TITLE
Silence ChangedInMarshmallow3Warning warnings

### DIFF
--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -20,8 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def _check_python_version():
-    """Check for Python version 3.5+
-    """
+    """Check for Python version 3.5+."""
     if sys.version_info < (3, 5):
         raise Exception('Qiskit requires Python version 3.5 or greater.')
 
@@ -69,7 +68,6 @@ def local_hardware_info():
 
     Returns:
         dict: The hardware information.
-
     """
     results = {
         'os': platform.system(),
@@ -80,8 +78,7 @@ def local_hardware_info():
 
 
 def _has_connection(hostname, port):
-    """Checks to see if internet connection exists to host
-    via specified port
+    """Checks if internet connection exists to host via specified port.
 
     If any exception is raised while trying to open a socket this will return
     false.

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -7,12 +7,14 @@
 """Common utilities for Qiskit."""
 
 import logging
-import re
-import sys
 import platform
-import warnings
+import re
 import socket
+import sys
+import warnings
+
 import psutil
+from marshmallow.warnings import ChangedInMarshmallow3Warning
 
 logger = logging.getLogger(__name__)
 
@@ -24,11 +26,13 @@ def _check_python_version():
         raise Exception('Qiskit requires Python version 3.5 or greater.')
 
 
-def _enable_deprecation_warnings():
-    """
+def _filter_deprecation_warnings():
+    """Apply filters to deprecation warnings.
+
     Force the `DeprecationWarning` warnings to be displayed for the qiskit
     module, overriding the system configuration as they are ignored by default
-    [1] for end-users.
+    [1] for end-users. Additionally, silence the `ChangedInMarshmallow3Warning`
+    messages.
 
     TODO: on Python 3.7, this might not be needed due to PEP-0565 [2].
 
@@ -47,9 +51,14 @@ def _enable_deprecation_warnings():
         # ._add_filter is internal and not available in some Python versions.
         pass
 
+    # Add a filter for ignoring ChangedInMarshmallow3Warning, as we depend on
+    # marhsmallow 2 explicitly. 2.17.0 introduced new deprecation warnings that
+    # are useful for eventually migrating, but too verbose for our purposes.
+    warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)
+
 
 _check_python_version()
-_enable_deprecation_warnings()
+_filter_deprecation_warnings()
 
 
 def local_hardware_info():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Add a warnings filter for ignoring `ChangedInMarshmallow3Warning`,
renaming the util function in the process.

Mashmallow 3 release seems to be relatively close, but it is technically still in beta (with release candidates) and 2.17.0 introduced some extra warnings that in practice are a bit noisy in our current usage. This PR disables them, giving us less verbosity during that window.

### Details and comments


