### PR TITLE
gitignoring cpp files created in cython folders under the passes folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ qiskit/providers/legacysimulators/qasm_simulator_cpp
 src/qasm-simulator-cpp/test/qubit_vector_tests
 
 *.o
+
+# Cython pass
+qiskit/transpiler/passes/**/cython/**/*.cpp


### PR DESCRIPTION
The `stochastic_swap` pass creates the following cpp files:
```
qiskit/transpiler/passes/mapping/cython/stochastic_swap/utils.cpp
qiskit/transpiler/passes/mapping/cython/stochastic_swap/_swap_trial.cpp
```
This PR ignores the files as well as any other `cpp` file in the subfolders of `cython` under the `passes` folder.