### PR TITLE
Add assemble_circuits() to root namespace

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -25,6 +25,7 @@ from qiskit.circuit import QuantumCircuit
 # pylint: disable=redefined-builtin
 from qiskit.tools.compiler import compile  # TODO remove after 0.8
 from qiskit.execute import (execute_circuits, execute)
+from qiskit.compiler.assembler import assemble_circuits
 
 # The qiskit.extensions.x imports needs to be placed here due to the
 # mechanism for adding gates dynamically.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The deprecation message for qiskit.compile() says that it is deprecated
and instead qiskit.assemble_circuits() in conjuction with transpile()
should be used instead of calling compile(). However, we never added
assemble_circuits to the root namespace on qiskit so you couldn't
actually call it that way. This commit corrects the oversight and
adds it to the root namespace.

### Details and comments
