### PR TITLE
Remove compiled_circuit_qasm from Qobj header

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -88,6 +88,8 @@ Removed
 - Removed ``QISKitError`` in favour of ``QiskitError``. (#1684)
 - The IBMQ provider (``qiskit.providers.ibmq``) has been moved to its own
   package (``pip install qiskit-ibmq-provider``). (#1700)
+- ``compiled_circuit_qasm`` has been removed from the Qobj header, since it
+  was part of the pre-qobj specification (#1715).
 
 `0.7.0`_ - 2018-12-19
 =====================

--- a/qiskit/converters/circuits_to_qobj.py
+++ b/qiskit/converters/circuits_to_qobj.py
@@ -94,15 +94,13 @@ def circuits_to_qobj(circuits, user_qobj_header=None, run_config=None,
 
         # TODO: why do we need creq_sizes and qreg_sizes in header
         # TODO: we need to rethink memory_slots as they are tied to classical bit
-        # TODO: when no more backends use the compiled_circuit_qasm lets delete it form header
         experimentheader = QobjExperimentHeader(qubit_labels=qubit_labels,
                                                 n_qubits=n_qubits,
                                                 qreg_sizes=qreg_sizes,
                                                 clbit_labels=clbit_labels,
                                                 memory_slots=memory_slots,
                                                 creg_sizes=creg_sizes,
-                                                name=circuit.name,
-                                                compiled_circuit_qasm=circuit.qasm())
+                                                name=circuit.name)
         # TODO: why do we need n_qubits and memory_slots in both the header and the config
         experimentconfig = QobjExperimentConfig(n_qubits=n_qubits, memory_slots=memory_slots)
 

--- a/qiskit/qobj/_converter.py
+++ b/qiskit/qobj/_converter.py
@@ -94,8 +94,6 @@ def qobj_to_dict_previous_version(qobj):
                 'operations': [instruction.as_dict() for instruction in
                                experiment.instructions]
             },
-            'compiled_circuit_qasm': getattr(experiment.header,
-                                             'compiled_circuit_qasm', None)
         }
 
         converted['circuits'].append(circuit)

--- a/qiskit/test/mock.py
+++ b/qiskit/test/mock.py
@@ -355,7 +355,7 @@ def new_fake_qobj():
             instructions=[
                 QobjInstruction(name='barrier', qubits=[1])
             ],
-            header=QobjExperimentHeader(compiled_circuit_qasm='fake-code'),
+            header=QobjExperimentHeader(),
             config=QobjItem(seed=123456)
         )]
     )

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -99,8 +99,6 @@ class TestQobjToCircuits(QiskitTestCase):
         """Check that qobj_to_circuits's result matches the qobj ini."""
         backend = BasicAer.get_backend('qasm_simulator')
         qobj_in = compile(self.circuit, backend, pass_manager=PassManager())
-        for i in qobj_in.experiments:
-            del i.header.compiled_circuit_qasm
         out_circuit = qobj_to_circuits(qobj_in)
         self.assertEqual(circuit_to_dag(out_circuit[0]), self.dag)
 
@@ -118,8 +116,6 @@ class TestQobjToCircuits(QiskitTestCase):
         circuit_b.measure(qreg2[0], creg2[1])
         qobj = compile([self.circuit, circuit_b], backend,
                        pass_manager=PassManager())
-        for i in qobj.experiments:
-            del i.header.compiled_circuit_qasm
 
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])

--- a/test/python/qobj/test_qobj_identifiers.py
+++ b/test/python/qobj/test_qobj_identifiers.py
@@ -33,31 +33,22 @@ class TestQobjIdentifiers(QiskitTestCase):
         backend = BasicAer.get_backend('qasm_simulator')
         qobj = compile(self.circuits, backend=backend)
         exp = qobj.experiments[0]
-        c_qasm = exp.header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
-        self.assertIn(self.qr_name, c_qasm)
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))
-        self.assertIn(self.cr_name, c_qasm)
 
     def test_builtin_qasm_simulator(self):
         backend = BasicAer.get_backend('qasm_simulator')
         qobj = compile(self.circuits, backend=backend)
         exp = qobj.experiments[0]
-        c_qasm = exp.header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
-        self.assertIn(self.qr_name, c_qasm)
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))
-        self.assertIn(self.cr_name, c_qasm)
 
     def test_builtin_unitary_simulator_py(self):
         backend = BasicAer.get_backend('unitary_simulator')
         qobj = compile(self.circuits, backend=backend)
         exp = qobj.experiments[0]
-        c_qasm = exp.header.compiled_circuit_qasm
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
-        self.assertIn(self.qr_name, c_qasm)
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))
-        self.assertIn(self.cr_name, c_qasm)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #1633 

Remove `compiled_circuit_qasm` from the Qobj header, since all the
backends support Qobj and it was part of the pre-Qobj transition.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


