### PR TITLE
Two tests have a try-except that masquerades an error into a fail

### DIFF
--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -16,7 +16,6 @@ from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.transpiler import PassManager, transpile, transpile_dag
 from qiskit import compile, execute
-from qiskit.exceptions import QiskitError
 from qiskit.test import QiskitTestCase, Path
 from qiskit.test.mock import FakeRueschlikon, FakeTenerife
 from qiskit.qobj import Qobj

--- a/test/python/tools/test_compiler.py
+++ b/test/python/tools/test_compiler.py
@@ -132,10 +132,8 @@ class TestCompiler(QiskitTestCase):
         circuit.barrier(qr)
         circuit.measure(qr, cr)
 
-        try:
-            circuits = transpile(circuit, backend)
-        except QiskitError:
-            circuits = None
+        circuits = transpile(circuit, backend)
+
         self.assertIsInstance(circuits, QuantumCircuit)
 
     def test_mapping_multi_qreg(self):
@@ -152,10 +150,8 @@ class TestCompiler(QiskitTestCase):
         qc.cx(qr[1], qr3[2])
         qc.measure(qr, cr)
 
-        try:
-            circuits = transpile(qc, backend)
-        except QiskitError:
-            circuits = None
+        circuits = transpile(qc, backend)
+
         self.assertIsInstance(circuits, QuantumCircuit)
 
     def test_mapping_already_satisfied(self):


### PR DESCRIPTION
When `transpile` fails in `test_mapping_correction` and `test_mapping_multi_qreg`, it is not possible to see the traceback because a try-catch masquerades an error into a fail.