### PR TITLE
Update BarrierBeforeFinalMeasures to preserve existing barriers

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -975,6 +975,15 @@ class DAGCircuit:
         """
         copy_node1 = {k: v for (k, v) in node1.items()}
         copy_node2 = {k: v for (k, v) in node2.items()}
+
+        # For barriers, qarg order is not significant so compare as sets
+        if 'barrier' == copy_node1['name'] == copy_node2['name']:
+            node1_qargs = set(copy_node1.pop('qargs', []))
+            node2_qargs = set(copy_node2.pop('qargs', []))
+
+            if node1_qargs != node2_qargs:
+                return False
+
         return copy_node1 == copy_node2
 
     def __eq__(self, other):
@@ -1277,6 +1286,10 @@ class DAGCircuit:
     def successors(self, node):
         """Returns the successors of a node."""
         return self.multi_graph.successors(node)
+
+    def ancestors(self, node):
+        """Returns the ancestors of a node."""
+        return nx.ancestors(self.multi_graph, node)
 
     def descendants(self, node):
         """Returns the descendants of a node."""

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -914,7 +914,7 @@ class DAGCircuit:
             n (int): reference to self.multi_graph node id
 
         Returns:
-            set(dict): set({predecessor_map, successor_map})
+            tuple(dict): tuple(predecessor_map, successor_map)
                 These map from wire (Register, int) to predecessor (successor)
                 nodes of n.
         """
@@ -1277,6 +1277,10 @@ class DAGCircuit:
     def successors(self, node):
         """Returns the successors of a node."""
         return self.multi_graph.successors(node)
+
+    def descendants(self, node):
+        """Returns the descendants of a node."""
+        return nx.descendants(self.multi_graph, node)
 
     def quantum_successors(self, node):
         """Returns the successors of a node that are connected by a quantum edge"""

--- a/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
@@ -7,7 +7,11 @@
 
 
 """
-This pass adds a barrier before the final measurements.
+This pass adds a barrier before the set of final measurements. Measurements
+are considered final if they are followed by no other operations (aside from
+other measurements or barriers.)
+
+A new barrier will not be added if an equivalent barrier is already present.
 """
 
 from qiskit.extensions.standard.barrier import Barrier
@@ -20,47 +24,58 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
 
     def run(self, dag):
         """Return a circuit with a barrier before last measurments."""
-        last_measures = []
-        for measure in dag.get_named_nodes('measure'):
-            is_last_measurement = all([after_measure in dag.output_map.values() for after_measure in
-                                       dag.successors(measure)])
-            if is_last_measurement:
-                last_measures.append(measure)
 
-        if not last_measures:
+        # Collect DAG nodes which are followed only by barriers or other measures.
+        final_op_types = ['measure', 'barrier']
+        final_ops = []
+        for candidate_op in dag.get_named_nodes(*final_op_types):
+            nodes_after_candidate = [dag.multi_graph.nodes[node_id]
+                                     for node_id in dag.descendants(candidate_op)]
+            is_final_op = all([node['type'] == 'out'
+                               or (node['type'] == 'op' and node['op'].name in final_op_types)
+                               for node in nodes_after_candidate])
+
+            if is_final_op:
+                final_ops.append(candidate_op)
+
+        if not final_ops:
             return dag
 
-        # create a laywer with the barrier and the measurements in last_measures operation
-        dag.add_basis_element('barrier', len(last_measures), 0, 0)
-        barried_layer = DAGCircuit()
-        last_measures_nodes = [dag.multi_graph.node[node] for node in last_measures]
-        last_measures_qubits = [node['qargs'][0] for node in last_measures_nodes]
-
-        # Add registers from the original dag.
+        # Create a layer with the barrier and add registers from the original dag.
+        barrier_layer = DAGCircuit()
         for qreg in dag.qregs.values():
-            barried_layer.add_qreg(qreg)
+            barrier_layer.add_qreg(qreg)
         for creg in dag.cregs.values():
-            barried_layer.add_creg(creg)
+            barrier_layer.add_creg(creg)
 
-        # Add the barrier operation
-        barried_layer.apply_operation_back(Barrier(qubits=last_measures_qubits))
+        final_qubits = []
+        for final_op in final_ops:
+            qubit = dag.multi_graph.node[final_op]['qargs'][0]
+            if qubit not in final_qubits:
+                final_qubits.append(qubit)
 
-        # Add the measurements to the behind the barrier
-        for last_measures_node in last_measures_nodes:
-            barried_layer.apply_operation_back(last_measures_node['op'])
+        dag.add_basis_element('barrier', len(final_qubits), 0, 0)
+        barrier_layer.apply_operation_back(Barrier(qubits=final_qubits))
 
