### PR TITLE
Handle empty output in mpl circuit drawer

### DIFF
--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -462,7 +462,8 @@ class MatplotlibDrawer:
         _wide_gate = 'u2 u3 cu2 cu3'.split()
         _barriers = {'coord': [], 'group': []}
         next_ops = self._ops.copy()
-        next_ops.pop(0)
+        if next_ops:
+            next_ops.pop(0)
         this_anc = 0
 
         #
@@ -682,7 +683,11 @@ class MatplotlibDrawer:
         #
         # adjust window size and draw horizontal lines
         #
-        max_anc = max([q_anchors[ii].get_index() for ii in self._qreg_dict])
+        anchors = [q_anchors[ii].get_index() for ii in self._qreg_dict]
+        if anchors:
+            max_anc = max(anchors)
+        else:
+            max_anc = 0
         n_fold = (max_anc - 1) // self._style.fold
         # window size
         if max_anc > self._style.fold > 0:

--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -688,7 +688,7 @@ class MatplotlibDrawer:
             max_anc = max(anchors)
         else:
             max_anc = 0
-        n_fold = (max_anc - 1) // self._style.fold
+        n_fold = max(0, max_anc - 1) // self._style.fold
         # window size
         if max_anc > self._style.fold > 0:
             self._cond['xmax'] = self._style.fold + 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

If an empty quantum circuit is passed into the draw function with the
mpl output specified it will stack trace. This is because internally the
mpl drawer assumes there will be always registers and operations that it
can iterate over. This commit fixes that so passing in an empty quantum
circuit is no longer fatal. It will return a blank white image, which is
consistent with the behavior of the latex and text output types.

### Details and comments

Fixes #1845
