### PR TITLE
Include BarrierBeforeFinalMeasurements in default transpile pipeline

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -57,6 +57,8 @@ Fixed
   qasm_simulator (#1624).
 - Fixed a minor conda env bug in Makefile (#1691).
 - Fixed a bug in BasicMapper pass operating over multiple registers (#1611).
+- Fixed a bug in BarrierBeforeFinalMeasurements which incorrectly moved measurements
+  used in conditional operations (#1705).
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,8 @@ Changed
   dependencies are not installed (#1669).
 - The ``qiskit.validation`` schemas are now strict and raise a more specific
   ``ModelValidationError`` (#1695).
+- The default transpile pipeline will now add a barrier before the set of
+  final measurements when compiling for both simulators and devices (#1591).
 
 Fixed
 -----

--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -187,8 +187,11 @@ def transpile_dag(dag, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
         # default set of passes
         # TODO: move each step here to a pass, and use a default passmanager below
         basis = basis_gates.split(',') if basis_gates else []
-        dag = Unroller(basis).run(dag)
         name = dag.name
+
+        dag = Unroller(basis).run(dag)
+        dag = BarrierBeforeFinalMeasurements().run(dag)
+
         # if a coupling map is given compile to the map
         if coupling_map:
             logger.info("pre-mapping properties: %s",
@@ -196,7 +199,7 @@ def transpile_dag(dag, basis_gates='u1,u2,u3,cx,id', coupling_map=None,
             # Insert swap gates
             coupling = CouplingMap(coupling_map)
             logger.info("initial layout: %s", initial_layout)
-            dag = BarrierBeforeFinalMeasurements().run(dag)
+
             dag, final_layout = swap_mapper(
                 dag, coupling, initial_layout, trials=20, seed=seed_mapper)
             logger.info("final layout: %s", final_layout)

--- a/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
@@ -23,7 +23,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
         last_measures = []
         for measure in dag.get_named_nodes('measure'):
             is_last_measurement = all([after_measure in dag.output_map.values() for after_measure in
-                                       dag.quantum_successors(measure)])
+                                       dag.successors(measure)])
             if is_last_measurement:
                 last_measures.append(measure)
 


### PR DESCRIPTION
Update the default transpile pipeline to add a barrier prior to the last round of measurements for both devices and simulators. Fixes #1591.