### PR TITLE
Correct order of instructions when loading OpenQASM

### DIFF
--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -35,9 +35,7 @@ def dag_to_circuit(dag):
     name = dag.name or None
     circuit = QuantumCircuit(*qregs.values(), *cregs.values(), name=name)
 
-    graph = dag.multi_graph
-    for node in nx.topological_sort(graph):
-        n = graph.nodes[node]
+    for _, n in dag.get_op_nodes(data=True):
         if n['type'] == 'op':
             if n['op'].name == 'U':
                 name = 'u_base'

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -7,7 +7,6 @@
 
 """Helper function for converting a dag to a circuit"""
 import collections
-import networkx as nx
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import ClassicalRegister
@@ -35,7 +34,9 @@ def dag_to_circuit(dag):
     name = dag.name or None
     circuit = QuantumCircuit(*qregs.values(), *cregs.values(), name=name)
 
-    for _, n in dag.get_op_nodes(data=True):
+    graph = dag.multi_graph
+    for node in dag.node_nums_in_topological_order():
+        n = graph.nodes[node]
         if n['type'] == 'op':
             if n['op'].name == 'U':
                 name = 'u_base'

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -147,6 +147,7 @@ class LoadFromQasmTest(QiskitTestCase):
         self.assertEqual(len(q_circuit.qregs), 2)
 
     def test_qasm_qas_string_order(self):
+        """ Test that gates are returned in qasm in ascending order"""
         expected_qasm = '\n'.join(["OPENQASM 2.0;",
                                    "include \"qelib1.inc\";",
                                    "qreg q[3];",

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -145,3 +145,18 @@ class LoadFromQasmTest(QiskitTestCase):
         self.assertEqual(q_circuit, expected_circuit)
         self.assertEqual(len(q_circuit.cregs), 2)
         self.assertEqual(len(q_circuit.qregs), 2)
+
+    def test_qasm_qas_string_order(self):
+        expected_qasm = '\n'.join(["OPENQASM 2.0;",
+                                   "include \"qelib1.inc\";",
+                                   "qreg q[3];",
+                                   "h q[0];",
+                                   "h q[1];",
+                                   "h q[2];"]) + '\n'
+        qasm_string = """OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        h q;"""
+        q_circuit = QuantumCircuit.from_qasm_str(qasm_string)
+
+        self.assertEqual(q_circuit.qasm(), expected_qasm)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1753 by using the lexicographical topological sort to order the gates. Added in a test to cover this.

