### PR TITLE
Fix qobj_to_circuits for circuits with initialize

### DIFF
--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -61,6 +61,8 @@ def qobj_to_circuits(qobj):
                     pass
                 if i.name in ['snapshot']:
                     instr_method(*params)
+                elif i.name == 'initialize':
+                    instr_method(params, qubits)
                 else:
                     instr_method(*params, *qubits, *clbits)
             circuits.append(circuit)

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -118,6 +118,7 @@ class TestQobjToCircuits(QiskitTestCase):
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
     def test_qobj_to_circuits_with_initialize(self):
+        """Check qobj_to_circuit's result with initialize."""
         q = QuantumRegister(2, name='q')
         circ = QuantumCircuit(q, name='circ')
         circ.initialize([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], q[:])

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -11,6 +11,8 @@
 
 import unittest
 
+import numpy as np
+
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import BasicAer
 from qiskit.compiler import assemble_circuits
@@ -114,6 +116,15 @@ class TestQobjToCircuits(QiskitTestCase):
 
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
+
+    def test_qobj_to_circuits_with_initialize(self):
+        q = QuantumRegister(2, name='q')
+        circ = QuantumCircuit(q, name='circ')
+        circ.initialize([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], q[:])
+        dag = circuit_to_dag(circ)
+        qobj = assemble_circuits(circ)
+        out_circuit = qobj_to_circuits(qobj)[0]
+        self.assertEqual(circuit_to_dag(out_circuit), dag)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now when you call qobj_to_circuits on a qobj that has an
initialize instruction in an experiment it will stacktrace with an error
because the number of positional arguments is not what's expected. This
is because the 2 positional arguments for initialize are lists and we're
currently calling initialize() on the output circuit with a * to convert
each list element into a positional argument. This commit fixes this by
special casing initialize instructions and properly passing the expected
positional args when calling initialize on the output circuit.

### Details and comments