### PR TITLE
Add "make test_ci" target for CIs, simplify "make test"

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -260,6 +260,10 @@ The order of precedence in the options is right to left. For example,
 ``QISKIT_TESTS=skip_online,rec`` will set the options as
 ``skip_online == False`` and ``rec == True``.
 
+Alternatively, the ``make test_ci`` target can be used instead of ``make test``
+in order to run in a setup that replicates the configuration we used in our
+CI systems more closely.
+
 Style guide
 ~~~~~~~~~~~
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ stage_generic: &stage_generic
     - pip install qiskit-ibmq-provider
   script:
     # Compile the executables and run the tests.
-    - make test
+    - make test_ci
 
 stage_linux: &stage_linux
   <<: *stage_generic

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-.PHONY: env lint test doc test_record test_mock
+.PHONY: env lint test doc test_record test_mock test_ci
 
 # Dependencies need to be installed on the Anaconda virtual environment.
 env:
@@ -24,21 +24,23 @@ style:
 # Use the -s (starting directory) flag for "unittest discover" is necessary,
 # otherwise the QuantumCircuit header will be modified during the discovery.
 test:
-	stestr run --concurrency 2
+	python3 -m unittest discover -s test -v
 
 test_mock:
-	env QISKIT_TESTS=mock_online stestr run --concurrency 2
+	env QISKIT_TESTS=mock_online python3 -m unittest discover -s test -v
 
 test_recording:
 	-rm test/cassettes/*
-	env QISKIT_TESTS=rec stestr run --concurrency 2
+	env QISKIT_TESTS=rec python3 -m unittest discover -s test -v
+
+test_ci:
+	stestr run --concurrency 2
 
 profile:
-	stestr run "profile*" --concurrency 2
+	python3 -m unittest discover -p "profile*.py" -v
 
 coverage:
-	PYTHON="coverage3 run --source qiskit --parallel-mode" stestr run --concurrency 2
-	coverage3 combine
+	coverage3 run --source qiskit -m unittest discover -s test -q
 	coverage3 report
 
 doc:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After the recent conversations among the "CI taskforce", this PR:
* introduces a `make test_ci` target used by the CIs
* reverts the `make test` command to its original implementation (ie using unittest directly)


### Details and comments

This hopefully preserves the original intent for the `make test` command (as in, keep it as "an as simple and close to python as possible, one time command that does not involve extra tools"), aimed at helping contributors starting out; and at the same time the new `make test_ci` command helps us being able to mimic the CIs a bit more faithfully.

