### PR TITLE
Noise-adaptive initial qubit layout pass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,8 @@ Added
   in terms of other, simpler instructions (#1816).
 - Added an ``Instruction.mirror()`` method that mirrors a composite instruction
   (reverses its sub-instructions) (#1816).
+- Added a ``NoiseAdaptiveLayout`` pass to compute a backend calibration-data aware initial 
+  qubit layout. (#2089)
 
 Changed
 -------

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -32,3 +32,4 @@ from .mapping.basic_swap import BasicSwap
 from .mapping.lookahead_swap import LookaheadSwap
 from .mapping.stochastic_swap import StochasticSwap
 from .mapping.enlarge_with_ancilla import EnlargeWithAncilla
+from .mapping.noise_adaptive_layout import NoiseAdaptiveLayout

--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018, IBM.
+# Copyright 2019, IBM.
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.

--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -134,7 +134,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         """
         Program graph has virtual qubits as nodes.
         Two nodes have an edge if the corresponding virtual qubits
-        participate in a CNOT gate. The edge is weighted by the
+        participate in a 2-qubit gate. The edge is weighted by the
         number of CNOTs between the pair.
         """
         idx = 0

--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""A pass for choosing a Layout of a circuit onto a Backend
+
+This pass associates a physical qubit (int) to each virtual qubit
+of the circuit (tuple(QuantumRegister, int)), using calibration data.
+
+The pass implements the qubit mapping method from:
+Noise-Adaptive Compiler Mappings for Noisy Intermediate-Scale Quantum Computers
+Prakash Murali, Jonathan M. Baker, Ali Javadi-Abhari, Frederic T. Chong, Margaret R. Martonosi
+ASPLOS 2019 (arXiv:1901.11054).
+
+Greedy mapping heuristic
+-------------------------
+
+Ordering of edges:
+Map qubits edge-by-edge in the order of decreasing frequency of occurence in the program dag.
+
+Initialization:
+If an edge exists with both endpoints unmapped,
+pick the best available hardware cx to execute this edge.
+Iterative step:
+When an edge exists with one endpoint unmapped,
+map that endpoint to a location which allows
+maximum reliability for CNOTs with previously mapped qubits.
+In the end if there are unmapped qubits (which don't
+participate in any CNOT), map them to any available
+hardware qubit.
+
+Note: even though a 'layout' is not strictly a property of the DAG,
+in the transpiler architecture it is best passed around between passes by
+being set in `property_set`.
+"""
+
+import math
+import networkx as nx
+
+from qiskit.mapper import Layout
+from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.transpiler.exceptions import TranspilerError
+
+
+class NoiseAdaptiveLayout(AnalysisPass):
+    """
+    Chooses a noise-adaptive Layout based on current calibration
+    data for the backend.
+    """
+
+    def __init__(self, backend_prop):
+        """
+        Chooses a Noise Adaptive Layout
+
+        Args:
+            backend_prop (BackendProperties): backend properties object
+
+        Raises:
+            TranspilerError: if invalid options
+        """
+        super().__init__()
+        self.backend_prop = backend_prop
+        self.swap_graph = nx.DiGraph()
+        self.cx_errors = {}
+        self.readout_errors = {}
+        self.available_hw_qubits = []
+        self.gate_list = []
+        self.gate_cost = {}
+        self.swap_paths = {}
+        self.swap_costs = {}
+        self.prog_graph = nx.Graph()
+        self.qreg_to_id = {}
+        self.pending_program_edges = []
+        self.prog2hw = {}
+
+    def _initialize_backend_prop(self):
+        """
+        Extract readout and CNOT errors and compute swap costs.
+        """
+        backend_prop = self.backend_prop
+        for ginfo in backend_prop.gates:
+            if ginfo.gate == 'cx':
+                for item in ginfo.parameters:
+                    if item.name == 'gate_error':
+                        g_reliab = 1.0 - item.value
+                        break
+                    else:
+                        g_reliab = 1.0
+                swap_reliab = -math.log(pow(g_reliab, 3))
+                self.swap_graph.add_edge(ginfo.qubits[0], ginfo.qubits[1], weight=swap_reliab)
+                self.swap_graph.add_edge(ginfo.qubits[1], ginfo.qubits[0], weight=swap_reliab)
+                self.cx_errors[(ginfo.qubits[0], ginfo.qubits[1])] = g_reliab
+                self.gate_list.append((ginfo.qubits[0], ginfo.qubits[1]))
+        idx = 0
+        for q in backend_prop.qubits:
+            for nduv in q:
+                if nduv.name == 'readout_error':
+                    self.readout_errors[idx] = 1.0 - nduv.value
+                    self.available_hw_qubits.append(idx)
+            idx += 1
+        for edge in self.cx_errors:
+            self.gate_cost[edge] = self.cx_errors[edge] * self.readout_errors[edge[0]] *\
+                self.readout_errors[edge[1]]
+        self.swap_paths, swap_costs_temp = nx.algorithms.shortest_paths.dense.\
+            floyd_warshall_predecessor_and_distance(self.swap_graph, weight='weight')
+        for i in swap_costs_temp:
+            self.swap_costs[i] = {}
+            for j in swap_costs_temp[i]:
+                if (i, j) in self.cx_errors:
+                    self.swap_costs[i][j] = self.cx_errors[(i, j)]
+                elif (j, i) in self.cx_errors:
+                    self.swap_costs[i][j] = self.cx_errors[(j, i)]
+                else:
+                    best_reliab = 0.0
+                    for n in self.swap_graph.neighbors(j):
+                        if (n, j) in self.cx_errors:
+                            reliab = math.exp(-swap_costs_temp[i][n])*self.cx_errors[(n, j)]
+                        else:
+                            reliab = math.exp(-swap_costs_temp[i][n])*self.cx_errors[(j, n)]
+                        if reliab > best_reliab:
+                            best_reliab = reliab
+                    self.swap_costs[i][j] = best_reliab
+
+    def _qreg_to_id(self, qubit):
+        """
+        Converts qreg with name and value to an integer id
+        """
+        return self.qreg_to_id[qubit[0].name + str(qubit[1])]
+
+    def _create_program_graph(self, dag):
+        """
+        Program graph has virtual qubits as nodes.
+        Two nodes have an edge if the corresponding virtual qubits
+        participate in a CNOT gate. The edge is weighted by the
+        number of CNOTs between the pair.
+        """
+        idx = 0
+        for q in dag.qubits():
+            self.qreg_to_id[q[0].name + str(q[1])] = idx
+            idx += 1
+        for gate in dag.twoQ_nodes():
+            qid1 = self._qreg_to_id(gate.qargs[0])
+            qid2 = self._qreg_to_id(gate.qargs[1])
+            min_q = min(qid1, qid2)
+            max_q = max(qid1, qid2)
+            edge_weight = 1
+            if self.prog_graph.has_edge(min_q, max_q):
+                edge_weight = self.prog_graph[min_q][max_q]['weight'] + 1
+            self.prog_graph.add_edge(min_q, max_q, weight=edge_weight)
+        return idx
+
+    def _select_next_edge(self):
+        """
+        If there is an edge with one endpoint mapped, return it.
+        Else return in the first edge
+        """
+        for edge in self.pending_program_edges:
+            q1_mapped = edge[0] in self.prog2hw
+            q2_mapped = edge[1] in self.prog2hw
+            assert not (q1_mapped and q2_mapped)
+            if q1_mapped or q2_mapped:
+                return edge
+        return self.pending_program_edges[0]
+
+    def _select_best_remaining_cx(self):
+        """
+        Select best remaining CNOT in the hardware for the next program edge.
+        """
+        candidates = []
+        for gate in self.gate_list:
+            chk1 = gate[0] in self.available_hw_qubits
+            chk2 = gate[1] in self.available_hw_qubits
+            if chk1 and chk2:
+                candidates.append(gate)
+        best_reliab = 0
+        best_item = None
+        for item in candidates:
+            if self.gate_cost[item] > best_reliab:
+                best_reliab = self.gate_cost[item]
+                best_item = item
+        return best_item
+
+    def _select_best_remaining_qubit(self, prog_qubit):
+        """
+        Select the best remaining hardware qubit for the next program qubit.
+        """
+        reliab_store = {}
+        for hw_qubit in self.available_hw_qubits:
+            reliab = 1
+            for n in self.prog_graph.neighbors(prog_qubit):
+                if n in self.prog2hw:
+                    reliab *= self.swap_costs[self.prog2hw[n]][hw_qubit]
+            reliab *= self.readout_errors[hw_qubit]
+            reliab_store[hw_qubit] = reliab
+        max_reliab = 0
+        best_hw_qubit = None
+        for hw_qubit in reliab_store:
+            if reliab_store[hw_qubit] > max_reliab:
+                max_reliab = reliab_store[hw_qubit]
+                best_hw_qubit = hw_qubit
+        return best_hw_qubit
+
+    def run(self, dag):
+        """Main run method for the noise adaptive layout."""
+        self._initialize_backend_prop()
+        num_qubits = self._create_program_graph(dag)
+        if num_qubits > len(self.swap_graph):
+            raise TranspilerError('Number of qubits greater than device.')
+        for end1, end2, _ in sorted(self.prog_graph.edges(data=True),
+                                    key=lambda x: x[2]['weight'], reverse=True):
+            self.pending_program_edges.append((end1, end2))
+        while self.pending_program_edges:
+            edge = self._select_next_edge()
+            q1_mapped = edge[0] in self.prog2hw
+            q2_mapped = edge[1] in self.prog2hw
+            if (not q1_mapped) and (not q2_mapped):
+                best_hw_edge = self._select_best_remaining_cx()
+                self.prog2hw[edge[0]] = best_hw_edge[0]
+                self.prog2hw[edge[1]] = best_hw_edge[1]
+                self.available_hw_qubits.remove(best_hw_edge[0])
+                self.available_hw_qubits.remove(best_hw_edge[1])
+            elif not q1_mapped:
+                best_hw_qubit = self._select_best_remaining_qubit(edge[0])
+                self.prog2hw[edge[0]] = best_hw_qubit
+                self.available_hw_qubits.remove(best_hw_qubit)
+            else:
+                best_hw_qubit = self._select_best_remaining_qubit(edge[1])
+                self.prog2hw[edge[1]] = best_hw_qubit
+                self.available_hw_qubits.remove(best_hw_qubit)
+            new_edges = [x for x in self.pending_program_edges
+                         if not (x[0] in self.prog2hw and x[1] in self.prog2hw)]
+            self.pending_program_edges = new_edges
+        for q in self.qreg_to_id:
+            qid = self.qreg_to_id[q]
+            if qid not in self.prog2hw:
+                self.prog2hw[qid] = self.available_hw_qubits[0]
+                self.available_hw_qubits.remove(self.prog2hw[qid])
+        layout = Layout()
+        for q in dag.qubits():
+            pid = self._qreg_to_id(q)
+            hwid = self.prog2hw[pid]
+            layout[(q[0], q[1])] = hwid
+        self.property_set['layout'] = layout

--- a/test/python/transpiler/test_noise_adaptive_layout.py
+++ b/test/python/transpiler/test_noise_adaptive_layout.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""Test the NoiseAdaptiveLayout pass"""
+
+from datetime import datetime
+import unittest
+from qiskit.transpiler.passes import NoiseAdaptiveLayout
+from qiskit.converters import circuit_to_dag
+from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.test import QiskitTestCase
+from qiskit.providers.models import BackendProperties
+from qiskit.providers.models.backendproperties import Nduv, Gate
+
+
+def make_qubit_with_error(readout_error):
+    """Create a qubit for BackendProperties"""
+    calib_time = datetime(year=2019, month=2, day=1, hour=0, minute=0, second=0)
+    return [Nduv(name="T1", date=calib_time, unit="µs", value=100.0),
+            Nduv(name="T2", date=calib_time, unit="µs", value=100.0),
+            Nduv(name="frequency", date=calib_time, unit="GHz", value=5.0),
+            Nduv(name="readout_error", date=calib_time, unit="", value=readout_error)]
+
+
+class TestNoiseAdaptiveLayout(QiskitTestCase):
+    """Tests the NoiseAdaptiveLayout pass."""
+
+    def test_on_linear_topology(self):
+        """
+        Test that the mapper identifies the correct gate in a linear topology
+        """
+        calib_time = datetime(year=2019, month=2, day=1, hour=0, minute=0, second=0)
+        qr = QuantumRegister(2, name='q')
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        dag = circuit_to_dag(circuit)
+        qubit_list = []
+        ro_errors = [0.01, 0.01, 0.01]
+        for ro_error in ro_errors:
+            qubit_list.append(make_qubit_with_error(ro_error))
+        p01 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.9)]
+        g01 = Gate(name="CX0_1", gate="cx", parameters=p01, qubits=[0, 1])
+        p12 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        g12 = Gate(name="CX1_2", gate="cx", parameters=p12, qubits=[1, 2])
+        gate_list = [g01, g12]
+        bprop = BackendProperties(last_update_date=calib_time, backend_name="test_backend",
+                                  qubits=qubit_list, backend_version="1.0.0", gates=gate_list,
+                                  general=[])
+        nalayout = NoiseAdaptiveLayout(bprop)
+        nalayout.run(dag)
+        initial_layout = nalayout.property_set['layout']
+        self.assertNotEqual(initial_layout[qr[0]], 0)
+        self.assertNotEqual(initial_layout[qr[1]], 0)
+
+    def test_bad_readout(self):
+        """Test that the mapper avoids bad readout unit"""
+        calib_time = datetime(year=2019, month=2, day=1, hour=0, minute=0, second=0)
+        qr = QuantumRegister(2, name='q')
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        dag = circuit_to_dag(circuit)
+        qubit_list = []
+        ro_errors = [0.01, 0.01, 0.8]
+        for ro_error in ro_errors:
+            qubit_list.append(make_qubit_with_error(ro_error))
+        p01 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        g01 = Gate(name="CX0_1", gate="cx", parameters=p01, qubits=[0, 1])
+        p12 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        g12 = Gate(name="CX1_2", gate="cx", parameters=p12, qubits=[1, 2])
+        gate_list = [g01, g12]
+        bprop = BackendProperties(last_update_date=calib_time, backend_name="test_backend",
+                                  qubits=qubit_list, backend_version="1.0.0", gates=gate_list,
+                                  general=[])
+        nalayout = NoiseAdaptiveLayout(bprop)
+        nalayout.run(dag)
+        initial_layout = nalayout.property_set['layout']
+        self.assertNotEqual(initial_layout[qr[0]], 2)
+        self.assertNotEqual(initial_layout[qr[1]], 2)
+
+    def test_grid_layout(self):
+        """
+        Test that the mapper identifies best location for a star-like program graph
+        Machine row1: (0, 1, 2)
+        Machine row2: (3, 4, 5)
+        """
+        calib_time = datetime(year=2019, month=2, day=1, hour=0, minute=0, second=0)
+        qr = QuantumRegister(4, name='q')
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[3])
+        circuit.cx(qr[1], qr[3])
+        circuit.cx(qr[2], qr[3])
+        dag = circuit_to_dag(circuit)
+        qubit_list = []
+        ro_errors = [0.01]*6
+        for ro_error in ro_errors:
+            qubit_list.append(make_qubit_with_error(ro_error))
+        p01 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.3)]
+        p03 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.3)]
+        p12 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.3)]
+        p14 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        p34 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        p45 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.1)]
+        p25 = [Nduv(date=calib_time, name='gate_error', unit='', value=0.3)]
+        g01 = Gate(name="CX0_1", gate="cx", parameters=p01, qubits=[0, 1])
+        g03 = Gate(name="CX0_3", gate="cx", parameters=p03, qubits=[0, 3])
+        g12 = Gate(name="CX1_2", gate="cx", parameters=p12, qubits=[1, 2])
+        g14 = Gate(name="CX1_4", gate="cx", parameters=p14, qubits=[1, 4])
+        g34 = Gate(name="CX3_4", gate="cx", parameters=p34, qubits=[3, 4])
+        g45 = Gate(name="CX4_5", gate="cx", parameters=p45, qubits=[4, 5])
+        g25 = Gate(name="CX2_5", gate="cx", parameters=p25, qubits=[2, 5])
+        gate_list = [g01, g03, g12, g14, g34, g45, g25]
+        bprop = BackendProperties(last_update_date=calib_time, backend_name="test_backend",
+                                  qubits=qubit_list, backend_version="1.0.0", gates=gate_list,
+                                  general=[])
+        nalayout = NoiseAdaptiveLayout(bprop)
+        nalayout.run(dag)
+        initial_layout = nalayout.property_set['layout']
+        for qid in range(4):
+            for qloc in [0, 2]:
+                self.assertNotEqual(initial_layout[qr[qid]], qloc)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pass uses backend calibration data to find a good initial qubit layout which will improve program success rate. The pass is based on the greedy heuristic from 
Prakash Murali, Jonathan M. Baker, Ali Javadi-Abhari, Frederic T. Chong, Margaret R. Martonosi. Noise-Adaptive Compiler Mappings for Noisy Intermediate-Scale Quantum Computers, ASPLOS 2019
(https://arxiv.org/abs/1901.11054)

### Summary
The pass uses backend calibration data to determine a good set of physical qubits for the program dag. It selects physical qubits based on CNOT and readout errors. The pass improves the program's success rate (fraction of runs that produce the correct answer) on real hardware evaluations as demonstrated in arXiv:1901.11054.

### Details and comments
This pass implements the noise-adaptive initial layout technique, it does not perform noise-adaptive swapping.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.