### PR TITLE
Add support for identity gate to latex drawer

### DIFF
--- a/qiskit/tools/visualization/_latex.py
+++ b/qiskit/tools/visualization/_latex.py
@@ -225,7 +225,7 @@ class QCircuitImage:
             # useful information for determining row spacing
             boxed_gates = ['u0', 'u1', 'u2', 'u3', 'x', 'y', 'z', 'h', 's',
                            'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'ch', 'cy',
-                           'crz', 'cu3']
+                           'crz', 'cu3', 'id']
             target_gates = ['cx', 'ccx']
             if op['name'] in boxed_gates:
                 self.has_box = True
@@ -546,6 +546,8 @@ class QCircuitImage:
                             self._latex[pos_1][columns] = "\\gate{Z}"
                         elif nm == "h":
                             self._latex[pos_1][columns] = "\\gate{H}"
+                        elif nm == "id":
+                            self._latex[pos_1][columns] = "\\gate{Id}"
                         elif nm == "s":
                             self._latex[pos_1][columns] = "\\gate{S}"
                         elif nm == "sdg":
@@ -606,6 +608,8 @@ class QCircuitImage:
                             self._latex[pos_1][columns] = "\\gate{Z}"
                         elif nm == "h":
                             self._latex[pos_1][columns] = "\\gate{H}"
+                        elif nm == "id":
+                            self._latex[pos_1][columns] = "\\gate{Id}"
                         elif nm == "s":
                             self._latex[pos_1][columns] = "\\gate{S}"
                         elif nm == "sdg":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

For whatever reason the latex circuit drawer was not able to handle the
identity gate. If it encountered one it would just leave a gap in the
circuit were it was expected. This commit fixes this oversight and adds
the identity gate to the list of single box gates. It will draw it as
"Id" in a single box.

### Details and comments

Partially-fixes issue #1870