### PR TITLE
Fix qobj.experiment.instructions.parameters serialization

### DIFF
--- a/qiskit/qobj/models.py
+++ b/qiskit/qobj/models.py
@@ -10,7 +10,8 @@
 from marshmallow.validate import Length, Range, Regexp
 
 from qiskit.validation.base import BaseModel, BaseSchema, bind_schema
-from qiskit.validation.fields import Integer, List, Nested, Raw, String
+from qiskit.validation.fields import (Integer, List, Nested, String,
+                                      InstructionParameter)
 
 
 class QobjConditionalSchema(BaseSchema):
@@ -31,7 +32,7 @@ class QobjInstructionSchema(BaseSchema):
     # Optional properties.
     qubits = List(Integer(validate=Range(min=0)),
                   validate=Length(min=1))
-    params = List(Raw())
+    params = List(InstructionParameter())
     memory = List(Integer(validate=Range(min=0)),
                   validate=Length(min=1))
     conditional = Nested(QobjConditionalSchema)

--- a/qiskit/validation/fields/__init__.py
+++ b/qiskit/validation/fields/__init__.py
@@ -12,8 +12,8 @@ When extending this module with new Fields:
     1. Distinguish a new type, like the ``Complex`` number in this module.
     2. Use a new Marshmallow field not used in ``qiskit`` yet.
 
-Marshamallow fields does not allow model validation so you need to create a new
-field, make it subclass of the Marshamallow field *and* ``ModelTypeValidator``,
+Marshmallow fields does not allow model validation so you need to create a new
+field, make it subclass of the Marshmallow field *and* ``ModelTypeValidator``,
 and redefine ``valid_types`` to be the list of valid types. Usually, **the
 same types this field deserializes to**. For instance::
 
@@ -24,45 +24,16 @@ same types this field deserializes to**. For instance::
 
 See ``ModelTypeValidator`` for more subclassing options.
 """
+
 from datetime import date, datetime
 
 from marshmallow import fields as _fields
-from marshmallow.utils import is_collection
 
 from qiskit.validation import ModelTypeValidator
 from qiskit.validation.fields.polymorphic import ByAttribute, ByType, TryFrom
 from qiskit.validation.fields.containers import Nested, List
 
-
-class Complex(ModelTypeValidator):
-    """Field for complex numbers.
-
-    Field for parsing complex numbers:
-    * deserializes to Python's `complex`.
-    * serializes to a tuple of 2 decimals `(real, imaginary)`
-    """
-
-    valid_types = (complex, )
-
-    default_error_messages = {
-        'invalid': '{input} cannot be parsed as a complex number.',
-        'format': '"{input}" cannot be formatted as complex number.',
-    }
-
-    def _serialize(self, value, attr, obj):
-        try:
-            return [value.real, value.imag]
-        except AttributeError:
-            self.fail('format', input=value)
-
-    def _deserialize(self, value, attr, data):
-        if not is_collection(value) or len(value) != 2:
-            self.fail('invalid', input=value)
-
-        try:
-            return complex(*value)
-        except (ValueError, TypeError):
-            self.fail('invalid', input=value)
+from .custom import Complex, InstructionParameter
 
 
 class String(_fields.String, ModelTypeValidator):

--- a/qiskit/validation/fields/custom.py
+++ b/qiskit/validation/fields/custom.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Fields custom to Terra to be used with Qiskit validated classes."""
+
+import numpy
+import sympy
+
+from marshmallow.utils import is_collection
+
+from qiskit.validation import ModelTypeValidator
+
+
+class Complex(ModelTypeValidator):
+    """Field for complex numbers.
+
+    Field for parsing complex numbers:
+    * deserializes to Python's `complex`.
+    * serializes to a tuple of 2 decimals `(real, imaginary)`
+    """
+
+    valid_types = (complex, )
+
+    default_error_messages = {
+        'invalid': '{input} cannot be parsed as a complex number.',
+        'format': '"{input}" cannot be formatted as complex number.',
+    }
+
+    def _serialize(self, value, attr, obj):
+        try:
+            return [value.real, value.imag]
+        except AttributeError:
+            self.fail('format', input=value)
+
+    def _deserialize(self, value, attr, data):
+        if not is_collection(value) or len(value) != 2:
+            self.fail('invalid', input=value)
+
+        try:
+            return complex(*value)
+        except (ValueError, TypeError):
+            self.fail('invalid', input=value)
+
+
+class InstructionParameter(ModelTypeValidator):
+    """Field for objects used in instruction parameters.
+
+    This field provides support for parsing objects of types that uses by
+    qobj.experiments.instructions.parameters:
+    * basic Python types: complex, int, float, str
+    * ``numpy``: integer, float
+    * ``sympy``: Symbol, Basic
+
+    Note that by using this field, serialization-deserialization round-tripping
+    becomes not possible, as certain types serialize to the same Python basic
+    type (for example, numpy.float and regular float). If possible, it is
+    recommended that more specific and defined fields are used instead.
+    """
+    valid_types = (complex, int, float, str,
+                   numpy.integer, numpy.float, sympy.Basic, sympy.Symbol)
+
+    def _serialize(self, value, attr, obj):
+        # pylint: disable=too-many-return-statements
+        if isinstance(value, (float, int, str)):
+            return value
+        if isinstance(value, complex):
+            return [value.real, value.imag]
+        if isinstance(value, numpy.integer):
+            return int(value)
+        if isinstance(value, numpy.float):
+            return float(value)
+        if isinstance(value, sympy.Symbol):
+            return str(value)
+        if isinstance(value, sympy.Basic):
+            if value.is_imaginary:
+                return [float(sympy.re(value)), float(sympy.im(value))]
+            else:
+                return float(value.evalf())
+
+        return self.fail('invalid', input=value)
+
+    def _deserialize(self, value, attr, data):
+        if is_collection(value) and len(value) != 2:
+            return complex(*value)
+
+        return value

--- a/test/python/aer_provider_integration_test/test_extensions_simulator.py
+++ b/test/python/aer_provider_integration_test/test_extensions_simulator.py
@@ -26,7 +26,6 @@ class TestExtensionsSimulator(QiskitTestCase):
     """
     _desired_fidelity = 0.99
 
-    @unittest.expectedFailure
     def test_snapshot(self):
         """snapshot a bell state in the middle of circuit"""
         basis_gates = ['cx', 'u1', 'u2', 'u3', 'snapshot']

--- a/test/python/aer_provider_integration_test/test_qasm_simulator.py
+++ b/test/python/aer_provider_integration_test/test_qasm_simulator.py
@@ -78,7 +78,6 @@ class TestAerQasmSimulator(QiskitTestCase):
         self.assertEqual(counts_if_true, {'111': 100})
         self.assertEqual(counts_if_false, {'001': 100})
 
-    @unittest.expectedFailure
     def test_teleport(self):
         """test teleportation as in tutorials"""
         self.log.info('test_teleport')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix #1951

Add a new validation field to handle the different types that can be used in `instruction.parameters`, that were causing serialization issues, using it instead of `Raw()`, re-enabling the tests xfailed in 1909.

### Details and comments

The root cause was that the Qobj ended up containing objects that could not be serialized by the default `json` serializer (numpy and sympy constructs) - if other fields are loosely defined in other parts of the spec, we should look into it further and extend this custom field, ensure that the producers of `Qobj` guarantee that the types used are known and serializable, or actually consider being more restrictive in the specs.

