### PR TITLE
make representation method of Unitary object more public

### DIFF
--- a/qiskit/quantum_info/operators/unitary.py
+++ b/qiskit/quantum_info/operators/unitary.py
@@ -31,12 +31,11 @@ class Unitary(Gate):
         Create unitary.
 
         Args:
-            representation (numpy.ndarray or list(list) or Unitary): unitary representation.
+            representation (numpy.ndarray or list(list) or Unitary): unitary representation
             label (str): identifier hint for backend
-            validate (bool): whether to validate unitarity of matrix when supplied
-                either here or with Unitary.matrix.
-            rtol (float): relative tolerance (see numpy.allclose).
-            atol (float): absolute tolerance (see numpy.allclose).
+            validate (bool): whether to validate unitarity of matrix
+            rtol (float): relative tolerance (see numpy.allclose)
+            atol (float): absolute tolerance (see numpy.allclose)
         """
         self.__validate = validate
         self.__rtol = rtol
@@ -72,6 +71,12 @@ class Unitary(Gate):
                 return False
         return True
 
+    def __str__(self):
+        return str(self.representation)
+
+    def __repr__(self):
+        return '{}\n{}'.format(super().__repr__(), self.__representation.__repr__())
+
     @property
     def dimension(self):
         """dimension of matrix
@@ -96,8 +101,8 @@ class Unitary(Gate):
         dim = self.dimension + other.dimension
         output = Unitary(
             numpy.empty((dim, dim), dtype='complex'), validate=False)
-        output._representation = numpy.kron(self._representation,
-                                            other._representation)
+        output._representation = numpy.kron(self.representation,
+                                            other.representation)
         return output
 
     def expand(self, other):
@@ -115,8 +120,8 @@ class Unitary(Gate):
         dim = self.dimension + other.dimension
         output = Unitary(
             numpy.empty((dim, dim), dtype='complex'), validate=False)
-        output._representation = numpy.kron(other._representation,
-                                            self._representation)
+        output._representation = numpy.kron(other.representation,
+                                            self.representation)
         return output
 
     def compose(self, other, front=False):
@@ -136,20 +141,20 @@ class Unitary(Gate):
         output = copy.deepcopy(self)
         if front:
             numpy.matmul(
-                other._representation,
-                output._representation,
-                out=output._representation)
+                other.representation,
+                output.representation,
+                out=output.representation)
         else:
             numpy.matmul(
-                output._representation,
-                other._representation,
-                out=output._representation)
+                output.representation,
+                other.representation,
+                out=output.representation)
         return output
 
     def conjugate(self):
         """Return the conjugate of the Unitary."""
         output = copy.deepcopy(self)
-        numpy.conj(output._representation, out=output._representation)
+        numpy.conj(output.representation, out=output.representation)
         return output
 
     def adjoint(self):
@@ -159,11 +164,11 @@ class Unitary(Gate):
     def transpose(self):
         """Return the transpose of the unitary."""
         output = copy.deepcopy(self)
-        output._representation = self._representation.transpose()
+        output._representation = self.representation.transpose()
         return output
 
     @property
-    def _representation(self):
+    def representation(self):
         """
         Get representation. Currently this is just a unitary matrix.
 
@@ -178,7 +183,7 @@ class Unitary(Gate):
         else:
             raise QiskitError("representation not defined")
 
-    @_representation.setter
+    @representation.setter
     def _representation(self, representation):
         """set matrix representation
 
@@ -219,10 +224,10 @@ class Unitary(Gate):
         uni = Unitary(numpy.empty((dim, dim), dtype='complex'), validate=False)
         if n >= 0:
             uni._representation = numpy.linalg.matrix_power(
-                self._representation, n)
+                self.representation, n)
         else:
             uni._representation = numpy.linalg.matrix_power(
-                self._representation.T.conj(), n)
+                self.representation.T.conj(), n)
         return uni
 
     @property

--- a/test/python/quantum_info/test_unitary.py
+++ b/test/python/quantum_info/test_unitary.py
@@ -58,12 +58,13 @@ class TestUnitary(QiskitTestCase):
         """test conjugate"""
         ymat = numpy.array([[0, -1j], [1j, 0]])
         uni = Unitary([[0, 1j], [-1j, 0]])
-        self.assertTrue(numpy.array_equal(uni.conjugate()._representation, ymat))
+        self.assertTrue(numpy.array_equal(uni.conjugate().representation, ymat))
 
     def test_adjoint(self):
         """test adjoint operation"""
         uni = Unitary([[0, 1j], [-1j, 0]])
