### PR TITLE
Only copy Layout when needed

### DIFF
--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -234,7 +234,7 @@ class StochasticSwap(TransformationPass):
                                 optimal_qubits = qubits
                                 need_copy = True
                             else:
-                                new_layout.swap(edge[1], edge[0])
+                                new_layout.swap(edge[0], edge[1])
 
 
                     # Were there any good swap choices?

--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -204,7 +204,7 @@ class StochasticSwap(TransformationPass):
                 # While there are still qubits available
                 while qubit_set:
                     # Compute the objective function
-                    min_cost = sum([xi[trial_layout[g[0]]][trial_layout[g[1]]] for g in gates])
+                    min_cost = sum(xi[trial_layout[g[0]]][trial_layout[g[1]]] for g in gates)
                     # Try to decrease objective function
                     cost_reduced = False
 
@@ -218,7 +218,7 @@ class StochasticSwap(TransformationPass):
                             new_layout.swap(edge[0], edge[1])
 
                             # Compute the objective function
-                            new_cost = sum([xi[new_layout[g[0]]][new_layout[g[1]]] for g in gates])
+                            new_cost = sum(xi[new_layout[g[0]]][new_layout[g[1]]] for g in gates)
                             # Record progress if we succceed
                             if new_cost < min_cost:
                                 logger.debug("layer_permutation: min_cost "
@@ -246,9 +246,9 @@ class StochasticSwap(TransformationPass):
                 # failed to improve the cost.
 
                 # Compute the coupling graph distance
-                dist = sum([coupling.distance(trial_layout[g[0]],
-                                              trial_layout[g[1]])
-                            for g in gates])
+                dist = sum(coupling.distance(trial_layout[g[0]],
+                                             trial_layout[g[1]])
+                           for g in gates)
                 logger.debug("layer_permutation: new swap distance = %s", dist)
                 # If all gates can be applied now, we are finished.
                 # Otherwise we need to consider a deeper swap circuit
@@ -263,9 +263,9 @@ class StochasticSwap(TransformationPass):
                 logger.debug("layer_permutation: increment depth to %s", depth_step)
 
             # Either we have succeeded at some depth d < dmax or failed
-            dist = sum([coupling.distance(trial_layout[g[0]],
-                                          trial_layout[g[1]])
-                        for g in gates])
+            dist = sum(coupling.distance(trial_layout[g[0]],
+                                         trial_layout[g[1]])
+                       for g in gates)
             logger.debug("layer_permutation: final distance for this trial = %s", dist)
             if dist == len(gates):
                 if depth_step < best_depth:

--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -230,12 +230,12 @@ class StochasticSwap(TransformationPass):
                                 cost_reduced = True
                                 min_cost = new_cost
                                 optimal_layout = new_layout
-                                optimal_edge = [self.initial_layout[q] for q in edge]
+                                optimal_edge = (self.initial_layout[edge[0]],
+                                                self.initial_layout[edge[1]])
                                 optimal_qubits = qubits
                                 need_copy = True
                             else:
                                 new_layout.swap(edge[0], edge[1])
-
 
                     # Were there any good swap choices?
                     if cost_reduced:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
It is 4x faster to undo a swap than it is to copy a `Layout` so only do so when needed.  For the 20x5 QV test this brings the time down from 30 -> 22 sec.


### Details and comments


