### PR TITLE
Remove `transpile_dag()`'s `format` kwarg

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,7 +67,8 @@ Removed
   as unsupported in Aer (#1615).
 - Removed circuit.add as deprecated (#1627)
 - Removed the unroller (#1629)
-- Remove deprecated result methods (#1659)
+- Removed deprecated result methods (#1659)
+- Removed deprecated transpile_dag() 'format' kwarg (#1664)
 
 `0.7.0`_ - 2018-12-19
 =====================

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -7,7 +7,6 @@
 
 """Tools for compiling a batch of quantum circuits."""
 import logging
-import warnings
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.mapper import CouplingMap, swap_mapper

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -122,7 +122,6 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
     final_dag = transpile_dag(dag, basis_gates=basis_gates,
                               coupling_map=coupling_map,
                               initial_layout=initial_layout,
-                              format='dag',
                               seed_mapper=seed_mapper,
                               pass_manager=pass_manager)
 
@@ -133,8 +132,7 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
 
 # pylint: disable=redefined-builtin
 def transpile_dag(dag, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
-                  initial_layout=None, format='dag', seed_mapper=None,
-                  pass_manager=None):
+                  initial_layout=None, seed_mapper=None, pass_manager=None):
     """Transform a dag circuit into another dag circuit (transpile), through
     consecutive passes on the dag.
 
@@ -163,7 +161,6 @@ def transpile_dag(dag, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
                                 ("q", 2): ("q", 2),
                                 ("q", 3): ("q", 3)
                               }
-        format (str): DEPRECATED The target format of the compilation: {'dag', 'json', 'qasm'}
         seed_mapper (int): random seed_mapper for the swap mapper
         pass_manager (PassManager): pass manager instance for the transpilation process
             If None, a default set of passes are run.
@@ -217,10 +214,5 @@ def transpile_dag(dag, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
             logger.info("post-mapping properties: %s",
                         dag.properties())
         dag.name = name
-
-    if format != 'dag':
-        warnings.warn("transpiler no longer supports different formats. "
-                      "only dag to dag transformations are supported.",
-                      DeprecationWarning)
 
     return dag

--- a/test/python/test_mapper.py
+++ b/test/python/test_mapper.py
@@ -264,7 +264,7 @@ class TestMapper(QiskitTestCase):
                ('qN', 1): ('q', 13), ('qN', 2): ('q', 4), ('qc', 0): ('q', 12),
                ('qNt', 0): ('q', 5), ('qNt', 1): ('q', 11), ('qt', 0): ('q', 6)}
         out_dag = transpile_dag(dag_circuit, initial_layout=lay,
-                                coupling_map=cmap, format='dag')
+                                coupling_map=cmap)
         meas_nodes = out_dag.get_named_nodes('measure')
         for n in meas_nodes:
             is_last_measure = all([after_measure in out_dag.output_map.values()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove the use of the deprecated `format` kwarg used in the `transpile_dag` function.


### Details and comments


