### PR TITLE
specify basepython in tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
+basepython = python3
 install_command = pip install -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}


### PR DESCRIPTION
### Summary

Specifiy basepython in tox testenv

### Details and comments

For versions of Linux that have both python2 and python3 installed,
tox will use python2 if not specified. This prevents tox targets like
lint from running as the version of pylint is only available for
python3.

This sets basepython for all testenvs to make this work.