-        self.assertTrue(numpy.array_equal(uni.adjoint()._representation, uni._representation))
+        self.assertTrue(numpy.array_equal(uni.adjoint().representation,
+                                          uni.representation))
 
     def test_tensor(self):
         """test tensor product of unitaries"""
@@ -73,7 +74,7 @@ class TestUnitary(QiskitTestCase):
         ux = Unitary(sx)
         uy = Unitary(sy)
         result = ux.tensor(uy.tensor(uy))
-        xmat = result._representation
+        xmat = result.representation
         self.assertTrue(numpy.array_equal(xmat, ymat))
 
     def test_expand(self):
@@ -84,7 +85,7 @@ class TestUnitary(QiskitTestCase):
         ux = Unitary(sx)
         uy = Unitary(sy)
         result = ux.expand(uy.expand(uy))
-        xmat = result._representation
+        xmat = result.representation
         self.assertTrue(numpy.array_equal(xmat, ymat))
 
     def test_compose(self):
@@ -95,20 +96,20 @@ class TestUnitary(QiskitTestCase):
         ux = Unitary(sx)
         uy = Unitary(sy)
         result = ux.compose(uy)
-        xmat = result._representation
+        xmat = result.representation
         self.assertTrue(numpy.array_equal(xmat, ymat))
 
     def test_power(self):
         """test unitary power"""
         uy = Unitary(numpy.array([[0, -1j], [1j, 0]]))
-        self.assertTrue(numpy.array_equal(uy.power(0)._representation,
+        self.assertTrue(numpy.array_equal(uy.power(0).representation,
                                           numpy.identity(2)))
-        self.assertTrue(numpy.array_equal(uy.power(1)._representation,
-                                          uy._representation))
-        self.assertTrue(numpy.array_equal(uy.power(2)._representation,
+        self.assertTrue(numpy.array_equal(uy.power(1).representation,
+                                          uy.representation))
+        self.assertTrue(numpy.array_equal(uy.power(2).representation,
                                           numpy.identity(2)))
-        self.assertTrue(numpy.array_equal(uy.power(-1)._representation,
-                                          numpy.linalg.matrix_power(uy._representation, -1)))
+        self.assertTrue(numpy.array_equal(uy.power(-1).representation,
+                                          numpy.linalg.matrix_power(uy.representation, -1)))
 
 
 class TestUnitaryCircuit(QiskitTestCase):
@@ -133,7 +134,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         self.assertIsInstance(dnode.op, Unitary)
         for qubit in dnode.qargs:
             self.assertTrue(qubit[1] in [0, 1])
-        self.assertTrue(numpy.allclose(dnode.op._representation,
+        self.assertTrue(numpy.allclose(dnode.op.representation,
                                        matrix))
 
     def test_2q_unitary(self):
@@ -162,7 +163,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         self.assertIsInstance(dnode.op, Unitary)
         for qubit in dnode.qargs:
             self.assertTrue(qubit[1] in [0, 1])
-        self.assertTrue(numpy.allclose(dnode.op._representation,
+        self.assertTrue(numpy.allclose(dnode.op.representation,
                                        matrix))
         qc3 = dag_to_circuit(dag)
         self.assertEqual(qc2, qc3)
@@ -187,7 +188,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         self.assertIsInstance(dnode.op, Unitary)
         for qubit in dnode.qargs:
             self.assertTrue(qubit[1] in [0, 1, 3])
-        self.assertTrue(numpy.allclose(dnode.op._representation,
+        self.assertTrue(numpy.allclose(dnode.op.representation,
                                        matrix))
 
     def test_qobj_with_unitary_matrix(self):


### PR DESCRIPTION
Also, implement __str__ and __repr__ methods.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Expose the "getter" for quantum_info.Unitary's representation. With this change `Unitary.representation` and `Unitary._representation` work.

This pr also implements `__str__` and `__repr__` methods to simplify viewing the representation e.g.
```
In [1]: print(unitary)
[[0.+0.j 1.+0.j]
 [1.+0.j 0.+0.j]]
```
```
In [2]: unitary
<qiskit.quantum_info.operators.unitary.Unitary object at 0x7f4a7473b2b0>
array([[0.+0.j, 1.+0.j],
          [1.+0.j, 0.+0.j]])
```
### Details and comments


