### PR TITLE
Removing pass instance cache

### DIFF
--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -23,11 +23,9 @@ class MetaPass(type):
         if '_pass_cache' not in cls.__dict__.keys():
             cls._pass_cache = {}
         args, kwargs = cls.normalize_parameters(*args, **kwargs)
-        hash_ = hash(MetaPass._freeze_init_parameters(cls.__init__, args, kwargs))
-        if hash_ not in cls._pass_cache:
-            new_pass = type.__call__(cls, *args, **kwargs)
-            cls._pass_cache[hash_] = new_pass
-        return cls._pass_cache[hash_]
+        pass_instance = type.__call__(cls, *args, **kwargs)
+        pass_instance._hash = hash(MetaPass._freeze_init_parameters(cls.__init__, args, kwargs))
+        return pass_instance
 
     @staticmethod
     def _freeze_init_parameters(init_method, args, kwargs):
@@ -66,6 +64,12 @@ class BasePass(metaclass=MetaPass):
             tuple: normalized (list(args), dict(kwargs))
         """
         return args, kwargs
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     def name(self):
         """ The name of the pass. """

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -22,7 +22,6 @@ class MetaPass(type):
     def __call__(cls, *args, **kwargs):
         if '_pass_cache' not in cls.__dict__.keys():
             cls._pass_cache = {}
-        args, kwargs = cls.normalize_parameters(*args, **kwargs)
         pass_instance = type.__call__(cls, *args, **kwargs)
         pass_instance._hash = hash(MetaPass._freeze_init_parameters(cls, args, kwargs))
         return pass_instance
@@ -32,7 +31,7 @@ class MetaPass(type):
         self_guard = object()
         init_signature = signature(class_.__init__)
         bound_signature = init_signature.bind(self_guard, *args, **kwargs)
-        arguments = [('__qualname__', class_.__name__)]
+        arguments = [('class_.__name__', class_.__name__)]
         for name, value in bound_signature.arguments.items():
             if value == self_guard:
                 continue
@@ -51,20 +50,6 @@ class BasePass(metaclass=MetaPass):
         self.preserves = []  # List of passes that preserves
         self.property_set = PropertySet()  # This pass's pointer to the pass manager's property set.
         self._hash = None
-
-    @classmethod
-    def normalize_parameters(cls, *args, **kwargs):
-        """
-        Because passes with the same args/kwargs are considered the same, this method allows to
-        modify the args/kargs to respect that identity.
-        Args:
-            *args: args to normalize
-            **kwargs: kwargs to normalize
-
-        Returns:
-            tuple: normalized (list(args), dict(kwargs))
-        """
-        return args, kwargs
 
     def __hash__(self):
         return self._hash

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -24,15 +24,15 @@ class MetaPass(type):
             cls._pass_cache = {}
         args, kwargs = cls.normalize_parameters(*args, **kwargs)
         pass_instance = type.__call__(cls, *args, **kwargs)
-        pass_instance._hash = hash(MetaPass._freeze_init_parameters(cls.__init__, args, kwargs))
+        pass_instance._hash = hash(MetaPass._freeze_init_parameters(cls, args, kwargs))
         return pass_instance
 
     @staticmethod
-    def _freeze_init_parameters(init_method, args, kwargs):
+    def _freeze_init_parameters(cls, args, kwargs):
         self_guard = object()
-        init_signature = signature(init_method)
+        init_signature = signature(cls.__init__)
         bound_signature = init_signature.bind(self_guard, *args, **kwargs)
-        arguments = []
+        arguments = [('__qualname__', cls.__name__)]
         for name, value in bound_signature.arguments.items():
             if value == self_guard:
                 continue

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -28,11 +28,11 @@ class MetaPass(type):
         return pass_instance
 
     @staticmethod
-    def _freeze_init_parameters(cls, args, kwargs):
+    def _freeze_init_parameters(class_, args, kwargs):
         self_guard = object()
-        init_signature = signature(cls.__init__)
+        init_signature = signature(class_.__init__)
         bound_signature = init_signature.bind(self_guard, *args, **kwargs)
-        arguments = [('__qualname__', cls.__name__)]
+        arguments = [('__qualname__', class_.__name__)]
         for name, value in bound_signature.arguments.items():
             if value == self_guard:
                 continue
@@ -50,6 +50,7 @@ class BasePass(metaclass=MetaPass):
         self.requires = []  # List of passes that requires
         self.preserves = []  # List of passes that preserves
         self.property_set = PropertySet()  # This pass's pointer to the pass manager's property set.
+        self._hash = None
 
     @classmethod
     def normalize_parameters(cls, *args, **kwargs):

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -20,8 +20,6 @@ class MetaPass(type):
     """
 
     def __call__(cls, *args, **kwargs):
