### PR TITLE
Parameterized circuit documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,7 @@ Added
   of gates (blocks) acting on 2 qubits.
 - Added a ``ConsolidateBlocks`` that turns previously-collected blocks of any size
   into equivalent Unitary operators in the circuit.
+- Added support for parameterized circuits. (#2103)
 
 Changed
 -------

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -114,29 +114,29 @@ class Instruction:
         for single_param in parameters:
             # example: u2(pi/2, sin(pi/4))
             if isinstance(single_param, sympy.Basic):
-                self.params.append(single_param)
+                self._params.append(single_param)
             # example: OpenQASM parsed instruction
             elif isinstance(single_param, node.Node):
-                self.params.append(single_param.sym())
+                self._params.append(single_param.sym())
             # example: u3(0.1, 0.2, 0.3)
             elif isinstance(single_param, (int, float)):
-                self.params.append(sympy.Number(single_param))
+                self._params.append(sympy.Number(single_param))
             # example: Initialize([complex(0,1), complex(0,0)])
             elif isinstance(single_param, complex):
-                self.params.append(single_param.real + single_param.imag * sympy.I)
+                self._params.append(single_param.real + single_param.imag * sympy.I)
             # example: snapshot('label')
             elif isinstance(single_param, str):
-                self.params.append(sympy.Symbol(single_param))
+                self._params.append(sympy.Symbol(single_param))
             # example: numpy.array([[1, 0], [0, 1]])
             elif isinstance(single_param, numpy.ndarray):
-                self.params.append(single_param)
+                self._params.append(single_param)
             # example: sympy.Matrix([[1, 0], [0, 1]])
             elif isinstance(single_param, sympy.Matrix):
-                self.params.append(single_param)
+                self._params.append(single_param)
             elif isinstance(single_param, sympy.Expr):
-                self.params.append(single_param)
+                self._params.append(single_param)
             elif isinstance(single_param, numpy.number):
-                self.params.append(sympy.Number(single_param.item()))
+                self._params.append(sympy.Number(single_param.item()))
             else:
                 raise QiskitError("invalid param type {0} in instruction "
                                   "{1}".format(type(single_param), self.name))

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -257,12 +257,11 @@ class QuantumCircuit:
                 these_symbols = set(param.free_symbols)
                 new_symbols = these_symbols - current_symbols
                 common_symbols = these_symbols & current_symbols
-                if new_symbols:
-                    for symbol in new_symbols:
-                        self._variable_table[symbol] = [(instruction, param_index)]
-                if common_symbols:
-                    for symbol in common_symbols:
-                        self._variable_table[symbol].append((instruction, param_index))
+
+                for symbol in new_symbols:
+                    self._variable_table[symbol] = [(instruction, param_index)]
+                for symbol in common_symbols:
+                    self._variable_table[symbol].append((instruction, param_index))
 
         return instruction
 

--- a/qiskit/circuit/variabletable.py
+++ b/qiskit/circuit/variabletable.py
@@ -5,9 +5,11 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 """
-Look-up table for varaible parameters in QuantumCircuit to support fast
+Look-up table for varaible parameters in QuantumCircuit.
 """
 from collections import MutableMapping
+
+from .instruction import Instruction
 
 
 class VariableTable(MutableMapping):
@@ -27,11 +29,14 @@ class VariableTable(MutableMapping):
         """set the value of variable
 
         Args:
-            key (Object): the variable to set
+            key (sympy.Symbol): the variable to set
             value (Number or dict): numeric constant or dictionary of
                 (Symbol:value) pairs
         """
         if key not in self._table:
+            for instruction, param_index in value:
+                assert isinstance(instruction, Instruction)
+                assert isinstance(param_index, int)
             self._table[key] = value
         else:
             for (instr, param_index) in self._table[key]:

--- a/test/python/circuit/test_variable_parameters.py
+++ b/test/python/circuit/test_variable_parameters.py
@@ -48,8 +48,9 @@ class TestVariableParameters(QiskitTestCase):
         rxg = RXGate(theta)
         qc.append(rxg, [qr[0]], [])
         vparams = qc.variable_table
+        self.assertEqual(len(vparams), 1)
         self.assertIs(theta, next(iter(vparams)))
-        self.assertIs(rxg, next(iter(next(iter(vparams[theta])))))
+        self.assertIs(rxg, vparams[theta][0][0])
 
     def test_fix_variable(self):
         """Test setting a varaible to a constant value"""
@@ -151,3 +152,28 @@ class TestVariableParameters(QiskitTestCase):
             self.assertEqual(circs[index].data[0][0].params[0], ones)
             self.assertEqual(circs[index].data[1][0].params[0], ones + tens)
             self.assertEqual(circs[index].data[2][0].params[0], -ones)
+
+    def test_parameter_expression_through_composite_instructions(self):
+        """Test evaluation of parameters through instruction."""
+        x = sympy.Symbol('x')
+        y = sympy.Symbol('y')
+        qr1 = QuantumRegister(1, name='qr1')
+        qc1 = QuantumCircuit(qr1)
+        qc1.rx(x, qr1)
+        qc1.rz(x + y, qr1)
+        qc1.ry(-x, qr1)
+        gate = qc1.to_instruction()
+
+        qc = QuantumCircuit(qr1)
+        qc.append(gate, [qr1[0]], [])
+
+        circs = []
+        x_list = numpy.arange(0, 5)
+        y_list = numpy.arange(10, 51, 10)
+        for ones, tens in zip(x_list, y_list):
+            circs.append(qc.assign_variables({x: ones, y: tens}))
+
+        for index, (ones, tens) in enumerate(zip(x_list, y_list)):
+            self.assertEqual(circs[index].data[0][0].params[0], ones)
+            self.assertEqual(circs[index].data[0][0].params[1], ones + tens)
+            self.assertEqual(circs[index].data[0][0].params[2], -ones)

--- a/test/python/circuit/test_variable_parameters.py
+++ b/test/python/circuit/test_variable_parameters.py
@@ -66,7 +66,7 @@ class TestVariableParameters(QiskitTestCase):
         self.assertEqual(qc.variable_table[theta][1][0].params[1], 0.6)
 
     def test_multiple_variables(self):
-        """Test setting a varaible to a constant value"""
+        """Test setting multiple variables"""
         theta = sympy.Symbol('θ')
         x = sympy.Symbol('x')
         qr = QuantumRegister(1)


### PR DESCRIPTION
Small changes following review of #2103 . There are still two open questions (one on when and how parameters of subcircuits are promoted to be parameters of their parent circuit, and one on the API of variable_table), but those can be fixed separately.