### PR TITLE
Typo in error message

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -48,7 +48,7 @@ class Gate(Instruction):
 
     def _define_decompositions(self):
         """ Populates self.decompositions with way to decompose this gate"""
-        raise NotImplementedError("No decomposition rules defined for ", self.name)
+        raise NotImplementedError("No decomposition rules defined for %s" % self.name)
 
     @property
     def matrix_rep(self):


### PR DESCRIPTION
When unrolling a gate without a decomposition rule we raises:
```
NotImplementedError: ('No decomposition rules defined for ', 'U')
```
and the error should be
```
NotImplementedError: No decomposition rules defined for U
```

This PR fixes that.