### PR TITLE
text drawer "modifies" the circuit

### DIFF
--- a/qiskit/tools/visualization/_text.py
+++ b/qiskit/tools/visualization/_text.py
@@ -865,6 +865,7 @@ class Layer:
 
     def _set_multibox(self, wire_type, bits, label, top_connect=None):
         # pylint: disable=invalid-name
+        bits = list(bits)
         if wire_type == "cl":
             bit_index = sorted([i for i, x in enumerate(self.cregs) if x in bits])
             bits.sort(key=self.cregs.index)


### PR DESCRIPTION
@ajavadia noticed that, after https://github.com/Qiskit/qiskit-terra/pull/1962, the text drawer "modifies" the `qargs` of gates in the circuit.

Indeed, that's happen because I'm doing a pop of a varialble `bits`, that is a pointer to the gate's `[q|c]args`: https://github.com/Qiskit/qiskit-terra/pull/1962/files#diff-600b5035095fd43ac99cc06b82d2b902R893

This PR makes sure that the array `bit` gets a fresh pointer before juggling with it.