### PR TITLE
test_move_measurements no skipped

### DIFF
--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -586,7 +586,6 @@ class TestCompiler(QiskitTestCase):
         qobj2 = compile(circ2, backend)
         self.assertIsInstance(qobj2, QasmQobj)
 
-    @unittest.skip('Temporary skipping (see #2025 and #2006')
     def test_move_measurements(self):
         """Measurements applied AFTER swap mapping.
         """
@@ -600,12 +599,11 @@ class TestCompiler(QiskitTestCase):
                ('qb', 1): ('q', 2), ('qb', 2): ('q', 14), ('qN', 0): ('q', 3),
                ('qN', 1): ('q', 13), ('qN', 2): ('q', 4), ('qc', 0): ('q', 12),
                ('qNt', 0): ('q', 5), ('qNt', 1): ('q', 11), ('qt', 0): ('q', 6)}
-        out_dag = transpile_dag(dag_circuit, initial_layout=lay,
-                                coupling_map=cmap)
+        out_dag = transpile_dag(dag_circuit, initial_layout=lay, coupling_map=cmap)
         meas_nodes = out_dag.named_nodes('measure')
-        for n in meas_nodes:
-            is_last_measure = all([after_measure._node_id in out_dag.output_map.values()
-                                   for after_measure in out_dag.quantum_successors(n)])
+        for meas_node in meas_nodes:
+            is_last_measure = all([after_measure.type == 'out'
+                                   for after_measure in out_dag.quantum_successors(meas_node)])
             self.assertTrue(is_last_measure)
 
     def test_kak_decomposition(self):


### PR DESCRIPTION
Follow up from https://github.com/Qiskit/qiskit-terra/pull/2025

Removing `@unittest.skip('Temporary skipping (see #2025 and #2006')` and fix it.