### PR TITLE
Remove Pauli v, w, and pauli_group() case arg as int

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -73,6 +73,7 @@ Removed
 - Removed the unroller (#1629)
 - Removed deprecated result methods (#1659)
 - Removed deprecated transpile_dag() 'format' kwarg (#1664)
+- Removed deprecated Pauli v, w, and pauli_group case arg as int (#1680)
 
 `0.7.0`_ - 2018-12-19
 =====================

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -12,7 +12,6 @@ Tools for working with Pauli Operators.
 
 A simple pauli class and some tools.
 """
-import warnings
 
 import numpy as np
 from scipy import sparse
@@ -214,22 +213,6 @@ class Pauli:
     def __hash__(self):
         """Make object is hashable, based on the pauli label to hash."""
         return hash(str(self))
-
-    @property
-    def v(self):
-        """Old getter of z."""
-        warnings.warn('Accessing property `v` is deprecated, please access `z` instead,'
-                      'Furthermore, use the `update_z` method if you would like to update'
-                      'the z vector', DeprecationWarning)
-        return self._z
-
-    @property
-    def w(self):
-        """Old getter of x."""
-        warnings.warn('Accessing property `w` is deprecated, please access `x` instead,'
-                      'Furthermore, use the `update_x` method if you would like to update'
-                      'the x vector', DeprecationWarning)
-        return self._x
 
     @property
     def z(self):
@@ -530,15 +513,6 @@ def pauli_group(number_of_qubits, case='weight'):
     """
     if number_of_qubits < 5:
         temp_set = []
-        if isinstance(case, int):
-            warnings.warn('Passing case as integer is deprecated, please pass `weight`'
-                          ' or `tensor` instead,', DeprecationWarning)
-            if case == 0:
-                case = 'weight'
-            elif case == 1:
-                case = 'tensor'
-            else:
-                case = 'na'
 
         if case == 'weight':
             tmp = pauli_group(number_of_qubits, case='tensor')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove Pauli v, w, and pauli_group() case arg as int


### Details and comments


