### PR TITLE
Update coupling distance and computing of random scalings in Stochastic mapper

### DIFF
--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -173,7 +173,7 @@ class StochasticSwap(TransformationPass):
         best_layout = None  # initialize best final layout
 
         cdist2 = coupling._dist_matrix**2
-        #scaling matrix
+        # Scaling matrix
         scale = np.zeros((num_qubits, num_qubits))
         utri_idx = np.triu_indices(num_qubits)
         for trial in range(trials):
@@ -188,7 +188,7 @@ class StochasticSwap(TransformationPass):
             data = 1 + np.random.normal(0, 1/num_qubits,
                                         size=num_qubits*(num_qubits+1)//2)
             scale[utri_idx] = data
-            xi = (scale+scale.T)*cdist2 # pylint: disable=invalid-name
+            xi = (scale+scale.T)*cdist2  # pylint: disable=invalid-name
 
             slice_circuit = DAGCircuit()  # circuit for this swap slice
             for register in trial_layout.get_virtual_bits().keys():

--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -171,6 +171,11 @@ class StochasticSwap(TransformationPass):
         best_depth = inf  # initialize best depth
         best_circuit = None  # initialize best swap circuit
         best_layout = None  # initialize best final layout
+
+        cdist2 = coupling._dist_matrix**2
+        #scaling matrix
+        scale = np.zeros((num_qubits, num_qubits))
+        utri_idx = np.triu_indices(num_qubits)
         for trial in range(trials):
             logger.debug("layer_permutation: trial %s", trial)
             trial_layout = layout.copy()
@@ -180,14 +185,10 @@ class StochasticSwap(TransformationPass):
                     trial_circuit.add_qreg(register[0])
 
             # Compute randomized distance
-            xi = {}  # pylint: disable=invalid-name
-            for i in range(num_qubits):
-                xi[i] = {}
-            for i in range(num_qubits):
-                for j in range(i, num_qubits):
-                    scale = 1 + np.random.normal(0, 1 / num_qubits)
-                    xi[i][j] = scale * coupling.distance(i, j) ** 2
-                    xi[j][i] = xi[i][j]
+            data = 1 + np.random.normal(0, 1/num_qubits,
+                                        size=num_qubits*(num_qubits+1)//2)
+            scale[utri_idx] = data
+            xi = (scale+scale.T)*cdist2 # pylint: disable=invalid-name
 
             slice_circuit = DAGCircuit()  # circuit for this swap slice
             for register in trial_layout.get_virtual_bits().keys():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
- Coupling map distance is now numpy array.
- All random scalings in Stochastic mapper are computed at once (50x+ faster).


### Details and comments


