### PR TITLE
Fix ibmqprovider version in CIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ stage_generic: &stage_generic
     - pip install -U -r requirements.txt
     - pip install -U -r requirements-dev.txt -c constraints.txt
     - pip install qiskit-aer
-    - pip install qiskit-ibmq-provider -c constraints.txt
+    - pip install "qiskit-ibmq-provider==0.1rc3" -c constraints.txt
   script:
     # Compile the executables and run the tests.
     - python setup.py build_ext --inplace

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
     - pip.exe install cython
     - pip.exe install stestr
     - pip.exe install qiskit-aer
-    - pip.exe install qiskit-ibmq-provider
+    - pip.exe install "qiskit-ibmq-provider==0.1rc3"
     - pip.exe install PyGithub
     - python setup.py build_ext --inplace
 # TODO: uncomment this when testing-cabal/subunit#33 is fixed


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As a new version of `IBMQProvider` was released in preparation for the terra release, CIs might choke when trying to install it, as it requires terra>=0.8 (which understandably is not released). This PR fixes installs 0.1rc3 instead during this window.


### Details and comments


