### PR TITLE
Collect2qBlocks and ConsolidateBlocks transpiler passes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -115,7 +115,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # pi = the PI constant
 # op = operation iterator
 # b = basis iterator
-good-names=i,j,k,n,m,ex,v,w,x,y,z,Run,_,logger,q,c,r,qr,cr,qc,pi,op,b,ar,br,
+good-names=i,j,k,n,m,ex,v,w,x,y,z,Run,_,logger,q,c,r,qr,cr,qc,nd,pi,op,b,ar,br,
     __unittest
 
 # Bad variable names which should always be refused, separated by a comma

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -76,6 +76,10 @@ Added
   are followed by a measurement instruction, moving the latter to the proper wire.
 - Added a ``CommutativeCancellation`` pass that cancels self-inverse gates and combines
   rotations about the Z axis, leveraging previously-found gate commutation relations.
+- Added a ``Collect2qBlocks`` pass that analyzes the circuit for uninterrupted sequences
+  of gates (blocks) acting on 2 qubits.
+- Added a ``ConsolidateBlocks`` that turns previously-collected blocks of any size
+  into equivalent Unitary operators in the circuit.
 
 Changed
 -------

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -35,24 +35,23 @@ def dag_to_circuit(dag):
     name = dag.name or None
     circuit = QuantumCircuit(*qregs.values(), *cregs.values(), name=name)
 
-    for node in dag.nodes_in_topological_order():
-        if node.type == 'op':
-            qubits = []
-            for qubit in node.qargs:
-                qubits.append(qregs[qubit[0].name][qubit[1]])
+    for node in dag.topological_op_nodes():
+        qubits = []
+        for qubit in node.qargs:
+            qubits.append(qregs[qubit[0].name][qubit[1]])
 
-            clbits = []
-            for clbit in node.cargs:
-                clbits.append(cregs[clbit[0].name][clbit[1]])
+        clbits = []
+        for clbit in node.cargs:
+            clbits.append(cregs[clbit[0].name][clbit[1]])
 
-            # Get arguments for classical control (if any)
-            if node.condition is None:
-                control = None
-            else:
-                control = (node.condition[0], node.condition[1])
+        # Get arguments for classical control (if any)
+        if node.condition is None:
+            control = None
+        else:
+            control = (node.condition[0], node.condition[1])
 
-            inst = copy.deepcopy(node.op)
-            inst.control = control
-            circuit.append(inst, qubits, clbits)
+        inst = copy.deepcopy(node.op)
+        inst.control = control
+        circuit.append(inst, qubits, clbits)
 
     return circuit

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -751,14 +751,24 @@ class DAGCircuit:
         return nx.is_isomorphic(slf, oth,
                                 node_match=lambda x, y: DAGNode.semantic_eq(x['node'], y['node']))
 
-    def nodes_in_topological_order(self):
+    def topological_nodes(self):
         """
-        Returns the nodes (their ids) in topological order.
+        Yield nodes in topological order.
 
         Returns:
-            list: The list of node numbers in topological order
+            generator(DAGNode): node in topological order
         """
-        return nx.lexicographical_topological_sort(self.multi_graph, key=lambda x: str(x.qargs))
+        return nx.lexicographical_topological_sort(self.multi_graph,
+                                                   key=lambda x: str(x.qargs))
+
+    def topological_op_nodes(self):
+        """
+        Yield op nodes in topological order.
+
+        Returns:
+            generator(DAGnode): op node in topological order
+        """
+        return (nd for nd in self.topological_nodes() if nd.type == 'op')
 
     def substitute_node_with_dag(self, node, input_dag, wires=None):
         """Replace one node with dag.
@@ -1255,30 +1265,29 @@ class DAGCircuit:
         A serial layer is a circuit with one gate. The layers have the
         same structure as in layers().
         """
-        for next_node in self.nodes_in_topological_order():
-            if next_node.type == "op":
-                new_layer = DAGCircuit()
-                for qreg in self.qregs.values():
-                    new_layer.add_qreg(qreg)
-                for creg in self.cregs.values():
-                    new_layer.add_creg(creg)
-                # Save the support of the operation we add to the layer
-                support_list = []
-                # Operation data
-                op = copy.copy(next_node.op)
-                qa = copy.copy(next_node.qargs)
-                ca = copy.copy(next_node.cargs)
-                co = copy.copy(next_node.condition)
-                _ = self._bits_in_condition(co)
+        for next_node in self.topological_op_nodes():
+            new_layer = DAGCircuit()
+            for qreg in self.qregs.values():
+                new_layer.add_qreg(qreg)
+            for creg in self.cregs.values():
+                new_layer.add_creg(creg)
+            # Save the support of the operation we add to the layer
+            support_list = []
+            # Operation data
+            op = copy.copy(next_node.op)
+            qa = copy.copy(next_node.qargs)
+            ca = copy.copy(next_node.cargs)
+            co = copy.copy(next_node.condition)
+            _ = self._bits_in_condition(co)
 
-                # Add node to new_layer
-                new_layer.apply_operation_back(op, qa, ca, co)
-                # Add operation to partition
-                if next_node.name not in ["barrier",
-                                          "snapshot", "save", "load", "noise"]:
-                    support_list.append(list(qa))
-                l_dict = {"graph": new_layer, "partition": support_list}
-                yield l_dict
+            # Add node to new_layer
+            new_layer.apply_operation_back(op, qa, ca, co)
+            # Add operation to partition
+            if next_node.name not in ["barrier",
+                                      "snapshot", "save", "load", "noise"]:
+                support_list.append(list(qa))
+            l_dict = {"graph": new_layer, "partition": support_list}
+            yield l_dict
 
     def multigraph_layers(self):
         """Yield layers of the multigraph."""
