### PR TITLE
Deprecate transpile_dag

### DIFF
--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -106,22 +106,57 @@ def _transpilation(circuit, basis_gates=None, coupling_map=None,
     dag = circuit_to_dag(circuit)
     del circuit
 
-    final_dag = transpile_dag(dag, basis_gates=basis_gates,
-                              coupling_map=coupling_map,
-                              initial_layout=initial_layout,
-                              skip_numeric_passes=is_parametric_circuit,
-                              seed_mapper=seed_mapper,
-                              pass_manager=pass_manager)
+    final_dag = _transpile_dag(dag, basis_gates=basis_gates,
+                               coupling_map=coupling_map,
+                               initial_layout=initial_layout,
+                               skip_numeric_passes=is_parametric_circuit,
+                               seed_mapper=seed_mapper,
+                               pass_manager=pass_manager)
 
     out_circuit = dag_to_circuit(final_dag)
 
     return out_circuit
 
 
-# pylint: disable=redefined-builtin
 def transpile_dag(dag, basis_gates=None, coupling_map=None,
                   initial_layout=None, skip_numeric_passes=None,
                   seed_mapper=None, pass_manager=None):
+    """Deprecated - Transform a dag circuit into another dag circuit
+    (transpile), through consecutive passes on the dag.
+
+    Args:
+        dag (DAGCircuit): dag circuit to transform via transpilation
+        basis_gates (list[str]): list of basis gate names supported by the
+            target. Default: ['u1','u2','u3','cx','id']
+        coupling_map (list): A graph of coupling::
+
+            [
+             [control0(int), target0(int)],
+             [control1(int), target1(int)],
+            ]
+
+            eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
+
+        initial_layout (Layout or None): A layout object
+        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
+        seed_mapper (int): random seed_mapper for the swap mapper
+        pass_manager (PassManager): pass manager instance for the transpilation process
+            If None, a default set of passes are run.
+            Otherwise, the passes defined in it will run.
+            If contains no passes in it, no dag transformations occur.
+
+    Returns:
+        DAGCircuit: transformed dag
+    """
+
+    warnings.warn("transpile_dag has been deprecated and will be removed in the "
+                  "0.9 release. Circuits can be transpiled directly to other "
+                  "circuits with the transpile function.", DeprecationWarning)
+    return _transpile_dag(dag, basis_gates, coupling_map, initial_layout,
+                          seed_mapper, pass_manager)
+
+def _transpile_dag(dag, basis_gates=None, coupling_map=None,
+                   initial_layout=None, seed_mapper=None, pass_manager=None):
     """Transform a dag circuit into another dag circuit (transpile), through
     consecutive passes on the dag.
 

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -153,10 +153,12 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
                   "0.9 release. Circuits can be transpiled directly to other "
                   "circuits with the transpile function.", DeprecationWarning)
     return _transpile_dag(dag, basis_gates, coupling_map, initial_layout,
-                          seed_mapper, pass_manager)
+                          skip_numeric_passes, seed_mapper, pass_manager)
+
 
 def _transpile_dag(dag, basis_gates=None, coupling_map=None,
-                   initial_layout=None, seed_mapper=None, pass_manager=None):
+                   initial_layout=None, skip_numeric_passes=None,
+                   seed_mapper=None, pass_manager=None):
     """Transform a dag circuit into another dag circuit (transpile), through
     consecutive passes on the dag.
 

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -8,9 +8,8 @@
 """Tests for pass cancelling 2 consecutive CNOTs on the same qubits."""
 
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.transpiler import PassManager, transpile_dag
+from qiskit.transpiler import PassManager, transpile
 from qiskit.transpiler.passes import CXCancellation
-from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
 
 
@@ -32,11 +31,10 @@ class TestCXCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
         circuit.cx(qr[1], qr[0])
         circuit.cx(qr[1], qr[0])
-        dag_circuit = circuit_to_dag(circuit)
 
         pass_manager = PassManager()
         pass_manager.append(CXCancellation())
-        dag_circuit = transpile_dag(dag_circuit, pass_manager=pass_manager)
-        resources_after = dag_circuit.count_ops()
+        out_circuit = transpile(circuit, pass_manager=pass_manager)
+        resources_after = out_circuit.count_ops()
 
         self.assertNotIn('cx', resources_after)

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -10,7 +10,7 @@
 import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
-from qiskit.transpiler import PassManager, transpile_dag
+from qiskit.transpiler import PassManager, transpile
 from qiskit.transpiler.passes import OptimizeSwapBeforeMeasure, DAGFixedPoint
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
@@ -107,7 +107,6 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         circuit.swap(qr[0], qr[1])
         circuit.swap(qr[0], qr[1])
         circuit.measure(qr[0], cr[0])
-        dag = circuit_to_dag(circuit)
 
         expected = QuantumCircuit(qr, cr)
         expected.measure(qr[0], cr[0])
@@ -116,9 +115,9 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         pass_manager.append(
             [OptimizeSwapBeforeMeasure(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile_dag(dag, pass_manager=pass_manager)
+        after = transpile(circuit, pass_manager=pass_manager)
 
-        self.assertEqual(circuit_to_dag(expected), after)
+        self.assertEqual(expected, after)
 
     def test_optimize_overlap_swap(self):
         """ Remove two swaps that overlap
@@ -136,7 +135,6 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         circuit.swap(qr[0], qr[1])
         circuit.swap(qr[1], qr[2])
         circuit.measure(qr[2], cr[0])
-        dag = circuit_to_dag(circuit)
 
         expected = QuantumCircuit(qr, cr)
         expected.measure(qr[0], cr[0])
@@ -145,9 +143,9 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         pass_manager.append(
             [OptimizeSwapBeforeMeasure(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile_dag(dag, pass_manager=pass_manager)
+        after = transpile(circuit, pass_manager=pass_manager)
 
-        self.assertEqual(circuit_to_dag(expected), after)
+        self.assertEqual(expected, after)
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -12,13 +12,11 @@
 import unittest.mock
 
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler import PassManager
-from qiskit.transpiler import transpile_dag
+from qiskit.transpiler import transpile
 from qiskit.transpiler import TranspilerAccessError, TranspilerError
 from qiskit.transpiler.passmanager import DoWhileController, ConditionalController, \
     FlowController, FlowControllerLinear
-from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
 from ._dummy_passes import (PassA_TP_NR_NP, PassB_TP_RA_PA, PassC_TP_RA_PA,
                             PassD_TP_NR_NP, PassE_AP_NR_NP, PassF_reduce_dag_property,
@@ -31,31 +29,31 @@ logger = "LocalLogger"
 class SchedulerTestCase(QiskitTestCase):
     """ Asserts for the scheduler. """
 
-    def assertScheduler(self, dag, passmanager, expected):
+    def assertScheduler(self, circuit, passmanager, expected):
         """
-        Runs transpiler(dag, passmanager) and checks if the passes run as expected.
+        Runs transpiler(circuit, passmanager) and checks if the passes run as expected.
         Args:
-            dag (DAGCircuit): DAG circuit to transform via transpilation.
+            circuit (QuantumCircuit): Circuit to transform via transpilation.
             passmanager (PassManager): pass manager instance for the transpilation process
             expected (list): List of things the passes are logging
         """
         with self.assertLogs(logger, level='INFO') as cm:
-            dag = transpile_dag(dag, pass_manager=passmanager)
-        self.assertIsInstance(dag, DAGCircuit)
+            out = transpile(circuit, pass_manager=passmanager)
+        self.assertIsInstance(out, QuantumCircuit)
         self.assertEqual([record.message for record in cm.records], expected)
 
-    def assertSchedulerRaises(self, dag, passmanager, expected, exception_type):
+    def assertSchedulerRaises(self, circuit, passmanager, expected, exception_type):
         """
-        Runs transpiler(dag, passmanager) and checks if the passes run as expected until
+        Runs transpiler(circuit, passmanager) and checks if the passes run as expected until
         exception_type is raised.
         Args:
-            dag (DAGCircuit): DAG circuit to transform via transpilation
+            circuit (QuantumCircuit): Circuit to transform via transpilation
             passmanager (PassManager): pass manager instance for the transpilation process
             expected (list): List of things the passes are logging
             exception_type (Exception): Exception that is expected to be raised.
         """
         with self.assertLogs(logger, level='INFO') as cm:
-            self.assertRaises(exception_type, transpile_dag, dag, pass_manager=passmanager)
+            self.assertRaises(exception_type, transpile, circuit, pass_manager=passmanager)
         self.assertEqual([record.message for record in cm.records], expected)
 
 
@@ -64,19 +62,19 @@ class TestPassManagerInit(SchedulerTestCase):
 
     def test_passes(self):
         """ A single chain of passes, with Requests and Preserves, at __init__ time"""
-        dag = circuit_to_dag(QuantumCircuit(QuantumRegister(1)))
+        circuit = QuantumCircuit(QuantumRegister(1))
         passmanager = PassManager(passes=[
             PassC_TP_RA_PA(),  # Request: PassA / Preserves: PassA
             PassB_TP_RA_PA(),  # Request: PassA / Preserves: PassA
             PassD_TP_NR_NP(argument1=[1, 2]),  # Requires: {}/ Preserves: {}
             PassB_TP_RA_PA()])
-        self.assertScheduler(dag, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                'run transformation pass PassC_TP_RA_PA',
-                                                'run transformation pass PassB_TP_RA_PA',
-                                                'run transformation pass PassD_TP_NR_NP',
-                                                'argument [1, 2]',
-                                                'run transformation pass PassA_TP_NR_NP',
-                                                'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
+                                                    'run transformation pass PassC_TP_RA_PA',
+                                                    'run transformation pass PassB_TP_RA_PA',
+                                                    'run transformation pass PassD_TP_NR_NP',
+                                                    'argument [1, 2]',
+                                                    'run transformation pass PassA_TP_NR_NP',
+                                                    'run transformation pass PassB_TP_RA_PA'])
 
 
 class TestUseCases(SchedulerTestCase):
@@ -84,7 +82,7 @@ class TestUseCases(SchedulerTestCase):
      many ways, and checks that passes are ran in the right order. """
 
     def setUp(self):
-        self.dag = circuit_to_dag(QuantumCircuit(QuantumRegister(1)))
+        self.circuit = QuantumCircuit(QuantumRegister(1))
         self.passmanager = PassManager()
 
     def test_chain(self):
@@ -93,30 +91,32 @@ class TestUseCases(SchedulerTestCase):
         self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
         self.passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {}/ Preserves: {}
         self.passmanager.append(PassB_TP_RA_PA())
-        self.assertScheduler(self.dag, self.passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                          'run transformation pass PassC_TP_RA_PA',
-                                                          'run transformation pass PassB_TP_RA_PA',
-                                                          'run transformation pass PassD_TP_NR_NP',
-                                                          'argument [1, 2]',
-                                                          'run transformation pass PassA_TP_NR_NP',
-                                                          'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run transformation pass PassA_TP_NR_NP',
+                              'run transformation pass PassC_TP_RA_PA',
+                              'run transformation pass PassB_TP_RA_PA',
+                              'run transformation pass PassD_TP_NR_NP',
+                              'argument [1, 2]',
+                              'run transformation pass PassA_TP_NR_NP',
+                              'run transformation pass PassB_TP_RA_PA'])
 
     def test_conditional_passes_true(self):
         """ A pass set with a conditional parameter. The callable is True. """
         self.passmanager.append(PassE_AP_NR_NP(True))
         self.passmanager.append(PassA_TP_NR_NP(),
                                 condition=lambda property_set: property_set['property'])
-        self.assertScheduler(self.dag, self.passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                          'set property as True',
-                                                          'run transformation pass PassA_TP_NR_NP'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run analysis pass PassE_AP_NR_NP',
+                              'set property as True',
+                              'run transformation pass PassA_TP_NR_NP'])
 
     def test_conditional_passes_false(self):
         """ A pass set with a conditional parameter. The callable is False. """
         self.passmanager.append(PassE_AP_NR_NP(False))
         self.passmanager.append(PassA_TP_NR_NP(),
                                 condition=lambda property_set: property_set['property'])
-        self.assertScheduler(self.dag, self.passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                          'set property as False'])
+        self.assertScheduler(self.circuit, self.passmanager, ['run analysis pass PassE_AP_NR_NP',
+                                                              'set property as False'])
 
     def test_conditional_and_loop(self):
         """ Run a conditional first, then a loop"""
@@ -127,7 +127,7 @@ class TestUseCases(SchedulerTestCase):
              PassF_reduce_dag_property()],
             do_while=lambda property_set: not property_set['property_fixed_point'],
             condition=lambda property_set: property_set['property'])
