### PR TITLE
Tidyup CouplingMap and give it a repr

### DIFF
--- a/qiskit/mapper/coupling.py
+++ b/qiskit/mapper/coupling.py
@@ -177,6 +177,10 @@ class CouplingMap:
             raise CouplingError(
                 "Nodes %s and %s are not connected" % (str(physical_qubit1), str(physical_qubit2)))
 
+    def __repr__(self):
+        """Return representation of the coupling graph."""
+        return 'CouplingMap({})'.format(self.__str__())
+
     def __str__(self):
         """Return a string representation of the coupling graph."""
         string = ""

--- a/qiskit/mapper/coupling.py
+++ b/qiskit/mapper/coupling.py
@@ -57,9 +57,9 @@ class CouplingMap:
         Gets the list of edges in the coupling graph.
 
         Returns:
-            Tuple(int,int): Each edge is a pair of physical qubits.
+            List(int,int): Each edge is a pair of physical qubits.
         """
-        return [edge for edge in self.graph.edges()]
+        return [[edge[0], edge[1]] for edge in self.graph.edges()]
 
     def add_physical_qubit(self, physical_qubit):
         """Add a physical qubit to the coupling graph as a node.

--- a/qiskit/mapper/coupling.py
+++ b/qiskit/mapper/coupling.py
@@ -179,13 +179,14 @@ class CouplingMap:
 
     def __repr__(self):
         """Return representation of the coupling graph."""
-        return 'CouplingMap({})'.format(self.__str__())
-
-    def __str__(self):
-        """Return a string representation of the coupling graph."""
-        string = ""
-        if self.get_edges():
-            string += "["
-            string += ", ".join(["[%s, %s]" % (src, dst) for (src, dst) in self.get_edges()])
-            string += "]"
-        return string
+        str_list = []
+        count = 0
+        for edge in self.get_edges():
+            if count == 9:
+                ending = "\n"
+                count = 0
+            else:
+                ending = ""
+            str_list.append("[{}, {}], {}".format(edge[0], edge[1], ending))
+            count += 1
+        return 'CouplingMap([\n'+"".join(str_list)+"\n])"

--- a/qiskit/transpiler/passes/mapping/check_cnot_direction.py
+++ b/qiskit/transpiler/passes/mapping/check_cnot_direction.py
@@ -54,7 +54,7 @@ class CheckCnotDirection(AnalysisPass):
             physical_q0 = self.layout[gate['qargs'][0]]
             physical_q1 = self.layout[gate['qargs'][1]]
 
-            if isinstance(gate['op'], (CXBase, CnotGate)) and (
-                    physical_q0, physical_q1) not in edges:
+            if isinstance(gate['op'], (CXBase, CnotGate)) and [
+                    physical_q0, physical_q1] not in edges:
                 self.property_set['is_direction_mapped'] = False
                 return

--- a/qiskit/transpiler/passes/mapping/cx_direction.py
+++ b/qiskit/transpiler/passes/mapping/cx_direction.py
@@ -75,7 +75,7 @@ class CXDirection(TransformationPass):
                     raise TranspilerError('The circuit requires a connection between physical '
                                           'qubits %s and %s' % (physical_q0, physical_q1))
 
-                if (physical_q0, physical_q1) not in self.coupling_map.get_edges():
+                if [physical_q0, physical_q1] not in self.coupling_map.get_edges():
                     # A flip needs to be done
 
                     # Create the involved registers

--- a/test/python/test_mapper_coupling.py
+++ b/test/python/test_mapper_coupling.py
@@ -19,16 +19,16 @@ class CouplingTest(QiskitTestCase):
         self.assertEqual([], coupling.physical_qubits)
         self.assertEqual([], coupling.get_edges())
         self.assertFalse(coupling.is_connected())
-        self.assertEqual("", str(coupling))
+        self.assertEqual([], coupling.get_edges())
 
     def test_coupling_str(self):
         coupling_list = [[0, 1], [0, 2], [1, 2]]
         coupling = CouplingMap(coupling_list)
-        expected = ("[[0, 1], [0, 2], [1, 2]]")
-        self.assertEqual(expected, str(coupling))
+        expected = [[0, 1], [0, 2], [1, 2]]
+        self.assertEqual(expected, coupling.get_edges())
 
     def test_coupling_distance(self):
-        coupling_list = [(0, 1), (0, 2), (1, 2)]
+        coupling_list = [[0, 1], [0, 2], [1, 2]]
         coupling = CouplingMap(coupling_list)
         self.assertTrue(coupling.is_connected())
         physical_qubits = coupling.physical_qubits
@@ -37,10 +37,10 @@ class CouplingTest(QiskitTestCase):
 
     def test_add_physical_qubits(self):
         coupling = CouplingMap()
-        self.assertEqual("", str(coupling))
+        self.assertEqual([], coupling.get_edges())
         coupling.add_physical_qubit(0)
         self.assertEqual([0], coupling.physical_qubits)
-        self.assertEqual("", str(coupling))
+        self.assertEqual([], coupling.get_edges())
 
     def test_add_physical_qubits_not_int(self):
         coupling = CouplingMap()
@@ -48,10 +48,10 @@ class CouplingTest(QiskitTestCase):
 
     def test_add_edge(self):
         coupling = CouplingMap()
-        self.assertEqual("", str(coupling))
+        self.assertEqual([], coupling.get_edges())
         coupling.add_edge(0, 1)
-        expected = ("[[0, 1]]")
-        self.assertEqual(expected, str(coupling))
+        expected = [[0, 1]]
+        self.assertEqual(expected, coupling.get_edges())
 
     def test_distance_error(self):
         """Test distance between unconected physical_qubits."""
@@ -65,7 +65,7 @@ class CouplingTest(QiskitTestCase):
         coupling = CouplingMap(coupling_list)
 
         qubits_expected = [0, 1, 2]
-        edges_expected = [(0, 1), (1, 2)]
+        edges_expected = [[0, 1], [1, 2]]
 
         self.assertEqual(coupling.physical_qubits, qubits_expected)
         self.assertEqual(coupling.get_edges(), edges_expected)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `CouplingMap` class was using a list of tuples for the edges rather than the nested list data structure that we use for all of our coupling maps.  This PR makes `CouplingMap` in line with this choice of coupling representation.  In addition, the `CouplingMap` tests were testing against the string representation of the class rather than against the coupling data itself.  This is fixed as well. Finally, `CouplingMap` has repr.

```python

CouplingMap([
[1, 0], [1, 2], [2, 3], [4, 3], [4, 10], [5, 4], [5, 6], [5, 9], [6, 8], [9, 8], 
[9, 10], [7, 8], [11, 3], [11, 10], [11, 12], [12, 2], [13, 1], [13, 12], 
])
```

### Details and comments


