### PR TITLE
When new passes instances are created, they are not initialized

### DIFF
--- a/qiskit/transpiler/_basepasses.py
+++ b/qiskit/transpiler/_basepasses.py
@@ -27,6 +27,9 @@ class MetaPass(type):
         if hash_ not in cls._pass_cache:
             new_pass = type.__call__(cls, *args, **kwargs)
             cls._pass_cache[hash_] = new_pass
+        else:
+            # rerun init to "restart" the instance.
+            cls._pass_cache[hash_].__init__(*args, **kwargs)
         return cls._pass_cache[hash_]
 
     @staticmethod

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -193,3 +193,19 @@ class PassK_check_fixed_point_property(DummyAP, FixedPoint):
     def run(self, dag):
         for base in PassK_check_fixed_point_property.__bases__:
             base.run(self, dag)
+
+class PassM_AP_NR_NP(DummyAP):
+    """ A dummy analysis pass that modifies self argument.
+    AP: Analysis Pass
+    NR: No Requires
+    NP: No Preserves
+    """
+
+    def __init__(self, argument=None):
+        super().__init__()
+        self.argument = argument
+
+    def run(self, dag):
+        super().run(dag)
+        self.argument = 'bar'
+        return dag

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -194,6 +194,7 @@ class PassK_check_fixed_point_property(DummyAP, FixedPoint):
         for base in PassK_check_fixed_point_property.__bases__:
             base.run(self, dag)
 
+
 class PassM_AP_NR_NP(DummyAP):
     """ A dummy analysis pass that modifies self argument.
     AP: Analysis Pass

--- a/test/python/transpiler/test_generic_pass.py
+++ b/test/python/transpiler/test_generic_pass.py
@@ -11,7 +11,8 @@
 
 import unittest.mock
 from qiskit.test import QiskitTestCase
-from ._dummy_passes import DummyAP, DummyTP, PassA_TP_NR_NP, PassD_TP_NR_NP, PassE_AP_NR_NP
+from ._dummy_passes import DummyAP, DummyTP, PassA_TP_NR_NP, PassD_TP_NR_NP, PassE_AP_NR_NP, \
+    PassM_AP_NR_NP
 
 
 class TestGenericPass(QiskitTestCase):
@@ -68,6 +69,17 @@ class TestGenericPass(QiskitTestCase):
         """ True is 1. They are not the same parameter."""
         self.assertNotEqual(PassE_AP_NR_NP(True), PassE_AP_NR_NP(1))
 
+    def test_self_mofication_is_erased(self):
+        """A new instance should be clean in the attributes set at __init__ time."""
+        pass_one = PassM_AP_NR_NP(argument='foo')
+        self.assertEqual(pass_one.argument, 'foo')
+
+        pass_one.run(None) # modifies self.argument='bar'
+        self.assertEqual(pass_one.argument, 'bar')
+
+        pass_two = PassM_AP_NR_NP(argument='foo')
+        self.assertEqual(pass_one, pass_two)
+        self.assertEqual(pass_two.argument, 'foo')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_generic_pass.py
+++ b/test/python/transpiler/test_generic_pass.py
@@ -74,12 +74,13 @@ class TestGenericPass(QiskitTestCase):
         pass_one = PassM_AP_NR_NP(argument='foo')
         self.assertEqual(pass_one.argument, 'foo')
 
-        pass_one.run(None) # modifies self.argument='bar'
+        pass_one.run(None)  # modifies self.argument='bar'
         self.assertEqual(pass_one.argument, 'bar')
 
         pass_two = PassM_AP_NR_NP(argument='foo')
         self.assertEqual(pass_one, pass_two)
         self.assertEqual(pass_two.argument, 'foo')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We "cache" instances of the passes for equivalence proposes. That means that
```
t = StochasticSwap(coupling, seed=123456);
tt = StochasticSwap(coupling, seed=123456)
```
will run `StochasticSwap.__init__` only once. Some passes (such as `StochasticSwap`) modified `self.initial_layout` during `run()`. This property is initialized in `init` time. Therefore, if you the transpiler runs `run` in between the mentioned two lines, the second instance is modified too.

This PR re runs initialization of the instance when is fetched from the cache and fixes #1769.

On the other hand, I'm not sure the effects of this when there are several instances of the transpiler running in parallel. I remember implementing this cache following @delapuente suggestion. I which we could have a cleaner way to say "passes are immutable, dont touch them".