### PR TITLE
Remove QISKitError (old capitalization)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -77,6 +77,7 @@ Removed
 - Removed deprecated ``Pauli`` ``v``, ``w``, and ``pauli_group`` case arg as int (#1680)
 - Removed deprecated ``state_fidelity()`` function from ``tools.qi`` (#1681)
 - Change elements in ``couplinglist`` of ``CouplingMap`` from tuples to lists (#1666)
+- Removed ``QISKitError`` in favour of ``QiskitError``. (#1684)
 
 `0.7.0`_ - 2018-12-19
 =====================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,18 +36,18 @@ install:
     - pip.exe install ipywidgets
     - pip.exe install stestr
     - pip.exe install qiskit-aer
-# TODO(mtreinish): uncomment this when testing-cabal/subunit#33 is fixed
+# TODO: uncomment this when testing-cabal/subunit#33 is fixed
 #   - pip.exe install junitxml
 
 # Use py.test for output of xunit test results.
 test_script:
     - stestr run
     - stestr last --subunit > test_results.subunit
-# TODO(mtreinish): uncomment this when testing-cabal/subunit#33 is fixed
+# TODO: uncomment this when testing-cabal/subunit#33 is fixed
 #    - subunit2junitxml test_results.subunit > test_results.xml
 
 # Upload the test results to appveyor so they are shown on the "Tests" tab.
 on_finish:
     - ps: $wc = New-Object 'System.Net.WebClient'
-# TODO(mtreinish): uncomment this when testing-cabal/subunit#33 is fixed
+# TODO: uncomment this when testing-cabal/subunit#33 is fixed
 #   - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test_results.xml))

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -15,7 +15,7 @@ import pkgutil
 from . import _util
 
 # qiskit errors operator
-from .exceptions import QiskitError, QISKitError
+from .exceptions import QiskitError
 
 # The main qiskit operators
 from qiskit.circuit import ClassicalRegister

--- a/qiskit/exceptions.py
+++ b/qiskit/exceptions.py
@@ -5,19 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""
-Exception for errors raised by the Qiskit.
-"""
+"""Exceptions for errors raised by Qiskit."""
 
 
-# NOTE(mtreinish): This class is here to maintain backwards compatibility and should not be
-# used directly. Instead use the QiskitError class.
-class QISKitError(Exception):
-    """Old Base class for errors raised by the Qiskit for backwards compat only, not for use."""
-
-
-class QiskitError(QISKitError):
-    """Base class for errors raised by the Qiskit."""
+class QiskitError(Exception):
+    """Base class for errors raised by Qiskit."""
 
     def __init__(self, *message):
         """Set the error message."""

--- a/qiskit/qiskiterror.py
+++ b/qiskit/qiskiterror.py
@@ -7,11 +7,10 @@
 
 """Exception for errors raised by Qiskit.
 
-Note: this module will be deprecated in Terra 0.7+. Please import the exceptions
+Note: this module will be deprecated in Terra 0.8+. Please import the exceptions
 from the `qiskit.exceptions` module instead.
 """
 
 # pylint: disable=unused-import
 
-from .exceptions import QISKitError
 from .exceptions import QiskitError

--- a/qiskit/tools/jupyter/_backend_monitor.py
+++ b/qiskit/tools/jupyter/_backend_monitor.py
@@ -19,7 +19,7 @@ from matplotlib import cm                               # pylint: disable=import
 from matplotlib.patches import Circle                   # pylint: disable=import-error
 import ipywidgets as widgets                            # pylint: disable=import-error
 from qiskit.providers.ibmq import IBMQ
-from qiskit.exceptions import QISKitError
+from qiskit.exceptions import QiskitError
 from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
 from qiskit.tools.visualization._gate_map import plot_gate_map
 
@@ -34,7 +34,7 @@ class BackendMonitor(Magics):
         """
         backend = self.shell.user_ns[line]
         if not isinstance(backend, IBMQBackend):
-            raise QISKitError('Input variable is not of type IBMQBackend.')
+            raise QiskitError('Input variable is not of type IBMQBackend.')
         title_style = "style='color:#ffffff;background-color:#000000;padding-top: 1%;"
         title_style += "padding-bottom: 1%;padding-left: 1%; margin-top: 0px'"
         title_html = "<h1 {style}>{name}</h1>".format(

--- a/qiskit/tools/monitor/backend_overview.py
+++ b/qiskit/tools/monitor/backend_overview.py
@@ -9,7 +9,7 @@
 """
 
 import math
-from qiskit.exceptions import QISKitError
+from qiskit.exceptions import QiskitError
 from qiskit.providers.ibmq import IBMQ
 from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
 
@@ -21,7 +21,7 @@ def get_unique_backends():
         list: Unique available backends.
 
     Raises:
-        QISKitError: No backends available.
+        QiskitError: No backends available.
     """
     backends = IBMQ.backends()
     unique_hardware_backends = []
@@ -31,7 +31,7 @@ def get_unique_backends():
             unique_hardware_backends.append(back)
             unique_names.append(back.name())
     if not unique_hardware_backends:
-        raise QISKitError('No backends available.')
+        raise QiskitError('No backends available.')
     return unique_hardware_backends
 
 
@@ -41,10 +41,10 @@ def backend_monitor(backend):
     Args:
         backend (IBMQBackend): Backend to monitor.
     Raises:
-        QISKitError: Input is not a IBMQ backend.
+        QiskitError: Input is not a IBMQ backend.
     """
     if not isinstance(backend, IBMQBackend):
-        raise QISKitError('Input variable is not of type IBMQBackend.')
+        raise QiskitError('Input variable is not of type IBMQBackend.')
     config = backend.configuration().to_dict()
     status = backend.status().to_dict()
     config_dict = {**status, **config}

--- a/qiskit/tools/visualization/_circuit_visualization.py
+++ b/qiskit/tools/visualization/_circuit_visualization.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# TODO(mtreinish): Remove after 0.7 and the deprecated methods are removed
+# TODO: Remove after 0.7 and the deprecated methods are removed
 # pylint: disable=unused-argument
 
 

--- a/qiskit/tools/visualization/_gate_map.py
+++ b/qiskit/tools/visualization/_gate_map.py
@@ -7,7 +7,7 @@
 
 """A module for visualizing device coupling maps"""
 
-from qiskit.exceptions import QISKitError
+from qiskit.exceptions import QiskitError
 from ._matplotlib import HAS_MATPLOTLIB
 if HAS_MATPLOTLIB:
     import matplotlib.pyplot as plt  # pylint: disable=import-error
@@ -77,14 +77,14 @@ def plot_gate_map(backend, figsize=None,
         Figure: A Matplotlib figure instance.
 
     Raises:
-        QISKitError: if tried to pass a simulator.
+        QiskitError: if tried to pass a simulator.
         ImportError: if matplotlib not installed.
     """
     if not HAS_MATPLOTLIB:
         raise ImportError('Must have Matplotlib installed.')
 
     if backend.configuration().simulator:
-        raise QISKitError('Requires a device backend, not simulator.')
+        raise QiskitError('Requires a device backend, not simulator.')
 
     mpl_data = {}
 

--- a/test/python/notebooks/test_backend_tools.ipynb
+++ b/test/python/notebooks/test_backend_tools.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "from qiskit import IBMQ\n",
-    "from qiskit.qiskiterror import QISKitError\n",
+    "from qiskit.qiskiterror import QiskitError\n",
     "from qiskit.tools.jupyter import *"
    ]
   },
@@ -54,7 +54,7 @@
     "        my_backend = back\n",
     "        break\n",
     "if my_backend is None:\n",
-    "    raise QISKitError('Could not load an operational IBMQ device backend.')"
+    "    raise QiskitError('Could not load an operational IBMQ device backend.')"
    ]
   },
   {

--- a/test/python/test_qcvv_fitters.py
+++ b/test/python/test_qcvv_fitters.py
@@ -48,7 +48,7 @@ class TestQCVVFitters(QiskitTestCase):
     def test_shape_rb_data(self):
         """Test randomized benchmark data shaping function."""
         raw_data = np.zeros((2, 2, 2))
-        # TODO(mtreinish): Come up with a more realistic input data set instead
+        # TODO: Come up with a more realistic input data set instead
         # of this synthetic example
         for i in range(2):
             raw_data[i][i][i] = i + 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #1646.

(Hopefully) Complete the round of deprecations for 0.7, by removing `QISKitError` (ie. the one with the old capitalization). In the process, a handful of old references were updated in `tools` and `tests`, and also took the chance to unify the convention used for some `TODO`s, relying on the git history instead.


### Details and comments


