### PR TITLE
Changed average_data to accept observable input in matrix form 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,7 @@ Added
 Changed
 -------
 
+- Changed ``average_data`` to accept observable input in matrix form (#1858)
 - Change random_state to take in dim over number of qubits (#1857)
 - The ``Exception`` subclasses have been moved to an ``.exceptions`` module
   within each package (for example, ``qiskit.exceptions.QiskitError``) (#1600).

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -7,6 +7,8 @@
 
 """A collection of useful functions for post processing results."""
 
+import numpy as np
+
 
 def average_data(counts, observable):
     """Compute the mean value of an diagonal observable.
@@ -39,10 +41,20 @@ def make_dict_observable(matrix_observable):
     form. Can also handle a list sorted of the diagonal elements.
 
     Args:
-        observable (list): The observable to be converted to dicitonary form. As
+        observable (list): The observable to be converted to dicitonary form.
 
     Results:
         A dictionary with all observable states as keys, and corresponding
         values being the observed value for that state. 
     """
-    raise NotImplementedError
+    dict_observable = {}
+    observable = np.array(matrix_observable)
+    observable_size = len(observable)
+    observable_bits = int(np.ceil(np.log2(observable_size)))
+    binary_formater = '0{}b'.format(observable_bits)
+    if observable.ndim == 2:
+        observable = observable.diagonal()
+    for state_no in range(observable_size):
+        state_str = format(state_no, binary_formater)
+        dict_observable[state_str] = observable[state_no]
+    return dict_observable

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -19,8 +19,11 @@ def average_data(counts, observable):
 
     Args:
         counts (dict): a dict of outcomes from an experiment
-        observable (dict or matrix): The observable to be averaged over. As an
-        example ZZ on qubits equals {"00": 1, "11": 1, "01": -1, "10": -1}
+        observable (dict or matrix or list): The observable to be averaged over.
+        As an example, ZZ on qubits can be given as:
+        * dict: {"00": 1, "11": 1, "01": -1, "10": -1}
+        * matrix: [[1, 0, 0, 0], [0, -1, 0, 0, ], [0, 0, -1, 0], [0, 0, 0, 1]]
+        * matrix diagonal (list): [1, -1, -1, 1]
 
     Returns:
         Double: Average of the observable

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -41,11 +41,12 @@ def make_dict_observable(matrix_observable):
     form. Can also handle a list sorted of the diagonal elements.
 
     Args:
-        observable (list): The observable to be converted to dicitonary form.
+        matrix_observable (list): The observable to be converted to dictionary
+        form. Can be a matrix or just an ordered list of observed values
 
-    Results:
-        A dictionary with all observable states as keys, and corresponding
-        values being the observed value for that state. 
+    Returns:
+        Dict: A dictionary with all observable states as keys, and corresponding
+        values being the observed value for that state
     """
     dict_observable = {}
     observable = np.array(matrix_observable)

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -34,6 +34,7 @@ def average_data(counts, observable):
             temp += counts[key] * observable[key] / tot
     return temp
 
+
 def make_dict_observable(matrix_observable):
     """Convert an observable in matrix form to dictionary form.
 

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -7,7 +7,7 @@
 
 """A collection of useful functions for post processing results."""
 
-import numpy as np
+from .make_observable import make_dict_observable
 
 
 def average_data(counts, observable):
@@ -36,30 +36,3 @@ def average_data(counts, observable):
         if key in observable:
             temp += counts[key] * observable[key] / tot
     return temp
-
-
-def make_dict_observable(matrix_observable):
-    """Convert an observable in matrix form to dictionary form.
-
-    Takes in a diagonal observable as a matrix and converts it to a dictionary
-    form. Can also handle a list sorted of the diagonal elements.
-
-    Args:
-        matrix_observable (list): The observable to be converted to dictionary
-        form. Can be a matrix or just an ordered list of observed values
-
-    Returns:
-        Dict: A dictionary with all observable states as keys, and corresponding
-        values being the observed value for that state
-    """
-    dict_observable = {}
-    observable = np.array(matrix_observable)
-    observable_size = len(observable)
-    observable_bits = int(np.ceil(np.log2(observable_size)))
-    binary_formater = '0{}b'.format(observable_bits)
-    if observable.ndim == 2:
-        observable = observable.diagonal()
-    for state_no in range(observable_size):
-        state_str = format(state_no, binary_formater)
-        dict_observable[state_str] = observable[state_no]
-    return dict_observable

--- a/qiskit/quantum_info/analyzation/average.py
+++ b/qiskit/quantum_info/analyzation/average.py
@@ -11,23 +11,38 @@
 def average_data(counts, observable):
     """Compute the mean value of an diagonal observable.
 
-    Takes in an observable in dictionary format and then
-    calculates the sum_i value(i) P(i) where value(i) is the value of
-    the observable for state i.
-
-    TODO: make the observable also include a matrix
+    Takes in a diagonal observable in dictionary, list or matrix format and then
+    calculates the sum_i value(i) P(i) where value(i) is the value of the
+    observable for state i.
 
     Args:
         counts (dict): a dict of outcomes from an experiment
-        observable (dict): The observable to be averaged over. As an example
-        ZZ on qubits equals {"00": 1, "11": 1, "01": -1, "10": -1}
+        observable (dict or matrix): The observable to be averaged over. As an
+        example ZZ on qubits equals {"00": 1, "11": 1, "01": -1, "10": -1}
 
     Returns:
         Double: Average of the observable
     """
+    if not isinstance(observable, dict):
+        observable = make_dict_observable(observable)
     temp = 0
     tot = sum(counts.values())
     for key in counts:
         if key in observable:
             temp += counts[key] * observable[key] / tot
     return temp
+
+def make_dict_observable(matrix_observable):
+    """Convert an observable in matrix form to dictionary form.
+
+    Takes in a diagonal observable as a matrix and converts it to a dictionary
+    form. Can also handle a list sorted of the diagonal elements.
+
+    Args:
+        observable (list): The observable to be converted to dicitonary form. As
+
+    Results:
+        A dictionary with all observable states as keys, and corresponding
+        values being the observed value for that state. 
+    """
+    raise NotImplementedError

--- a/qiskit/quantum_info/analyzation/make_observable.py
+++ b/qiskit/quantum_info/analyzation/make_observable.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Helper functions for building dictionaries from matrices and lists."""
+
+import numpy as np
+
+
+def make_dict_observable(matrix_observable):
+    """Convert an observable in matrix form to dictionary form.
+
+    Takes in a diagonal observable as a matrix and converts it to a dictionary
+    form. Can also handle a list sorted of the diagonal elements.
+
+    Args:
+        matrix_observable (list): The observable to be converted to dictionary
+        form. Can be a matrix or just an ordered list of observed values
+
+    Returns:
+        Dict: A dictionary with all observable states as keys, and corresponding
+        values being the observed value for that state
+    """
+    dict_observable = {}
+    observable = np.array(matrix_observable)
+    observable_size = len(observable)
+    observable_bits = int(np.ceil(np.log2(observable_size)))
+    binary_formater = '0{}b'.format(observable_bits)
+    if observable.ndim == 2:
+        observable = observable.diagonal()
+    for state_no in range(observable_size):
+        state_str = format(state_no, binary_formater)
+        dict_observable[state_str] = observable[state_no]
+    return dict_observable

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -115,8 +115,14 @@ class TestAnalyzation(QiskitTestCase):
         matrix_expected = {"00": 4, "01": -3, "10": 2, "11": -1}
         long_list_in = [1, 1, -1, -1, -1, -1, 1, 1]
         long_list_out = make_dict_observable(long_list_in)
-        long_list_expected = {"000": 1, "001": 1, "010": -1, "011": -1, "100":
-                -1, "101": -1, "110": 1, "111": 1}
+        long_list_expected = {"000": 1,
+                              "001": 1,
+                              "010": -1,
+                              "011": -1,
+                              "100": -1,
+                              "101": -1,
+                              "110": 1,
+                              "111": 1}
         self.assertEqual(list_out, list_expected)
         self.assertEqual(matrix_out, matrix_expected)
         self.assertEqual(long_list_out, long_list_expected)

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -19,7 +19,7 @@ class TestAnalyzation(QiskitTestCase):
     """Test qiskit.Result API"""
 
     def test_average_data_dict_obverable(self):
-        """Test average_data."""
+        """Test average_data for dictionary observable input"""
         qr = qiskit.QuantumRegister(2)
         cr = qiskit.ClassicalRegister(2)
         qc = qiskit.QuantumCircuit(qr, cr, name="qc")
@@ -41,8 +41,8 @@ class TestAnalyzation(QiskitTestCase):
         self.assertAlmostEqual(mean_zi, 0, places=1)
         self.assertAlmostEqual(mean_iz, 0, places=1)
 
-    def test_average_data_array_obverable(self):
-        """Test average_data."""
+    def test_average_data_list_obverable(self):
+        """Test average_data for list observable input."""
         qr = qiskit.QuantumRegister(3)
         cr = qiskit.ClassicalRegister(3)
         qc = qiskit.QuantumCircuit(qr, cr, name="qc")
@@ -70,7 +70,7 @@ class TestAnalyzation(QiskitTestCase):
         self.assertAlmostEqual(mean_zzi, 1, places=1)
 
     def test_average_data_matrix_obverable(self):
-        """Test average_data."""
+        """Test average_data for matrix observable input."""
         qr = qiskit.QuantumRegister(2)
         cr = qiskit.ClassicalRegister(2)
         qc = qiskit.QuantumCircuit(qr, cr, name="qc")

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -12,6 +12,7 @@ import unittest
 import qiskit
 from qiskit import BasicAer
 from qiskit.quantum_info.analyzation.average import average_data
+from qiskit.quantum_info.analyzation.make_observable import make_dict_observable
 from qiskit.test import QiskitTestCase
 
 
@@ -100,6 +101,25 @@ class TestAnalyzation(QiskitTestCase):
         self.assertAlmostEqual(mean_zz, 1, places=1)
         self.assertAlmostEqual(mean_zi, 0, places=1)
         self.assertAlmostEqual(mean_iz, 0, places=1)
+
+    def test_make_dict_observable(self):
+        """Test make_dict_observable."""
+        list_in = [1, 1, -1, -1]
+        list_out = make_dict_observable(list_in)
+        list_expected = {"00": 1, "01": 1, "10": -1, "11": -1}
+        matrix_in = [[4, 0, 0, 0],
+                     [0, -3, 0, 0],
+                     [0, 0, 2, 0],
+                     [0, 0, 0, -1]]
+        matrix_out = make_dict_observable(matrix_in)
+        matrix_expected = {"00": 4, "01": -3, "10": 2, "11": -1}
+        long_list_in = [1, 1, -1, -1, -1, -1, 1, 1]
+        long_list_out = make_dict_observable(long_list_in)
+        long_list_expected = {"000": 1, "001": 1, "010": -1, "011": -1, "100":
+                -1, "101": -1, "110": 1, "111": 1}
+        self.assertEqual(list_out, list_expected)
+        self.assertEqual(matrix_out, matrix_expected)
+        self.assertEqual(long_list_out, long_list_expected)
 
 
 if __name__ == '__main__':

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -18,7 +18,7 @@ from qiskit.test import QiskitTestCase
 class TestAnalyzation(QiskitTestCase):
     """Test qiskit.Result API"""
 
-    def test_average_data(self):
+    def test_average_data_dict_obverable(self):
         """Test average_data."""
         qr = qiskit.QuantumRegister(2)
         cr = qiskit.ClassicalRegister(2)
@@ -36,6 +36,61 @@ class TestAnalyzation(QiskitTestCase):
         observable = {"00": 1, "11": -1, "01": 1, "10": -1}
         mean_zi = average_data(counts, observable)
         observable = {"00": 1, "11": -1, "01": -1, "10": 1}
+        mean_iz = average_data(counts, observable)
+        self.assertAlmostEqual(mean_zz, 1, places=1)
+        self.assertAlmostEqual(mean_zi, 0, places=1)
+        self.assertAlmostEqual(mean_iz, 0, places=1)
+
+    def test_average_data_array_obverable(self):
+        """Test average_data."""
+        qr = qiskit.QuantumRegister(2)
+        cr = qiskit.ClassicalRegister(2)
+        qc = qiskit.QuantumCircuit(qr, cr, name="qc")
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        shots = 10000
+        backend = BasicAer.get_backend('qasm_simulator')
+        result = qiskit.execute(qc, backend, shots=shots).result()
+        counts = result.get_counts(qc)
+        observable = [1, -1, -1, 1]
+        mean_zz = average_data(counts=counts, observable=observable)
+        observable = [1, 1, -1, -1]
+        mean_zi = average_data(counts, observable)
+        observable = [1, -1, 1, -1]
+        mean_iz = average_data(counts, observable)
+        self.assertAlmostEqual(mean_zz, 1, places=1)
+        self.assertAlmostEqual(mean_zi, 0, places=1)
+        self.assertAlmostEqual(mean_iz, 0, places=1)
+
+    def test_average_data_matrix_obverable(self):
+        """Test average_data."""
+        qr = qiskit.QuantumRegister(2)
+        cr = qiskit.ClassicalRegister(2)
+        qc = qiskit.QuantumCircuit(qr, cr, name="qc")
+        qc.h(qr[0])
+        qc.cx(qr[0], qr[1])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        shots = 10000
+        backend = BasicAer.get_backend('qasm_simulator')
+        result = qiskit.execute(qc, backend, shots=shots).result()
+        counts = result.get_counts(qc)
+        observable = [[1, 0, 0, 0],
+                      [0, -1, 0, 0],
+                      [0, 0, -1, 0],
+                      [0, 0, 0, 1]]
+        mean_zz = average_data(counts=counts, observable=observable)
+        observable = [[1, 0, 0, 0],
+                      [0, 1, 0, 0],
+                      [0, 0, -1, 0],
+                      [0, 0, 0, -1]]
+        mean_zi = average_data(counts, observable)
+        observable = [[1, 0, 0, 0],
+                      [0, -1, 0, 0],
+                      [0, 0, 1, 0],
+                      [0, 0, 0, -1]]
         mean_iz = average_data(counts, observable)
         self.assertAlmostEqual(mean_zz, 1, places=1)
         self.assertAlmostEqual(mean_zi, 0, places=1)

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -43,26 +43,31 @@ class TestAnalyzation(QiskitTestCase):
 
     def test_average_data_array_obverable(self):
         """Test average_data."""
-        qr = qiskit.QuantumRegister(2)
-        cr = qiskit.ClassicalRegister(2)
+        qr = qiskit.QuantumRegister(3)
+        cr = qiskit.ClassicalRegister(3)
         qc = qiskit.QuantumCircuit(qr, cr, name="qc")
         qc.h(qr[0])
         qc.cx(qr[0], qr[1])
+        qc.cx(qr[0], qr[2])
         qc.measure(qr[0], cr[0])
         qc.measure(qr[1], cr[1])
+        qc.measure(qr[2], cr[2])
         shots = 10000
         backend = BasicAer.get_backend('qasm_simulator')
         result = qiskit.execute(qc, backend, shots=shots).result()
         counts = result.get_counts(qc)
-        observable = [1, -1, -1, 1]
-        mean_zz = average_data(counts=counts, observable=observable)
-        observable = [1, 1, -1, -1]
-        mean_zi = average_data(counts, observable)
-        observable = [1, -1, 1, -1]
-        mean_iz = average_data(counts, observable)
-        self.assertAlmostEqual(mean_zz, 1, places=1)
-        self.assertAlmostEqual(mean_zi, 0, places=1)
-        self.assertAlmostEqual(mean_iz, 0, places=1)
+        observable = [1, -1, -1, 1, -1, 1, 1, -1]
+        mean_zzz = average_data(counts=counts, observable=observable)
+        observable = [1, 1, 1, 1, -1, -1, -1, -1]
+        mean_zii = average_data(counts, observable)
+        observable = [1, 1, -1, -1, 1, 1, -1, -1]
+        mean_izi = average_data(counts, observable)
+        observable = [1, 1, -1, -1, -1, -1, 1, 1]
+        mean_zzi = average_data(counts, observable)
+        self.assertAlmostEqual(mean_zzz, 0, places=1)
+        self.assertAlmostEqual(mean_zii, 0, places=1)
+        self.assertAlmostEqual(mean_izi, 0, places=1)
+        self.assertAlmostEqual(mean_zzi, 1, places=1)
 
     def test_average_data_matrix_obverable(self):
         """Test average_data."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As per discussion in #1322 I have altered the ``average_data`` function to accept an observable given as a sorted list.

### Details and comments

When passed a list or matrix as an observable, ``average_data`` will now call ``make_dict_observable`` to convert into dictionary format. The function then continues as before.  This address the feature request in #1322 and has accompanying tests.