-        # Remove barriers in front the measurements in the original dag
-        for last_measure in last_measures:
-            for predecesor in dag.multi_graph.predecessors(last_measure):
-                if dag.multi_graph.nodes[predecesor]['type'] == 'op' and \
-                        isinstance(dag.multi_graph.nodes[predecesor]['op'], Barrier):
-                    dag._remove_op_node(predecesor)
+        # Preserve order of final ops collected earlier from the original DAG.
+        ordered_node_ids = [node_id for node_id in dag.node_nums_in_topological_order()
+                            if node_id in set(final_ops)]
+        ordered_final_nodes = [dag.multi_graph.node[node] for node in ordered_node_ids]
 
-        # Remove the measurements from the original dag
-        for last_measure in last_measures:
-            dag._remove_op_node(last_measure)
+        # If a barrier equivalent to the new barrier was already present in the
+        # DAG, it would be first on the list of final nodes to re-add. Check if
+        # it exists and return the DAG unmodified if so.
+        barrier_to_add = barrier_layer.get_op_nodes(data=True)[0][1]
+        if ordered_final_nodes[0] == barrier_to_add:
+            return dag
 
-        # Extend the original dag with the barried layer
-        dag.extend_back(barried_layer)
+        # Move final ops to the new layer and append the new layer to the DAG.
+        for final_node in ordered_final_nodes:
+            barrier_layer.apply_operation_back(final_node['op'])
+
+        for final_op in final_ops:
+            dag._remove_op_node(final_op)
+
+        dag.extend_back(barrier_layer)
 
         return dag

--- a/test/python/transpiler/test_add_barrier_before_measuremets.py
+++ b/test/python/transpiler/test_add_barrier_before_measuremets.py
@@ -95,6 +95,7 @@ class TestAddBarrierBeforeMeasuremets(QiskitTestCase):
          q1:--------|--[m]--  -> q1:-------|---|--[m]--
                     |   |                  |   |   |
          c0:--------.---|---      c0:----------.---|---
+                        |                          |
          c1:------------.---      c0:--------------.---
         """
         qr0 = QuantumRegister(1, 'q0')
@@ -151,8 +152,8 @@ class TestAddBarrierBeforeMeasuremets(QiskitTestCase):
     def test_preserve_measure_for_conditional(self):
         """ Test barrier is inserted after any measurements used for conditionals
 
-         q0:--[H]--[m]------------     q0:--[H]--[m]-------|-------
-                    |                             |        |
+         q0:--[H]--[m]------------     q0:--[H]--[m]---------------
+                    |                             |
          q1:--------|--[ z]--[m]--  -> q1:--------|--[ z]--|--[m]--
                     |    |    |                   |    |       |
          c0:--------.--[=1]---|---     c0:--------.--[=1]------|---
@@ -211,11 +212,11 @@ class TestAddBarrierBeforeMeasuremetsWhenABarrierIsAlreadyThere(QiskitTestCase):
 
     def test_remove_barrier_in_different_qregs(self):
         """ Two measurements in different qregs to the same creg
-                                     |
+
          q0:--|--[m]------     q0:---|--[m]------
-                  |                  |   |
+                  |                      |
          q1:--|---|--[m]--  -> q1:---|---|--[m]--
-                  |   |              |   |   |
+                  |   |                  |   |
          c0:------.---|---     c0:-------.---|---
             ----------.---        -----------.---
         """
@@ -231,8 +232,99 @@ class TestAddBarrierBeforeMeasuremetsWhenABarrierIsAlreadyThere(QiskitTestCase):
 
         expected = QuantumCircuit(qr0, qr1, cr0)
         expected.barrier(qr0, qr1)
+        expected.barrier(qr0)
+        expected.barrier(qr1)
         expected.measure(qr0, cr0[0])
         expected.measure(qr1, cr0[1])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
