### PR TITLE
Center histogram labels with multiple executions

### DIFF
--- a/qiskit/tools/visualization/_counts_visualization.py
+++ b/qiskit/tools/visualization/_counts_visualization.py
@@ -74,6 +74,7 @@ def plot_histogram(data, figsize=(7, 5), color=None, number_to_keep=None,
         color = [color]
 
     all_pvalues = []
+    length = len(data)
     for item, execution in enumerate(data):
         if number_to_keep is not None:
             data_temp = dict(Counter(execution).most_common(number_to_keep))
@@ -107,7 +108,8 @@ def plot_histogram(data, figsize=(7, 5), color=None, number_to_keep=None,
                 rects.append(ax.bar(idx+item*width, val, width, label=label,
                                     color=color[item % len(color)],
                                     zorder=2))
-        ax.set_xticks(ind)
+        bar_center = (width / 2) * (length - 1)
+        ax.set_xticks(ind + bar_center)
         ax.set_xticklabels(labels_dict.keys(), fontsize=14, rotation=70)
         # attach some text labels
         if bar_labels:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When we were plotting multiple executions in the histogram plot the
xtick (and label) were being put on the position of the first bar.
However this goes contrary to expectations since the tick is normally
expected in the center of the group of bars for that particular result.
This commit adjusts this by apply an offset to the xtick position to
always keep in centered in the group.

### Details and comments

Fixes #1812
