### PR TITLE
[Requires Aer 0.2] Backends have coupling_map and basis_gates properties

### DIFF
--- a/qiskit/providers/basebackend.py
+++ b/qiskit/providers/basebackend.py
@@ -42,12 +42,12 @@ class BaseBackend(ABC):
     def coupling_map(self):
         """Coupling map for the backend."""
         return self._configuration.coupling_map
-    
+
     @property
     def basis_gates(self):
         """Basis gates for the backend."""
         return self._configuration.basis_gates
-    
+
     @abstractmethod
     def run(self, qobj):
         """Run a Qobj on the the backend."""

--- a/qiskit/providers/basebackend.py
+++ b/qiskit/providers/basebackend.py
@@ -38,6 +38,16 @@ class BaseBackend(ABC):
         self._configuration = configuration
         self._provider = provider
 
+    @property
+    def coupling_map(self):
+        """Coupling map for the backend."""
+        return self._configuration.coupling_map
+    
+    @property
+    def basis_gates(self):
+        """Basis gates for the backend."""
+        return self._configuration.basis_gates
+    
     @abstractmethod
     def run(self, qobj):
         """Run a Qobj on the the backend."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR allows users to directly get a backends `coupling_map` and `basis_gates` as properties.  This is done because these two quantities are the minimum required properties for mapping a circuit to hardware.

### Details and comments
At present, `Aer` backends do not have `coupling_map` (https://github.com/Qiskit/qiskit-aer/issues/87).  However, the qiskit specification says that `coupling_map` is a required entry in the `backend.configuration`, along with `basis_gates`.  Given that both are required, the corresponding backend properties should always exist.

