### PR TITLE
Addressed issue with instruction.py which prohibited inheritance of Q…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,17 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+
+`0.7.2`_ - 2019-03-05
+=====================
+
+
+Fixed
+-----
+
+- Fixed a bug whereby inheriting from QuantumRegister or ClassicalRegister
+  would cause a QiskitError in instruction.py
+
 `0.7.1`_ - 2019-03-04
 =====================
 

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -49,7 +49,7 @@ class Instruction(object):
         """
         if not all(isinstance(i[0], QuantumRegister) and isinstance(i[1], int) for i in qargs):
             raise QiskitError("qarg not (QuantumRegister, int) tuple")
-        if not all(isinstance(i[1], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
+        if not all(isinstance(i[0], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
             raise QiskitError("carg not (ClassicalRegister, int) tuple")
         self.name = name
         self.param = []  # a list of gate params stored as sympy objects

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -47,9 +47,9 @@ class Instruction(object):
         Raises:
             QiskitError: when the register is not in the correct format.
         """
-        if not all((type(i[0]), type(i[1])) == (QuantumRegister, int) for i in qargs):
+        if not all(isinstance(i[0], QuantumRegister) and isinstance(i[1], int) for i in qargs):
             raise QiskitError("qarg not (QuantumRegister, int) tuple")
-        if not all((type(i[0]), type(i[1])) == (ClassicalRegister, int) for i in cargs):
+        if not all(isinstance(i[1], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
             raise QiskitError("carg not (ClassicalRegister, int) tuple")
         self.name = name
         self.param = []  # a list of gate params stored as sympy objects


### PR DESCRIPTION
### Summary
Addressed an issue whereby inheriting from `QuantumRegister` or `ClassicalRegister` would cause a `QiskitError` in `instruction.py`. This PR addresses issue #1892 .


### Details and comments
Checking type-equality is brittle and should be avoided unless it is desired that _only_ the given type be accepted. Since these classes are made available to the public, it is expected that they may eventually be inherited from.

