### PR TITLE
Move purity function to quantum_information namespace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Added
 - Added a RunConfig object for configurations for run configurations to be used 
   in compile and circuits_to_qobj. (#1629)
 - Added support for register slicing when applying operations to a register (#1643).
+- Added function for purity of a mixed state in ``qiskit.quantum_information``
+  (#1733)
 
 Changed
 -------
@@ -53,6 +55,8 @@ Changed
   ``ModelValidationError`` (#1695).
 - The default transpile pipeline will now add a barrier before the set of
   final measurements when compiling for both simulators and devices (#1591).
+- Purity function in ``qiskit.tools.qi.qi`` calls new version in
+  ``qiskit.quantum_information`` and issues deprecation warning (#1733)
 
 Fixed
 -----

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -8,6 +8,6 @@
 """Quantum Information  methods."""
 
 from .operators.pauli import Pauli, pauli_group
-from .states._states import basis_state, random_state, projector
+from .states._states import basis_state, random_state, projector, purity
 from .states._measures import state_fidelity
 from .operators._measures import process_fidelity

--- a/qiskit/quantum_info/states/_states.py
+++ b/qiskit/quantum_info/states/_states.py
@@ -72,3 +72,17 @@ def projector(state, flatten=False):
     if flatten:
         return density_matrix.flatten(order='F')
     return density_matrix
+
+
+def purity(state):
+    """Calculate the purity of a quantum state.
+
+    Args:
+        state (ndarray): a quantum state
+    Returns:
+        float: purity.
+    """
+    rho = np.array(state)
+    if rho.ndim == 1:
+        return 1.0
+    return np.real(np.trace(rho.dot(rho)))

--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -15,6 +15,7 @@ over time.
 """
 
 import math
+import warnings
 
 import numpy as np
 import scipy.linalg as la
@@ -23,6 +24,7 @@ from scipy.stats import unitary_group
 
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info import pauli_group
+from qiskit.quantum_info import purity as new_purity
 
 
 ###############################################################
@@ -435,10 +437,11 @@ def purity(state):
     Returns:
         float: purity.
     """
-    rho = np.array(state)
-    if rho.ndim == 1:
-        rho = outer(rho)
-    return np.real(np.trace(rho.dot(rho)))
+    warnings.warn('The purity() function in qiskit.tools.qi has been '
+                  'deprecated and will be removed in the future. Instead use '
+                  'the purity() function in qiskit.quantum_info',
+                  DeprecationWarning)
+    return new_purity(state)
 
 
 def concurrence(state):

--- a/test/python/quantum_info/test_states.py
+++ b/test/python/quantum_info/test_states.py
@@ -16,6 +16,7 @@ from qiskit import execute, QuantumRegister, QuantumCircuit, BasicAer
 from qiskit.quantum_info import basis_state, random_state
 from qiskit.quantum_info import state_fidelity
 from qiskit.quantum_info import projector
+from qiskit.quantum_info import purity
 from qiskit.test import QiskitTestCase
 
 
@@ -96,6 +97,60 @@ class TestStates(QiskitTestCase):
         backend = BasicAer.get_backend('statevector_simulator')
         qc_state = execute(qc, backend).result().get_statevector(qc)
         self.assertAlmostEqual(state_fidelity(qc_state, state), 1.0, places=7)
+
+    def test_purity_list_input(self):
+        rho1 = [[1, 0], [0, 0]]
+        rho2 = [[0.5, 0], [0, 0.5]]
+        rho3 = 0.7 * np.array(rho1) + 0.3 * np.array(rho2)
+        test_pass = (purity(rho1) == 1.0 and
+                     purity(rho2) == 0.5 and
+                     round(purity(rho3), 10) == 0.745)
+        self.assertTrue(test_pass)
+
+    def test_purity_1d_list_input(self):
+        input_state = [1, 0]
+        res = purity(input_state)
+        self.assertEqual(1, res)
+
+    def test_purity_basis_state_input(self):
+        state_1 = basis_state('0', 1)
+        state_2 = basis_state('11', 2)
+        state_3 = basis_state('010', 3)
+        self.assertEqual(purity(state_1), 1.0)
+        self.assertEqual(purity(state_2), 1.0)
+        self.assertEqual(purity(state_3), 1.0)
+
+    def test_purity_pure_state(self):
+        state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
+        state_2 = (1/np.sqrt(3))*(basis_state('00', 2)
+                                  + basis_state('01', 2) + basis_state('11', 2))
+        state_3 = 0.5*(basis_state('000', 3) + basis_state('001', 3)
+                       + basis_state('010', 3) + basis_state('100', 3))
+        self.assertEqual(purity(state_1), 1.0)
+        self.assertEqual(purity(state_2), 1.0)
+        self.assertEqual(purity(state_3), 1.0)
+
+    def test_purity_pure_matrix_state(self):
+        state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
+        state_1 = projector(state_1)
+        state_2 = (1/np.sqrt(3))*(basis_state('00', 2)
+                                  + basis_state('01', 2) + basis_state('11', 2))
+        state_2 = projector(state_2)
+        state_3 = 0.5*(basis_state('000', 3) + basis_state('001', 3)
+                       + basis_state('010', 3) + basis_state('100', 3))
+        state_3 = projector(state_3)
+        self.assertAlmostEqual(purity(state_1), 1.0, places=10)
+        self.assertAlmostEqual(purity(state_2), 1.0, places=10)
+        self.assertEqual(purity(state_3), 1.0)
+
+    def test_purity_mixed_state(self):
+        state_1 = 0.5*(projector(basis_state('0', 1))
+                       + projector(basis_state('1', 1)))
+        state_2 = (1/3.0)*(projector(basis_state('00', 2))
+                           + projector(basis_state('01', 2))
+                           + projector(basis_state('10', 2)))
+        self.assertEqual(purity(state_1), 0.5)
+        self.assertEqual(purity(state_2), 1.0/3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The purity function in ``qiskit.tools.qi.qi`` has been moved to ``qiskit.quantum_information`` as per #1219

### Details and comments

Issue #1219 calls for the ``qiskit.tools.qi.qi.purity`` to be moved into the new ``quantum_information`` namespace as well as the addition of a "real test" for this function. I have implemented this change and written a few tests for the purity function. The old purity function in ``qiskit.tools.qi.qi`` now calls the new function and issues a deprecation warning.
