### PR TITLE
Layout object simplification

### DIFF
--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -91,7 +91,7 @@ class Layout(dict):
             'The element %s should be a (Register, integer) tuple or an integer' % (thing,))
 
     def __len__(self):
-        return max([key for key in self.keys() if isinstance(key, int)], default=-1) + 1
+        return dict.__len__(self) // 2
 
     # Override dict's built-in copy method which would return a dict instead of a Layout.
     def copy(self):
@@ -116,7 +116,10 @@ class Layout(dict):
             physical_bit (int): A physical bit. For example, 3.
         """
         if physical_bit is None:
-            physical_bit = len(self)
+            physical_candidate = len(self)
+            while self.get(physical_candidate) is not None:
+                physical_candidate += 1
+            physical_bit = physical_candidate
         self[virtual_bit] = physical_bit
 
     def add_register(self, reg):
@@ -136,29 +139,12 @@ class Layout(dict):
         """
         return list(self.get_virtual_bits().keys())
 
-    def set_length(self, amount_of_physical_bits):
-        """
-        Extends the layout length to `amount_of_physical_bits`.
-        Args:
-            amount_of_physical_bits (int): The amount of physical_qubits to
-            set in the layout.
-        Raises:
-            LayoutError: If amount_of_physical_bits is used to reduced the
-            length instead of extending it.
-        """
-        current_length = len(self)
-        if amount_of_physical_bits < current_length:
-            raise LayoutError('Lenght setting cannot be smaller than the current amount of physical'
-                              ' (qu)bits.')
-        for new_physical_bit in range(current_length, amount_of_physical_bits):
-            self[new_physical_bit] = None
-
     def idle_physical_bits(self):
         """
         Returns a list of physical (qu)bits that are not mapped to a virtual (qu)bit.
         """
         idle_physical_bit_list = []
-        for physical_bit in range(self.__len__()):
+        for physical_bit in self.get_physical_bits():
             if self[physical_bit] is None:
                 idle_physical_bit_list.append(physical_bit)
         return idle_physical_bit_list

--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -49,17 +49,22 @@ class Layout():
             input_list (list): For example,
             [(QuantumRegister(3, 'qr'), 0), None,
              (QuantumRegister(3, 'qr'), 2), (QuantumRegister(3, 'qr'), 3)]
+
+        Raises:
+            LayoutError: If the elements are not (Register, integer) or None
         """
         for physical, virtual in enumerate(input_list):
             if Layout.is_virtual(virtual):
                 self._set_type_checked_item(virtual, physical)
+            else:
+                raise LayoutError("The list should contain elements of the form"
+                                  " (Register, integer) or None")
 
     @staticmethod
     def is_virtual(value):
         """Checks if value has the format of a virtual qubit """
-        return value is None or isinstance(value, tuple) and \
-               len(value) == 2 and \
-               isinstance(value[0], Register) and isinstance(value[1], int)
+        return value is None or isinstance(value, tuple) and len(value) == 2 and isinstance(
+            value[0], Register) and isinstance(value[1], int)
 
     def __getitem__(self, item):
         if item in self._p2v:
@@ -82,10 +87,10 @@ class Layout():
         self._set_type_checked_item(virtual, physical)
 
     def _set_type_checked_item(self, virtual, physical):
-        if physical in self._p2v:
-            del self._p2v[physical]
-        if virtual in self._p2v:
-            del self._v2p[virtual]
+        old = self._v2p.pop(virtual, None)
+        self._p2v.pop(old, None)
+        old = self._p2v.pop(physical, None)
+        self._v2p.pop(old, None)
 
         self._p2v[physical] = virtual
         if virtual is not None:

--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -51,12 +51,6 @@ class Layout(dict):
         for key, value in enumerate(input_list):
             self[key] = value
 
-    def __getitem__(self, item):
-        # N.B. Layout.__len__ is O(layout size). Short circuit early when possible.
-        if isinstance(item, int) and item not in self and item < len(self):
-            return None
-        return dict.__getitem__(self, item)
-
     def __setitem__(self, key, value):
         Layout._checktype(key)
         Layout._checktype(value)

--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -12,7 +12,6 @@ Layout is the relation between virtual (qu)bits and physical (qu)bits.
 Virtual (qu)bits are tuples (eg, `(QuantumRegister(3, 'qr'),2)`.
 Physical (qu)bits are numbers.
 """
-from copy import deepcopy
 from qiskit.mapper.exceptions import LayoutError
 from qiskit.circuit.register import Register
 
@@ -109,8 +108,9 @@ class Layout():
 
     def copy(self):
         layout_copy = type(self)()
