### PR TITLE
Quantum channels

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -8,6 +8,7 @@
 """Quantum Information  methods."""
 
 from .operators.pauli import Pauli, pauli_group
+from .operators.channel import Choi, SuperOp, Kraus, Stinespring, Chi, PTM
 from .states._states import basis_state, random_state, projector, purity
 from .states._measures import state_fidelity
 from .operators._measures import process_fidelity

--- a/qiskit/quantum_info/operators/channel/__init__.py
+++ b/qiskit/quantum_info/operators/channel/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""
+Quantum Channel Representations Package
+
+For explanation of terminology and details of operations see Ref. [1]
+
+References:
+    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
+        Open access: arXiv:1111.6950 [quant-ph]
+"""
+
+from .superop import SuperOp
+from .choi import Choi
+from .kraus import Kraus
+from .stinespring import Stinespring
+from .ptm import PTM
+from .chi import Chi

--- a/qiskit/quantum_info/operators/channel/basechannel.py
+++ b/qiskit/quantum_info/operators/channel/basechannel.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT
+
+
+class QuantumChannel(ABC):
+    """Quantum channel representation base class."""
+
+    ATOL = ATOL_DEFAULT
+    MAX_ATOL = 1e-4
+
+    def __init__(self, rep, data, input_dim, output_dim):
+        if not isinstance(rep, str):
+            raise QiskitError("rep must be a string not a {}".format(rep.__class__))
+        self._rep = rep
+        self._data = data
+        self._input_dim = input_dim
+        self._output_dim = output_dim
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__) and self.dims == other.dims:
+            return np.allclose(self.data, other.data, atol=self.atol)
+        return False
+
+    def __repr__(self):
+        return '{}({}, input_dim={}, output_dim={})'.format(self.rep,
+                                                            self.data,
+                                                            self._input_dim,
+                                                            self._output_dim)
+
+    @property
+    def rep(self):
+        """Return Channel representation"""
+        return self._rep
+
+    @property
+    def dims(self):
+        """Return tuple (input dimension, output dimension)"""
+        return self._input_dim, self._output_dim
+
+    @property
+    def data(self):
+        """Return data"""
+        return self._data
+
+    @property
+    def atol(self):
+        """Atol parameter for float comparisons."""
+        # NOTE: This should really be a class method so that it can
+        # be overriden for all QuantumChannel subclasses
+        return QuantumChannel.ATOL
+
+    @atol.setter
+    def atol(cls, atol):
+        """Set atol parameter for float comparisons."""
+        MAX_ATOL = QuantumChannel.MAX_ATOL
+        if atol < 0:
+            raise QiskitError("Invalid atol: must be non-negative.")
+        if atol > MAX_ATOL:
+            raise QiskitError("Invalid atol: must be less than {}.".format(MAX_ATOL))
+        QuantumChannel.ATOL = atol
+
+    def copy(self):
+        """Make a copy of current channel."""
+        # The constructor of subclasses from raw data should be a copy
+        return self.__class__(self._data, self._input_dim, self._output_dim)
+
+    @abstractmethod
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        pass
+
+    @abstractmethod
+    def is_cptp(self):
+        """Check if channel is completely-positive trace-preserving."""
+        pass
+
+    @abstractmethod
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        pass
+
+    @abstractmethod
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        pass
+
+    def adjoint(self, inplace=False):
+        """Return the adjoint channel"""
+        return self.conjugate(inplace=inplace).transpose(inplace=inplace)
+
+    @abstractmethod
+    def compose(self, other, inplace=False, front=False):
+        """Return the composition channel.
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            QuantumChannel: the composition channel.
+        """
+        pass
+
+    @abstractmethod
+    def tensor(self, other, inplace=False, front=False):
+        """Return the tensor product channel.
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            QuantumChannel: the tensor product channel.
+        """
+        pass
+
+    def power(self, n, inplace=False):
+        """ Rreturn composition of Channel with itself n times."""
+        if not isinstance(n, int) or n < 1:
+            raise QiskitError("Can only power with positive integer powers.")
+        if self._input_dim != self._output_dim:
+            raise QiskitError("Can only power with input_dim = output_dim.")
+        # Update inplace
+        if inplace:
+            if n == 1:
+                return self
+            # cache current state to apply n-times
+            cache = self.copy()
+            for _ in range(1, n):
+                self.compose(cache, inplace=True)
+            return self
+        # Return new object
+        ret = self.copy()
+        for _ in range(1, n):
+            ret = ret.compose(self)
+        return ret
+
+    @abstractmethod
+    def add(self, other, inplace=False):
+        """Add another QuantumChannel"""
+        pass
+
+    @abstractmethod
+    def subtract(self, other, inplace=False):
+        """Subtract another QuantumChannel"""
+        pass
+
+    @abstractmethod
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        pass
+
+    def _check_state(self, state):
+        """Check input state is valid for quantum channel"""
+        state = np.array(state)
+        shape = state.shape
+        ndim = state.ndim
+        if ndim > 2:
+            raise QiskitError('Input state is not a vector or matrix.')
+        if shape[0] != self._input_dim:
+            raise QiskitError('Input state is wrong size for channel input dimension.')
+        # Flatten column-vector to vector
+        if ndim == 2:
+            if shape[1] != 1 and shape[1] != self._input_dim:
+                raise QiskitError('Input state is wrong size for channel input dimension.')
+            if shape[1] == 1:
+                # flatten colum-vector to vector
+                state = np.reshape(state, shape[0])
+        return state
+
+    def _format_density_matrix(self, state):
+        """Check if input state is valid for quantum channel and convert to density matrix"""
+        if state.ndim == 1:
+            state = np.outer(state, np.transpose(np.conj(state)))
+        return state
+
+    # Overloads
+    def __matmul__(self, other):
+        return self.compose(other)
+
+    def __imatmul__(self, other):
+        return self.compose(other, inplace=True)
+
+    def __pow__(self, n):
+        return self.power(n)
+
+    def __ipow__(self, n):
+        return self.power(n, inplace=True)
+
+    def __mul__(self, other):
+        return self.multiply(other)
+
+    def __imul__(self, other):
+        return self.multiply(other, inplace=False)
+
+    def __truediv__(self, other):
+        return self.multiply(1 / other)
+
+    def __itruediv__(self, other):
+        return self.multiply(1 / other, inplace=False)
+
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __add__(self, other):
+        return self.add(other)
+
+    def __iadd__(self, other):
+        return self.add(other, inplace=True)
+
+    def __sub__(self, other):
+        return self.subtract(other)
+
+    def __isub__(self, other):
+        return self.subtract(other, inplace=True)
+
+    def __neg__(self):
+        return self.multiply(-1)

--- a/qiskit/quantum_info/operators/channel/basechannel.py
+++ b/qiskit/quantum_info/operators/channel/basechannel.py
@@ -4,6 +4,9 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
+"""
+Abstract base class for Quantum Channels.
+"""
 
 from abc import ABC, abstractmethod
 
@@ -21,7 +24,8 @@ class QuantumChannel(ABC):
 
     def __init__(self, rep, data, input_dim, output_dim):
         if not isinstance(rep, str):
-            raise QiskitError("rep must be a string not a {}".format(rep.__class__))
+            raise QiskitError("rep must be a string not a {}".format(
+                rep.__class__))
         self._rep = rep
         self._data = data
         self._input_dim = input_dim
@@ -33,10 +37,8 @@ class QuantumChannel(ABC):
         return False
 
     def __repr__(self):
-        return '{}({}, input_dim={}, output_dim={})'.format(self.rep,
-                                                            self.data,
-                                                            self._input_dim,
-                                                            self._output_dim)
+        return '{}({}, input_dim={}, output_dim={})'.format(
+            self.rep, self.data, self._input_dim, self._output_dim)
 
     @property
     def rep(self):
@@ -61,17 +63,19 @@ class QuantumChannel(ABC):
         return QuantumChannel.ATOL
 
     @atol.setter
-    def atol(cls, atol):
+    def atol(self, atol):
         """Set atol parameter for float comparisons."""
-        MAX_ATOL = QuantumChannel.MAX_ATOL
+        max_atol = QuantumChannel.MAX_ATOL
         if atol < 0:
             raise QiskitError("Invalid atol: must be non-negative.")
-        if atol > MAX_ATOL:
-            raise QiskitError("Invalid atol: must be less than {}.".format(MAX_ATOL))
+        if atol > max_atol:
+            raise QiskitError(
+                "Invalid atol: must be less than {}.".format(max_atol))
         QuantumChannel.ATOL = atol
 
     def copy(self):
         """Make a copy of current channel."""
+        # pylint: disable=no-value-for-parameter
         # The constructor of subclasses from raw data should be a copy
         return self.__class__(self._data, self._input_dim, self._output_dim)
 
@@ -178,11 +182,13 @@ class QuantumChannel(ABC):
         if ndim > 2:
             raise QiskitError('Input state is not a vector or matrix.')
         if shape[0] != self._input_dim:
-            raise QiskitError('Input state is wrong size for channel input dimension.')
+            raise QiskitError(
+                'Input state is wrong size for channel input dimension.')
         # Flatten column-vector to vector
         if ndim == 2:
             if shape[1] != 1 and shape[1] != self._input_dim:
-                raise QiskitError('Input state is wrong size for channel input dimension.')
+                raise QiskitError(
+                    'Input state is wrong size for channel input dimension.')
             if shape[1] == 1:
                 # flatten colum-vector to vector
                 state = np.reshape(state, shape[0])

--- a/qiskit/quantum_info/operators/channel/basechannel.py
+++ b/qiskit/quantum_info/operators/channel/basechannel.py
@@ -34,7 +34,8 @@ class QuantumChannel(ABC):
 
     def __eq__(self, other):
         if isinstance(other, self.__class__) and self.dims == other.dims:
-            return np.allclose(self.data, other.data, atol=self.atol)
+            return np.allclose(
+                self.data, other.data, rtol=self.rtol, atol=self.atol)
         return False
 
     def __repr__(self):
@@ -104,11 +105,11 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (QuantumState): A statevector or density matrix.
 
         Returns:
             QuantumState: the output quantum state.

--- a/qiskit/quantum_info/operators/channel/basechannel.py
+++ b/qiskit/quantum_info/operators/channel/basechannel.py
@@ -13,14 +13,15 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from qiskit.qiskiterror import QiskitError
-from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT
+from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 
 
 class QuantumChannel(ABC):
     """Quantum channel representation base class."""
 
     ATOL = ATOL_DEFAULT
-    MAX_ATOL = 1e-4
+    RTOL = RTOL_DEFAULT
+    MAX_TOL = 1e-4
 
     def __init__(self, rep, data, input_dim, output_dim):
         if not isinstance(rep, str):
@@ -57,21 +58,39 @@ class QuantumChannel(ABC):
 
     @property
     def atol(self):
-        """Atol parameter for float comparisons."""
+        """The absolute tolerence parameter for float comparisons."""
         # NOTE: This should really be a class method so that it can
         # be overriden for all QuantumChannel subclasses
         return QuantumChannel.ATOL
 
     @atol.setter
     def atol(self, atol):
-        """Set atol parameter for float comparisons."""
-        max_atol = QuantumChannel.MAX_ATOL
+        """Set the absolute tolerence parameter for float comparisons."""
+        max_tol = QuantumChannel.MAX_TOL
         if atol < 0:
             raise QiskitError("Invalid atol: must be non-negative.")
-        if atol > max_atol:
+        if atol > max_tol:
             raise QiskitError(
-                "Invalid atol: must be less than {}.".format(max_atol))
+                "Invalid atol: must be less than {}.".format(max_tol))
         QuantumChannel.ATOL = atol
+
+    @property
+    def rtol(self):
+        """The relative tolerence parameter for float comparisons."""
+        # NOTE: This should really be a class method so that it can
+        # be overriden for all QuantumChannel subclasses
+        return QuantumChannel.RTOL
+
+    @rtol.setter
+    def rtol(self, rtol):
+        """Set the relative tolerence parameter for float comparisons."""
+        max_tol = QuantumChannel.MAX_TOL
+        if rtol < 0:
+            raise QiskitError("Invalid rtol: must be non-negative.")
+        if rtol > max_tol:
+            raise QiskitError(
+                "Invalid rtol: must be less than {}.".format(max_tol))
+        QuantumChannel.RTOL = rtol
 
     def copy(self):
         """Make a copy of current channel."""

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -81,16 +81,16 @@ class Chi(QuantumChannel):
         tmp = Choi(self)
         return tmp.is_cptp()
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): The input statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
         """
-        return Choi(self).evolve(state)
+        return Choi(self)._evolve(state)
 
     def conjugate(self, inplace=False):
         """Return the conjugate of the  QuantumChannel.

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from .basechannel import QuantumChannel
+from .choi import Choi
+from .transformations import _to_chi, _bipartite_tensor
+
+
+class Chi(QuantumChannel):
+    """Pauli basis Chi-matrix representation of a quantum channel
+
+    The Chi-matrix is the Pauli-basis representation of the Chi-Matrix.
+    """
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            if input_dim != output_dim:
+                raise QiskitError("Cannot convert to Chi-matrix: input_dim " +
+                                  "({}) != output_dim ({})".format(input_dim, output_dim))
+            chi_mat = _to_chi(data.rep, data._data, input_dim, output_dim)
+        else:
+            chi_mat = np.array(data, dtype=complex)
+            # Determine input and output dimensions
+            dl, dr = chi_mat.shape
+            if dl != dr:
+                raise QiskitError('Invalid Choi-matrix input.')
+            if output_dim is None and input_dim is None:
+                output_dim = int(np.sqrt(dl))
+                input_dim = dl // output_dim
+            elif input_dim is None:
+                input_dim = dl // output_dim
+            elif output_dim is None:
+                output_dim = dl // input_dim
+            # Check dimensions
+            if input_dim * output_dim != dl:
+                raise QiskitError("Invalid input and output dimension for Chi-matrix input.")
+            nqubits = int(np.log2(input_dim))
+            if 2 ** nqubits != input_dim:
+                raise QiskitError("Input is not an n-qubit Chi matrix.")
+        super().__init__('Chi', chi_mat, input_dim, output_dim)
+
+    @property
+    def _bipartite_shape(self):
+        """Return the shape for bipartite matrix"""
+        return (self._input_dim, self._output_dim,
+                self._input_dim, self._output_dim)
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        return Choi(self).evolve(state)
+
+    def is_cptp(self):
+        """Test if channel completely-positive and trace preserving (CPTP)"""
+        # We convert to the Choi representation to check if CPTP
+        tmp = Choi(self)
+        return tmp.is_cptp()
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        # Since conjugation is basis dependent we transform
+        # to the Choi representation to compute the
+        # conjugate channel
+        tmp = Chi(Choi(self).conjugate(inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+        return tmp
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # Since conjugation is basis dependent we transform
+        # to the Choi representation to compute the
+        # conjugate channel
+        tmp = Chi(Choi(self).transpose(inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+        return tmp
+
+    def compose(self, other, inplace=False, front=False):
+        """Return Choi for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): a quantum channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            Chi: The Chi representation for the composition channel.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel object or if the
+            dimensions don't match.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Since we cannot directly add two channels in the Chi
+        # representation we convert to the Choi representation
+        tmp = Chi(Choi(self).compose(other, inplace=True, front=front))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return Chi for the tensor product channel.
+
+        Args:
+            other (Chi): A Choi channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            Chi: The Chi for the composition channel.
+
+        Raises:
+            QiskitError: if b is not a Chi object
+        """
+        if not isinstance(other, Chi):
+            raise QiskitError('Input channels must Chi')
+
+        # Reshuffle indicies
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+
+        # Combined channel dimensions
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+
+        data = _bipartite_tensor(self._data, other.data, front=front,
+                                 shape_a=self._bipartite_shape,
+                                 shape_b=other._bipartite_shape)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return Chi(data, input_dim, output_dim)
+
+    def add(self, other, inplace=False):
+        """Add another channel"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, Chi):
+            other = Chi(other)
+        if inplace:
+            self._data += other._data
+            return self
+        input_dim, output_dim = self.dims
+        return Chi(self._data + other.data, input_dim, output_dim)
+
+    def subtract(self, other, inplace=False):
+        """Subtract another channel"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, Chi):
+            other = Chi(other)
+        if inplace:
+            self._data -= other.data
+            return self
+        input_dim, output_dim = self.dims
+        return Chi(self._data - other.data, input_dim, output_dim)
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        if inplace:
+            self._data *= other
+            return self
+        input_dim, output_dim = self.dims
+        return Chi(other * self._data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -144,20 +144,19 @@ class Chi(QuantumChannel):
         Raises:
             QiskitError: if b is not a Chi object
         """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
         if not isinstance(other, Chi):
-            raise QiskitError('Input channels must Chi')
-
-        # Reshuffle indicies
+            other = Chi(other)
+        # Combined channel dimensions
         a_in, a_out = self.dims
         b_in, b_out = other.dims
-
-        # Combined channel dimensions
         input_dim = a_in * b_in
         output_dim = a_out * b_out
-
-        data = _bipartite_tensor(self._data, other.data, front=front,
-                                 shape_a=self._bipartite_shape,
-                                 shape_b=other._bipartite_shape)
+        if front:
+            data = np.kron(self._data, other.data)
+        else:
+            data = np.kron(other.data, self._data)
         if inplace:
             self._data = data
             self._input_dim = input_dim

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -75,25 +75,33 @@ class Chi(QuantumChannel):
         return (self._input_dim, self._output_dim, self._input_dim,
                 self._output_dim)
 
+    def is_cptp(self):
+        """Return True if completely-positive trace-preserving."""
+        # We convert to the Choi representation to check if CPTP
+        tmp = Choi(self)
+        return tmp.is_cptp()
+
     def evolve(self, state):
-        """Apply the channel to a quantum state.
+        """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (quantum_state like): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
         """
         return Choi(self).evolve(state)
 
-    def is_cptp(self):
-        """Test if channel completely-positive and trace preserving (CPTP)"""
-        # We convert to the Choi representation to check if CPTP
-        tmp = Choi(self)
-        return tmp.is_cptp()
-
     def conjugate(self, inplace=False):
-        """Return the conjugate channel"""
+        """Return the conjugate of the  QuantumChannel.
+
+        Args:
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the conjugate of the quantum channel as a Chi object.
+        """
         # Since conjugation is basis dependent we transform
         # to the Choi representation to compute the
         # conjugate channel
@@ -105,7 +113,15 @@ class Chi(QuantumChannel):
         return tmp
 
     def transpose(self, inplace=False):
-        """Return the transpose channel"""
+        """Return the transpose of the QuantumChannel.
+
+        Args:
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the transpose of the quantum channel as a Chi object.
+        """
         # Since conjugation is basis dependent we transform
         # to the Choi representation to compute the
         # conjugate channel
@@ -116,23 +132,38 @@ class Chi(QuantumChannel):
             self._output_dim = tmp._output_dim
         return tmp
 
-    def compose(self, other, inplace=False, front=False):
-        """Return Choi for the composition channel B(A(input))
+    def adjoint(self, inplace=False):
+        """Return the adjoint of the QuantumChannel.
 
         Args:
-            other (QuantumChannel): a quantum channel
-            inplace (bool): If True modify the current object inplace [default: False]
-            front (bool): If True compose in reverse order A(B(input)) [default: False]
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
 
         Returns:
-            Chi: The Chi representation for the composition channel.
+            Chi: the adjoint of the quantum channel as a Chi object.
+        """
+        return super().adjoint(inplace=inplace)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return the composition channel self∘other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                            [Default: False]
+            front (bool): If False compose in standard order other(self(input))
+                          otherwise compose in reverse order self(other(input))
+                          [default: False]
+
+        Returns:
+            Chi: The composition channel as a Chi object.
 
         Raises:
-            QiskitError: if other is not a QuantumChannel object or if the
-            dimensions don't match.
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
         """
         if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
+            raise QiskitError('other is not a QuantumChannel subclass')
         # Check dimensions match up
         if front and self._input_dim != other._output_dim:
             raise QiskitError(
@@ -150,47 +181,75 @@ class Chi(QuantumChannel):
             return self
         return tmp
 
-    def tensor(self, other, inplace=False, front=False):
-        """Return Chi for the tensor product channel.
+    def power(self, n, inplace=False):
+        """Return the compose of a QuantumChannel with itself n times.
 
         Args:
-            other (Chi): A Choi channel
-            inplace (bool): If True modify the current object inplace [default: False]
-            front (bool): If False return (other ⊗ self),
-                          if True return (self ⊗ other) [Default: False]
+            n (int): the number of times to compose with self (n>0).
+            inplace (bool): If True modify the current object inplace
+                            [Default: False]
+
         Returns:
-            Chi: The Chi for the composition channel.
+            Chi: the n-times composition channel as a Chi object.
 
         Raises:
-            QiskitError: if b is not a Chi object
+            QiskitError: if the input and output dimensions of the
+            QuantumChannel are not equal, or the power is not a positive
+            integer.
         """
-        if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
-        if not isinstance(other, Chi):
-            other = Chi(other)
-        # Combined channel dimensions
-        a_in, a_out = self.dims
-        b_in, b_out = other.dims
-        input_dim = a_in * b_in
-        output_dim = a_out * b_out
-        if front:
-            data = np.kron(self._data, other.data)
-        else:
-            data = np.kron(other.data, self._data)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
-        return Chi(data, input_dim, output_dim)
+        return super().power(n, inplace=inplace)
+
+    def tensor(self, other, inplace=False):
+        """Return the tensor product channel self ⊗ other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the tensor product channel self ⊗ other as a Chi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        return self._tensor_product(other, inplace=inplace, reverse=False)
+
+    def expand(self, other, inplace=False):
+        """Return the tensor product channel other ⊗ self.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the tensor product channel other ⊗ self as a Chi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        return self._tensor_product(other, inplace=inplace, reverse=True)
 
     def add(self, other, inplace=False):
-        """Add another channel"""
+        """Return the QuantumChannel self + other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the linear addition self + other as a Chi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
         if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
+            raise QiskitError('other is not a QuantumChannel subclass')
         if self.dims != other.dims:
-            raise QiskitError("Channel dimensions are not equal")
+            raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Chi):
             other = Chi(other)
         if inplace:
@@ -200,11 +259,24 @@ class Chi(QuantumChannel):
         return Chi(self._data + other.data, input_dim, output_dim)
 
     def subtract(self, other, inplace=False):
-        """Subtract another channel"""
+        """Return the QuantumChannel self - other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the linear subtraction self - other as Chi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
         if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
+            raise QiskitError('other is not a QuantumChannel subclass')
         if self.dims != other.dims:
-            raise QiskitError("Channel dimensions are not equal")
+            raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Chi):
             other = Chi(other)
         if inplace:
@@ -214,11 +286,59 @@ class Chi(QuantumChannel):
         return Chi(self._data - other.data, input_dim, output_dim)
 
     def multiply(self, other, inplace=False):
-        """Multiple by a scalar"""
+        """Return the QuantumChannel self + other.
+
+        Args:
+            other (complex): a complex number
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            Chi: the scalar multiplication other * self as a Chi object.
+
+        Raises:
+            QiskitError: if other is not a valid scalar.
+        """
         if not isinstance(other, Number):
-            raise QiskitError("Not a number")
+            raise QiskitError("other is not a number")
         if inplace:
             self._data *= other
             return self
         input_dim, output_dim = self.dims
         return Chi(other * self._data, input_dim, output_dim)
+
+    def _tensor_product(self, other, inplace=False, reverse=False):
+        """Return the tensor product channel.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                            [default: False]
+            reverse (bool): If False return self ⊗ other, if True return
+                            if True return (other ⊗ self) [Default: False
+        Returns:
+            Chi: the tensor product channel as a Chi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('other is not a QuantumChannel subclass')
+        if not isinstance(other, Chi):
+            other = Chi(other)
+        # Combined channel dimensions
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+        if reverse:
+            data = np.kron(other.data, self._data)
+        else:
+            data = np.kron(self._data, other.data)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return Chi(data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -319,7 +319,7 @@ class Choi(QuantumChannel):
         """Test if Choi-matrix is completely-positive (CP)"""
         # Test if Choi-matrix is Hermitian
         # This is required for eigenvalues to be real
-        if not is_hermitian_matrix(self._data, atol=self.atol):
+        if not is_hermitian_matrix(self._data, rtol=self.rtol, atol=self.atol):
             return False
         # Check eigenvalues are all positive
         vals = np.linalg.eigvalsh(self._data)
@@ -336,7 +336,7 @@ class Choi(QuantumChannel):
             np.reshape(self._data, (d_in, d_out, d_in, d_out)),
             axis1=1,
             axis2=3)
-        return is_identity_matrix(mat, atol=self.atol)
+        return is_identity_matrix(mat, rtol=self.rtol, atol=self.atol)
 
     def _tensor_product(self, other, inplace=False, reverse=False):
         """Return the tensor product channel.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -72,11 +72,11 @@ class Choi(QuantumChannel):
         """Return True if completely-positive trace-preserving."""
         return self._is_cp() and self._is_tp()
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): The input statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -1,0 +1,232 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import is_identity_matrix
+from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
+from .basechannel import QuantumChannel
+from .transformations import _to_choi, _bipartite_tensor
+
+
+class Choi(QuantumChannel):
+    """Choi-matrix representation of a quantum channel"""
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            choi_mat = _to_choi(data.rep, data._data, input_dim, output_dim)
+        else:
+            choi_mat = np.array(data, dtype=complex)
+            # Determine input and output dimensions
+            dl, dr = choi_mat.shape
+            if dl != dr:
+                raise QiskitError('Invalid Choi-matrix input.')
+            if output_dim is None and input_dim is None:
+                output_dim = int(np.sqrt(dl))
+                input_dim = dl // output_dim
+            elif input_dim is None:
+                input_dim = dl // output_dim
+            elif output_dim is None:
+                output_dim = dl // input_dim
+            # Check dimensions
+            if input_dim * output_dim != dl:
+                raise QiskitError("Invalid input and output dimension for Choi-matrix input.")
+        super().__init__('Choi', choi_mat, input_dim, output_dim)
+
+    @property
+    def _bipartite_shape(self):
+        """Return the shape for bipartite matrix"""
+        return (self._input_dim, self._output_dim,
+                self._input_dim, self._output_dim)
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        state = self._format_density_matrix(self._check_state(state))
+        return np.einsum('AB,AiBj->ij', state,
+                         np.reshape(self._data, self._bipartite_shape))
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        if inplace:
+            np.conjugate(self._data, out=self._data)
+            return self
+        return Choi(np.conj(self._data), self._input_dim, self._output_dim)
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # Make bipartite matrix
+        di = self._input_dim
+        do = self._output_dim
+        data = np.reshape(self._data, (di, do, di, do))
+        # Swap input and output indicies on bipartite matrix
+        data = np.transpose(data, (1, 0, 3, 2))
+        # Transpose channel has input and output dimensions swapped
+        data = np.reshape(data, (di * do, di * do))
+        if inplace:
+            self._data = data
+            self._input_dim = do
+            self._output_dim = di
+            return self
+        return Choi(data, do, di)
+
+    def is_cptp(self):
+        """Test if Choi-matrix is completely-positive and trace preserving (CPTP)"""
+        return self._is_cp() and self._is_tp()
+
+    def _is_cp(self):
+        """Test if Choi-matrix is completely-positive (CP)"""
+        # Test if Choi-matrix is Hermitian
+        # This is required for eigenvalues to be real
+        if not is_hermitian_matrix(self._data, atol=self.atol):
+            return False
+        # Check eigenvalues are all positive
+        vals = np.linalg.eigvalsh(self._data)
+        for v in vals:
+            if v < -self.atol:
+                return False
+        return True
+
+    def _is_tp(self):
+        """Test if Choi-matrix is trace-preserving (TP)"""
+        # Check if the partial trace is the identity matrix
+        din, dout = self.dims
+        tr = np.trace(np.reshape(self._data, (din, dout, din, dout)),
+                      axis1=1, axis2=3)
+        return is_identity_matrix(tr, atol=self.atol)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): a quantum channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            Choi: The Choi for the composition channel.
+
+        Raises:
+            QiskitError: if other is not a Choi object or if the
+            dimensions don't match.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Convert to Choi matrix
+        if not isinstance(other, Choi):
+            other = Choi(other)
+
+        if front:
+            a = np.reshape(other._data, other._bipartite_shape)
+            b = np.reshape(self._data, self._bipartite_shape)
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+        else:
+            a = np.reshape(self._data, self._bipartite_shape)
+            b = np.reshape(other._data, other._bipartite_shape)
+            input_dim = self._input_dim
+            output_dim = other._output_dim
+
+        # Contract Choi matrices for composition
+        data = np.reshape(np.einsum('iAjB,AkBl->ikjl', a, b),
+                          (input_dim * output_dim, input_dim * output_dim))
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return Choi(data, input_dim, output_dim)
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return Choi for the tensor product channel.
+
+        Args:
+            other (Choi): A Choi channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            Choi: The Choi for the composition channel.
+
+        Raises:
+            QiskitError: if b is not a Choi object
+        """
+        if not isinstance(other, Choi):
+            raise QiskitError('Input channels must Choi')
+        # Reshuffle indicies
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+
+        # Combined channel dimensions
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+
+        data = _bipartite_tensor(self._data, other.data, front=front,
+                                 shape_a=self._bipartite_shape,
+                                 shape_b=other._bipartite_shape)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return Choi(data, input_dim, output_dim)
+
+    def add(self, other, inplace=False):
+        """Add another Choi-matrix"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, Choi):
+            other = Choi(other)
+        if inplace:
+            self._data += other._data
+            return self
+        input_dim, output_dim = self.dims
+        return Choi(self._data + other.data, input_dim, output_dim)
+
+    def subtract(self, other, inplace=False):
+        """Subtract another Choi-matrix"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, Choi):
+            other = Choi(other)
+        if inplace:
+            self._data -= other.data
+            return self
+        input_dim, output_dim = self.dims
+        return Choi(self._data - other.data, input_dim, output_dim)
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        if inplace:
+            self._data *= other
+            return self
+        input_dim, output_dim = self.dims
+        return Choi(other * self._data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from qiskit.qiskiterror import QiskitError
 from qiskit.quantum_info.operators.predicates import is_identity_matrix
-from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
+from qiskit.quantum_info.operators.predicates import is_positive_semidefinite_matrix
 from .basechannel import QuantumChannel
 from .transformations import _to_choi, _bipartite_tensor
 
@@ -317,16 +317,8 @@ class Choi(QuantumChannel):
 
     def _is_cp(self):
         """Test if Choi-matrix is completely-positive (CP)"""
-        # Test if Choi-matrix is Hermitian
-        # This is required for eigenvalues to be real
-        if not is_hermitian_matrix(self._data, rtol=self.rtol, atol=self.atol):
-            return False
-        # Check eigenvalues are all positive
-        vals = np.linalg.eigvalsh(self._data)
-        for v in vals:
-            if v < -self.atol:
-                return False
-        return True
+        return is_positive_semidefinite_matrix(
+            self._data, rtol=self.rtol, atol=self.atol)
 
     def _is_tp(self):
         """Test if Choi-matrix is trace-preserving (TP)"""

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -127,7 +127,7 @@ class Kraus(QuantumChannel):
         accum = 0j
         for op in self._data[0]:
             accum += np.dot(np.transpose(np.conj(op)), op)
-        return is_identity_matrix(accum, atol=self.atol)
+        return is_identity_matrix(accum, rtol=self.rtol, atol=self.atol)
 
     def evolve(self, state):
         """Apply the channel to a quantum state.

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -129,11 +129,11 @@ class Kraus(QuantumChannel):
             accum += np.dot(np.transpose(np.conj(op)), op)
         return is_identity_matrix(accum, rtol=self.rtol, atol=self.atol)
 
