### PR TITLE
Switch to travis addon for homebrew on osx jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,13 +46,15 @@ stage_osx: &stage_osx
   osx_image: xcode9.2
   language: generic
   env: MPLBACKEND=ps
+  addons:
+    homebrew:
+      packages:
+      - pyenv
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      brew upgrade pyenv
-      pyenv install --list
       pyenv install 3.6.5
       virtualenv --python ~/.pyenv/versions/3.6.5/bin/python venv
       source venv/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ stage_osx: &stage_osx
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
       brew upgrade pyenv
+      pyenv install --list
       pyenv install 3.6.5
       virtualenv --python ~/.pyenv/versions/3.6.5/bin/python venv
       source venv/bin/activate
@@ -65,6 +66,7 @@ stage_osx_python3_7: &stage_osx_python3_7
       brew upgrade pyenv
       brew install freetype
       brew install pkg-config
+      pyenv install --list
       pyenv install 3.7.0
       virtualenv --python ~/.pyenv/versions/3.7.0/bin/python venv
       source venv/bin/activate

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,9 @@ stage_osx: &stage_osx
     homebrew:
       packages:
       - pyenv
+      - freetype
+      - pkg-config
+      update: true
   before_install:
     # Travis does not provide support for Python 3 under osx - it needs to be
     # installed manually.
@@ -65,10 +68,6 @@ stage_osx_python3_7: &stage_osx_python3_7
   before_install:
     |
     if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      brew upgrade pyenv
-      brew install freetype
-      brew install pkg-config
-      pyenv install --list
       pyenv install 3.7.0
       virtualenv --python ~/.pyenv/versions/3.7.0/bin/python venv
       source venv/bin/activate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently the osx jobs are failing trying upgrade the pyenv version to the latest (which is needed to install the python versions we test in CI). According to the travis docs the best way to use homebrew on osx jobs is to rely on the travis addon instead of doing it manually in the install scripts. This commit makes this change so we install the latest version of pyenv (and the python 3.7 dependencies) via the addon instead of out of band. This fixes the failure and makes sure we have the latest versions of the homebrew package installed as needed.

### Details and comments
