### PR TITLE
Use strict marshmallow schemas, add custom exception

### DIFF
--- a/qiskit/validation/__init__.py
+++ b/qiskit/validation/__init__.py
@@ -7,6 +7,5 @@
 
 """Models and schemas for Terra."""
 
-from marshmallow import ValidationError
-
 from .base import BaseModel, BaseSchema, bind_schema, ModelTypeValidator
+from .exceptions import ModelValidationError

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -31,7 +31,7 @@ from marshmallow import Schema, post_dump, post_load
 from marshmallow import fields as _fields
 from marshmallow.utils import is_collection
 
-from .exceptions import QiskitValidationError
+from .exceptions import ModelValidationError
 
 
 class ModelTypeValidator(_fields.Field):
@@ -229,7 +229,7 @@ class _SchemaBinder:
         try:
             _ = instance.schema.validate(instance.to_dict())
         except ValidationError as ex:
-            raise QiskitValidationError(
+            raise ModelValidationError(
                 ex.messages, ex.field_names, ex.fields, ex.data, **ex.kwargs)
 
     @staticmethod
@@ -241,7 +241,7 @@ class _SchemaBinder:
             try:
                 _ = self.shallow_schema.validate(kwargs)
             except ValidationError as ex:
-                raise QiskitValidationError(
+                raise ModelValidationError(
                     ex.messages, ex.field_names, ex.fields, ex.data, **ex.kwargs)
 
             init_method(self, **kwargs)
@@ -326,7 +326,7 @@ class BaseModel(SimpleNamespace):
         try:
             data, _ = self.schema.dump(self)
         except ValidationError as ex:
-            raise QiskitValidationError(
+            raise ModelValidationError(
                 ex.messages, ex.field_names, ex.fields, ex.data, **ex.kwargs)
 
         return data
@@ -341,7 +341,7 @@ class BaseModel(SimpleNamespace):
         try:
             data, _ = cls.schema.load(dict_)
         except ValidationError as ex:
-            raise QiskitValidationError(
+            raise ModelValidationError(
                 ex.messages, ex.field_names, ex.fields, ex.data, **ex.kwargs)
 
         return data

--- a/qiskit/validation/exceptions.py
+++ b/qiskit/validation/exceptions.py
@@ -12,7 +12,7 @@ from marshmallow import ValidationError
 from qiskit.exceptions import QiskitError
 
 
-class QiskitValidationError(ValidationError, QiskitError):
+class ModelValidationError(ValidationError, QiskitError):
     """Raised when a sequence subscript is out of range."""
     def __init__(self, message, field_names=None, fields=None, data=None,
                  **kwargs):

--- a/qiskit/validation/exceptions.py
+++ b/qiskit/validation/exceptions.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Exceptions for errors raised by the validation."""
+
+
+from marshmallow import ValidationError
+from qiskit.exceptions import QiskitError
+
+
+class QiskitValidationError(ValidationError, QiskitError):
+    """Raised when a sequence subscript is out of range."""
+    def __init__(self, message, field_names=None, fields=None, data=None,
+                 **kwargs):
+        super().__init__(message, field_names, fields, data, **kwargs)
+        # Populate self.message, as it is required by QiskitError.
+        self.message = message

--- a/qiskit/validation/fields/containers.py
+++ b/qiskit/validation/fields/containers.py
@@ -10,9 +10,10 @@
 from collections.abc import Iterable
 
 from marshmallow import fields as _fields
+from marshmallow.exceptions import ValidationError
 from marshmallow.utils import is_collection
 
-from qiskit.validation import ValidationError, ModelTypeValidator
+from qiskit.validation import ModelTypeValidator
 
 
 class Nested(_fields.Nested, ModelTypeValidator):

--- a/qiskit/validation/fields/polymorphic.py
+++ b/qiskit/validation/fields/polymorphic.py
@@ -10,10 +10,11 @@
 from collections.abc import Iterable
 from functools import partial
 
+from marshmallow.exceptions import ValidationError
 from marshmallow.utils import is_collection
 from marshmallow_polyfield import PolyField
 
-from qiskit.validation import ValidationError, ModelTypeValidator
+from qiskit.validation import ModelTypeValidator
 
 
 class BasePolyField(PolyField, ModelTypeValidator):

--- a/test/python/validation/test_fields.py
+++ b/test/python/validation/test_fields.py
@@ -9,7 +9,7 @@
 
 from qiskit.validation import fields
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema
-from qiskit.validation.exceptions import QiskitValidationError
+from qiskit.validation.exceptions import ModelValidationError
 from qiskit.validation.fields import TryFrom, ByAttribute, ByType
 from qiskit.test import QiskitTestCase
 
@@ -82,13 +82,13 @@ class TestFields(QiskitTestCase):
 
     def test_try_from_field_invalid(self):
         """Test the TryFrom field, with invalid kind of object."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner(auto_pets=[Cat(fur_density=1.5), NotAPet()])
         self.assertIn('auto_pets', str(context_manager.exception))
 
     def test_try_from_field_invalid_from_dict(self):
         """Test the TryFrom field, instantiation from dict, with invalid."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner.from_dict({'auto_pets': [{'fur_density': 1.5},
                                                   {'name': 'John Doe'}]})
         self.assertIn('auto_pets', str(context_manager.exception))
@@ -111,13 +111,13 @@ class TestFields(QiskitTestCase):
 
     def test_by_attribute_field_invalid(self):
         """Test the ByAttribute field, with invalid kind of object."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner(by_attribute_pets=[Cat(fur_density=1.5), NotAPet()])
         self.assertIn('by_attribute_pets', str(context_manager.exception))
 
     def test_by_attribute_field_invalid_from_dict(self):
         """Test the ByAttribute field, instantiation from dict, with invalid."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner.from_dict({'by_attribute_pets': [{'fur_density': 1.5},
                                                           {'name': 'John Doe'}]})
         self.assertIn('by_attribute_pets', str(context_manager.exception))
@@ -134,12 +134,12 @@ class TestFields(QiskitTestCase):
 
     def test_by_type_field_invalid(self):
         """Test the ByType field, with invalid kind of object."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner(by_type_contact=123)
         self.assertIn('by_type_contact', str(context_manager.exception))
 
     def test_by_type_field_invalid_from_dict(self):
         """Test the ByType field, instantiation from dict, with invalid."""
-        with self.assertRaises(QiskitValidationError) as context_manager:
+        with self.assertRaises(ModelValidationError) as context_manager:
             _ = PetOwner.from_dict({'by_type_contact': 123})
         self.assertIn('by_type_contact', str(context_manager.exception))

--- a/test/python/validation/test_fields.py
+++ b/test/python/validation/test_fields.py
@@ -7,8 +7,9 @@
 
 """Test polymorphic and validated fields."""
 
-from qiskit.validation import fields, ValidationError
+from qiskit.validation import fields
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema
+from qiskit.validation.exceptions import QiskitValidationError
 from qiskit.validation.fields import TryFrom, ByAttribute, ByType
 from qiskit.test import QiskitTestCase
 
@@ -81,13 +82,13 @@ class TestFields(QiskitTestCase):
 
     def test_try_from_field_invalid(self):
         """Test the TryFrom field, with invalid kind of object."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner(auto_pets=[Cat(fur_density=1.5), NotAPet()])
         self.assertIn('auto_pets', str(context_manager.exception))
 
     def test_try_from_field_invalid_from_dict(self):
         """Test the TryFrom field, instantiation from dict, with invalid."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner.from_dict({'auto_pets': [{'fur_density': 1.5},
                                                   {'name': 'John Doe'}]})
         self.assertIn('auto_pets', str(context_manager.exception))
@@ -110,13 +111,13 @@ class TestFields(QiskitTestCase):
 
     def test_by_attribute_field_invalid(self):
         """Test the ByAttribute field, with invalid kind of object."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner(by_attribute_pets=[Cat(fur_density=1.5), NotAPet()])
         self.assertIn('by_attribute_pets', str(context_manager.exception))
 
     def test_by_attribute_field_invalid_from_dict(self):
         """Test the ByAttribute field, instantiation from dict, with invalid."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner.from_dict({'by_attribute_pets': [{'fur_density': 1.5},
                                                           {'name': 'John Doe'}]})
         self.assertIn('by_attribute_pets', str(context_manager.exception))