-        if '_pass_cache' not in cls.__dict__.keys():
-            cls._pass_cache = {}
         pass_instance = type.__call__(cls, *args, **kwargs)
         pass_instance._hash = hash(MetaPass._freeze_init_parameters(cls, args, kwargs))
         return pass_instance

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -193,3 +193,19 @@ class PassK_check_fixed_point_property(DummyAP, FixedPoint):
     def run(self, dag):
         for base in PassK_check_fixed_point_property.__bases__:
             base.run(self, dag)
+
+class PassM_AP_NR_NP(DummyAP):
+    """ A dummy analysis pass that modifies internal state at runtime
+    AP: Analysis Pass
+    NR: No Requires
+    NP: No Preserves
+    """
+
+    def __init__(self, argument1):
+        super().__init__()
+        self.argument1 = argument1
+
+    def run(self, dag):
+        super().run(dag)
+        self.argument1 *= 2
+        logging.getLogger(logger).info('self.argument1 = %s', self.argument1)

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -194,6 +194,7 @@ class PassK_check_fixed_point_property(DummyAP, FixedPoint):
         for base in PassK_check_fixed_point_property.__bases__:
             base.run(self, dag)
 
+
 class PassM_AP_NR_NP(DummyAP):
     """ A dummy analysis pass that modifies internal state at runtime
     AP: Analysis Pass

--- a/test/python/transpiler/test_generic_pass.py
+++ b/test/python/transpiler/test_generic_pass.py
@@ -44,6 +44,12 @@ class TestGenericPass(QiskitTestCase):
         pass2 = PassD_TP_NR_NP(argument1=[2, 1])
         self.assertNotEqual(pass1, pass2)
 
+    def test_pass_args_kwargs(self):
+        """ Same pass if same args and kwargs"""
+        pass1 = PassD_TP_NR_NP(argument1=[1, 2])
+        pass2 = PassD_TP_NR_NP([1, 2])
+        self.assertEqual(pass1, pass2)
+
     def test_pass_kwargs_out_of_order(self):
         """ Passes instances with same arguments (independently of the order) are the same"""
         pass1 = PassD_TP_NR_NP(argument1=1, argument2=2)

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -282,7 +282,7 @@ class TestUseCases(SchedulerTestCase):
                                    TranspilerAccessError)
 
     def test_ignore_request_pm(self):
-        """ A pass manager that ignores requests does not run the passes decleared in the 'requests'
+        """ A pass manager that ignores requires does not run the passes decleared in the 'requires'
         field of the passes."""
         passmanager = PassManager(ignore_requires=True)
         passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -22,7 +22,7 @@ from qiskit.test import QiskitTestCase
 from ._dummy_passes import (PassA_TP_NR_NP, PassB_TP_RA_PA, PassC_TP_RA_PA,
                             PassD_TP_NR_NP, PassE_AP_NR_NP, PassF_reduce_dag_property,
                             PassH_Bad_TP, PassI_Bad_AP, PassJ_Bad_NoReturn,
-                            PassK_check_fixed_point_property)
+                            PassK_check_fixed_point_property, PassM_AP_NR_NP)
 
 logger = "LocalLogger"
 
@@ -445,6 +445,17 @@ class TestUseCases(SchedulerTestCase):
                                     'run transformation pass PassA_TP_NR_NP',
                                     'run transformation pass PassF_reduce_dag_property',
                                     'dag property = 5'], TranspilerError)
+
+    def test_fresh_initial_state(self):
+        """ New construction gives fresh instance """
+        self.passmanager.append(PassM_AP_NR_NP(argument1=1))
+        self.passmanager.append(PassA_TP_NR_NP())
+        self.passmanager.append(PassM_AP_NR_NP(argument1=1))
+        self.assertScheduler(self.dag, self.passmanager, ['run analysis pass PassM_AP_NR_NP',
+                                                          'self.argument1 = 2',
+                                                          'run transformation pass PassA_TP_NR_NP',
+                                                          'run analysis pass PassM_AP_NR_NP',
+                                                          'self.argument1 = 2'])
 
 
 class DoXTimesController(FlowController):


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit-terra/issues/1769

This PR removes the pass instance cache that was creating obscure and hard to trace bugs. It's replaced by the usual `__hash__` and `__eq__` approach. 