@@ -1322,12 +1331,11 @@ class DAGCircuit:
         # Iterate through the nodes of self in topological order
         # and form tuples containing sequences of gates
         # on the same qubit(s).
-        tops_node = list(self.nodes_in_topological_order())
-        nodes_seen = dict(zip(tops_node, [False] * len(tops_node)))
-        for node in tops_node:
-            if node.type == "op" and node.name in namelist \
-                    and node.condition is None and not nodes_seen[node]:
-
+        topo_ops = list(self.topological_op_nodes())
+        nodes_seen = dict(zip(topo_ops, [False] * len(topo_ops)))
+        for node in topo_ops:
+            if node.name in namelist and node.condition is None \
+                    and not nodes_seen[node]:
                 group = [node]
                 nodes_seen[node] = True
                 s = list(self.multi_graph.successors(node))
@@ -1381,13 +1389,12 @@ class DAGCircuit:
         Returns a dictionary of counts keyed on the operation name.
         """
         op_dict = {}
-        for node in self.nodes_in_topological_order():
+        for node in self.topological_op_nodes():
             name = node.name
-            if node.type == "op":
-                if name not in op_dict:
-                    op_dict[name] = 1
-                else:
-                    op_dict[name] += 1
+            if name not in op_dict:
+                op_dict[name] = 1
+            else:
+                op_dict[name] += 1
         return op_dict
 
     def properties(self):

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -361,7 +361,7 @@ class UnitarySimulatorPy(BaseBackend):
             raise BasicAerError('Number of qubits {} '.format(n_qubits) +
                                 'is greater than maximum ({}) '.format(max_qubits) +
                                 'for "{}".'.format(self.name()))
-        if qobj.config.shots != 1:
+        if hasattr(qobj.config, 'shots') and qobj.config.shots != 1:
             logger.info('"%s" only supports 1 shot. Setting shots=1.',
                         self.name())
             qobj.config.shots = 1

--- a/qiskit/tools/compiler.py
+++ b/qiskit/tools/compiler.py
@@ -9,7 +9,8 @@
 import warnings
 import logging
 
-from qiskit.compiler import assemble_circuits, RunConfig
+from qiskit.compiler.assembler import assemble_circuits
+from qiskit.compiler.run_config import RunConfig
 from qiskit import transpiler
 
 logger = logging.getLogger(__name__)

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -25,6 +25,8 @@ from .commutation_analysis import CommutationAnalysis
 from .optimize_swap_before_measure import OptimizeSwapBeforeMeasure
 from .commutative_cancellation import CommutativeCancellation
 from .remove_reset_in_zero_state import RemoveResetInZeroState
+from .collect_2q_blocks import Collect2qBlocks
+from .consolidate_blocks import ConsolidateBlocks
 from .mapping.barrier_before_final_measurements import BarrierBeforeFinalMeasurements
 from .mapping.check_map import CheckMap
 from .mapping.check_cnot_direction import CheckCnotDirection

--- a/qiskit/transpiler/passes/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/collect_2q_blocks.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""
+Traverse the DAG and find blocks of gates that act consecutively on
+pairs of qubits. Write the blocks to propert_set as a dictionary
+of the form:
+
+    {(q0, q1): [[g0, g1, g2], [g5]],
+     (q0, q2): [[g3, g4]]
+     ..
+     .
+    }
+
+Based on implementation by Andrew Cross.
+"""
+
+from collections import defaultdict
+
+from qiskit.transpiler.basepasses import AnalysisPass
+
+
+class Collect2qBlocks(AnalysisPass):
+    """Pass to collect sequences of uninterrupted gates acting on 2 qubits.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def run(self, dag):
+        """collect blocks of adjacent gates acting on a pair of "cx" qubits.
+        
+        The blocks contain "op" nodes in topological sort order
+        such that all gates in a block act on the same pair of
+        qubits and are adjacent in the circuit. the blocks are built
+        by examining predecessors and successors of "cx" gates in
+        the circuit. u1, u2, u3, cx, id gates will be included.
+        
+        Return a list of tuples of "op" node labels.
+        """
+        # Initiate the commutation set
+        self.property_set['commutation_set'] = defaultdict(list)
+
+        good_names = ["cx", "u1", "u2", "u3", "id"]
+        block_list = []
+        nodes = list(dag.nodes_in_topological_order())
+        nodes_seen = dict(zip(nodes, [False] * len(nodes)))
+        for nd in dag.nodes_in_topological_order():
+            group = []
+            # Explore predecessors and successors of cx gates
+            if nd.name == "cx" and nd.condition is None and not nodes_seen[nd]:
+                these_qubits = sorted(nd.qargs)
+                # print("// looking at node %s on %s" % (nd.name, str(these_qubits)))
+                # Explore predecessors of the "cx" node
+                pred = list(dag.predecessors(nd))
+                explore = True
+                while explore:
+                    pred_next = []
+                    #print("//   pred = %s, types = %s" %
+                    #      (str(pred), str(list(map(lambda x: x.name, pred)))))
+                    # If there is one predecessor, add it if it's on the right qubits
+                    if len(pred) == 1 and not nodes_seen[pred[0]]:
+                        pnd = pred[0]
+                        if pnd.name in good_names:
+                            if (pnd.name == "cx" and sorted(pnd.qargs) == these_qubits) or \
+                                pnd.name != "cx":
+                                group.append(pnd)
+                                nodes_seen[pnd] = True
+                                pred_next.extend(dag.predecessors(pnd))
+                    # If there are two, then we consider cases
+                    elif len(pred) == 2:
+                        # First, check if there is a relationship
+                        if pred[0] in dag.predecessors(pred[1]):
+                            sorted_pred = [pred[1]]   # was [pred[1], pred[0]]
+                        elif pred[1] in dag.predecessors(pred[0]):
+                            sorted_pred = [pred[0]]   # was [pred[0], pred[1]]
+                        else:
+                            # We need to avoid accidentally adding a cx on these_qubits
+                            # since these must have a dependency through the other predecessor
+                            # in this case
+                            if pred[0].name == "cx" and sorted(pred[0].qargs) == these_qubits:
+                               sorted_pred = [pred[1]]
+                            elif pred[1].name == "cx" and sorted(pred[1].qargs) == these_qubits:
+                                sorted_pred = [pred[0]]
+                            else:
+                                sorted_pred = pred
+                        if len(sorted_pred) == 2 and sorted_pred[0].name == "cx" and \
+                           sorted_pred[1].name == "cx":
+                            break  # stop immediately if we hit a pair of cx
+                        # Examine each predecessor
+                        for pnd in sorted_pred:
+                            if pnd.name not in good_names:
+                                continue
+                            # If a predecessor is a single qubit gate, add it
+                            if pnd.name != "cx":
+                                if not nodes_seen[pnd]:
+                                    group.append(pnd)
+                                    nodes_seen[pnd] = True
+                                    pred_next.extend(dag.predecessors(pnd))
+                            # If cx, check qubits
+                            else:
+                                pred_qubits = sorted(pnd.qargs)
+                                if pred_qubits == these_qubits:
+                                    # add if on same qubits
+                                    if not nodes_seen[pnd]:
+                                        group.append(pnd)
+                                        nodes_seen[pnd] = True
+                                        pred_next.extend(dag.predecessors(pnd))
+                                else:
+                                    # remove qubit from consideration if not
+                                    these_qubits = list(set(these_qubits) -
+                                                        set(pred_qubits))
+                    # Update predecessors
+                    # Stop if there aren't any more
+                    pred = list(set(pred_next))
+                    if len(pred) == 0:
+                        explore = False
+                # Reverse the predecessor list and append the "cx" node
+                group.reverse()
+                group.append(nd)
+                nodes_seen[nd] = True
+                # Reset these_qubits
+                these_qubits = sorted(nd.qargs)
+                # Explore successors of the "cx" node
+                succ = list(dag.successors(nd))
+                explore = True
+                while explore:
+                    succ_next = []
+                    #print("//   succ = %s, types = %s" %
+                    #      (str(succ), str(list(map(lambda x: x.name, succ)))))
+                    # If there is one successor, add it if its on the right qubits
+                    if len(succ) == 1 and not nodes_seen[succ[0]]:
+                        snd = succ[0]
+                        if snd.name in good_names:
+                            if (snd.name == "cx" and sorted(snd.qargs) == these_qubits) or \
+                                snd.name != "cx":
+                                group.append(snd)
+                                nodes_seen[snd] = True
+                                succ_next.extend(dag.successors(snd))
+                    # If there are two, then we consider cases
+                    elif len(succ) == 2:
+                        # First, check if there is a relationship
+                        if succ[0] in dag.successors(succ[1]):
+                            sorted_succ = [succ[1]]  # was [succ[1], succ[0]]
+                        elif succ[1] in dag.successors(succ[0]):
+                            sorted_succ = [succ[0]]  # was [succ[0], succ[1]]
+                        else:
+                            # We need to avoid accidentally adding a cx on these_qubits
+                            # since these must have a dependency through the other successor
+                            # in this case
+                            if succ[0].name == "cx" and sorted(succ[0].qargs) == these_qubits:
+                               sorted_succ = [succ[1]]
+                            elif succ[1].name == "cx" and sorted(succ[1].qargs) == these_qubits:
+                                 sorted_succ = [succ[0]]
+                            else:
+                                sorted_succ = succ
+                        if len(sorted_succ) == 2 and \
+                           sorted_succ[0].name == "cx" and \
+                           sorted_succ[1].name == "cx":
+                            break  # stop immediately if we hit a pair of cx
+                        # Examine each successor
+                        for snd in sorted_succ:
+                            if snd.name not in good_names:
+                                continue
+                            # If a successor is a single qubit gate, add it
+                            if snd.name != "cx":
+                                if not nodes_seen[snd]:
+                                    group.append(snd)
+                                    nodes_seen[snd] = True
+                                    succ_next.extend(dag.successors(snd))
+                            else:
+                                # If cx, check qubits
+                                succ_qubits = sorted(snd.qargs)
+                                if succ_qubits == these_qubits:
+                                    # add if on same qubits
+                                    if not nodes_seen[snd]:
+                                        group.append(snd)
+                                        nodes_seen[snd] = True
+                                        succ_next.extend(dag.successors(snd))
+                                else:
+                                    # remove qubit from consideration if not
+                                    these_qubits = list(set(these_qubits) -
+                                                        set(succ_qubits))
+                    # Update successors
+                    # Stop if there aren't any more
+                    succ = list(set(succ_next))
+                    if len(succ) == 0:
+                        explore = False
+
+                block_list.append(tuple(group))
+            
+        self.property_set['block_list'] = block_list

--- a/qiskit/transpiler/passes/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/collect_2q_blocks.py
@@ -27,19 +27,15 @@ from qiskit.transpiler.basepasses import AnalysisPass
 class Collect2qBlocks(AnalysisPass):
     """Pass to collect sequences of uninterrupted gates acting on 2 qubits.
     """
-
-    def __init__(self):
-        super().__init__()
-
     def run(self, dag):
         """collect blocks of adjacent gates acting on a pair of "cx" qubits.
