### PR TITLE
compare Instructions params

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -91,7 +91,7 @@ class Instruction:
         res = False
         if type(self) is type(other) and \
                 self.name == other.name and \
-                self.params == other.params:
+                [float(param) for param in other.params] == [float(param) for param in self.params]:
             res = True
         return res
 

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -90,8 +90,9 @@ class Instruction:
         """
         res = False
         if type(self) is type(other) and \
-                self.name == other.name and \
-                [float(param) for param in other.params] == [float(param) for param in self.params]:
+                self.name == other.name and (self.params == other.params or
+                                             [float(param) for param in other.params] == [
+                                                 float(param) for param in self.params]):
             res = True
         return res
 

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -171,15 +171,14 @@ class Optimize1qGates(TransformationPass):
             if right_name == "u2":
                 new_op = U2Gate(right_parameters[1], right_parameters[2], run_qarg)
             if right_name == "u3":
-                new_op = U3Gate(*right_parameters, run_qarg)
-            dag.node(run[0])['name'] = right_name
-            dag.node(run[0])['op'] = new_op
+                new_op = U3Gate(right_parameters[0],  right_parameters[1], right_parameters[2], run_qarg)
+
+            dag.apply_operation_back(new_op)
 
             # Delete the other nodes in the run
-            for current_node in run[1:]:
+            for current_node in run:
                 dag._remove_op_node(current_node)
-            if right_name == "nop":
-                dag._remove_op_node(run[0])
+
         return dag
 
     @staticmethod

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -173,7 +173,8 @@ class Optimize1qGates(TransformationPass):
             if right_name == "u3":
                 new_op = U3Gate(right_parameters[0],  right_parameters[1], right_parameters[2], run_qarg)
 
-            dag.apply_operation_back(new_op)
+            if (right_name != 'nop'):
+                dag.apply_operation_back(new_op)
 
             # Delete the other nodes in the run
             for current_node in run:

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -22,7 +22,6 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.quantum_info.operators.quaternion import quaternion_from_euler
 from qiskit.transpiler.passes.unroller import Unroller
 
-
 _CHOP_THRESHOLD = 1e-15
 
 
@@ -48,7 +47,6 @@ class Optimize1qGates(TransformationPass):
                         or len(current_node.qargs) != 1
                         or current_node.qargs[0] != run_qarg
                         or left_name not in ["u1", "u2", "u3", "id"]):
-
                     raise MapperError("internal error")
                 if left_name == "u1":
                     left_parameters = (0, 0, current_node.op.params[0])
@@ -171,9 +169,10 @@ class Optimize1qGates(TransformationPass):
             if right_name == "u2":
                 new_op = U2Gate(right_parameters[1], right_parameters[2], run_qarg)
             if right_name == "u3":
-                new_op = U3Gate(right_parameters[0],  right_parameters[1], right_parameters[2], run_qarg)
+                new_op = U3Gate(right_parameters[0], right_parameters[1], right_parameters[2],
+                                run_qarg)
 
-            if (right_name != 'nop'):
+            if right_name != 'nop':
                 dag.apply_operation_back(new_op)
 
             # Delete the other nodes in the run

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -36,7 +36,6 @@ class TestOptimize1qGates(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
-    @unittest.expectedFailure
     def test_optimize_h_gates_pass_manager(self):
         """Transpile: qr:--[H]-[H]-[H]-- == qr:--[u2]-- """
         qr = QuantumRegister(1, 'qr')

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -105,9 +105,8 @@ class TestOptimize1qGates(QiskitTestCase):
         simplified_dag = Optimize1qGates().run(dag)
 
         params = set()
-        for node_id in simplified_dag.named_nodes('u1'):
-            node = simplified_dag.node(node_id)
-            params.add(node['op'].params[0])
+        for node in simplified_dag.named_nodes('u1'):
+            params.add(node.op.params[0])
 
         expected_params = {sympy.Number(-3 * np.pi / 2),
                            sympy.Number(1.0 + 0.55 * np.pi),

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -115,7 +115,6 @@ class TestOptimize1qGates(QiskitTestCase):
 
         self.assertEqual(params, expected_params)
 
-    @unittest.expectedFailure
     def test_ignores_conditional_rotations(self):
         """Conditional rotations should not be considered in the chain.
 


### PR DESCRIPTION
Partially fixes #1989 (the `test.python.transpiler.test_optimize_1q_gates.TestOptimize1qGates.test_optimize_h_gates_pass_manager` case)

The `sympy.py` value needs to match the float version of pi:
```
> sympy.pi == 3.141592653589793                                                                
False

> float(sympy.pi) == float(3.141592653589793)                                                  
True
```

The second element of this patch is that the instruction `snapshot` creates params with symbols (i.e. `[1.00000000000000, statevector]`, so literal comparison (as before) is needed too.