@@ -133,12 +134,12 @@ class TestFields(QiskitTestCase):
 
     def test_by_type_field_invalid(self):
         """Test the ByType field, with invalid kind of object."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner(by_type_contact=123)
         self.assertIn('by_type_contact', str(context_manager.exception))
 
     def test_by_type_field_invalid_from_dict(self):
         """Test the ByType field, instantiation from dict, with invalid."""
-        with self.assertRaises(ValidationError) as context_manager:
+        with self.assertRaises(QiskitValidationError) as context_manager:
             _ = PetOwner.from_dict({'by_type_contact': 123})
         self.assertIn('by_type_contact', str(context_manager.exception))

--- a/test/python/validation/test_models.py
+++ b/test/python/validation/test_models.py
@@ -9,8 +9,9 @@
 
 from datetime import datetime
 
-from qiskit.validation import fields, ValidationError
+from qiskit.validation import fields
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema
+from qiskit.validation.exceptions import ModelValidationError
 from qiskit.test import QiskitTestCase
 
 
@@ -67,20 +68,20 @@ class TestModels(QiskitTestCase):
 
     def test_instantiate_required(self):
         """Test model instantiation without required fields."""
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person()
 
         # From dict.
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person.from_dict({})
 
     def test_instantiate_wrong_type(self):
         """Test model instantiation with fields of the wrong type."""
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person(name=1)
 
         # From dict.
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person.from_dict({'name': 1})
 
     def test_instantiate_deserialized_types(self):
@@ -89,14 +90,14 @@ class TestModels(QiskitTestCase):
 
         person = Person(name='Foo', birth_date=birth_date)
         self.assertEqual(person.birth_date, birth_date)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person(name='Foo', birth_date=birth_date.isoformat())
 
         # From dict.
         person_dict = Person.from_dict({'name': 'Foo',
                                         'birth_date': birth_date.isoformat()})
         self.assertEqual(person_dict.birth_date, birth_date)
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Person.from_dict({'name': 'Foo', 'birth_date': birth_date})
 
         self.assertEqual(person, person_dict)
@@ -136,11 +137,11 @@ class TestModels(QiskitTestCase):
 
     def test_instantiate_nested_wrong_type(self):
         """Test model instantiation with nested fields of the wrong type."""
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Book(title='A Book', author=NotAPerson())
 
         # From dict.
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Book.from_dict({'title': 'A Book',
                                 'author': {'fur_density': '1.2'}})
 

--- a/test/python/validation/test_validators.py
+++ b/test/python/validation/test_validators.py
@@ -9,7 +9,7 @@
 
 from marshmallow.validate import Regexp
 
-from qiskit.validation import fields, ValidationError
+from qiskit.validation import fields, ModelValidationError
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema, ObjSchema, Obj
 from qiskit.validation.validate import PatternProperties
 from qiskit.test import QiskitTestCase
@@ -45,21 +45,21 @@ class TestValidators(QiskitTestCase):
     def test_patternproperties_invalid_key(self):
         """Test the PatternProperties validator fails when invalid key"""
         invalid_key_data = {'counts': {'00': 50, '0x11': 50}}
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Histogram(**invalid_key_data)
 
         # From dict
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Histogram.from_dict(invalid_key_data)
 
     def test_patternproperties_invalid_value(self):
         """Test the PatternProperties validator fails when invalid value"""
         invalid_value_data = {'counts': {'0x00': 'so many', '0x11': 50}}
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Histogram(**invalid_value_data)
 
         # From dict
-        with self.assertRaises(ValidationError):
+        with self.assertRaises(ModelValidationError):
             _ = Histogram.from_dict(invalid_value_data)
 
     def test_patternproperties_to_dict(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As a spiritual successor of sorts to #1642, this PR:
* makes the parent `qiskit.validation.base.BaseSchema` "strict" (in practice, it raises an Exception directly when dumping/loading/validating), silencing that particular `ChangedInMarshmallow3Warning`.
* introduces a custom exception for the `qiskit.validation` module, `ModelValidationError`. This brings the module in line with the project's philosophy, raising exceptions that inherit from `QiskitError`.
* for the public interface, intercepts the exceptions raised due to the new strict parameter, and re-raises them as `ModelValidationError`.


### Details and comments

In practice, it helps removing the `ChangedInMarshmallow3Warning` that could still appear under some conditions even after #1642 (such as importing the models without passing through `qiskit._util`), and the new exception helps third-party not having to add a dependency on marshmallow just for catching that exception

