### PR TITLE
Adding support for 2-or-moreQ gates in the text drawer 

### DIFF
--- a/qiskit/tools/visualization/_text.py
+++ b/qiskit/tools/visualization/_text.py
@@ -215,11 +215,13 @@ class BoxOnQuWireMid(MultiBox, BoxOnQuWire):
 class BoxOnQuWireBot(MultiBox, BoxOnQuWire):
     """ Draws the bottom part of a box that affects more than one quantum wire"""
 
-    def __init__(self, label, input_length):
+    def __init__(self, label, input_length, bot_connect='─'):
         super().__init__(label)
         self.top_format = "│ %s │"
+        self.top_pad = " "
+        self.bot_connect = bot_connect
 
-        self.mid_content = self.bot_connect = self.top_connect = ""
+        self.mid_content = self.top_connect = ""
         if input_length <= 2:
             self.top_connect = label
 
@@ -755,9 +757,9 @@ class TextDrawing():
                 layer.set_qubit(instruction['qargs'][0],
                                 BoxOnQuWire(TextDrawing.label_for_box(instruction)))
 
-            elif len(instruction['qubits']) >= 2 and not instruction['cargs']:
+            elif len(instruction['qargs']) >= 2 and not instruction['cargs']:
                 # multiple qubit gate
-                layer.set_qu_multibox(instruction['qubits'], TextDrawing.label_for_box(instruction))
+                layer.set_qu_multibox(instruction['qargs'], TextDrawing.label_for_box(instruction))
 
             else:
                 raise VisualizationError(
@@ -876,7 +878,8 @@ class Layer:
         affected_bits[0].connect(wire_char, ['bot'])
         for affected_bit in affected_bits[1:-1]:
             affected_bit.connect(wire_char, ['bot', 'top'])
-        affected_bits[-1].connect(wire_char, ['top'], label)
+        if not isinstance(affected_bits[-1], MultiBox):
+            affected_bits[-1].connect(wire_char, ['top'], label)
 
         if label:
             for affected_bit in affected_bits:

--- a/test/python/tools/visualization/test_circuit_text_drawer.py
+++ b/test/python/tools/visualization/test_circuit_text_drawer.py
@@ -379,6 +379,21 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
         circuit.ch(qr[2], qr[0])
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
+    def test_text_rzz(self):
+        """ rzz drawing. """
+        expected = '\n'.join(["        ┌────────┐               ",
+                              "q_0: |0>┤        ├───────────────",
+                              "        │ Rzz(0) │┌─────────────┐",
+                              "q_1: |0>┤        ├┤             ├",
+                              "        └────────┘│ Rzz(1.5708) │",
+                              "q_2: |0>──────────┤             ├",
+                              "                  └─────────────┘"])
+        qr = QuantumRegister(3, 'q')
+        circuit = QuantumCircuit(qr)
+        circuit.rzz(0, qr[0], qr[1])
+        circuit.rzz(pi / 2, qr[2], qr[1])
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
     def test_text_cu1(self):
         """ cu1 drawing. """
         expected = '\n'.join(["                          ",


### PR DESCRIPTION
Fixes #1733

The following circuit is text drew like this:
```
q = QuantumRegister(2)
qc = QuantumCircuit(q);
qc.rzz(0, q[0], q[1])
```

```
         ┌────────┐
q0_0: |0>┤        ├
         │ Rzz(0) │
q0_1: |0>┤        ├
         └────────┘
```