### PR TITLE
Fix DAGCircuit.collect_runs()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -87,7 +87,8 @@ Deprecated
 Fixed
 -----
 
-- Fixed #1892, whereby inheriting from QuantumRegister or ClassicalRegister would cause a QiskitError in instruction.py
+- Fixed #1892, whereby inheriting from QuantumRegister or ClassicalRegister would
+  cause a QiskitError in instruction.py (#1908).
 - Fixed #829 by removing dependence on scipy unitary_group (#1857).
 - Fixed a bug with measurement sampling optimization in BasicAer
   qasm_simulator (#1624).
@@ -99,6 +100,8 @@ Fixed
 - Fixed a bug that with transpile ignoring initial layout when
   coupling map is provided (#1711).
 - Fixed a bug in the definition of the rzz gate (#1940).
+- Fixed a bug in DAGCircuit.collect_runs() that did not exclude conditional gates (#1943).
+
 
 Removed
 -------

--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -1336,7 +1336,7 @@ class DAGCircuit:
             next_layer = []
 
     def collect_runs(self, namelist):
-        """Return a set of runs of "op" nodes with the given names.
+        """Return a set of non-conditional runs of "op" nodes with the given names.
 
         For example, "... h q[0]; cx q[0],q[1]; cx q[0],q[1]; h q[1]; .."
         would produce the tuple of cx nodes as an element of the set returned
@@ -1357,7 +1357,7 @@ class DAGCircuit:
         for node in tops_node:
             nd = self.multi_graph.node[node]
             if nd["type"] == "op" and nd["name"] in namelist \
-                    and not nodes_seen[node]:
+                    and nd["condition"] is None and not nodes_seen[node]:
                 group = [node]
                 nodes_seen[node] = True
                 s = list(self.multi_graph.successors(node))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1871 Fixes #1820 

`dag.collect_runs()` should only collect runs of gates that are non-conditional, otherwise the optimizations that are based on them won't work.


