### PR TITLE
Handle opaque instructions and identity in qobj_to_circuits

### DIFF
--- a/qiskit/assembler/disassemble.py
+++ b/qiskit/assembler/disassemble.py
@@ -46,7 +46,7 @@ def _experiments_to_circuits(qobj):
                 if i.name == 'id':
                     name = 'iden'
                 qubits = []
-                params = []
+                params = getattr(i, 'params', [])
                 try:
                     for qubit in i.qubits:
                         qubit_label = x.header.qubit_labels[qubit]
@@ -60,10 +60,6 @@ def _experiments_to_circuits(qobj):
                         clbit_label = x.header.clbit_labels[clbit]
                         clbits.append(
                             creg_dict[clbit_label[0]][clbit_label[1]])
-                except Exception:  # pylint: disable=broad-except
-                    pass
-                try:
-                    params = i.params
                 except Exception:  # pylint: disable=broad-except
                     pass
                 if hasattr(circuit, name):

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -138,6 +138,7 @@ class TestQobjToCircuits(QiskitTestCase):
         self.assertEqual(circuit_to_dag(out_circuit), dag)
 
     def test_qobj_to_circuits_with_opaque(self):
+        """Check qobj_to_circuit's result with an opaque instruction."""
         opaque_inst = Instruction(name='my_inst', num_qubits=4,
                                   num_clbits=2, params=[0.5, 0.4])
         q = QuantumRegister(6, name='q')

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -15,9 +15,9 @@ import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import BasicAer
+from qiskit.circuit import Instruction
 from qiskit.compiler import assemble
 from qiskit.converters import qobj_to_circuits
-
 from qiskit.qobj import QasmQobj, QasmQobjConfig, QobjHeader
 from qiskit.transpiler import PassManager
 from qiskit.converters import circuit_to_dag
@@ -124,6 +124,28 @@ class TestQobjToCircuits(QiskitTestCase):
         circ.initialize([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], q[:])
         dag = circuit_to_dag(circ)
         qobj = assemble(circ)
+        out_circuit = qobj_to_circuits(qobj)[0]
+        self.assertEqual(circuit_to_dag(out_circuit), dag)
+
+    def test_qobj_to_circuits_with_identity(self):
+        """Check qobj_to_circuit's result with initialize."""
+        q = QuantumRegister(2, name='q')
+        circ = QuantumCircuit(q, name='circ')
+        circ.iden(q)
+        dag = circuit_to_dag(circ)
+        qobj = assemble_circuits(circ)
+        out_circuit = qobj_to_circuits(qobj)[0]
+        self.assertEqual(circuit_to_dag(out_circuit), dag)
+
+    def test_qobj_to_circuits_with_opaque(self):
+        opaque_inst = Instruction(name='my_inst', num_qubits=4,
+                                  num_clbits=2, params=[0.5, 0.4])
+        q = QuantumRegister(6, name='q')
+        c = ClassicalRegister(4, name='c')
+        circ = QuantumCircuit(q, c, name='circ')
+        circ.append(opaque_inst, [q[0], q[2], q[5], q[3]], [c[3], c[0]])
+        dag = circuit_to_dag(circ)
+        qobj = assemble_circuits(circ)
         out_circuit = qobj_to_circuits(qobj)[0]
         self.assertEqual(circuit_to_dag(out_circuit), dag)
 

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -133,7 +133,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circ = QuantumCircuit(q, name='circ')
         circ.iden(q)
         dag = circuit_to_dag(circ)
-        qobj = assemble_circuits(circ)
+        qobj = assemble(circ)
         out_circuit = qobj_to_circuits(qobj)[0]
         self.assertEqual(circuit_to_dag(out_circuit), dag)
 
@@ -146,7 +146,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circ = QuantumCircuit(q, c, name='circ')
         circ.append(opaque_inst, [q[0], q[2], q[5], q[3]], [c[3], c[0]])
         dag = circuit_to_dag(circ)
-        qobj = assemble_circuits(circ)
+        qobj = assemble(circ)
         out_circuit = qobj_to_circuits(qobj)[0]
         self.assertEqual(circuit_to_dag(out_circuit), dag)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the qobj_to_circuits converter to handle opaque/custom
instructions that aren't decomposed in the qobj. At the same time the
identity gate handling is fixed because it is a special case where the
gate name doesn't match the function name (id vs iden()) and needs to be
handled that way.

### Details and comments