### PR TITLE
Updated apply_operation_front/back to return DAGNodes

### DIFF
--- a/qiskit/dagcircuit/_dagcircuit.py
+++ b/qiskit/dagcircuit/_dagcircuit.py
@@ -307,7 +307,7 @@ class DAGCircuit:
             condition (tuple or None): optional condition (ClassicalRegister, int)
 
         Returns:
-            int: the current max node id
+            DAGNode: the current max node
 
         Raises:
             DAGCircuitError: if a leaf node is connected to multiple outputs
@@ -339,7 +339,8 @@ class DAGCircuit:
             self.multi_graph.remove_edge(ie[0], self.output_map[q])
             self.multi_graph.add_edge(self._id_to_node[self._max_node_id], self.output_map[q],
                                       name="%s[%s]" % (q[0].name, q[1]), wire=q)
-        return self._max_node_id
+
+        return self._id_to_node[self._max_node_id]
 
     def apply_operation_front(self, op, qargs=None, cargs=None, condition=None):
         """Apply an operation to the input of the circuit.
@@ -352,7 +353,7 @@ class DAGCircuit:
             condition (tuple or None): optional condition (ClassicalRegister, value)
 
         Returns:
-            int: the current max node id
+            DAGNode: the current max node
 
         Raises:
             DAGCircuitError: if initial nodes connected to multiple out edges
@@ -380,7 +381,7 @@ class DAGCircuit:
             self.multi_graph.add_edge(self.input_map[q], self._id_to_node[self._max_node_id],
                                       name="%s[%s]" % (q[0].name, q[1]), wire=q)
 
-        return self._max_node_id
+        return self._id_to_node[self._max_node_id]
 
     def _check_edgemap_registers(self, edge_map, keyregs, valregs, valreg=True):
         """Check that wiremap neither fragments nor leaves duplicate registers.

--- a/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
@@ -74,7 +74,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
         our_descendants = barrier_layer.descendants(new_barrier_node)
         our_qubits = final_qubits
 
-        existing_barriers = barrier_layer.named_nodes('barrier')
+        existing_barriers = sorted(barrier_layer.named_nodes('barrier'))
         # remove element from the list
         for i, node in enumerate(existing_barriers):
             if node == new_barrier_node:

--- a/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
@@ -55,7 +55,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
 
                            for final_op in final_ops)
 
-        new_barrier_id = barrier_layer.apply_operation_back(Barrier(qubits=final_qubits))
+        new_barrier_node = barrier_layer.apply_operation_back(Barrier(qubits=final_qubits))
 
         # Preserve order of final ops collected earlier from the original DAG.
         ordered_final_nodes = [node for node in dag.nodes_in_topological_order()
@@ -70,14 +70,14 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
 
         # Check to see if the new barrier added to the DAG is equivalent to any
         # existing barriers, and if so, consolidate the two.
-        our_ancestors = barrier_layer.ancestors(new_barrier_id)
-        our_descendants = barrier_layer.descendants(new_barrier_id)
+        our_ancestors = barrier_layer.ancestors(new_barrier_node)
+        our_descendants = barrier_layer.descendants(new_barrier_node)
         our_qubits = final_qubits
 
         existing_barriers = barrier_layer.named_nodes('barrier')
         # remove element from the list
         for i, node in enumerate(existing_barriers):
-            if node._node_id == new_barrier_id:
+            if node == new_barrier_node:
                 del existing_barriers[i]
                 break
 
@@ -93,15 +93,15 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
                     and our_descendants.isdisjoint(their_ancestors)
             ):
                 merge_barrier = Barrier(qubits=(our_qubits | their_qubits))
-                merge_barrier_id = barrier_layer.apply_operation_front(merge_barrier)
+                merge_barrier_node = barrier_layer.apply_operation_front(merge_barrier)
 
                 our_ancestors = our_ancestors | their_ancestors
                 our_descendants = our_descendants | their_descendants
 
                 barrier_layer._remove_op_node(candidate_barrier)
-                barrier_layer._remove_op_node(new_barrier_id)
+                barrier_layer._remove_op_node(new_barrier_node)
 
-                new_barrier_id = merge_barrier_id
+                new_barrier_node = merge_barrier_node
 
         dag.extend_back(barrier_layer)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #1997 

Updates `apply_operation_front()` and `apply_operation_back()` to return `DAGNode`s instead of `node_id`s so that the returned value can then be used later on without getting a deprecation warning.