+    def test_should_not_remove_adjacent_barriers(self):
+        """ If an existing but non-equivalent barrier exists, maintain it in the output dag.
+
+         q:---[H]--|--[m]--------     q:---[H]--|--|--[m]--------
+           ---[H]------|---[m]---  ->   ---[H]--|------|---[m]---
+                       |    |                          |    |
+         c:------------.----|----     c:---------------.----|---
+           -----------------.----       --------------------.---
+        """
+        qr = QuantumRegister(2, 'q')
+        cr = ClassicalRegister(2, 'c')
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.h(qr)
+        circuit.barrier(qr[0])
+        circuit.measure(qr[0], cr[0])
+        circuit.measure(qr[1], cr[1])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.h(qr)
+        expected.barrier(qr)
+        expected.barrier(qr[0])
+        expected.measure(qr[0], cr[0])
+        expected.measure(qr[1], cr[1])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
+    def test_preserve_barriers_for_measurement_ordering(self):
+        """ If the circuit has a barrier to enforce a measurement order, preserve it in the output.
+
+         q:---[m]--|-------     q:---|--[m]--|-------
+           ----|---|--[m]--  ->   ---|---|---|--[m]--
+               |       |                 |       |
+         c:----.-------|---     c:-------.-------|---
+           ------------.---       ---------------.---
+        """
+        qr = QuantumRegister(2, 'q')
+        cr = ClassicalRegister(2, 'c')
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.measure(qr[0], cr[0])
+        circuit.barrier(qr)
+        circuit.measure(qr[1], cr[1])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.barrier(qr)
+        expected.measure(qr[0], cr[0])
+        expected.barrier(qr)
+        expected.measure(qr[1], cr[1])
+
+        pass_ = BarrierBeforeFinalMeasurements()
+        result = pass_.run(circuit_to_dag(circuit))
+
+        self.assertEqual(result, circuit_to_dag(expected))
+
+    def test_measures_followed_by_barriers_should_be_final(self):
+        """ If a measurement is followed only by a barrier, insert the barrier before it.
+
+         q:---[H]--|--[m]--|-------     q:---[H]--|--[m]-|-------
+           ---[H]--|---|---|--[m]--  ->   ---[H]--|---|--|--[m]--
+                       |       |                      |      |
+         c:------------.-------|---     c:------------.------|---
+           --------------------.---       -------------------.---
+        """
+        qr = QuantumRegister(2, 'q')
+        cr = ClassicalRegister(2, 'c')
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.h(qr)
+        circuit.barrier(qr)
+        circuit.measure(qr[0], cr[0])
+        circuit.barrier(qr)
+        circuit.measure(qr[1], cr[1])
+
+        expected = QuantumCircuit(qr, cr)
+        expected.h(qr)
+        expected.barrier(qr)
+        expected.measure(qr[0], cr[0])
+        expected.barrier(qr)
+        expected.measure(qr[1], cr[1])
 
         pass_ = BarrierBeforeFinalMeasurements()
         result = pass_.run(circuit_to_dag(circuit))

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -12,7 +12,6 @@ from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.mapper import CouplingMap
 from qiskit.converters import circuit_to_dag
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
-from qiskit.transpiler import PassManager, transpile_dag
 from qiskit.test import QiskitTestCase
 
 
@@ -35,15 +34,11 @@ class TestLookaheadSwap(QiskitTestCase):
         # Create coupling map which contains all two-qubit gates in the circuit.
         coupling_map = CouplingMap([[0, 1], [0, 2]])
 
-        pass_manager = PassManager()
-        pass_manager.append(LookaheadSwap(coupling_map))
-        mapped_dag = transpile_dag(original_dag, pass_manager=pass_manager)
+        mapped_dag = LookaheadSwap(coupling_map).run(original_dag)
 
         self.assertEqual(original_dag, mapped_dag)
 
-        second_pass_manager = PassManager()
-        second_pass_manager.append(LookaheadSwap(coupling_map))
-        remapped_dag = transpile_dag(mapped_dag, pass_manager=second_pass_manager)
+        remapped_dag = LookaheadSwap(coupling_map).run(mapped_dag)
 
         self.assertEqual(mapped_dag, remapped_dag)
 
@@ -61,9 +56,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         coupling_map = CouplingMap([[0, 1], [1, 2]])
 
-        pass_manager = PassManager()
-        pass_manager.append([LookaheadSwap(coupling_map)])
-        mapped_dag = transpile_dag(dag_circuit, pass_manager=pass_manager)
+        mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
         self.assertEqual(mapped_dag.count_ops().get('swap', 0),
                          dag_circuit.count_ops().get('swap', 0) + 1)
@@ -89,9 +82,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         coupling_map = CouplingMap([[0, 1], [1, 2]])
 
-        pass_manager = PassManager()
-        pass_manager.append([LookaheadSwap(coupling_map)])
-        mapped_dag = transpile_dag(dag_circuit, pass_manager=pass_manager)
+        mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
         self.assertEqual(mapped_dag.count_ops().get('swap', 0),
                          dag_circuit.count_ops().get('swap', 0) + 1)
@@ -118,9 +109,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         coupling_map = CouplingMap([[0, 1], [1, 2]])
 
-        pass_manager = PassManager()
-        pass_manager.append([LookaheadSwap(coupling_map)])
-        mapped_dag = transpile_dag(dag_circuit, pass_manager=pass_manager)
+        mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
         mapped_measure_qargs = set(mapped_dag.multi_graph.nodes(data=True)[op]['qargs'][0]
                                    for op in mapped_dag.get_named_nodes('measure'))
@@ -150,9 +139,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         coupling_map = CouplingMap([[0, 1], [1, 2]])
 
-        pass_manager = PassManager()
-        pass_manager.append([LookaheadSwap(coupling_map)])
-        mapped_dag = transpile_dag(dag_circuit, pass_manager=pass_manager)
+        mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
         mapped_barrier_qargs = [set(mapped_dag.multi_graph.nodes(data=True)[op]['qargs'])
                                 for op in mapped_dag.get_named_nodes('barrier')][0]


### PR DESCRIPTION
Fixes #1709 by including barriers as ops to be re-inserted in the DAG after the new barrier. Also, removes the existing logic to consolidate barriers (this can be re-added, but probably as a separate pass).