-        layout_copy._p2v = deepcopy(self._p2v)
-        layout_copy._v2p = deepcopy(self._v2p)
+
+        layout_copy._p2v = self._p2v.copy()
+        layout_copy._v2p = self._v2p.copy()
 
         return layout_copy
 

--- a/qiskit/mapper/_layout.py
+++ b/qiskit/mapper/_layout.py
@@ -56,6 +56,7 @@ class Layout():
 
     @staticmethod
     def is_virtual(value):
+        """Checks if value has the format of a virtual qubit """
         return value is None or isinstance(value, tuple) and \
                len(value) == 2 and \
                isinstance(value[0], Register) and isinstance(value[1], int)
@@ -107,6 +108,7 @@ class Layout():
         return len(self._p2v)
 
     def copy(self):
+        """Returns a copy of a Layout instance."""
         layout_copy = type(self)()
 
         layout_copy._p2v = self._p2v.copy()

--- a/qiskit/transpiler/passes/mapping/basic_swap.py
+++ b/qiskit/transpiler/passes/mapping/basic_swap.py
@@ -13,8 +13,6 @@ a cx is not in the coupling map possibilities, it inserts one or more swaps in f
 compatible.
 """
 
-from copy import copy
-
 from qiskit.transpiler._basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.mapper import Layout
@@ -59,7 +57,7 @@ class BasicSwap(TransformationPass):
             else:
                 self.initial_layout = Layout.generate_trivial_layout(*dag.qregs.values())
 
-        current_layout = copy(self.initial_layout)
+        current_layout = self.initial_layout.copy()
 
         for layer in dag.serial_layers():
             subdag = layer['graph']

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -79,24 +79,18 @@ class LayoutTest(QiskitTestCase):
         """Length of the layout is the amount of physical bits"""
         layout = Layout()
         self.assertEqual(len(layout), 0)
-        layout.add((self.qr, 0))
+        layout.add((self.qr, 2))
         self.assertEqual(len(layout), 1)
         layout.add((self.qr, 1), 3)
-        self.assertEqual(len(layout), 4)
-
-    def test_layout_set_len(self):
-        """Length setter"""
-        layout = Layout()
-        layout.add((self.qr, 1), 3)
-        layout.set_length(4)
-        self.assertEqual(len(layout), 4)
+        self.assertEqual(len(layout), 2)
 
     def test_layout_idle_physical_bits(self):
         """Get physical_bits that are not mapped"""
         layout = Layout()
         layout.add((self.qr, 1), 2)
-        layout.set_length(4)
-        self.assertEqual(layout.idle_physical_bits(), [0, 1, 3])
+        layout.add(None, 4)
+        layout.add(None, 6)
+        self.assertEqual(layout.idle_physical_bits(), [4, 6])
 
     def test_layout_get_bits(self):
         """Get the map from the (qu)bits view"""
@@ -172,6 +166,14 @@ class LayoutTest(QiskitTestCase):
 
         edge_map = layout.combine_into_edge_map(another_layout)
         self.assertDictEqual(edge_map, {(self.qr, 0): (self.qr, 1), (self.qr, 1): (self.qr, 0)})
+
+    def test_set_virtual_without_physical(self):
+        """When adding a virtual without care in which physical is going"""
+        layout = Layout()
+        layout.add((self.qr, 1), 2)
+        layout.add((self.qr, 0))
+
+        self.assertDictEqual(layout.get_virtual_bits(), {(self.qr, 0): 1, (self.qr, 1): 2})
 
     def test_layout_combine_smaller(self):
         """combine_into_edge_map() method with another_layout is smaller and raises an Error"""

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -93,7 +93,6 @@ class LayoutTest(QiskitTestCase):
         layout.add((self.qr, 1), 3)
         self.assertEqual(len(layout), 2)
 
-
     def test_layout_idle_physical_bits(self):
         """Get physical_bits that are not mapped"""
         layout = Layout()

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -141,7 +141,7 @@ class LayoutTest(QiskitTestCase):
         layout[(self.qr, 0)] = 1
 
         with self.assertRaises(KeyError):
-            layout[0]
+            _ = layout[0]
 
     def test_virtual_keyerror(self):
         """When asking for an unexistant virtual qubit, KeyError"""
@@ -149,7 +149,7 @@ class LayoutTest(QiskitTestCase):
         layout[(self.qr, 0)] = 1
 
         with self.assertRaises(KeyError):
-            layout[(self.qr, 1)]
+            _ = layout[(self.qr, 1)]
 
     def test_layout_swap(self):
         """swap() method"""

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -75,6 +75,22 @@ class LayoutTest(QiskitTestCase):
         self.assertEqual(layout[(self.qr, 0)], 0)
         self.assertEqual(layout[0], (self.qr, 0))
 
+    def test_layout_avoid_dangling_physical(self):
+        """ No dangling pointers for physical qubits."""
+        layout = Layout({(self.qr, 0): 0})
+        self.assertEqual(layout[0], (self.qr, 0))
+        layout[(self.qr, 0)] = 1
+        with self.assertRaises(KeyError):
+            _ = layout[0]
+
+    def test_layout_avoid_dangling_virtual(self):
+        """ No dangling pointers for virtual qubits."""
+        layout = Layout({(self.qr, 0): 0})
+        self.assertEqual(layout[0], (self.qr, 0))
+        layout[0] = (self.qr, 1)
+        with self.assertRaises(KeyError):
+            print(layout[(self.qr, 0)])
+
     def test_layout_len(self):
         """Length of the layout is the amount of physical bits"""
         layout = Layout()

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -134,6 +134,14 @@ class LayoutTest(QiskitTestCase):
         with self.assertRaises(KeyError):
             layout[0]
 
+    def test_virtual_keyerror(self):
+        """When asking for an unexistant virtual qubit, KeyError"""
+        layout = Layout()
+        layout[(self.qr, 0)] = 1
+
+        with self.assertRaises(KeyError):
+            layout[(self.qr, 1)]
+
     def test_layout_swap(self):
         """swap() method"""
         layout = Layout()

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -84,6 +84,16 @@ class LayoutTest(QiskitTestCase):
         layout.add((self.qr, 1), 3)
         self.assertEqual(len(layout), 2)
 
+    def test_layout_len_with_idle(self):
+        """Length of the layout is the amount of physical bits"""
+        layout = Layout()
+        self.assertEqual(len(layout), 0)
+        layout.add((self.qr, 2))
+        self.assertEqual(len(layout), 1)
+        layout.add((self.qr, 1), 3)
+        self.assertEqual(len(layout), 2)
+
+
     def test_layout_idle_physical_bits(self):
         """Get physical_bits that are not mapped"""
         layout = Layout()
@@ -212,15 +222,18 @@ class LayoutTest(QiskitTestCase):
 
         layout_dict_copy = layout.copy()
         self.assertTrue(isinstance(layout_dict_copy, Layout))
-        self.assertDictEqual(layout, layout_dict_copy)
+        self.assertDictEqual(layout.get_physical_bits(), layout_dict_copy.get_physical_bits())
+        self.assertDictEqual(layout.get_virtual_bits(), layout_dict_copy.get_virtual_bits())
 
         layout_copy_copy = copy.copy(layout)
         self.assertTrue(isinstance(layout_copy_copy, Layout))
-        self.assertDictEqual(layout, layout_copy_copy)
+        self.assertDictEqual(layout.get_physical_bits(), layout_dict_copy.get_physical_bits())
+        self.assertDictEqual(layout.get_virtual_bits(), layout_dict_copy.get_virtual_bits())
 
         layout_copy_deepcopy = copy.deepcopy(layout)
         self.assertTrue(isinstance(layout_copy_deepcopy, Layout))
-        self.assertDictEqual(layout, layout_copy_deepcopy)
+        self.assertDictEqual(layout.get_physical_bits(), layout_dict_copy.get_physical_bits())
+        self.assertDictEqual(layout.get_virtual_bits(), layout_dict_copy.get_virtual_bits())
 
     def test_layout_error_str_key(self):
         """Layout does not work with strings"""

--- a/test/python/test_layout.py
+++ b/test/python/test_layout.py
@@ -126,6 +126,14 @@ class LayoutTest(QiskitTestCase):
         self.assertEqual(layout[(QuantumRegister(2, 'q0'), 1)], 1)
         self.assertEqual(layout[(QuantumRegister(1, 'q1'), 0)], 2)
 
+    def test_physical_keyerror(self):
+        """When asking for an unexistant physical qubit, KeyError"""
+        layout = Layout()
+        layout[(self.qr, 0)] = 1
+
+        with self.assertRaises(KeyError):
+            layout[0]
+
     def test_layout_swap(self):
         """swap() method"""
         layout = Layout()


### PR DESCRIPTION
The layout object is going to be used as a way to define which part of the coupling map is going to be used for the mappers in general, and the swappers in particular.

This means, if you are using physical qubit 2, they assumption should not be that physical qubits 0 and 1 are available. This PR fixes that and, by that, simplifies the object structure.