### PR TITLE
Fix typo in setuptools extras declaration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
     package_data=PACKAGE_DATA,
     include_package_data=True,
     python_requires=">=3.5",
-    extra_requires={
+    extras_require={
         'visualization': ['matplotlib>=2.1', 'nxpd>=0.2', 'ipywidgets>=7.3.0',
                           'pydot'],
         'full-featured-simulators': ['qiskit-aer>=0.1']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The name of the key is extras_require not extra_requires to declare
optional dependencies. [1] This commit corrects the typo so it works
correctly.

[1] https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

### Details and comments