### PR TITLE
Fix register label in mpl conditional drawing

### DIFF
--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -559,7 +559,7 @@ class MatplotlibDrawer:
                         ii in self._creg_dict]
                 mask = 0
                 for index, cbit in enumerate(self._creg):
-                    if cbit.name == op['condition'][0]:
+                    if cbit.reg == op['condition'][0]:
                         mask |= (1 << index)
                 val = op['condition'][1]
                 # cbit list to consider


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #1651 the register labels were updated to reflect their actual value.
However, in that change a single usage of the old label was missed and
remained. This was in the code path when there was a conditional in the
circuit. This commit corrects the oversight and updates the last
remnant of the old label name.

### Details and comments