### PR TITLE
MatplotlibDrawer: Fix gate parameter display

### DIFF
--- a/qiskit/tools/visualization/_matplotlib.py
+++ b/qiskit/tools/visualization/_matplotlib.py
@@ -537,7 +537,7 @@ class MatplotlibDrawer:
                 if verbose:
                     print(op)
 
-                if 'op' in op.keys() and hasattr(op['op'], 'param'):
+                if 'op' in op.keys() and hasattr(op['op'], 'params'):
                     param = self.param_parse(op['op'].params, self._style.pimode)
                 else:
                     param = None


### PR DESCRIPTION
### Summary

The `MatplotlibDrawer` would never show gate parameters due to a typo in the `params` attribute detection.

`matplotlib_ref.png` in the visualization tests will need updating. The image output of matplotlib on my (macOS) machine seems to differ slightly from where the file was last generated, however, and the respective tests aren't run by default anyway, so I left it for now.