### PR TITLE
Remove `inplace` from QuantumChannel and Unitary

### DIFF
--- a/qiskit/quantum_info/operators/channel/basechannel.py
+++ b/qiskit/quantum_info/operators/channel/basechannel.py
@@ -117,54 +117,28 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def conjugate(self, inplace=False):
-        """Return the conjugate of the  QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            QuantumChannel: the conjugate of the quantum channel.
-        """
+    def conjugate(self):
+        """Return the conjugate of the QuantumChannel."""
         pass
 
     @abstractmethod
-    def transpose(self, inplace=False):
-        """Return the transpose of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            QuantumChannel: the transpose of the quantum channel.
-        """
+    def transpose(self):
+        """Return the transpose of the QuantumChannel."""
         pass
 
-    def adjoint(self, inplace=False):
-        """Return the adjoint of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            QuantumChannel: the adjoint of the quantum channel.
-        """
-        return self.conjugate(inplace=inplace).transpose(inplace=inplace)
+    def adjoint(self):
+        """Return the adjoint of the QuantumChannel."""
+        return self.conjugate().transpose()
 
     @abstractmethod
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition channel self∘other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
-                          [default: False]
+                          [default: False].
 
         Returns:
             QuantumChannel: the composition channel.
@@ -172,13 +146,11 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             QuantumChannel: the tensor product channel self ⊗ other.
@@ -186,26 +158,22 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product channel other ⊗ self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             QuantumChannel: the tensor product channel other ⊗ self.
         """
         pass
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             QuantumChannel: the n-times composition channel.
@@ -219,29 +187,17 @@ class QuantumChannel(ABC):
             raise QiskitError("Can only power with positive integer powers.")
         if self._input_dim != self._output_dim:
             raise QiskitError("Can only power with input_dim = output_dim.")
-        # Update inplace
-        if inplace:
-            if n == 1:
-                return self
-            # cache current state to apply n-times
-            cache = self.copy()
-            for _ in range(1, n):
-                self.compose(cache, inplace=True)
-            return self
-        # Return new object
         ret = self.copy()
         for _ in range(1, n):
             ret = ret.compose(self)
         return ret
 
     @abstractmethod
-    def add(self, other, inplace=False):
+    def add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             QuantumChannel: the linear addition self + other.
@@ -253,13 +209,11 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def subtract(self, other, inplace=False):
+    def subtract(self, other):
         """Return the QuantumChannel self - other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             QuantumChannel: the linear subtraction self - other.
@@ -271,13 +225,11 @@ class QuantumChannel(ABC):
         pass
 
     @abstractmethod
