### PR TITLE
Simple Qobj repr

### DIFF
--- a/qiskit/qobj/qobj.py
+++ b/qiskit/qobj/qobj.py
@@ -142,6 +142,13 @@ class Qobj(QobjItem):
 
         super().__init__(**kwargs)
 
+    def __repr__(self):
+        return "Qobj<{0} qubits, {1} {2}, {3} shots>".format(
+            self.config.n_qubits,
+            len(self.experiments),
+            'circuits' if self.type == 'QASM' else 'schedules',
+            self.config.shots)
+
 
 class QobjHeader(QobjItem):
     """Header for a Qobj.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

A simple `Qobj` representation.

A qobj is now printed like this:
```
Qobj<2 qubits, 10 circuits, 1024 shots>
```
vs
```
Qobj(config=QobjConfig(max_credits=10, memory_slots=2, n_qubits=2, shots=1024), experiments=[QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])]), QobjExperiment(config=QobjExperimentConfig(memory_slots=2, n_qubits=2), header=QobjExperimentHeader(clbit_labels=[['c0', 0], ['c0', 1]], creg_sizes=[['c0', 2]], memory_slots=2, n_qubits=2, name='circuit0', qreg_sizes=[['q0', 2]], qubit_labels=[['q0', 0], ['q0', 1]]), instructions=[QobjInstruction(name='h', qubits=[0]), QobjInstruction(name='cx', qubits=[0, 1]), QobjInstruction(name='barrier', qubits=[0, 1]), QobjInstruction(memory=[1], name='measure', qubits=[1]), QobjInstruction(memory=[0], name='measure', qubits=[0])])], header=QobjHeader(), qobj_id='fc6afd56-6576-4acc-8d7a-0fccaf50478c', schema_version='1.0.0', type='QASM')
```


### Details and comments


