### PR TITLE
allow non-sympy instruction params

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -101,7 +101,10 @@ def assemble_circuits(circuits, run_config=None, qobj_header=None, qobj_id=None)
                     current_instruction.register = clbit_indices
 
             if op.params:
-                params = list(map(lambda x: x.evalf(), op.params))
+                # Evalute Sympy parameters
+                params = [
+                    x.evalf() if hasattr(x, 'evalf') else x for x in op.params
+                ]
                 params = [sympy.matrix2numpy(x, dtype=complex)
                           if isinstance(x, sympy.Matrix) else x for x in params]
                 if len(params) == 1 and isinstance(params[0], numpy.ndarray):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This change lets instruction params be any type, not just sympy expression. If they are sympy expressions they are evaluated as before.

This is needed to pass numpy matrices in for instructions (eg unitary) without unnecessarily wrapping them in a sympy matrix.

### Details and comments