-        
+
         The blocks contain "op" nodes in topological sort order
         such that all gates in a block act on the same pair of
         qubits and are adjacent in the circuit. the blocks are built
         by examining predecessors and successors of "cx" gates in
         the circuit. u1, u2, u3, cx, id gates will be included.
-        
+
         Return a list of tuples of "op" node labels.
         """
         # Initiate the commutation set
@@ -54,20 +50,17 @@ class Collect2qBlocks(AnalysisPass):
             # Explore predecessors and successors of cx gates
             if nd.name == "cx" and nd.condition is None and not nodes_seen[nd]:
                 these_qubits = sorted(nd.qargs)
-                # print("// looking at node %s on %s" % (nd.name, str(these_qubits)))
                 # Explore predecessors of the "cx" node
                 pred = list(dag.predecessors(nd))
                 explore = True
                 while explore:
                     pred_next = []
-                    #print("//   pred = %s, types = %s" %
-                    #      (str(pred), str(list(map(lambda x: x.name, pred)))))
                     # If there is one predecessor, add it if it's on the right qubits
                     if len(pred) == 1 and not nodes_seen[pred[0]]:
                         pnd = pred[0]
                         if pnd.name in good_names:
                             if (pnd.name == "cx" and sorted(pnd.qargs) == these_qubits) or \
-                                pnd.name != "cx":
+                                    pnd.name != "cx":
                                 group.append(pnd)
                                 nodes_seen[pnd] = True
                                 pred_next.extend(dag.predecessors(pnd))
@@ -83,7 +76,7 @@ class Collect2qBlocks(AnalysisPass):
                             # since these must have a dependency through the other predecessor
                             # in this case
                             if pred[0].name == "cx" and sorted(pred[0].qargs) == these_qubits:
-                               sorted_pred = [pred[1]]
+                                sorted_pred = [pred[1]]
                             elif pred[1].name == "cx" and sorted(pred[1].qargs) == these_qubits:
                                 sorted_pred = [pred[0]]
                             else:
@@ -117,7 +110,7 @@ class Collect2qBlocks(AnalysisPass):
                     # Update predecessors
                     # Stop if there aren't any more
                     pred = list(set(pred_next))
-                    if len(pred) == 0:
+                    if not pred:
                         explore = False
                 # Reverse the predecessor list and append the "cx" node
                 group.reverse()
@@ -130,14 +123,12 @@ class Collect2qBlocks(AnalysisPass):
                 explore = True
                 while explore:
                     succ_next = []
-                    #print("//   succ = %s, types = %s" %
-                    #      (str(succ), str(list(map(lambda x: x.name, succ)))))
                     # If there is one successor, add it if its on the right qubits
                     if len(succ) == 1 and not nodes_seen[succ[0]]:
                         snd = succ[0]
                         if snd.name in good_names:
                             if (snd.name == "cx" and sorted(snd.qargs) == these_qubits) or \
-                                snd.name != "cx":
+                                    snd.name != "cx":
                                 group.append(snd)
                                 nodes_seen[snd] = True
                                 succ_next.extend(dag.successors(snd))
@@ -153,9 +144,9 @@ class Collect2qBlocks(AnalysisPass):
                             # since these must have a dependency through the other successor
                             # in this case
                             if succ[0].name == "cx" and sorted(succ[0].qargs) == these_qubits:
-                               sorted_succ = [succ[1]]
+                                sorted_succ = [succ[1]]
                             elif succ[1].name == "cx" and sorted(succ[1].qargs) == these_qubits:
-                                 sorted_succ = [succ[0]]
+                                sorted_succ = [succ[0]]
                             else:
                                 sorted_succ = succ
                         if len(sorted_succ) == 2 and \
@@ -188,9 +179,11 @@ class Collect2qBlocks(AnalysisPass):
                     # Update successors
                     # Stop if there aren't any more
                     succ = list(set(succ_next))
-                    if len(succ) == 0:
+                    if not succ:
                         explore = False
 
                 block_list.append(tuple(group))
-            
+
         self.property_set['block_list'] = block_list
+
+        return dag

--- a/qiskit/transpiler/passes/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/collect_2q_blocks.py
@@ -43,9 +43,9 @@ class Collect2qBlocks(AnalysisPass):
 
         good_names = ["cx", "u1", "u2", "u3", "id"]
         block_list = []
-        nodes = list(dag.nodes_in_topological_order())
+        nodes = list(dag.topological_nodes())
         nodes_seen = dict(zip(nodes, [False] * len(nodes)))
-        for nd in dag.nodes_in_topological_order():
+        for nd in dag.topological_op_nodes():
             group = []
             # Explore predecessors and successors of cx gates
             if nd.name == "cx" and nd.condition is None and not nodes_seen[nd]:

--- a/qiskit/transpiler/passes/commutation_analysis.py
+++ b/qiskit/transpiler/passes/commutation_analysis.py
@@ -49,7 +49,7 @@ class CommutationAnalysis(AnalysisPass):
             self.property_set['commutation_set'][wire_name] = []
 
         # Add edges to the dictionary for each qubit
-        for node in dag.nodes_in_topological_order():
+        for node in dag.topological_op_nodes():
             for (_, _, edge_data) in dag.multi_graph.edges(node, data=True):
 
                 edge_name = edge_data['name']

--- a/qiskit/transpiler/passes/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/consolidate_blocks.py
@@ -60,7 +60,7 @@ class ConsolidateBlocks(TransformationPass):
         blocks = self.property_set['block_list']
         nodes_seen = set()
 
-        for node in dag.nodes_in_topological_order():
+        for node in dag.topological_op_nodes():
             # skip already-visited nodes or input/output nodes
             if node in nodes_seen or node.type == 'in' or node.type == 'out':
                 continue

--- a/qiskit/transpiler/passes/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/consolidate_blocks.py
@@ -20,8 +20,8 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.quantum_info.operators import Unitary
 from qiskit.providers.basicaer import UnitarySimulatorPy
 from qiskit.compiler.assembler import assemble_circuits
+from qiskit.transpiler.passes.unroller import Unroller
 from qiskit.transpiler.basepasses import TransformationPass
-from . import Unroller
 
 
 class ConsolidateBlocks(TransformationPass):

--- a/qiskit/transpiler/passes/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/consolidate_blocks.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""
+Replace each block of consecutive gates by a single Unitary node.
+The blocks are collected by a previous pass, such as Collect2qBlocks.
+"""
+
+from qiskit.circuit import QuantumRegister, QuantumCircuit
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.quantum_info.operators import Unitary
+from qiskit.providers.basicaer import UnitarySimulatorPy
+from qiskit.compiler.assembler import assemble_circuits
+from qiskit.transpiler.basepasses import TransformationPass
+
+            # Test:  1. the unitary has to be on right wires (right order)
+            #        2. 3 qubit blocks must work
+            #        3. gates across multiple registers must work
+class ConsolidateBlocks(TransformationPass):
+    """
+    Pass to consolidate sequences of uninterrupted gates acting on
+    the same qubits into a Unitary node, to be resynthesized later,
+    to a potentially more optimal subcircuit.
+
+    Important note: this pass assumes that the 'blocks_list' property that
+    it reads is given such that blocks are in topological order.
+    """
+
+    def run(self, dag):
+        """iterate over each block and replace it with an equivalent Unitary
+        on the same wires.
+        """
+        new_dag = DAGCircuit()
+        for qreg in dag.qregs.values():
+            new_dag.add_qreg(qreg)
+        for creg in dag.cregs.values():
+            new_dag.add_creg(creg)
+
+        sim = UnitarySimulatorPy()
+
+        # compute ordered indices for the global circuit wires
+        global_index_map = {}
+        for wire in dag.wires:
+            if not isinstance(wire[0], QuantumRegister):
+                continue
+            global_qregs = list(dag.qregs.values())
+            global_index_map[wire] = global_qregs.index(wire[0]) + wire[1]
+
+        blocks = self.property_set['block_list']
+        nodes_seen = set()
+
+        for node in dag.nodes_in_topological_order():
+            # skip already-visited nodes or input/output nodes
+            if node in nodes_seen or node.type == 'in' or node.type == 'out':
+                continue
+            # check if the node belongs to the next block
+            if blocks and node in blocks[0]:
+                block = blocks[0]
+                # find the qubits involved in this block
+                block_qargs = set()
+                for nd in block:
+                    block_qargs |= set(nd.qargs)
+                # convert block to a sub-circuit, then simulate unitary and add
+                block_width = len(block_qargs)
+                q = QuantumRegister(block_width)
+                subcirc = QuantumCircuit(q)
+                block_index_map = self._block_qargs_to_indices(block_qargs,
+                                                               global_index_map)
+                for nd in block:
+                    nodes_seen.add(nd)
+                    subcirc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
+                qobj = assemble_circuits(subcirc)
+                unitary_matrix = sim.run(qobj).result().get_unitary()
+                unitary = Unitary(unitary_matrix)
+                new_dag.apply_operation_back(unitary, block_qargs)
+                del blocks[0]
+            else:
+                # the node could belong to some future block, but in that case
+                # we simply skip it. It is guaranteed that we will revisit that
+                # future block, via its other nodes
+                for block in blocks[1:]:
+                    if node in block:
+                        break
+                # 
+                else:
+                    nodes_seen.add(node)
+                    new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+            
+        return new_dag
+
+    def _block_qargs_to_indices(self, block_qargs, global_index_map):
+        """
+        Map each qubit in block_qargs to its wire position among the block's wires.
+        
+        Args:
+            block_qargs (list[tuple]): list of qubits that a block acts on
+            global_index_map (dict{tuple: int}): mapping from each qubit in the
+                circuit to its wire position within that circuit
+
+        Returns:
+            dict{tuple: int}: mapping from qarg to position in block
+        """
+        block_indices = [global_index_map[q] for q in block_qargs]
+        ordered_block_indices = sorted(block_indices)
+        block_positions = {q: ordered_block_indices.index(global_index_map[q])
+                           for q in block_qargs}
+        return block_positions