-    def evolve(self, state):
-        """Apply the channel to a quantum state.
+    def _evolve(self, state):
+        """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             QuantumState: the output quantum state.

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import is_identity_matrix
+from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT
+from .basechannel import QuantumChannel
+from .choi import Choi
+from .transformations import _to_kraus
+
+
+class Kraus(QuantumChannel):
+    """Kraus representation of a quantum channel."""
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            kraus = _to_kraus(data.rep, data._data, input_dim, output_dim)
+
+        else:
+            # Check if it is a single unitary matrix A for channel:
+            # E(rho) = A * rho * A^\dagger
+            if isinstance(data, np.ndarray) or np.array(data).ndim == 2:
+                # Convert single Kraus op to general Kraus pair
+                kraus = ([np.array(data, dtype=complex)], None)
+                shape = kraus[0][0].shape
+
+            # Check if single Kraus set [A_i] for channel:
+            # E(rho) = sum_i A_i * rho * A_i^dagger
+            elif isinstance(data, list) and len(data) > 0:
+                # Get dimensions from first Kraus op
+                kraus = [np.array(data[0], dtype=complex)]
+                shape = kraus[0].shape
+                # Iterate over remaining ops and check they are same shape
+                for a in data[1:]:
+                    op = np.array(a, dtype=complex)
+                    if op.shape != shape:
+                        raise QiskitError("Kraus operators are different dimensions.")
+                    kraus.append(op)
+                # Convert single Kraus set to general Kraus pair
+                kraus = (kraus, None)
+
+            # Check if generalized Kraus set ([A_i], [B_i]) for channel:
+            # E(rho) = sum_i A_i * rho * B_i^dagger
+            elif isinstance(data, tuple) and len(data) == 2 and len(data[0]) > 0:
+                kraus_left = [np.array(data[0][0], dtype=complex)]
+                shape = kraus_left[0].shape
+                for a in data[0][1:]:
+                    op = np.array(a, dtype=complex)
+                    if op.shape != shape:
+                        raise QiskitError("Kraus operators are different dimensions.")
+                    kraus_left.append(op)
+                if data[1] is None:
+                    kraus = (kraus_left, None)
+                else:
+                    kraus_right = []
+                    for b in data[1]:
+                        op = np.array(b, dtype=complex)
+                        if op.shape != shape:
+                            raise QiskitError("Kraus operators are different dimensions.")
+                        kraus_right.append(op)
+                    kraus = (kraus_left, kraus_right)
+            else:
+                raise QiskitError("Invalid input for Kraus channel.")
+        dout, din = kraus[0][0].shape
+        if (input_dim and input_dim != din) or (output_dim and output_dim != dout):
+            raise QiskitError("Invalid dimensions for Kraus input.")
+
+        if kraus[1] is None or np.allclose(kraus[0], kraus[1]):
+            # Standard Kraus map
+            super().__init__('Kraus', (kraus[0], None), input_dim=din, output_dim=dout)
+        else:
+            # General (non-CPTP) Kraus map
+            super().__init__('Kraus', kraus, input_dim=din, output_dim=dout)
+
+    @property
+    def data(self):
+        """Return list of Kraus matrices for channel."""
+        if self._data[1] is None:
+            # If only a single Kraus set, don't return the tuple
+            # Just the fist set
+            return self._data[0]
+        else:
+            # Otherwise return the tuple of both kraus sets
+            return self._data
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix or statevector.
+        """
+        state = self._check_state(state)
+        if state.ndim == 1 and self._data[1] is None and len(self._data[0]) == 1:
+            # If we only have a single Kraus operator we can implement unitary-type
+            # evolution of a state vector psi -> K[0].psi
+            return np.dot(self._data[0][0], state)
+        # Otherwise we always return a density matrix
+        state = self._format_density_matrix(state)
+        kraus_l, kraus_r = self._data
+        if kraus_r is None:
+            kraus_r = kraus_l
+        return np.einsum('AiB,BC,AjC->ij', kraus_l, state, np.conjugate(kraus_r))
+
+    def is_cptp(self, atol=ATOL_DEFAULT):
+        """Test if the Kraus channel is a CPTP map."""
+        if self._data[1] is not None:
+            return False
+        accum = 0j
+        for op in self._data[0]:
+            accum += np.dot(np.transpose(np.conj(op)), op)
+        return is_identity_matrix(accum, atol=atol)
+
+    def canonical(self, inplace=False):
+        """Convert to canonical Kraus representation"""
+        tmp = Kraus(Choi(self))
+        if inplace:
+            self._data = tmp._data
+            return self
+        return tmp
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        kraus_l, kraus_r = self._data
+        kraus_l = [k.conj() for k in kraus_l]
+        if kraus_r is not None:
+            kraus_r = [k.conj() for k in kraus_r]
+        if inplace:
+            self._data = (kraus_l, kraus_r)
+            return self
+        return Kraus((kraus_l, kraus_r), *self.dims)
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        kraus_l, kraus_r = self._data
+        kraus_l = [k.T for k in kraus_l]
+        if kraus_r is not None:
+            kraus_r = [k.T for k in kraus_r]
+        dout, din = self.dims
+        if inplace:
+            self._data = (kraus_l, kraus_r)
+            self._output_dim = dout
+            self._input_dim = din
+            return self
+        return Kraus((kraus_l, kraus_r), din, dout)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return Kraus representation for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): A channel rep object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            Kraus: The Kraus representation for the composition channel.
+
+        Raises:
+            QiskitError: if dimensions do not allow channels to be composed.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Convert to Choi matrix
+        if not isinstance(other, Kraus):
+            other = Kraus(other)
+
+        if front:
+            ka_l, ka_r = self._data
+            kb_l, kb_r = other._data
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+        else:
+            ka_l, ka_r = other._data
+            kb_l, kb_r = self._data
+            input_dim = self._input_dim
+            output_dim = other._output_dim
+
+        kab_l = [np.dot(a, b) for a in ka_l for b in kb_l]
+        if ka_r is None and kb_r is None:
+            kab_r = None
+        elif ka_r is None:
+            kab_r = [np.dot(a, b) for a in ka_l for b in kb_r]
+        elif kb_r is None:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_l]
+        else:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
+        data = (kab_l, kab_r)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return Kraus(data, input_dim, output_dim)
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return Kraus for the tensor product channel.
+
+        Args:
+            other (Kraus): A Kraus
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            Kraus: The Kraus for the composition channel.
+
+        Raises:
+            QiskitError: if b is not a Kraus object
+        """
+        # Convert other to Kraus
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if not isinstance(other, Kraus):
+            other = Kraus(other)
+
+        # Get tensor matrix
+        ka_l, ka_r = self._data
+        kb_l, kb_r = other._data
+        if front:
+            kab_l = [np.kron(a, b) for a in ka_l for b in kb_l]
+        else:
+            kab_l = [np.kron(b, a) for a in ka_l for b in kb_l]
+        if ka_r is None and kb_r is None:
+            kab_r = None
+        else:
+            if ka_r is None:
+                ka_r = ka_l
+            if kb_r is None:
+                kb_r = kb_l
+            if front:
+                kab_r = [np.kron(a, b) for a in ka_r for b in kb_r]
+            else:
+                kab_r = [np.kron(b, a) for a in ka_r for b in kb_r]
+        data = (kab_l, kab_r)
+        input_dim = self._input_dim * other._input_dim
+        output_dim = self._output_dim * other._output_dim
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return Kraus(data, input_dim, output_dim)
+
+    def add(self, other, inplace=False):
+        """Add another QuantumChannel"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Since we cannot directly add two channels in the Kraus
+        # representation we try and use the other channels method
+        # or convert to the Choi representation
+        tmp = Kraus(Choi(self).add(other, inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def subtract(self, other, inplace=False):
+        """Subtract another QuantumChannel"""
+        # Since we cannot directly subtract two channels in the Kraus
+        # representation we try and use the other channels method
+        # or convert to the Choi representation
+        tmp = Kraus(Choi(self).subtract(other, inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        # If the number is complex we need to convert to general
+        # kraus channel so we multiply via Choi representation
+        if isinstance(other, complex) or other < 0:
+            # Convert to Choi-matrix
+            tmp = Kraus(Choi(self).multiply(other, inplace=True))
+            if inplace:
+                self._data = tmp._data
+                self._input_dim = tmp._input_dim
+                self._output_dim = tmp._output_dim
+                return self
+            return tmp
+        # If the number is real we can update the Kraus operators
+        # directly
+        else:
+            s = np.sqrt(other)
+            if inplace:
+                for j, _ in enumerate(self._data[0]):
+                    self._data[0][j] *= s
+                if self._data[1] is not None:
+                    for j, _ in enumerate(self._data[1]):
+                        self._data[1][j] *= s
+            else:
+                kraus_r = None
+                kraus_l = [s * k for k in self._data[0]]
+                if self._data[1] is not None:
+                    kraus_r = [s * k for k in self._data[1]]
+                return Kraus((kraus_l, kraus_r),
+                             self._input_dim, self._output_dim)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -1,0 +1,216 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from .basechannel import QuantumChannel
+from .choi import Choi
+from .superop import SuperOp
+from .transformations import _to_ptm, _bipartite_tensor
+
+
+class PTM(QuantumChannel):
+    """Pauli transfer matrix (PTM) representation of a quantum channel.
+
+    The PTM is the Pauli-basis representation of the PTM.
+    """
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            ptm = _to_ptm(data.rep, data._data, input_dim, output_dim)
+        else:
+            # Should we force this to be real?
+            ptm = np.array(data, dtype=complex)
+            # Determine input and output dimensions
+            dout, din = ptm.shape
+            if output_dim is None:
+                output_dim = int(np.sqrt(dout))
+            if input_dim is None:
+                input_dim = int(np.sqrt(din))
+            # Check dimensions
+            if output_dim ** 2 != dout or input_dim ** 2 != din or input_dim != output_dim:
+                raise QiskitError("Invalid input and output dimension for PTM input.")
+            nqubits = int(np.log2(input_dim))
+            if 2 ** nqubits != input_dim:
+                raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
+        super().__init__('PTM', ptm, input_dim, output_dim)
+
+    @property
+    def _bipartite_shape(self):
+        """Return the shape for bipartite matrix"""
+        return (self._output_dim, self._output_dim,
+                self._input_dim, self._input_dim)
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        return SuperOp(self).evolve(state)
+
+    def is_cptp(self):
+        """Test if channel completely-positive and trace preserving (CPTP)"""
+        # We convert to the Choi representation to check if CPTP
+        tmp = Choi(self)
+        return tmp.is_cptp()
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        # Since conjugation is basis dependent we transform
+        # to the SuperOp representation to compute the
+        # conjugate channel
+        tmp = PTM(SuperOp(self).conjugate(inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+        return tmp
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # Since conjugation is basis dependent we transform
+        # to the SuperOp representation to compute the
+        # conjugate channel
+        tmp = PTM(SuperOp(self).transpose(inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+        return tmp
+
+    def compose(self, other, inplace=False, front=False):
+        """Return PTM for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            PTM: The PTM for the composition channel.
+
+        Raises:
+            QiskitError: if other is not a PTM object
+            QiskitError: if dimensions don't match.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Convert other to PTM
+        if not isinstance(other, PTM):
+            other = PTM(other)
+
+        if front:
+            # Composition A(B(input))
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+            if inplace:
+                np.dot(self._data, other.data, out=self._data)
+                self._input_dim = input_dim
+                self._output_dim = output_dim
+                return self
+            return PTM(np.dot(self._data, other.data), input_dim, output_dim)
+        # Composition B(A(input))
+        input_dim = self._input_dim
+        output_dim = other._output_dim
+        if inplace:
+            np.dot(other.data, self._data, out=self._data)
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return PTM(np.dot(other.data, self._data), input_dim, output_dim)
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return PTM for the tensor product channel.
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            PTM: The PTM for the composition channel.
+
+        Raises:
+            QiskitError: if b is not a PTM object
+        """
+        # Convert other to PTM
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if not isinstance(other, PTM):
+            other = PTM(other)
+
+        # Reshuffle indicies
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+
+        # Combined channel dimensions
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+
+        data = _bipartite_tensor(self._data, other.data, front=front,
+                                 shape_a=self._bipartite_shape,
+                                 shape_b=other._bipartite_shape)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return PTM(data, input_dim, output_dim)
+
+    def add(self, other, inplace=False):
+        """Add another channel"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, PTM):
+            other = PTM(other)
+        if inplace:
+            self._data += other._data
+            return self
+        input_dim, output_dim = self.dims
+        return PTM(self._data + other.data, input_dim, output_dim)
+
+    def subtract(self, other, inplace=False):
+        """Subtract another PTM"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, PTM):
+            other = PTM(other)
+        if inplace:
+            self._data -= other.data
+            return self
+        input_dim, output_dim = self.dims
+        return PTM(self._data - other.data, input_dim, output_dim)
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        if inplace:
+            self._data *= other
+            return self
+        input_dim, output_dim = self.dims
+        return PTM(other * self._data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -157,18 +157,15 @@ class PTM(QuantumChannel):
             raise QiskitError('Other is not a channel rep')
         if not isinstance(other, PTM):
             other = PTM(other)
-
-        # Reshuffle indicies
+        # Combined channel dimensions
         a_in, a_out = self.dims
         b_in, b_out = other.dims
-
-        # Combined channel dimensions
         input_dim = a_in * b_in
         output_dim = a_out * b_out
-
-        data = _bipartite_tensor(self._data, other.data, front=front,
-                                 shape_a=self._bipartite_shape,
-                                 shape_b=other._bipartite_shape)
+        if front:
+            data = np.kron(self._data, other.data)
+        else:
+            data = np.kron(other.data, self._data)
         if inplace:
             self._data = data
             self._input_dim = input_dim

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -75,16 +75,16 @@ class PTM(QuantumChannel):
         return (self._output_dim, self._output_dim, self._input_dim,
                 self._input_dim)
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): The input statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
         """
-        return SuperOp(self).evolve(state)
+        return SuperOp(self)._evolve(state)
 
     def is_cptp(self):
         """Return True if completely-positive trace-preserving."""

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -4,6 +4,28 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
+"""
+Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
+
+The PTM is the n-qubit superoperator defined with respect to vectorization in
+the Pauli basis. For a quantum channel E, the PTM is defined by
+
+    PTM_{i,j} = Tr[P_i.E(P_j)]
+
+where [P_i, i=0,...4^{n-1}] is the n-qubit Pauli basis in lexicographic order.
+
+Evolution is given by
+
+    |E(ρ)⟩⟩_p = PTM|ρ⟩⟩_p
+
+where |A⟩⟩_p denotes vectorization in the Pauli basis: ⟨i|A⟩⟩_p = Tr[P_i.A]
+
+See [1] for further details.
+
+References:
+    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
+        Open access: arXiv:1111.6950 [quant-ph]
+"""
 
 from numbers import Number
 
@@ -13,7 +35,7 @@ from qiskit.qiskiterror import QiskitError
 from .basechannel import QuantumChannel
 from .choi import Choi
 from .superop import SuperOp
-from .transformations import _to_ptm, _bipartite_tensor
+from .transformations import _to_ptm
 
 
 class PTM(QuantumChannel):
@@ -38,18 +60,20 @@ class PTM(QuantumChannel):
             if input_dim is None:
                 input_dim = int(np.sqrt(din))
             # Check dimensions
-            if output_dim ** 2 != dout or input_dim ** 2 != din or input_dim != output_dim:
-                raise QiskitError("Invalid input and output dimension for PTM input.")
+            if output_dim**2 != dout or input_dim**2 != din or input_dim != output_dim:
+                raise QiskitError(
+                    "Invalid input and output dimension for PTM input.")
             nqubits = int(np.log2(input_dim))
-            if 2 ** nqubits != input_dim:
-                raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
+            if 2**nqubits != input_dim:
+                raise QiskitError(
+                    "Input is not an n-qubit Pauli transfer matrix.")
         super().__init__('PTM', ptm, input_dim, output_dim)
 
     @property
     def _bipartite_shape(self):
         """Return the shape for bipartite matrix"""
-        return (self._output_dim, self._output_dim,
-                self._input_dim, self._input_dim)
+        return (self._output_dim, self._output_dim, self._input_dim,
+                self._input_dim)
 
     def evolve(self, state):
         """Apply the channel to a quantum state.
@@ -58,7 +82,7 @@ class PTM(QuantumChannel):
             state (quantum_state like): A statevector or density matrix.
 
         Returns:
-            A density matrix.
+            DensityMatrix: the output quantum state as a density matrix.
         """
         return SuperOp(self).evolve(state)
 
@@ -111,9 +135,11 @@ class PTM(QuantumChannel):
             raise QiskitError('Other is not a channel rep')
         # Check dimensions match up
         if front and self._input_dim != other._output_dim:
-            raise QiskitError('input_dim of self must match output_dim of other')
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
         if not front and self._output_dim != other._input_dim:
-            raise QiskitError('input_dim of other must match output_dim of self')
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
         # Convert other to PTM
         if not isinstance(other, PTM):
             other = PTM(other)

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import is_identity_matrix
+from .basechannel import QuantumChannel
+from .kraus import Kraus
+from .choi import Choi
+from .transformations import _to_stinespring
+
+
+class Stinespring(QuantumChannel):
+    """Stinespring representation of a quantum channel"""
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            stine = _to_stinespring(data.rep, data._data, input_dim, output_dim)
+        else:
+            if not isinstance(data, tuple):
+                # Convert single Stinespring set to length 1 tuple
+                stine = (np.array(data, dtype=complex), None)
+            if isinstance(data, tuple) and len(data) == 2:
+                if data[1] is None:
+                    stine = (np.array(data[0], dtype=complex), None)
+                else:
+                    stine = (np.array(data[0], dtype=complex),
+                             np.array(data[1], dtype=complex))
+
+            dim_left, dim_right = stine[0].shape
+            # If two stinespring matrices check they are same shape
+            if stine[1] is not None:
+                if stine[1].shape != (dim_left, dim_right):
+                    raise QiskitError("Invalid Stinespring input.")
+            if input_dim is None:
+                input_dim = dim_right
+            if output_dim is None:
+                output_dim = input_dim
+            if input_dim != dim_right:
+                raise QiskitError("Invalid input dimension")
+            if dim_left % output_dim != 0:
+                raise QiskitError("Invalid output dimension")
+        # Record the dimension to be traced over for stinespring
+        # evolution
+        if stine[1] is None or (stine[1] == stine[0]).all():
+            # Standard Stinespring map
+            super().__init__('Stinespring', (stine[0], None),
+                             input_dim=input_dim,
+                             output_dim=output_dim)
+        else:
+            # General (non-CPTP) Stinespring map
+            super().__init__('Stinespring', stine,
+                             input_dim=input_dim,
+                             output_dim=output_dim)
+
+    @property
+    def data(self):
+        # Override to deal with data being either tuple or not
+        if self._data[1] is None:
+            return self._data[0]
+        else:
+            return self._data
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        state = self._check_state(state)
+        if state.ndim == 1 and self._data[1] is None and \
+           self._data[0].shape[0] // self._output_dim == 1:
+            # If the shape of the stinespring operator is equal to the output_dim
+            # evolution of a state vector psi -> stine.psi
+            return np.dot(self._data[0], state)
+        # Otherwise we always return a density matrix
+        state = self._format_density_matrix(state)
+        state = self._format_density_matrix(self._check_state(state))
+        stine_l, stine_r = self._data
+        if stine_r is None:
+            stine_r = stine_l
+        din, dout = self.dims
+        dtr = stine_l.shape[0] // dout
+        shape = (dout, dtr, din)
+        return np.einsum('iAB,BC,jAC->ij',
+                         np.reshape(stine_l, shape), state,
+                         np.reshape(np.conjugate(stine_r), shape))
+
+    def is_cptp(self):
+        """Test if channel completely-positive and trace preserving (CPTP)"""
+        # We convert to the Choi representation to check if CPTP
+        if self._data[1] is not None:
+            return False
+        check = np.dot(np.transpose(np.conj(self._data[0])), self._data[0])
+        return is_identity_matrix(check, atol=self.atol)
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        if inplace:
+            np.conjugate(self._data[0], out=self._data[0])
+            if self._data[1] is not None:
+                np.conjugate(self._data[1], out=self._data[1])
+            return self
+        stine_l = np.conjugate(self._data[0])
+        stine_r = None
+        if self._data[1] is not None:
+            stine_r = np.conjugate(self._data[1])
+        return Stinespring((stine_l, stine_r), *self.dims)
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # To compute the transpose channel we first convert to the
+        # Kraus representation
+        din, dout = self.dims
+        dtr = self._data[0].shape[0] // dout
+        stine = [None, None]
+        for i, s in enumerate(self._data):
+            if s is not None:
+                stine[i] = np.reshape(np.transpose(np.reshape(s, (dout, dtr, din)),
+                                                   (2, 1, 0)),
+                                      (din * dtr, dout))
+        if inplace:
+            self._data = tuple(stine)
+            self._input_dim = dout
+            self._output_dim = din
+            return self
+        # Return new stinespring operator with output and input dims swapped
+        return Stinespring(tuple(stine), input_dim=dout, output_dim=din)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return PTM for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            Stinespring: The Stinespring representation for the composition channel.
+
+        Raises:
+            QiskitError: if other is not a PTM object
+            QiskitError: if dimensions don't match.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Since we cannot directly compose two channels in Stinespring
+        # representation we convert to the Kraus representation
+        tmp = Stinespring(Kraus(self).compose(other, inplace=True, front=front))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return Stinespring for the tensor product channel.
+
+        Args:
+            other (Stinespring): A SuperOp
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            Stinespring: the tensor product channel.
+
+        Raises:
+            QiskitError: if other is not a Stinespring object
+        """
+        if not isinstance(other, Stinespring):
+            raise QiskitError('Input channels must Stinespring')
+
+        # Tensor stinespring ops
+        sa_l, sa_r = self._data
+        sb_l, sb_r = other._data
+
+        # Reshuffle tensor dimensions
+        din_a, dout_a = self.dims
+        din_b, dout_b = other.dims
+        dtr_a = sa_l.shape[0] // dout_a
+        dtr_b = sb_l.shape[0] // dout_b
+        if front:
+            shape_in = (dout_a, dtr_a, dout_b, dtr_b, din_a * din_b)
+            shape_out = (dout_a * dtr_a * dout_b * dtr_b, din_a * din_b)
+        else:
+            shape_in = (dout_b, dtr_b, dout_a, dtr_a, din_b * din_a)
+            shape_out = (dout_b * dtr_b * dout_a * dtr_a, din_b * din_a)
+
+        # Compute left stinepsring op
+        if front:
+            sab_l = np.kron(sa_l, sb_l)
+        else:
+            sab_l = np.kron(sb_l, sa_l)
+        # Reravel indicies
+        sab_l = np.reshape(np.transpose(np.reshape(sab_l, shape_in),
+                                        (0, 2, 1, 3, 4)), shape_out)
+
+        # Compute right stinespring op
+        if sa_r is None and sb_r is None:
+            sab_r = None
+        else:
+            if sa_r is None:
+                sa_r = sa_l
+            elif sb_r is None:
+                sb_r = sb_l
+            if front:
+                sab_r = np.kron(sa_r, sb_r)
+            else:
+                sab_r = np.kron(sb_r, sa_r)
+            # Reravel indicies
+            sab_r = np.reshape(np.transpose(np.reshape(sab_r, shape_in),
+                                            (0, 2, 1, 3, 4)), shape_out)
+        if inplace:
+            self._data = (sab_l, sab_r)
+            self._input_dim = din_a * din_b
+            self._output_dim = dout_a * dout_b
+            return self
+        return Stinespring((sab_l, sab_r), din_a * din_b, dout_a * dout_b)
+
+    def add(self, other, inplace=False):
+        """Add another QuantumChannel"""
+        # Since we cannot directly add two channels in the Stinespring
+        # representation we convert to the Choi representation
+        tmp = Stinespring(Choi(self).add(other, inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def subtract(self, other, inplace=False):
+        """Subtract another QuantumChannel"""
+        # Since we cannot directly subtract two channels in the Stinespring
+        # representation we convert to the Choi representation
+        tmp = Stinespring(Choi(self).subtract(other, inplace=True))
+        if inplace:
+            self._data = tmp._data
+            self._input_dim = tmp._input_dim
+            self._output_dim = tmp._output_dim
+            return self
+        return tmp
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        # If the number is complex or negative we need to convert to
+        # general Stinespring representation so we first convert to
+        # the Choi representation
+        if isinstance(other, complex) or other < 1:
+            # Convert to Choi-matrix
+            tmp = Stinespring(Choi(self).multiply(other, inplace=True))
+            if inplace:
+                self._data = tmp._data
+                self._input_dim = tmp._input_dim
+                self._output_dim = tmp._output_dim
+                return self
+            return tmp
+        # If the number is real we can update the Kraus operators
+        # directly
+        num = np.sqrt(other)
+        if inplace:
+            self._data[0] *= num
+            if self._data[1] is not None:
+                self._data[1] *= num
+            return self
+        stine_l, stine_r = self._data
+        stine_l = num * self._data[0]
+        stine_r = None
+        if self._data[1] is not None:
+            stine_r = num * self._data[1]
+        return Stinespring((stine_l, stine_r), *self.dims)

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -127,7 +127,7 @@ class Stinespring(QuantumChannel):
         if self._data[1] is not None:
             return False
         check = np.dot(np.transpose(np.conj(self._data[0])), self._data[0])
-        return is_identity_matrix(check, atol=self.atol)
+        return is_identity_matrix(check, rtol=self.rtol, atol=self.atol)
 
     def conjugate(self, inplace=False):
         """Return the conjugate of the  QuantumChannel.

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -94,11 +94,11 @@ class Stinespring(QuantumChannel):
         else:
             return self._data
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             QuantumState: the output quantum state.

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -68,11 +68,11 @@ class SuperOp(QuantumChannel):
         tmp = Choi(self)
         return tmp.is_cptp()
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): The input statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -4,6 +4,22 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
+"""
+Superoperator representation of a Quantum Channel.
+
+
+For a quantum channel E, the superoperator is defined as the matrix S such that
+
+    |E(ρ)⟩⟩ = S|ρ⟩⟩
+
+where |A⟩⟩ denotes the column stacking vectorization of a matrix A.
+
+See [1] for further details.
+
+References:
+    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
+        Open access: arXiv:1111.6950 [quant-ph]
+"""
 
 from numbers import Number
 import numpy as np
@@ -22,7 +38,8 @@ class SuperOp(QuantumChannel):
         # If so we disregard the dimension kwargs
         if issubclass(data.__class__, QuantumChannel):
             input_dim, output_dim = data.dims
-            super_mat = _to_superop(data.rep, data._data, input_dim, output_dim)
+            super_mat = _to_superop(data.rep, data._data, input_dim,
+                                    output_dim)
         else:
             # We initialize directly from superoperator matrix
             super_mat = np.array(data, dtype=complex)
@@ -33,15 +50,17 @@ class SuperOp(QuantumChannel):
             if input_dim is None:
                 input_dim = int(np.sqrt(din))
             # Check dimensions
-            if output_dim ** 2 != dout or input_dim ** 2 != din:
-                raise QiskitError("Invalid input and output dimension for superoperator input.")
+            if output_dim**2 != dout or input_dim**2 != din:
+                raise QiskitError(
+                    "Invalid input and output dimension for superoperator input."
+                )
         super().__init__('SuperOp', super_mat, input_dim, output_dim)
 
     @property
     def _bipartite_shape(self):
         """Return the shape for bipartite matrix"""
-        return (self._output_dim, self._output_dim,
-                self._input_dim, self._input_dim)
+        return (self._output_dim, self._output_dim, self._input_dim,
+                self._input_dim)
 
     def evolve(self, state):
         """Apply the channel to a quantum state.
@@ -50,13 +69,15 @@ class SuperOp(QuantumChannel):
             state (quantum_state like): A statevector or density matrix.
 
         Returns:
-            A density matrix.
+            DensityMatrix: the output quantum state as a density matrix.
         """
         state = self._format_density_matrix(self._check_state(state))
         shape_in = self._input_dim * self._input_dim
         shape_out = (self._output_dim, self._output_dim)
-        return np.reshape(np.dot(self._data, np.reshape(state, shape_in, order='F')),
-                          shape_out, order='F')
+        return np.reshape(
+            np.dot(self._data, np.reshape(state, shape_in, order='F')),
+            shape_out,
+            order='F')
 
     def is_cptp(self):
         """Test if channel completely-positive and trace preserving (CPTP)"""
@@ -102,9 +123,11 @@ class SuperOp(QuantumChannel):
             raise QiskitError('Other is not a channel rep')
         # Check dimensions match up
         if front and self._input_dim != other._output_dim:
-            raise QiskitError('input_dim of self must match output_dim of other')
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
         if not front and self._output_dim != other._input_dim:
-            raise QiskitError('input_dim of other must match output_dim of self')
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
         # Convert other to SuperOp
         if not isinstance(other, SuperOp):
             other = SuperOp(other)
@@ -121,7 +144,8 @@ class SuperOp(QuantumChannel):
                 self._input_dim = input_dim
                 self._output_dim = output_dim
                 return self
-            return SuperOp(np.dot(self._data, other.data), input_dim, output_dim)
+            return SuperOp(
+                np.dot(self._data, other.data), input_dim, output_dim)
         # Composition B(A(input))
         input_dim = self._input_dim
         output_dim = other._output_dim
@@ -163,9 +187,12 @@ class SuperOp(QuantumChannel):
         input_dim = a_in * b_in
         output_dim = a_out * b_out
 
-        data = _bipartite_tensor(self._data, other.data, front=front,
-                                 shape_a=self._bipartite_shape,
-                                 shape_b=other._bipartite_shape)
+        data = _bipartite_tensor(
+            self._data,
+            other.data,
+            front=front,
+            shape1=self._bipartite_shape,
+            shape2=other._bipartite_shape)
         if inplace:
             self._data = data
             self._input_dim = input_dim

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -62,11 +62,17 @@ class SuperOp(QuantumChannel):
         return (self._output_dim, self._output_dim, self._input_dim,
                 self._input_dim)
 
+    def is_cptp(self):
+        """Return True if completely-positive trace-preserving."""
+        # We convert to the Choi representation to check if CPTP
+        tmp = Choi(self)
+        return tmp.is_cptp()
+
     def evolve(self, state):
-        """Apply the channel to a quantum state.
+        """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (quantum_state like): The input statevector or density matrix.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
@@ -79,21 +85,31 @@ class SuperOp(QuantumChannel):
             shape_out,
             order='F')
 
-    def is_cptp(self):
-        """Test if channel completely-positive and trace preserving (CPTP)"""
-        # We convert to the Choi representation to check if CPTP
-        tmp = Choi(self)
-        return tmp.is_cptp()
-
     def conjugate(self, inplace=False):
-        """Return the conjugate channel"""
+        """Return the conjugate of the  QuantumChannel.
+
+        Args:
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the conjugate of the quantum channel as a SuperOp object.
+        """
         if inplace:
             np.conjugate(self._data, out=self._data)
             return self
         return SuperOp(np.conj(self._data), self._input_dim, self._output_dim)
 
     def transpose(self, inplace=False):
-        """Return the transpose channel"""
+        """Return the transpose of the QuantumChannel.
+
+        Args:
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the transpose of the quantum channel as a SuperOp object.
+        """
         # Swaps input and output dimensions
         output_dim = self._input_dim
         input_dim = self._output_dim
@@ -104,20 +120,35 @@ class SuperOp(QuantumChannel):
             return self
         return SuperOp(np.transpose(self._data), input_dim, output_dim)
 
-    def compose(self, other, inplace=False, front=False):
-        """Return SuperOp for the composition channel B(A(input))
+    def adjoint(self, inplace=False):
+        """Return the adjoint of the QuantumChannel.
 
         Args:
-            other (QuantumChannel): A quantum channel representation object
-            inplace (bool): If True modify the current object inplace [default: False]
-            front (bool): If True compose in reverse order A(B(input)) [default: False]
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
 
         Returns:
-            SuperOp: The SuperOp for the composition channel.
+            SuperOp: the adjoint of the quantum channel as a SuperOp object.
+        """
+        return super().adjoint(inplace=inplace)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return the composition channel self∘other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                            [Default: False]
+            front (bool): If False compose in standard order other(self(input))
+                          otherwise compose in reverse order self(other(input))
+                          [default: False]
+
+        Returns:
+            SuperOp: The composition channel as a SuperOp object.
 
         Raises:
-            QiskitError: if other is not a SuperOp object
-            QiskitError: if dimensions don't match.
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
         """
         if not issubclass(other.__class__, QuantumChannel):
             raise QiskitError('Other is not a channel rep')
@@ -159,50 +190,22 @@ class SuperOp(QuantumChannel):
             return self
         return SuperOp(np.dot(other.data, self._data), input_dim, output_dim)
 
-    def tensor(self, other, inplace=False, front=False):
-        """Return SuperOp for the tensor product channel.
+    def power(self, n, inplace=False):
+        """Return the compose of a QuantumChannel with itself n times.
 
         Args:
-            other (QuantumChannel): A quantum channel representation object
-            inplace (bool): If True modify the current object inplace [default: False]
-            front (bool): If False return (other ⊗ self),
-                          if True return (self ⊗ other) [Default: False]
+            n (int): the number of times to compose with self (n>0).
+            inplace (bool): If True modify the current object inplace
+                            [Default: False]
+
         Returns:
-            SuperOp: The SuperOp for the composition channel.
+            SuperOp: the n-times composition channel as a SuperOp object.
 
         Raises:
-            QiskitError: if b is not a SuperOp object
+            QiskitError: if the input and output dimensions of the
+            QuantumChannel are not equal, or the power is not a positive
+            integer.
         """
-        # Convert other to SuperOp
-        if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
-        if not isinstance(other, SuperOp):
-            other = SuperOp(other)
-
-        # Reshuffle indicies
-        a_in, a_out = self.dims
-        b_in, b_out = other.dims
-
-        # Combined channel dimensions
-        input_dim = a_in * b_in
-        output_dim = a_out * b_out
-
-        data = _bipartite_tensor(
-            self._data,
-            other.data,
-            front=front,
-            shape1=self._bipartite_shape,
-            shape2=other._bipartite_shape)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
-        return SuperOp(data, input_dim, output_dim)
-
-    def power(self, n, inplace=False):
-        """ Rreturn composition of Channel with itself n times."""
         if not isinstance(n, int) or n < 1:
             raise QiskitError("Can only power with positive integer powers.")
         if self._input_dim != self._output_dim:
@@ -217,12 +220,59 @@ class SuperOp(QuantumChannel):
         # Return new object
         return SuperOp(np.linalg.matrix_power(self._data, n), *self.dims)
 
+    def tensor(self, other, inplace=False):
+        """Return the tensor product channel self ⊗ other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the tensor product channel self ⊗ other as a SuperOp
+            object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        return self._tensor_product(other, inplace=inplace, reverse=False)
+
+    def expand(self, other, inplace=False):
+        """Return the tensor product channel other ⊗ self.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the tensor product channel other ⊗ self as a SuperOp
+            object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        return self._tensor_product(other, inplace=inplace, reverse=True)
+
     def add(self, other, inplace=False):
-        """Add another channel"""
+        """Return the QuantumChannel self + other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the linear addition self + other as a SuperOp object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
         if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
+            raise QiskitError('other is not a QuantumChannel subclass')
         if self.dims != other.dims:
-            raise QiskitError("Channel dimensions are not equal")
+            raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, SuperOp):
             other = SuperOp(other)
 
@@ -233,11 +283,24 @@ class SuperOp(QuantumChannel):
         return SuperOp(self._data + other.data, input_dim, output_dim)
 
     def subtract(self, other, inplace=False):
