### PR TITLE
Optimize1qGates change node "in-place"

### DIFF
--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -22,7 +22,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.quantum_info.operators.quaternion import quaternion_from_euler
 from qiskit.transpiler.passes.unroller import Unroller
 from qiskit.dagcircuit import DAGCircuit
-from qiskit import QuantumRegister
+from qiskit.circuit import QuantumRegister
 
 _CHOP_THRESHOLD = 1e-15
 

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -38,8 +38,6 @@ class Optimize1qGates(TransformationPass):
         """Return a new circuit that has been optimized."""
         runs = dag.collect_runs(["u1", "u2", "u3", "id"])
         for run in runs:
-            run_qarg = (QuantumRegister(1, 'q'), 0)
-
             right_name = "u1"
             right_parameters = (0, 0, 0)  # (theta, phi, lambda)
 
@@ -163,7 +161,10 @@ class Optimize1qGates(TransformationPass):
                 if right_name == "u1" and np.mod(right_parameters[2], (2 * np.pi)) == 0:
                     right_name = "nop"
 
-            # Replace the data of the first node in the run
+            # Replace the the first node in the run with a dummy DAG which contains a dummy
+            # qubit. The name is irrelevant, because substitute_node_with_dag will take care of
+            # putting it in the right place.
+            run_qarg = (QuantumRegister(1, 'q'), 0)
             new_op = Instruction("", [], [], [])
             if right_name == "u1":
                 new_op = U1Gate(right_parameters[2], run_qarg)

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -143,6 +143,28 @@ class TestOptimize1qGates(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
+    def test_in_the_back(self):
+        """Optimizations can be in the back of the circuit.
+        See https://github.com/Qiskit/qiskit-terra/issues/2004.
+
+        qr0:--[U1]-[U1]-[H]--    qr0:--[U1]-[H]--
+        """
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.u1(0.3, qr)
+        circuit.u1(0.4, qr)
+        circuit.h(qr)
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr,)
+        expected.u1(0.7, qr)
+        circuit.h(qr)
+
+        pass_ = Optimize1qGates()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -158,7 +158,7 @@ class TestOptimize1qGates(QiskitTestCase):
 
         expected = QuantumCircuit(qr,)
         expected.u1(0.7, qr)
-        circuit.h(qr)
+        expected.h(qr)
 
         pass_ = Optimize1qGates()
         after = pass_.run(dag)


### PR DESCRIPTION
Fixes #2004

In PR #2000, I changed the strategy of `optimize_1q_gates`, because the way that was altering the nodes in place was incorrect. Sadly, that fixes introduced #2004. This PR is going back to the change-in-place strategy (kinda, it replace one of the nodes in the run with a DAG that contain a single node with the optimization) while doing it correctly.