### PR TITLE
Fix instruction inheritance issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,17 @@ The format is based on `Keep a Changelog`_.
 `UNRELEASED`_
 =============
 
+
+`0.7.2`_ - 2019-03-05
+=====================
+
+
+Fixed
+-----
+
+- Fixed a bug whereby inheriting from QuantumRegister or ClassicalRegister
+  would cause a QiskitError in instruction.py
+
 `0.7.1`_ - 2019-03-04
 =====================
 

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -49,7 +49,7 @@ class Instruction(object):
         """
         if not all(isinstance(i[0], QuantumRegister) and isinstance(i[1], int) for i in qargs):
             raise QiskitError("qarg not (QuantumRegister, int) tuple")
-        if not all(isinstance(i[1], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
+        if not all(isinstance(i[0], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
             raise QiskitError("carg not (ClassicalRegister, int) tuple")
         self.name = name
         self.param = []  # a list of gate params stored as sympy objects

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -47,9 +47,9 @@ class Instruction(object):
         Raises:
             QiskitError: when the register is not in the correct format.
         """
-        if not all((type(i[0]), type(i[1])) == (QuantumRegister, int) for i in qargs):
+        if not all(isinstance(i[0], QuantumRegister) and isinstance(i[1], int) for i in qargs):
             raise QiskitError("qarg not (QuantumRegister, int) tuple")
-        if not all((type(i[0]), type(i[1])) == (ClassicalRegister, int) for i in cargs):
+        if not all(isinstance(i[1], ClassicalRegister) and isinstance(i[1], int) for i in cargs):
             raise QiskitError("carg not (ClassicalRegister, int) tuple")
         self.name = name
         self.param = []  # a list of gate params stored as sympy objects


### PR DESCRIPTION
Fixes #1892 

### Summary

Modified the way in which type-checking is done in `instruction.py` to allow `QuantumRegister` and `ClassicalRegister` to be inherited from.

### Details and comments

Type-equality checking is brittle and should be avoided except in the case where inheritance is to be disregarded for a class. That appears to be the case for neither `QuantumRegister` nor `ClassicalRegister`.