--- a/qiskit/transpiler/passes/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/consolidate_blocks.py
@@ -5,7 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=cell-var-from-loop 
+# pylint: disable=cell-var-from-loop
 
 """
 Replace each block of consecutive gates by a single Unitary node.
@@ -20,8 +20,8 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.quantum_info.operators import Unitary
 from qiskit.providers.basicaer import UnitarySimulatorPy
 from qiskit.compiler.assembler import assemble_circuits
-from qiskit.transpiler.passes import Unroller
 from qiskit.transpiler.basepasses import TransformationPass
+from . import Unroller
 
 
 class ConsolidateBlocks(TransformationPass):

--- a/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/mapping/barrier_before_final_measurements.py
@@ -57,7 +57,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
             Barrier(len(final_qubits)), list(final_qubits), [])
 
         # Preserve order of final ops collected earlier from the original DAG.
-        ordered_final_nodes = [node for node in dag.nodes_in_topological_order()
+        ordered_final_nodes = [node for node in dag.topological_op_nodes()
                                if node in set(final_ops)]
 
         # Move final ops to the new layer and append the new layer to the DAG.

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -81,9 +81,8 @@ def _get_layered_instructions(circuit, reverse_bits=False, justify=None):
         cregs += [(creg, bitno) for bitno in range(creg.size)]
 
     if justify == 'none':
-        for node in dag.nodes_in_topological_order():
-            if node.type == 'op':
-                ops.append([node])
+        for node in dag.topological_op_nodes():
+            ops.append([node])
 
     if justify == 'left':
         for dag_layer in dag.layers():

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -218,15 +218,15 @@ class TestDagOperations(QiskitTestCase):
             (self.qubit0, self.qubit2)}
         self.assertEqual(expected_qargs, node_qargs)
 
-    def test_nodes_in_topological_order(self):
-        """The node_nums_in_topological_order() method"""
+    def test_topological_nodes(self):
+        """The topological_nodes() method"""
         self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(HGate(), [self.qubit0], [])
         self.dag.apply_operation_back(CnotGate(), [self.qubit2, self.qubit1], [])
         self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit2], [])
         self.dag.apply_operation_back(HGate(), [self.qubit2], [])
 
-        named_nodes = self.dag.nodes_in_topological_order()
+        named_nodes = self.dag.topological_nodes()
 
         expected = [('qr[0]', []),
                     ('qr[1]', []),
@@ -243,6 +243,23 @@ class TestDagOperations(QiskitTestCase):
                     ('cr[0]', []),
                     ('cr[1]', []),
                     ('cr[1]', [])]
+        self.assertEqual(expected, [(i.name, i.qargs) for i in named_nodes])
+
+    def test_topological_op_nodes(self):
+        """The topological_op_nodes() method"""
+        self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit1], [])
+        self.dag.apply_operation_back(HGate(), [self.qubit0], [])
+        self.dag.apply_operation_back(CnotGate(), [self.qubit2, self.qubit1], [])
+        self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit2], [])
+        self.dag.apply_operation_back(HGate(), [self.qubit2], [])
+
+        named_nodes = self.dag.topological_op_nodes()
+
+        expected = [('cx', [(QuantumRegister(3, 'qr'), 0), (QuantumRegister(3, 'qr'), 1)]),
+                    ('h', [(QuantumRegister(3, 'qr'), 0)]),
+                    ('cx', [(QuantumRegister(3, 'qr'), 2), (QuantumRegister(3, 'qr'), 1)]),
+                    ('cx', [(QuantumRegister(3, 'qr'), 0), (QuantumRegister(3, 'qr'), 2)]),
+                    ('h', [(QuantumRegister(3, 'qr'), 2)])]
         self.assertEqual(expected, [(i.name, i.qargs) for i in named_nodes])
 
     def test_dag_nodes_on_wire(self):
@@ -285,7 +302,7 @@ class TestDagOperations(QiskitTestCase):
         self.assertEqual(node_names, ['cx', 'h', 'cx'])
 
     def test_remove_op_node(self):
-        """ Test remove_op_node method."""
+        """Test remove_op_node method."""
         self.dag.apply_operation_back(HGate(), [self.qubit0])
 
         op_nodes = self.dag.gate_nodes()
@@ -295,38 +312,28 @@ class TestDagOperations(QiskitTestCase):
         self.assertEqual(len(self.dag.gate_nodes()), 0)
 
     def test_remove_op_node_longer(self):
-        """ Test remove_op_node method in a "longer" dag"""
+        """Test remove_op_node method in a "longer" dag"""
         self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit1])
         self.dag.apply_operation_back(HGate(), [self.qubit0])
         self.dag.apply_operation_back(CnotGate(), [self.qubit2, self.qubit1])
         self.dag.apply_operation_back(CnotGate(), [self.qubit0, self.qubit2])
         self.dag.apply_operation_back(HGate(), [self.qubit2])
 
-        named_nodes = [node for node in self.dag.nodes_in_topological_order()]
-        self.dag.remove_op_node(named_nodes[2])
+        op_nodes = [node for node in self.dag.topological_op_nodes()]
+        self.dag.remove_op_node(op_nodes[0])
 
-        expected = [('qr[0]', []),
-                    ('h', [self.qubit0]),
-                    ('qr[1]', []),
-                    ('qr[2]', []),
+        expected = [('h', [self.qubit0]),
                     ('cx', [self.qubit2, self.qubit1]),
                     ('cx', [self.qubit0, self.qubit2]),
-                    ('h', [self.qubit2]),
-                    ('qr[0]', []),
-                    ('qr[1]', []),
-                    ('qr[2]', []),
-                    ('cr[0]', []),
-                    ('cr[0]', []),
-                    ('cr[1]', []),
-                    ('cr[1]', [])]
+                    ('h', [self.qubit2])]
         self.assertEqual(expected,
-                         [(i.name, i.qargs) for i in self.dag.nodes_in_topological_order()])
+                         [(i.name, i.qargs) for i in self.dag.topological_op_nodes()])
 
     def test_remove_non_op_node(self):
-        """ Try to remove a non-op node with remove_op_node method."""
+        """Try to remove a non-op node with remove_op_node method."""
         self.dag.apply_operation_back(HGate(), [self.qubit0])
 
-        in_node = next(self.dag.nodes_in_topological_order())
+        in_node = next(self.dag.topological_nodes())
         self.assertRaises(DAGCircuitError, self.dag.remove_op_node, in_node)
 
 

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -39,7 +39,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(qr[0], qr[1])
         dag = circuit_to_dag(qc)
 
-        topo_ops = [i for i in dag.nodes_in_topological_order() if i.type == 'op']
+        topo_ops = [i for i in dag.topological_op_nodes()]
         block_1 = [topo_ops[1], topo_ops[2]]
         block_2 = [topo_ops[0], topo_ops[3]]
 

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""
+Tests for the Collect2qBlocks transpiler pass.
+"""
+
+import unittest
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.converters import circuit_to_dag
+from qiskit.transpiler.passes import Collect2qBlocks
+from qiskit.test import QiskitTestCase
+
+
+class TestCollect2qBlocks(QiskitTestCase):
+    """
+    Tests to verify that blocks of 2q interactions are found correctly.
+    """
+
+    def test_blocks_in_topological_order(self):
+        """the pass returns blocks in correct topological order
+                                                     ______
+         q0:--[u1]-------.----      q0:-------------|      |--
+                         |                 ______   |  U2  |
+         q1:--[u2]--(+)-(+)---   =  q1:---|      |--|______|--
+                     |                    |  U1  |
+         q2:---------.--------      q2:---|______|------------
+        """
+        qr = QuantumRegister(3, "qr")
+        qc = QuantumCircuit(qr)
+        qc.u1(0.5, qr[0])
+        qc.u2(0.2, 0.6, qr[1])
+        qc.cx(qr[2], qr[1])
+        qc.cx(qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        topo_ops = [i for i in dag.nodes_in_topological_order() if i.type == 'op']
+        block_1 = [topo_ops[1], topo_ops[2]]
+        block_2 = [topo_ops[0], topo_ops[3]]
+
+        pass_ = Collect2qBlocks()
+        pass_.run(dag)
+        self.assertTrue(pass_.property_set['block_list'], [block_1, block_2])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2019, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
+"""
+Tests for the ConsolidateBlocks transpiler pass.
+"""
+
+import unittest
+import numpy as np
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.quantum_info.operators import Unitary
+from qiskit.converters import circuit_to_dag
+from qiskit.execute import execute
+from qiskit.transpiler.passes import ConsolidateBlocks
+from qiskit.providers.basicaer import UnitarySimulatorPy
+from qiskit.quantum_info.operators.measures import process_fidelity
+from qiskit.test import QiskitTestCase
+
+
+class TestConsolidateBlocks(QiskitTestCase):
+    """
+    Tests to verify that consolidating blocks of gates into unitaries
+    works correctly.
+    """
+    def test_consolidate_small_block(self):
+        """test a small block of gates can be turned into a unitary on same wires"""
+        qr = QuantumRegister(2, "qr")
+        qc = QuantumCircuit(qr)
+        qc.u1(0.5, qr[0])
+        qc.u2(0.2, 0.6, qr[1])
+        qc.cx(qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        pass_ = ConsolidateBlocks()
+        pass_.property_set['block_list'] = [dag.op_nodes()]
+        new_dag = pass_.run(dag)
+
+        sim = UnitarySimulatorPy()
+        result = execute(qc, sim).result()
+        unitary = Unitary(result.get_unitary())
+        self.assertEqual(len(new_dag.op_nodes()), 1)
+        fidelity = process_fidelity(new_dag.op_nodes()[0].op.representation, unitary.representation)
+        self.assertAlmostEqual(fidelity, 1.0, places=7)
+
+    def test_wire_order(self):
+        """order of qubits and the corresponding unitary is correct"""
+        qr = QuantumRegister(2, "qr")
+        qc = QuantumCircuit(qr)
+        qc.cx(qr[1], qr[0])
+        dag = circuit_to_dag(qc)
+
+        pass_ = ConsolidateBlocks()
+        pass_.property_set['block_list'] = [dag.op_nodes()]
+        new_dag = pass_.run(dag)
+
+        new_node = new_dag.op_nodes()[0]
+        self.assertEqual(new_node.qargs, [qr[0], qr[1]])
+        # the canonical CNOT matrix occurs when the control is more
+        # significant than target, which is the case here
+        fidelity = process_fidelity(new_node.op.representation, np.array([[1, 0, 0, 0],
+                                                                          [0, 1, 0, 0],
+                                                                          [0, 0, 0, 1],
+                                                                          [0, 0, 1, 0]]))
+        self.assertAlmostEqual(fidelity, 1.0, places=7)
+
+    def test_topological_order_preserved(self):
+        """the original topological order of nodes is preserved
+                                                     ______
+         q0:--[u1]-------.----      q0:-------------|      |--
+                         |                 ______   |  U2  |
+         q1:--[u2]--(+)-(+)---   =  q1:---|      |--|______|--
+                     |                    |  U1  |
+         q2:---------.--------      q2:---|______|------------
+        """
+        qr = QuantumRegister(3, "qr")
+        qc = QuantumCircuit(qr)
+        qc.u1(0.5, qr[0])
+        qc.u2(0.2, 0.6, qr[1])
+        qc.cx(qr[2], qr[1])
+        qc.cx(qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        pass_ = ConsolidateBlocks()
+        topo_ops = [i for i in dag.nodes_in_topological_order() if i.type == 'op']
+        block_1 = [topo_ops[1], topo_ops[2]]
+        block_2 = [topo_ops[0], topo_ops[3]]
+        pass_.property_set['block_list'] = [block_1, block_2]
+        new_dag = pass_.run(dag)
+
+        new_topo_ops = [i for i in new_dag.nodes_in_topological_order() if i.type == 'op']
+        self.assertEqual(len(new_topo_ops), 2)
+        self.assertEqual(new_topo_ops[0].qargs, [qr[1], qr[2]])
+        self.assertEqual(new_topo_ops[1].qargs, [qr[0], qr[1]])
+
+    def test_3q_blocks(self):
+        """blocks of more than 2 qubits work."""
+        qr = QuantumRegister(3, "qr")
+        qc = QuantumCircuit(qr)
+        qc.u1(0.5, qr[0])
+        qc.u2(0.2, 0.6, qr[1])
+        qc.cx(qr[2], qr[1])
+        qc.cx(qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        pass_ = ConsolidateBlocks()
+        pass_.property_set['block_list'] = [dag.op_nodes()]
+        new_dag = pass_.run(dag)
+
+        sim = UnitarySimulatorPy()
+        result = execute(qc, sim).result()
+        unitary = Unitary(result.get_unitary())
+        self.assertEqual(len(new_dag.op_nodes()), 1)
+        fidelity = process_fidelity(new_dag.op_nodes()[0].op.representation, unitary.representation)
+        self.assertAlmostEqual(fidelity, 1.0, places=7)
+
+    def test_block_spanning_two_regs(self):
+        """blocks spanning wires on different quantum registers work."""
+        qr0 = QuantumRegister(1, "qr0")
+        qr1 = QuantumRegister(1, "qr1")
+        qc = QuantumCircuit(qr0, qr1)
+        qc.u1(0.5, qr0[0])
+        qc.u2(0.2, 0.6, qr1[0])
+        qc.cx(qr0[0], qr1[0])
+        dag = circuit_to_dag(qc)
+
+        pass_ = ConsolidateBlocks()
+        pass_.property_set['block_list'] = [dag.op_nodes()]
+        new_dag = pass_.run(dag)
+
+        sim = UnitarySimulatorPy()
+        result = execute(qc, sim).result()
+        unitary = Unitary(result.get_unitary())
+        self.assertEqual(len(new_dag.op_nodes()), 1)
+        fidelity = process_fidelity(new_dag.op_nodes()[0].op.representation, unitary.representation)
+        self.assertAlmostEqual(fidelity, 1.0, places=7)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -37,7 +37,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         pass_ = ConsolidateBlocks()
-        pass_.property_set['block_list'] = [dag.op_nodes()]
+        pass_.property_set['block_list'] = [list(dag.topological_op_nodes())]
         new_dag = pass_.run(dag)
 
         sim = UnitarySimulatorPy()
@@ -86,13 +86,13 @@ class TestConsolidateBlocks(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         pass_ = ConsolidateBlocks()
-        topo_ops = [i for i in dag.nodes_in_topological_order() if i.type == 'op']
+        topo_ops = list(dag.topological_op_nodes())
         block_1 = [topo_ops[1], topo_ops[2]]
         block_2 = [topo_ops[0], topo_ops[3]]
         pass_.property_set['block_list'] = [block_1, block_2]
         new_dag = pass_.run(dag)
 
-        new_topo_ops = [i for i in new_dag.nodes_in_topological_order() if i.type == 'op']
+        new_topo_ops = [i for i in new_dag.topological_op_nodes() if i.type == 'op']
         self.assertEqual(len(new_topo_ops), 2)
         self.assertEqual(new_topo_ops[0].qargs, [qr[1], qr[2]])
         self.assertEqual(new_topo_ops[1].qargs, [qr[0], qr[1]])
@@ -108,7 +108,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         pass_ = ConsolidateBlocks()
-        pass_.property_set['block_list'] = [dag.op_nodes()]
+        pass_.property_set['block_list'] = [list(dag.topological_op_nodes())]
         new_dag = pass_.run(dag)
 
         sim = UnitarySimulatorPy()
@@ -129,7 +129,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         pass_ = ConsolidateBlocks()
-        pass_.property_set['block_list'] = [dag.op_nodes()]
+        pass_.property_set['block_list'] = [list(dag.topological_op_nodes())]
         new_dag = pass_.run(dag)
 
         sim = UnitarySimulatorPy()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Two passes are added, one for analyzing a circuit to find blocks of sequential 1- or 2-qubit gates. The other for replacing previously found blocks (this time of arbitrary width) by an equivalent Unitary operator node. This can later be resynthesized, e.g. using methods in #2119 and #2121.

Example:

![image](https://user-images.githubusercontent.com/8622381/56182369-d2c54480-5fdf-11e9-99ed-2b9812c549fc.png)

```python
qv = QuantumCircuit.from_qasm_str(qasm)
pm = PassManager()
pm.append(Collect2qBlocks())
pm.append(ConsolidateBlocks())
qv2 = pm.run(qv)
```

```
                                                                     
 q_0: |0>────────────────────────────────────────────────────────────
                                                                     
 q_1: |0>────────────────────────────────────────────────────────────
                                                                     
 q_2: |0>────────────────────────────────────────────────────────────
                                  ┌──────────┐            ░ ┌─┐      
 q_3: |0>─────────────────────────┤0         ├────────────░─┤M├──────
         ┌─────────┐              │  unitary │┌─────────┐ ░ └╥┘   ┌─┐
 q_4: |0>┤0        ├──────────────┤1         ├┤0        ├─░──╫────┤M├
         │         │              └──────────┘│         │ ░  ║    └╥┘
 q_5: |0>┤         ├──────────────────────────┤         ├────╫─────╫─
         │         │┌────────────┐            │         │    ║     ║ 
 q_6: |0>┤         ├┤ U1(0.7854) ├────────────┤         ├────╫─────╫─
         │ unitary │└────────────┘            │ unitary │    ║     ║ 
 q_7: |0>┤         ├──────────────────────────┤         ├────╫─────╫─
         │         │                          │         │    ║     ║ 
 q_8: |0>┤         ├──────────────────────────┤         ├────╫─────╫─
         │         │                          │         │ ░  ║ ┌─┐ ║ 
 q_9: |0>┤1        ├──────────────────────────┤1        ├─░──╫─┤M├─╫─
         └─────────┘                          └─────────┘ ░  ║ └╥┘ ║ 
q_10: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_11: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_12: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_13: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_14: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_15: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_16: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_17: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_18: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
q_19: |0>────────────────────────────────────────────────────╫──╫──╫─
                                                             ║  ║  ║ 
  c_0: 0 ════════════════════════════════════════════════════╩══╬══╬═
                                                                ║  ║ 
  c_1: 0 ═══════════════════════════════════════════════════════╩══╬═
                                                                   ║ 
  c_2: 0 ══════════════════════════════════════════════════════════╩═
                                                                     
```
