### PR TITLE
Add qiskit.test facilities for providers and backends

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -304,7 +304,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=self.circuit.*,qc.*,qcs.h,qc1.h,qc2.cx,qc.h,self.u1,self.cx,self.ccx,trial_circuit,requests.codes.ok
+generated-members=self.circuit.*,qc.*,qcs.h,qc1.h,qc2.cx,self.u1,self.cx,self.ccx,trial_circuit,requests.codes.ok
 # self.circuit.*: false positives when self.circuit == QuantumCircuit, as it
 # provides a "__getitem__" dynamic method and gate definition is dynamic.
 # For qiskit.extensions.standard, self.foo is also needed.

--- a/.pylintrc
+++ b/.pylintrc
@@ -304,7 +304,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=self.circuit.*,qcs.h,qc1.h,qc2.cx,qc.h,self.u1,self.cx,self.ccx,trial_circuit,requests.codes.ok
+generated-members=self.circuit.*,qc.*,qcs.h,qc1.h,qc2.cx,qc.h,self.u1,self.cx,self.ccx,trial_circuit,requests.codes.ok
 # self.circuit.*: false positives when self.circuit == QuantumCircuit, as it
 # provides a "__getitem__" dynamic method and gate definition is dynamic.
 # For qiskit.extensions.standard, self.foo is also needed.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,7 +44,8 @@ Changed
 - The ``Exception`` subclasses have been moved to an ``.exceptions`` module
   within each package (for example, ``qiskit.exceptions.QiskitError``) (#1600).
 - The ``QiskitTestCase`` and testing utilities are now included as part of
-  ``qiskit.test`` and thus available for third-party implementations (#1616)
+  ``qiskit.test`` and thus available for third-party implementations, with
+  convenience test cases for providers and backends. (#1616, #1844)
 - The snapshot instruction now takes ``label`` and ``snap_type`` instead of
   ``slot`` (#1615).
 - The test folders have been reorganized to match the python modules (#1625)

--- a/qiskit/test/__init__.py
+++ b/qiskit/test/__init__.py
@@ -9,4 +9,5 @@
 
 from .base import QiskitTestCase
 from .decorators import requires_aer_provider, requires_qe_access, slow_test
+from .reference_circuits import ReferenceCircuits
 from .utils import Path

--- a/qiskit/test/providers/__init__.py
+++ b/qiskit/test/providers/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Base TestCases for provider and backends."""
+
+from .backend import BackendTestCase
+from .provider import ProviderTestCase

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -7,8 +7,9 @@
 
 """Base TestCase for testing backends."""
 
-from qiskit.tools.compiler import compile  # pylint: disable=redefined-builtin
+from unittest import SkipTest
 
+from qiskit.tools.compiler import compile  # pylint: disable=redefined-builtin
 from ..base import QiskitTestCase
 from ..reference_circuits import ReferenceCircuits
 
@@ -31,11 +32,15 @@ class BackendTestCase(QiskitTestCase):
     backend_cls = None
     circuit = ReferenceCircuits.bell()
 
-    __test__ = False
-
     def setUp(self):
         super().setUp()
         self.backend = self._get_backend()
+
+    @classmethod
+    def setUpClass(cls):
+        if cls is BackendTestCase:
+            raise SkipTest('Skipping base class tests')
+        super().setUpClass()
 
     def _get_backend(self):
         """Return an instance of a Provider."""

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -7,7 +7,7 @@
 
 """Base TestCase for testing backends."""
 
-from qiskit.tools import compile
+from qiskit.tools.compiler import compile  # pylint: disable=redefined-builtin
 
 from ..base import QiskitTestCase
 from ..reference_circuits import ReferenceCircuits
@@ -35,7 +35,7 @@ class BackendTestCase(QiskitTestCase):
 
     def _get_backend(self):
         """Return an instance of a Provider."""
-        return self.backend_cls()
+        return self.backend_cls()  # pylint: disable=not-callable
 
     def test_configuration(self):
         """Test backend.configuration()."""

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Base TestCase for testing backends."""
+
+from qiskit.tools import compile
+
+from ..base import QiskitTestCase
+from ..reference_circuits import ReferenceCircuits
+
+
+class BackendTestCase(QiskitTestCase):
+    """Test case for backends.
+
+    Implementers of backends are encouraged to subclass and customize this
+    TestCase, as it contains a "canonical" series of tests in order to ensure
+    the backend functionality matches the specifications.
+
+    Members:
+        backend_cls (BaseBackend): backend to be used in this test case. Its
+            instantiation can be further customized by overriding the
+            ``_get_backend`` function.
+        circuit (QuantumCircuit): circuit to be used for the tests.
+    """
+    backend_cls = None
+    circuit = ReferenceCircuits.bell()
+
+    def setUp(self):
+        super().setUp()
+        self.backend = self._get_backend()
+
+    def _get_backend(self):
+        """Return an instance of a Provider."""
+        return self.backend_cls()
+
+    def test_configuration(self):
+        """Test backend.configuration()."""
+        configuration = self.backend.configuration()
+        return configuration
+
+    def test_properties(self):
+        """Test backend.properties()."""
+        properties = self.backend.properties()
+        if self.backend.configuration().simulator:
+            self.assertEqual(properties, None)
+        return properties
+
+    def test_status(self):
+        """Test backend.status()."""
+        status = self.backend.status()
+        return status
+
+    def test_run_circuit(self):
+        """Test running a single circuit."""
+        qobj = compile(self.circuit, self.backend)
+        job = self.backend.run(qobj)
+        result = job.result()
+        self.assertEqual(result.success, True)
+        return result

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -26,8 +26,6 @@ class BackendTestCase(QiskitTestCase):
             instantiation can be further customized by overriding the
             ``_get_backend`` function.
         circuit (QuantumCircuit): circuit to be used for the tests.
-        __test__ (bool): flag for including the class in test discovery.
-            Subclasses should explicitly set it to `True`.
     """
     backend_cls = None
     circuit = ReferenceCircuits.bell()

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -25,6 +25,8 @@ class BackendTestCase(QiskitTestCase):
             instantiation can be further customized by overriding the
             ``_get_backend`` function.
         circuit (QuantumCircuit): circuit to be used for the tests.
+        __test__ (bool): flag for including the class in test discovery.
+            Subclasses should explicitly set it to `True`.
     """
     backend_cls = None
     circuit = ReferenceCircuits.bell()

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -29,6 +29,8 @@ class BackendTestCase(QiskitTestCase):
     backend_cls = None
     circuit = ReferenceCircuits.bell()
 
+    __test__ = False
+
     def setUp(self):
         super().setUp()
         self.backend = self._get_backend()

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -22,6 +22,8 @@ class ProviderTestCase(QiskitTestCase):
             instantiation can be further customized by overriding the
             ``_get_provider`` function.
         backend_name (str): name of a backend provided by the provider.
+        __test__ (bool): flag for including the class in test discovery.
+            Subclasses should explicitly set it to `True`.
     """
     provider_cls = None
     backend_name = ''

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -32,7 +32,7 @@ class ProviderTestCase(QiskitTestCase):
 
     def _get_provider(self):
         """Return an instance of a Provider."""
-        return self.provider_cls()
+        return self.provider_cls()  # pylint: disable=not-callable
 
     def test_backends(self):
         """Test the provider has backends."""

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -7,6 +7,8 @@
 
 """Base TestCase for testing Providers."""
 
+from unittest import SkipTest
+
 from ..base import QiskitTestCase
 
 
@@ -28,11 +30,15 @@ class ProviderTestCase(QiskitTestCase):
     provider_cls = None
     backend_name = ''
 
-    __test__ = False
-
     def setUp(self):
         super().setUp()
         self.provider = self._get_provider()
+
+    @classmethod
+    def setUpClass(cls):
+        if cls is ProviderTestCase:
+            raise SkipTest('Skipping base class tests')
+        super().setUpClass()
 
     def _get_provider(self):
         """Return an instance of a Provider."""

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -26,6 +26,8 @@ class ProviderTestCase(QiskitTestCase):
     provider_cls = None
     backend_name = ''
 
+    __test__ = False
+
     def setUp(self):
         super().setUp()
         self.provider = self._get_provider()

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Base TestCase for testing Providers."""
+
+from ..base import QiskitTestCase
+
+
+class ProviderTestCase(QiskitTestCase):
+    """Test case for Providers.
+
+    Implementers of providers are encouraged to subclass and customize this
+    TestCase, as it contains a "canonical" series of tests in order to ensure
+    the provider functionality matches the specifications.
+
+    Members:
+        provider_cls (BaseProvider): provider to be used in this test case. Its
+            instantiation can be further customized by overriding the
+            ``_get_provider`` function.
+        backend_name (str): name of a backend provided by the provider.
+    """
+    provider_cls = None
+    backend_name = ''
+
+    def setUp(self):
+        super().setUp()
+        self.provider = self._get_provider()
+
+    def _get_provider(self):
+        """Return an instance of a Provider."""
+        return self.provider_cls()
+
+    def test_backends(self):
+        """Test the provider has backends."""
+        backends = self.provider.backends()
+        self.assertTrue(len(backends) > 0)
+
+    def test_get_backend(self):
+        """Test getting a backend from the provider."""
+        backend = self.provider.get_backend(name=self.backend_name)
+        self.assertEqual(backend.name(), self.backend_name)

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -24,8 +24,6 @@ class ProviderTestCase(QiskitTestCase):
             instantiation can be further customized by overriding the
             ``_get_provider`` function.
         backend_name (str): name of a backend provided by the provider.
-        __test__ (bool): flag for including the class in test discovery.
-            Subclasses should explicitly set it to `True`.
     """
     provider_cls = None
     backend_name = ''

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -27,6 +27,7 @@ class ReferenceCircuits:
 
     @staticmethod
     def bell_no_measure():
+        """Return a Bell circuit."""
         qr = QuantumRegister(2, name='qr')
         qc = QuantumCircuit(qr, name='bell_no_measure')
         qc.h(qr[0])

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Reference circuits used by the tests."""
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+
+class ReferenceCircuits:
+
+    @staticmethod
+    def bell():
+        """Return a Bell circuit."""
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='qc')
+        qc = QuantumCircuit(qr, cr, name='bell')
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr, cr)
+
+        return qc

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -24,3 +24,12 @@ class ReferenceCircuits:
         qc.measure(qr, cr)
 
         return qc
+
+    @staticmethod
+    def bell_no_measure():
+        qr = QuantumRegister(2, name='qr')
+        qc = QuantumCircuit(qr, name='bell_no_measure')
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+
+        return qc

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -11,6 +11,7 @@ from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 
 class ReferenceCircuits:
+    """Container for reference circuits used by the tests."""
 
     @staticmethod
     def bell():

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -10,10 +10,10 @@
 from qiskit import BasicAer
 from qiskit.providers.basicaer import BasicAerProvider
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
-from qiskit.test.providers import ProviderTestCase
+from qiskit.test import providers
 
 
-class TestBasicAerBackends(ProviderTestCase):
+class TestBasicAerBackends(providers.ProviderTestCase):
     """Qiskit BasicAer Backends (Object) Tests."""
 
     provider_cls = BasicAerProvider

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -16,7 +16,6 @@ from qiskit.test.providers import ProviderTestCase
 class TestBasicAerBackends(ProviderTestCase):
     """Qiskit BasicAer Backends (Object) Tests."""
 
-    __test__ = True
     provider_cls = SimulatorsProvider
     backend_name = 'qasm_simulator'
 

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-
 """BasicAer Backends Test."""
 
 from qiskit import BasicAer

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -16,7 +16,7 @@ from qiskit.test.providers import ProviderTestCase
 class TestBasicAerBackends(ProviderTestCase):
     """Qiskit BasicAer Backends (Object) Tests."""
 
-    provider_cls = SimulatorsProvider
+    provider_cls = BasicAerProvider
     backend_name = 'qasm_simulator'
 
     def test_deprecated(self):

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -8,58 +8,18 @@
 
 """BasicAer Backends Test."""
 
-import json
-import jsonschema
-
 from qiskit import BasicAer
 from qiskit.providers.basicaer import BasicAerProvider
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
-from qiskit.test import Path, QiskitTestCase
+from qiskit.test.providers import ProviderTestCase
 
 
-class TestBasicAerBackends(QiskitTestCase):
+class TestBasicAerBackends(ProviderTestCase):
     """Qiskit BasicAer Backends (Object) Tests."""
 
-    def test_basicaer_backends_exist(self):
-        """Test if there are local backends."""
-        basicaer = BasicAerProvider()
-        local = basicaer.backends()
-        self.assertTrue(len(local) > 0)
-
-    def test_get_backend(self):
-        """Test get backends."""
-        backend = BasicAer.backends(name='qasm_simulator')[0]
-        self.assertEqual(backend.name(), 'qasm_simulator')
-
-    def test_basicaer_backend_status(self):
-        """Test backend_status."""
-        schema_path = self._get_resource_path(
-            'backend_status_schema.json', path=Path.SCHEMAS)
-        with open(schema_path, 'r') as schema_file:
-            schema = json.load(schema_file)
-
-        for backend in BasicAer.backends():
-            status = backend.status()
-            jsonschema.validate(status.to_dict(), schema)
-
-    def test_basicaer_backend_configuration(self):
-        """Test backend configuration."""
-        schema_path = self._get_resource_path(
-            'backend_configuration_schema.json', path=Path.SCHEMAS)
-        with open(schema_path, 'r') as schema_file:
-            schema = json.load(schema_file)
-
-        basicaer = BasicAer.backends()
-        for backend in basicaer:
-            configuration = backend.configuration()
-            jsonschema.validate(configuration.to_dict(), schema)
-
-    def test_basicaer_backend_properties(self):
-        """Test backend properties."""
-        simulators = BasicAer.backends()
-        for backend in simulators:
-            properties = backend.properties()
-            self.assertEqual(properties, None)
+    __test__ = True
+    provider_cls = SimulatorsProvider
+    backend_name = 'qasm_simulator'
 
     def test_deprecated(self):
         """Test that deprecated names map the same backends as the new names.

--- a/test/python/basicaer/test_basicaer_integration.py
+++ b/test/python/basicaer/test_basicaer_integration.py
@@ -5,16 +5,13 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=redefined-builtin
-
-
 """BasicAer provider integration tests (compile and run)."""
 
 import unittest
 
 from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit import compile, execute
+from qiskit import compile, execute  # pylint: disable=redefined-builtin
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase
 

--- a/test/python/basicaer/test_basicaer_qobj_headers.py
+++ b/test/python/basicaer/test_basicaer_qobj_headers.py
@@ -5,7 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-
 """Tests for all BasicAer  simulators."""
 
 from qiskit import BasicAer

--- a/test/python/basicaer/test_multi_registers_convention.py
+++ b/test/python/basicaer/test_multi_registers_convention.py
@@ -5,20 +5,12 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=unused-import
-# pylint: disable=redefined-builtin
-
 """Test Qiskit's QuantumCircuit class for multiple registers."""
 
-import os
-import tempfile
-import unittest
-
 from qiskit import BasicAer
-from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit import compile, execute
-from qiskit import QiskitError
-from qiskit.quantum_info import state_fidelity, process_fidelity, Pauli, basis_state
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
+from qiskit import compile  # pylint: disable=redefined-builtin
+from qiskit.quantum_info import Pauli, basis_state, process_fidelity, state_fidelity
 from qiskit.test import QiskitTestCase
 
 
@@ -26,8 +18,7 @@ class TestCircuitMultiRegs(QiskitTestCase):
     """QuantumCircuit Qasm tests."""
 
     def test_circuit_multi(self):
-        """Test circuit multi regs declared at start.
-        """
+        """Test circuit multi regs declared at start."""
         qreg0 = QuantumRegister(2, 'q0')
         creg0 = ClassicalRegister(2, 'c0')
         qreg1 = QuantumRegister(2, 'q1')

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -15,10 +15,10 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile  # pylint: disable=redefined-builtin
 from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.test import Path
-from qiskit.test.providers import BackendTestCase
+from qiskit.test import providers
 
 
-class TestBasicAerQasmSimulator(BackendTestCase):
+class TestBasicAerQasmSimulator(providers.BackendTestCase):
     """Test the Basic qasm_simulator."""
 
     backend_cls = QasmSimulatorPy

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile  # pylint: disable=redefined-builtin
-from qiskit.providers.builtinsimulators import QasmSimulatorPy
+from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.test import Path
 from qiskit.test.providers import BackendTestCase
 

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -5,14 +5,14 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=missing-docstring,redefined-builtin
+"""Test QASM simulator."""
 
 import unittest
 
 import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit import compile
+from qiskit import compile  # pylint: disable=redefined-builtin
 from qiskit.providers.builtinsimulators import QasmSimulatorPy
 from qiskit.test import Path
 from qiskit.test.providers import BackendTestCase
@@ -53,6 +53,7 @@ class TestBasicAerQasmSimulator(BackendTestCase):
         self.assertDictAlmostEqual(counts, target, threshold)
 
     def test_if_statement(self):
+        """Test if statements."""
         shots = 100
         qr = QuantumRegister(3, 'qr')
         cr = ClassicalRegister(3, 'cr')
@@ -85,7 +86,7 @@ class TestBasicAerQasmSimulator(BackendTestCase):
         self.assertEqual(counts_if_false, {'001': 100})
 
     def test_teleport(self):
-        """test teleportation as in tutorials"""
+        """Test teleportation as in tutorials"""
         self.log.info('test_teleport')
         pi = np.pi
         shots = 2000
@@ -131,6 +132,7 @@ class TestBasicAerQasmSimulator(BackendTestCase):
         self.assertLess(error, 0.05)
 
     def test_memory(self):
+        """Test memory."""
         qr = QuantumRegister(4, 'qr')
         cr0 = ClassicalRegister(2, 'cr0')
         cr1 = ClassicalRegister(2, 'cr1')

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -10,18 +10,24 @@
 import unittest
 
 import numpy as np
-from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
+
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile
-from qiskit import BasicAer
-from qiskit.test import QiskitTestCase, Path
+from qiskit.providers.builtinsimulators import QasmSimulatorPy
+from qiskit.test import Path
+from qiskit.test.providers import BackendTestCase
 
 
-class TestBasicAerQasmSimulator(QiskitTestCase):
+class TestBasicAerQasmSimulator(BackendTestCase):
     """Test the Basic qasm_simulator."""
 
+    __test__ = True
+    backend_cls = QasmSimulatorPy
+
     def setUp(self):
+        super(TestBasicAerQasmSimulator, self).setUp()
+
         self.seed = 88
-        self.backend = BasicAer.get_backend('qasm_simulator')
         qasm_filename = self._get_resource_path('example.qasm', Path.QASMS)
         compiled_circuit = QuantumCircuit.from_qasm_file(qasm_filename)
         compiled_circuit.name = 'test'

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -21,7 +21,6 @@ from qiskit.test.providers import BackendTestCase
 class TestBasicAerQasmSimulator(BackendTestCase):
     """Test the Basic qasm_simulator."""
 
-    __test__ = True
     backend_cls = QasmSimulatorPy
 
     def setUp(self):

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -5,6 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+"""Test StateVectorSimulatorPy."""
+
 import unittest
 
 from qiskit.providers.builtinsimulators import StatevectorSimulatorPy

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -17,7 +17,6 @@ from qiskit.test.providers import BackendTestCase
 class StatevectorSimulatorTest(BackendTestCase):
     """Test BasicAer statevector simulator."""
 
-    __test__ = True
     backend_cls = StatevectorSimulatorPy
     circuit = ReferenceCircuits.bell_no_measure()
 

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -9,7 +9,7 @@
 
 import unittest
 
-from qiskit.providers.builtinsimulators import StatevectorSimulatorPy
+from qiskit.providers.basicaer import StatevectorSimulatorPy
 from qiskit.test import ReferenceCircuits
 from qiskit.test.providers import BackendTestCase
 

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -11,10 +11,10 @@ import unittest
 
 from qiskit.providers.basicaer import StatevectorSimulatorPy
 from qiskit.test import ReferenceCircuits
-from qiskit.test.providers import BackendTestCase
+from qiskit.test import providers
 
 
-class StatevectorSimulatorTest(BackendTestCase):
+class StatevectorSimulatorTest(providers.BackendTestCase):
     """Test BasicAer statevector simulator."""
 
     backend_cls = StatevectorSimulatorPy

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -5,30 +5,24 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=missing-docstring,broad-except
-
 import unittest
-from qiskit import QuantumCircuit, QuantumRegister
-from qiskit import execute
-from qiskit import BasicAer
-from qiskit.test import QiskitTestCase
+
+from qiskit.providers.builtinsimulators import StatevectorSimulatorPy
+from qiskit.test import ReferenceCircuits
+from qiskit.test.providers import BackendTestCase
 
 
-class StatevectorSimulatorTest(QiskitTestCase):
+class StatevectorSimulatorTest(BackendTestCase):
     """Test BasicAer statevector simulator."""
 
-    def setUp(self):
-        qr = QuantumRegister(2)
-        self.q_circuit = QuantumCircuit(qr)
-        self.q_circuit.h(qr[0])
-        self.q_circuit.cx(qr[0], qr[1])
+    __test__ = True
+    backend_cls = StatevectorSimulatorPy
+    circuit = ReferenceCircuits.bell_no_measure()
 
-    def test_statevector_simulator(self):
+    def test_run_circuit(self):
         """Test final state vector for single circuit run."""
-        result = execute(self.q_circuit,
-                         backend=BasicAer.get_backend('statevector_simulator')).result()
-        self.assertEqual(result.success, True)
-        actual = result.get_statevector(self.q_circuit)
+        result = super().test_run_circuit()
+        actual = result.get_statevector(self.circuit)
 
         # state is 1/sqrt(2)|00> + 1/sqrt(2)|11>, up to a global phase
         self.assertAlmostEqual((abs(actual[0]))**2, 1/2)

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile  # pylint: disable=redefined-builtin
-from qiskit.providers.builtinsimulators import UnitarySimulatorPy
+from qiskit.providers.basicaer import UnitarySimulatorPy
 from qiskit.test import ReferenceCircuits
 from qiskit.test.providers import BackendTestCase
 

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -9,19 +9,21 @@
 # pylint: disable=redefined-builtin
 
 import unittest
+
 import numpy as np
 
-from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile
-from qiskit import BasicAer
-from qiskit.test import QiskitTestCase
+from qiskit.providers.builtinsimulators import UnitarySimulatorPy
+from qiskit.test import ReferenceCircuits
+from qiskit.test.providers import BackendTestCase
 
 
-class BasicAerUnitarySimulatorPyTest(QiskitTestCase):
+class BasicAerUnitarySimulatorPyTest(BackendTestCase):
     """Test BasicAer unitary simulator."""
-
-    def setUp(self):
-        self.backend = BasicAer.get_backend('unitary_simulator')
+    __test__ = True
+    backend_cls = UnitarySimulatorPy
+    circuit = ReferenceCircuits.bell_no_measure()
 
     def test_basicaer_unitary_simulator_py(self):
         """Test unitary simulator."""

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -20,7 +20,7 @@ from qiskit.test.providers import BackendTestCase
 
 class BasicAerUnitarySimulatorPyTest(BackendTestCase):
     """Test BasicAer unitary simulator."""
-    __test__ = True
+
     backend_cls = UnitarySimulatorPy
     circuit = ReferenceCircuits.bell_no_measure()
 

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -15,10 +15,10 @@ from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit import compile  # pylint: disable=redefined-builtin
 from qiskit.providers.basicaer import UnitarySimulatorPy
 from qiskit.test import ReferenceCircuits
-from qiskit.test.providers import BackendTestCase
+from qiskit.test import providers
 
 
-class BasicAerUnitarySimulatorPyTest(BackendTestCase):
+class BasicAerUnitarySimulatorPyTest(providers.BackendTestCase):
     """Test BasicAer unitary simulator."""
 
     backend_cls = UnitarySimulatorPy

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -5,15 +5,14 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=missing-docstring
-# pylint: disable=redefined-builtin
+"""Tests for unitary simulator."""
 
 import unittest
 
 import numpy as np
 
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit import compile
+from qiskit import compile  # pylint: disable=redefined-builtin
 from qiskit.providers.builtinsimulators import UnitarySimulatorPy
 from qiskit.test import ReferenceCircuits
 from qiskit.test.providers import BackendTestCase


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Continuing #1616, add a mini-framework (as in, two specializations of `QiskitTestCase`: `ProviderTestCase` and `BackendTestCase`) containing a minimal amount of tests for providers and backends, in order to have a "canonical" set of tests that a provider implementer can use (by inheriting and customizing), for both our and theirs convenience - `basicaer` has been used as the guinea pig for the changes.


### Details and comments

For the moment, the tests included have been kept as minimal as possible - this PR is intended to set the basics in place, and later fine-tune the specific tests and circuits as needed.