-        """Subtract another Superoperator"""
+        """Return the QuantumChannel self - other.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the linear subtraction self - other as SuperOp object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
         if not issubclass(other.__class__, QuantumChannel):
-            raise QiskitError('Other is not a channel rep')
+            raise QiskitError('other is not a QuantumChannel subclass')
         if self.dims != other.dims:
-            raise QiskitError("Channel dimensions are not equal")
+            raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, SuperOp):
             other = SuperOp(other)
         if inplace:
@@ -247,11 +310,68 @@ class SuperOp(QuantumChannel):
         return SuperOp(self._data - other.data, input_dim, output_dim)
 
     def multiply(self, other, inplace=False):
-        """Multiple by a scalar"""
+        """Return the QuantumChannel self + other.
+
+        Args:
+            other (complex): a complex number
+            inplace (bool): If True modify the current object inplace
+                           [Default: False]
+
+        Returns:
+            SuperOp: the scalar multiplication other * self as a SuperOp object.
+
+        Raises:
+            QiskitError: if other is not a valid scalar.
+        """
         if not isinstance(other, Number):
-            raise QiskitError("Not a number")
+            raise QiskitError("other is not a number")
         if inplace:
             self._data *= other
             return self
         input_dim, output_dim = self.dims
         return SuperOp(other * self._data, input_dim, output_dim)
+
+    def _tensor_product(self, other, inplace=False, reverse=False):
+        """Return the tensor product channel.
+
+        Args:
+            other (QuantumChannel): a quantum channel subclass
+            inplace (bool): If True modify the current object inplace
+                            [default: False]
+            reverse (bool): If False return self ⊗ other, if True return
+                            if True return (other ⊗ self) [Default: False
+        Returns:
+            SuperOp: the tensor product channel as a SuperOp object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass.
+        """
+        # Convert other to SuperOp
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('other is not a QuantumChannel subclass')
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+
+        # Reshuffle indicies
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+
+        # Combined channel dimensions
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+
+        if reverse:
+            data = _bipartite_tensor(other.data, self._data,
+                                     shape1=other._bipartite_shape,
+                                     shape2=self._bipartite_shape)
+        else:
+            data = _bipartite_tensor(self._data, other.data,
+                                     shape1=self._bipartite_shape,
+                                     shape2=other._bipartite_shape)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return SuperOp(data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from .basechannel import QuantumChannel
+from .transformations import _to_superop, _bipartite_tensor
+from .choi import Choi
+
+
+class SuperOp(QuantumChannel):
+    """Superoperator representation of a quantum channel"""
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            super_mat = _to_superop(data.rep, data._data, input_dim, output_dim)
+        else:
+            # We initialize directly from superoperator matrix
+            super_mat = np.array(data, dtype=complex)
+            # Determine input and output dimensions
+            dout, din = super_mat.shape
+            if output_dim is None:
+                output_dim = int(np.sqrt(dout))
+            if input_dim is None:
+                input_dim = int(np.sqrt(din))
+            # Check dimensions
+            if output_dim ** 2 != dout or input_dim ** 2 != din:
+                raise QiskitError("Invalid input and output dimension for superoperator input.")
+        super().__init__('SuperOp', super_mat, input_dim, output_dim)
+
+    @property
+    def _bipartite_shape(self):
+        """Return the shape for bipartite matrix"""
+        return (self._output_dim, self._output_dim,
+                self._input_dim, self._input_dim)
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A density matrix.
+        """
+        state = self._format_density_matrix(self._check_state(state))
+        shape_in = self._input_dim * self._input_dim
+        shape_out = (self._output_dim, self._output_dim)
+        return np.reshape(np.dot(self._data, np.reshape(state, shape_in, order='F')),
+                          shape_out, order='F')
+
+    def is_cptp(self):
+        """Test if channel completely-positive and trace preserving (CPTP)"""
+        # We convert to the Choi representation to check if CPTP
+        tmp = Choi(self)
+        return tmp.is_cptp()
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        if inplace:
+            np.conjugate(self._data, out=self._data)
+            return self
+        return SuperOp(np.conj(self._data), self._input_dim, self._output_dim)
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # Swaps input and output dimensions
+        output_dim = self._input_dim
+        input_dim = self._output_dim
+        if inplace:
+            self._data = np.transpose(self._data)
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return SuperOp(np.transpose(self._data), input_dim, output_dim)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return SuperOp for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            SuperOp: The SuperOp for the composition channel.
+
+        Raises:
+            QiskitError: if other is not a SuperOp object
+            QiskitError: if dimensions don't match.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Convert other to SuperOp
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+
+        if front:
+            # Composition A(B(input))
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+            if inplace:
+                if self.dims == other.dims:
+                    np.dot(self._data, other.data, out=self._data)
+                else:
+                    self._data = np.dot(self._data, other.data)
+                self._input_dim = input_dim
+                self._output_dim = output_dim
+                return self
+            return SuperOp(np.dot(self._data, other.data), input_dim, output_dim)
+        # Composition B(A(input))
+        input_dim = self._input_dim
+        output_dim = other._output_dim
+        if inplace:
+            if self.dims == other.dims:
+                np.dot(other.data, self._data, out=self._data)
+            else:
+                self._data = np.dot(other.data, self._data)
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return SuperOp(np.dot(other.data, self._data), input_dim, output_dim)
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return SuperOp for the tensor product channel.
+
+        Args:
+            other (QuantumChannel): A quantum channel representation object
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            SuperOp: The SuperOp for the composition channel.
+
+        Raises:
+            QiskitError: if b is not a SuperOp object
+        """
+        # Convert other to SuperOp
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+
+        # Reshuffle indicies
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+
+        # Combined channel dimensions
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+
+        data = _bipartite_tensor(self._data, other.data, front=front,
+                                 shape_a=self._bipartite_shape,
+                                 shape_b=other._bipartite_shape)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # return new object
+        return SuperOp(data, input_dim, output_dim)
+
+    def power(self, n, inplace=False):
+        """ Rreturn composition of Channel with itself n times."""
+        if not isinstance(n, int) or n < 1:
+            raise QiskitError("Can only power with positive integer powers.")
+        if self._input_dim != self._output_dim:
+            raise QiskitError("Can only power with input_dim = output_dim.")
+        # Override base class power so we can implement more efficiently
+        # using Numpy.matrix_power
+        if inplace:
+            if n == 1:
+                return self
+            self._data = np.linalg.matrix_power(self._data, n)
+            return self
+        # Return new object
+        return SuperOp(np.linalg.matrix_power(self._data, n), *self.dims)
+
+    def add(self, other, inplace=False):
+        """Add another channel"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+
+        if inplace:
+            self._data += other._data
+            return self
+        input_dim, output_dim = self.dims
+        return SuperOp(self._data + other.data, input_dim, output_dim)
+
+    def subtract(self, other, inplace=False):
+        """Subtract another Superoperator"""
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+        if inplace:
+            self._data -= other.data
+            return self
+        input_dim, output_dim = self.dims
+        return SuperOp(self._data - other.data, input_dim, output_dim)
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        if inplace:
+            self._data *= other
+            return self
+        input_dim, output_dim = self.dims
+        return SuperOp(other * self._data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -1,0 +1,394 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+import logging
+
+import numpy as np
+import scipy.linalg as la
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import is_hermitian_matrix
+from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT
+
+logger = logging.getLogger(__name__)
+
+
+def _to_choi(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the Choi representation."""
+    if rep == 'Choi':
+        return data
+    if rep == 'UnitaryChannel':
+        return _from_unitary('Choi', data, input_dim, output_dim)
+    if rep == 'SuperOp':
+        return _superop_to_choi(data, input_dim, output_dim)
+    if rep == 'Kraus':
+        return _kraus_to_choi(data, input_dim, output_dim)
+    if rep == 'Chi':
+        return _chi_to_choi(data, input_dim, output_dim)
+    if rep == 'PTM':
+        data = _ptm_to_superop(data, input_dim, output_dim)
+        return _superop_to_choi(data, input_dim, output_dim)
+    if rep == 'Stinespring':
+        data = _stinespring_to_kraus(data, input_dim, output_dim)
+        return _kraus_to_choi(data, input_dim, output_dim)
+    raise QiskitError('Invalid QuantumChannel {}'.format(rep))
+
+
+def _to_superop(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the SuperOp representation."""
+    if rep == 'SuperOp':
+        return data
+    if rep == 'UnitaryChannel':
+        return _from_unitary('SuperOp', data, input_dim, output_dim)
+    if rep == 'Choi':
+        return _choi_to_superop(data, input_dim, output_dim)
+    if rep == 'Kraus':
+        return _kraus_to_superop(data, input_dim, output_dim)
+    if rep == 'Chi':
+        data = _chi_to_choi(data, input_dim, output_dim)
+        return _choi_to_superop(data, input_dim, output_dim)
+    if rep == 'PTM':
+        return _ptm_to_superop(data, input_dim, output_dim)
+    if rep == 'Stinespring':
+        data = _stinespring_to_kraus(data, input_dim, output_dim)
+        return _kraus_to_superop(data, input_dim, output_dim)
+    raise QiskitError('Invalid QuantumChannel {}'.format(rep))
+
+
+def _to_kraus(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the Kraus representation."""
+    if rep == 'Kraus':
+        return data
+    if rep == 'Stinespring':
+        return _stinespring_to_kraus(data, input_dim, output_dim)
+    if rep == 'UnitaryChannel':
+        return _from_unitary('Kraus', data, input_dim, output_dim)
+    # Convert via Choi and Kraus
+    if rep != 'Choi':
+        data = _to_choi(rep, data, input_dim, output_dim)
+    return _choi_to_kraus(data, input_dim, output_dim)
+
+
+def _to_chi(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the Chi representation."""
+    if rep == 'Chi':
+        return data
+    # Check valid n-qubit input
+    _check_nqubit_dim(input_dim, output_dim)
+    if rep == 'UnitaryChannel':
+        return _from_unitary('Chi', data, input_dim, output_dim)
+    # Convert via Choi representation
+    if rep != 'Choi':
+        data = _to_choi(rep, data, input_dim, output_dim)
+    return _choi_to_chi(data, input_dim, output_dim)
+
+
+def _to_ptm(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the PTM representation."""
+    if rep == 'PTM':
+        return data
+    # Check valid n-qubit input
+    _check_nqubit_dim(input_dim, output_dim)
+    if rep == 'UnitaryChannel':
+        return _from_unitary('PTM', data, input_dim, output_dim)
+    # Convert via Superoperator representation
+    if rep != 'SuperOp':
+        data = _to_superop(rep, data, input_dim, output_dim)
+    return _superop_to_ptm(data, input_dim, output_dim)
+
+
+def _to_stinespring(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the Stinespring representation."""
+    if rep == 'Stinespring':
+        return data
+    if rep == 'UnitaryChannel':
+        return _from_unitary('Stinespring', data, input_dim, output_dim)
+    # Convert via Superoperator representation
+    if rep != 'Kraus':
+        data = _to_kraus(rep, data, input_dim, output_dim)
+    return _kraus_to_stinespring(data, input_dim, output_dim)
+
+
+def _to_unitary(rep, data, input_dim, output_dim):
+    """Transform a QuantumChannel to the UnitaryChannel representation."""
+    if rep == 'UnitaryChannel':
+        return data
+    # Convert via Kraus representation
+    if rep != 'Kraus':
+        data = _to_kraus(rep, data, input_dim, output_dim)
+    return _kraus_to_unitary(data, input_dim, output_dim)
+
+
+def _from_unitary(rep, data, input_dim, output_dim):
+    """Transform UnitaryChannel representation to other representation."""
+    if rep == 'UnitaryChannel':
+        return data
+    if rep == 'SuperOp':
+        return np.kron(np.conj(data), data)
+    if rep == 'Choi':
+        vec = np.ravel(data, order='F')
+        return np.outer(vec, np.conj(vec))
+    if rep == 'Kraus':
+        return ([data], None)
+    if rep == 'Stinespring':
+        return (data, None)
+    if rep == 'Chi':
+        _check_nqubit_dim(input_dim, output_dim)
+        data = _from_unitary('Choi', data, input_dim, output_dim)
+        return _choi_to_chi(data, input_dim, output_dim)
+    if rep == 'PTM':
+        _check_nqubit_dim(input_dim, output_dim)
+        data = _from_unitary('SuperOp', data, input_dim, output_dim)
+        return _superop_to_ptm(data, input_dim, output_dim)
+    raise QiskitError('Invalid QuantumChannel {}'.format(rep))
+
+
+def _kraus_to_unitary(data, input_dim, output_dim):
+    """Transform Kraus representation to UnitaryChannel representation."""
+    kraus_l, kraus_r = data
+    if input_dim != output_dim or kraus_r is not None or len(kraus_l) > 1:
+        logger.error('Channel cannot be converted to UnitaryChannel representation')
+        raise QiskitError('Channel cannot be converted to UnitaryChannel representation')
+    return kraus_l[0]
+
+
+def _superop_to_choi(data, input_dim, output_dim):
+    """Transform SuperOp representation to Choi representation."""
+    shape = (output_dim, output_dim, input_dim, input_dim)
+    return _reshuffle(data, shape)
+
+
+def _choi_to_superop(data, input_dim, output_dim):
+    """Transform Choi to SuperOp representation."""
+    shape = (input_dim, output_dim, input_dim, output_dim)
+    return _reshuffle(data, shape)
+
+
+def _kraus_to_choi(data, input_dim, output_dim):
+    """Transform Kraus representation to Choi representation."""
+    choi = 0
+    kraus_l, kraus_r = data
+    if kraus_r is None:
+        for a in kraus_l:
+            u = a.ravel(order='F')
+            choi += np.dot(u[:, None], u.conj()[None, :])
+    else:
+        for a, b in zip(kraus_l, kraus_r):
+            choi += np.dot(a.ravel(order='F')[:, None],
+                           b.ravel(order='F').conj()[None, :])
+    return choi
+
+
+def _choi_to_kraus(data, input_dim, output_dim, atol=ATOL_DEFAULT):
+    """Transform Choi representation to Kraus representation."""
+    # Check if hermitian matrix
+    if is_hermitian_matrix(data, atol=atol):
+        # Get eigen-decomposition of Choi-matrix
+        w, v = la.eigh(data)
+        # Check eigenvaleus are non-negative
+        if len(w[w < -atol]) == 0:
+            # CP-map Kraus representation
+            kraus = []
+            for val, vec in zip(w, v.T):
+                if abs(val) > atol:
+                    k = np.sqrt(val) * vec.reshape((output_dim, input_dim), order='F')
+                    kraus.append(k)
+            # If we are converting a zero matrix, we need to return a Kraus set
+            # with a single zero-element Kraus matrix
+            if not kraus:
+                kraus.append(np.zeros((output_dim, input_dim), dtype=complex))
+            return (kraus, None)
+    # Non-CP-map generalized Kraus representation
+    U, s, Vh = la.svd(data)
+    kraus_l = []
+    kraus_r = []
+    for val, vecL, vecR in zip(s, U.T, Vh.conj()):
+        kraus_l.append(np.sqrt(val) * vecL.reshape((output_dim, input_dim), order='F'))
+        kraus_r.append(np.sqrt(val) * vecR.reshape((output_dim, input_dim), order='F'))
+    return (kraus_l, kraus_r)
+
+
+def _stinespring_to_kraus(data, input_dim, output_dim):
+    """Transform Stinespring representation to Kraus representation."""
+    kraus_pair = []
+    for stine in data:
+        if stine is None:
+            kraus_pair.append(None)
+        else:
+            trace_dim = stine.shape[0] // output_dim
+            iden = np.eye(output_dim)
+            kraus = []
+            for j in range(trace_dim):
+                v = np.zeros(trace_dim)
+                v[j] = 1
+                kraus.append(np.kron(iden, v[None, :]).dot(stine))
+            kraus_pair.append(kraus)
+    return tuple(kraus_pair)
+
+
+def _kraus_to_stinespring(data, input_dim, output_dim):
+    """Transform Kraus representation to Stinespring representation."""
+    stine_pair = [None, None]
+    for i, kraus in enumerate(data):
+        if kraus is not None:
+            num_kraus = len(kraus)
+            stine = np.zeros((output_dim * num_kraus, input_dim), dtype=complex)
+            for j, k in enumerate(kraus):
+                v = np.zeros(num_kraus)
+                v[j] = 1
+                stine += np.kron(k, v[:, None])
+            stine_pair[i] = stine
+    return tuple(stine_pair)
+
+
+def _kraus_to_superop(data, input_dim, output_dim):
+    """Transform Kraus representation to SuperOp representation."""
+    kraus_l, kraus_r = data
+    superop = 0
+    if kraus_r is None:
+        for a in kraus_l:
+            superop += np.kron(np.conj(a), a)
+    else:
+        for a, b in zip(kraus_l, kraus_r):
+            superop += np.kron(np.conj(b), a)
+    return superop
+
+
+def _chi_to_choi(data, input_dim, output_dim):
+    """Transform Chi representation to a Choi representation."""
+    num_qubits = int(np.log2(input_dim))
+    return _transform_basis(data, num_qubits, _pauli2col(), 2)
+
+
+def _choi_to_chi(data, input_dim, output_dim):
+    """Transform Choi representation to the Chi representation."""
+    num_qubits = int(np.log2(input_dim))
+    return _transform_basis(data, num_qubits, _col2pauli(), 2)
+
+
+def _ptm_to_superop(data, input_dim, output_dim):
+    """Transform PTM representation to SuperOp representation."""
+    num_qubits = int(np.log2(input_dim))
+    return _transform_basis(data, num_qubits, _pauli2col(), 2)
+
+
+def _superop_to_ptm(data, input_dim, output_dim):
+    """Transform SuperOp representation to PTM representation."""
+    num_qubits = int(np.log2(input_dim))
+    return _transform_basis(data, num_qubits, _col2pauli(), 2)
+
+
+def _bipartite_tensor(a, b, front=False, shape_a=None, shape_b=None):
+    """Tensor product to bipartite matrices and reravel indicies.
+
+    This is used for tensor product of superoperators and Choi matrices.
+
+    Args:
+        a (matrix like): a bipartite matrix
+        b (matrix like): a bipartite matrix
+        front (bool): If False return (b ⊗ a) if True return (a ⊗ b) [Default: False]
+        shape_a (tuple): bipartite-shape for matrix a (a0, a1, a2, a3)
+        shape_b (tuple): bipartite-shape for matrix b (b0, b1, b2, b3)
+
+    Returns:
+        a bipartite matrix for reravel(a ⊗ b) or  reravel(b ⊗ a).
+    """
+    # Convert inputs to numpy arrays
+    a = np.array(a)
+    b = np.array(b)
+
+    # Determine bipartite dimensions if not provided
+    dim_a0, dim_a1 = a.shape
+    dim_b0, dim_b1 = b.shape
+    if shape_a is None:
+        a0 = int(np.sqrt(dim_a0))
+        a1 = int(np.sqrt(dim_a1))
+        shape_a = (a0, a0, a1, a1)
+    if shape_b is None:
+        b0 = int(np.sqrt(dim_b0))
+        b1 = int(np.sqrt(dim_b1))
+        shape_b = (b0, b0, b1, b1)
+    # Check dimensions
+    if len(shape_a) != 4 or shape_a[0] * shape_a[1] != dim_a0 or \
+            shape_a[2] * shape_a[3] != dim_a1:
+        raise QiskitError("Invalid shape_a")
+    if len(shape_b) != 4 or shape_b[0] * shape_b[1] != dim_b0 or \
+            shape_b[2] * shape_b[3] != dim_b1:
+        raise QiskitError("Invalid shape_b")
+
+    if front:
+        # Return A ⊗ B
+        return _reravel(a, b, shape_a, shape_b)
+    # Return B ⊗ A
+    return _reravel(b, a, shape_b, shape_a)
+
+
+def _reravel(a, b, shape_a, shape_b):
+    """
+    shape_a and shape_b length-4 lists.
+    """
+    data = np.kron(a, b)
+    # Reshuffle indicies
+    left_dims = shape_a[:2] + shape_b[:2]
+    right_dims = shape_a[2:] + shape_b[2:]
+    tensor_shape = left_dims + right_dims
+    final_shape = (np.product(left_dims), np.product(right_dims))
+
+    # Tensor product matrices
+    data = np.kron(a, b)
+    data = np.reshape(np.transpose(np.reshape(data, tensor_shape),
+                                   (0, 2, 1, 3, 4, 6, 5, 7)),
+                      final_shape)
+    return data
+
+
+def _transform_basis(data, num_qubits, basis_mat, factor=1):
+    """Change of basis of bipartite matrix represenation."""
+    # Change basis
+    # Note that we manually renormalized after change of basis
+    # to avoid rounding errors from square-roots of 2.
+    cob = basis_mat
+    for j in range(num_qubits - 1):
+        dim = int(np.sqrt(len(cob)))
+        cob = _bipartite_tensor(basis_mat, cob, (2, 2, 2, 2), (dim, dim, dim, dim))
+    return np.dot(np.dot(cob, data), cob.conj().T) / factor ** num_qubits
+
+
+def _pauli2col():
+    """Change of basis matrix from col-vec to Pauli."""
+    # This matrix is given by:
+    # sum_{i=0}^3 =|\sigma_i>><i|=
+    return np.array([[1, 0, 0, 1],
+                     [0, 1, 1j, 0],
+                     [0, 1, -1j, 0],
+                     [1, 0j, 0, -1]], dtype=complex)
+
+
+def _col2pauli():
+    """Change of basis matrix from Pauli col-vec."""
+    # This matrix is given by:
+    # sum_{i=0}^3 |i>><\sigma_i|
+    return np.array([[1, 0, 0, 1],
+                     [0, 1, 1, 0],
+                     [0, -1j, 1j, 0],
+                     [1, 0j, 0, -1]], dtype=complex)
+
+
+def _reshuffle(a, shape):
+    """Reshuffle the indicies of a bipartite matrix A[ij,kl] -> A[lj,ki]."""
+    return np.reshape(np.transpose(np.reshape(a, shape), (3, 1, 2, 0)),
+                      (shape[3] * shape[1], shape[0] * shape[2]))
+
+
+def _check_nqubit_dim(input_dim, output_dim):
+    """Return true if dims correspond to an n-qubit channel."""
+    if input_dim != output_dim:
+        raise QiskitError('Not an n-qubit channel: input_dim' +
+                          ' ({}) != output_dim ({})'.format(input_dim, output_dim))
+    num_qubits = int(np.log2(input_dim))
+    if 2 ** num_qubits != input_dim:
+        raise QiskitError('Not an n-qubit channel: input_dim != 2 ** n')

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -328,20 +328,19 @@ def _superop_to_ptm(data, input_dim, output_dim):
     return _transform_to_pauli(data, num_qubits)
 
 
-def _bipartite_tensor(mat1, mat2, front=False, shape1=None, shape2=None):
-    """Tensor product to bipartite matrices and reravel indicies.
+def _bipartite_tensor(mat1, mat2, shape1=None, shape2=None):
+    """Tensor product (A ⊗ B) to bipartite matrices and reravel indicies.
 
     This is used for tensor product of superoperators and Choi matrices.
 
     Args:
         mat1 (matrix_like): a bipartite matrix A
         mat2 (matrix_like): a bipartite matrix B
-        front (bool): If False return (B ⊗ A) if True return (A ⊗ B) [Default: False]
         shape1 (tuple): bipartite-shape for matrix A (a0, a1, a2, a3)
         shape2 (tuple): bipartite-shape for matrix B (b0, b1, b2, b3)
 
     Returns:
-        np.array: a bipartite matrix for reravel(a ⊗ b) or  reravel(b ⊗ a).
+        np.array: a bipartite matrix for reravel(A ⊗ B).
 
     Raises:
         QiskitError: if input matrices are wrong shape.
@@ -369,11 +368,7 @@ def _bipartite_tensor(mat1, mat2, front=False, shape1=None, shape2=None):
             shape2[2] * shape2[3] != dim_b1:
         raise QiskitError("Invalid shape_b")
 
-    if front:
-        # Return A ⊗ B
-        return _reravel(mat1, mat2, shape1, shape2)
-    # Return B ⊗ A
-    return _reravel(mat2, mat1, shape2, shape1)
+    return _reravel(mat1, mat2, shape1, shape2)
 
 
 def _reravel(mat1, mat2, shape1, shape2):

--- a/qiskit/quantum_info/operators/channel/unitary.py
+++ b/qiskit/quantum_info/operators/channel/unitary.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+from numbers import Number
+import numpy as np
+
+from qiskit.qiskiterror import QiskitError
+from qiskit.quantum_info.operators.predicates import is_unitary_matrix
+from .basechannel import QuantumChannel
+from .transformations import _to_unitary
+
+
+class UnitaryChannel(QuantumChannel):
+    """UnitaryChannel representation of a unitary quantum channel"""
+
+    def __init__(self, data, input_dim=None, output_dim=None):
+        # Check if input is a quantum channel object
+        # If so we disregard the dimension kwargs
+        if issubclass(data.__class__, QuantumChannel):
+            input_dim, output_dim = data.dims
+            unitary = _to_unitary(data.rep, data._data, input_dim, output_dim)
+        else:
+            # We initialize directly from superoperator matrix
+            unitary = np.array(data, dtype=complex)
+            # Determine input and output dimensions
+            dout, din = unitary.shape
+            if output_dim is None:
+                output_dim = dout
+            if input_dim is None:
+                input_dim = din
+            # Check dimensions
+            if output_dim != input_dim:
+                raise QiskitError('Invalid unitary matrix: must be square')
+            if output_dim != dout or input_dim != din:
+                raise QiskitError("Invalid input and output dimension for unitary matrix.")
+        super().__init__('UnitaryChannel', unitary, input_dim, output_dim)
+
+    def is_cptp(self, atol=None):
+        """Test if channel is completely-positive trace-preserving (CPTP)"""
+        # If the matrix is a unitary matrix the channel is CPTP
+        return is_unitary_matrix(self._data, atol=atol)
+
+    def evolve(self, state):
+        """Apply the channel to a quantum state.
+
+        Args:
+            state (quantum_state like): A statevector or density matrix.
+
+        Returns:
+            A state of the same form as the input state (statevector or
+            density matrix).
+        """
+        state = self._check_state(state)
+        if state.ndim == 1 or state.ndim == 2 and state.shape[1] == 1:
+            # Return evolved statevector
+            return np.dot(self._data, state)
+        # Return evolved density matrix
+        return np.dot(np.dot(self._data, state), np.transpose(np.conj(self._data)))
+
+    def conjugate(self, inplace=False):
+        """Return the conjugate channel"""
+        if inplace:
+            np.conjugate(self._data, out=self._data)
+            return self
+        return UnitaryChannel(np.conj(self._data), self._input_dim, self._output_dim)
+
+    def transpose(self, inplace=False):
+        """Return the transpose channel"""
+        # Swaps input and output dimensions
+        output_dim = self._input_dim
+        input_dim = self._output_dim
+        if inplace:
+            self._data = np.transpose(self._data)
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return UnitaryChannel(np.transpose(self._data), input_dim, output_dim)
+
+    def compose(self, other, inplace=False, front=False):
+        """Return UnitaryChannel for the composition channel B(A(input))
+
+        Args:
+            other (QuantumChannel): A unitary channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If True compose in reverse order A(B(input)) [default: False]
+
+        Returns:
+            UnitaryChannel: The composition channel.
+
+        Raises:
+            QiskitError: if other is a non-unitary channel.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Check dimensions match up
+        if front and self._input_dim != other._output_dim:
+            raise QiskitError('input_dim of self must match output_dim of other')
+        if not front and self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        # Convert to UnitaryChannel matrix
+        if not isinstance(other, UnitaryChannel):
+            other = UnitaryChannel(other)
+
+        if front:
+            # Composition A(B(input))
+            if self._input_dim != other._output_dim:
+                raise QiskitError('input_dim of self must match output_dim of other')
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+            if inplace:
+                np.dot(self._data, other.data, out=self._data)
+                self._input_dim = input_dim
+                self._output_dim = output_dim
+                return self
+            return UnitaryChannel(np.dot(self._data, other.data), input_dim, output_dim)
+        # Composition B(A(input))
+        if self._output_dim != other._input_dim:
+            raise QiskitError('input_dim of other must match output_dim of self')
+        input_dim = self._input_dim
+        output_dim = other._output_dim
+        if inplace:
+            # Numpy out raises error if we try and use out=self._data here
+            self._data = np.dot(other.data, self._data)
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        return UnitaryChannel(np.dot(other.data, self._data), input_dim, output_dim)
+
+    def tensor(self, other, inplace=False, front=False):
+        """Return the tensor product unitary channel.
+
+        Args:
+            other (QuantumChannel): A unitary channel
+            inplace (bool): If True modify the current object inplace [default: False]
+            front (bool): If False return (other ⊗ self),
+                          if True return (self ⊗ other) [Default: False]
+        Returns:
+            UnitaryChannel: The tensor product channel.
+
+        Raises:
+            QiskitError: if other is a non-unitary channel.
+        """
+        if not issubclass(other.__class__, QuantumChannel):
+            raise QiskitError('Other is not a channel rep')
+        # Convert to Choi matrix
+        if not isinstance(other, UnitaryChannel):
+            other = UnitaryChannel(other)
+
+        # Combined channel dimensions
+        a_in, a_out = self.dims
+        b_in, b_out = other.dims
+        input_dim = a_in * b_in
+        output_dim = a_out * b_out
+        if front:
+            data = np.kron(self._data, other._data)
+        else:
+            data = np.kron(other._data, self._data)
+        if inplace:
+            self._data = data
+            self._input_dim = input_dim
+            self._output_dim = output_dim
+            return self
+        # Not inplace so return new object
+        return UnitaryChannel(data, input_dim, output_dim)
+
+    def power(self, n, inplace=False):
+        """ Rreturn composition of Channel with itself n times."""
+        if not isinstance(n, int) or n < 1:
+            raise QiskitError("Can only power with positive integer powers.")
+        if self._input_dim != self._output_dim:
+            raise QiskitError("Can only power with input_dim = output_dim.")
+        # Override base class power so we can implement more efficiently
+        # using Numpy.matrix_power
+        if inplace:
+            if n == 1:
+                return self
+            self._data = np.linalg.matrix_power(self._data, n)
+            return self
+        # Return new object
+        return UnitaryChannel(np.linalg.matrix_power(self._data, n), *self.dims)
+
+    def add(self, other, inplace=False):
+        """Add another UnitaryChannel"""
+        if not isinstance(other, UnitaryChannel):
+            raise QiskitError('Other channel must be a UnitaryChannel')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if inplace:
+            self._data += other._data
+            return self
+        input_dim, output_dim = self.dims
+        return UnitaryChannel(self._data + other.data, input_dim, output_dim)
+
+    def subtract(self, other, inplace=False):
+        """Subtract another UnitaryChannel"""
+        if not isinstance(other, UnitaryChannel):
+            raise QiskitError('Other channel must be a UnitaryChannel')
+        if self.dims != other.dims:
+            raise QiskitError("Channel dimensions are not equal")
+        if inplace:
+            self._data -= other.data
+            return self
+        input_dim, output_dim = self.dims
+        return UnitaryChannel(self._data - other.data, input_dim, output_dim)
+
+    def multiply(self, other, inplace=False):
+        """Multiple by a scalar"""
+        if not isinstance(other, Number):
+            raise QiskitError("Not a number")
+        if inplace:
+            self._data *= other
+            return self
+        input_dim, output_dim = self.dims
+        return UnitaryChannel(other * self._data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/unitarychannel.py
+++ b/qiskit/quantum_info/operators/channel/unitarychannel.py
@@ -50,7 +50,7 @@ class UnitaryChannel(QuantumChannel):
     def is_cptp(self):
         """Return True if completely-positive trace-preserving."""
         # If the matrix is a unitary matrix the channel is CPTP
-        return is_unitary_matrix(self._data, atol=self.atol)
+        return is_unitary_matrix(self._data, rtol=self.rtol, atol=self.atol)
 
     def evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.

--- a/qiskit/quantum_info/operators/channel/unitarychannel.py
+++ b/qiskit/quantum_info/operators/channel/unitarychannel.py
@@ -4,6 +4,13 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
+"""
+Unitary representation of a QuantumChannel
+
+For a quantum channel E this is a matrix U such that:
+
+    E(ρ) = U.ρ.U^dagger
+"""
 
 from numbers import Number
 import numpy as np
@@ -36,13 +43,14 @@ class UnitaryChannel(QuantumChannel):
             if output_dim != input_dim:
                 raise QiskitError('Invalid unitary matrix: must be square')
             if output_dim != dout or input_dim != din:
-                raise QiskitError("Invalid input and output dimension for unitary matrix.")
+                raise QiskitError(
+                    "Invalid input and output dimension for unitary matrix.")
         super().__init__('UnitaryChannel', unitary, input_dim, output_dim)
 
-    def is_cptp(self, atol=None):
+    def is_cptp(self):
         """Test if channel is completely-positive trace-preserving (CPTP)"""
         # If the matrix is a unitary matrix the channel is CPTP
-        return is_unitary_matrix(self._data, atol=atol)
+        return is_unitary_matrix(self._data, atol=self.atol)
 
     def evolve(self, state):
         """Apply the channel to a quantum state.
@@ -51,22 +59,23 @@ class UnitaryChannel(QuantumChannel):
             state (quantum_state like): A statevector or density matrix.
 
         Returns:
-            A state of the same form as the input state (statevector or
-            density matrix).
+            QuantumState: the output quantum state.
         """
         state = self._check_state(state)
         if state.ndim == 1 or state.ndim == 2 and state.shape[1] == 1:
             # Return evolved statevector
             return np.dot(self._data, state)
         # Return evolved density matrix
-        return np.dot(np.dot(self._data, state), np.transpose(np.conj(self._data)))
+        return np.dot(
+            np.dot(self._data, state), np.transpose(np.conj(self._data)))
 
     def conjugate(self, inplace=False):
         """Return the conjugate channel"""
         if inplace:
             np.conjugate(self._data, out=self._data)
             return self
-        return UnitaryChannel(np.conj(self._data), self._input_dim, self._output_dim)
+        return UnitaryChannel(
+            np.conj(self._data), self._input_dim, self._output_dim)
 
     def transpose(self, inplace=False):
         """Return the transpose channel"""
@@ -98,9 +107,11 @@ class UnitaryChannel(QuantumChannel):
             raise QiskitError('Other is not a channel rep')
         # Check dimensions match up
         if front and self._input_dim != other._output_dim:
-            raise QiskitError('input_dim of self must match output_dim of other')
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
         if not front and self._output_dim != other._input_dim:
-            raise QiskitError('input_dim of other must match output_dim of self')
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
         # Convert to UnitaryChannel matrix
         if not isinstance(other, UnitaryChannel):
             other = UnitaryChannel(other)
@@ -108,7 +119,8 @@ class UnitaryChannel(QuantumChannel):
         if front:
             # Composition A(B(input))
             if self._input_dim != other._output_dim:
-                raise QiskitError('input_dim of self must match output_dim of other')
+                raise QiskitError(
+                    'input_dim of self must match output_dim of other')
             input_dim = other._input_dim
             output_dim = self._output_dim
             if inplace:
@@ -116,10 +128,12 @@ class UnitaryChannel(QuantumChannel):
                 self._input_dim = input_dim
                 self._output_dim = output_dim
                 return self
-            return UnitaryChannel(np.dot(self._data, other.data), input_dim, output_dim)
+            return UnitaryChannel(
+                np.dot(self._data, other.data), input_dim, output_dim)
         # Composition B(A(input))
         if self._output_dim != other._input_dim:
-            raise QiskitError('input_dim of other must match output_dim of self')
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
         input_dim = self._input_dim
         output_dim = other._output_dim
         if inplace:
@@ -128,7 +142,8 @@ class UnitaryChannel(QuantumChannel):
             self._input_dim = input_dim
             self._output_dim = output_dim
             return self
-        return UnitaryChannel(np.dot(other.data, self._data), input_dim, output_dim)
+        return UnitaryChannel(
+            np.dot(other.data, self._data), input_dim, output_dim)
 
     def tensor(self, other, inplace=False, front=False):
         """Return the tensor product unitary channel.
@@ -181,7 +196,8 @@ class UnitaryChannel(QuantumChannel):
             self._data = np.linalg.matrix_power(self._data, n)
             return self
         # Return new object
-        return UnitaryChannel(np.linalg.matrix_power(self._data, n), *self.dims)
+        return UnitaryChannel(
+            np.linalg.matrix_power(self._data, n), *self.dims)
 
     def add(self, other, inplace=False):
         """Add another UnitaryChannel"""

--- a/qiskit/quantum_info/operators/channel/unitarychannel.py
+++ b/qiskit/quantum_info/operators/channel/unitarychannel.py
@@ -52,11 +52,11 @@ class UnitaryChannel(QuantumChannel):
         # If the matrix is a unitary matrix the channel is CPTP
         return is_unitary_matrix(self._data, rtol=self.rtol, atol=self.atol)
 
-    def evolve(self, state):
+    def _evolve(self, state):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
-            state (quantum_state like): A statevector or density matrix.
+            state (QuantumState): The input statevector or density matrix.
 
         Returns:
             QuantumState: the output quantum state.

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -62,22 +62,22 @@ def matrix_equal(mat1,
     return np.allclose(mat1, mat2, rtol=rtol, atol=atol)
 
 
-def is_square_matrix(op):
+def is_square_matrix(mat):
     """Test if an array is a square matrix."""
-    mat = np.array(op)
+    mat = np.array(mat)
     if mat.ndim != 2:
         return False
     shape = mat.shape
     return shape[0] == shape[1]
 
 
-def is_diagonal_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
+def is_diagonal_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a diagonal matrix"""
     if atol is None:
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(op)
+    mat = np.array(mat)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, np.diag(np.diagonal(mat)), rtol=rtol, atol=atol)
@@ -95,28 +95,28 @@ def is_symmetric_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     return np.allclose(mat, mat.T, rtol=rtol, atol=atol)
 
 
-def is_hermitian_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
+def is_hermitian_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a Hermitian matrix"""
     if atol is None:
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    mat = np.array(op)
+    mat = np.array(mat)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, np.conj(mat.T), rtol=rtol, atol=atol)
 
 
-def is_positive_semidefinite_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
+def is_positive_semidefinite_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if a matrix is positive semidefinite"""
     if atol is None:
         atol = ATOL_DEFAULT
     if rtol is None:
         rtol = RTOL_DEFAULT
-    if not is_hermitian_matrix(op, rtol=rtol, atol=atol):
+    if not is_hermitian_matrix(mat, rtol=rtol, atol=atol):
         return False
     # Check eigenvalues are all positive
-    vals = np.linalg.eigvalsh(op)
+    vals = np.linalg.eigvalsh(mat)
     for v in vals:
         if v < -atol:
             return False

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -5,6 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+# pylint: disable=len-as-condition
+"""
+Predicates for operators.
+"""
+
 import numpy as np
 
 ATOL_DEFAULT = 1e-8
@@ -66,12 +71,24 @@ def is_identity_matrix(op, ignore_phase=False, atol=ATOL_DEFAULT):
     return np.allclose(mat, iden, atol=atol)
 
 
-def matrix_equal(a, b, ignore_phase=False, atol=ATOL_DEFAULT):
-    """Test if two arrays are equal"""
+def matrix_equal(mat1, mat2, ignore_phase=False, atol=ATOL_DEFAULT):
+    """Test if two arrays are equal.
+
+    Args:
+        mat1 (matrix_like): a matrix
+        mat2 (matrix_like): a matrix
+        ignore_phase (bool): ignore complex-phase differences between
+            matrices [Default: False]
+        atol (double): comparison threhsold [Default {}].
+
+    Returns:
+        bool: True if the matrices are equal or False otherwise.
+    """.format(ATOL_DEFAULT)
+
     if atol is None:
         atol = ATOL_DEFAULT
-    mat1 = np.array(a)
-    mat2 = np.array(b)
+    mat1 = np.array(mat1)
+    mat2 = np.array(mat2)
     if mat1.shape != mat2.shape:
         return False
     if ignore_phase:

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -39,7 +39,7 @@ def matrix_equal(mat1,
         atol (double): the absolute tolerance parameter [Default {}].
 
     Returns:
-        bool: True if the matrices are equal or False otherwise.  
+        bool: True if the matrices are equal or False otherwise.
     """.format(RTOL_DEFAULT, ATOL_DEFAULT)
 
     if atol is None:
@@ -113,7 +113,7 @@ def is_identity_matrix(mat,
         # If the matrix is equal to an identity up to a phase, we can
         # remove the phase by multiplying each entry by the complex
         # conjugate of the phase of the [0, 0] entry.
-        theta =  np.angle(mat[0, 0])
+        theta = np.angle(mat[0, 0])
         mat *= np.exp(-1j * theta)
     # Check if square identity
     iden = np.eye(len(mat))

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -44,6 +44,8 @@ def matrix_equal(mat1,
 
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat1 = np.array(mat1)
     mat2 = np.array(mat2)
     if mat1.shape != mat2.shape:
@@ -73,6 +75,8 @@ def is_diagonal_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a diagonal matrix"""
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat = np.array(op)
     if mat.ndim != 2:
         return False
@@ -83,6 +87,8 @@ def is_symmetric_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a symmetrix matrix"""
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat = np.array(op)
     if mat.ndim != 2:
         return False
@@ -93,10 +99,28 @@ def is_hermitian_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a Hermitian matrix"""
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat = np.array(op)
     if mat.ndim != 2:
         return False
     return np.allclose(mat, np.conj(mat.T), rtol=rtol, atol=atol)
+
+
+def is_positive_semidefinite_matrix(op, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
+    """Test if a matrix is positive semidefinite"""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
+    if not is_hermitian_matrix(op, rtol=rtol, atol=atol):
+        return False
+    # Check eigenvalues are all positive
+    vals = np.linalg.eigvalsh(op)
+    for v in vals:
+        if v < -atol:
+            return False
+    return True
 
 
 def is_identity_matrix(mat,
@@ -106,6 +130,8 @@ def is_identity_matrix(mat,
     """Test if an array is an identity matrix."""
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat = np.array(mat)
     if mat.ndim != 2:
         return False
@@ -124,6 +150,8 @@ def is_unitary_matrix(mat, rtol=RTOL_DEFAULT, atol=ATOL_DEFAULT):
     """Test if an array is a unitary matrix."""
     if atol is None:
         atol = ATOL_DEFAULT
+    if rtol is None:
+        rtol = RTOL_DEFAULT
     mat = np.array(mat)
     # Compute A^dagger.A and see if it is identity matrix
     mat = np.conj(mat.T).dot(mat)

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+import numpy as np
+
+ATOL_DEFAULT = 1e-8
+
+
+def is_square_matrix(op):
+    """Test if an array is a square matrix."""
+    mat = np.array(op)
+    if mat.ndim != 2:
+        return False
+    shape = mat.shape
+    return shape[0] == shape[1]
+
+
+def is_diagonal_matrix(op, atol=ATOL_DEFAULT):
+    """Test if an array is a diagonal matrix"""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat = np.array(op)
+    if mat.ndim != 2:
+        return False
+    return np.allclose(mat, np.diag(np.diagonal(mat)), atol=atol)
+
+
+def is_symmetric_matrix(op, atol=ATOL_DEFAULT):
+    """Test if an array is a symmetrix matrix"""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat = np.array(op)
+    if mat.ndim != 2:
+        return False
+    return np.allclose(mat, mat.T, atol=atol)
+
+
+def is_hermitian_matrix(op, atol=ATOL_DEFAULT):
+    """Test if an array is a Hermitian matrix"""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat = np.array(op)
+    if mat.ndim != 2:
+        return False
+    return np.allclose(mat, np.conj(mat.T), atol=atol)
+
+
+def is_identity_matrix(op, ignore_phase=False, atol=ATOL_DEFAULT):
+    """Test if an array is an identity matrix."""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat = np.array(op)
+    if mat.ndim != 2:
+        return False
+    if ignore_phase:
+        # If the matrix is equal to an identity up to a phase, we can
+        # remove the phase by multiplying each entry by the complex
+        # conjugate of the [0, 0] entry.
+        mat *= np.conj(mat[0, 0])
+    # Check if square identity
+    iden = np.eye(len(mat))
+    return np.allclose(mat, iden, atol=atol)
+
+
+def matrix_equal(a, b, ignore_phase=False, atol=ATOL_DEFAULT):
+    """Test if two arrays are equal"""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat1 = np.array(a)
+    mat2 = np.array(b)
+    if mat1.shape != mat2.shape:
+        return False
+    if ignore_phase:
+        # Get phase of first non-zero entry of mat1 and mat2
+        # and multiply all entries by the conjugate
+        phases1 = np.angle(mat1[mat1 != 0].ravel(order='F'))
+        if len(phases1) > 0:
+            mat1 *= np.exp(-1j * phases1[0])
+        phases2 = np.angle(mat2[mat2 != 0].ravel(order='F'))
+        if len(phases2) > 0:
+            mat2 *= np.exp(-1j * phases2[0])
+    return np.allclose(mat1, mat2, atol=atol)
+
+
+def is_unitary_matrix(op, atol=ATOL_DEFAULT):
+    """Test if an array is a unitary matrix."""
+    if atol is None:
+        atol = ATOL_DEFAULT
+    mat = np.array(op)
+    # Compute A^dagger.A and see if it is identity matrix
+    mat = np.conj(mat.T).dot(mat)
+    return is_identity_matrix(mat, ignore_phase=False, atol=atol)

--- a/test/python/quantum_info/channel/__init__.py
+++ b/test/python/quantum_info/channel/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Qiskit quantum information channel integration tests."""

--- a/test/python/quantum_info/channel/base.py
+++ b/test/python/quantum_info/channel/base.py
@@ -111,7 +111,7 @@ class ChannelTestCase(QiskitTestCase):
                        atol=1e-6,
                        equal_nan=False,
                        msg=None):
-        """Assert to objects are equal using Numpy.allclose."""
+        """Assert two objects are equal using Numpy.allclose."""
         comparison = np.allclose(
             obj1, obj2, rtol=rtol, atol=atol, equal_nan=equal_nan)
         if msg is None:

--- a/test/python/quantum_info/channel/base.py
+++ b/test/python/quantum_info/channel/base.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Tests for quantum channel representation class."""
+
+import numpy as np
+
+from qiskit.test import QiskitTestCase
+
+
+class ChannelTestCase(QiskitTestCase):
+    """Tests for Channel representations."""
+
+    # Pauli-matrix unitaries
+    matI = np.eye(2)
+    matX = np.array([[0, 1], [1, 0]])
+    matY = np.array([[0, -1j], [1j, 0]])
+    matZ = np.diag([1, -1])
+    matH = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+
+    # Pauli-matrix superoperators
+    sopI = np.eye(4)
+    sopX = np.kron(matX.conj(), matX)
+    sopY = np.kron(matY.conj(), matY)
+    sopZ = np.kron(matZ.conj(), matZ)
+    sopH = np.kron(matH.conj(), matH)
+
+    # Choi-matrices for Pauli-matrix unitaries
+    choiI = np.array([[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 1]])
+    choiX = np.array([[0, 0, 0, 0], [0, 1, 1, 0], [0, 1, 1, 0], [0, 0, 0, 0]])
+    choiY = np.array([[0, 0, 0, 0], [0, 1, -1, 0], [0, -1, 1, 0], [0, 0, 0,
+                                                                   0]])
+    choiZ = np.array([[1, 0, 0, -1], [0, 0, 0, 0], [0, 0, 0, 0], [-1, 0, 0,
+                                                                  1]])
+    choiH = np.array([[1, 1, 1, -1], [1, 1, 1, -1], [1, 1, 1, -1],
+                      [-1, -1, -1, 1]]) / 2
+
+    # Chi-matrices for Pauli-matrix unitaries
+    chiI = np.diag([2, 0, 0, 0])
+    chiX = np.diag([0, 2, 0, 0])
+    chiY = np.diag([0, 0, 2, 0])
+    chiZ = np.diag([0, 0, 0, 2])
+    chiH = np.array([[0, 0, 0, 0], [0, 1, 0, 1], [0, 0, 0, 0], [0, 1, 0, 1]])
+
+    # PTM-matrices for Pauli-matrix unitaries
+    ptmI = np.diag([1, 1, 1, 1])
+    ptmX = np.diag([1, 1, -1, -1])
+    ptmY = np.diag([1, -1, 1, -1])
+    ptmZ = np.diag([1, -1, -1, 1])
+    ptmH = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, -1, 0], [0, 1, 0, 0]])
+
+    # Depolarizing channels
+    def depol_kraus(self, p):
+        """Depolarizing channel Kraus operators"""
+        return [
+            np.sqrt(1 - p * 3 / 4) * self.matI,
+            np.sqrt(p / 4) * self.matX,
+            np.sqrt(p / 4) * self.matY,
+            np.sqrt(p / 4) * self.matZ
+        ]
+
+    def depol_sop(self, p):
+        """Depolarizing channel superoperator matrix"""
+        return (1 - p) * self.sopI + p * np.array(
+            [[1, 0, 0, 1], [0, 0, 0, 0], [0, 0, 0, 0], [1, 0, 0, 1]]) / 2
+
+    def depol_choi(self, p):
+        """Depolarizing channel Choi-matrix"""
+        return (1 - p) * self.choiI + p * np.eye(4) / 2
+
+    def depol_chi(self, p):
+        """Depolarizing channel Chi-matrix"""
+        return 2 * np.diag([1 - 3 * p / 4, p / 4, p / 4, p / 4])
+
+    def depol_ptm(self, p):
+        """Depolarizing channel PTM"""
+        return np.diag([1, 1 - p, 1 - p, 1 - p])
+
+    def depol_stine(self, p):
+        """Depolarizing channel Stinespring matrix"""
+        kraus = self.depol_kraus(p)
+        basis = np.eye(4).reshape((4, 4, 1))
+        return np.sum([np.kron(k, b) for k, b in zip(kraus, basis)], axis=0)
+
+    def rand_rho(self, n):
+        """Return random density matrix"""
+        psi = np.random.rand(n) + 1j * np.random.rand(n)
+        rho = np.outer(psi, psi.conj())
+        rho /= np.trace(rho)
+        return rho
+
+    def rand_matrix(self, d1, d2, real=False):
+        """Return a random rectangular matrix."""
+        if real:
+            return np.random.rand(d1, d2)
+        return np.random.rand(d1, d2) + 1j * np.random.rand(d1, d2)
+
+    def rand_kraus(self, input_dim, output_dim, n):
+        """Return a random (non-CPTP) Kraus operator map"""
+        return [self.rand_matrix(output_dim, input_dim) for _ in range(n)]
+
+    def assertAllClose(self,
+                       obj1,
+                       obj2,
+                       rtol=1e-5,
+                       atol=1e-6,
+                       equal_nan=False,
+                       msg=None):
+        """Assert to objects are equal using Numpy.allclose."""
+        comparison = np.allclose(
+            obj1, obj2, rtol=rtol, atol=atol, equal_nan=equal_nan)
+        if msg is None:
+            msg = ''
+        msg += '({} != {})'.format(obj1, obj2)
+        self.assertTrue(comparison, msg=msg)

--- a/test/python/quantum_info/channel/test_adjoint.py
+++ b/test/python/quantum_info/channel/test_adjoint.py
@@ -1,0 +1,299 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Equivalence tests for quantum channel methods."""
+
+import unittest
+
+import numpy as np
+
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from qiskit.quantum_info.operators.channel.choi import Choi
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators.channel.stinespring import Stinespring
+from qiskit.quantum_info.operators.channel.ptm import PTM
+from qiskit.quantum_info.operators.channel.chi import Chi
+from .base import ChannelTestCase
+
+
+class TestEquivalence(ChannelTestCase):
+    """Tests for channel equivalence.
+
+    Tests that performing conjugate, transpose, adjoint
+    in the UnitaryChannel representation is equivalent to performing the same
+    operations in other representations.
+    """
+
+    unitaries = [
+        ChannelTestCase.matI, ChannelTestCase.matX, ChannelTestCase.matY,
+        ChannelTestCase.matZ, ChannelTestCase.matH
+    ]
+
+    chois = [
+        ChannelTestCase.choiI, ChannelTestCase.choiX, ChannelTestCase.choiY,
+        ChannelTestCase.choiZ, ChannelTestCase.choiH
+    ]
+
+    chis = [
+        ChannelTestCase.chiI, ChannelTestCase.chiX, ChannelTestCase.chiY,
+        ChannelTestCase.chiZ, ChannelTestCase.chiH
+    ]
+
+    sops = [
+        ChannelTestCase.sopI, ChannelTestCase.sopX, ChannelTestCase.sopY,
+        ChannelTestCase.sopZ, ChannelTestCase.sopH
+    ]
+
+    ptms = [
+        ChannelTestCase.ptmI, ChannelTestCase.ptmX, ChannelTestCase.ptmY,
+        ChannelTestCase.ptmZ, ChannelTestCase.ptmH
+    ]
+
+    def _compare_transpose_to_unitary(self, chans, mats):
+        """Test transpose is equivalent"""
+        unitaries = [UnitaryChannel(np.transpose(i)) for i in mats]
+        channels = [i.transpose() for i in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def _compare_conjugate_to_unitary(self, chans, mats):
+        """Test conjugate is equivalent"""
+        unitaries = [UnitaryChannel(np.conjugate(i)) for i in mats]
+        channels = [i.conjugate() for i in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def _compare_adjoint_to_unitary(self, chans, mats):
+        """Test adjoint is equivalent"""
+        unitaries = [
+            UnitaryChannel(np.conjugate(np.transpose(i))) for i in mats
+        ]
+        channels = [i.adjoint() for i in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def test_choi_conjugate(self):
+        """Test conjugate of Choi matrices is correct."""
+        mats = self.unitaries
+        chans = [Choi(mat) for mat in self.chois]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_superop_conjugate(self):
+        """Test conjugate of SuperOp matrices is correct."""
+        mats = self.unitaries
+        chans = [SuperOp(mat) for mat in self.sops]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_kraus_conjugate(self):
+        """Test conjugate of Kraus matrices is correct."""
+        mats = self.unitaries
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_stinespring_conjugate(self):
+        """Test conjugate of Stinespring matrices is correct."""
+        mats = self.unitaries
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_chi_conjugate(self):
+        """Test conjugate of Chi matrices is correct."""
+        mats = self.unitaries
+        chans = [Chi(mat) for mat in self.chis]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_ptm_conjugate(self):
+        """Test conjugate of PTM matrices is correct."""
+        mats = self.unitaries
+        chans = [PTM(mat) for mat in self.ptms]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_choi_conjugate_random(self):
+        """Test conjugate of Choi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_superop_conjugate_random(self):
+        """Test conjugate of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_kraus_conjugate_random(self):
+        """Test conjugate of Kraus matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_stinespring_conjugate_random(self):
+        """Test conjugate of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_chi_conjugate_random(self):
+        """Test conjugate of Chi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_ptm_conjugate_random(self):
+        """Test conjugate of PTM matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_conjugate_to_unitary(chans, mats)
+
+    def test_choi_transpose(self):
+        """Test transpose of Choi matrices is correct."""
+        mats = self.unitaries
+        chans = [Choi(mat) for mat in self.chois]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_superop_transpose(self):
+        """Test transpose of SuperOp matrices is correct."""
+        mats = self.unitaries
+        chans = [SuperOp(mat) for mat in self.sops]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_kraus_transpose(self):
+        """Test transpose of Kraus matrices is correct."""
+        mats = self.unitaries
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_stinespring_transpose(self):
+        """Test transpose of Stinespring matrices is correct."""
+        mats = self.unitaries
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_chi_transpose(self):
+        """Test transpose of Chi matrices is correct."""
+        mats = self.unitaries
+        chans = [Chi(mat) for mat in self.chis]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_ptm_transpose(self):
+        """Test transpose of PTM matrices is correct."""
+        mats = self.unitaries
+        chans = [PTM(mat) for mat in self.ptms]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_choi_transpose_random(self):
+        """Test transpose of Choi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_superop_transpose_random(self):
+        """Test transpose of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_kraus_transpose_random(self):
+        """Test transpose of Kraus matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_stinespring_transpose_random(self):
+        """Test transpose of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_chi_transpose_random(self):
+        """Test transpose of Chi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_ptm_transpose_random(self):
+        """Test transpose of PTM matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_transpose_to_unitary(chans, mats)
+
+    def test_choi_adjoint(self):
+        """Test adjoint of Choi matrices is correct."""
+        mats = self.unitaries
+        chans = [Choi(mat) for mat in self.chois]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_superop_adjoint(self):
+        """Test adjoint of SuperOp matrices is correct."""
+        mats = self.unitaries
+        chans = [SuperOp(mat) for mat in self.sops]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_kraus_adjoint(self):
+        """Test adjoint of Kraus matrices is correct."""
+        mats = self.unitaries
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_stinespring_adjoint(self):
+        """Test adjoint of Stinespring matrices is correct."""
+        mats = self.unitaries
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_chi_adjoint(self):
+        """Test adjoint of Chi matrices is correct."""
+        mats = self.unitaries
+        chans = [Chi(mat) for mat in self.chis]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_ptm_adjoint(self):
+        """Test adjoint of PTM matrices is correct."""
+        mats = self.unitaries
+        chans = [PTM(mat) for mat in self.ptms]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_choi_adjoint_random(self):
+        """Test adjoint of Choi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_superop_adjoint_random(self):
+        """Test adjoint of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_kraus_adjoint_random(self):
+        """Test adjoint of Kraus matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_stinespring_adjoint_random(self):
+        """Test adjoint of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_chi_adjoint_random(self):
+        """Test adjoint of Chi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+    def test_ptm_adjoint_random(self):
+        """Test adjoint of PTM matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_adjoint_to_unitary(chans, mats)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_chi.py
+++ b/test/python/quantum_info/channel/test_chi.py
@@ -59,26 +59,26 @@ class TestChi(ChannelTestCase):
         # Identity channel
         chan = Chi(self.chiI)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         chan = Chi(self.chiH)
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = Chi(self.depol_chi(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -102,27 +102,27 @@ class TestChi(ChannelTestCase):
         chan1 = Chi(self.chiX)
         chan2 = Chi(self.chiY)
         chan = chan1.compose(chan2)
-        targ = Chi(self.chiZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Chi(self.chiZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Chi(self.depol_chi(0.5))
         chan = chan1.compose(chan1)
-        targ = Chi(self.depol_chi(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Chi(self.depol_chi(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose random
         chi1 = self.rand_matrix(4, 4, real=True)
         chi2 = self.rand_matrix(4, 4, real=True)
         chan1 = Chi(chi1, input_dim=2, output_dim=2)
         chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan1.compose(chan2)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 @ chan2
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_inplace(self):
         """Test inplace compose method."""
@@ -133,29 +133,29 @@ class TestChi(ChannelTestCase):
         chan1 = Chi(self.chiX)
         chan2 = Chi(self.chiY)
         chan1.compose(chan2, inplace=True)
-        targ = Chi(self.chiZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Chi(self.chiZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Chi(self.depol_chi(0.5))
         chan1.compose(chan1, inplace=True)
-        targ = Chi(self.depol_chi(0.75)).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Chi(self.depol_chi(0.75))._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Compose random
         chi1 = self.rand_matrix(4, 4, real=True)
         chi2 = self.rand_matrix(4, 4, real=True)
         chan1 = Chi(chi1, input_dim=2, output_dim=2)
         chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan1.compose(chan2, inplace=True)
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Chi(chi1, input_dim=2, output_dim=2)
         chan2 = Chi(chi2, input_dim=2, output_dim=2)
         chan1 @= chan2
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
     def test_compose_front(self):
         """Test front compose method."""
@@ -166,18 +166,18 @@ class TestChi(ChannelTestCase):
         chan1 = Chi(self.chiX)
         chan2 = Chi(self.chiY)
         chan = chan2.compose(chan1, front=True)
-        targ = Chi(self.chiZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Chi(self.chiZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose random
         chi1 = self.rand_matrix(4, 4, real=True)
         chi2 = self.rand_matrix(4, 4, real=True)
         chan1 = Chi(chi1, input_dim=2, output_dim=2)
         chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_front_inplace(self):
         """Test inplace front compose method."""
@@ -188,18 +188,18 @@ class TestChi(ChannelTestCase):
         chan1 = Chi(self.chiX)
         chan2 = Chi(self.chiY)
         chan2.compose(chan1, front=True, inplace=True)
-        targ = Chi(self.chiZ).evolve(rho)
-        self.assertAllClose(chan2.evolve(rho), targ)
+        targ = Chi(self.chiZ)._evolve(rho)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
         # Compose random
         chi1 = self.rand_matrix(4, 4, real=True)
         chi2 = self.rand_matrix(4, 4, real=True)
         chan1 = Chi(chi1, input_dim=2, output_dim=2)
         chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan2.compose(chan1, front=True, inplace=True)
         self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -222,7 +222,7 @@ class TestChi(ChannelTestCase):
         chan = chan_dep.expand(chan_dep)
         targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -245,7 +245,7 @@ class TestChi(ChannelTestCase):
         chan_dep.tensor(chan_dep, inplace=True)
         targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep.evolve(rho), targ)
+        self.assertAllClose(chan_dep._evolve(rho), targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -272,11 +272,11 @@ class TestChi(ChannelTestCase):
         chan = chan_dep.tensor(chan_dep)
         targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         # Test operator overload
         chan = chan_dep ^ chan_dep
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_tensor_inplace(self):
         """Test inplace tensor method."""
@@ -305,12 +305,12 @@ class TestChi(ChannelTestCase):
         chan_dep.tensor(chan_dep, inplace=True)
         targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep.evolve(rho), targ)
+        self.assertAllClose(chan_dep._evolve(rho), targ)
         # Test operator overload
         chan_dep = Chi(self.depol_chi(1))
         chan_dep ^= chan_dep
         self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep.evolve(rho), targ)
+        self.assertAllClose(chan_dep._evolve(rho), targ)
 
     def test_power(self):
         """Test power method."""

--- a/test/python/quantum_info/channel/test_chi.py
+++ b/test/python/quantum_info/channel/test_chi.py
@@ -1,0 +1,452 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Tests for Chi quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import Chi
+from .base import ChannelTestCase
+
+
+class TestChi(ChannelTestCase):
+    """Tests for Chi channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        mat4 = np.eye(4) / 2.0
+        chan = Chi(mat4)
+        self.assertAllClose(chan.data, mat4)
+        self.assertEqual(chan.dims, (2, 2))
+
+        mat16 = np.eye(16) / 4
+        chan = Chi(mat16)
+        self.assertAllClose(chan.data, mat16)
+        self.assertEqual(chan.dims, (4, 4))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, Chi, mat16, input_dim=2, output_dim=4)
+
+        # Non multi-qubit dimensions should raise exception
+        self.assertRaises(
+            QiskitError, Chi, np.eye(6) / 2, input_dim=3, output_dim=2)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        mat = self.rand_matrix(4, 4, real=True)
+        self.assertEqual(Chi(mat), Chi(mat))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = Chi(mat)
+        cpy = orig.copy()
+        cpy._data[0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+
+        # Identity channel
+        chan = Chi(self.chiI)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        chan = Chi(self.chiH)
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = Chi(self.depol_chi(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(Chi(self.depol_chi(0.25)).is_cptp())
+        # Non-CPTP should return false
+        self.assertFalse(
+            Chi(1.25 * self.chiI - 0.25 * self.depol_chi(1)).is_cptp())
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, Chi(np.eye(4)).compose, Chi(np.eye(16)))
+        self.assertRaises(QiskitError, Chi(np.eye(4)).compose, np.eye(4))
+        self.assertRaises(QiskitError, Chi(np.eye(4)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Chi(self.chiX)
+        chan2 = Chi(self.chiY)
+        chan = chan1.compose(chan2)
+        targ = Chi(self.chiZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Chi(self.depol_chi(0.5))
+        chan = chan1.compose(chan1)
+        targ = Chi(self.depol_chi(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose random
+        chi1 = self.rand_matrix(4, 4, real=True)
+        chi2 = self.rand_matrix(4, 4, real=True)
+        chan1 = Chi(chi1, input_dim=2, output_dim=2)
+        chan2 = Chi(chi2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 @ chan2
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Chi(self.chiX)
+        chan2 = Chi(self.chiY)
+        chan1.compose(chan2, inplace=True)
+        targ = Chi(self.chiZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Chi(self.depol_chi(0.5))
+        chan1.compose(chan1, inplace=True)
+        targ = Chi(self.depol_chi(0.75)).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Compose random
+        chi1 = self.rand_matrix(4, 4, real=True)
+        chi2 = self.rand_matrix(4, 4, real=True)
+        chan1 = Chi(chi1, input_dim=2, output_dim=2)
+        chan2 = Chi(chi2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Chi(chi1, input_dim=2, output_dim=2)
+        chan2 = Chi(chi2, input_dim=2, output_dim=2)
+        chan1 @= chan2
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Chi(self.chiX)
+        chan2 = Chi(self.chiY)
+        chan = chan2.compose(chan1, front=True)
+        targ = Chi(self.chiZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose random
+        chi1 = self.rand_matrix(4, 4, real=True)
+        chi2 = self.rand_matrix(4, 4, real=True)
+        chan1 = Chi(chi1, input_dim=2, output_dim=2)
+        chan2 = Chi(chi2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Chi(self.chiX)
+        chan2 = Chi(self.chiY)
+        chan2.compose(chan1, front=True, inplace=True)
+        targ = Chi(self.chiZ).evolve(rho)
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+        # Compose random
+        chi1 = self.rand_matrix(4, 4, real=True)
+        chi2 = self.rand_matrix(4, 4, real=True)
+        chan1 = Chi(chi1, input_dim=2, output_dim=2)
+        chan2 = Chi(chi2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan2.compose(chan1, front=True, inplace=True)
+        self.assertEqual(chan2.dims, (2, 2))
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_expand(self):
+        """Test expand method."""
+        # Pauli channels
+        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
+        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
+        for i, chi1 in enumerate(paulis):
+            for j, chi2 in enumerate(paulis):
+                chan1 = Chi(chi1)
+                chan2 = Chi(chi2)
+                chan = chan1.expand(chan2)
+                # Target for diagonal Pauli channel
+                targ = Chi(np.diag(targs[i + 4 * j]))
+                self.assertEqual(chan.dims, (4, 4))
+                self.assertEqual(chan, targ)
+
+        # Completely depolarizing
+        rho = np.diag([1, 0, 0, 0])
+        chan_dep = Chi(self.depol_chi(1))
+        chan = chan_dep.expand(chan_dep)
+        targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        # Pauli channels
+        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
+        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
+        for i, chi1 in enumerate(paulis):
+            for j, chi2 in enumerate(paulis):
+                chan1 = Chi(chi1)
+                chan2 = Chi(chi2)
+                chan1.expand(chan2, inplace=True)
+                # Target for diagonal Pauli channel
+                targ = Chi(np.diag(targs[i + 4 * j]))
+                self.assertEqual(chan1.dims, (4, 4))
+                self.assertEqual(chan1, targ)
+
+        # Completely depolarizing
+        rho = np.diag([1, 0, 0, 0])
+        chan_dep = Chi(self.depol_chi(1))
+        chan_dep.tensor(chan_dep, inplace=True)
+        targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan_dep.dims, (4, 4))
+        self.assertAllClose(chan_dep.evolve(rho), targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        # Pauli channels
+        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
+        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
+        for i, chi1 in enumerate(paulis):
+            for j, chi2 in enumerate(paulis):
+                chan1 = Chi(chi1)
+                chan2 = Chi(chi2)
+                chan = chan2.tensor(chan1)
+                # Target for diagonal Pauli channel
+                targ = Chi(np.diag(targs[i + 4 * j]))
+                self.assertEqual(chan.dims, (4, 4))
+                self.assertEqual(chan, targ)
+                # Test overload
+                chan = chan2 ^ chan1
+                self.assertEqual(chan.dims, (4, 4))
+                self.assertEqual(chan, targ)
+
+        # Completely depolarizing
+        rho = np.diag([1, 0, 0, 0])
+        chan_dep = Chi(self.depol_chi(1))
+        chan = chan_dep.tensor(chan_dep)
+        targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho), targ)
+        # Test operator overload
+        chan = chan_dep ^ chan_dep
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        # Pauli channels
+        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
+        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
+        for i, chi1 in enumerate(paulis):
+            for j, chi2 in enumerate(paulis):
+                chan1 = Chi(chi1)
+                chan2 = Chi(chi2)
+                chan2.tensor(chan1, inplace=True)
+                # Target for diagonal Pauli channel
+                targ = Chi(np.diag(targs[i + 4 * j]))
+                self.assertEqual(chan2.dims, (4, 4))
+                self.assertEqual(chan2, targ)
+                # Test operator overload
+                chan1 = Chi(chi1)
+                chan2 = Chi(chi2)
+                chan2 ^= chan1
+                self.assertEqual(chan2.dims, (4, 4))
+                self.assertEqual(chan2, targ)
+
+        # Completely depolarizing
+        rho = np.diag([1, 0, 0, 0])
+        chan_dep = Chi(self.depol_chi(1))
+        chan_dep.tensor(chan_dep, inplace=True)
+        targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan_dep.dims, (4, 4))
+        self.assertAllClose(chan_dep.evolve(rho), targ)
+        # Test operator overload
+        chan_dep = Chi(self.depol_chi(1))
+        chan_dep ^= chan_dep
+        self.assertEqual(chan_dep.dims, (4, 4))
+        self.assertAllClose(chan_dep.evolve(rho), targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = Chi(self.depol_chi(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id**3
+        chan3 = depol.power(3)
+        targ3 = Chi(self.depol_chi(1 - p_id3))
+        self.assertEqual(chan3, targ3)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = Chi(self.depol_chi(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id**3
+        depol.power(3, inplace=True)
+        targ3 = Chi(self.depol_chi(1 - p_id3))
+        self.assertEqual(depol, targ3)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = Chi(self.depol_chi(1))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        mat1 = 0.5 * self.chiI
+        mat2 = 0.5 * self.depol_chi(1)
+        targ = Chi(mat1 + mat2)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        self.assertEqual(chan1.add(chan2), targ)
+        self.assertEqual(chan1 + chan2, targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        mat1 = 0.5 * self.chiI
+        mat2 = 0.5 * self.depol_chi(1)
+        targ = Chi(mat1 + mat2)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        chan1.add(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        chan1 += chan2
+        self.assertEqual(chan1, targ)
+
+    def test_add_except(self):
+        """Test add method raises exceptions."""
+        chan1 = Chi(self.chiI)
+        chan2 = Chi(np.eye(16))
+        self.assertRaises(QiskitError, chan1.add, chan2)
+        self.assertRaises(QiskitError, chan1.add, 5)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        mat1 = 0.5 * self.chiI
+        mat2 = 0.5 * self.depol_chi(1)
+        targ = Chi(mat1 - mat2)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        self.assertEqual(chan1.subtract(chan2), targ)
+        self.assertEqual(chan1 - chan2, targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        mat1 = 0.5 * self.chiI
+        mat2 = 0.5 * self.depol_chi(1)
+        targ = Chi(mat1 - mat2)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        chan1.subtract(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = Chi(mat1)
+        chan2 = Chi(mat2)
+        chan1 -= chan2
+        self.assertEqual(chan1, targ)
+
+    def test_subtract_except(self):
+        """Test subtract method raises exceptions."""
+        chan1 = Chi(self.chiI)
+        chan2 = Chi(np.eye(16))
+        self.assertRaises(QiskitError, chan1.subtract, chan2)
+        self.assertRaises(QiskitError, chan1.subtract, 5)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        chan = Chi(self.chiI)
+        val = 0.5
+        targ = Chi(val * self.chiI)
+        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(val * chan, targ)
+        self.assertEqual(chan * val, targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        chan = Chi(self.chiI)
+        val = 0.5
+        targ = Chi(val * self.chiI)
+        chan.multiply(val, inplace=True)
+        self.assertEqual(chan, targ)
+
+        chan = Chi(self.chiI)
+        chan *= val
+        self.assertEqual(chan, targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = Chi(self.chiI)
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        chan = Chi(self.chiI)
+        targ = Chi(-self.chiI)
+        self.assertEqual(-chan, targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_choi.py
+++ b/test/python/quantum_info/channel/test_choi.py
@@ -1,0 +1,604 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+
+"""Tests for Choi quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import Choi
+from .base import ChannelTestCase
+
+
+class TestChoi(ChannelTestCase):
+    """Tests for Choi channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        mat4 = np.eye(4) / 2.0
+        chan = Choi(mat4)
+        self.assertAllClose(chan.data, mat4)
+        self.assertEqual(chan.dims, (2, 2))
+
+        mat8 = np.eye(8) / 2.0
+        chan = Choi(mat8, input_dim=4)
+        self.assertAllClose(chan.data, mat8)
+        self.assertEqual(chan.dims, (4, 2))
+
+        chan = Choi(mat8, input_dim=2)
+        self.assertAllClose(chan.data, mat8)
+        self.assertEqual(chan.dims, (2, 4))
+
+        mat16 = np.eye(16) / 4
+        chan = Choi(mat16)
+        self.assertAllClose(chan.data, mat16)
+        self.assertEqual(chan.dims, (4, 4))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, Choi, mat8, input_dim=4, output_dim=4)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        mat = self.rand_matrix(4, 4)
+        self.assertEqual(Choi(mat), Choi(mat))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = Choi(mat)
+        cpy = orig.copy()
+        cpy._data[0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+        # Identity channel
+        chan = Choi(self.choiI)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        chan = Choi(self.choiH)
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = Choi(self.depol_choi(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(Choi(self.depol_choi(0.25)).is_cptp())
+        # Non-CPTP should return false
+        self.assertFalse(Choi(1.25 * self.choiI - 0.25 * self.depol_choi(1)).is_cptp())
+
+    def test_conjugate(self):
+        """Test conjugate method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Conjugate channel swaps Y-basis states
+        targ = Choi(np.kron(Zp, Ym) + np.kron(Zm, Yp))
+        chan_conj = chan.conjugate()
+        self.assertEqual(chan_conj, targ)
+
+    def test_conjugate_inplace(self):
+        """Test inplace conjugate method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Conjugate channel swaps Y-basis states
+        targ = Choi(np.kron(Zp, Ym) + np.kron(Zm, Yp))
+        chan = chan.conjugate(inplace=True)
+        self.assertEqual(chan, targ)
+
+    def test_transpose(self):
+        """Test transpose method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Transpose channel swaps basis
+        targ = Choi(np.kron(Yp, Zp) + np.kron(Ym, Zm))
+        chan_t = chan.transpose()
+        self.assertEqual(chan_t, targ)
+
+    def test_transpose_inplace(self):
+        """Test inplace transpose method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Transpose channel swaps basis
+        targ = Choi(np.kron(Yp, Zp) + np.kron(Ym, Zm))
+        chan.transpose(inplace=True)
+        self.assertEqual(chan, targ)
+
+    def test_adjoint(self):
+        """Test adjoint method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Ajoint channel swaps Y-basis elements abd Z<->Y bases
+        targ = Choi(np.kron(Ym, Zp) + np.kron(Yp, Zm))
+        chan_adj = chan.adjoint()
+        self.assertEqual(chan_adj, targ)
+
+    def test_adjoint_inplace(self):
+        """Test inplace adjoint method."""
+        # Test channel measures in Z basis and prepares in Y basis
+        # Zp -> Yp, Zm -> Ym
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
+        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
+        # Ajoint channel swaps Y-basis elements abd Z<->Y bases
+        targ = Choi(np.kron(Ym, Zp) + np.kron(Yp, Zm))
+        chan.adjoint(inplace=True)
+        self.assertEqual(chan, targ)
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, Choi(np.eye(4)).compose, Choi(np.eye(8)))
+        self.assertRaises(QiskitError, Choi(np.eye(4)).compose, np.eye(4))
+        self.assertRaises(QiskitError, Choi(np.eye(4)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # UnitaryChannel evolution
+        chan1 = Choi(self.choiX)
+        chan2 = Choi(self.choiY)
+        chan = chan1.compose(chan2)
+        targ = Choi(self.choiZ)
+        self.assertEqual(chan, targ)
+
+        # 50% depolarizing channel
+        chan1 = Choi(self.depol_choi(0.5))
+        chan = chan1.compose(chan1)
+        targ = Choi(self.depol_choi(0.75))
+        self.assertEqual(chan, targ)
+
+        # Measure and rotation
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        # X-gate second does nothing
+        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        self.assertEqual(chan1.compose(chan2), targ)
+        self.assertEqual(chan1 @ chan2, targ)
+        # X-gate first swaps Z states
+        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
+        self.assertEqual(chan2.compose(chan1), targ)
+        self.assertEqual(chan2 @ chan1, targ)
+
+        # Compose different dimensions
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        chan = chan2.compose(chan1)
+        self.assertEqual(chan.dims, (4, 4))
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # UnitaryChannel evolution
+        chan1 = Choi(self.choiX)
+        chan2 = Choi(self.choiY)
+        chan1.compose(chan2, inplace=True)
+        targ = Choi(self.choiZ)
+        self.assertEqual(chan1, targ)
+
+        # 50% depolarizing channel
+        chan1 = Choi(self.depol_choi(0.5))
+        chan1.compose(chan1, inplace=True)
+        targ = Choi(self.depol_choi(0.75))
+        self.assertEqual(chan1, targ)
+
+        # Measure and rotation
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
+        # X-gate second does nothing
+        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan1 @= chan2
+        self.assertEqual(chan1, targ)
+        # X-gate first swaps Z states
+        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan2.compose(chan1, inplace=True)
+        self.assertEqual(chan2, targ)
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan2 @= chan1
+        self.assertEqual(chan2, targ)
+
+        # Compose different dimensions
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan2.compose(chan1, inplace=True)
+        self.assertEqual(chan2.dims, (4, 4))
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # UnitaryChannel evolution
+        chan1 = Choi(self.choiX)
+        chan2 = Choi(self.choiY)
+        chan = chan1.compose(chan2, front=True)
+        targ = Choi(self.choiZ)
+        self.assertEqual(chan, targ)
+
+        # 50% depolarizing channel
+        chan1 = Choi(self.depol_choi(0.5))
+        chan = chan1.compose(chan1, front=True)
+        targ = Choi(self.depol_choi(0.75))
+        self.assertEqual(chan, targ)
+
+        # Measure and rotation
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        # X-gate second does nothing
+        chan = chan2.compose(chan1, front=True)
+        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        self.assertEqual(chan, targ)
+        # X-gate first swaps Z states
+        chan = chan1.compose(chan2, front=True)
+        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
+        self.assertEqual(chan, targ)
+
+        # Compose different dimensions
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan = chan1.compose(chan2, front=True)
+        self.assertEqual(chan.dims, (4, 4))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # UnitaryChannel evolution
+        chan1 = Choi(self.choiX)
+        chan2 = Choi(self.choiY)
+        chan1.compose(chan2, front=True, inplace=True)
+        targ = Choi(self.choiZ)
+        self.assertEqual(chan1, targ)
+
+        # 50% depolarizing channel
+        chan1 = Choi(self.depol_choi(0.5))
+        chan1.compose(chan1, inplace=True, front=True)
+        targ = Choi(self.depol_choi(0.75))
+        self.assertEqual(chan1, targ)
+
+        # Measure and rotation
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
+        # X-gate second does nothing
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan2.compose(chan1, inplace=True, front=True)
+        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        self.assertEqual(chan2, targ)
+        # X-gate first swaps Z states
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        chan1.compose(chan2, inplace=True, front=True)
+        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
+        self.assertEqual(chan1, targ)
+
+        # Compose different dimensions
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan1.compose(chan2, inplace=True, front=True)
+        self.assertEqual(chan1.dims, (4, 4))
+        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
+        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
+        chan2.compose(chan1, inplace=True, front=True)
+        self.assertEqual(chan2.dims, (2, 2))
+
+    def test_expand(self):
+        """Test expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+
+        # X \otimes I
+        chan = chan1.expand(chan2)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan2.expand(chan1)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = Choi(self.depol_choi(1))
+        chan = chan_dep.expand(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan1.expand(chan2, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan2.expand(chan1, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = Choi(self.depol_choi(1))
+        chan.expand(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+
+        # X \otimes I
+        rho_targ = np.kron(rho1, rho0)
+        chan = chan2.tensor(chan1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = chan2 ^ chan1
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        rho_targ = np.kron(rho0, rho1)
+        chan = chan1.tensor(chan2)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = chan1 ^ chan2
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        chan_dep = Choi(self.depol_choi(1))
+        chan = chan_dep.tensor(chan_dep)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = chan_dep ^ chan_dep
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        rho_targ = np.kron(rho1, rho0)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan2.tensor(chan1, inplace=True)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan2 ^= chan1
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        rho_targ = np.kron(rho0, rho1)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan1.tensor(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(self.choiX)
+        chan1 ^= chan2
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        chan = Choi(self.depol_choi(1))
+        chan.tensor(chan, inplace=True)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = Choi(self.depol_choi(1))
+        chan ^= chan
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = Choi(self.depol_choi(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        chan3 = depol.power(3)
+        targ3 = Choi(self.depol_choi(1 - p_id3))
+        self.assertEqual(chan3, targ3)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = Choi(self.depol_choi(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        depol.power(3, inplace=True)
+        targ3 = Choi(self.depol_choi(1 - p_id3))
+        self.assertEqual(depol, targ3)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = Choi(self.depol_choi(1))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        mat1 = 0.5 * self.choiI
+        mat2 = 0.5 * self.depol_choi(1)
+        targ = Choi(mat1 + mat2)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        self.assertEqual(chan1.add(chan2), targ)
+        self.assertEqual(chan1 + chan2, targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        mat1 = 0.5 * self.choiI
+        mat2 = 0.5 * self.depol_choi(1)
+        targ = Choi(mat1 + mat2)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        chan1.add(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        chan1 += chan2
+        self.assertEqual(chan1, targ)
+
+    def test_add_except(self):
+        """Test add method raises exceptions."""
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(np.eye(8))
+        self.assertRaises(QiskitError, chan1.add, chan2)
+        self.assertRaises(QiskitError, chan1.add, 5)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        mat1 = 0.5 * self.choiI
+        mat2 = 0.5 * self.depol_choi(1)
+        targ = Choi(mat1 - mat2)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        self.assertEqual(chan1.subtract(chan2), targ)
+        self.assertEqual(chan1 - chan2, targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        mat1 = 0.5 * self.choiI
+        mat2 = 0.5 * self.depol_choi(1)
+        targ = Choi(mat1 - mat2)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        chan1.subtract(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = Choi(mat1)
+        chan2 = Choi(mat2)
+        chan1 -= chan2
+        self.assertEqual(chan1, targ)
+
+    def test_subtract_except(self):
+        """Test subtract method raises exceptions."""
+        chan1 = Choi(self.choiI)
+        chan2 = Choi(np.eye(8))
+        self.assertRaises(QiskitError, chan1.subtract, chan2)
+        self.assertRaises(QiskitError, chan1.subtract, 5)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        chan = Choi(self.choiI)
+        val = 0.5
+        targ = Choi(val * self.choiI)
+        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(val * chan, targ)
+        self.assertEqual(chan * val, targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        chan = Choi(self.choiI)
+        val = 0.5
+        targ = Choi(val * self.choiI)
+        chan.multiply(val, inplace=True)
+        self.assertEqual(chan, targ)
+
+        chan = Choi(self.choiI)
+        chan *= val
+        self.assertEqual(chan, targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = Choi(self.choiI)
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        chan = Choi(self.choiI)
+        targ = Choi(-1 * self.choiI)
+        self.assertEqual(-chan, targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_choi.py
+++ b/test/python/quantum_info/channel/test_choi.py
@@ -64,26 +64,26 @@ class TestChoi(ChannelTestCase):
         # Identity channel
         chan = Choi(self.choiI)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         chan = Choi(self.choiH)
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = Choi(self.depol_choi(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -344,20 +344,20 @@ class TestChoi(ChannelTestCase):
         chan = chan1.expand(chan2)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan2.expand(chan1)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = Choi(self.depol_choi(1))
         chan = chan_dep.expand(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -370,7 +370,7 @@ class TestChoi(ChannelTestCase):
         chan1.expand(chan2, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = Choi(self.choiI)
@@ -378,14 +378,14 @@ class TestChoi(ChannelTestCase):
         chan2.expand(chan1, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = Choi(self.depol_choi(1))
         chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -398,29 +398,29 @@ class TestChoi(ChannelTestCase):
         rho_targ = np.kron(rho1, rho0)
         chan = chan2.tensor(chan1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = chan2 ^ chan1
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         rho_targ = np.kron(rho0, rho1)
         chan = chan1.tensor(chan2)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = chan1 ^ chan2
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         chan_dep = Choi(self.depol_choi(1))
         chan = chan_dep.tensor(chan_dep)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = chan_dep ^ chan_dep
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor_inplace(self):
         """Test inplace tensor method."""
@@ -433,12 +433,12 @@ class TestChoi(ChannelTestCase):
         chan2 = Choi(self.choiX)
         chan2.tensor(chan1, inplace=True)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
         chan1 = Choi(self.choiI)
         chan2 = Choi(self.choiX)
         chan2 ^= chan1
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # I \otimes X
         rho_targ = np.kron(rho0, rho1)
@@ -446,23 +446,23 @@ class TestChoi(ChannelTestCase):
         chan2 = Choi(self.choiX)
         chan1.tensor(chan2, inplace=True)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
         chan1 = Choi(self.choiI)
         chan2 = Choi(self.choiX)
         chan1 ^= chan2
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         chan = Choi(self.depol_choi(1))
         chan.tensor(chan, inplace=True)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = Choi(self.depol_choi(1))
         chan ^= chan
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_power(self):
         """Test power method."""

--- a/test/python/quantum_info/channel/test_evolve.py
+++ b/test/python/quantum_info/channel/test_evolve.py
@@ -36,9 +36,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim, dim)
                 chan1 = UnitaryChannel(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _other_to_unitary(self, rep, qubits_test_cases,
@@ -50,9 +50,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim, dim)
                 chan1 = rep(UnitaryChannel(mat))
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = UnitaryChannel(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _choi_to_other_cp(self, rep, qubits_test_cases,
@@ -64,9 +64,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = dim * self.rand_rho(dim ** 2)
                 chan1 = Choi(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _choi_to_other_noncp(self, rep, qubits_test_cases,
@@ -78,9 +78,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim ** 2, dim ** 2)
                 chan1 = Choi(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _superop_to_other(self, rep, qubits_test_cases,
@@ -92,9 +92,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim ** 2, dim ** 2)
                 chan1 = SuperOp(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _kraus_to_other_single(self, rep, qubits_test_cases,
@@ -106,9 +106,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 kraus = self.rand_kraus(dim, dim, dim ** 2)
                 chan1 = Kraus(kraus)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _kraus_to_other_double(self, rep, qubits_test_cases,
@@ -121,9 +121,9 @@ class TestTransformations(ChannelTestCase):
                 kraus_l = self.rand_kraus(dim, dim, dim ** 2)
                 kraus_r = self.rand_kraus(dim, dim, dim ** 2)
                 chan1 = Kraus((kraus_l, kraus_r))
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _stinespring_to_other_single(self, rep, qubits_test_cases,
@@ -135,9 +135,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim ** 2, dim)
                 chan1 = Stinespring(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _stinespring_to_other_double(self, rep, qubits_test_cases,
@@ -150,9 +150,9 @@ class TestTransformations(ChannelTestCase):
                 mat_l = self.rand_matrix(dim ** 2, dim)
                 mat_r = self.rand_matrix(dim ** 2, dim)
                 chan1 = Stinespring((mat_l, mat_r))
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _chi_to_other(self, rep, qubits_test_cases,
@@ -164,9 +164,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
                 chan1 = Chi(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def _ptm_to_other(self, rep, qubits_test_cases,
@@ -178,9 +178,9 @@ class TestTransformations(ChannelTestCase):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
                 chan1 = PTM(mat)
-                rho1 = chan1.evolve(rho)
+                rho1 = chan1._evolve(rho)
                 chan2 = rep(chan1)
-                rho2 = chan2.evolve(rho)
+                rho2 = chan2._evolve(rho)
                 self.assertAllClose(rho1, rho2)
 
     def test_unitary_to_choi(self):

--- a/test/python/quantum_info/channel/test_evolve.py
+++ b/test/python/quantum_info/channel/test_evolve.py
@@ -1,0 +1,473 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+
+"""Tests for quantum channel representation transformations."""
+
+import unittest
+
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from qiskit.quantum_info.operators.channel.choi import Choi
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators.channel.stinespring import Stinespring
+from qiskit.quantum_info.operators.channel.ptm import PTM
+from qiskit.quantum_info.operators.channel.chi import Chi
+from .base import ChannelTestCase
+
+
+class TestTransformations(ChannelTestCase):
+    """Random tests for equivalence of channel evolution."""
+
+    qubits_test_cases = (1, 2)
+    repetitions = 2
+
+    def _unitary_to_other(self, rep, qubits_test_cases,
+                          repetitions):
+        """Test UnitaryChannel to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim, dim)
+                chan1 = UnitaryChannel(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _other_to_unitary(self, rep, qubits_test_cases,
+                          repetitions):
+        """Test Other to UnitaryChannel evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim, dim)
+                chan1 = rep(UnitaryChannel(mat))
+                rho1 = chan1.evolve(rho)
+                chan2 = UnitaryChannel(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _choi_to_other_cp(self, rep, qubits_test_cases,
+                          repetitions):
+        """Test CP Choi to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = dim * self.rand_rho(dim ** 2)
+                chan1 = Choi(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _choi_to_other_noncp(self, rep, qubits_test_cases,
+                             repetitions):
+        """Test CP Choi to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim ** 2, dim ** 2)
+                chan1 = Choi(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _superop_to_other(self, rep, qubits_test_cases,
+                          repetitions):
+        """Test SuperOp to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim ** 2, dim ** 2)
+                chan1 = SuperOp(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _kraus_to_other_single(self, rep, qubits_test_cases,
+                               repetitions):
+        """Test single Kraus to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                kraus = self.rand_kraus(dim, dim, dim ** 2)
+                chan1 = Kraus(kraus)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _kraus_to_other_double(self, rep, qubits_test_cases,
+                               repetitions):
+        """Test double Kraus to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                kraus_l = self.rand_kraus(dim, dim, dim ** 2)
+                kraus_r = self.rand_kraus(dim, dim, dim ** 2)
+                chan1 = Kraus((kraus_l, kraus_r))
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _stinespring_to_other_single(self, rep, qubits_test_cases,
+                                     repetitions):
+        """Test single Stinespring to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim ** 2, dim)
+                chan1 = Stinespring(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _stinespring_to_other_double(self, rep, qubits_test_cases,
+                                     repetitions):
+        """Test double Stinespring to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat_l = self.rand_matrix(dim ** 2, dim)
+                mat_r = self.rand_matrix(dim ** 2, dim)
+                chan1 = Stinespring((mat_l, mat_r))
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _chi_to_other(self, rep, qubits_test_cases,
+                      repetitions):
+        """Test Chi to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
+                chan1 = Chi(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def _ptm_to_other(self, rep, qubits_test_cases,
+                      repetitions):
+        """Test PTM to Other evolution."""
+        for nq in qubits_test_cases:
+            dim = 2 ** nq
+            for _ in range(repetitions):
+                rho = self.rand_rho(dim)
+                mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
+                chan1 = PTM(mat)
+                rho1 = chan1.evolve(rho)
+                chan2 = rep(chan1)
+                rho2 = chan2.evolve(rho)
+                self.assertAllClose(rho1, rho2)
+
+    def test_unitary_to_choi(self):
+        """Test UnitaryChannel to Choi evolution."""
+        self._unitary_to_other(Choi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_unitary_to_superop(self):
+        """Test UnitaryChannel to SuperOp evolution."""
+        self._unitary_to_other(SuperOp, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_unitary_to_kraus(self):
+        """Test UnitaryChannel to Kraus evolution."""
+        self._unitary_to_other(Kraus, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_unitary_to_stinespring(self):
+        """Test UnitaryChannel to Stinespring evolution."""
+        self._unitary_to_other(Stinespring, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_unitary_to_chi(self):
+        """Test UnitaryChannel to Chi evolution."""
+        self._unitary_to_other(Chi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_unitary_to_ptm(self):
+        """Test UnitaryChannel to PTM evolution."""
+        self._unitary_to_other(PTM, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_unitary(self):
+        """Test Choi to UnitaryChannel evolution."""
+        self._other_to_unitary(Choi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_superop_cp(self):
+        """Test CP Choi to SuperOp evolution."""
+        self._choi_to_other_cp(SuperOp, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_kraus_cp(self):
+        """Test CP Choi to Kraus evolution."""
+        self._choi_to_other_cp(Kraus, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_stinespring_cp(self):
+        """Test CP Choi to Stinespring evolution."""
+        self._choi_to_other_cp(Stinespring, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_chi_cp(self):
+        """Test CP Choi to Chi evolution."""
+        self._choi_to_other_cp(Chi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_ptm_cp(self):
+        """Test CP Choi to PTM evolution."""
+        self._choi_to_other_cp(PTM, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_choi_to_superop_noncp(self):
+        """Test CP Choi to SuperOp evolution."""
+        self._choi_to_other_noncp(SuperOp, self.qubits_test_cases,
+                                  self.repetitions)
+
+    def test_choi_to_kraus_noncp(self):
+        """Test CP Choi to Kraus evolution."""
+        self._choi_to_other_noncp(Kraus, self.qubits_test_cases,
+                                  self.repetitions)
+
+    def test_choi_to_stinespring_noncp(self):
+        """Test CP Choi to Stinespring evolution."""
+        self._choi_to_other_noncp(Stinespring, self.qubits_test_cases,
+                                  self.repetitions)
+
+    def test_choi_to_chi_noncp(self):
+        """Test Choi to Chi evolution."""
+        self._choi_to_other_noncp(Chi, self.qubits_test_cases,
+                                  self.repetitions)
+
+    def test_choi_to_ptm_noncp(self):
+        """Test Non-CP Choi to PTM evolution."""
+        self._choi_to_other_noncp(PTM, self.qubits_test_cases,
+                                  self.repetitions)
+
+    def test_superop_to_unitary(self):
+        """Test SuperOp to UnitaryChannel evolution."""
+        self._other_to_unitary(SuperOp, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_superop_to_choi(self):
+        """Test SuperOp to Choi evolution."""
+        self._superop_to_other(Choi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_superop_to_kraus(self):
+        """Test SuperOp to Kraus evolution."""
+        self._superop_to_other(Kraus, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_superop_to_stinespring(self):
+        """Test SuperOp to Stinespring evolution."""
+        self._superop_to_other(Stinespring, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_superop_to_chi(self):
+        """Test SuperOp to Chi evolution."""
+        self._superop_to_other(Chi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_superop_to_ptm(self):
+        """Test SuperOp to PTM evolution."""
+        self._superop_to_other(PTM, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_kraus_to_unitary(self):
+        """Test Kraus to UnitaryChannel evolution."""
+        self._other_to_unitary(Kraus, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_kraus_to_choi_single(self):
+        """Test single Kraus to Choi evolution."""
+        self._kraus_to_other_single(Choi, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_superop_single(self):
+        """Test single Kraus to SuperOp evolution."""
+        self._kraus_to_other_single(SuperOp, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_stinespring_single(self):
+        """Test single Krausp to Stinespring evolution."""
+        self._kraus_to_other_single(Stinespring, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_chi_single(self):
+        """Test single Kraus to Chi evolution."""
+        self._kraus_to_other_single(Chi, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_ptm_single(self):
+        """Test single Kraus to PTM evolution."""
+        self._kraus_to_other_single(PTM, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_choi_double(self):
+        """Test single Kraus to Choi evolution."""
+        self._kraus_to_other_double(Choi, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_superop_double(self):
+        """Test single Kraus to SuperOp evolution."""
+        self._kraus_to_other_double(SuperOp, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_stinespring_double(self):
+        """Test single Krausp to Stinespring evolution."""
+        self._kraus_to_other_double(Stinespring, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_chi_double(self):
+        """Test single Kraus to Chi evolution."""
+        self._kraus_to_other_double(Chi, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_kraus_to_ptm_double(self):
+        """Test single Kraus to PTM evolution."""
+        self._kraus_to_other_double(PTM, self.qubits_test_cases,
+                                    self.repetitions)
+
+    def test_stinespring_to_unitary(self):
+        """Test Stinespring to UnitaryChannel evolution."""
+        self._other_to_unitary(Stinespring, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_stinespring_to_choi_single(self):
+        """Test single Stinespring to Choi evolution."""
+        self._stinespring_to_other_single(Choi, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_superop_single(self):
+        """Test single Stinespring to SuperOp evolution."""
+        self._stinespring_to_other_single(SuperOp, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_kraus_single(self):
+        """Test single Stinespring to Kraus evolution."""
+        self._stinespring_to_other_single(Kraus, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_chi_single(self):
+        """Test single Stinespring to Chi evolution."""
+        self._stinespring_to_other_single(Chi, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_ptm_single(self):
+        """Test single Stinespring to PTM evolution."""
+        self._stinespring_to_other_single(PTM, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_choi_double(self):
+        """Test single Stinespring to Choi evolution."""
+        self._stinespring_to_other_double(Choi, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_superop_double(self):
+        """Test single Stinespring to SuperOp evolution."""
+        self._stinespring_to_other_double(SuperOp, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_kraus_double(self):
+        """Test single Stinespring to Kraus evolution."""
+        self._stinespring_to_other_double(Kraus, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_chi_double(self):
+        """Test single Stinespring to Chi evolution."""
+        self._stinespring_to_other_double(Chi, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_stinespring_to_ptm_double(self):
+        """Test single Stinespring to PTM evolution."""
+        self._stinespring_to_other_double(PTM, self.qubits_test_cases,
+                                          self.repetitions)
+
+    def test_ptm_to_unitary(self):
+        """Test PTM to UnitaryChannel evolution."""
+        self._other_to_unitary(PTM, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_ptm_to_choi(self):
+        """Test PTM to Choi evolution."""
+        self._ptm_to_other(Choi, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_ptm_to_superop(self):
+        """Test PTM to SuperOp evolution."""
+        self._ptm_to_other(SuperOp, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_ptm_to_kraus(self):
+        """Test PTM to Kraus evolution."""
+        self._ptm_to_other(Kraus, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_ptm_to_stinespring(self):
+        """Test PTM to Stinespring evolution."""
+        self._ptm_to_other(Stinespring, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_ptm_to_chi(self):
+        """Test PTM to Chi evolution."""
+        self._ptm_to_other(Chi, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_chi_to_unitary(self):
+        """Test Chi to UnitaryChannel evolution."""
+        self._other_to_unitary(Chi, self.qubits_test_cases,
+                               self.repetitions)
+
+    def test_chi_to_choi(self):
+        """Test Chi to Choi evolution."""
+        self._chi_to_other(Choi, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_chi_to_superop(self):
+        """Test Chi to SuperOp evolution."""
+        self._chi_to_other(SuperOp, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_chi_to_kraus(self):
+        """Test Chi to Kraus evolution."""
+        self._chi_to_other(Kraus, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_chi_to_stinespring(self):
+        """Test Chi to Stinespring evolution."""
+        self._chi_to_other(Stinespring, self.qubits_test_cases,
+                           self.repetitions)
+
+    def test_chi_to_ptm(self):
+        """Test Chi to PTM evolution."""
+        self._chi_to_other(PTM, self.qubits_test_cases,
+                           self.repetitions)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_kraus.py
+++ b/test/python/quantum_info/channel/test_kraus.py
@@ -1,0 +1,633 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+
+"""Tests for Kraus quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import Kraus
+from .base import ChannelTestCase
+
+
+class TestKraus(ChannelTestCase):
+    """Tests for Kraus channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        # Initialize from unitary
+        chan = Kraus(self.matI)
+        self.assertAllClose(chan.data, [self.matI])
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize from Kraus
+        chan = Kraus(self.depol_kraus(0.5))
+        self.assertAllClose(chan.data, self.depol_kraus(0.5))
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize from Non-CPTP
+        kraus_l, kraus_r = [self.matI, self.matX], [self.matY, self.matZ]
+        chan = Kraus((kraus_l, kraus_r))
+        self.assertAllClose(chan.data, (kraus_l, kraus_r))
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize with redundant second op
+        chan = Kraus((kraus_l, kraus_l))
+        self.assertAllClose(chan.data, kraus_l)
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize from rectangular
+        kraus = [np.zeros((4, 2))]
+        chan = Kraus(kraus)
+        self.assertAllClose(chan.data, kraus)
+        self.assertEqual(chan.dims, (2, 4))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, Kraus, kraus, input_dim=4, output_dim=4)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        kraus = [self.rand_matrix(2, 2) for _ in range(2)]
+        self.assertEqual(Kraus(kraus), Kraus(kraus))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = Kraus(mat)
+        cpy = orig.copy()
+        cpy._data[0][0][0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+        # Identity channel
+        chan = Kraus(self.matI)
+        target_psi = np.array([0, 1])
+        self.assertAllClose(chan.evolve(input_psi), target_psi)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+        chan = Kraus(mat)
+        target_psi = np.array([1, -1]) / np.sqrt(2)
+        self.assertAllClose(chan.evolve(input_psi), target_psi)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = Kraus(self.depol_kraus(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(Kraus(self.depol_kraus(0.5)).is_cptp())
+        self.assertTrue(Kraus(self.matX).is_cptp())
+        # Non-CPTP should return false
+        self.assertFalse(Kraus(([self.matI], [self.matX])).is_cptp())
+        self.assertFalse(Kraus(([self.matI, self.matX])).is_cptp())
+
+    def test_conjugate(self):
+        """Test conjugate method."""
+        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+        # Single Kraus list
+        targ = Kraus([np.conjugate(k) for k in kraus_l])
+        chan1 = Kraus(kraus_l)
+        chan = chan1.conjugate()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+        # Double Kraus list
+        targ = Kraus(([np.conjugate(k) for k in kraus_l],
+                      [np.conjugate(k) for k in kraus_r]))
+        chan1 = Kraus((kraus_l, kraus_r))
+        chan = chan1.conjugate()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+
+    def test_conjugate_inplace(self):
+        """Test inplace conjugate method."""
+        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+        # Single Kraus list
+        targ = Kraus([np.conjugate(k) for k in kraus_l])
+        chan = Kraus(kraus_l)
+        chan.conjugate(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+        # Double Kraus list
+        targ = Kraus(([np.conjugate(k) for k in kraus_l],
+                      [np.conjugate(k) for k in kraus_r]))
+        chan = Kraus((kraus_l, kraus_r))
+        chan.conjugate(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+
+    def test_transpose(self):
+        """Test transpose method."""
+        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+        # Single Kraus list
+        targ = Kraus([np.transpose(k) for k in kraus_l])
+        chan1 = Kraus(kraus_l)
+        chan = chan1.transpose()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double Kraus list
+        targ = Kraus(([np.transpose(k) for k in kraus_l],
+                      [np.transpose(k) for k in kraus_r]))
+        chan1 = Kraus((kraus_l, kraus_r))
+        chan = chan1.transpose()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_transpose_inplace(self):
+        """Test inplace transpose method."""
+        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+        # Single Kraus list
+        targ = Kraus([np.transpose(k) for k in kraus_l])
+        chan = Kraus(kraus_l)
+        chan.transpose(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double Kraus list
+        targ = Kraus(([np.transpose(k) for k in kraus_l],
+                      [np.transpose(k) for k in kraus_r]))
+        chan = Kraus((kraus_l, kraus_r))
+        chan.transpose(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_adjoint(self):
+        """Test adjoint method."""
+        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+        # Single Kraus list
+        targ = Kraus([np.transpose(k).conj() for k in kraus_l])
+        chan1 = Kraus(kraus_l)
+        chan = chan1.adjoint()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double Kraus list
+        targ = Kraus(([np.transpose(k).conj() for k in kraus_l],
+                      [np.transpose(k).conj() for k in kraus_r]))
+        chan1 = Kraus((kraus_l, kraus_r))
+        chan = chan1.adjoint()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_adjoint_inplace(self):
+        """Test inplace adjoint method."""
+        kraus_l = [self.rand_matrix(4, 2) for _ in range(4)]
+        kraus_r = [self.rand_matrix(4, 2) for _ in range(4)]
+        # Single Kraus list
+        targ = Kraus([np.transpose(k).conj() for k in kraus_l])
+        chan = Kraus(kraus_l)
+        chan.adjoint(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double Kraus list
+        targ = Kraus(([np.transpose(k).conj() for k in kraus_l],
+                      [np.transpose(k).conj() for k in kraus_r]))
+        chan = Kraus((kraus_l, kraus_r))
+        chan.adjoint(inplace=True)
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, Kraus(np.eye(2)).compose, Kraus(np.eye(4)))
+        self.assertRaises(QiskitError, Kraus(np.eye(2)).compose, np.eye(2))
+        self.assertRaises(QiskitError, Kraus(np.eye(2)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Kraus(self.matX)
+        chan2 = Kraus(self.matY)
+        chan = chan1.compose(chan2)
+        targ = Kraus(self.matZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Kraus(self.depol_kraus(0.5))
+        chan = chan1.compose(chan1)
+        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 @ chan2
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Kraus(self.matX)
+        chan2 = Kraus(self.matY)
+        chan1.compose(chan2, inplace=True)
+        targ = Kraus(self.matZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan = Kraus(self.depol_kraus(0.5))
+        chan.compose(chan, inplace=True)
+        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        chan1 @= chan2
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Kraus(self.matX)
+        chan2 = Kraus(self.matY)
+        chan = chan1.compose(chan2, front=True)
+        targ = Kraus(self.matZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Kraus(self.depol_kraus(0.5))
+        chan = chan1.compose(chan1, front=True)
+        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Kraus(self.matX)
+        chan2 = Kraus(self.matY)
+        chan1.compose(chan2, inplace=True, front=True)
+        targ = Kraus(self.matZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan = Kraus(self.depol_kraus(0.5))
+        chan.compose(chan, inplace=True, front=True)
+        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan2.compose(chan1, inplace=True, front=True)
+        self.assertEqual(chan2.dims, (2, 2))
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_expand(self):
+        """Test expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+
+        # X \otimes I
+        chan = chan1.expand(chan2)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan2.expand(chan1)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = Kraus(self.depol_kraus(1))
+        chan = chan_dep.expand(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+        chan1.expand(chan2, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+        chan2.expand(chan1, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = Kraus(self.depol_kraus(1))
+        chan.expand(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+
+        # X \otimes I
+        chan = chan2.tensor(chan1)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan1.tensor(chan2)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = Kraus(self.depol_kraus(1))
+        chan = chan_dep.tensor(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+        chan2.tensor(chan1, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = Kraus(self.matI)
+        chan2 = Kraus(self.matX)
+        chan1.tensor(chan2, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = Kraus(self.depol_kraus(1))
+        chan.tensor(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        rho = np.diag([1, 0])
+        p_id = 0.9
+        chan = Kraus(self.depol_kraus(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        chan3 = chan.power(3)
+        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
+        self.assertAllClose(chan3.evolve(rho), targ3a)
+        targ3b = Kraus(self.depol_kraus(1 - p_id3)).evolve(rho)
+        self.assertAllClose(chan3.evolve(rho), targ3b)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        rho = np.diag([1, 0])
+        p_id = 0.9
+        chan = Kraus(self.depol_kraus(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
+        targ3b = Kraus(self.depol_kraus(1 - p_id3)).evolve(rho)
+        chan.power(3, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ3a)
+        self.assertAllClose(chan.evolve(rho), targ3b)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = Kraus(self.depol_kraus(0.9))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Random Single-Kraus maps
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        chan = chan1.add(chan2)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 + chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Random Single-Kraus maps
+        chan = Kraus((kraus1, kraus2))
+        targ = 2 * chan.evolve(rho)
+        chan = chan.add(chan)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Random Single-Kraus maps
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        chan1.add(chan2, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Kraus(kraus1)
+        chan1 += chan2
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Random Single-Kraus maps
+        chan = Kraus((kraus1, kraus2))
+        targ = 2 * chan.evolve(rho)
+        chan.add(chan, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Random Single-Kraus maps
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        chan = chan1.subtract(chan2)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 - chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Random Single-Kraus maps
+        chan = Kraus((kraus1, kraus2))
+        targ = 0 * chan.evolve(rho)
+        chan = chan.subtract(chan)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Random Single-Kraus maps
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        chan1.subtract(chan2, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Kraus(kraus1)
+        chan1 -= chan2
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Random Single-Kraus maps
+        chan = Kraus((kraus1, kraus2))
+        targ = 0 * chan.evolve(rho)
+        chan.subtract(chan, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        # Random initial state and Kraus ops
+        rho = self.rand_rho(2)
+        val = 0.5
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Single Kraus set
+        chan1 = Kraus(kraus1)
+        targ = val * chan1.evolve(rho)
+        chan = chan1.multiply(val)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = val * chan1
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 * val
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Double Kraus set
+        chan2 = Kraus((kraus1, kraus2))
+        targ = val * chan2.evolve(rho)
+        chan = chan2.multiply(val)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = val * chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan2 * val
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        # Random initial state and Kraus ops
+        rho = self.rand_rho(2)
+        val = 0.5
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
+
+        # Single Kraus set
+        chan1 = Kraus(kraus1)
+        targ = val * chan1.evolve(rho)
+        chan1.multiply(val, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Kraus(kraus1)
+        chan1 *= val
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Double Kraus set
+        chan2 = Kraus((kraus1, kraus2))
+        targ = val * chan2.evolve(rho)
+        chan2.multiply(val, inplace=True)
+        self.assertAllClose(chan2.evolve(rho), targ)
+        chan2 = Kraus((kraus1, kraus2))
+        chan2 *= val
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = Kraus(self.depol_kraus(1))
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        rho = np.diag([1, 0])
+        targ = np.diag([-0.5, -0.5])
+        chan = -Kraus(self.depol_kraus(1))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_kraus.py
+++ b/test/python/quantum_info/channel/test_kraus.py
@@ -72,29 +72,29 @@ class TestKraus(ChannelTestCase):
         # Identity channel
         chan = Kraus(self.matI)
         target_psi = np.array([0, 1])
-        self.assertAllClose(chan.evolve(input_psi), target_psi)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        self.assertAllClose(chan._evolve(input_psi), target_psi)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_psi)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         chan = Kraus(mat)
         target_psi = np.array([1, -1]) / np.sqrt(2)
-        self.assertAllClose(chan.evolve(input_psi), target_psi)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        self.assertAllClose(chan._evolve(input_psi), target_psi)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_psi)
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = Kraus(self.depol_kraus(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -222,26 +222,26 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(self.matX)
         chan2 = Kraus(self.matY)
         chan = chan1.compose(chan2)
-        targ = Kraus(self.matZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.matZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Kraus(self.depol_kraus(0.5))
         chan = chan1.compose(chan1)
-        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan1.compose(chan2)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 @ chan2
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_inplace(self):
         """Test inplace compose method."""
@@ -252,28 +252,28 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(self.matX)
         chan2 = Kraus(self.matY)
         chan1.compose(chan2, inplace=True)
-        targ = Kraus(self.matZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Kraus(self.matZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan = Kraus(self.depol_kraus(0.5))
         chan.compose(chan, inplace=True)
-        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan1.compose(chan2, inplace=True)
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
         chan1 @= chan2
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
     def test_compose_front(self):
         """Test front compose method."""
@@ -284,23 +284,23 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(self.matX)
         chan2 = Kraus(self.matY)
         chan = chan1.compose(chan2, front=True)
-        targ = Kraus(self.matZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.matZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Kraus(self.depol_kraus(0.5))
         chan = chan1.compose(chan1, front=True)
-        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_front_inplace(self):
         """Test inplace front compose method."""
@@ -311,23 +311,23 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(self.matX)
         chan2 = Kraus(self.matY)
         chan1.compose(chan2, inplace=True, front=True)
-        targ = Kraus(self.matZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Kraus(self.matZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan = Kraus(self.depol_kraus(0.5))
         chan.compose(chan, inplace=True, front=True)
-        targ = Kraus(self.depol_kraus(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan2.compose(chan1, inplace=True, front=True)
         self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -340,20 +340,20 @@ class TestKraus(ChannelTestCase):
         chan = chan1.expand(chan2)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan2.expand(chan1)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = Kraus(self.depol_kraus(1))
         chan = chan_dep.expand(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -366,7 +366,7 @@ class TestKraus(ChannelTestCase):
         chan1.expand(chan2, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = Kraus(self.matI)
@@ -374,14 +374,14 @@ class TestKraus(ChannelTestCase):
         chan2.expand(chan1, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = Kraus(self.depol_kraus(1))
         chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -394,20 +394,20 @@ class TestKraus(ChannelTestCase):
         chan = chan2.tensor(chan1)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan1.tensor(chan2)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = Kraus(self.depol_kraus(1))
         chan = chan_dep.tensor(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor_inplace(self):
         """Test inplace tensor method."""
@@ -420,7 +420,7 @@ class TestKraus(ChannelTestCase):
         chan2.tensor(chan1, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = Kraus(self.matI)
@@ -428,14 +428,14 @@ class TestKraus(ChannelTestCase):
         chan1.tensor(chan2, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = Kraus(self.depol_kraus(1))
         chan.tensor(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_power(self):
         """Test power method."""
@@ -447,10 +447,10 @@ class TestKraus(ChannelTestCase):
         # Compose 3 times
         p_id3 = p_id ** 3
         chan3 = chan.power(3)
-        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
-        self.assertAllClose(chan3.evolve(rho), targ3a)
-        targ3b = Kraus(self.depol_kraus(1 - p_id3)).evolve(rho)
-        self.assertAllClose(chan3.evolve(rho), targ3b)
+        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
+        self.assertAllClose(chan3._evolve(rho), targ3a)
+        targ3b = Kraus(self.depol_kraus(1 - p_id3))._evolve(rho)
+        self.assertAllClose(chan3._evolve(rho), targ3b)
 
     def test_power_inplace(self):
         """Test inplace power method."""
@@ -461,11 +461,11 @@ class TestKraus(ChannelTestCase):
 
         # Compose 3 times
         p_id3 = p_id ** 3
-        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
-        targ3b = Kraus(self.depol_kraus(1 - p_id3)).evolve(rho)
+        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
+        targ3b = Kraus(self.depol_kraus(1 - p_id3))._evolve(rho)
         chan.power(3, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ3a)
-        self.assertAllClose(chan.evolve(rho), targ3b)
+        self.assertAllClose(chan._evolve(rho), targ3a)
+        self.assertAllClose(chan._evolve(rho), targ3b)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -486,17 +486,17 @@ class TestKraus(ChannelTestCase):
         # Random Single-Kraus maps
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        targ = chan1._evolve(rho) + chan2._evolve(rho)
         chan = chan1.add(chan2)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 + chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
-        targ = 2 * chan.evolve(rho)
+        targ = 2 * chan._evolve(rho)
         chan = chan.add(chan)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_add_inplace(self):
         """Test inplace add method."""
@@ -507,18 +507,18 @@ class TestKraus(ChannelTestCase):
         # Random Single-Kraus maps
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        targ = chan1._evolve(rho) + chan2._evolve(rho)
         chan1.add(chan2, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Kraus(kraus1)
         chan1 += chan2
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
-        targ = 2 * chan.evolve(rho)
+        targ = 2 * chan._evolve(rho)
         chan.add(chan, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_subtract(self):
         """Test subtract method."""
@@ -529,17 +529,17 @@ class TestKraus(ChannelTestCase):
         # Random Single-Kraus maps
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        targ = chan1._evolve(rho) - chan2._evolve(rho)
         chan = chan1.subtract(chan2)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 - chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
-        targ = 0 * chan.evolve(rho)
+        targ = 0 * chan._evolve(rho)
         chan = chan.subtract(chan)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_subtract_inplace(self):
         """Test inplace subtract method."""
@@ -550,18 +550,18 @@ class TestKraus(ChannelTestCase):
         # Random Single-Kraus maps
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
-        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        targ = chan1._evolve(rho) - chan2._evolve(rho)
         chan1.subtract(chan2, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Kraus(kraus1)
         chan1 -= chan2
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
-        targ = 0 * chan.evolve(rho)
+        targ = 0 * chan._evolve(rho)
         chan.subtract(chan, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply(self):
         """Test multiply method."""
@@ -572,23 +572,23 @@ class TestKraus(ChannelTestCase):
 
         # Single Kraus set
         chan1 = Kraus(kraus1)
-        targ = val * chan1.evolve(rho)
+        targ = val * chan1._evolve(rho)
         chan = chan1.multiply(val)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = val * chan1
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 * val
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Double Kraus set
         chan2 = Kraus((kraus1, kraus2))
-        targ = val * chan2.evolve(rho)
+        targ = val * chan2._evolve(rho)
         chan = chan2.multiply(val)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = val * chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan2 * val
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply_inplace(self):
         """Test inplace multiply method."""
@@ -599,21 +599,21 @@ class TestKraus(ChannelTestCase):
 
         # Single Kraus set
         chan1 = Kraus(kraus1)
-        targ = val * chan1.evolve(rho)
+        targ = val * chan1._evolve(rho)
         chan1.multiply(val, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Kraus(kraus1)
         chan1 *= val
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Double Kraus set
         chan2 = Kraus((kraus1, kraus2))
-        targ = val * chan2.evolve(rho)
+        targ = val * chan2._evolve(rho)
         chan2.multiply(val, inplace=True)
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
         chan2 = Kraus((kraus1, kraus2))
         chan2 *= val
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
@@ -626,7 +626,7 @@ class TestKraus(ChannelTestCase):
         rho = np.diag([1, 0])
         targ = np.diag([-0.5, -0.5])
         chan = -Kraus(self.depol_kraus(1))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
 
 if __name__ == '__main__':

--- a/test/python/quantum_info/channel/test_linearops.py
+++ b/test/python/quantum_info/channel/test_linearops.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Equivalence tests for quantum channel methods."""
+
+import unittest
+
+import numpy as np
+
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from qiskit.quantum_info.operators.channel.choi import Choi
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators.channel.stinespring import Stinespring
+from qiskit.quantum_info.operators.channel.ptm import PTM
+from qiskit.quantum_info.operators.channel.chi import Chi
+from .base import ChannelTestCase
+
+
+class TestEquivalence(ChannelTestCase):
+    """Tests for channel equivalence for linear operations.
+
+    This tests that addition, subtraction, multiplication and negatation
+    work for all representations as if they were performed in the SuperOp
+    representation.s equivalent to performing the same
+    operations in other representations.
+    """
+
+    def _compare_add_to_superop(self, rep, dim, samples, unitary=False):
+        """Test channel addition is equivalent to SuperOp"""
+        for _ in range(samples):
+            if unitary:
+                mat1 = self.rand_matrix(dim, dim)
+                mat2 = self.rand_matrix(dim, dim)
+                sop1 = np.kron(np.conj(mat1), mat1)
+                sop2 = np.kron(np.conj(mat2), mat2)
+            else:
+                sop1 = self.rand_matrix(dim * dim, dim * dim)
+                sop2 = self.rand_matrix(dim * dim, dim * dim)
+            targ = rep(SuperOp(sop1 + sop2))
+            channel = rep(SuperOp(sop1)).add(rep(SuperOp(sop2)))
+            self.assertEqual(channel, targ)
+
+    def _compare_subtract_to_superop(self, rep, dim, samples, unitary=False):
+        """Test channel subtraction is equivalent to SuperOp"""
+        for _ in range(samples):
+            if unitary:
+                mat1 = self.rand_matrix(dim, dim)
+                mat2 = self.rand_matrix(dim, dim)
+                sop1 = np.kron(np.conj(mat1), mat1)
+                sop2 = np.kron(np.conj(mat2), mat2)
+            else:
+                sop1 = self.rand_matrix(dim * dim, dim * dim)
+                sop2 = self.rand_matrix(dim * dim, dim * dim)
+            targ = rep(SuperOp(sop1 - sop2))
+            channel = rep(SuperOp(sop1)).subtract(rep(SuperOp(sop2)))
+            self.assertEqual(channel, targ)
+
+    def _compare_multiply_to_superop(self, rep, dim, samples, unitary=False):
+        """Test channel scalar multiplication is equivalent to SuperOp"""
+        for _ in range(samples):
+            if unitary:
+                mat1 = self.rand_matrix(dim, dim)
+                sop1 = np.kron(np.conj(mat1), mat1)
+            else:
+                sop1 = self.rand_matrix(dim * dim, dim * dim)
+            val = 2 * (np.random.rand() - 0.5)
+            targ = rep(SuperOp(val * sop1))
+            channel = rep(SuperOp(sop1)).multiply(val)
+            self.assertEqual(channel, targ)
+
+    def _compare_negate_to_superop(self, rep, dim, samples, unitary=False):
+        """Test negative channel is equivalent to SuperOp"""
+        for _ in range(samples):
+            if unitary:
+                mat1 = self.rand_matrix(dim, dim)
+                sop1 = np.kron(np.conj(mat1), mat1)
+            else:
+                sop1 = self.rand_matrix(dim * dim, dim * dim)
+            targ = rep(SuperOp(-1 * sop1))
+            channel = -rep(SuperOp(sop1))
+            self.assertEqual(channel, targ)
+
+    def _check_add_other_reps(self, chan):
+        """Check addition works for other representations"""
+        current_rep = chan.__class__
+        other_reps = [
+            UnitaryChannel, Choi, SuperOp, Kraus, Stinespring, Chi, PTM
+        ]
+        for rep in other_reps:
+            self.assertEqual(current_rep, chan.add(rep(chan)).__class__)
+
+    def _check_subtract_other_reps(self, chan):
+        """Check subtraction works for other representations"""
+        current_rep = chan.__class__
+        other_reps = [
+            UnitaryChannel, Choi, SuperOp, Kraus, Stinespring, Chi, PTM
+        ]
+        for rep in other_reps:
+            self.assertEqual(current_rep, chan.subtract(rep(chan)).__class__)
+
+    def test_choi_add(self):
+        """Test addition of Choi matrices is correct."""
+        self._compare_add_to_superop(Choi, 4, 10)
+
+    def test_kraus_add(self):
+        """Test addition of Kraus matrices is correct."""
+        self._compare_add_to_superop(Kraus, 4, 10)
+
+    def test_stinespring_add(self):
+        """Test addition of Stinespring matrices is correct."""
+        self._compare_add_to_superop(Stinespring, 4, 10)
+
+    def test_chi_add(self):
+        """Test addition of Chi matrices is correct."""
+        self._compare_add_to_superop(Chi, 4, 10)
+
+    def test_ptm_add(self):
+        """Test addition of PTM matrices is correct."""
+        self._compare_add_to_superop(PTM, 4, 10)
+
+    def test_choi_subtract(self):
+        """Test subtraction of Choi matrices is correct."""
+        self._compare_subtract_to_superop(Choi, 4, 10)
+
+    def test_kraus_subtract(self):
+        """Test subtraction of Kraus matrices is correct."""
+        self._compare_subtract_to_superop(Kraus, 4, 10)
+
+    def test_stinespring_subtract(self):
+        """Test subtraction of Stinespring matrices is correct."""
+        self._compare_subtract_to_superop(Stinespring, 4, 10)
+
+    def test_chi_subtract(self):
+        """Test subtraction of Chi matrices is correct."""
+        self._compare_subtract_to_superop(Chi, 4, 10)
+
+    def test_ptm_subtract(self):
+        """Test subtraction of PTM matrices is correct."""
+        self._compare_subtract_to_superop(PTM, 4, 10)
+
+    def test_choi_multiply(self):
+        """Test scalar multiplication of Choi matrices is correct."""
+        self._compare_multiply_to_superop(Choi, 4, 10)
+
+    def test_kraus_multiply(self):
+        """Test scalar multiplication of Kraus matrices is correct."""
+        self._compare_multiply_to_superop(Kraus, 4, 10)
+
+    def test_stinespring_multiply(self):
+        """Test scalar multiplication of Stinespring matrices is correct."""
+        self._compare_multiply_to_superop(Stinespring, 4, 10)
+
+    def test_chi_multiply(self):
+        """Test scalar multiplication of Chi matrices is correct."""
+        self._compare_multiply_to_superop(Chi, 4, 10)
+
+    def test_ptm_multiply(self):
+        """Test scalar multiplication of PTM matrices is correct."""
+        self._compare_multiply_to_superop(PTM, 4, 10)
+
+    def test_choi_add_other_rep(self):
+        """Test addition of Choi matrices is correct."""
+        chan = Choi(self.choiI)
+        self._check_add_other_reps(chan)
+
+    def test_superop_add_other_rep(self):
+        """Test addition of SuperOp matrices is correct."""
+        chan = SuperOp(self.sopI)
+        self._check_add_other_reps(chan)
+
+    def test_kraus_add_other_rep(self):
+        """Test addition of Kraus matrices is correct."""
+        chan = Kraus(self.matI)
+        self._check_add_other_reps(chan)
+
+    def test_stinespring_add_other_rep(self):
+        """Test addition of Stinespring matrices is correct."""
+        chan = Stinespring(self.matI)
+        self._check_add_other_reps(chan)
+
+    def test_chi_add_other_rep(self):
+        """Test addition of Chi matrices is correct."""
+        chan = Chi(self.chiI)
+        self._check_add_other_reps(chan)
+
+    def test_ptm_add_other_rep(self):
+        """Test addition of PTM matrices is correct."""
+        chan = PTM(self.ptmI)
+        self._check_add_other_reps(chan)
+
+    def test_choi_subtract_other_rep(self):
+        """Test subtraction of Choi matrices is correct."""
+        chan = Choi(self.choiI)
+        self._check_subtract_other_reps(chan)
+
+    def test_superop_subtract_other_rep(self):
+        """Test subtraction of SuperOp matrices is correct."""
+        chan = SuperOp(self.sopI)
+        self._check_subtract_other_reps(chan)
+
+    def test_kraus_subtract_other_rep(self):
+        """Test subtraction of Kraus matrices is correct."""
+        chan = Kraus(self.matI)
+        self._check_subtract_other_reps(chan)
+
+    def test_stinespring_subtract_other_rep(self):
+        """Test subtraction of Stinespring matrices is correct."""
+        chan = Stinespring(self.matI)
+        self._check_subtract_other_reps(chan)
+
+    def test_chi_subtract_other_rep(self):
+        """Test subtraction of Chi matrices is correct."""
+        chan = Chi(self.chiI)
+        self._check_subtract_other_reps(chan)
+
+    def test_ptm_subtract_other_rep(self):
+        """Test subtraction of PTM matrices is correct."""
+        chan = PTM(self.ptmI)
+        self._check_subtract_other_reps(chan)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_ptm.py
+++ b/test/python/quantum_info/channel/test_ptm.py
@@ -1,0 +1,449 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Tests for PTM quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import PTM
+from .base import ChannelTestCase
+
+
+class TestPTM(ChannelTestCase):
+    """Tests for PTM channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        mat4 = np.eye(4) / 2.0
+        chan = PTM(mat4)
+        self.assertAllClose(chan.data, mat4)
+        self.assertEqual(chan.dims, (2, 2))
+
+        mat16 = np.eye(16) / 4
+        chan = PTM(mat16)
+        self.assertAllClose(chan.data, mat16)
+        self.assertEqual(chan.dims, (4, 4))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, PTM, mat16, input_dim=2, output_dim=4)
+
+        # Non multi-qubit dimensions should raise exception
+        self.assertRaises(
+            QiskitError, PTM, np.eye(6) / 2, input_dim=3, output_dim=2)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        mat = self.rand_matrix(4, 4, real=True)
+        self.assertEqual(PTM(mat), PTM(mat))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = PTM(mat)
+        cpy = orig.copy()
+        cpy._data[0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+
+        # Identity channel
+        chan = PTM(self.ptmI)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        chan = PTM(self.ptmH)
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = PTM(self.depol_ptm(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(PTM(self.depol_ptm(0.25)).is_cptp())
+        # Non-CPTP should return false
+        self.assertFalse(
+            PTM(1.25 * self.ptmI - 0.25 * self.depol_ptm(1)).is_cptp())
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, PTM(np.eye(4)).compose, PTM(np.eye(16)))
+        self.assertRaises(QiskitError, PTM(np.eye(4)).compose, np.eye(4))
+        self.assertRaises(QiskitError, PTM(np.eye(4)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = PTM(self.ptmX)
+        chan2 = PTM(self.ptmY)
+        chan = chan1.compose(chan2)
+        targ = PTM(self.ptmZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = PTM(self.depol_ptm(0.5))
+        chan = chan1.compose(chan1)
+        targ = PTM(self.depol_ptm(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose random
+        ptm1 = self.rand_matrix(4, 4, real=True)
+        ptm2 = self.rand_matrix(4, 4, real=True)
+        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
+        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 @ chan2
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = PTM(self.ptmX)
+        chan2 = PTM(self.ptmY)
+        chan1.compose(chan2, inplace=True)
+        targ = PTM(self.ptmZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = PTM(self.depol_ptm(0.5))
+        chan1.compose(chan1, inplace=True)
+        targ = PTM(self.depol_ptm(0.75)).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Compose random
+        ptm1 = self.rand_matrix(4, 4, real=True)
+        ptm2 = self.rand_matrix(4, 4, real=True)
+        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
+        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
+        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
+        chan1 @= chan2
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = PTM(self.ptmX)
+        chan2 = PTM(self.ptmY)
+        chan = chan2.compose(chan1, front=True)
+        targ = PTM(self.ptmZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose random
+        ptm1 = self.rand_matrix(4, 4, real=True)
+        ptm2 = self.rand_matrix(4, 4, real=True)
+        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
+        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = PTM(self.ptmX)
+        chan2 = PTM(self.ptmY)
+        chan2.compose(chan1, front=True, inplace=True)
+        targ = PTM(self.ptmZ).evolve(rho)
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+        # Compose random
+        ptm1 = self.rand_matrix(4, 4, real=True)
+        ptm2 = self.rand_matrix(4, 4, real=True)
+        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
+        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan2.compose(chan1, front=True, inplace=True)
+        self.assertEqual(chan2.dims, (2, 2))
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_expand(self):
+        """Test expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+
+        # X \otimes I
+        chan = chan1.expand(chan2)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan2.expand(chan1)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = PTM(self.depol_ptm(1))
+        chan = chan_dep.expand(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+        chan1.expand(chan2, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+        chan2.expand(chan1, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = PTM(self.depol_ptm(1))
+        chan.tensor(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+
+        # X \otimes I
+        chan = chan2.tensor(chan1)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan1.tensor(chan2)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = PTM(self.depol_ptm(1))
+        chan = chan_dep.tensor(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+        chan2.tensor(chan1, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(self.ptmX)
+        chan1.tensor(chan2, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = PTM(self.depol_ptm(1))
+        chan.tensor(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = PTM(self.depol_ptm(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id**3
+        chan3 = depol.power(3)
+        targ3 = PTM(self.depol_ptm(1 - p_id3))
+        self.assertEqual(chan3, targ3)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = PTM(self.depol_ptm(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id**3
+        depol.power(3, inplace=True)
+        targ3 = PTM(self.depol_ptm(1 - p_id3))
+        self.assertEqual(depol, targ3)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = PTM(self.depol_ptm(1))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        mat1 = 0.5 * self.ptmI
+        mat2 = 0.5 * self.depol_ptm(1)
+        targ = PTM(mat1 + mat2)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        self.assertEqual(chan1.add(chan2), targ)
+        self.assertEqual(chan1 + chan2, targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        mat1 = 0.5 * self.ptmI
+        mat2 = 0.5 * self.depol_ptm(1)
+        targ = PTM(mat1 + mat2)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        chan1.add(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        chan1 += chan2
+        self.assertEqual(chan1, targ)
+
+    def test_add_except(self):
+        """Test add method raises exceptions."""
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(np.eye(16))
+        self.assertRaises(QiskitError, chan1.add, chan2)
+        self.assertRaises(QiskitError, chan1.add, 5)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        mat1 = 0.5 * self.ptmI
+        mat2 = 0.5 * self.depol_ptm(1)
+        targ = PTM(mat1 - mat2)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        self.assertEqual(chan1.subtract(chan2), targ)
+        self.assertEqual(chan1 - chan2, targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        mat1 = 0.5 * self.ptmI
+        mat2 = 0.5 * self.depol_ptm(1)
+        targ = PTM(mat1 - mat2)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        chan1.subtract(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = PTM(mat1)
+        chan2 = PTM(mat2)
+        chan1 -= chan2
+        self.assertEqual(chan1, targ)
+
+    def test_subtract_except(self):
+        """Test subtract method raises exceptions."""
+        chan1 = PTM(self.ptmI)
+        chan2 = PTM(np.eye(16))
+        self.assertRaises(QiskitError, chan1.subtract, chan2)
+        self.assertRaises(QiskitError, chan1.subtract, 5)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        chan = PTM(self.ptmI)
+        val = 0.5
+        targ = PTM(val * self.ptmI)
+        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(val * chan, targ)
+        self.assertEqual(chan * val, targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        chan = PTM(self.ptmI)
+        val = 0.5
+        targ = PTM(val * self.ptmI)
+        chan.multiply(val, inplace=True)
+        self.assertEqual(chan, targ)
+
+        chan = PTM(self.ptmI)
+        chan *= val
+        self.assertEqual(chan, targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = PTM(self.ptmI)
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        chan = PTM(self.ptmI)
+        targ = PTM(-self.ptmI)
+        self.assertEqual(-chan, targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_ptm.py
+++ b/test/python/quantum_info/channel/test_ptm.py
@@ -59,26 +59,26 @@ class TestPTM(ChannelTestCase):
         # Identity channel
         chan = PTM(self.ptmI)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         chan = PTM(self.ptmH)
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = PTM(self.depol_ptm(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -102,27 +102,27 @@ class TestPTM(ChannelTestCase):
         chan1 = PTM(self.ptmX)
         chan2 = PTM(self.ptmY)
         chan = chan1.compose(chan2)
-        targ = PTM(self.ptmZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = PTM(self.ptmZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = PTM(self.depol_ptm(0.5))
         chan = chan1.compose(chan1)
-        targ = PTM(self.depol_ptm(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = PTM(self.depol_ptm(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose random
         ptm1 = self.rand_matrix(4, 4, real=True)
         ptm2 = self.rand_matrix(4, 4, real=True)
         chan1 = PTM(ptm1, input_dim=2, output_dim=2)
         chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan1.compose(chan2)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 @ chan2
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_inplace(self):
         """Test inplace compose method."""
@@ -133,29 +133,29 @@ class TestPTM(ChannelTestCase):
         chan1 = PTM(self.ptmX)
         chan2 = PTM(self.ptmY)
         chan1.compose(chan2, inplace=True)
-        targ = PTM(self.ptmZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = PTM(self.ptmZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = PTM(self.depol_ptm(0.5))
         chan1.compose(chan1, inplace=True)
-        targ = PTM(self.depol_ptm(0.75)).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = PTM(self.depol_ptm(0.75))._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Compose random
         ptm1 = self.rand_matrix(4, 4, real=True)
         ptm2 = self.rand_matrix(4, 4, real=True)
         chan1 = PTM(ptm1, input_dim=2, output_dim=2)
         chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan1.compose(chan2, inplace=True)
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = PTM(ptm1, input_dim=2, output_dim=2)
         chan2 = PTM(ptm2, input_dim=2, output_dim=2)
         chan1 @= chan2
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
     def test_compose_front(self):
         """Test front compose method."""
@@ -166,18 +166,18 @@ class TestPTM(ChannelTestCase):
         chan1 = PTM(self.ptmX)
         chan2 = PTM(self.ptmY)
         chan = chan2.compose(chan1, front=True)
-        targ = PTM(self.ptmZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = PTM(self.ptmZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose random
         ptm1 = self.rand_matrix(4, 4, real=True)
         ptm2 = self.rand_matrix(4, 4, real=True)
         chan1 = PTM(ptm1, input_dim=2, output_dim=2)
         chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_front_inplace(self):
         """Test inplace front compose method."""
@@ -188,18 +188,18 @@ class TestPTM(ChannelTestCase):
         chan1 = PTM(self.ptmX)
         chan2 = PTM(self.ptmY)
         chan2.compose(chan1, front=True, inplace=True)
-        targ = PTM(self.ptmZ).evolve(rho)
-        self.assertAllClose(chan2.evolve(rho), targ)
+        targ = PTM(self.ptmZ)._evolve(rho)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
         # Compose random
         ptm1 = self.rand_matrix(4, 4, real=True)
         ptm2 = self.rand_matrix(4, 4, real=True)
         chan1 = PTM(ptm1, input_dim=2, output_dim=2)
         chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan2.compose(chan1, front=True, inplace=True)
         self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -212,20 +212,20 @@ class TestPTM(ChannelTestCase):
         chan = chan1.expand(chan2)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan2.expand(chan1)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = PTM(self.depol_ptm(1))
         chan = chan_dep.expand(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -238,7 +238,7 @@ class TestPTM(ChannelTestCase):
         chan1.expand(chan2, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = PTM(self.ptmI)
@@ -246,14 +246,14 @@ class TestPTM(ChannelTestCase):
         chan2.expand(chan1, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = PTM(self.depol_ptm(1))
         chan.tensor(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -266,20 +266,20 @@ class TestPTM(ChannelTestCase):
         chan = chan2.tensor(chan1)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan1.tensor(chan2)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = PTM(self.depol_ptm(1))
         chan = chan_dep.tensor(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor_inplace(self):
         """Test inplace tensor method."""
@@ -292,7 +292,7 @@ class TestPTM(ChannelTestCase):
         chan2.tensor(chan1, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = PTM(self.ptmI)
@@ -300,14 +300,14 @@ class TestPTM(ChannelTestCase):
         chan1.tensor(chan2, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = PTM(self.depol_ptm(1))
         chan.tensor(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_power(self):
         """Test power method."""

--- a/test/python/quantum_info/channel/test_stinespring.py
+++ b/test/python/quantum_info/channel/test_stinespring.py
@@ -1,0 +1,622 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+
+"""Tests for Stinespring quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import Stinespring
+from .base import ChannelTestCase
+
+
+class TestStinespring(ChannelTestCase):
+    """Tests for Stinespring channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        # Initialize from unitary
+        chan = Stinespring(self.matI)
+        self.assertAllClose(chan.data, self.matI)
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize from Stinespring
+        chan = Stinespring(self.depol_stine(0.5))
+        self.assertAllClose(chan.data, self.depol_stine(0.5))
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize from Non-CPTP
+        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
+        chan = Stinespring((stine_l, stine_r))
+        self.assertAllClose(chan.data, (stine_l, stine_r))
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Initialize with redundant second op
+        chan = Stinespring((stine_l, stine_l))
+        self.assertAllClose(chan.data, stine_l)
+        self.assertEqual(chan.dims, (2, 2))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, Stinespring, stine_l, input_dim=4, output_dim=4)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        stine = tuple(self.rand_matrix(4, 2) for _ in range(2))
+        self.assertEqual(Stinespring(stine), Stinespring(stine))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = Stinespring(mat)
+        cpy = orig.copy()
+        cpy._data[0][0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+
+        # Identity channel
+        chan = Stinespring(self.matI)
+        target_psi = np.array([0, 1])
+        self.assertAllClose(chan.evolve(input_psi), target_psi)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+        chan = Stinespring(mat)
+        target_psi = np.array([1, -1]) / np.sqrt(2)
+        self.assertAllClose(chan.evolve(input_psi), target_psi)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = Stinespring(self.depol_stine(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(Stinespring(self.depol_stine(0.5)).is_cptp())
+        self.assertTrue(Stinespring(self.matX).is_cptp())
+        # Non-CP
+        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
+        self.assertFalse(Stinespring((stine_l, stine_r)).is_cptp())
+        self.assertFalse(Stinespring(self.matI + self.matX).is_cptp())
+
+    def test_conjugate(self):
+        """Test conjugate method."""
+        stine_l, stine_r = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+        # Single Stinespring list
+        targ = Stinespring(stine_l.conj(), output_dim=4)
+        chan1 = Stinespring(stine_l, output_dim=4)
+        chan = chan1.conjugate()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+        # Double Stinespring list
+        targ = Stinespring((stine_l.conj(), stine_r.conj()), output_dim=4)
+        chan1 = Stinespring((stine_l, stine_r), output_dim=4)
+        chan = chan1.conjugate()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (2, 4))
+
+    def test_conjugate_inplace(self):
+        """Test inplace conjugate method."""
+        stine_l, stine_r = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+        # Single Stinespring list
+        targ = Stinespring(stine_l.conj(), output_dim=4)
+        chan1 = Stinespring(stine_l, output_dim=4)
+        chan1.conjugate(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (2, 4))
+        # Double Stinespring list
+        targ = Stinespring((stine_l.conj(), stine_r.conj()), output_dim=4)
+        chan1 = Stinespring((stine_l, stine_r), output_dim=4)
+        chan1.conjugate(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (2, 4))
+
+    def test_transpose(self):
+        """Test transpose method."""
+        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
+        # Single square Stinespring list
+        targ = Stinespring(stine_l.T, 4, 2)
+        chan1 = Stinespring(stine_l, 2, 4)
+        chan = chan1.transpose()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double square Stinespring list
+        targ = Stinespring((stine_l.T, stine_r.T), 4, 2)
+        chan1 = Stinespring((stine_l, stine_r), 2, 4)
+        chan = chan1.transpose()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_transpose_inplace(self):
+        """Test inplace transpose method."""
+        stine_l, stine_r = self.rand_matrix(4, 4), self.rand_matrix(4, 4)
+        # Single square Stinespring list
+        targ = Stinespring(stine_l.T, 4, 4)
+        chan1 = Stinespring(stine_l, 4, 4)
+        chan1.transpose(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (4, 4))
+        # Double square Stinespring list
+        targ = Stinespring((stine_l.T, stine_r.T), 4, 4)
+        chan1 = Stinespring((stine_l, stine_r), 4, 4)
+        chan1.transpose(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (4, 4))
+
+    def test_adjoint(self):
+        """Test adjoint method."""
+        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
+        # Single square Stinespring list
+        targ = Stinespring(stine_l.T.conj(), 4, 2)
+        chan1 = Stinespring(stine_l, 2, 4)
+        chan = chan1.adjoint()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+        # Double square Stinespring list
+        targ = Stinespring((stine_l.T.conj(), stine_r.T.conj()), 4, 2)
+        chan1 = Stinespring((stine_l, stine_r), 2, 4)
+        chan = chan1.adjoint()
+        self.assertEqual(chan, targ)
+        self.assertEqual(chan.dims, (4, 2))
+
+    def test_adjoint_inplace(self):
+        """Test inplace adjoint method."""
+        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
+        # Single square Stinespring list
+        targ = Stinespring(stine_l.T.conj(), 4, 2)
+        chan1 = Stinespring(stine_l, 2, 4)
+        chan1.adjoint(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (4, 2))
+        # Double square Stinespring list
+        targ = Stinespring((stine_l.T.conj(), stine_r.T.conj()), 4, 2)
+        chan1 = Stinespring((stine_l, stine_r), 2, 4)
+        chan1.adjoint(inplace=True)
+        self.assertEqual(chan1, targ)
+        self.assertEqual(chan1.dims, (4, 2))
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, Stinespring(np.eye(2)).compose, Stinespring(np.eye(4)))
+        self.assertRaises(QiskitError, Stinespring(np.eye(2)).compose, np.eye(2))
+        self.assertRaises(QiskitError, Stinespring(np.eye(2)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Stinespring(self.matX)
+        chan2 = Stinespring(self.matY)
+        chan = chan1.compose(chan2)
+        targ = Stinespring(self.matZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Stinespring(self.depol_stine(0.5))
+        chan = chan1.compose(chan1)
+        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 @ chan2
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Stinespring(self.matX)
+        chan2 = Stinespring(self.matY)
+        chan1.compose(chan2, inplace=True)
+        targ = Stinespring(self.matZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan = Stinespring(self.depol_stine(0.5))
+        chan.compose(chan, inplace=True)
+        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
+        chan1 @= chan2
+        self.assertEqual(chan1.dims, (2, 2))
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Stinespring(self.matX)
+        chan2 = Stinespring(self.matY)
+        chan = chan1.compose(chan2, front=True)
+        targ = Stinespring(self.matZ).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan1 = Stinespring(self.depol_stine(0.5))
+        chan = chan1.compose(chan1, front=True)
+        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+
+        # UnitaryChannel evolution
+        chan1 = Stinespring(self.matX)
+        chan2 = Stinespring(self.matY)
+        chan1.compose(chan2, inplace=True, front=True)
+        targ = Stinespring(self.matZ).evolve(rho)
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # 50% depolarizing channel
+        chan = Stinespring(self.depol_stine(0.5))
+        chan.compose(chan, inplace=True, front=True)
+        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Compose different dimensions
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
+        targ = chan2.evolve(chan1.evolve(rho))
+        chan2.compose(chan1, inplace=True, front=True)
+        self.assertEqual(chan2.dims, (2, 2))
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_expand(self):
+        """Test expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+
+        # X \otimes I
+        chan = chan1.expand(chan2)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan2.expand(chan1)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = Stinespring(self.depol_stine(1))
+        chan = chan_dep.expand(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+        chan1.expand(chan2, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+        chan2.expand(chan1, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = Stinespring(self.depol_stine(1))
+        chan.expand(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+
+        # X \otimes I
+        chan = chan2.tensor(chan1)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan1.tensor(chan2)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan_dep = Stinespring(self.depol_stine(1))
+        chan = chan_dep.tensor(chan_dep)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+        chan2.tensor(chan1, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = Stinespring(self.matI)
+        chan2 = Stinespring(self.matX)
+        chan1.tensor(chan2, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # Completely depolarizing
+        chan = Stinespring(self.depol_stine(1))
+        chan.tensor(chan, inplace=True)
+        rho_targ = np.diag([1, 1, 1, 1]) / 4
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        rho = np.diag([1, 0])
+        p_id = 0.9
+        chan = Stinespring(self.depol_stine(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        chan3 = chan.power(3)
+        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
+        self.assertAllClose(chan3.evolve(rho), targ3a)
+        targ3b = Stinespring(self.depol_stine(1 - p_id3)).evolve(rho)
+        self.assertAllClose(chan3.evolve(rho), targ3b)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        rho = np.diag([1, 0])
+        p_id = 0.9
+        chan = Stinespring(self.depol_stine(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
+        targ3b = Stinespring(self.depol_stine(1 - p_id3)).evolve(rho)
+        chan.power(3, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ3a)
+        self.assertAllClose(chan.evolve(rho), targ3b)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = Stinespring(self.depol_stine(0.9))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Random Single-Stinespring maps
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
+        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        chan = chan1.add(chan2)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 + chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Random Single-Stinespring maps
+        chan = Stinespring((stine1, stine2))
+        targ = 2 * chan.evolve(rho)
+        chan = chan.add(chan)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Random Single-Stinespring maps
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
+        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        chan1.add(chan2, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan1 += chan2
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Random Single-Stinespring maps
+        chan = Stinespring((stine1, stine2))
+        targ = 2 * chan.evolve(rho)
+        chan.add(chan, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Random Single-Stinespring maps
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
+        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        chan = chan1.subtract(chan2)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 - chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Random Single-Stinespring maps
+        chan = Stinespring((stine1, stine2))
+        targ = 0 * chan.evolve(rho)
+        chan = chan.subtract(chan)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        # Random input test state
+        rho = self.rand_rho(2)
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Random Single-Stinespring maps
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
+        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        chan1.subtract(chan2, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan1 -= chan2
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Random Single-Stinespring maps
+        chan = Stinespring((stine1, stine2))
+        targ = 0 * chan.evolve(rho)
+        chan.subtract(chan, inplace=True)
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        # Random initial state and Stinespring ops
+        rho = self.rand_rho(2)
+        val = 0.5
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Single Stinespring set
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        targ = val * chan1.evolve(rho)
+        chan = chan1.multiply(val)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = val * chan1
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan1 * val
+        self.assertAllClose(chan.evolve(rho), targ)
+
+        # Double Stinespring set
+        chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
+        targ = val * chan2.evolve(rho)
+        chan = chan2.multiply(val)
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = val * chan2
+        self.assertAllClose(chan.evolve(rho), targ)
+        chan = chan2 * val
+        self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        # Random initial state and Stinespring ops
+        rho = self.rand_rho(2)
+        val = 0.5
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
+
+        # Single Stinespring set
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        targ = val * chan1.evolve(rho)
+        chan1.multiply(val, inplace=True)
+        self.assertAllClose(chan1.evolve(rho), targ)
+        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
+        chan1 *= val
+        self.assertAllClose(chan1.evolve(rho), targ)
+
+        # Double Stinespring set
+        chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
+        targ = val * chan2.evolve(rho)
+        chan2.multiply(val, inplace=True)
+        self.assertAllClose(chan2.evolve(rho), targ)
+        chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
+        chan2 *= val
+        self.assertAllClose(chan2.evolve(rho), targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = Stinespring(self.depol_stine(1))
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        rho = np.diag([1, 0])
+        targ = np.diag([-0.5, -0.5])
+        chan = -Stinespring(self.depol_stine(1))
+        self.assertAllClose(chan.evolve(rho), targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_stinespring.py
+++ b/test/python/quantum_info/channel/test_stinespring.py
@@ -67,29 +67,29 @@ class TestStinespring(ChannelTestCase):
         # Identity channel
         chan = Stinespring(self.matI)
         target_psi = np.array([0, 1])
-        self.assertAllClose(chan.evolve(input_psi), target_psi)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        self.assertAllClose(chan._evolve(input_psi), target_psi)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_psi)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         chan = Stinespring(mat)
         target_psi = np.array([1, -1]) / np.sqrt(2)
-        self.assertAllClose(chan.evolve(input_psi), target_psi)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_psi)
+        self.assertAllClose(chan._evolve(input_psi), target_psi)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_psi)
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = Stinespring(self.depol_stine(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -211,26 +211,26 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(self.matX)
         chan2 = Stinespring(self.matY)
         chan = chan1.compose(chan2)
-        targ = Stinespring(self.matZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.matZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Stinespring(self.depol_stine(0.5))
         chan = chan1.compose(chan1)
-        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan1.compose(chan2)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 @ chan2
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_inplace(self):
         """Test inplace compose method."""
@@ -241,28 +241,28 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(self.matX)
         chan2 = Stinespring(self.matY)
         chan1.compose(chan2, inplace=True)
-        targ = Stinespring(self.matZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Stinespring(self.matZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan = Stinespring(self.depol_stine(0.5))
         chan.compose(chan, inplace=True)
-        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan1.compose(chan2, inplace=True)
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
         chan1 @= chan2
         self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
     def test_compose_front(self):
         """Test front compose method."""
@@ -273,23 +273,23 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(self.matX)
         chan2 = Stinespring(self.matY)
         chan = chan1.compose(chan2, front=True)
-        targ = Stinespring(self.matZ).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.matZ)._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan1 = Stinespring(self.depol_stine(0.5))
         chan = chan1.compose(chan1, front=True)
-        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_compose_front_inplace(self):
         """Test inplace front compose method."""
@@ -300,23 +300,23 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(self.matX)
         chan2 = Stinespring(self.matY)
         chan1.compose(chan2, inplace=True, front=True)
-        targ = Stinespring(self.matZ).evolve(rho)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        targ = Stinespring(self.matZ)._evolve(rho)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # 50% depolarizing channel
         chan = Stinespring(self.depol_stine(0.5))
         chan.compose(chan, inplace=True, front=True)
-        targ = Stinespring(self.depol_stine(0.75)).evolve(rho)
-        self.assertAllClose(chan.evolve(rho), targ)
+        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Compose different dimensions
         stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2.evolve(chan1.evolve(rho))
+        targ = chan2._evolve(chan1._evolve(rho))
         chan2.compose(chan1, inplace=True, front=True)
         self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -329,20 +329,20 @@ class TestStinespring(ChannelTestCase):
         chan = chan1.expand(chan2)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan2.expand(chan1)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = Stinespring(self.depol_stine(1))
         chan = chan_dep.expand(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -355,7 +355,7 @@ class TestStinespring(ChannelTestCase):
         chan1.expand(chan2, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = Stinespring(self.matI)
@@ -363,14 +363,14 @@ class TestStinespring(ChannelTestCase):
         chan2.expand(chan1, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = Stinespring(self.depol_stine(1))
         chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -383,20 +383,20 @@ class TestStinespring(ChannelTestCase):
         chan = chan2.tensor(chan1)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan1.tensor(chan2)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan_dep = Stinespring(self.depol_stine(1))
         chan = chan_dep.tensor(chan_dep)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensor_inplace(self):
         """Test inplace tensor method."""
@@ -409,7 +409,7 @@ class TestStinespring(ChannelTestCase):
         chan2.tensor(chan1, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = Stinespring(self.matI)
@@ -417,14 +417,14 @@ class TestStinespring(ChannelTestCase):
         chan1.tensor(chan2, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # Completely depolarizing
         chan = Stinespring(self.depol_stine(1))
         chan.tensor(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_power(self):
         """Test power method."""
@@ -436,10 +436,10 @@ class TestStinespring(ChannelTestCase):
         # Compose 3 times
         p_id3 = p_id ** 3
         chan3 = chan.power(3)
-        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
-        self.assertAllClose(chan3.evolve(rho), targ3a)
-        targ3b = Stinespring(self.depol_stine(1 - p_id3)).evolve(rho)
-        self.assertAllClose(chan3.evolve(rho), targ3b)
+        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
+        self.assertAllClose(chan3._evolve(rho), targ3a)
+        targ3b = Stinespring(self.depol_stine(1 - p_id3))._evolve(rho)
+        self.assertAllClose(chan3._evolve(rho), targ3b)
 
     def test_power_inplace(self):
         """Test inplace power method."""
@@ -450,11 +450,11 @@ class TestStinespring(ChannelTestCase):
 
         # Compose 3 times
         p_id3 = p_id ** 3
-        targ3a = chan.evolve(chan.evolve(chan.evolve(rho)))
-        targ3b = Stinespring(self.depol_stine(1 - p_id3)).evolve(rho)
+        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
+        targ3b = Stinespring(self.depol_stine(1 - p_id3))._evolve(rho)
         chan.power(3, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ3a)
-        self.assertAllClose(chan.evolve(rho), targ3b)
+        self.assertAllClose(chan._evolve(rho), targ3a)
+        self.assertAllClose(chan._evolve(rho), targ3b)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -475,17 +475,17 @@ class TestStinespring(ChannelTestCase):
         # Random Single-Stinespring maps
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        targ = chan1._evolve(rho) + chan2._evolve(rho)
         chan = chan1.add(chan2)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 + chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
-        targ = 2 * chan.evolve(rho)
+        targ = 2 * chan._evolve(rho)
         chan = chan.add(chan)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_add_inplace(self):
         """Test inplace add method."""
@@ -496,18 +496,18 @@ class TestStinespring(ChannelTestCase):
         # Random Single-Stinespring maps
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1.evolve(rho) + chan2.evolve(rho)
+        targ = chan1._evolve(rho) + chan2._evolve(rho)
         chan1.add(chan2, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan1 += chan2
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
-        targ = 2 * chan.evolve(rho)
+        targ = 2 * chan._evolve(rho)
         chan.add(chan, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_subtract(self):
         """Test subtract method."""
@@ -518,17 +518,17 @@ class TestStinespring(ChannelTestCase):
         # Random Single-Stinespring maps
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        targ = chan1._evolve(rho) - chan2._evolve(rho)
         chan = chan1.subtract(chan2)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 - chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
-        targ = 0 * chan.evolve(rho)
+        targ = 0 * chan._evolve(rho)
         chan = chan.subtract(chan)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_subtract_inplace(self):
         """Test inplace subtract method."""
@@ -539,18 +539,18 @@ class TestStinespring(ChannelTestCase):
         # Random Single-Stinespring maps
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1.evolve(rho) - chan2.evolve(rho)
+        targ = chan1._evolve(rho) - chan2._evolve(rho)
         chan1.subtract(chan2, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan1 -= chan2
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
-        targ = 0 * chan.evolve(rho)
+        targ = 0 * chan._evolve(rho)
         chan.subtract(chan, inplace=True)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply(self):
         """Test multiply method."""
@@ -561,23 +561,23 @@ class TestStinespring(ChannelTestCase):
 
         # Single Stinespring set
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        targ = val * chan1.evolve(rho)
+        targ = val * chan1._evolve(rho)
         chan = chan1.multiply(val)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = val * chan1
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan1 * val
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
         # Double Stinespring set
         chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
-        targ = val * chan2.evolve(rho)
+        targ = val * chan2._evolve(rho)
         chan = chan2.multiply(val)
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = val * chan2
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
         chan = chan2 * val
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply_inplace(self):
         """Test inplace multiply method."""
@@ -588,21 +588,21 @@ class TestStinespring(ChannelTestCase):
 
         # Single Stinespring set
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        targ = val * chan1.evolve(rho)
+        targ = val * chan1._evolve(rho)
         chan1.multiply(val, inplace=True)
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
         chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
         chan1 *= val
-        self.assertAllClose(chan1.evolve(rho), targ)
+        self.assertAllClose(chan1._evolve(rho), targ)
 
         # Double Stinespring set
         chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
-        targ = val * chan2.evolve(rho)
+        targ = val * chan2._evolve(rho)
         chan2.multiply(val, inplace=True)
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
         chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
         chan2 *= val
-        self.assertAllClose(chan2.evolve(rho), targ)
+        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
@@ -615,7 +615,7 @@ class TestStinespring(ChannelTestCase):
         rho = np.diag([1, 0])
         targ = np.diag([-0.5, -0.5])
         chan = -Stinespring(self.depol_stine(1))
-        self.assertAllClose(chan.evolve(rho), targ)
+        self.assertAllClose(chan._evolve(rho), targ)
 
 
 if __name__ == '__main__':

--- a/test/python/quantum_info/channel/test_superop.py
+++ b/test/python/quantum_info/channel/test_superop.py
@@ -58,27 +58,27 @@ class TestSuperOp(ChannelTestCase):
         # Identity channel
         chan = SuperOp(self.sopI)
         target_rho = np.array([[0, 0], [0, 1]])
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Hadamard channel
         mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
         chan = SuperOp(np.kron(mat.conj(), mat))
         target_rho = np.array([[1, -1], [-1, 1]]) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
         # Completely depolarizing channel
         chan = SuperOp(self.depol_sop(1))
         target_rho = np.eye(2) / 2
-        self.assertAllClose(chan.evolve(input_psi), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
-        self.assertAllClose(chan.evolve(input_rho), target_rho)
-        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+        self.assertAllClose(chan._evolve(input_psi), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan._evolve(input_rho), target_rho)
+        self.assertAllClose(chan._evolve(np.array(input_rho)), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -305,13 +305,13 @@ class TestSuperOp(ChannelTestCase):
         chan = chan1.expand(chan2)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan = chan2.expand(chan1)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_expand_inplace(self):
         """Test inplace expand method."""
@@ -324,7 +324,7 @@ class TestSuperOp(ChannelTestCase):
         chan1.expand(chan2, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = SuperOp(self.sopI)
@@ -332,7 +332,7 @@ class TestSuperOp(ChannelTestCase):
         chan2.expand(chan1, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -345,18 +345,18 @@ class TestSuperOp(ChannelTestCase):
         chan = chan2.tensor(chan1)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = chan2 ^ chan1
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         # I \otimes X
         chan = chan1.tensor(chan2)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
         chan = chan1 ^ chan2
         self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
     def test_tensorinplace(self):
         """Test inplace tensor method."""
@@ -369,12 +369,12 @@ class TestSuperOp(ChannelTestCase):
         chan2.tensor(chan1, inplace=True)
         rho_targ = np.kron(rho1, rho0)
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
         chan1 = SuperOp(self.sopI)
         chan2 = SuperOp(self.sopX)
         chan2 ^= chan1
         self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
         # I \otimes X
         chan1 = SuperOp(self.sopI)
@@ -382,12 +382,12 @@ class TestSuperOp(ChannelTestCase):
         chan1.tensor(chan2, inplace=True)
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
         chan1 = SuperOp(self.sopI)
         chan2 = SuperOp(self.sopX)
         chan1 ^= chan2
         self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
 
     def test_power(self):
         """Test power method."""

--- a/test/python/quantum_info/channel/test_superop.py
+++ b/test/python/quantum_info/channel/test_superop.py
@@ -1,0 +1,529 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+
+"""Tests for SuperOp quantum channel representation class."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel import SuperOp
+from .base import ChannelTestCase
+
+
+class TestSuperOp(ChannelTestCase):
+    """Tests for SuperOp channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        chan = SuperOp(self.sopI)
+        self.assertAllClose(chan.data, self.sopI)
+        self.assertEqual(chan.dims, (2, 2))
+
+        mat = np.zeros((4, 16))
+        chan = SuperOp(mat)
+        self.assertAllClose(chan.data, mat)
+        self.assertEqual(chan.dims, (4, 2))
+
+        chan = SuperOp(mat.T)
+        self.assertAllClose(chan.data, mat.T)
+        self.assertEqual(chan.dims, (2, 4))
+
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, SuperOp, mat, input_dim=4, output_dim=4)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        mat = self.rand_matrix(4, 4)
+        self.assertEqual(SuperOp(mat), SuperOp(mat))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(4)
+        orig = SuperOp(mat)
+        cpy = orig.copy()
+        cpy._data[0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        input_psi = [0, 1]
+        input_rho = [[0, 0], [0, 1]]
+        # Identity channel
+        chan = SuperOp(self.sopI)
+        target_rho = np.array([[0, 0], [0, 1]])
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Hadamard channel
+        mat = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+        chan = SuperOp(np.kron(mat.conj(), mat))
+        target_rho = np.array([[1, -1], [-1, 1]]) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+        # Completely depolarizing channel
+        chan = SuperOp(self.depol_sop(1))
+        target_rho = np.eye(2) / 2
+        self.assertAllClose(chan.evolve(input_psi), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_psi)), target_rho)
+        self.assertAllClose(chan.evolve(input_rho), target_rho)
+        self.assertAllClose(chan.evolve(np.array(input_rho)), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        self.assertTrue(SuperOp(self.depol_sop(0.25)).is_cptp())
+        # Non-CPTP should return false
+        self.assertFalse(SuperOp(1.25 * self.sopI - 0.25 * self.depol_sop(1)).is_cptp())
+
+    def test_conjugate(self):
+        """Test conjugate method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        targ = SuperOp(np.conjugate(mat))
+        self.assertEqual(chan.conjugate(), targ)
+
+    def test_conjugate_inplace(self):
+        """Test inplace conjugate method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        chan.conjugate(inplace=True)
+        targ = SuperOp(np.conjugate(mat))
+        self.assertEqual(chan, targ)
+
+    def test_transpose(self):
+        """Test transpose method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        targ = SuperOp(np.transpose(mat))
+        self.assertEqual(chan.transpose(), targ)
+
+    def test_transpose_inplace(self):
+        """Test inplace transpose method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        chan.transpose(inplace=True)
+        targ = SuperOp(np.transpose(mat))
+        self.assertEqual(chan, targ)
+
+    def test_adjoint(self):
+        """Test adjoint method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        targ = SuperOp(np.transpose(np.conj(mat)))
+        self.assertEqual(chan.adjoint(), targ)
+
+    def test_adjoint_inplace(self):
+        """Test inplace adjoint method."""
+        mat = self.rand_matrix(4, 4)
+        chan = SuperOp(mat)
+        chan.adjoint(inplace=True)
+        targ = SuperOp(np.transpose(np.conj(mat)))
+        self.assertEqual(chan, targ)
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError, SuperOp(np.eye(4)).compose, SuperOp(np.eye(16)))
+        self.assertRaises(QiskitError, SuperOp(np.eye(4)).compose, np.eye(4))
+        self.assertRaises(QiskitError, SuperOp(np.eye(4)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        # UnitaryChannel evolution
+        chan1 = SuperOp(self.sopX)
+        chan2 = SuperOp(self.sopY)
+        chan = chan1.compose(chan2)
+        targ = SuperOp(self.sopZ)
+        self.assertEqual(chan, targ)
+
+        # 50% depolarizing channel
+        chan1 = SuperOp(self.depol_sop(0.5))
+        chan = chan1.compose(chan1)
+        targ = SuperOp(self.depol_sop(0.75))
+        self.assertEqual(chan, targ)
+
+        # Random superoperator
+        mat1 = self.rand_matrix(4, 4)
+        mat2 = self.rand_matrix(4, 4)
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        targ = SuperOp(np.dot(mat2, mat1))
+        self.assertEqual(chan1.compose(chan2), targ)
+        self.assertEqual(chan1 @ chan2, targ)
+        targ = SuperOp(np.dot(mat1, mat2))
+        self.assertEqual(chan2.compose(chan1), targ)
+        self.assertEqual(chan2 @ chan1, targ)
+
+        # Compose different dimensions
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan = chan1.compose(chan2)
+        self.assertEqual(chan.dims, (2, 2))
+        chan = chan2.compose(chan1)
+        self.assertEqual(chan.dims, (4, 4))
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        # UnitaryChannel evolution
+        chan1 = SuperOp(self.sopX)
+        chan2 = SuperOp(self.sopY)
+        targ = SuperOp(self.sopZ)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        # 50% depolarizing channel
+        chan1 = SuperOp(self.depol_sop(0.5))
+        chan1.compose(chan1, inplace=True)
+        targ = SuperOp(self.depol_sop(0.75))
+        self.assertEqual(chan1, targ)
+
+        # Random superoperator
+        mat1 = self.rand_matrix(4, 4)
+        mat2 = self.rand_matrix(4, 4)
+
+        targ = SuperOp(np.dot(mat2, mat1))
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1 @= chan2
+        self.assertEqual(chan1, targ)
+
+        targ = SuperOp(np.dot(mat1, mat2))
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan2.compose(chan1, inplace=True)
+        self.assertEqual(chan2, targ)
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan2 @= chan1
+        self.assertEqual(chan2, targ)
+
+        # Compose different dimensions
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1.dims, (2, 2))
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan2.compose(chan1, inplace=True)
+        self.assertEqual(chan2.dims, (4, 4))
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        # UnitaryChannel evolution
+        chan1 = SuperOp(self.sopX)
+        chan2 = SuperOp(self.sopY)
+        chan = chan1.compose(chan2, front=True)
+        targ = SuperOp(self.sopZ)
+        self.assertEqual(chan, targ)
+
+        # 50% depolarizing channel
+        chan1 = SuperOp(self.depol_sop(0.5))
+        chan = chan1.compose(chan1, front=True)
+        targ = SuperOp(self.depol_sop(0.75))
+        self.assertEqual(chan, targ)
+
+        # Random superoperator
+        mat1 = self.rand_matrix(4, 4)
+        mat2 = self.rand_matrix(4, 4)
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        targ = SuperOp(np.dot(mat2, mat1))
+        self.assertEqual(chan2.compose(chan1, front=True), targ)
+        targ = SuperOp(np.dot(mat1, mat2))
+        self.assertEqual(chan1.compose(chan2, front=True), targ)
+
+        # Compose different dimensions
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan = chan1.compose(chan2, front=True)
+        self.assertEqual(chan.dims, (4, 4))
+        chan = chan2.compose(chan1, front=True)
+        self.assertEqual(chan.dims, (2, 2))
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        # UnitaryChannel evolution
+        chan1 = SuperOp(self.sopX)
+        chan2 = SuperOp(self.sopY)
+        targ = SuperOp(self.sopZ)
+        chan1.compose(chan2, inplace=True, front=True)
+        self.assertEqual(chan1, targ)
+
+        # 50% depolarizing channel
+        chan1 = SuperOp(self.depol_sop(0.5))
+        chan1.compose(chan1, inplace=True, front=True)
+        targ = SuperOp(self.depol_sop(0.75))
+        self.assertEqual(chan1, targ)
+
+        # Random superoperator
+        mat1 = self.rand_matrix(4, 4)
+        mat2 = self.rand_matrix(4, 4)
+
+        targ = SuperOp(np.dot(mat2, mat1))
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan2.compose(chan1, inplace=True, front=True)
+        self.assertEqual(chan2, targ)
+        targ = SuperOp(np.dot(mat1, mat2))
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1.compose(chan2, inplace=True, front=True)
+        self.assertEqual(chan1, targ)
+
+        # Compose different dimensions
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan1.compose(chan2, inplace=True, front=True)
+        self.assertEqual(chan1.dims, (4, 4))
+        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
+        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
+        chan2.compose(chan1, inplace=True, front=True)
+        self.assertEqual(chan2.dims, (2, 2))
+
+    def test_expand(self):
+        """Test expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+
+        # X \otimes I
+        chan = chan1.expand(chan2)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan = chan2.expand(chan1)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan1.expand(chan2, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan2.expand(chan1, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+    def test_tensor(self):
+        """Test tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+
+        # X \otimes I
+        chan = chan2.tensor(chan1)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = chan2 ^ chan1
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        # I \otimes X
+        chan = chan1.tensor(chan2)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+        chan = chan1 ^ chan2
+        self.assertEqual(chan.dims, (4, 4))
+        self.assertAllClose(chan.evolve(rho_init), rho_targ)
+
+    def test_tensorinplace(self):
+        """Test inplace tensor method."""
+        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
+        rho_init = np.kron(rho0, rho0)
+
+        # X \otimes I
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan2.tensor(chan1, inplace=True)
+        rho_targ = np.kron(rho1, rho0)
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan2 ^= chan1
+        self.assertEqual(chan2.dims, (4, 4))
+        self.assertAllClose(chan2.evolve(rho_init), rho_targ)
+
+        # I \otimes X
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan1.tensor(chan2, inplace=True)
+        rho_targ = np.kron(rho0, rho1)
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(self.sopX)
+        chan1 ^= chan2
+        self.assertEqual(chan1.dims, (4, 4))
+        self.assertAllClose(chan1.evolve(rho_init), rho_targ)
+
+    def test_power(self):
+        """Test power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = SuperOp(self.depol_sop(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        chan3 = depol.power(3)
+        targ3 = SuperOp(self.depol_sop(1 - p_id3))
+        self.assertEqual(chan3, targ3)
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        # 10% depolarizing channel
+        p_id = 0.9
+        depol = SuperOp(self.depol_sop(1 - p_id))
+
+        # Compose 3 times
+        p_id3 = p_id ** 3
+        depol.power(3, inplace=True)
+        targ3 = SuperOp(self.depol_sop(1 - p_id3))
+        self.assertEqual(depol, targ3)
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = SuperOp(self.depol_sop(1))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        mat1 = 0.5 * self.sopI
+        mat2 = 0.5 * self.depol_sop(1)
+        targ = SuperOp(mat1 + mat2)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        self.assertEqual(chan1.add(chan2), targ)
+        self.assertEqual(chan1 + chan2, targ)
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        mat1 = 0.5 * self.sopI
+        mat2 = 0.5 * self.depol_sop(1)
+        targ = SuperOp(mat1 + mat2)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1.add(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1 += chan2
+        self.assertEqual(chan1, targ)
+
+    def test_add_except(self):
+        """Test add method raises exceptions."""
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(np.eye(16))
+        self.assertRaises(QiskitError, chan1.add, chan2)
+        self.assertRaises(QiskitError, chan1.add, 5)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        mat1 = 0.5 * self.sopI
+        mat2 = 0.5 * self.depol_sop(1)
+        targ = SuperOp(mat1 - mat2)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        self.assertEqual(chan1.subtract(chan2), targ)
+        self.assertEqual(chan1 - chan2, targ)
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        mat1 = 0.5 * self.sopI
+        mat2 = 0.5 * self.depol_sop(1)
+        targ = SuperOp(mat1 - mat2)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1.subtract(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        chan1 -= chan2
+        self.assertEqual(chan1, targ)
+
+    def test_subtract_except(self):
+        """Test subtract method raises exceptions."""
+        chan1 = SuperOp(self.sopI)
+        chan2 = SuperOp(np.eye(16))
+        self.assertRaises(QiskitError, chan1.subtract, chan2)
+        self.assertRaises(QiskitError, chan1.subtract, 5)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        chan = SuperOp(self.sopI)
+        val = 0.5
+        targ = SuperOp(val * self.sopI)
+        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(val * chan, targ)
+        self.assertEqual(chan * val, targ)
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        chan = SuperOp(self.sopI)
+        val = 0.5
+        targ = SuperOp(val * self.sopI)
+        chan.multiply(val, inplace=True)
+        self.assertEqual(chan, targ)
+
+        chan = SuperOp(self.sopI)
+        chan *= val
+        self.assertEqual(chan, targ)
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = SuperOp(self.sopI)
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        chan = SuperOp(self.sopI)
+        targ = SuperOp(-self.sopI)
+        self.assertEqual(-chan, targ)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_tensor_compose.py
+++ b/test/python/quantum_info/channel/test_tensor_compose.py
@@ -1,0 +1,450 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Equivalence tests for quantum channel methods."""
+
+import unittest
+
+import numpy as np
+
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from qiskit.quantum_info.operators.channel.choi import Choi
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators.channel.stinespring import Stinespring
+from qiskit.quantum_info.operators.channel.ptm import PTM
+from qiskit.quantum_info.operators.channel.chi import Chi
+from .base import ChannelTestCase
+
+
+class TestEquivalence(ChannelTestCase):
+    """Tests for channel equivalence.
+
+    Tests that performing compose, tensor, conjugate, transpose, adjoint
+    in the UnitaryChannel representation is equivalent to performing the same
+    operations in other representations.
+    """
+
+    unitaries = [
+        ChannelTestCase.matI, ChannelTestCase.matX, ChannelTestCase.matY,
+        ChannelTestCase.matZ, ChannelTestCase.matH
+    ]
+
+    chois = [
+        ChannelTestCase.choiI, ChannelTestCase.choiX, ChannelTestCase.choiY,
+        ChannelTestCase.choiZ, ChannelTestCase.choiH
+    ]
+
+    chis = [
+        ChannelTestCase.chiI, ChannelTestCase.chiX, ChannelTestCase.chiY,
+        ChannelTestCase.chiZ, ChannelTestCase.chiH
+    ]
+
+    sops = [
+        ChannelTestCase.sopI, ChannelTestCase.sopX, ChannelTestCase.sopY,
+        ChannelTestCase.sopZ, ChannelTestCase.sopH
+    ]
+
+    ptms = [
+        ChannelTestCase.ptmI, ChannelTestCase.ptmX, ChannelTestCase.ptmY,
+        ChannelTestCase.ptmZ, ChannelTestCase.ptmH
+    ]
+
+    def _compare_tensor_to_unitary(self, chans, mats):
+        """Test tensor product is equivalent"""
+        unitaries = [UnitaryChannel(np.kron(j, i)) for i in mats for j in mats]
+        channels = [j.tensor(i) for i in chans for j in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def _compare_expand_to_unitary(self, chans, mats):
+        """Test expand product is equivalent"""
+        unitaries = [UnitaryChannel(np.kron(i, j)) for i in mats for j in mats]
+        channels = [j.expand(i) for i in chans for j in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def _compare_compose_to_unitary(self, chans, mats):
+        """Test compose is equivalent"""
+        unitaries = [UnitaryChannel(np.dot(i, j)) for i in mats for j in mats]
+        channels = [j.compose(i) for i in chans for j in chans]
+        for chan, uni in zip(channels, unitaries):
+            self.assertEqual(chan, chan.__class__(uni))
+
+    def _check_tensor_other_reps(self, chan):
+        """Check tensor works for other representations"""
+        current_rep = chan.__class__
+        other_reps = [
+            UnitaryChannel, Choi, SuperOp, Kraus, Stinespring, Chi, PTM
+        ]
+        for rep in other_reps:
+            self.assertEqual(current_rep, chan.tensor(rep(chan)).__class__)
+
+    def _check_expand_other_reps(self, chan):
+        """Check expand works for other representations"""
+        current_rep = chan.__class__
+        other_reps = [
+            UnitaryChannel, Choi, SuperOp, Kraus, Stinespring, Chi, PTM
+        ]
+        for rep in other_reps:
+            self.assertEqual(current_rep, chan.expand(rep(chan)).__class__)
+
+    def _check_compose_other_reps(self, chan):
+        """Check compose works for other representations"""
+        current_rep = chan.__class__
+        other_reps = [
+            UnitaryChannel, Choi, SuperOp, Kraus, Stinespring, Chi, PTM
+        ]
+        for rep in other_reps:
+            self.assertEqual(current_rep, chan.compose(rep(chan)).__class__)
+
+    def test_choi_tensor(self):
+        """Test tensor of Choi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Choi(mat) for mat in
+            [self.choiI, self.choiX, self.choiY, self.choiZ, self.choiH]
+        ]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_choi_tensor_random(self):
+        """Test tensor of random Choi matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_choi_tensor_other_reps(self):
+        """Test tensor of Choi works with other reps."""
+        chan = Choi(self.choiI)
+        self._check_tensor_other_reps(chan)
+
+    def test_superop_tensor(self):
+        """Test tensor of SuperOp matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            SuperOp(mat)
+            for mat in [self.sopI, self.sopX, self.sopY, self.sopZ, self.sopH]
+        ]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_superop_tensor_random(self):
+        """Test tensor of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_superop_tensor_other_reps(self):
+        """Test tensor of SuperOp works with other reps."""
+        chan = SuperOp(self.sopI)
+        self._check_tensor_other_reps(chan)
+
+    def test_kraus_tensor(self):
+        """Test tensor of Kraus matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_kraus_tensor_random(self):
+        """Test tensor of Kraus matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_kraus_tensor_other_reps(self):
+        """Test tensor of Kraus works with other reps."""
+        chan = Kraus(self.matI)
+        self._check_tensor_other_reps(chan)
+
+    def test_stinespring_tensor(self):
+        """Test tensor of Stinespring matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_stinespring_tensor_random(self):
+        """Test tensor of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_stinespring_tensor_other_reps(self):
+        """Test tensor of Stinespring works with other reps."""
+        chan = Stinespring(self.matI)
+        self._check_tensor_other_reps(chan)
+
+    def test_chi_tensor(self):
+        """Test tensor of Chi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Chi(mat)
+            for mat in [self.chiI, self.chiX, self.chiY, self.chiZ, self.chiH]
+        ]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_chi_tensor_random(self):
+        """Test tensor of Chi matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_chi_tensor_other_reps(self):
+        """Test tensor of Chi works with other reps."""
+        chan = Chi(self.chiI)
+        self._check_tensor_other_reps(chan)
+
+    def test_ptm_tensor(self):
+        """Test tensor of PTM matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            PTM(mat)
+            for mat in [self.ptmI, self.ptmX, self.ptmY, self.ptmZ, self.ptmH]
+        ]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_ptm_tensor_random(self):
+        """Test tensor of PTM matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_tensor_to_unitary(chans, mats)
+
+    def test_ptm_tensor_other_reps(self):
+        """Test tensor of PTM works with other reps."""
+        chan = PTM(self.ptmI)
+        self._check_tensor_other_reps(chan)
+
+    def test_choi_expand(self):
+        """Test expand of Choi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Choi(mat) for mat in
+            [self.choiI, self.choiX, self.choiY, self.choiZ, self.choiH]
+        ]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_choi_expand_random(self):
+        """Test expand of random Choi matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_choi_expand_other_reps(self):
+        """Test expand of Choi works with other reps."""
+        chan = Choi(self.choiI)
+        self._check_expand_other_reps(chan)
+
+    def test_superop_expand(self):
+        """Test expand of SuperOp matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            SuperOp(mat)
+            for mat in [self.sopI, self.sopX, self.sopY, self.sopZ, self.sopH]
+        ]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_superop_expand_random(self):
+        """Test expand of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_superop_expand_other_reps(self):
+        """Test expand of SuperOp works with other reps."""
+        chan = SuperOp(self.sopI)
+        self._check_expand_other_reps(chan)
+
+    def test_kraus_expand(self):
+        """Test expand of Kraus matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_kraus_expand_random(self):
+        """Test expand of Kraus matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_kraus_expand_other_reps(self):
+        """Test expand of Kraus works with other reps."""
+        chan = Kraus(self.matI)
+        self._check_expand_other_reps(chan)
+
+    def test_stinespring_expand(self):
+        """Test expand of Stinespring matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_stinespring_expand_random(self):
+        """Test expand of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_stinespring_expand_other_reps(self):
+        """Test expand of Stinespring works with other reps."""
+        chan = Stinespring(self.matI)
+        self._check_expand_other_reps(chan)
+
+    def test_chi_expand(self):
+        """Test expand of Chi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Chi(mat)
+            for mat in [self.chiI, self.chiX, self.chiY, self.chiZ, self.chiH]
+        ]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_chi_expand_random(self):
+        """Test expand of Chi matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_chi_expand_other_reps(self):
+        """Test expand of Chi works with other reps."""
+        chan = Chi(self.chiI)
+        self._check_expand_other_reps(chan)
+
+    def test_ptm_expand(self):
+        """Test expand of PTM matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            PTM(mat)
+            for mat in [self.ptmI, self.ptmX, self.ptmY, self.ptmZ, self.ptmH]
+        ]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_ptm_expand_random(self):
+        """Test expand of PTM matrices is correct."""
+        mats = [self.rand_matrix(2, 2) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_expand_to_unitary(chans, mats)
+
+    def test_ptm_expand_other_reps(self):
+        """Test expand of PTM works with other reps."""
+        chan = PTM(self.ptmI)
+        self._check_expand_other_reps(chan)
+
+    def test_choi_compose(self):
+        """Test compose of Choi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Choi(mat) for mat in
+            [self.choiI, self.choiX, self.choiY, self.choiZ, self.choiH]
+        ]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_choi_compose_random(self):
+        """Test compose of Choi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Choi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_choi_compose_other_reps(self):
+        """Test compose of Choi works with other reps."""
+        chan = Choi(self.choiI)
+        self._check_compose_other_reps(chan)
+
+    def test_superop_compose(self):
+        """Test compose of SuperOp matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            SuperOp(mat)
+            for mat in [self.sopI, self.sopX, self.sopY, self.sopZ, self.sopH]
+        ]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_superop_compose_random(self):
+        """Test compose of SuperOp matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [SuperOp(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_superop_compose_other_reps(self):
+        """Test compose of Superop works with other reps."""
+        chan = SuperOp(self.sopI)
+        self._check_compose_other_reps(chan)
+
+    def test_kraus_compose(self):
+        """Test compose of Kraus matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Kraus(mat) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_kraus_compose_random(self):
+        """Test compose of Kraus matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Kraus(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_kraus_compose_other_reps(self):
+        """Test compose of Kraus works with other reps."""
+        chan = Kraus(self.matI)
+        self._check_compose_other_reps(chan)
+
+    def test_stinespring_compose(self):
+        """Test compose of Stinespring matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [Stinespring(mat) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_stinespring_compose_random(self):
+        """Test compose of Stinespring matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Stinespring(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_stinespring_compose_other_reps(self):
+        """Test compose of Stinespring works with other reps."""
+        chan = Stinespring(self.matI)
+        self._check_compose_other_reps(chan)
+
+    def test_chi_compose(self):
+        """Test compose of Chi matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            Chi(mat)
+            for mat in [self.chiI, self.chiX, self.chiY, self.chiZ, self.chiH]
+        ]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_chi_compose_random(self):
+        """Test compose of Chi matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [Chi(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_chi_compose_other_reps(self):
+        """Test compose of Chi works with other reps."""
+        chan = Chi(self.chiI)
+        self._check_compose_other_reps(chan)
+
+    def test_ptm_compose(self):
+        """Test compose of PTM matrices is correct."""
+        mats = [self.matI, self.matX, self.matY, self.matZ, self.matH]
+        chans = [
+            PTM(mat)
+            for mat in [self.ptmI, self.ptmX, self.ptmY, self.ptmZ, self.ptmH]
+        ]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_ptm_compose_random(self):
+        """Test compose of PTM matrices is correct."""
+        mats = [self.rand_matrix(4, 4) for _ in range(4)]
+        chans = [PTM(UnitaryChannel(mat)) for mat in mats]
+        self._compare_compose_to_unitary(chans, mats)
+
+    def test_ptm_compose_other_reps(self):
+        """Test compose of PTM works with other reps."""
+        chan = PTM(self.ptmI)
+        self._check_compose_other_reps(chan)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_transformations.py
+++ b/test/python/quantum_info/channel/test_transformations.py
@@ -1,0 +1,654 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Tests for quantum channel representation transformations."""
+
+import unittest
+
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.predicates import matrix_equal
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from qiskit.quantum_info.operators.channel.choi import Choi
+from qiskit.quantum_info.operators.channel.superop import SuperOp
+from qiskit.quantum_info.operators.channel.kraus import Kraus
+from qiskit.quantum_info.operators.channel.stinespring import Stinespring
+from qiskit.quantum_info.operators.channel.ptm import PTM
+from qiskit.quantum_info.operators.channel.chi import Chi
+from .base import ChannelTestCase
+
+
+class TestTransformations(ChannelTestCase):
+    """Tests for UnitaryChannel channel representation."""
+
+    unitary_mat = [
+        ChannelTestCase.matI, ChannelTestCase.matX, ChannelTestCase.matY,
+        ChannelTestCase.matZ, ChannelTestCase.matH
+    ]
+    unitary_choi = [
+        ChannelTestCase.choiI, ChannelTestCase.choiX, ChannelTestCase.choiY,
+        ChannelTestCase.choiZ, ChannelTestCase.choiH
+    ]
+    unitary_chi = [
+        ChannelTestCase.chiI, ChannelTestCase.chiX, ChannelTestCase.chiY,
+        ChannelTestCase.chiZ, ChannelTestCase.chiH
+    ]
+    unitary_sop = [
+        ChannelTestCase.sopI, ChannelTestCase.sopX, ChannelTestCase.sopY,
+        ChannelTestCase.sopZ, ChannelTestCase.sopH
+    ]
+    unitary_ptm = [
+        ChannelTestCase.ptmI, ChannelTestCase.ptmX, ChannelTestCase.ptmY,
+        ChannelTestCase.ptmZ, ChannelTestCase.ptmH
+    ]
+
+    def test_unitary_to_unitary(self):
+        """Test UnitaryChannel to UnitaryChannel transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_choi(self):
+        """Test UnitaryChannel to Choi transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = Choi(choi)
+            chan2 = Choi(UnitaryChannel(mat))
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_superop(self):
+        """Test UnitaryChannel to SuperOp transformation."""
+        # Test unitary channels
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(UnitaryChannel(mat))
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_kraus(self):
+        """Test UnitaryChannel to Kraus transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Kraus(mat)
+            chan2 = Kraus(UnitaryChannel(mat))
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_stinespring(self):
+        """Test UnitaryChannel to Stinespring transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Stinespring(mat)
+            chan2 = Stinespring(UnitaryChannel(chan1))
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_chi(self):
+        """Test UnitaryChannel to Chi transformation."""
+        # Test unitary channels
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = Chi(chi)
+            chan2 = Chi(UnitaryChannel(mat))
+            self.assertEqual(chan1, chan2)
+
+    def test_unitary_to_ptm(self):
+        """Test UnitaryChannel to PTM transformation."""
+        # Test unitary channels
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(UnitaryChannel(mat))
+            self.assertEqual(chan1, chan2)
+
+    def test_choi_to_unitary(self):
+        """Test Choi to UnitaryChannel transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(Choi(choi))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+
+    def test_choi_to_choi(self):
+        """Test Choi to Choi transformation."""
+        # Test unitary channels
+        for choi in self.unitary_choi:
+            chan1 = Choi(choi)
+            chan2 = Choi(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_choi_to_superop(self):
+        """Test Choi to SuperOp transformation."""
+        # Test unitary channels
+        for choi, sop in zip(self.unitary_choi, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(Choi(choi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(Choi(self.depol_choi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_choi_to_kraus(self):
+        """Test Choi to Kraus transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(Choi(choi))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            chan = Kraus(Choi(self.depol_choi(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_choi_to_stinespring(self):
+        """Test Choi to Stinespring transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(Choi(choi))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            chan = Stinespring(Choi(self.depol_choi(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_choi_to_chi(self):
+        """Test Choi to Chi transformation."""
+        # Test unitary channels
+        for choi, chi in zip(self.unitary_choi, self.unitary_chi):
+            chan1 = Chi(chi)
+            chan2 = Chi(Choi(choi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(Choi(self.depol_choi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_choi_to_ptm(self):
+        """Test Choi to PTM transformation."""
+        # Test unitary channels
+        for choi, ptm in zip(self.unitary_choi, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(Choi(choi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(Choi(self.depol_choi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_superop_to_unitary(self):
+        """Test SuperOp to UnitaryChannel transformation."""
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(SuperOp(sop))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+        self.assertRaises(QiskitError, UnitaryChannel,
+                          SuperOp(self.depol_sop(0.5)))
+
+    def test_superop_to_choi(self):
+        """Test SuperOp to Choi transformation."""
+        # Test unitary channels
+        for choi, sop in zip(self.unitary_choi, self.unitary_sop):
+            chan1 = Choi(choi)
+            chan2 = Choi(SuperOp(sop))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0, 0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(SuperOp(self.depol_sop(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_superop_to_superop(self):
+        """Test SuperOp to SuperOp transformation."""
+        # Test unitary channels
+        for sop in self.unitary_sop:
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0, 0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_superop_to_kraus(self):
+        """Test SuperOp to Kraus transformation."""
+        # Test unitary channels
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(SuperOp(sop))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            chan = Kraus(SuperOp(self.depol_sop(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_superop_to_stinespring(self):
+        """Test SuperOp to Stinespring transformation."""
+        # Test unitary channels
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = Stinespring(mat)
+            chan2 = Stinespring(SuperOp(sop))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            chan = Stinespring(SuperOp(self.depol_sop(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_superop_to_chi(self):
+        """Test SuperOp to Chi transformation."""
+        # Test unitary channels
+        for sop, ptm in zip(self.unitary_sop, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(SuperOp(sop))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(SuperOp(self.depol_sop(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_superop_to_ptm(self):
+        """Test SuperOp to PTM transformation."""
+        # Test unitary channels
+        for sop, ptm in zip(self.unitary_sop, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(SuperOp(sop))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(SuperOp(self.depol_sop(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_kraus_to_unitary(self):
+        """Test Kraus to UnitaryChannel transformation."""
+        for mat in self.unitary_mat:
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(Kraus(mat))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+        self.assertRaises(QiskitError, UnitaryChannel,
+                          Kraus(self.depol_kraus(0.5)))
+
+    def test_kraus_to_choi(self):
+        """Test Kraus to Choi transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = Choi(choi)
+            chan2 = Choi(Kraus(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(Kraus(self.depol_kraus(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_kraus_to_superop(self):
+        """Test Kraus to SuperOp transformation."""
+        # Test unitary channels
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(Kraus(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(Kraus(self.depol_kraus(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_kraus_to_kraus(self):
+        """Test Kraus to Kraus transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Kraus(mat)
+            chan2 = Kraus(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Kraus(self.depol_kraus(p))
+            chan2 = Kraus(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_kraus_to_stinespring(self):
+        """Test Kraus to Stinespring transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Stinespring(mat)
+            chan2 = Stinespring(Kraus(mat))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            chan = Stinespring(Kraus(self.depol_kraus(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_kraus_to_chi(self):
+        """Test Kraus to Chi transformation."""
+        # Test unitary channels
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = Chi(chi)
+            chan2 = Chi(Kraus(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(Kraus(self.depol_kraus(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_kraus_to_ptm(self):
+        """Test Kraus to PTM transformation."""
+        # Test unitary channels
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(Kraus(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(Kraus(self.depol_kraus(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_unitary(self):
+        """Test Stinespring to UnitaryChannel transformation."""
+        for mat in self.unitary_mat:
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(Stinespring(mat))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+        self.assertRaises(QiskitError, UnitaryChannel,
+                          Stinespring(self.depol_stine(0.5)))
+
+    def test_stinespring_to_choi(self):
+        """Test Stinespring to Choi transformation."""
+        # Test unitary channels
+        for mat, choi in zip(self.unitary_mat, self.unitary_choi):
+            chan1 = Choi(choi)
+            chan2 = Choi(Stinespring(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(Stinespring(self.depol_stine(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_superop(self):
+        """Test Stinespring to SuperOp transformation."""
+        # Test unitary channels
+        for mat, sop in zip(self.unitary_mat, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(Kraus(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(Stinespring(self.depol_stine(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_kraus(self):
+        """Test Stinespring to Kraus transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Kraus(mat)
+            chan2 = Kraus(Stinespring(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Kraus(self.depol_kraus(p))
+            chan2 = Kraus(Stinespring(self.depol_stine(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_stinespring(self):
+        """Test Stinespring to Stinespring transformation."""
+        # Test unitary channels
+        for mat in self.unitary_mat:
+            chan1 = Stinespring(mat)
+            chan2 = Stinespring(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Stinespring(self.depol_stine(p))
+            chan2 = Stinespring(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_chi(self):
+        """Test Stinespring to Chi transformation."""
+        # Test unitary channels
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = Chi(chi)
+            chan2 = Chi(Stinespring(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(Stinespring(self.depol_stine(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_stinespring_to_ptm(self):
+        """Test Stinespring to PTM transformation."""
+        # Test unitary channels
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(Stinespring(mat))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(Stinespring(self.depol_stine(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_chi_to_unitary(self):
+        """Test Chi to UnitaryChannel transformation."""
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(Chi(chi))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+        self.assertRaises(QiskitError, UnitaryChannel, Chi(
+            self.depol_chi(0.5)))
+
+    def test_chi_to_choi(self):
+        """Test Chi to Choi transformation."""
+        # Test unitary channels
+        for chi, choi in zip(self.unitary_chi, self.unitary_choi):
+            chan1 = Choi(choi)
+            chan2 = Choi(Chi(chi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(Chi(self.depol_chi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_chi_to_superop(self):
+        """Test Chi to SuperOp transformation."""
+        # Test unitary channels
+        for chi, sop in zip(self.unitary_chi, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(Chi(chi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(Chi(self.depol_chi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_chi_to_kraus(self):
+        """Test Chi to Kraus transformation."""
+        # Test unitary channels
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(Chi(chi))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            chan = Kraus(Chi(self.depol_chi(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_chi_to_stinespring(self):
+        """Test Chi to Stinespring transformation."""
+        # Test unitary channels
+        for mat, chi in zip(self.unitary_mat, self.unitary_chi):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(Chi(chi))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            chan = Stinespring(Chi(self.depol_chi(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_chi_to_chi(self):
+        """Test Chi to Chi transformation."""
+        # Test unitary channels
+        for chi in self.unitary_chi:
+            chan1 = Chi(chi)
+            chan2 = Chi(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(chan1)
+            self.assertEqual(chan1, chan2)
+
+    def test_chi_to_ptm(self):
+        """Test Chi to PTM transformation."""
+        # Test unitary channels
+        for chi, ptm in zip(self.unitary_chi, self.unitary_ptm):
+            chan1 = PTM(ptm)
+            chan2 = PTM(Chi(chi))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(Chi(self.depol_chi(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_ptm_to_unitary(self):
+        """Test PTM to UnitaryChannel transformation."""
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = UnitaryChannel(mat)
+            chan2 = UnitaryChannel(PTM(ptm))
+            self.assertTrue(
+                matrix_equal(chan2.data, chan1.data, ignore_phase=True))
+        self.assertRaises(QiskitError, UnitaryChannel, PTM(
+            self.depol_ptm(0.5)))
+
+    def test_ptm_to_choi(self):
+        """Test PTM to Choi transformation."""
+        # Test unitary channels
+        for ptm, choi in zip(self.unitary_ptm, self.unitary_choi):
+            chan1 = Choi(choi)
+            chan2 = Choi(PTM(ptm))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Choi(self.depol_choi(p))
+            chan2 = Choi(PTM(self.depol_ptm(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_ptm_to_superop(self):
+        """Test PTM to SuperOp transformation."""
+        # Test unitary channels
+        for ptm, sop in zip(self.unitary_ptm, self.unitary_sop):
+            chan1 = SuperOp(sop)
+            chan2 = SuperOp(PTM(ptm))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = SuperOp(self.depol_sop(p))
+            chan2 = SuperOp(PTM(self.depol_ptm(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_ptm_to_kraus(self):
+        """Test PTM to Kraus transformation."""
+        # Test unitary channels
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(PTM(ptm))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            chan = Kraus(PTM(self.depol_ptm(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_ptm_to_stinespring(self):
+        """Test PTM to Stinespring transformation."""
+        # Test unitary channels
+        for mat, ptm in zip(self.unitary_mat, self.unitary_ptm):
+            chan1 = Kraus(mat)
+            chan2 = Kraus(PTM(ptm))
+            self.assertTrue(
+                matrix_equal(chan2.data[0], chan1.data[0], ignore_phase=True))
+        # Test depolarizing channels
+        rho = np.diag([1, 0])
+        for p in [0.25, 0.5, 0.75, 1]:
+            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            chan = Stinespring(PTM(self.depol_ptm(p)))
+            self.assertAllClose(chan.evolve(rho), targ)
+
+    def test_ptm_to_chi(self):
+        """Test PTM to Chi transformation."""
+        # Test unitary channels
+        for chi, ptm in zip(self.unitary_chi, self.unitary_ptm):
+            chan1 = Chi(chi)
+            chan2 = Chi(PTM(ptm))
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = Chi(self.depol_chi(p))
+            chan2 = Chi(PTM(self.depol_ptm(p)))
+            self.assertEqual(chan1, chan2)
+
+    def test_ptm_to_ptm(self):
+        """Test PTM to PTM transformation."""
+        # Test unitary channels
+        for ptm in self.unitary_ptm:
+            chan1 = PTM(ptm)
+            chan2 = PTM(chan1)
+            self.assertEqual(chan1, chan2)
+        # Test depolarizing channels
+        for p in [0.25, 0.5, 0.75, 1]:
+            chan1 = PTM(self.depol_ptm(p))
+            chan2 = PTM(chan1)
+            self.assertEqual(chan1, chan2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/channel/test_transformations.py
+++ b/test/python/quantum_info/channel/test_transformations.py
@@ -150,9 +150,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            targ = Kraus(self.depol_kraus(p))._evolve(rho)
             chan = Kraus(Choi(self.depol_choi(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_choi_to_stinespring(self):
         """Test Choi to Stinespring transformation."""
@@ -165,9 +165,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            targ = Stinespring(self.depol_stine(p))._evolve(rho)
             chan = Stinespring(Choi(self.depol_choi(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_choi_to_chi(self):
         """Test Choi to Chi transformation."""
@@ -242,9 +242,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            targ = Kraus(self.depol_kraus(p))._evolve(rho)
             chan = Kraus(SuperOp(self.depol_sop(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_superop_to_stinespring(self):
         """Test SuperOp to Stinespring transformation."""
@@ -257,9 +257,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            targ = Stinespring(self.depol_stine(p))._evolve(rho)
             chan = Stinespring(SuperOp(self.depol_sop(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_superop_to_chi(self):
         """Test SuperOp to Chi transformation."""
@@ -347,9 +347,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            targ = Stinespring(self.depol_stine(p))._evolve(rho)
             chan = Stinespring(Kraus(self.depol_kraus(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_kraus_to_chi(self):
         """Test Kraus to Chi transformation."""
@@ -512,9 +512,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            targ = Kraus(self.depol_kraus(p))._evolve(rho)
             chan = Kraus(Chi(self.depol_chi(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_chi_to_stinespring(self):
         """Test Chi to Stinespring transformation."""
@@ -527,9 +527,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            targ = Stinespring(self.depol_stine(p))._evolve(rho)
             chan = Stinespring(Chi(self.depol_chi(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_chi_to_chi(self):
         """Test Chi to Chi transformation."""
@@ -604,9 +604,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Kraus(self.depol_kraus(p)).evolve(rho)
+            targ = Kraus(self.depol_kraus(p))._evolve(rho)
             chan = Kraus(PTM(self.depol_ptm(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_ptm_to_stinespring(self):
         """Test PTM to Stinespring transformation."""
@@ -619,9 +619,9 @@ class TestTransformations(ChannelTestCase):
         # Test depolarizing channels
         rho = np.diag([1, 0])
         for p in [0.25, 0.5, 0.75, 1]:
-            targ = Stinespring(self.depol_stine(p)).evolve(rho)
+            targ = Stinespring(self.depol_stine(p))._evolve(rho)
             chan = Stinespring(PTM(self.depol_ptm(p)))
-            self.assertAllClose(chan.evolve(rho), targ)
+            self.assertAllClose(chan._evolve(rho), targ)
 
     def test_ptm_to_chi(self):
         """Test PTM to Chi transformation."""

--- a/test/python/quantum_info/channel/test_unitarychannel.py
+++ b/test/python/quantum_info/channel/test_unitarychannel.py
@@ -53,14 +53,14 @@ class TestUnitaryChannel(ChannelTestCase):
         target_psi = np.array([1, 1]) / np.sqrt(2)
         target_rho = np.array([[0.5, 0.5], [0.5, 0.5]])
         # Test list vector evolve
-        self.assertAllClose(chan.evolve([1, 0]), target_psi)
+        self.assertAllClose(chan._evolve([1, 0]), target_psi)
         # Test np.array vector evolve
-        self.assertAllClose(chan.evolve(np.array([1, 0])), target_psi)
+        self.assertAllClose(chan._evolve(np.array([1, 0])), target_psi)
         # Test list density matrix evolve
-        self.assertAllClose(chan.evolve([[1, 0], [0, 0]]), target_rho)
+        self.assertAllClose(chan._evolve([[1, 0], [0, 0]]), target_rho)
         # Test np.array density matrix evolve
         self.assertAllClose(
-            chan.evolve(np.array([[1, 0], [0, 0]])), target_rho)
+            chan._evolve(np.array([[1, 0], [0, 0]])), target_rho)
 
     def test_is_cptp(self):
         """Test is_cptp method."""

--- a/test/python/quantum_info/channel/test_unitarychannel.py
+++ b/test/python/quantum_info/channel/test_unitarychannel.py
@@ -1,0 +1,366 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=invalid-name,missing-docstring
+"""Tests for UnitaryChannel quantum channel representation class."""
+
+import unittest
+import numpy as np
+import scipy.linalg as la
+
+from qiskit import QiskitError
+from qiskit.quantum_info.operators.channel.unitarychannel import UnitaryChannel
+from .base import ChannelTestCase
+
+
+class TestUnitaryChannel(ChannelTestCase):
+    """Tests for UnitaryChannel channel representation."""
+
+    def test_init(self):
+        """Test initialization"""
+        mat = np.eye(3)
+        chan = UnitaryChannel(mat)
+        self.assertAllClose(chan.data, mat)
+        self.assertEqual(chan.dims, (3, 3))
+
+        # Non-square matrix should raise exception
+        self.assertRaises(QiskitError, UnitaryChannel, np.zeros((2, 3)))
+        # Wrong input or output dims should raise exception
+        self.assertRaises(QiskitError, UnitaryChannel, mat, input_dim=2)
+        self.assertRaises(QiskitError, UnitaryChannel, mat, output_dim=2)
+
+    def test_equal(self):
+        """Test __eq__ method"""
+        mat = self.rand_matrix(2, 2)
+        self.assertEqual(UnitaryChannel(mat), UnitaryChannel(mat))
+
+    def test_copy(self):
+        """Test copy method"""
+        mat = np.eye(2)
+        orig = UnitaryChannel(mat)
+        cpy = orig.copy()
+        cpy._data[0, 0] = 0.0
+        self.assertFalse(cpy == orig)
+
+    def test_evolve(self):
+        """Test evolve method."""
+        # Test hadamard
+        chan = UnitaryChannel(np.array([[1, 1], [1, -1]]) / np.sqrt(2))
+        target_psi = np.array([1, 1]) / np.sqrt(2)
+        target_rho = np.array([[0.5, 0.5], [0.5, 0.5]])
+        # Test list vector evolve
+        self.assertAllClose(chan.evolve([1, 0]), target_psi)
+        # Test np.array vector evolve
+        self.assertAllClose(chan.evolve(np.array([1, 0])), target_psi)
+        # Test list density matrix evolve
+        self.assertAllClose(chan.evolve([[1, 0], [0, 0]]), target_rho)
+        # Test np.array density matrix evolve
+        self.assertAllClose(
+            chan.evolve(np.array([[1, 0], [0, 0]])), target_rho)
+
+    def test_is_cptp(self):
+        """Test is_cptp method."""
+        # X-90 rotation
+        X90 = la.expm(-1j * 0.5 * np.pi * np.array([[0, 1], [1, 0]]) / 2)
+        self.assertTrue(UnitaryChannel(X90).is_cptp())
+        # Non-unitary should return false
+        self.assertFalse(UnitaryChannel([[1, 0], [0, 0]]).is_cptp())
+
+    def test_conjugate(self):
+        """Test conjugate method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        uni_conj = chan.conjugate()
+        self.assertEqual(uni_conj, UnitaryChannel(matr - 1j * mati))
+
+    def test_conjugate_inplace(self):
+        """Test inplace conjugate method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        chan.conjugate(inplace=True)
+        self.assertEqual(chan, UnitaryChannel(matr - 1j * mati))
+
+    def test_transpose(self):
+        """Test transpose method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        uni_t = chan.transpose()
+        self.assertEqual(uni_t, UnitaryChannel(matr.T + 1j * mati.T))
+
+    def test_transpose_inplace(self):
+        """Test inplace transpose method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        chan.transpose(inplace=True)
+        self.assertEqual(chan, UnitaryChannel(matr.T + 1j * mati.T))
+
+    def test_adjoint(self):
+        """Test adjoint method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        uni_adj = chan.adjoint()
+        self.assertEqual(uni_adj, UnitaryChannel(matr.T - 1j * mati.T))
+
+    def test_adjoint_inplace(self):
+        """Test inplace adjoint method."""
+        matr = np.array([[1, 2], [3, 4]])
+        mati = np.array([[1, 2], [3, 4]])
+        chan = UnitaryChannel(matr + 1j * mati)
+        chan.adjoint(inplace=True)
+        self.assertEqual(chan, UnitaryChannel(matr.T - 1j * mati.T))
+
+    def test_compose_except(self):
+        """Test compose different dimension exception"""
+        self.assertRaises(QiskitError,
+                          UnitaryChannel(np.eye(2)).compose,
+                          UnitaryChannel(np.eye(3)))
+        self.assertRaises(QiskitError,
+                          UnitaryChannel(np.eye(2)).compose, np.eye(2))
+        self.assertRaises(QiskitError, UnitaryChannel(np.eye(2)).compose, 2)
+
+    def test_compose(self):
+        """Test compose method."""
+        matX = np.array([[0, 1], [1, 0]], dtype=complex)
+        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+
+        chan1 = UnitaryChannel(matX)
+        chan2 = UnitaryChannel(matY)
+
+        targ = UnitaryChannel(np.dot(matY, matX))
+        self.assertEqual(chan1.compose(chan2), targ)
+        self.assertEqual(chan1 @ chan2, targ)
+
+        targ = UnitaryChannel(np.dot(matX, matY))
+        self.assertEqual(chan2.compose(chan1), targ)
+        self.assertEqual(chan2 @ chan1, targ)
+
+    def test_compose_inplace(self):
+        """Test inplace compose method."""
+        matX = np.array([[0, 1], [1, 0]], dtype=complex)
+        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+
+        targ = UnitaryChannel(np.dot(matY, matX))
+        chan1 = UnitaryChannel(matX)
+        chan2 = UnitaryChannel(matY)
+        chan1.compose(chan2, inplace=True)
+        self.assertEqual(chan1, targ)
+        chan1 = UnitaryChannel(matX)
+        chan2 = UnitaryChannel(matY)
+        chan1 @= chan2
+        self.assertEqual(chan1, targ)
+
+        targ = UnitaryChannel(np.dot(matX, matY))
+        chan1 = UnitaryChannel(matX)
+        chan2 = UnitaryChannel(matY)
+        chan2.compose(chan1, inplace=True)
+        self.assertEqual(chan2, targ)
+        chan1 = UnitaryChannel(matX)
+        chan2 = UnitaryChannel(matY)
+        chan2 @= chan1
+        self.assertEqual(chan2, targ)
+
+    def test_compose_front(self):
+        """Test front compose method."""
+        matX = np.array([[0, 1], [1, 0]], dtype=complex)
+        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+
+        chanYX = UnitaryChannel(matY).compose(UnitaryChannel(matX), front=True)
+        matYX = np.dot(matY, matX)
+        self.assertEqual(chanYX, UnitaryChannel(matYX))
+
+        chanXY = UnitaryChannel(matX).compose(UnitaryChannel(matY), front=True)
+        matXY = np.dot(matX, matY)
+        self.assertEqual(chanXY, UnitaryChannel(matXY))
+
+    def test_compose_front_inplace(self):
+        """Test inplace front compose method."""
+        matX = np.array([[0, 1], [1, 0]], dtype=complex)
+        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
+
+        matYX = np.dot(matY, matX)
+        chan = UnitaryChannel(matY)
+        chan.compose(UnitaryChannel(matX), inplace=True, front=True)
+        self.assertEqual(chan, UnitaryChannel(matYX))
+
+        matXY = np.dot(matX, matY)
+        chan = UnitaryChannel(matX)
+        chan.compose(UnitaryChannel(matY), inplace=True, front=True)
+        self.assertEqual(chan, UnitaryChannel(matXY))
+
+    def test_expand(self):
+        """Test expand method."""
+        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
+        mat2 = np.eye(3, dtype=complex)
+
+        mat21 = np.kron(mat2, mat1)
+        chan21 = UnitaryChannel(mat1).expand(UnitaryChannel(mat2))
+        self.assertEqual(chan21.dims, (6, 6))
+        self.assertEqual(chan21, UnitaryChannel(mat21))
+
+        mat12 = np.kron(mat1, mat2)
+        chan12 = UnitaryChannel(mat2).expand(UnitaryChannel(mat1))
+        self.assertEqual(chan12.dims, (6, 6))
+        self.assertEqual(chan12, UnitaryChannel(mat12))
+
+    def test_expand_inplace(self):
+        """Test inplace expand method."""
+        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
+        mat2 = np.eye(3, dtype=complex)
+
+        mat21 = np.kron(mat2, mat1)
+        chan = UnitaryChannel(mat1)
+        chan.expand(UnitaryChannel(mat2), inplace=True)
+        self.assertEqual(chan.dims, (6, 6))
+        self.assertEqual(chan, UnitaryChannel(mat21))
+
+        mat12 = np.kron(mat1, mat2)
+        chan = UnitaryChannel(mat2)
+        chan.expand(UnitaryChannel(mat1), inplace=True)
+        self.assertEqual(chan.dims, (6, 6))
+        self.assertEqual(chan, UnitaryChannel(mat12))
+
+    def test_tensor(self):
+        """Test tensor method."""
+        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
+        mat2 = np.eye(3, dtype=complex)
+
+        mat21 = np.kron(mat2, mat1)
+        chan21 = UnitaryChannel(mat2).tensor(UnitaryChannel(mat1))
+        self.assertEqual(chan21.dims, (6, 6))
+        self.assertEqual(chan21, UnitaryChannel(mat21))
+
+        mat12 = np.kron(mat1, mat2)
+        chan12 = UnitaryChannel(mat1).tensor(UnitaryChannel(mat2))
+        self.assertEqual(chan12.dims, (6, 6))
+        self.assertEqual(chan12, UnitaryChannel(mat12))
+
+    def test_tensor_inplace(self):
+        """Test inplace tensor method."""
+        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
+        mat2 = np.eye(3, dtype=complex)
+
+        mat21 = np.kron(mat2, mat1)
+        chan = UnitaryChannel(mat2)
+        chan.tensor(UnitaryChannel(mat1), inplace=True)
+        self.assertEqual(chan.dims, (6, 6))
+        self.assertEqual(chan, UnitaryChannel(mat21))
+
+        mat12 = np.kron(mat1, mat2)
+        chan = UnitaryChannel(mat1)
+        chan.tensor(UnitaryChannel(mat2), inplace=True)
+        self.assertEqual(chan.dims, (6, 6))
+        self.assertEqual(chan, UnitaryChannel(mat12))
+
+    def test_power(self):
+        """Test power method."""
+        X90 = la.expm(-1j * 0.5 * np.pi * np.array([[0, 1], [1, 0]]) / 2)
+        chan = UnitaryChannel(X90)
+        self.assertEqual(chan.power(2), UnitaryChannel([[0, -1j], [-1j, 0]]))
+        self.assertEqual(chan.power(4), UnitaryChannel(-1 * np.eye(2)))
+        self.assertEqual(chan.power(8), UnitaryChannel(np.eye(2)))
+
+    def test_power_inplace(self):
+        """Test inplace power method."""
+        X90 = la.expm(-1j * 0.5 * np.pi * np.array([[0, 1], [1, 0]]) / 2)
+        chan = UnitaryChannel(X90)
+        chan.power(2, inplace=True)
+        self.assertEqual(chan, UnitaryChannel([[0, -1j], [-1j, 0]]))
+        chan.power(2, inplace=True)
+        self.assertEqual(chan, UnitaryChannel(-1 * np.eye(2)))
+        chan.power(4, inplace=True)
+        self.assertEqual(chan, UnitaryChannel(np.eye(2)))
+
+    def test_power_except(self):
+        """Test power method raises exceptions."""
+        chan = UnitaryChannel(np.eye(3))
+        # Negative power raises error
+        self.assertRaises(QiskitError, chan.power, -1)
+        # 0 power raises error
+        self.assertRaises(QiskitError, chan.power, 0)
+        # Non-integer power raises error
+        self.assertRaises(QiskitError, chan.power, 0.5)
+
+    def test_add(self):
+        """Test add method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        self.assertEqual(chan.add(chan), UnitaryChannel([[2, 4], [6, 8]]))
+        self.assertEqual(chan + chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+    def test_add_inplace(self):
+        """Test inplace add method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan.add(chan, inplace=True)
+        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan += chan
+        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+    def test_add_except(self):
+        """Test add method raises exceptions."""
+        chan1 = UnitaryChannel([[1, 2], [3, 4]])
+        chan2 = UnitaryChannel(np.eye(3))
+        self.assertRaises(QiskitError, chan1.add, chan2)
+
+    def test_subtract(self):
+        """Test subtract method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        self.assertEqual(chan.subtract(chan), UnitaryChannel(np.zeros((2, 2))))
+        self.assertEqual(chan - chan, UnitaryChannel(np.zeros((2, 2))))
+
+    def test_subtract_inplace(self):
+        """Test inplace subtract method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan.subtract(chan, inplace=True)
+        self.assertEqual(chan, UnitaryChannel(np.zeros((2, 2))))
+
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan -= chan
+        self.assertEqual(chan, UnitaryChannel(np.zeros((2, 2))))
+
+    def test_subtract_except(self):
+        """Test subtract method raises exceptions."""
+        chan1 = UnitaryChannel([[1, 2], [3, 4]])
+        chan2 = UnitaryChannel(np.eye(3))
+        self.assertRaises(QiskitError, chan1.subtract, chan2)
+
+    def test_multiply(self):
+        """Test multiply method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        self.assertEqual(chan.multiply(2), UnitaryChannel([[2, 4], [6, 8]]))
+        self.assertEqual(2 * chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+    def test_multiply_inplace(self):
+        """Test inplace multiply method."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan.multiply(2.0, inplace=True)
+        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        chan *= 2
+        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
+
+    def test_multiply_except(self):
+        """Test multiply method raises exceptions."""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.multiply, chan)
+
+    def test_negate(self):
+        """Test negate method"""
+        chan = UnitaryChannel([[1, 2], [3, 4]])
+        targ = UnitaryChannel([[-1, -2], [-3, -4]])
+        self.assertEqual(-chan, targ)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
Closes #1193 

### Summary

Adds quantum channel package to `quantum_info`. This package contains classes for representing quantum channels (CPTP maps, and also general Non-CPTP operator maps) and is essentially an implementation of the paper: 

*Tensor networks and graphical calculus for open quantum systems*
Wood, Biamonte, Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
Open access: [arXiv: arXiv:1111.6950v3](https://arxiv.org/abs/1111.6950)

### Details and comments

* Contains classes for channel representations: 
  * `Choi`: Choi-Jamiolkowski process matrix
  * `SuperOp`: Linear superoperator
  * `Chi`: Pauli-basis Chi matrix
  * `PTM`: Pauli transfer-matrix superoperator
  * `Kraus`:  Kraus / operator-sum operators
  * `Stinespring`: Stinespring / system-environment insometry
  * `UnitaryChannel`: single-matrix Kraus representation (not generic operator map like other reps, and not exposed to user by default)

* The classes can be converted into each other using their init methods eg: `SuperOp(Kraus([k1, k2]))`
* All classes contain methods for
  * `is_cptp`: check if map is completely positive trace preserving
  * `evolve`: evolve a quantum state by the channel
  * `adjoint`: compute to the adjoint channel
  * `conjugate`: compute the conjugate channel
  * `transpose`: compute the transposed channel
  * `compose`: compose with another channel B(A(rho))
  * `tensor`: tensor product with another channel A \otimes B
  * `expand`: expand with another channel B \otimes A (reverse order tensor product)
  * `power`: compose channel with itself n times
  * `add`: linear addition of two channels
  * `subtract`: linear subtraction of two channels
  * `multiply`: scalar multiplication of a channel
* Operator overloads:
  * `+,-,*` for add, subtract, multiply
  * `@` for compose
  * `^` for tensor

Closes #1193 

### Tests

- [x] Tests for `Choi` class
- [x] Tests for `SuperOp` class
- [x] Tests for `Chi` class
- [x] Tests for `PTM` class
- [x] Tests for `Stinespring` class
- [x] Tests for `Kraus` class
- [x] Tests for `UnitaryChannel` helper class
- [x] Equivalence tests for evolution
- [x] Equivalence tests for tensor, expand
- [x] Equivalence tests for compose
- [x] Equivalence tests for conjugate, transpose, adjoint
- [x] Equivalence tests for add, subtract, multiply

### Future PR:

- Integrate with Ericks `Unitary` class in PR #1961 
- Integrate with Qiskit Aer noise model