### PR TITLE
DAG.nodes() to remove dag.multi_graph.nodes()

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -991,6 +991,15 @@ class DAGCircuit:
         """
         return self.multi_graph.nodes[node_id]
 
+    def nodes(self):
+        """Iterator for node values.
+
+        Yield:
+            node: the node.
+        """
+        for node in self.multi_graph.nodes.values():
+            yield node
+
     def get_op_nodes(self, op=None, data=False):
         """Deprecated. Use op_nodes()."""
         warnings.warn('The method get_op_nodes() is being replaced by op_nodes()',

--- a/qiskit/transpiler/passes/mapping/lookahead_swap.py
+++ b/qiskit/transpiler/passes/mapping/lookahead_swap.py
@@ -205,8 +205,7 @@ def _map_free_gates(layout, gates, coupling_map):
         # Gates without a partition (barrier, snapshot, save, load, noise) may
         # still have associated qubits. Look for them in the qargs.
         if not gate['partition']:
-            qubits = [n for n in gate['graph'].multi_graph.nodes.values()
-                      if n['type'] == 'op'][0]['qargs']
+            qubits = [n for n in gate['graph'].nodes() if n['type'] == 'op'][0]['qargs']
 
             if not qubits:
                 continue
@@ -259,7 +258,7 @@ def _score_step(step):
 
 
 def _copy_circuit_metadata(source_dag, coupling_map):
-    """Return a copy of source_dag with metadata but without a multi_graph.
+    """Return a copy of source_dag with metadata but empty.
     Generate only a single qreg in the output DAG, matching the size of the
     coupling_map."""
 
@@ -278,8 +277,7 @@ def _copy_circuit_metadata(source_dag, coupling_map):
 def _transform_gate_for_layout(gate, layout):
     """Return op implementing a virtual gate on given layout."""
 
-    mapped_op = deepcopy([n for n in gate['graph'].multi_graph.nodes.values()
-                          if n['type'] == 'op'][0])
+    mapped_op = deepcopy([n for n in gate['graph'].nodes() if n['type'] == 'op'][0])
 
     device_qreg = QuantumRegister(len(layout.get_physical_bits()), 'q')
     mapped_op['qargs'] = [(device_qreg, layout[a]) for a in mapped_op['qargs']]

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -171,10 +171,9 @@ class Optimize1qGates(TransformationPass):
                 new_op = U2Gate(right_parameters[1], right_parameters[2], run_qarg)
             if right_name == "u3":
                 new_op = U3Gate(*right_parameters, run_qarg)
-            nx.set_node_attributes(dag.multi_graph, name='name',
-                                   values={run[0]: right_name})
-            nx.set_node_attributes(dag.multi_graph, name='op',
-                                   values={run[0]: new_op})
+            dag.node(run[0])['name'] = right_name
+            dag.node(run[0])['op'] = new_op
+
             # Delete the other nodes in the run
             for current_node in run[1:]:
                 dag._remove_op_node(current_node)

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -11,7 +11,6 @@ Transpiler pass to optimize chains of single-qubit u1, u2, u3 gates by combining
 a single gate.
 """
 
-import networkx as nx
 import numpy as np
 
 from qiskit.mapper import MapperError

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -111,7 +111,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
-        mapped_measure_qargs = set(mapped_dag.multi_graph.nodes(data=True)[op]['qargs'][0]
+        mapped_measure_qargs = set(mapped_dag.node(op)['qargs'][0]
                                    for op in mapped_dag.named_nodes('measure'))
 
         self.assertIn(mapped_measure_qargs,
@@ -141,7 +141,7 @@ class TestLookaheadSwap(QiskitTestCase):
 
         mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
 
-        mapped_barrier_qargs = [set(mapped_dag.multi_graph.nodes(data=True)[op]['qargs'])
+        mapped_barrier_qargs = [set(mapped_dag.node(op)['qargs'])
                                 for op in mapped_dag.named_nodes('barrier')][0]
 
         self.assertIn(mapped_barrier_qargs,


### PR DESCRIPTION
This PR removes the direct access to `dag.multi_graph.nodes` by extending the DAG API with `nodes()`.