### PR TITLE
fixes Instruction params getting nested list for reals

### DIFF
--- a/qiskit/qobj/qobj.py
+++ b/qiskit/qobj/qobj.py
@@ -57,7 +57,7 @@ class QobjItem(SimpleNamespace):
         if isinstance(obj, sympy.Symbol):
             return str(obj)
         if isinstance(obj, sympy.Basic):
-            if obj.is_complex:
+            if obj.is_imaginary:
                 return [float(sympy.re(obj)), float(sympy.im(obj))]
             else:
                 return float(obj.evalf())


### PR DESCRIPTION
On some backends Gate parameters get mapped to list of [re, im]. This fix properly tests sympy objects for whether this is needed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


