### PR TITLE
gate_map and dag_drawer available, but raise at point of use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,9 @@ Changed
   and falling back to mpl) is no longer present. Instead the default output
   is the ascii art ``text`` output backend.
 - Changed param to params in Instruction (#1665).
+- ``dag_drawer`` and ``plot_gate_map`` are available via importing
+  ``qiskit.tools.visualization``. They will raise at the point of use, if
+  dependencies are not installed (#1669).
 
 Fixed
 -----

--- a/qiskit/tools/visualization/__init__.py
+++ b/qiskit/tools/visualization/__init__.py
@@ -20,6 +20,9 @@ from qiskit.tools.visualization._state_visualization import (plot_state_hinton,
                                                              plot_state)
 
 from ._circuit_visualization import circuit_drawer, qx_color_scheme
+from ._dag_visualization import dag_drawer
+from ._gate_map import plot_gate_map
+
 from .exceptions import VisualizationError
 from ._matplotlib import HAS_MATPLOTLIB
 
@@ -32,6 +35,3 @@ if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
                                                             iplot_state_hinton,
                                                             iplot_histogram,
                                                             iplot_state_paulivec)
-
-if HAS_MATPLOTLIB:
-    from ._gate_map import plot_gate_map

--- a/qiskit/tools/visualization/_dag_visualization.py
+++ b/qiskit/tools/visualization/_dag_visualization.py
@@ -13,12 +13,6 @@ Visualization function for DAG circuit representation.
 
 import sys
 import copy
-try:
-    import nxpd
-    import pydot  # pylint: disable=unused-import
-except ImportError:
-    raise ImportError("dag_drawer requires nxpd, pydot, and Graphviz. "
-                      "Run 'pip install nxpd pydot', and install graphviz")
 from .exceptions import VisualizationError
 
 
@@ -46,6 +40,13 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
     Raises:
         VisualizationError: when style is not recognized.
     """
+    try:
+        import nxpd
+        import pydot  # pylint: disable=unused-import
+    except ImportError:
+        raise ImportError("dag_drawer requires nxpd, pydot, and Graphviz. "
+                          "Run 'pip install nxpd pydot', and install graphviz")
+
     G = copy.deepcopy(dag.multi_graph)  # don't modify the original graph attributes
     G.graph['dpi'] = 100 * scale
 

--- a/qiskit/tools/visualization/_dag_visualization.py
+++ b/qiskit/tools/visualization/_dag_visualization.py
@@ -39,6 +39,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
 
     Raises:
         VisualizationError: when style is not recognized.
+        ImportError: when nxpd or pydot not installed.
     """
     try:
         import nxpd

--- a/qiskit/tools/visualization/_gate_map.py
+++ b/qiskit/tools/visualization/_gate_map.py
@@ -7,12 +7,11 @@
 
 """A module for visualizing device coupling maps"""
 
+from qiskit.exceptions import QISKitError
 from ._matplotlib import HAS_MATPLOTLIB
 if HAS_MATPLOTLIB:
     import matplotlib.pyplot as plt  # pylint: disable=import-error
     import matplotlib.patches as mpatches
-
-from qiskit.exceptions import QISKitError
 
 
 class _GraphDist():
@@ -78,7 +77,8 @@ def plot_gate_map(backend, figsize=None,
         Figure: A Matplotlib figure instance.
 
     Raises:
-        QISKitError: Tried to pass a simulator.
+        QISKitError: if tried to pass a simulator.
+        ImportError: if matplotlib not installed.
     """
     if not HAS_MATPLOTLIB:
         raise ImportError('Must have Matplotlib installed.')

--- a/qiskit/tools/visualization/_gate_map.py
+++ b/qiskit/tools/visualization/_gate_map.py
@@ -7,8 +7,11 @@
 
 """A module for visualizing device coupling maps"""
 
-import matplotlib.pyplot as plt  # pylint: disable=import-error
-import matplotlib.patches as mpatches  # pylint: disable=import-error
+from ._matplotlib import HAS_MATPLOTLIB
+if HAS_MATPLOTLIB:
+    import matplotlib.pyplot as plt  # pylint: disable=import-error
+    import matplotlib.patches as mpatches
+
 from qiskit.exceptions import QISKitError
 
 
@@ -77,6 +80,9 @@ def plot_gate_map(backend, figsize=None,
     Raises:
         QISKitError: Tried to pass a simulator.
     """
+    if not HAS_MATPLOTLIB:
+        raise ImportError('Must have Matplotlib installed.')
+
     if backend.configuration().simulator:
         raise QISKitError('Requires a device backend, not simulator.')
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I'm adding `dag_drawer` and `gate_map` to import from `qiskit.tools.visualization`. These were apparently omitted in order to keep dependencies light. But this should only be a problem at the point of use, not import. Right now we have a situation where some things are imported and some things are not, creating an inconsistent API.

This commit makes everything consistent (we have functions that raise dependency errors at the point of use (e.g. plot_histogram), but are still imported).

All the dependencies that were optional (nxpd, matplotlib) will remain optional.
