### PR TITLE
Clean up unused code in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-import os
-import platform
-from distutils.command.build import build
-from multiprocessing import cpu_count
-from subprocess import call
-
 from setuptools import setup, find_packages
-from setuptools.dist import Distribution
 
 
 requirements = [
@@ -29,12 +22,6 @@ requirements = [
     "scipy>=0.19,!=0.19.1",
     "sympy>=1.3"
 ]
-
-
-# This is for creating wheel specific platforms
-class BinaryDistribution(Distribution):
-    def has_ext_modules(self):
-        return True
 
 
 setup(
@@ -64,7 +51,6 @@ setup(
     install_requires=requirements,
     include_package_data=True,
     python_requires=">=3.5",
-    distclass=BinaryDistribution,
     extra_requires={
         'visualization': ['matplotlib>=2.1', 'nxpd>=0.2', 'ipywidgets>=7.3.0',
                           'pydot'],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since #1644 we've removed all the C++ code from the terra repository.
That commit updated the setup.py and build process to not assume we're
compiling code to build the simulators. However we missed a lot of
parameters imports and other code in the setup.py which are not needed
or don't apply anymore now that terra is just python code. This commit
cleans that all up so we minimize what we include in the setup.py.

### Details and comments