### PR TITLE
a small optimization in parallel compilation cases

### DIFF
--- a/qiskit/transpiler/_transpiler.py
+++ b/qiskit/transpiler/_transpiler.py
@@ -100,6 +100,7 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
         return circuit
 
     dag = circuit_to_dag(circuit)
+    del circuit
 
     # pick a trivial layout if the circuit already satisfies the coupling constraints
     # else layout on the most densely connected physical qubit subset


### PR DESCRIPTION
I'm not an expert here, but it seems that there an advantage in getting rid the pointer to circuit after `_transpilation()` converts it to DAG, specially when there are several instances of `_transpilation()` running in parallel.

For a set of 1000 circuits generated with Randomized Benchmarking from Ignis, compile takes slightly less in my machine:
```
133.00766 segs # without the patch
109.01785 segs # with the patch
```