### PR TITLE
fix occasionally failing tests from non-unique Kraus conversion

### DIFF
--- a/test/python/quantum_info/channel/test_linearops.py
+++ b/test/python/quantum_info/channel/test_linearops.py
@@ -42,8 +42,8 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
-            targ = rep(SuperOp(sop1 + sop2))
-            channel = rep(SuperOp(sop1)).add(rep(SuperOp(sop2)))
+            targ = SuperOp(sop1 + sop2)
+            channel = SuperOp(rep(SuperOp(sop1)).add(rep(SuperOp(sop2))))
             self.assertEqual(channel, targ)
 
     def _compare_subtract_to_superop(self, rep, dim, samples, unitary=False):
@@ -57,8 +57,8 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
-            targ = rep(SuperOp(sop1 - sop2))
-            channel = rep(SuperOp(sop1)).subtract(rep(SuperOp(sop2)))
+            targ = SuperOp(sop1 - sop2)
+            channel = SuperOp(rep(SuperOp(sop1)).subtract(rep(SuperOp(sop2))))
             self.assertEqual(channel, targ)
 
     def _compare_multiply_to_superop(self, rep, dim, samples, unitary=False):
@@ -70,8 +70,8 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
             val = 2 * (np.random.rand() - 0.5)
-            targ = rep(SuperOp(val * sop1))
-            channel = rep(SuperOp(sop1)).multiply(val)
+            targ = SuperOp(val * sop1)
+            channel = SuperOp(rep(SuperOp(sop1)).multiply(val))
             self.assertEqual(channel, targ)
 
     def _compare_negate_to_superop(self, rep, dim, samples, unitary=False):
@@ -82,8 +82,8 @@ class TestEquivalence(ChannelTestCase):
                 sop1 = np.kron(np.conj(mat1), mat1)
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
-            targ = rep(SuperOp(-1 * sop1))
-            channel = -rep(SuperOp(sop1))
+            targ = SuperOp(-1 * sop1)
+            channel = SuperOp(-rep(SuperOp(sop1)))
             self.assertEqual(channel, targ)
 
     def _check_add_other_reps(self, chan):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes occasionally failing channel test for `Kraus.add` and `Kraus.subtract` by making sure all comparisons happen in the unique `SuperOp` representation

### Details and comments
