### PR TITLE
Support `None` for simulator backend coupling_map

### DIFF
--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -50,6 +50,12 @@ class QasmSimulatorPy(BaseBackend):
 
     MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
+    CMAP = []
+    for i in range(min(24, MAX_QUBITS_MEMORY)):
+        for j in range(min(24, MAX_QUBITS_MEMORY)):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
         'backend_version': '2.0.0',
@@ -61,6 +67,7 @@ class QasmSimulatorPy(BaseBackend):
         'open_pulse': False,
         'memory': True,
         'max_shots': 65536,
+        'coupling_map': CMAP,
         'description': 'A python simulator for qasm experiments',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'unitary'],
         'gates': [

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -50,12 +50,6 @@ class QasmSimulatorPy(BaseBackend):
 
     MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
-    CMAP = []
-    for i in range(min(24, MAX_QUBITS_MEMORY)):
-        for j in range(min(24, MAX_QUBITS_MEMORY)):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
         'backend_version': '2.0.0',
@@ -67,7 +61,7 @@ class QasmSimulatorPy(BaseBackend):
         'open_pulse': False,
         'memory': True,
         'max_shots': 65536,
-        'coupling_map': CMAP,
+        'coupling_map': None,
         'description': 'A python simulator for qasm experiments',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'unitary'],
         'gates': [

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -35,12 +35,6 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
 
     MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
-    CMAP = []
-    for i in range(min(24, MAX_QUBITS_MEMORY)):
-        for j in range(min(24, MAX_QUBITS_MEMORY)):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
         'backend_version': '1.0.0',
@@ -52,7 +46,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         'open_pulse': False,
         'memory': True,
         'max_shots': 65536,
-        'coupling_map': CMAP,
+        'coupling_map': None,
         'description': 'A Python statevector simulator for qobj files',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'snapshot'],
         'gates': [

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -35,6 +35,12 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
 
     MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
 
+    CMAP = []
+    for i in range(min(24, MAX_QUBITS_MEMORY)):
+        for j in range(min(24, MAX_QUBITS_MEMORY)):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
         'backend_version': '1.0.0',
@@ -46,6 +52,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         'open_pulse': False,
         'memory': True,
         'max_shots': 65536,
+        'coupling_map': CMAP,
         'description': 'A Python statevector simulator for qobj files',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'snapshot'],
         'gates': [

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -48,12 +48,6 @@ class UnitarySimulatorPy(BaseBackend):
 
     MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
-    CMAP = []
-    for i in range(min(24, MAX_QUBITS_MEMORY)):
-        for j in range(min(24, MAX_QUBITS_MEMORY)):
-            if i != j:
-                CMAP.append([i, j])
-
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': '1.0.0',
@@ -65,7 +59,7 @@ class UnitarySimulatorPy(BaseBackend):
         'open_pulse': False,
         'memory': False,
         'max_shots': 65536,
-        'coupling_map': CMAP,
+        'coupling_map': None,
         'description': 'A python simulator for unitary matrix corresponding to a circuit',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id'],
         'gates': [

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -48,6 +48,12 @@ class UnitarySimulatorPy(BaseBackend):
 
     MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()['memory'] * (1024 ** 3) / 16)))
 
+    CMAP = []
+    for i in range(min(24, MAX_QUBITS_MEMORY)):
+        for j in range(min(24, MAX_QUBITS_MEMORY)):
+            if i != j:
+                CMAP.append([i, j])
+
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
         'backend_version': '1.0.0',
@@ -59,6 +65,7 @@ class UnitarySimulatorPy(BaseBackend):
         'open_pulse': False,
         'memory': False,
         'max_shots': 65536,
+        'coupling_map': CMAP,
         'description': 'A python simulator for unitary matrix corresponding to a circuit',
         'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id'],
         'gates': [

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -56,7 +56,7 @@ class BackendConfigurationSchema(BaseSchema):
     sample_name = String()
     coupling_map = List(List(Integer(),
                              validate=Length(min=1)),
-                        validate=Length(min=1))
+                        validate=Length(min=1), allow_none=True)
     n_registers = Integer(validate=Range(min=1))
     register_map = List(List(Integer(validate=OneOf([0, 1])),
                              validate=Length(min=1)),

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -63,7 +63,7 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
     if coupling_map:
         coupling_map = coupling_map
     elif backend:
-        coupling_map = backend.configuration().coupling_map
+        coupling_map = getattr(backend.configuration(), 'coupling_map', None)
         dev_qubits = backend.configuration().n_qubits
     else:
         coupling_map = None

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -182,7 +182,7 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
 
     # TODO: move this to the mapper pass
     num_qubits = sum([qreg.size for qreg in dag.qregs.values()])
-    if num_qubits == 1 or coupling_map == "all-to-all":
+    if num_qubits == 1 or len(coupling_map) == num_qubits*(num_qubits-1):
         coupling_map = None
 
     if basis_gates is None:

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -63,6 +63,10 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
     if coupling_map:
         coupling_map = coupling_map
     elif backend:
+        # This needs to be changed not to allow a fall back to None.
+        # This has to be here otherwise tests will fail until Aer gets
+        # updates, but I cannot update Aer until the all-to-all check
+        # is in place.
         coupling_map = getattr(backend.configuration(), 'coupling_map', None)
         dev_qubits = backend.configuration().n_qubits
     else:

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -186,7 +186,11 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
 
     # TODO: move this to the mapper pass
     num_qubits = sum([qreg.size for qreg in dag.qregs.values()])
-    if num_qubits == 1 or len(coupling_map) == num_qubits*(num_qubits-1):
+    # Check if coupling map is an all-to-all mapping.
+    is_all_to_all = False
+    if coupling_map:
+        is_all_to_all = len(coupling_map) == num_qubits*(num_qubits-1)
+    if num_qubits == 1 or is_all_to_all:
         coupling_map = None
 
     if basis_gates is None:

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -58,25 +58,14 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
         return_form_is_single = True
 
     # Check for valid parameters for the experiments.
-    dev_qubits = None
     basis_gates = basis_gates or backend.configuration().basis_gates
     if coupling_map:
         coupling_map = coupling_map
     elif backend:
-        # This needs to be changed not to allow a fall back to None.
-        # This has to be here otherwise tests will fail until Aer gets
-        # updates, but I cannot update Aer until the all-to-all check
-        # is in place.
+        # This needs to be removed once Aer 0.2 is out
         coupling_map = getattr(backend.configuration(), 'coupling_map', None)
-        dev_qubits = backend.configuration().n_qubits
     else:
         coupling_map = None
-
-    # Check if coupling_map is all to all
-    # If so, set coupling_map = None which was old way for simulators
-    if coupling_map and dev_qubits:
-        if len(coupling_map) == dev_qubits*(dev_qubits-1):
-            coupling_map = None
 
     if not basis_gates:
         raise TranspilerError('no basis_gates or backend to compile to')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`transpile` now works correctly for simulators with `coupling_map` as required by the qiskit spec.  `BasicAer` simulators now have `coupling_map` attributes in their configuration files


### Details and comments
This PR is required for https://github.com/Qiskit/qiskit-aer/pull/93 to pass as well.