-        self.assertScheduler(self.dag, self.passmanager,
+        self.assertScheduler(self.circuit, self.passmanager,
                              ['run analysis pass PassE_AP_NR_NP',
                               'set property as True',
                               'run analysis pass PassG_calculates_dag_property',
@@ -185,7 +185,7 @@ class TestUseCases(SchedulerTestCase):
              PassF_reduce_dag_property()],
             do_while=lambda property_set: not property_set['property_fixed_point'],
             condition=lambda property_set: not property_set['property_fixed_point'])
-        self.assertScheduler(self.dag, self.passmanager,
+        self.assertScheduler(self.circuit, self.passmanager,
                              ['run analysis pass PassG_calculates_dag_property',
                               'set property as 8 (from dag.property)',
                               'run analysis pass PassK_check_fixed_point_property',
@@ -233,22 +233,24 @@ class TestUseCases(SchedulerTestCase):
         """ When a pass is still a valid pass (because following passes preserved it), it should not
         run again"""
         self.passmanager.append([PassB_TP_RA_PA(), PassA_TP_NR_NP(), PassB_TP_RA_PA()])
-        self.assertScheduler(self.dag, self.passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                          'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run transformation pass PassA_TP_NR_NP',
+                              'run transformation pass PassB_TP_RA_PA'])
 
     def test_do_not_repeat_based_on_idempotence(self):
         """ Repetition can be optimized to a single execution when the pass is idempotent"""
         self.passmanager.append(PassA_TP_NR_NP())
         self.passmanager.append([PassA_TP_NR_NP(), PassA_TP_NR_NP()])
         self.passmanager.append(PassA_TP_NR_NP())
-        self.assertScheduler(self.dag, self.passmanager, ['run transformation pass PassA_TP_NR_NP'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run transformation pass PassA_TP_NR_NP'])
 
     def test_non_idempotent_pass(self):
         """ Two or more runs of a non-idempotent pass cannot be optimized. """
         self.passmanager.append(PassF_reduce_dag_property())
         self.passmanager.append([PassF_reduce_dag_property(), PassF_reduce_dag_property()])
         self.passmanager.append(PassF_reduce_dag_property())
-        self.assertScheduler(self.dag, self.passmanager,
+        self.assertScheduler(self.circuit, self.passmanager,
                              ['run transformation pass PassF_reduce_dag_property',
                               'dag property = 6',
                               'run transformation pass PassF_reduce_dag_property',
@@ -261,7 +263,7 @@ class TestUseCases(SchedulerTestCase):
     def test_fenced_property_set(self):
         """ Transformation passes are not allowed to modified the property set. """
         self.passmanager.append(PassH_Bad_TP())
-        self.assertSchedulerRaises(self.dag, self.passmanager,
+        self.assertSchedulerRaises(self.circuit, self.passmanager,
                                    ['run transformation pass PassH_Bad_TP'],
                                    TranspilerAccessError)
 
@@ -274,10 +276,9 @@ class TestUseCases(SchedulerTestCase):
         circ.cx(qr[0], qr[1])
         circ.cx(qr[1], qr[0])
         circ.cx(qr[1], qr[0])
-        dag = circuit_to_dag(circ)
 
         self.passmanager.append(PassI_Bad_AP())
-        self.assertSchedulerRaises(dag, self.passmanager,
+        self.assertSchedulerRaises(circ, self.passmanager,
                                    ['run analysis pass PassI_Bad_AP',
                                     'cx_runs: {(5, 6, 7, 8)}'],
                                    TranspilerAccessError)
@@ -290,11 +291,11 @@ class TestUseCases(SchedulerTestCase):
         passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
         passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {} / Preserves: {}
         passmanager.append(PassB_TP_RA_PA())
-        self.assertScheduler(self.dag, passmanager, ['run transformation pass PassC_TP_RA_PA',
-                                                     'run transformation pass PassB_TP_RA_PA',
-                                                     'run transformation pass PassD_TP_NR_NP',
-                                                     'argument [1, 2]',
-                                                     'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassC_TP_RA_PA',
+                                                         'run transformation pass PassB_TP_RA_PA',
+                                                         'run transformation pass PassD_TP_NR_NP',
+                                                         'argument [1, 2]',
+                                                         'run transformation pass PassB_TP_RA_PA'])
 
     def test_ignore_preserves_pm(self):
         """ A pass manager that ignores preserves does not record the passes decleared in the
@@ -304,14 +305,14 @@ class TestUseCases(SchedulerTestCase):
         passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
         passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {} / Preserves: {}
         passmanager.append(PassB_TP_RA_PA())
-        self.assertScheduler(self.dag, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassC_TP_RA_PA',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassB_TP_RA_PA',
-                                                     'run transformation pass PassD_TP_NR_NP',
-                                                     'argument [1, 2]',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassC_TP_RA_PA',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassB_TP_RA_PA',
+                                                         'run transformation pass PassD_TP_NR_NP',
+                                                         'argument [1, 2]',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassB_TP_RA_PA'])
 
     def test_pass_non_idempotence_pm(self):
         """ A pass manager that considers every pass as not idempotent, allows the immediate
@@ -321,26 +322,26 @@ class TestUseCases(SchedulerTestCase):
         passmanager.append(PassA_TP_NR_NP())  # Normally removed for optimization, not here.
         passmanager.append(PassB_TP_RA_PA())  # Normally required is ignored for optimization,
         # not here
-        self.assertScheduler(self.dag, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassB_TP_RA_PA'])
 
     def test_pass_non_idempotence_passset(self):
         """ A pass set that is not idempotent. """
         passmanager = PassManager()
         passmanager.append([PassA_TP_NR_NP(), PassB_TP_RA_PA()], ignore_preserves=True)
-        self.assertScheduler(self.dag, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run transformation pass PassB_TP_RA_PA'])
+        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run transformation pass PassB_TP_RA_PA'])
 
     def test_analysis_pass_is_idempotent(self):
         """ Analysis passes are idempotent. """
         passmanager = PassManager()
         passmanager.append(PassE_AP_NR_NP(argument1=1))
         passmanager.append(PassE_AP_NR_NP(argument1=1))
-        self.assertScheduler(self.dag, passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                     'set property as 1'])
+        self.assertScheduler(self.circuit, passmanager, ['run analysis pass PassE_AP_NR_NP',
+                                                         'set property as 1'])
 
     def test_ap_before_and_after_a_tp(self):
         """ A default transformation does not preserves anything and analysis passes
@@ -349,11 +350,11 @@ class TestUseCases(SchedulerTestCase):
         passmanager.append(PassE_AP_NR_NP(argument1=1))
         passmanager.append(PassA_TP_NR_NP())
         passmanager.append(PassE_AP_NR_NP(argument1=1))
-        self.assertScheduler(self.dag, passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                     'set property as 1',
-                                                     'run transformation pass PassA_TP_NR_NP',
-                                                     'run analysis pass PassE_AP_NR_NP',
-                                                     'set property as 1'])
+        self.assertScheduler(self.circuit, passmanager, ['run analysis pass PassE_AP_NR_NP',
+                                                         'set property as 1',
+                                                         'run transformation pass PassA_TP_NR_NP',
+                                                         'run analysis pass PassE_AP_NR_NP',
+                                                         'set property as 1'])
 
     def test_pass_option_precedence(self):
         """ The precedence of options is, in order of priority:
@@ -371,7 +372,7 @@ class TestUseCases(SchedulerTestCase):
     def test_pass_no_return_a_dag(self):
         """ Passes instances with same arguments (independently of the order) are the same. """
         self.passmanager.append(PassJ_Bad_NoReturn())
-        self.assertSchedulerRaises(self.dag, self.passmanager,
+        self.assertSchedulerRaises(self.circuit, self.passmanager,
                                    ['run transformation pass PassJ_Bad_NoReturn'], TranspilerError)
 
     def test_fixed_point_pass(self):
@@ -381,7 +382,7 @@ class TestUseCases(SchedulerTestCase):
              PassA_TP_NR_NP(),
              PassF_reduce_dag_property()],
             do_while=lambda property_set: not property_set['property_fixed_point'])
-        self.assertScheduler(self.dag, self.passmanager,
+        self.assertScheduler(self.circuit, self.passmanager,
                              ['run analysis pass PassG_calculates_dag_property',
                               'set property as 8 (from dag.property)',
                               'run analysis pass PassK_check_fixed_point_property',
@@ -433,7 +434,7 @@ class TestUseCases(SchedulerTestCase):
              PassF_reduce_dag_property()],
             do_while=lambda property_set: not property_set['property_fixed_point'],
             max_iteration=2)
-        self.assertSchedulerRaises(self.dag, self.passmanager,
+        self.assertSchedulerRaises(self.circuit, self.passmanager,
                                    ['run analysis pass PassG_calculates_dag_property',
                                     'set property as 8 (from dag.property)',
                                     'run analysis pass PassK_check_fixed_point_property',
@@ -452,11 +453,12 @@ class TestUseCases(SchedulerTestCase):
         self.passmanager.append(PassM_AP_NR_NP(argument1=1))
         self.passmanager.append(PassA_TP_NR_NP())
         self.passmanager.append(PassM_AP_NR_NP(argument1=1))
-        self.assertScheduler(self.dag, self.passmanager, ['run analysis pass PassM_AP_NR_NP',
-                                                          'self.argument1 = 2',
-                                                          'run transformation pass PassA_TP_NR_NP',
-                                                          'run analysis pass PassM_AP_NR_NP',
-                                                          'self.argument1 = 2'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run analysis pass PassM_AP_NR_NP',
+                              'self.argument1 = 2',
+                              'run transformation pass PassA_TP_NR_NP',
+                              'run analysis pass PassM_AP_NR_NP',
+                              'self.argument1 = 2'])
 
 
 class DoXTimesController(FlowController):
@@ -477,19 +479,20 @@ class TestControlFlowPlugin(SchedulerTestCase):
 
     def setUp(self):
         self.passmanager = PassManager()
-        self.dag = circuit_to_dag(QuantumCircuit(QuantumRegister(1)))
+        self.circuit = QuantumCircuit(QuantumRegister(1))
 
     def test_control_flow_plugin(self):
         """ Adds a control flow plugin with a single parameter and runs it. """
         FlowController.add_flow_controller('do_x_times', DoXTimesController)
         self.passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()], do_x_times=lambda x: 3)
-        self.assertScheduler(self.dag, self.passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                          'run transformation pass PassB_TP_RA_PA',
-                                                          'run transformation pass PassC_TP_RA_PA',
-                                                          'run transformation pass PassB_TP_RA_PA',
-                                                          'run transformation pass PassC_TP_RA_PA',
-                                                          'run transformation pass PassB_TP_RA_PA',
-                                                          'run transformation pass PassC_TP_RA_PA'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run transformation pass PassA_TP_NR_NP',
+                              'run transformation pass PassB_TP_RA_PA',
+                              'run transformation pass PassC_TP_RA_PA',
+                              'run transformation pass PassB_TP_RA_PA',
+                              'run transformation pass PassC_TP_RA_PA',
+                              'run transformation pass PassB_TP_RA_PA',
+                              'run transformation pass PassC_TP_RA_PA'])
 
     def test_callable_control_flow_plugin(self):
         """ Removes do_while, then adds it back. Checks max_iteration still working. """
@@ -500,7 +503,7 @@ class TestControlFlowPlugin(SchedulerTestCase):
         self.assertEqual(controllers_length, len(FlowController.registered_controllers))
         self.passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()],
                                 do_while=lambda property_set: True, max_iteration=2)
-        self.assertSchedulerRaises(self.dag, self.passmanager,
+        self.assertSchedulerRaises(self.circuit, self.passmanager,
                                    ['run transformation pass PassA_TP_NR_NP',
                                     'run transformation pass PassB_TP_RA_PA',
                                     'run transformation pass PassC_TP_RA_PA',

--- a/test/python/transpiler/test_remove_reset_in_zero_state.py
+++ b/test/python/transpiler/test_remove_reset_in_zero_state.py
@@ -10,7 +10,7 @@
 import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.transpiler import PassManager, transpile_dag
+from qiskit.transpiler import PassManager, transpile
 from qiskit.transpiler.passes import RemoveResetInZeroState, DAGFixedPoint
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
@@ -84,7 +84,6 @@ class TestRemoveResetInZeroStateFixedPoint(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.reset(qr[0])
         circuit.reset(qr[0])
-        dag = circuit_to_dag(circuit)
 
         expected = QuantumCircuit(qr)
 
@@ -92,9 +91,9 @@ class TestRemoveResetInZeroStateFixedPoint(QiskitTestCase):
         pass_manager.append(
             [RemoveResetInZeroState(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile_dag(dag, pass_manager=pass_manager)
+        after = transpile(circuit, pass_manager=pass_manager)
 
-        self.assertEqual(circuit_to_dag(expected), after)
+        self.assertEqual(expected, after)
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -16,7 +16,7 @@ import sympy
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import compile, BasicAer
 from qiskit.extensions.standard import CnotGate
-from qiskit.transpiler import PassManager, transpile_dag, transpile, TranspilerError
+from qiskit.transpiler import PassManager, transpile, TranspilerError
 from qiskit.compiler import assemble_circuits
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase, Path
@@ -36,10 +36,9 @@ class TestTranspileDag(QiskitTestCase):
         """Verify BarrierBeforeFinalMeasurements pass is called in default pipeline for devices."""
 
         circ = QuantumCircuit.from_qasm_file(self._get_resource_path('example.qasm', Path.QASMS))
-        dag_circuit = circuit_to_dag(circ)
         layout = Layout.generate_trivial_layout(*circ.qregs)
-        transpile_dag(dag_circuit, coupling_map=FakeRueschlikon().configuration().coupling_map,
-                      initial_layout=layout)
+        transpile(circ, coupling_map=FakeRueschlikon().configuration().coupling_map,
+                  initial_layout=layout)
 
         self.assertTrue(mock_pass.called)
 
@@ -76,12 +75,11 @@ class TestTranspileDag(QiskitTestCase):
         circ.h(qr[0])
         circ.cx(qr[0], qr[1])
         circ.cx(qr[0], qr[1])
-        dag_circuit = circuit_to_dag(circ)
 
-        after = transpile_dag(dag_circuit, coupling_map=[[0, 1], [1, 0]])
+        after = transpile(circ, coupling_map=[[0, 1], [1, 0]])
 
         expected = QuantumCircuit(QuantumRegister(2, 'q'))
-        self.assertEqual(after, circuit_to_dag(expected))
+        self.assertEqual(after, expected)
 
     def test_pass_manager_empty(self):
         """Test passing an empty PassManager() to the transpiler.
@@ -96,12 +94,11 @@ class TestTranspileDag(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
         circuit.cx(qr[0], qr[1])
         circuit.cx(qr[0], qr[1])
-        dag_circuit = circuit_to_dag(circuit)
-        resources_before = dag_circuit.count_ops()
+        resources_before = circuit.count_ops()
 
         pass_manager = PassManager()
-        dag_circuit = transpile_dag(dag_circuit, pass_manager=pass_manager)
-        resources_after = dag_circuit.count_ops()
+        out_circuit = transpile(circuit, pass_manager=pass_manager)
+        resources_after = out_circuit.count_ops()
 
         self.assertDictEqual(resources_before, resources_after)
 
@@ -113,12 +110,12 @@ class TestTranspileDag(QiskitTestCase):
         circ = QuantumCircuit.from_qasm_file(
             self._get_resource_path('move_measurements.qasm', Path.QASMS))
 
-        dag_circuit = circuit_to_dag(circ)
         lay = Layout({('qa', 0): ('q', 0), ('qa', 1): ('q', 1), ('qb', 0): ('q', 15),
                       ('qb', 1): ('q', 2), ('qb', 2): ('q', 14), ('qN', 0): ('q', 3),
                       ('qN', 1): ('q', 13), ('qN', 2): ('q', 4), ('qc', 0): ('q', 12),
                       ('qNt', 0): ('q', 5), ('qNt', 1): ('q', 11), ('qt', 0): ('q', 6)})
-        out_dag = transpile_dag(dag_circuit, initial_layout=lay, coupling_map=cmap)
+        out = transpile(circ, initial_layout=lay, coupling_map=cmap)
+        out_dag = circuit_to_dag(out)
         meas_nodes = out_dag.named_nodes('measure')
         for meas_node in meas_nodes:
             is_last_measure = all([after_measure.type == 'out'


### PR DESCRIPTION
Fixes #1408 . Deprecates `transpiler.transpile_dag` in favor of `transpiler.transpile`. 