### PR TITLE
Optimize gates up to fixed point in the default pipeline

### DIFF
--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -16,7 +16,7 @@ from qiskit.converters import circuit_to_dag
 from qiskit.converters import dag_to_circuit
 from qiskit.extensions.standard import SwapGate
 from qiskit.mapper.layout import Layout
-from qiskit.transpiler import PassManager
+from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.passes.unroller import Unroller
 
 from .passes.cx_cancellation import CXCancellation

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -169,7 +169,7 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
 
             eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
 
-        initial_layout (Layout): A layout object
+        initial_layout (Layout or None): A layout object
         seed_mapper (int): random seed_mapper for the swap mapper
         pass_manager (PassManager): pass manager instance for the transpilation process
             If None, a default set of passes are run.
@@ -196,6 +196,9 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
                       "instead of 'u1,u2,u3,cx'. The string format will be "
                       "removed after 0.9", DeprecationWarning, 2)
         basis_gates = basis_gates.split(',')
+
+    if initial_layout is None:
+        initial_layout = Layout.generate_trivial_layout(*dag.qregs.values())
 
     if pass_manager:
         # run the passes specified by the pass manager

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -673,6 +673,27 @@ class TestCompiler(QiskitTestCase):
 
         self.assertTrue(mock_pass.called)
 
+    def test_optimize_to_nothing(self):
+        """ Optimze gates up to fixed point in the default pipeline
+        See https://github.com/Qiskit/qiskit-terra/issues/2035 """
+        qr = QuantumRegister(2)
+        circ = QuantumCircuit(qr)
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.x(qr[0])
+        circ.y(qr[0])
+        circ.z(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.cx(qr[0], qr[1])
+        dag_circuit = circuit_to_dag(circ)
+
+        after = transpile_dag(dag_circuit, coupling_map=[[0, 1], [1, 0]])
+
+        expected = QuantumCircuit(QuantumRegister(2, 'q'))
+        self.assertEqual(after, circuit_to_dag(expected))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #2035 

The default pipeline runs `Optimize1qGates()` and `CXCancellation()` until the DAG reaches a fixed point.