### PR TITLE
Performance issue because optimizations-until-fixed-point approach

### DIFF
--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -23,7 +23,7 @@ from .passes.cx_cancellation import CXCancellation
 from .passes.decompose import Decompose
 from .passes.optimize_1q_gates import Optimize1qGates
 from .passes.fixed_point import FixedPoint
-from .passes.count_ops import CountOps
+from .passes.depth import Depth
 from .passes.mapping.barrier_before_final_measurements import BarrierBeforeFinalMeasurements
 from .passes.mapping.check_map import CheckMap
 from .passes.mapping.cx_direction import CXDirection
@@ -253,10 +253,10 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
             pm_4_optimization = PassManager()
             pm_4_optimization.append([Optimize1qGates(),
                                       CXCancellation(),
-                                      CountOps(),
-                                      FixedPoint('count_ops')],
+                                      Depth(),
+                                      FixedPoint('depth')],
                                      do_while=lambda property_set: not property_set[
-                                         'count_ops_fixed_point'])
+                                         'depth_fixed_point'])
             dag = transpile_dag(dag, pass_manager=pm_4_optimization)
 
         dag.name = name

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -22,7 +22,8 @@ from qiskit.transpiler.passes.unroller import Unroller
 from .passes.cx_cancellation import CXCancellation
 from .passes.decompose import Decompose
 from .passes.optimize_1q_gates import Optimize1qGates
-from .passes.dag_fixed_point import DAGFixedPoint
+from .passes.fixed_point import FixedPoint
+from .passes.count_ops import CountOps
 from .passes.mapping.barrier_before_final_measurements import BarrierBeforeFinalMeasurements
 from .passes.mapping.check_map import CheckMap
 from .passes.mapping.cx_direction import CXDirection
@@ -250,9 +251,12 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
 
             # Simplify single qubit gates and CXs
             pm_4_optimization = PassManager()
-            pm_4_optimization.append([Optimize1qGates(), CXCancellation(), DAGFixedPoint()],
+            pm_4_optimization.append([Optimize1qGates(),
+                                      CXCancellation(),
+                                      CountOps(),
+                                      FixedPoint('count_ops')],
                                      do_while=lambda property_set: not property_set[
-                                         'dag_fixed_point'])
+                                         'count_ops_fixed_point'])
             dag = transpile_dag(dag, pass_manager=pm_4_optimization)
 
         dag.name = name


### PR DESCRIPTION
@mtreinish discovered that #2086 affected significantly the performance of the transpiler "by default". 

<img width="690" alt="Screen Shot 2019-04-09 at 9 37 27 PM" src="https://user-images.githubusercontent.com/766693/55845839-6f37a480-5b11-11e9-8fe7-6331fd3a2316.png">

That makes sense, since the optimizations `Optimize1qGates()` and `CXCancellation()` are run at least twice in order to find the fixed point. This is something that it was not done before.

However, I run the code of the benchmark locally, to see if something can be made.

Before #2086 

<img width="1003" alt="Screen Shot 2019-04-09 at 9 53 31 PM" src="https://user-images.githubusercontent.com/766693/55845977-04d33400-5b12-11e9-856d-4b9535372ce2.png">

After #2086 

<img width="1005" alt="Screen Shot 2019-04-09 at 9 55 46 PM" src="https://user-images.githubusercontent.com/766693/55846041-45cb4880-5b12-11e9-812a-6069e468e97d.png">


Notice that most of the extra time is in the comparison of DAGs `dag_circuit.py:741(__eq__)`. So this PR moves away from this approach and search for a fixed point in depth. This reduce the time significantly.

<img width="1012" alt="Screen Shot 2019-04-09 at 10 02 46 PM" src="https://user-images.githubusercontent.com/766693/55846406-95f6da80-5b13-11e9-8aa4-9eb466859651.png">
