### PR TITLE
Remove numeric passes from default set for parameterized circuits.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -676,6 +676,14 @@ class QuantumCircuit:
             new_circuit.variable_table[variable] = value_dict
         return new_circuit
 
+    @property
+    def unassigned_variables(self):
+        """Returns a set containing any variables which have not yet been assigned."""
+        return {variable
+                for variable, parameterized_instructions in self.variable_table.items()
+                if any(instruction.params[parameter_index].free_symbols
+                       for instruction, parameter_index in parameterized_instructions)}
+
 
 def _circuit_from_qasm(qasm):
     # pylint: disable=cyclic-import

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -101,12 +101,15 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
     if pass_manager and not pass_manager.working_list:
         return circuit
 
+    is_parametric_circuit = bool(circuit.unassigned_variables)
+
     dag = circuit_to_dag(circuit)
     del circuit
 
     final_dag = transpile_dag(dag, basis_gates=basis_gates,
                               coupling_map=coupling_map,
                               initial_layout=initial_layout,
+                              skip_numeric_passes=is_parametric_circuit,
                               seed_mapper=seed_mapper,
                               pass_manager=pass_manager)
 
@@ -117,7 +120,8 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
 
 # pylint: disable=redefined-builtin
 def transpile_dag(dag, basis_gates=None, coupling_map=None,
-                  initial_layout=None, seed_mapper=None, pass_manager=None):
+                  initial_layout=None, skip_numeric_passes=None,
+                  seed_mapper=None, pass_manager=None):
     """Transform a dag circuit into another dag circuit (transpile), through
     consecutive passes on the dag.
 
@@ -135,6 +139,7 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
             eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
 
         initial_layout (Layout or None): A layout object
+        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
         seed_mapper (int): random seed_mapper for the swap mapper
         pass_manager (PassManager): pass manager instance for the transpilation process
             If None, a default set of passes are run.
@@ -164,6 +169,7 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
             pass_manager = default_pass_manager(basis_gates,
                                                 CouplingMap(coupling_map),
                                                 initial_layout,
+                                                skip_numeric_passes,
                                                 seed_mapper=seed_mapper)
         else:
             pass_manager = default_pass_manager_simulator(basis_gates)

--- a/test/python/circuit/test_variable_parameters.py
+++ b/test/python/circuit/test_variable_parameters.py
@@ -177,3 +177,29 @@ class TestVariableParameters(QiskitTestCase):
             self.assertEqual(circs[index].data[0][0].params[0], ones)
             self.assertEqual(circs[index].data[0][0].params[1], ones + tens)
             self.assertEqual(circs[index].data[0][0].params[2], -ones)
+
+    def test_unassigned_variables(self):
+        """Test to check for presence of unassigned variables."""
+        x = sympy.Symbol('x')
+        y = sympy.Symbol('y')
+        qr = QuantumRegister(1, name='qr')
+        qc = QuantumCircuit(qr)
+
+        self.assertEqual(len(qc.unassigned_variables), 0)
+
+        qc.h(qr[0])
+        self.assertEqual(len(qc.unassigned_variables), 0)
+
+        qc.rx(x, qr[0])
+        self.assertEqual(len(qc.unassigned_variables), 1)
+        self.assertIs(x, next(iter(qc.unassigned_variables)))
+
+        qc.variable_table[x] = 0
+        self.assertEqual(len(qc.unassigned_variables), 0)
+
+        qc.rx(y, qr[0])
+        self.assertEqual(len(qc.unassigned_variables), 1)
+        self.assertIs(y, next(iter(qc.unassigned_variables)))
+
+        qc.variable_table[y] = 0.1
+        self.assertEqual(len(qc.unassigned_variables), 0)

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -12,6 +12,7 @@
 import math
 from unittest.mock import patch
 
+import sympy
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import compile, BasicAer
 from qiskit.extensions.standard import CnotGate
@@ -492,3 +493,34 @@ class TestTranspile(QiskitTestCase):
 
         self.assertRaises(TranspilerError, transpile,
                           qc, backend, initial_layout=bad_initial_layout)
+
+    def test_parameterized_circuit_for_simulator(self):
+        """Verify that a parameterized circuit can be transpiled for a simulator backend."""
+        qr = QuantumRegister(2, name='qr')
+        qc = QuantumCircuit(qr)
+
+        theta = sympy.Symbol('theta')
+        qc.rz(theta, qr[0])
+
+        transpiled_qc = transpile(qc, backend=BasicAer.get_backend('qasm_simulator'))
+
+        expected_qc = QuantumCircuit(qr)
+        expected_qc.u1(theta, qr[0])
+
+        self.assertEqual(expected_qc, transpiled_qc)
+
+    def test_parameterized_circuit_for_device(self):
+        """Verify that a parameterized circuit can be transpiled for a device backend."""
+        qr = QuantumRegister(2, name='qr')
+        qc = QuantumCircuit(qr)
+
+        theta = sympy.Symbol('theta')
+        qc.rz(theta, qr[0])
+
+        transpiled_qc = transpile(qc, backend=FakeMelbourne())
+
+        qr = QuantumRegister(14, 'q')
+        expected_qc = QuantumCircuit(qr)
+        expected_qc.u1(theta, qr[0])
+
+        self.assertEqual(expected_qc, transpiled_qc)


### PR DESCRIPTION
Fixes #2145 by removing `Optimize1qGates` from default set of passes when the circuit has variables which have not yet been assigned a value. Also, adds a `QuantumCircuit.unassigned_variables` property.