-    def multiply(self, other, inplace=False):
+    def multiply(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (complex): a complex number
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (complex): a complex number.
 
         Returns:
             QuantumChannel: the scalar multiplication other * self.
@@ -317,32 +269,17 @@ class QuantumChannel(ABC):
     def __matmul__(self, other):
         return self.compose(other)
 
-    def __imatmul__(self, other):
-        return self.compose(other, inplace=True)
-
     def __pow__(self, n):
         return self.power(n)
-
-    def __ipow__(self, n):
-        return self.power(n, inplace=True)
 
     def __xor__(self, other):
         return self.tensor(other)
 
-    def __ixor__(self, other):
-        return self.tensor(other, inplace=True)
-
     def __mul__(self, other):
         return self.multiply(other)
 
-    def __imul__(self, other):
-        return self.multiply(other, inplace=False)
-
     def __truediv__(self, other):
         return self.multiply(1 / other)
-
-    def __itruediv__(self, other):
-        return self.multiply(1 / other, inplace=False)
 
     def __rmul__(self, other):
         return self.__mul__(other)
@@ -350,14 +287,8 @@ class QuantumChannel(ABC):
     def __add__(self, other):
         return self.add(other)
 
-    def __iadd__(self, other):
-        return self.add(other, inplace=True)
-
     def __sub__(self, other):
         return self.subtract(other)
-
-    def __isub__(self, other):
-        return self.subtract(other, inplace=True)
 
     def __neg__(self):
         return self.multiply(-1)

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -135,22 +135,6 @@ class Chi(QuantumChannel):
         # representation we convert to the Choi representation
         return Chi(Choi(self).compose(other, front=front))
 
-    def power(self, n):
-        """Return the compose of a QuantumChannel with itself n times.
-
-        Args:
-            n (int): the number of times to compose with self (n>0).
-
-        Returns:
-            Chi: the n-times composition channel as a Chi object.
-
-        Raises:
-            QiskitError: if the input and output dimensions of the
-            QuantumChannel are not equal, or the power is not a positive
-            integer.
-        """
-        return super().power(n)
-
     def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -92,65 +92,25 @@ class Chi(QuantumChannel):
         """
         return Choi(self)._evolve(state)
 
-    def conjugate(self, inplace=False):
-        """Return the conjugate of the  QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Chi: the conjugate of the quantum channel as a Chi object.
-        """
+    def conjugate(self):
+        """Return the conjugate of the QuantumChannel."""
         # Since conjugation is basis dependent we transform
         # to the Choi representation to compute the
         # conjugate channel
-        tmp = Chi(Choi(self).conjugate(inplace=True))
-        if inplace:
-            self._data = tmp._data
-            self._input_dim = tmp._input_dim
-            self._output_dim = tmp._output_dim
-        return tmp
+        return Chi(Choi(self).conjugate())
 
-    def transpose(self, inplace=False):
-        """Return the transpose of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Chi: the transpose of the quantum channel as a Chi object.
-        """
+    def transpose(self):
+        """Return the transpose of the QuantumChannel."""
         # Since conjugation is basis dependent we transform
         # to the Choi representation to compute the
         # conjugate channel
-        tmp = Chi(Choi(self).transpose(inplace=True))
-        if inplace:
-            self._data = tmp._data
-            self._input_dim = tmp._input_dim
-            self._output_dim = tmp._output_dim
-        return tmp
+        return Chi(Choi(self).transpose())
 
-    def adjoint(self, inplace=False):
-        """Return the adjoint of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Chi: the adjoint of the quantum channel as a Chi object.
-        """
-        return super().adjoint(inplace=inplace)
-
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition channel self∘other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -173,21 +133,13 @@ class Chi(QuantumChannel):
                 'input_dim of other must match output_dim of self')
         # Since we cannot directly add two channels in the Chi
         # representation we convert to the Choi representation
-        tmp = Chi(Choi(self).compose(other, inplace=True, front=front))
-        if inplace:
-            self._data = tmp._data
-            self._input_dim = tmp._input_dim
-            self._output_dim = tmp._output_dim
-            return self
-        return tmp
+        return Chi(Choi(self).compose(other, front=front))
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             Chi: the n-times composition channel as a Chi object.
@@ -197,15 +149,13 @@ class Chi(QuantumChannel):
             QuantumChannel are not equal, or the power is not a positive
             integer.
         """
-        return super().power(n, inplace=inplace)
+        return super().power(n)
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Chi: the tensor product channel self ⊗ other as a Chi object.
@@ -213,15 +163,13 @@ class Chi(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product channel other ⊗ self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Chi: the tensor product channel other ⊗ self as a Chi object.
@@ -229,15 +177,13 @@ class Chi(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
-    def add(self, other, inplace=False):
+    def add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Chi: the linear addition self + other as a Chi object.
@@ -252,19 +198,14 @@ class Chi(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Chi):
             other = Chi(other)
-        if inplace:
-            self._data += other._data
-            return self
         input_dim, output_dim = self.dims
         return Chi(self._data + other.data, input_dim, output_dim)
 
-    def subtract(self, other, inplace=False):
+    def subtract(self, other):
         """Return the QuantumChannel self - other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Chi: the linear subtraction self - other as Chi object.
@@ -279,19 +220,14 @@ class Chi(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Chi):
             other = Chi(other)
-        if inplace:
-            self._data -= other.data
-            return self
         input_dim, output_dim = self.dims
         return Chi(self._data - other.data, input_dim, output_dim)
 
-    def multiply(self, other, inplace=False):
+    def multiply(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (complex): a complex number
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (complex): a complex number.
 
         Returns:
             Chi: the scalar multiplication other * self as a Chi object.
@@ -301,19 +237,14 @@ class Chi(QuantumChannel):
         """
         if not isinstance(other, Number):
             raise QiskitError("other is not a number")
-        if inplace:
-            self._data *= other
-            return self
         input_dim, output_dim = self.dims
         return Chi(other * self._data, input_dim, output_dim)
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
+            other (QuantumChannel): a quantum channel subclass.
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -335,10 +266,4 @@ class Chi(QuantumChannel):
             data = np.kron(other.data, self._data)
         else:
             data = np.kron(self._data, other.data)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
         return Chi(data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -209,9 +209,6 @@ class Choi(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Choi):
             other = Choi(other)
-        if inplace:
-            self._data += other._data
-            return self
         input_dim, output_dim = self.dims
         return Choi(self._data + other.data, input_dim, output_dim)
 
@@ -234,9 +231,6 @@ class Choi(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, Choi):
             other = Choi(other)
-        if inplace:
-            self._data -= other.data
-            return self
         input_dim, output_dim = self.dims
         return Choi(self._data - other.data, input_dim, output_dim)
 
@@ -254,9 +248,6 @@ class Choi(QuantumChannel):
         """
         if not isinstance(other, Number):
             raise QiskitError("other is not a number")
-        if inplace:
-            self._data *= other
-            return self
         input_dim, output_dim = self.dims
         return Choi(other * self._data, input_dim, output_dim)
 

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -85,31 +85,12 @@ class Choi(QuantumChannel):
         return np.einsum('AB,AiBj->ij', state,
                          np.reshape(self._data, self._bipartite_shape))
 
-    def conjugate(self, inplace=False):
-        """Return the conjugate of the  QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Choi: the conjugate of the quantum channel as a Choi object.
-        """
-        if inplace:
-            np.conjugate(self._data, out=self._data)
-            return self
+    def conjugate(self):
+        """Return the conjugate of the QuantumChannel."""
         return Choi(np.conj(self._data), self._input_dim, self._output_dim)
 
-    def transpose(self, inplace=False):
-        """Return the transpose of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Choi: the transpose of the quantum channel as a Choi object.
-        """
+    def transpose(self):
+        """Return the transpose of the QuantumChannel."""
         # Make bipartite matrix
         d_in, d_out = self.dims
         data = np.reshape(self._data, (d_in, d_out, d_in, d_out))
@@ -117,32 +98,13 @@ class Choi(QuantumChannel):
         data = np.transpose(data, (1, 0, 3, 2))
         # Transpose channel has input and output dimensions swapped
         data = np.reshape(data, (d_in * d_out, d_in * d_out))
-        if inplace:
-            self._data = data
-            self._input_dim = d_out
-            self._output_dim = d_in
-            return self
         return Choi(data, d_out, d_in)
 
-    def adjoint(self, inplace=False):
-        """Return the adjoint of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            Choi: the adjoint of the quantum channel as a Choi object.
-        """
-        return super().adjoint(inplace=inplace)
-
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition channel self∘other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -182,20 +144,13 @@ class Choi(QuantumChannel):
         data = np.reshape(
             np.einsum('iAjB,AkBl->ikjl', first, second),
             (input_dim * output_dim, input_dim * output_dim))
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
         return Choi(data, input_dim, output_dim)
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             Choi: the n-times composition channel as a Choi object.
@@ -205,15 +160,13 @@ class Choi(QuantumChannel):
             QuantumChannel are not equal, or the power is not a positive
             integer.
         """
-        return super().power(n, inplace=inplace)
+        return super().power(n)
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Choi: the tensor product channel self ⊗ other as a Choi object.
@@ -221,15 +174,13 @@ class Choi(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product channel other ⊗ self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Choi: the tensor product channel other ⊗ self as a Choi object.
@@ -237,15 +188,13 @@ class Choi(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
-    def add(self, other, inplace=False):
+    def add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Choi: the linear addition self + other as a Choi object.
@@ -266,13 +215,11 @@ class Choi(QuantumChannel):
         input_dim, output_dim = self.dims
         return Choi(self._data + other.data, input_dim, output_dim)
 
-    def subtract(self, other, inplace=False):
+    def subtract(self, other):
         """Return the QuantumChannel self - other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             Choi: the linear subtraction self - other as Choi object.
@@ -293,13 +240,11 @@ class Choi(QuantumChannel):
         input_dim, output_dim = self.dims
         return Choi(self._data - other.data, input_dim, output_dim)
 
-    def multiply(self, other, inplace=False):
+    def multiply(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (complex): a complex number
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (complex): a complex number.
 
         Returns:
             Choi: the scalar multiplication other * self as a Choi object.
@@ -330,13 +275,11 @@ class Choi(QuantumChannel):
             axis2=3)
         return is_identity_matrix(mat, rtol=self.rtol, atol=self.atol)
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
+            other (QuantumChannel): a quantum channel subclass.
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -371,10 +314,4 @@ class Choi(QuantumChannel):
                 other.data,
                 shape1=self._bipartite_shape,
                 shape2=other._bipartite_shape)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
         return Choi(data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -146,22 +146,6 @@ class Choi(QuantumChannel):
             (input_dim * output_dim, input_dim * output_dim))
         return Choi(data, input_dim, output_dim)
 
-    def power(self, n):
-        """Return the compose of a QuantumChannel with itself n times.
-
-        Args:
-            n (int): the number of times to compose with self (n>0).
-
-        Returns:
-            Choi: the n-times composition channel as a Choi object.
-
-        Raises:
-            QiskitError: if the input and output dimensions of the
-            QuantumChannel are not equal, or the power is not a positive
-            integer.
-        """
-        return super().power(n)
-
     def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -224,22 +224,6 @@ class Kraus(QuantumChannel):
             kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
         return Kraus((kab_l, kab_r), input_dim, output_dim)
 
-    def power(self, n):
-        """Return the compose of a QuantumChannel with itself n times.
-
-        Args:
-            n (int): the number of times to compose with self (n>0).
-
-        Returns:
-            Kraus: the n-times composition channel as a Kraus object.
-
-        Raises:
-            QiskitError: if the input and output dimensions of the
-            QuantumChannel are not equal, or the power is not a positive
-            integer.
-        """
-        return super().power(n)
-
     def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -92,65 +92,25 @@ class PTM(QuantumChannel):
         tmp = Choi(self)
         return tmp.is_cptp()
 
-    def conjugate(self, inplace=False):
-        """Return the conjugate of the  QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            PTM: the conjugate of the quantum channel as a PTM object.
-        """
+    def conjugate(self):
+        """Return the conjugate of the QuantumChannel."""
         # Since conjugation is basis dependent we transform
         # to the SuperOp representation to compute the
         # conjugate channel
-        tmp = PTM(SuperOp(self).conjugate(inplace=True))
-        if inplace:
-            self._data = tmp._data
-            self._input_dim = tmp._input_dim
-            self._output_dim = tmp._output_dim
-        return tmp
+        return PTM(SuperOp(self).conjugate())
 
-    def transpose(self, inplace=False):
-        """Return the transpose of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            PTM: the transpose of the quantum channel as a PTM object.
-        """
+    def transpose(self):
+        """Return the transpose of the QuantumChannel."""
         # Since conjugation is basis dependent we transform
         # to the SuperOp representation to compute the
         # conjugate channel
-        tmp = PTM(SuperOp(self).transpose(inplace=True))
-        if inplace:
-            self._data = tmp._data
-            self._input_dim = tmp._input_dim
-            self._output_dim = tmp._output_dim
-        return tmp
+        return PTM(SuperOp(self).transpose())
 
-    def adjoint(self, inplace=False):
-        """Return the adjoint of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            PTM: the adjoint of the quantum channel as a PTM object.
-        """
-        return super().adjoint(inplace=inplace)
-
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition channel self∘other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -179,29 +139,17 @@ class PTM(QuantumChannel):
             # Composition A(B(input))
             input_dim = other._input_dim
             output_dim = self._output_dim
-            if inplace:
-                np.dot(self._data, other.data, out=self._data)
-                self._input_dim = input_dim
-                self._output_dim = output_dim
-                return self
             return PTM(np.dot(self._data, other.data), input_dim, output_dim)
         # Composition B(A(input))
         input_dim = self._input_dim
         output_dim = other._output_dim
-        if inplace:
-            np.dot(other.data, self._data, out=self._data)
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
         return PTM(np.dot(other.data, self._data), input_dim, output_dim)
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             PTM: the n-times composition channel as a PTM object.
@@ -211,15 +159,13 @@ class PTM(QuantumChannel):
             QuantumChannel are not equal, or the power is not a positive
             integer.
         """
-        return super().power(n, inplace=inplace)
+        return super().power(n)
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             PTM: the tensor product channel self ⊗ other as a PTM object.
@@ -227,15 +173,13 @@ class PTM(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product channel other ⊗ self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             PTM: the tensor product channel other ⊗ self as a PTM object.
@@ -243,15 +187,13 @@ class PTM(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
-    def add(self, other, inplace=False):
+    def add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             PTM: the linear addition self + other as a PTM object.
@@ -266,19 +208,14 @@ class PTM(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, PTM):
             other = PTM(other)
-        if inplace:
-            self._data += other._data
-            return self
         input_dim, output_dim = self.dims
         return PTM(self._data + other.data, input_dim, output_dim)
 
-    def subtract(self, other, inplace=False):
+    def subtract(self, other):
         """Return the QuantumChannel self - other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             PTM: the linear subtraction self - other as PTM object.
@@ -293,19 +230,14 @@ class PTM(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, PTM):
             other = PTM(other)
-        if inplace:
-            self._data -= other.data
-            return self
         input_dim, output_dim = self.dims
         return PTM(self._data - other.data, input_dim, output_dim)
 
-    def multiply(self, other, inplace=False):
+    def multiply(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (complex): a complex number
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (complex): a complex number.
 
         Returns:
             PTM: the scalar multiplication other * self as a PTM object.
@@ -315,19 +247,14 @@ class PTM(QuantumChannel):
         """
         if not isinstance(other, Number):
             raise QiskitError("other is not a number")
-        if inplace:
-            self._data *= other
-            return self
         input_dim, output_dim = self.dims
         return PTM(other * self._data, input_dim, output_dim)
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
+            other (QuantumChannel): a quantum channel subclass.
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -350,10 +277,4 @@ class PTM(QuantumChannel):
             data = np.kron(other.data, self._data)
         else:
             data = np.kron(self._data, other.data)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
         return PTM(data, input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -145,22 +145,6 @@ class PTM(QuantumChannel):
         output_dim = other._output_dim
         return PTM(np.dot(other.data, self._data), input_dim, output_dim)
 
-    def power(self, n):
-        """Return the compose of a QuantumChannel with itself n times.
-
-        Args:
-            n (int): the number of times to compose with self (n>0).
-
-        Returns:
-            PTM: the n-times composition channel as a PTM object.
-
-        Raises:
-            QiskitError: if the input and output dimensions of the
-            QuantumChannel are not equal, or the power is not a positive
-            integer.
-        """
-        return super().power(n)
-
     def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -180,23 +180,6 @@ class Stinespring(QuantumChannel):
         return Stinespring(
             Kraus(self).compose(other, front=front))
 
-    def power(self, n):
-        """Return the compose of a QuantumChannel with itself n times.
-
-        Args:
-            n (int): the number of times to compose with self (n>0).
-
-        Returns:
-            Stinespring: the n-times composition channel as a Stinespring
-            object.
-
-        Raises:
-            QiskitError: if the input and output dimensions of the
-            QuantumChannel are not equal, or the power is not a positive
-            integer.
-        """
-        return super().power(n)
-
     def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -85,60 +85,22 @@ class SuperOp(QuantumChannel):
             shape_out,
             order='F')
 
-    def conjugate(self, inplace=False):
-        """Return the conjugate of the  QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            SuperOp: the conjugate of the quantum channel as a SuperOp object.
-        """
-        if inplace:
-            np.conjugate(self._data, out=self._data)
-            return self
+    def conjugate(self):
+        """Return the conjugate of the QuantumChannel."""
         return SuperOp(np.conj(self._data), self._input_dim, self._output_dim)
 
-    def transpose(self, inplace=False):
-        """Return the transpose of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            SuperOp: the transpose of the quantum channel as a SuperOp object.
-        """
+    def transpose(self):
+        """Return the transpose of the QuantumChannel."""
         # Swaps input and output dimensions
         output_dim = self._input_dim
         input_dim = self._output_dim
-        if inplace:
-            self._data = np.transpose(self._data)
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
         return SuperOp(np.transpose(self._data), input_dim, output_dim)
 
-    def adjoint(self, inplace=False):
-        """Return the adjoint of the QuantumChannel.
-
-        Args:
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
-
-        Returns:
-            SuperOp: the adjoint of the quantum channel as a SuperOp object.
-        """
-        return super().adjoint(inplace=inplace)
-
-    def compose(self, other, inplace=False, front=False):
+    def compose(self, other, front=False):
         """Return the composition channel self∘other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -167,36 +129,18 @@ class SuperOp(QuantumChannel):
             # Composition A(B(input))
             input_dim = other._input_dim
             output_dim = self._output_dim
-            if inplace:
-                if self.dims == other.dims:
-                    np.dot(self._data, other.data, out=self._data)
-                else:
-                    self._data = np.dot(self._data, other.data)
-                self._input_dim = input_dim
-                self._output_dim = output_dim
-                return self
             return SuperOp(
                 np.dot(self._data, other.data), input_dim, output_dim)
         # Composition B(A(input))
         input_dim = self._input_dim
         output_dim = other._output_dim
-        if inplace:
-            if self.dims == other.dims:
-                np.dot(other.data, self._data, out=self._data)
-            else:
-                self._data = np.dot(other.data, self._data)
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
         return SuperOp(np.dot(other.data, self._data), input_dim, output_dim)
 
-    def power(self, n, inplace=False):
+    def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
 
         Args:
             n (int): the number of times to compose with self (n>0).
-            inplace (bool): If True modify the current object inplace
-                            [Default: False]
 
         Returns:
             SuperOp: the n-times composition channel as a SuperOp object.
@@ -212,21 +156,13 @@ class SuperOp(QuantumChannel):
             raise QiskitError("Can only power with input_dim = output_dim.")
         # Override base class power so we can implement more efficiently
         # using Numpy.matrix_power
-        if inplace:
-            if n == 1:
-                return self
-            self._data = np.linalg.matrix_power(self._data, n)
-            return self
-        # Return new object
         return SuperOp(np.linalg.matrix_power(self._data, n), *self.dims)
 
-    def tensor(self, other, inplace=False):
+    def tensor(self, other):
         """Return the tensor product channel self ⊗ other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             SuperOp: the tensor product channel self ⊗ other as a SuperOp
@@ -235,15 +171,13 @@ class SuperOp(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=False)
+        return self._tensor_product(other, reverse=False)
 
-    def expand(self, other, inplace=False):
+    def expand(self, other):
         """Return the tensor product channel other ⊗ self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             SuperOp: the tensor product channel other ⊗ self as a SuperOp
@@ -252,15 +186,13 @@ class SuperOp(QuantumChannel):
         Raises:
             QiskitError: if other is not a QuantumChannel subclass.
         """
-        return self._tensor_product(other, inplace=inplace, reverse=True)
+        return self._tensor_product(other, reverse=True)
 
-    def add(self, other, inplace=False):
+    def add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             SuperOp: the linear addition self + other as a SuperOp object.
@@ -275,20 +207,14 @@ class SuperOp(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, SuperOp):
             other = SuperOp(other)
-
-        if inplace:
-            self._data += other._data
-            return self
         input_dim, output_dim = self.dims
         return SuperOp(self._data + other.data, input_dim, output_dim)
 
-    def subtract(self, other, inplace=False):
+    def subtract(self, other):
         """Return the QuantumChannel self - other.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (QuantumChannel): a quantum channel subclass.
 
         Returns:
             SuperOp: the linear subtraction self - other as SuperOp object.
@@ -303,19 +229,14 @@ class SuperOp(QuantumChannel):
             raise QiskitError("other QuantumChannel dimensions are not equal")
         if not isinstance(other, SuperOp):
             other = SuperOp(other)
-        if inplace:
-            self._data -= other.data
-            return self
         input_dim, output_dim = self.dims
         return SuperOp(self._data - other.data, input_dim, output_dim)
 
-    def multiply(self, other, inplace=False):
+    def multiply(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
-            other (complex): a complex number
-            inplace (bool): If True modify the current object inplace
-                           [Default: False]
+            other (complex): a complex number.
 
         Returns:
             SuperOp: the scalar multiplication other * self as a SuperOp object.
@@ -325,19 +246,14 @@ class SuperOp(QuantumChannel):
         """
         if not isinstance(other, Number):
             raise QiskitError("other is not a number")
-        if inplace:
-            self._data *= other
-            return self
         input_dim, output_dim = self.dims
         return SuperOp(other * self._data, input_dim, output_dim)
 
-    def _tensor_product(self, other, inplace=False, reverse=False):
+    def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass
-            inplace (bool): If True modify the current object inplace
-                            [default: False]
+            other (QuantumChannel): a quantum channel subclass.
             reverse (bool): If False return self ⊗ other, if True return
                             if True return (other ⊗ self) [Default: False
         Returns:
@@ -368,10 +284,4 @@ class SuperOp(QuantumChannel):
             data = _bipartite_tensor(self._data, other.data,
                                      shape1=self._bipartite_shape,
                                      shape2=other._bipartite_shape)
-        if inplace:
-            self._data = data
-            self._input_dim = input_dim
-            self._output_dim = output_dim
-            return self
-        # return new object
         return SuperOp(data, input_dim, output_dim)

--- a/test/python/quantum_info/channel/test_chi.py
+++ b/test/python/quantum_info/channel/test_chi.py
@@ -124,39 +124,6 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Chi(self.chiX)
-        chan2 = Chi(self.chiY)
-        chan1.compose(chan2, inplace=True)
-        targ = Chi(self.chiZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan1 = Chi(self.depol_chi(0.5))
-        chan1.compose(chan1, inplace=True)
-        targ = Chi(self.depol_chi(0.75))._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Compose random
-        chi1 = self.rand_matrix(4, 4, real=True)
-        chi2 = self.rand_matrix(4, 4, real=True)
-        chan1 = Chi(chi1, input_dim=2, output_dim=2)
-        chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Chi(chi1, input_dim=2, output_dim=2)
-        chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        chan1 @= chan2
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-
     def test_compose_front(self):
         """Test front compose method."""
         # Random input test state
@@ -178,28 +145,6 @@ class TestChi(ChannelTestCase):
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Chi(self.chiX)
-        chan2 = Chi(self.chiY)
-        chan2.compose(chan1, front=True, inplace=True)
-        targ = Chi(self.chiZ)._evolve(rho)
-        self.assertAllClose(chan2._evolve(rho), targ)
-
-        # Compose random
-        chi1 = self.rand_matrix(4, 4, real=True)
-        chi2 = self.rand_matrix(4, 4, real=True)
-        chan1 = Chi(chi1, input_dim=2, output_dim=2)
-        chan2 = Chi(chi2, input_dim=2, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan2.compose(chan1, front=True, inplace=True)
-        self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -223,29 +168,6 @@ class TestChi(ChannelTestCase):
         targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        # Pauli channels
-        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
-        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
-        for i, chi1 in enumerate(paulis):
-            for j, chi2 in enumerate(paulis):
-                chan1 = Chi(chi1)
-                chan2 = Chi(chi2)
-                chan1.expand(chan2, inplace=True)
-                # Target for diagonal Pauli channel
-                targ = Chi(np.diag(targs[i + 4 * j]))
-                self.assertEqual(chan1.dims, (4, 4))
-                self.assertEqual(chan1, targ)
-
-        # Completely depolarizing
-        rho = np.diag([1, 0, 0, 0])
-        chan_dep = Chi(self.depol_chi(1))
-        chan_dep.tensor(chan_dep, inplace=True)
-        targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep._evolve(rho), targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -278,40 +200,6 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        # Pauli channels
-        paulis = [self.chiI, self.chiX, self.chiY, self.chiZ]
-        targs = 4 * np.eye(16)  # diagonals of Pauli channel Chi mats
-        for i, chi1 in enumerate(paulis):
-            for j, chi2 in enumerate(paulis):
-                chan1 = Chi(chi1)
-                chan2 = Chi(chi2)
-                chan2.tensor(chan1, inplace=True)
-                # Target for diagonal Pauli channel
-                targ = Chi(np.diag(targs[i + 4 * j]))
-                self.assertEqual(chan2.dims, (4, 4))
-                self.assertEqual(chan2, targ)
-                # Test operator overload
-                chan1 = Chi(chi1)
-                chan2 = Chi(chi2)
-                chan2 ^= chan1
-                self.assertEqual(chan2.dims, (4, 4))
-                self.assertEqual(chan2, targ)
-
-        # Completely depolarizing
-        rho = np.diag([1, 0, 0, 0])
-        chan_dep = Chi(self.depol_chi(1))
-        chan_dep.tensor(chan_dep, inplace=True)
-        targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep._evolve(rho), targ)
-        # Test operator overload
-        chan_dep = Chi(self.depol_chi(1))
-        chan_dep ^= chan_dep
-        self.assertEqual(chan_dep.dims, (4, 4))
-        self.assertAllClose(chan_dep._evolve(rho), targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -323,18 +211,6 @@ class TestChi(ChannelTestCase):
         chan3 = depol.power(3)
         targ3 = Chi(self.depol_chi(1 - p_id3))
         self.assertEqual(chan3, targ3)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        p_id = 0.9
-        depol = Chi(self.depol_chi(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id**3
-        depol.power(3, inplace=True)
-        targ3 = Chi(self.depol_chi(1 - p_id3))
-        self.assertEqual(depol, targ3)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -357,22 +233,6 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan1.add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        mat1 = 0.5 * self.chiI
-        mat2 = 0.5 * self.depol_chi(1)
-        targ = Chi(mat1 + mat2)
-
-        chan1 = Chi(mat1)
-        chan2 = Chi(mat2)
-        chan1.add(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = Chi(mat1)
-        chan2 = Chi(mat2)
-        chan1 += chan2
-        self.assertEqual(chan1, targ)
-
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = Chi(self.chiI)
@@ -391,22 +251,6 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan1.subtract(chan2), targ)
         self.assertEqual(chan1 - chan2, targ)
 
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        mat1 = 0.5 * self.chiI
-        mat2 = 0.5 * self.depol_chi(1)
-        targ = Chi(mat1 - mat2)
-
-        chan1 = Chi(mat1)
-        chan2 = Chi(mat2)
-        chan1.subtract(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = Chi(mat1)
-        chan2 = Chi(mat2)
-        chan1 -= chan2
-        self.assertEqual(chan1, targ)
-
     def test_subtract_except(self):
         """Test subtract method raises exceptions."""
         chan1 = Chi(self.chiI)
@@ -422,18 +266,6 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
         self.assertEqual(chan * val, targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        chan = Chi(self.chiI)
-        val = 0.5
-        targ = Chi(val * self.chiI)
-        chan.multiply(val, inplace=True)
-        self.assertEqual(chan, targ)
-
-        chan = Chi(self.chiI)
-        chan *= val
-        self.assertEqual(chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_choi.py
+++ b/test/python/quantum_info/channel/test_choi.py
@@ -103,18 +103,6 @@ class TestChoi(ChannelTestCase):
         chan_conj = chan.conjugate()
         self.assertEqual(chan_conj, targ)
 
-    def test_conjugate_inplace(self):
-        """Test inplace conjugate method."""
-        # Test channel measures in Z basis and prepares in Y basis
-        # Zp -> Yp, Zm -> Ym
-        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
-        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
-        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
-        # Conjugate channel swaps Y-basis states
-        targ = Choi(np.kron(Zp, Ym) + np.kron(Zm, Yp))
-        chan = chan.conjugate(inplace=True)
-        self.assertEqual(chan, targ)
-
     def test_transpose(self):
         """Test transpose method."""
         # Test channel measures in Z basis and prepares in Y basis
@@ -127,18 +115,6 @@ class TestChoi(ChannelTestCase):
         chan_t = chan.transpose()
         self.assertEqual(chan_t, targ)
 
-    def test_transpose_inplace(self):
-        """Test inplace transpose method."""
-        # Test channel measures in Z basis and prepares in Y basis
-        # Zp -> Yp, Zm -> Ym
-        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
-        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
-        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
-        # Transpose channel swaps basis
-        targ = Choi(np.kron(Yp, Zp) + np.kron(Ym, Zm))
-        chan.transpose(inplace=True)
-        self.assertEqual(chan, targ)
-
     def test_adjoint(self):
         """Test adjoint method."""
         # Test channel measures in Z basis and prepares in Y basis
@@ -150,18 +126,6 @@ class TestChoi(ChannelTestCase):
         targ = Choi(np.kron(Ym, Zp) + np.kron(Yp, Zm))
         chan_adj = chan.adjoint()
         self.assertEqual(chan_adj, targ)
-
-    def test_adjoint_inplace(self):
-        """Test inplace adjoint method."""
-        # Test channel measures in Z basis and prepares in Y basis
-        # Zp -> Yp, Zm -> Ym
-        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
-        Yp, Ym = np.array([[1, -1j], [1j, 1]]) / 2, np.array([[1, 1j], [-1j, 1]]) / 2
-        chan = Choi(np.kron(Zp, Yp) + np.kron(Zm, Ym))
-        # Ajoint channel swaps Y-basis elements abd Z<->Y bases
-        targ = Choi(np.kron(Ym, Zp) + np.kron(Yp, Zm))
-        chan.adjoint(inplace=True)
-        self.assertEqual(chan, targ)
 
     def test_compose_except(self):
         """Test compose different dimension exception"""
@@ -206,55 +170,6 @@ class TestChoi(ChannelTestCase):
         chan = chan2.compose(chan1)
         self.assertEqual(chan.dims, (4, 4))
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # UnitaryChannel evolution
-        chan1 = Choi(self.choiX)
-        chan2 = Choi(self.choiY)
-        chan1.compose(chan2, inplace=True)
-        targ = Choi(self.choiZ)
-        self.assertEqual(chan1, targ)
-
-        # 50% depolarizing channel
-        chan1 = Choi(self.depol_choi(0.5))
-        chan1.compose(chan1, inplace=True)
-        targ = Choi(self.depol_choi(0.75))
-        self.assertEqual(chan1, targ)
-
-        # Measure and rotation
-        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
-        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
-        # X-gate second does nothing
-        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan1 @= chan2
-        self.assertEqual(chan1, targ)
-        # X-gate first swaps Z states
-        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan2.compose(chan1, inplace=True)
-        self.assertEqual(chan2, targ)
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan2 @= chan1
-        self.assertEqual(chan2, targ)
-
-        # Compose different dimensions
-        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
-        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
-        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
-        chan2.compose(chan1, inplace=True)
-        self.assertEqual(chan2.dims, (4, 4))
-
     def test_compose_front(self):
         """Test front compose method."""
         # UnitaryChannel evolution
@@ -292,47 +207,6 @@ class TestChoi(ChannelTestCase):
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
 
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # UnitaryChannel evolution
-        chan1 = Choi(self.choiX)
-        chan2 = Choi(self.choiY)
-        chan1.compose(chan2, front=True, inplace=True)
-        targ = Choi(self.choiZ)
-        self.assertEqual(chan1, targ)
-
-        # 50% depolarizing channel
-        chan1 = Choi(self.depol_choi(0.5))
-        chan1.compose(chan1, inplace=True, front=True)
-        targ = Choi(self.depol_choi(0.75))
-        self.assertEqual(chan1, targ)
-
-        # Measure and rotation
-        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
-        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]]) / 2
-        # X-gate second does nothing
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan2.compose(chan1, inplace=True, front=True)
-        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        self.assertEqual(chan2, targ)
-        # X-gate first swaps Z states
-        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
-        chan2 = Choi(self.choiX)
-        chan1.compose(chan2, inplace=True, front=True)
-        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
-        self.assertEqual(chan1, targ)
-
-        # Compose different dimensions
-        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
-        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
-        chan1.compose(chan2, inplace=True, front=True)
-        self.assertEqual(chan1.dims, (4, 4))
-        chan1 = Choi(np.eye(8) / 4, input_dim=2, output_dim=4)
-        chan2 = Choi(np.eye(8) / 2, input_dim=4, output_dim=2)
-        chan2.compose(chan1, inplace=True, front=True)
-        self.assertEqual(chan2.dims, (2, 2))
-
     def test_expand(self):
         """Test expand method."""
         rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
@@ -355,34 +229,6 @@ class TestChoi(ChannelTestCase):
         # Completely depolarizing
         chan_dep = Choi(self.depol_choi(1))
         chan = chan_dep.expand(chan_dep)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan1.expand(chan2, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan2.expand(chan1, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = Choi(self.depol_choi(1))
-        chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
@@ -422,48 +268,6 @@ class TestChoi(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        rho_targ = np.kron(rho1, rho0)
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan2.tensor(chan1, inplace=True)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan2 ^= chan1
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        rho_targ = np.kron(rho0, rho1)
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan1.tensor(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(self.choiX)
-        chan1 ^= chan2
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        chan = Choi(self.depol_choi(1))
-        chan.tensor(chan, inplace=True)
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-        chan = Choi(self.depol_choi(1))
-        chan ^= chan
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -475,18 +279,6 @@ class TestChoi(ChannelTestCase):
         chan3 = depol.power(3)
         targ3 = Choi(self.depol_choi(1 - p_id3))
         self.assertEqual(chan3, targ3)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        p_id = 0.9
-        depol = Choi(self.depol_choi(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id ** 3
-        depol.power(3, inplace=True)
-        targ3 = Choi(self.depol_choi(1 - p_id3))
-        self.assertEqual(depol, targ3)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -509,22 +301,6 @@ class TestChoi(ChannelTestCase):
         self.assertEqual(chan1.add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        mat1 = 0.5 * self.choiI
-        mat2 = 0.5 * self.depol_choi(1)
-        targ = Choi(mat1 + mat2)
-
-        chan1 = Choi(mat1)
-        chan2 = Choi(mat2)
-        chan1.add(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = Choi(mat1)
-        chan2 = Choi(mat2)
-        chan1 += chan2
-        self.assertEqual(chan1, targ)
-
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = Choi(self.choiI)
@@ -543,22 +319,6 @@ class TestChoi(ChannelTestCase):
         self.assertEqual(chan1.subtract(chan2), targ)
         self.assertEqual(chan1 - chan2, targ)
 
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        mat1 = 0.5 * self.choiI
-        mat2 = 0.5 * self.depol_choi(1)
-        targ = Choi(mat1 - mat2)
-
-        chan1 = Choi(mat1)
-        chan2 = Choi(mat2)
-        chan1.subtract(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = Choi(mat1)
-        chan2 = Choi(mat2)
-        chan1 -= chan2
-        self.assertEqual(chan1, targ)
-
     def test_subtract_except(self):
         """Test subtract method raises exceptions."""
         chan1 = Choi(self.choiI)
@@ -574,18 +334,6 @@ class TestChoi(ChannelTestCase):
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
         self.assertEqual(chan * val, targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        chan = Choi(self.choiI)
-        val = 0.5
-        targ = Choi(val * self.choiI)
-        chan.multiply(val, inplace=True)
-        self.assertEqual(chan, targ)
-
-        chan = Choi(self.choiI)
-        chan *= val
-        self.assertEqual(chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_kraus.py
+++ b/test/python/quantum_info/channel/test_kraus.py
@@ -121,23 +121,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (2, 4))
 
-    def test_conjugate_inplace(self):
-        """Test inplace conjugate method."""
-        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
-        # Single Kraus list
-        targ = Kraus([np.conjugate(k) for k in kraus_l])
-        chan = Kraus(kraus_l)
-        chan.conjugate(inplace=True)
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (2, 4))
-        # Double Kraus list
-        targ = Kraus(([np.conjugate(k) for k in kraus_l],
-                      [np.conjugate(k) for k in kraus_r]))
-        chan = Kraus((kraus_l, kraus_r))
-        chan.conjugate(inplace=True)
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (2, 4))
-
     def test_transpose(self):
         """Test transpose method."""
         kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
@@ -155,23 +138,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (4, 2))
 
-    def test_transpose_inplace(self):
-        """Test inplace transpose method."""
-        kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
-        # Single Kraus list
-        targ = Kraus([np.transpose(k) for k in kraus_l])
-        chan = Kraus(kraus_l)
-        chan.transpose(inplace=True)
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (4, 2))
-        # Double Kraus list
-        targ = Kraus(([np.transpose(k) for k in kraus_l],
-                      [np.transpose(k) for k in kraus_r]))
-        chan = Kraus((kraus_l, kraus_r))
-        chan.transpose(inplace=True)
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (4, 2))
-
     def test_adjoint(self):
         """Test adjoint method."""
         kraus_l, kraus_r = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
@@ -186,24 +152,6 @@ class TestKraus(ChannelTestCase):
                       [np.transpose(k).conj() for k in kraus_r]))
         chan1 = Kraus((kraus_l, kraus_r))
         chan = chan1.adjoint()
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (4, 2))
-
-    def test_adjoint_inplace(self):
-        """Test inplace adjoint method."""
-        kraus_l = [self.rand_matrix(4, 2) for _ in range(4)]
-        kraus_r = [self.rand_matrix(4, 2) for _ in range(4)]
-        # Single Kraus list
-        targ = Kraus([np.transpose(k).conj() for k in kraus_l])
-        chan = Kraus(kraus_l)
-        chan.adjoint(inplace=True)
-        self.assertEqual(chan, targ)
-        self.assertEqual(chan.dims, (4, 2))
-        # Double Kraus list
-        targ = Kraus(([np.transpose(k).conj() for k in kraus_l],
-                      [np.transpose(k).conj() for k in kraus_r]))
-        chan = Kraus((kraus_l, kraus_r))
-        chan.adjoint(inplace=True)
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (4, 2))
 
@@ -243,38 +191,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Kraus(self.matX)
-        chan2 = Kraus(self.matY)
-        chan1.compose(chan2, inplace=True)
-        targ = Kraus(self.matZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan = Kraus(self.depol_kraus(0.5))
-        chan.compose(chan, inplace=True)
-        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-        # Compose different dimensions
-        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
-        chan1 = Kraus(kraus1)
-        chan2 = Kraus(kraus2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Kraus(kraus1)
-        chan2 = Kraus(kraus2)
-        chan1 @= chan2
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-
     def test_compose_front(self):
         """Test front compose method."""
         # Random input test state
@@ -302,33 +218,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Kraus(self.matX)
-        chan2 = Kraus(self.matY)
-        chan1.compose(chan2, inplace=True, front=True)
-        targ = Kraus(self.matZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan = Kraus(self.depol_kraus(0.5))
-        chan.compose(chan, inplace=True, front=True)
-        targ = Kraus(self.depol_kraus(0.75))._evolve(rho)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-        # Compose different dimensions
-        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
-        chan1 = Kraus(kraus1)
-        chan2 = Kraus(kraus2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan2.compose(chan1, inplace=True, front=True)
-        self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2._evolve(rho), targ)
-
     def test_expand(self):
         """Test expand method."""
         rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
@@ -351,34 +240,6 @@ class TestKraus(ChannelTestCase):
         # Completely depolarizing
         chan_dep = Kraus(self.depol_kraus(1))
         chan = chan_dep.expand(chan_dep)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = Kraus(self.matI)
-        chan2 = Kraus(self.matX)
-        chan1.expand(chan2, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = Kraus(self.matI)
-        chan2 = Kraus(self.matX)
-        chan2.expand(chan1, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = Kraus(self.depol_kraus(1))
-        chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
@@ -409,34 +270,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = Kraus(self.matI)
-        chan2 = Kraus(self.matX)
-        chan2.tensor(chan1, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = Kraus(self.matI)
-        chan2 = Kraus(self.matX)
-        chan1.tensor(chan2, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = Kraus(self.depol_kraus(1))
-        chan.tensor(chan, inplace=True)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -451,21 +284,6 @@ class TestKraus(ChannelTestCase):
         self.assertAllClose(chan3._evolve(rho), targ3a)
         targ3b = Kraus(self.depol_kraus(1 - p_id3))._evolve(rho)
         self.assertAllClose(chan3._evolve(rho), targ3b)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        rho = np.diag([1, 0])
-        p_id = 0.9
-        chan = Kraus(self.depol_kraus(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id ** 3
-        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
-        targ3b = Kraus(self.depol_kraus(1 - p_id3))._evolve(rho)
-        chan.power(3, inplace=True)
-        self.assertAllClose(chan._evolve(rho), targ3a)
-        self.assertAllClose(chan._evolve(rho), targ3b)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -498,28 +316,6 @@ class TestKraus(ChannelTestCase):
         chan = chan.add(chan)
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
-
-        # Random Single-Kraus maps
-        chan1 = Kraus(kraus1)
-        chan2 = Kraus(kraus2)
-        targ = chan1._evolve(rho) + chan2._evolve(rho)
-        chan1.add(chan2, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Kraus(kraus1)
-        chan1 += chan2
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Random Single-Kraus maps
-        chan = Kraus((kraus1, kraus2))
-        targ = 2 * chan._evolve(rho)
-        chan.add(chan, inplace=True)
-        self.assertAllClose(chan._evolve(rho), targ)
-
     def test_subtract(self):
         """Test subtract method."""
         # Random input test state
@@ -539,28 +335,6 @@ class TestKraus(ChannelTestCase):
         chan = Kraus((kraus1, kraus2))
         targ = 0 * chan._evolve(rho)
         chan = chan.subtract(chan)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
-
-        # Random Single-Kraus maps
-        chan1 = Kraus(kraus1)
-        chan2 = Kraus(kraus2)
-        targ = chan1._evolve(rho) - chan2._evolve(rho)
-        chan1.subtract(chan2, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Kraus(kraus1)
-        chan1 -= chan2
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Random Single-Kraus maps
-        chan = Kraus((kraus1, kraus2))
-        targ = 0 * chan._evolve(rho)
-        chan.subtract(chan, inplace=True)
         self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply(self):
@@ -589,31 +363,6 @@ class TestKraus(ChannelTestCase):
         self.assertAllClose(chan._evolve(rho), targ)
         chan = chan2 * val
         self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        # Random initial state and Kraus ops
-        rho = self.rand_rho(2)
-        val = 0.5
-        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(2, 4, 4)
-
-        # Single Kraus set
-        chan1 = Kraus(kraus1)
-        targ = val * chan1._evolve(rho)
-        chan1.multiply(val, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Kraus(kraus1)
-        chan1 *= val
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Double Kraus set
-        chan2 = Kraus((kraus1, kraus2))
-        targ = val * chan2._evolve(rho)
-        chan2.multiply(val, inplace=True)
-        self.assertAllClose(chan2._evolve(rho), targ)
-        chan2 = Kraus((kraus1, kraus2))
-        chan2 *= val
-        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_ptm.py
+++ b/test/python/quantum_info/channel/test_ptm.py
@@ -124,39 +124,6 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = PTM(self.ptmX)
-        chan2 = PTM(self.ptmY)
-        chan1.compose(chan2, inplace=True)
-        targ = PTM(self.ptmZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan1 = PTM(self.depol_ptm(0.5))
-        chan1.compose(chan1, inplace=True)
-        targ = PTM(self.depol_ptm(0.75))._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Compose random
-        ptm1 = self.rand_matrix(4, 4, real=True)
-        ptm2 = self.rand_matrix(4, 4, real=True)
-        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
-        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
-        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        chan1 @= chan2
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-
     def test_compose_front(self):
         """Test front compose method."""
         # Random input test state
@@ -178,28 +145,6 @@ class TestPTM(ChannelTestCase):
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = PTM(self.ptmX)
-        chan2 = PTM(self.ptmY)
-        chan2.compose(chan1, front=True, inplace=True)
-        targ = PTM(self.ptmZ)._evolve(rho)
-        self.assertAllClose(chan2._evolve(rho), targ)
-
-        # Compose random
-        ptm1 = self.rand_matrix(4, 4, real=True)
-        ptm2 = self.rand_matrix(4, 4, real=True)
-        chan1 = PTM(ptm1, input_dim=2, output_dim=2)
-        chan2 = PTM(ptm2, input_dim=2, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan2.compose(chan1, front=True, inplace=True)
-        self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_expand(self):
         """Test expand method."""
@@ -223,34 +168,6 @@ class TestPTM(ChannelTestCase):
         # Completely depolarizing
         chan_dep = PTM(self.depol_ptm(1))
         chan = chan_dep.expand(chan_dep)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = PTM(self.ptmI)
-        chan2 = PTM(self.ptmX)
-        chan1.expand(chan2, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = PTM(self.ptmI)
-        chan2 = PTM(self.ptmX)
-        chan2.expand(chan1, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = PTM(self.depol_ptm(1))
-        chan.tensor(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
@@ -281,34 +198,6 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = PTM(self.ptmI)
-        chan2 = PTM(self.ptmX)
-        chan2.tensor(chan1, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = PTM(self.ptmI)
-        chan2 = PTM(self.ptmX)
-        chan1.tensor(chan2, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = PTM(self.depol_ptm(1))
-        chan.tensor(chan, inplace=True)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -320,18 +209,6 @@ class TestPTM(ChannelTestCase):
         chan3 = depol.power(3)
         targ3 = PTM(self.depol_ptm(1 - p_id3))
         self.assertEqual(chan3, targ3)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        p_id = 0.9
-        depol = PTM(self.depol_ptm(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id**3
-        depol.power(3, inplace=True)
-        targ3 = PTM(self.depol_ptm(1 - p_id3))
-        self.assertEqual(depol, targ3)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -354,22 +231,6 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan1.add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        mat1 = 0.5 * self.ptmI
-        mat2 = 0.5 * self.depol_ptm(1)
-        targ = PTM(mat1 + mat2)
-
-        chan1 = PTM(mat1)
-        chan2 = PTM(mat2)
-        chan1.add(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = PTM(mat1)
-        chan2 = PTM(mat2)
-        chan1 += chan2
-        self.assertEqual(chan1, targ)
-
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = PTM(self.ptmI)
@@ -388,22 +249,6 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan1.subtract(chan2), targ)
         self.assertEqual(chan1 - chan2, targ)
 
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        mat1 = 0.5 * self.ptmI
-        mat2 = 0.5 * self.depol_ptm(1)
-        targ = PTM(mat1 - mat2)
-
-        chan1 = PTM(mat1)
-        chan2 = PTM(mat2)
-        chan1.subtract(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = PTM(mat1)
-        chan2 = PTM(mat2)
-        chan1 -= chan2
-        self.assertEqual(chan1, targ)
-
     def test_subtract_except(self):
         """Test subtract method raises exceptions."""
         chan1 = PTM(self.ptmI)
@@ -419,18 +264,6 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
         self.assertEqual(chan * val, targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        chan = PTM(self.ptmI)
-        val = 0.5
-        targ = PTM(val * self.ptmI)
-        chan.multiply(val, inplace=True)
-        self.assertEqual(chan, targ)
-
-        chan = PTM(self.ptmI)
-        chan *= val
-        self.assertEqual(chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_stinespring.py
+++ b/test/python/quantum_info/channel/test_stinespring.py
@@ -116,22 +116,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (2, 4))
 
-    def test_conjugate_inplace(self):
-        """Test inplace conjugate method."""
-        stine_l, stine_r = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
-        # Single Stinespring list
-        targ = Stinespring(stine_l.conj(), output_dim=4)
-        chan1 = Stinespring(stine_l, output_dim=4)
-        chan1.conjugate(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (2, 4))
-        # Double Stinespring list
-        targ = Stinespring((stine_l.conj(), stine_r.conj()), output_dim=4)
-        chan1 = Stinespring((stine_l, stine_r), output_dim=4)
-        chan1.conjugate(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (2, 4))
-
     def test_transpose(self):
         """Test transpose method."""
         stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
@@ -148,22 +132,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (4, 2))
 
-    def test_transpose_inplace(self):
-        """Test inplace transpose method."""
-        stine_l, stine_r = self.rand_matrix(4, 4), self.rand_matrix(4, 4)
-        # Single square Stinespring list
-        targ = Stinespring(stine_l.T, 4, 4)
-        chan1 = Stinespring(stine_l, 4, 4)
-        chan1.transpose(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (4, 4))
-        # Double square Stinespring list
-        targ = Stinespring((stine_l.T, stine_r.T), 4, 4)
-        chan1 = Stinespring((stine_l, stine_r), 4, 4)
-        chan1.transpose(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (4, 4))
-
     def test_adjoint(self):
         """Test adjoint method."""
         stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
@@ -179,22 +147,6 @@ class TestStinespring(ChannelTestCase):
         chan = chan1.adjoint()
         self.assertEqual(chan, targ)
         self.assertEqual(chan.dims, (4, 2))
-
-    def test_adjoint_inplace(self):
-        """Test inplace adjoint method."""
-        stine_l, stine_r = self.rand_matrix(4, 2), self.rand_matrix(4, 2)
-        # Single square Stinespring list
-        targ = Stinespring(stine_l.T.conj(), 4, 2)
-        chan1 = Stinespring(stine_l, 2, 4)
-        chan1.adjoint(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (4, 2))
-        # Double square Stinespring list
-        targ = Stinespring((stine_l.T.conj(), stine_r.T.conj()), 4, 2)
-        chan1 = Stinespring((stine_l, stine_r), 2, 4)
-        chan1.adjoint(inplace=True)
-        self.assertEqual(chan1, targ)
-        self.assertEqual(chan1.dims, (4, 2))
 
     def test_compose_except(self):
         """Test compose different dimension exception"""
@@ -232,38 +184,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Stinespring(self.matX)
-        chan2 = Stinespring(self.matY)
-        chan1.compose(chan2, inplace=True)
-        targ = Stinespring(self.matZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan = Stinespring(self.depol_stine(0.5))
-        chan.compose(chan, inplace=True)
-        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-        # Compose different dimensions
-        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        chan1 @= chan2
-        self.assertEqual(chan1.dims, (2, 2))
-        self.assertAllClose(chan1._evolve(rho), targ)
-
     def test_compose_front(self):
         """Test front compose method."""
         # Random input test state
@@ -291,33 +211,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan.dims, (2, 2))
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-
-        # UnitaryChannel evolution
-        chan1 = Stinespring(self.matX)
-        chan2 = Stinespring(self.matY)
-        chan1.compose(chan2, inplace=True, front=True)
-        targ = Stinespring(self.matZ)._evolve(rho)
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # 50% depolarizing channel
-        chan = Stinespring(self.depol_stine(0.5))
-        chan.compose(chan, inplace=True, front=True)
-        targ = Stinespring(self.depol_stine(0.75))._evolve(rho)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-        # Compose different dimensions
-        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan2 = Stinespring(stine2, input_dim=4, output_dim=2)
-        targ = chan2._evolve(chan1._evolve(rho))
-        chan2.compose(chan1, inplace=True, front=True)
-        self.assertEqual(chan2.dims, (2, 2))
-        self.assertAllClose(chan2._evolve(rho), targ)
-
     def test_expand(self):
         """Test expand method."""
         rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
@@ -340,34 +233,6 @@ class TestStinespring(ChannelTestCase):
         # Completely depolarizing
         chan_dep = Stinespring(self.depol_stine(1))
         chan = chan_dep.expand(chan_dep)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = Stinespring(self.matI)
-        chan2 = Stinespring(self.matX)
-        chan1.expand(chan2, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = Stinespring(self.matI)
-        chan2 = Stinespring(self.matX)
-        chan2.expand(chan1, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = Stinespring(self.depol_stine(1))
-        chan.expand(chan, inplace=True)
         rho_targ = np.diag([1, 1, 1, 1]) / 4
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
@@ -398,34 +263,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = Stinespring(self.matI)
-        chan2 = Stinespring(self.matX)
-        chan2.tensor(chan1, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = Stinespring(self.matI)
-        chan2 = Stinespring(self.matX)
-        chan1.tensor(chan2, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # Completely depolarizing
-        chan = Stinespring(self.depol_stine(1))
-        chan.tensor(chan, inplace=True)
-        rho_targ = np.diag([1, 1, 1, 1]) / 4
-        self.assertEqual(chan.dims, (4, 4))
-        self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -440,21 +277,6 @@ class TestStinespring(ChannelTestCase):
         self.assertAllClose(chan3._evolve(rho), targ3a)
         targ3b = Stinespring(self.depol_stine(1 - p_id3))._evolve(rho)
         self.assertAllClose(chan3._evolve(rho), targ3b)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        rho = np.diag([1, 0])
-        p_id = 0.9
-        chan = Stinespring(self.depol_stine(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id ** 3
-        targ3a = chan._evolve(chan._evolve(chan._evolve(rho)))
-        targ3b = Stinespring(self.depol_stine(1 - p_id3))._evolve(rho)
-        chan.power(3, inplace=True)
-        self.assertAllClose(chan._evolve(rho), targ3a)
-        self.assertAllClose(chan._evolve(rho), targ3b)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -487,28 +309,6 @@ class TestStinespring(ChannelTestCase):
         chan = chan.add(chan)
         self.assertAllClose(chan._evolve(rho), targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
-
-        # Random Single-Stinespring maps
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1._evolve(rho) + chan2._evolve(rho)
-        chan1.add(chan2, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan1 += chan2
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Random Single-Stinespring maps
-        chan = Stinespring((stine1, stine2))
-        targ = 2 * chan._evolve(rho)
-        chan.add(chan, inplace=True)
-        self.assertAllClose(chan._evolve(rho), targ)
-
     def test_subtract(self):
         """Test subtract method."""
         # Random input test state
@@ -528,28 +328,6 @@ class TestStinespring(ChannelTestCase):
         chan = Stinespring((stine1, stine2))
         targ = 0 * chan._evolve(rho)
         chan = chan.subtract(chan)
-        self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        # Random input test state
-        rho = self.rand_rho(2)
-        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
-
-        # Random Single-Stinespring maps
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan2 = Stinespring(stine2, input_dim=2, output_dim=4)
-        targ = chan1._evolve(rho) - chan2._evolve(rho)
-        chan1.subtract(chan2, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan1 -= chan2
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Random Single-Stinespring maps
-        chan = Stinespring((stine1, stine2))
-        targ = 0 * chan._evolve(rho)
-        chan.subtract(chan, inplace=True)
         self.assertAllClose(chan._evolve(rho), targ)
 
     def test_multiply(self):
@@ -578,31 +356,6 @@ class TestStinespring(ChannelTestCase):
         self.assertAllClose(chan._evolve(rho), targ)
         chan = chan2 * val
         self.assertAllClose(chan._evolve(rho), targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        # Random initial state and Stinespring ops
-        rho = self.rand_rho(2)
-        val = 0.5
-        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(16, 2)
-
-        # Single Stinespring set
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        targ = val * chan1._evolve(rho)
-        chan1.multiply(val, inplace=True)
-        self.assertAllClose(chan1._evolve(rho), targ)
-        chan1 = Stinespring(stine1, input_dim=2, output_dim=4)
-        chan1 *= val
-        self.assertAllClose(chan1._evolve(rho), targ)
-
-        # Double Stinespring set
-        chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
-        targ = val * chan2._evolve(rho)
-        chan2.multiply(val, inplace=True)
-        self.assertAllClose(chan2._evolve(rho), targ)
-        chan2 = Stinespring((stine1, stine2), input_dim=2, output_dim=4)
-        chan2 *= val
-        self.assertAllClose(chan2._evolve(rho), targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_superop.py
+++ b/test/python/quantum_info/channel/test_superop.py
@@ -93,14 +93,6 @@ class TestSuperOp(ChannelTestCase):
         targ = SuperOp(np.conjugate(mat))
         self.assertEqual(chan.conjugate(), targ)
 
-    def test_conjugate_inplace(self):
-        """Test inplace conjugate method."""
-        mat = self.rand_matrix(4, 4)
-        chan = SuperOp(mat)
-        chan.conjugate(inplace=True)
-        targ = SuperOp(np.conjugate(mat))
-        self.assertEqual(chan, targ)
-
     def test_transpose(self):
         """Test transpose method."""
         mat = self.rand_matrix(4, 4)
@@ -108,28 +100,12 @@ class TestSuperOp(ChannelTestCase):
         targ = SuperOp(np.transpose(mat))
         self.assertEqual(chan.transpose(), targ)
 
-    def test_transpose_inplace(self):
-        """Test inplace transpose method."""
-        mat = self.rand_matrix(4, 4)
-        chan = SuperOp(mat)
-        chan.transpose(inplace=True)
-        targ = SuperOp(np.transpose(mat))
-        self.assertEqual(chan, targ)
-
     def test_adjoint(self):
         """Test adjoint method."""
         mat = self.rand_matrix(4, 4)
         chan = SuperOp(mat)
         targ = SuperOp(np.transpose(np.conj(mat)))
         self.assertEqual(chan.adjoint(), targ)
-
-    def test_adjoint_inplace(self):
-        """Test inplace adjoint method."""
-        mat = self.rand_matrix(4, 4)
-        chan = SuperOp(mat)
-        chan.adjoint(inplace=True)
-        targ = SuperOp(np.transpose(np.conj(mat)))
-        self.assertEqual(chan, targ)
 
     def test_compose_except(self):
         """Test compose different dimension exception"""
@@ -172,55 +148,6 @@ class TestSuperOp(ChannelTestCase):
         chan = chan2.compose(chan1)
         self.assertEqual(chan.dims, (4, 4))
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        # UnitaryChannel evolution
-        chan1 = SuperOp(self.sopX)
-        chan2 = SuperOp(self.sopY)
-        targ = SuperOp(self.sopZ)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        # 50% depolarizing channel
-        chan1 = SuperOp(self.depol_sop(0.5))
-        chan1.compose(chan1, inplace=True)
-        targ = SuperOp(self.depol_sop(0.75))
-        self.assertEqual(chan1, targ)
-
-        # Random superoperator
-        mat1 = self.rand_matrix(4, 4)
-        mat2 = self.rand_matrix(4, 4)
-
-        targ = SuperOp(np.dot(mat2, mat1))
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1 @= chan2
-        self.assertEqual(chan1, targ)
-
-        targ = SuperOp(np.dot(mat1, mat2))
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan2.compose(chan1, inplace=True)
-        self.assertEqual(chan2, targ)
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan2 @= chan1
-        self.assertEqual(chan2, targ)
-
-        # Compose different dimensions
-        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
-        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1.dims, (2, 2))
-        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
-        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
-        chan2.compose(chan1, inplace=True)
-        self.assertEqual(chan2.dims, (4, 4))
-
     def test_compose_front(self):
         """Test front compose method."""
         # UnitaryChannel evolution
@@ -254,46 +181,6 @@ class TestSuperOp(ChannelTestCase):
         chan = chan2.compose(chan1, front=True)
         self.assertEqual(chan.dims, (2, 2))
 
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        # UnitaryChannel evolution
-        chan1 = SuperOp(self.sopX)
-        chan2 = SuperOp(self.sopY)
-        targ = SuperOp(self.sopZ)
-        chan1.compose(chan2, inplace=True, front=True)
-        self.assertEqual(chan1, targ)
-
-        # 50% depolarizing channel
-        chan1 = SuperOp(self.depol_sop(0.5))
-        chan1.compose(chan1, inplace=True, front=True)
-        targ = SuperOp(self.depol_sop(0.75))
-        self.assertEqual(chan1, targ)
-
-        # Random superoperator
-        mat1 = self.rand_matrix(4, 4)
-        mat2 = self.rand_matrix(4, 4)
-
-        targ = SuperOp(np.dot(mat2, mat1))
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan2.compose(chan1, inplace=True, front=True)
-        self.assertEqual(chan2, targ)
-        targ = SuperOp(np.dot(mat1, mat2))
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1.compose(chan2, inplace=True, front=True)
-        self.assertEqual(chan1, targ)
-
-        # Compose different dimensions
-        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
-        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
-        chan1.compose(chan2, inplace=True, front=True)
-        self.assertEqual(chan1.dims, (4, 4))
-        chan1 = SuperOp(self.rand_matrix(16, 4), input_dim=2, output_dim=4)
-        chan2 = SuperOp(self.rand_matrix(4, 16), output_dim=2)
-        chan2.compose(chan1, inplace=True, front=True)
-        self.assertEqual(chan2.dims, (2, 2))
-
     def test_expand(self):
         """Test expand method."""
         rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
@@ -312,27 +199,6 @@ class TestSuperOp(ChannelTestCase):
         rho_targ = np.kron(rho0, rho1)
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
-
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan1.expand(chan2, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan2.expand(chan1, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
 
     def test_tensor(self):
         """Test tensor method."""
@@ -358,37 +224,6 @@ class TestSuperOp(ChannelTestCase):
         self.assertEqual(chan.dims, (4, 4))
         self.assertAllClose(chan._evolve(rho_init), rho_targ)
 
-    def test_tensorinplace(self):
-        """Test inplace tensor method."""
-        rho0, rho1 = np.diag([1, 0]), np.diag([0, 1])
-        rho_init = np.kron(rho0, rho0)
-
-        # X \otimes I
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan2.tensor(chan1, inplace=True)
-        rho_targ = np.kron(rho1, rho0)
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan2 ^= chan1
-        self.assertEqual(chan2.dims, (4, 4))
-        self.assertAllClose(chan2._evolve(rho_init), rho_targ)
-
-        # I \otimes X
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan1.tensor(chan2, inplace=True)
-        rho_targ = np.kron(rho0, rho1)
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(self.sopX)
-        chan1 ^= chan2
-        self.assertEqual(chan1.dims, (4, 4))
-        self.assertAllClose(chan1._evolve(rho_init), rho_targ)
-
     def test_power(self):
         """Test power method."""
         # 10% depolarizing channel
@@ -400,18 +235,6 @@ class TestSuperOp(ChannelTestCase):
         chan3 = depol.power(3)
         targ3 = SuperOp(self.depol_sop(1 - p_id3))
         self.assertEqual(chan3, targ3)
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        # 10% depolarizing channel
-        p_id = 0.9
-        depol = SuperOp(self.depol_sop(1 - p_id))
-
-        # Compose 3 times
-        p_id3 = p_id ** 3
-        depol.power(3, inplace=True)
-        targ3 = SuperOp(self.depol_sop(1 - p_id3))
-        self.assertEqual(depol, targ3)
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -434,22 +257,6 @@ class TestSuperOp(ChannelTestCase):
         self.assertEqual(chan1.add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        mat1 = 0.5 * self.sopI
-        mat2 = 0.5 * self.depol_sop(1)
-        targ = SuperOp(mat1 + mat2)
-
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1.add(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1 += chan2
-        self.assertEqual(chan1, targ)
-
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = SuperOp(self.sopI)
@@ -468,22 +275,6 @@ class TestSuperOp(ChannelTestCase):
         self.assertEqual(chan1.subtract(chan2), targ)
         self.assertEqual(chan1 - chan2, targ)
 
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        mat1 = 0.5 * self.sopI
-        mat2 = 0.5 * self.depol_sop(1)
-        targ = SuperOp(mat1 - mat2)
-
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1.subtract(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        chan1 -= chan2
-        self.assertEqual(chan1, targ)
-
     def test_subtract_except(self):
         """Test subtract method raises exceptions."""
         chan1 = SuperOp(self.sopI)
@@ -499,18 +290,6 @@ class TestSuperOp(ChannelTestCase):
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
         self.assertEqual(chan * val, targ)
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        chan = SuperOp(self.sopI)
-        val = 0.5
-        targ = SuperOp(val * self.sopI)
-        chan.multiply(val, inplace=True)
-        self.assertEqual(chan, targ)
-
-        chan = SuperOp(self.sopI)
-        chan *= val
-        self.assertEqual(chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/channel/test_unitarychannel.py
+++ b/test/python/quantum_info/channel/test_unitarychannel.py
@@ -78,14 +78,6 @@ class TestUnitaryChannel(ChannelTestCase):
         uni_conj = chan.conjugate()
         self.assertEqual(uni_conj, UnitaryChannel(matr - 1j * mati))
 
-    def test_conjugate_inplace(self):
-        """Test inplace conjugate method."""
-        matr = np.array([[1, 2], [3, 4]])
-        mati = np.array([[1, 2], [3, 4]])
-        chan = UnitaryChannel(matr + 1j * mati)
-        chan.conjugate(inplace=True)
-        self.assertEqual(chan, UnitaryChannel(matr - 1j * mati))
-
     def test_transpose(self):
         """Test transpose method."""
         matr = np.array([[1, 2], [3, 4]])
@@ -94,14 +86,6 @@ class TestUnitaryChannel(ChannelTestCase):
         uni_t = chan.transpose()
         self.assertEqual(uni_t, UnitaryChannel(matr.T + 1j * mati.T))
 
-    def test_transpose_inplace(self):
-        """Test inplace transpose method."""
-        matr = np.array([[1, 2], [3, 4]])
-        mati = np.array([[1, 2], [3, 4]])
-        chan = UnitaryChannel(matr + 1j * mati)
-        chan.transpose(inplace=True)
-        self.assertEqual(chan, UnitaryChannel(matr.T + 1j * mati.T))
-
     def test_adjoint(self):
         """Test adjoint method."""
         matr = np.array([[1, 2], [3, 4]])
@@ -109,14 +93,6 @@ class TestUnitaryChannel(ChannelTestCase):
         chan = UnitaryChannel(matr + 1j * mati)
         uni_adj = chan.adjoint()
         self.assertEqual(uni_adj, UnitaryChannel(matr.T - 1j * mati.T))
-
-    def test_adjoint_inplace(self):
-        """Test inplace adjoint method."""
-        matr = np.array([[1, 2], [3, 4]])
-        mati = np.array([[1, 2], [3, 4]])
-        chan = UnitaryChannel(matr + 1j * mati)
-        chan.adjoint(inplace=True)
-        self.assertEqual(chan, UnitaryChannel(matr.T - 1j * mati.T))
 
     def test_compose_except(self):
         """Test compose different dimension exception"""
@@ -143,31 +119,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan2.compose(chan1), targ)
         self.assertEqual(chan2 @ chan1, targ)
 
-    def test_compose_inplace(self):
-        """Test inplace compose method."""
-        matX = np.array([[0, 1], [1, 0]], dtype=complex)
-        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
-
-        targ = UnitaryChannel(np.dot(matY, matX))
-        chan1 = UnitaryChannel(matX)
-        chan2 = UnitaryChannel(matY)
-        chan1.compose(chan2, inplace=True)
-        self.assertEqual(chan1, targ)
-        chan1 = UnitaryChannel(matX)
-        chan2 = UnitaryChannel(matY)
-        chan1 @= chan2
-        self.assertEqual(chan1, targ)
-
-        targ = UnitaryChannel(np.dot(matX, matY))
-        chan1 = UnitaryChannel(matX)
-        chan2 = UnitaryChannel(matY)
-        chan2.compose(chan1, inplace=True)
-        self.assertEqual(chan2, targ)
-        chan1 = UnitaryChannel(matX)
-        chan2 = UnitaryChannel(matY)
-        chan2 @= chan1
-        self.assertEqual(chan2, targ)
-
     def test_compose_front(self):
         """Test front compose method."""
         matX = np.array([[0, 1], [1, 0]], dtype=complex)
@@ -180,21 +131,6 @@ class TestUnitaryChannel(ChannelTestCase):
         chanXY = UnitaryChannel(matX).compose(UnitaryChannel(matY), front=True)
         matXY = np.dot(matX, matY)
         self.assertEqual(chanXY, UnitaryChannel(matXY))
-
-    def test_compose_front_inplace(self):
-        """Test inplace front compose method."""
-        matX = np.array([[0, 1], [1, 0]], dtype=complex)
-        matY = np.array([[0, -1j], [1j, 0]], dtype=complex)
-
-        matYX = np.dot(matY, matX)
-        chan = UnitaryChannel(matY)
-        chan.compose(UnitaryChannel(matX), inplace=True, front=True)
-        self.assertEqual(chan, UnitaryChannel(matYX))
-
-        matXY = np.dot(matX, matY)
-        chan = UnitaryChannel(matX)
-        chan.compose(UnitaryChannel(matY), inplace=True, front=True)
-        self.assertEqual(chan, UnitaryChannel(matXY))
 
     def test_expand(self):
         """Test expand method."""
@@ -211,23 +147,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan12.dims, (6, 6))
         self.assertEqual(chan12, UnitaryChannel(mat12))
 
-    def test_expand_inplace(self):
-        """Test inplace expand method."""
-        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
-        mat2 = np.eye(3, dtype=complex)
-
-        mat21 = np.kron(mat2, mat1)
-        chan = UnitaryChannel(mat1)
-        chan.expand(UnitaryChannel(mat2), inplace=True)
-        self.assertEqual(chan.dims, (6, 6))
-        self.assertEqual(chan, UnitaryChannel(mat21))
-
-        mat12 = np.kron(mat1, mat2)
-        chan = UnitaryChannel(mat2)
-        chan.expand(UnitaryChannel(mat1), inplace=True)
-        self.assertEqual(chan.dims, (6, 6))
-        self.assertEqual(chan, UnitaryChannel(mat12))
-
     def test_tensor(self):
         """Test tensor method."""
         mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
@@ -243,23 +162,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan12.dims, (6, 6))
         self.assertEqual(chan12, UnitaryChannel(mat12))
 
-    def test_tensor_inplace(self):
-        """Test inplace tensor method."""
-        mat1 = np.array([[0, 1], [1, 0]], dtype=complex)
-        mat2 = np.eye(3, dtype=complex)
-
-        mat21 = np.kron(mat2, mat1)
-        chan = UnitaryChannel(mat2)
-        chan.tensor(UnitaryChannel(mat1), inplace=True)
-        self.assertEqual(chan.dims, (6, 6))
-        self.assertEqual(chan, UnitaryChannel(mat21))
-
-        mat12 = np.kron(mat1, mat2)
-        chan = UnitaryChannel(mat1)
-        chan.tensor(UnitaryChannel(mat2), inplace=True)
-        self.assertEqual(chan.dims, (6, 6))
-        self.assertEqual(chan, UnitaryChannel(mat12))
-
     def test_power(self):
         """Test power method."""
         X90 = la.expm(-1j * 0.5 * np.pi * np.array([[0, 1], [1, 0]]) / 2)
@@ -267,17 +169,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan.power(2), UnitaryChannel([[0, -1j], [-1j, 0]]))
         self.assertEqual(chan.power(4), UnitaryChannel(-1 * np.eye(2)))
         self.assertEqual(chan.power(8), UnitaryChannel(np.eye(2)))
-
-    def test_power_inplace(self):
-        """Test inplace power method."""
-        X90 = la.expm(-1j * 0.5 * np.pi * np.array([[0, 1], [1, 0]]) / 2)
-        chan = UnitaryChannel(X90)
-        chan.power(2, inplace=True)
-        self.assertEqual(chan, UnitaryChannel([[0, -1j], [-1j, 0]]))
-        chan.power(2, inplace=True)
-        self.assertEqual(chan, UnitaryChannel(-1 * np.eye(2)))
-        chan.power(4, inplace=True)
-        self.assertEqual(chan, UnitaryChannel(np.eye(2)))
 
     def test_power_except(self):
         """Test power method raises exceptions."""
@@ -295,16 +186,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan.add(chan), UnitaryChannel([[2, 4], [6, 8]]))
         self.assertEqual(chan + chan, UnitaryChannel([[2, 4], [6, 8]]))
 
-    def test_add_inplace(self):
-        """Test inplace add method."""
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan.add(chan, inplace=True)
-        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
-
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan += chan
-        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
-
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = UnitaryChannel([[1, 2], [3, 4]])
@@ -317,16 +198,6 @@ class TestUnitaryChannel(ChannelTestCase):
         self.assertEqual(chan.subtract(chan), UnitaryChannel(np.zeros((2, 2))))
         self.assertEqual(chan - chan, UnitaryChannel(np.zeros((2, 2))))
 
-    def test_subtract_inplace(self):
-        """Test inplace subtract method."""
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan.subtract(chan, inplace=True)
-        self.assertEqual(chan, UnitaryChannel(np.zeros((2, 2))))
-
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan -= chan
-        self.assertEqual(chan, UnitaryChannel(np.zeros((2, 2))))
-
     def test_subtract_except(self):
         """Test subtract method raises exceptions."""
         chan1 = UnitaryChannel([[1, 2], [3, 4]])
@@ -338,16 +209,6 @@ class TestUnitaryChannel(ChannelTestCase):
         chan = UnitaryChannel([[1, 2], [3, 4]])
         self.assertEqual(chan.multiply(2), UnitaryChannel([[2, 4], [6, 8]]))
         self.assertEqual(2 * chan, UnitaryChannel([[2, 4], [6, 8]]))
-
-    def test_multiply_inplace(self):
-        """Test inplace multiply method."""
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan.multiply(2.0, inplace=True)
-        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
-
-        chan = UnitaryChannel([[1, 2], [3, 4]])
-        chan *= 2
-        self.assertEqual(chan, UnitaryChannel([[2, 4], [6, 8]]))
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""

--- a/test/python/quantum_info/test_unitary.py
+++ b/test/python/quantum_info/test_unitary.py
@@ -60,14 +60,6 @@ class TestUnitary(QiskitTestCase):
         uni = Unitary([[0, 1j], [-1j, 0]])
         self.assertTrue(numpy.array_equal(uni.conjugate()._representation, ymat))
 
-    def test_conjugate_inplace(self):
-        """test inplace conjugate"""
-        ymat = numpy.array([[0, -1j], [1j, 0]])
-        uni = Unitary([[0, 1j], [-1j, 0]])
-        uni_conj = uni.conjugate(inplace=True)
-        self.assertTrue(numpy.array_equal(uni._representation, ymat))
-        self.assertTrue(uni._representation is uni_conj._representation)
-
     def test_adjoint(self):
         """test adjoint operation"""
         uni = Unitary([[0, 1j], [-1j, 0]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After discussion with Ali, this removes the `inplace` kwarg from `QuantumChannel` and `Unitary` objects.

### Details and comments


