### PR TITLE
Test to verify mpl draws an empty circuit empty

### DIFF
--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -10,12 +10,13 @@
 import tempfile
 import unittest
 
-from matplotlib import pyplot as plt
-from matplotlib.testing import compare
-
 from qiskit import QuantumCircuit
 from qiskit.test import QiskitTestCase
 from qiskit import visualization
+
+if visualization.HAS_MATPLOTLIB:
+    from matplotlib import pyplot as plt
+    from matplotlib.testing import compare
 
 
 class TestMatplotlibDrawer(QiskitTestCase):

--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -8,6 +8,7 @@
 # pylint: disable=no-member,invalid-name,missing-docstring
 
 import tempfile
+import unittest
 
 from matplotlib import pyplot as plt
 from matplotlib.testing import compare
@@ -31,6 +32,8 @@ class TestMatplotlibDrawer(QiskitTestCase):
         expected.set_size_inches(2.508333333333333, 0.2508333333333333)
         return expected
 
+    @unittest.skipIf(not visualization.HAS_MATPLOTLIB,
+                     'matplotlib not available.')
     def test_empty_circuit(self):
         qc = QuantumCircuit()
         res = visualization.circuit_drawer(qc, output='mpl')

--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+# pylint: disable=no-member,invalid-name,missing-docstring
+
+import tempfile
+
+from matplotlib import pyplot as plt
+from matplotlib.testing import compare
+
+from qiskit import QuantumCircuit
+from qiskit.test import QiskitTestCase
+from qiskit import visualization
+
+
+class TestMatplotlibDrawer(QiskitTestCase):
+
+    def _expected_empty(self):
+        # Generate blank
+        expected = plt.figure()
+        expected.patch.set_facecolor(color='#ffffff')
+        ax = expected.add_subplot(111)
+        ax.axis('off')
+        ax.set_aspect('equal')
+        ax.tick_params(labelbottom=False, labeltop=False,
+                       labelleft=False, labelright=False)
+        expected.set_size_inches(2.508333333333333, 0.2508333333333333)
+        return expected
+
+    def test_empty_circuit(self):
+        qc = QuantumCircuit()
+        res = visualization.circuit_drawer(qc, output='mpl')
+        res_out_file = tempfile.NamedTemporaryFile(suffix='.png')
+        self.addCleanup(res_out_file.close)
+        res.savefig(res_out_file.name)
+        expected = self._expected_empty()
+        expected_image_file = tempfile.NamedTemporaryFile(suffix='.png')
+        self.addCleanup(expected_image_file.close)
+        expected.savefig(expected_image_file.name)
+        self.assertIsNone(compare.compare_images(expected_image_file.name,
+                                                 res_out_file.name, 0.0001))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a test that verifies that when we call the mpl backend
it draws an empty image of the expected size. This is just a white image
background of the default size.

### Details and comments

Related to #1845 and #2097
