### PR TITLE
change qobj format of unitary and snapshot

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -107,16 +107,12 @@ def assemble_circuits(circuits, run_config=None, qobj_header=None, qobj_id=None)
                 ]
                 params = [sympy.matrix2numpy(x, dtype=complex)
                           if isinstance(x, sympy.Matrix) else x for x in params]
-                if len(params) == 1 and isinstance(params[0], numpy.ndarray):
-                    # TODO: Aer expects list of rows for unitary instruction params;
-                    # change to matrix in Aer.
-                    params = params[0]
                 current_instruction.params = params
             # TODO: I really dont like this for snapshot. I also think we should change
             # type to snap_type
             if op.name == "snapshot":
                 current_instruction.label = str(op.params[0])
-                current_instruction.type = str(op.params[1])
+                current_instruction.snapshot_type = str(op.params[1])
             if op.name == 'unitary':
                 if op._label:
                     current_instruction.label = op._label

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -8,7 +8,6 @@
 """Assemble function for converting a list of circuits into a qobj"""
 import uuid
 
-import numpy
 import sympy
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This changes the format of "unitary" and "snapshots" in assembler

* "unitary" now has a standard format for params with `"params": [mat]` rather than `"params": mat` which needed a special case to catch.
* "snapshot" changes `"type"` to more descriptive `"snapshot_type"`.

These need to be synced with Aer [PR 161](https://github.com/Qiskit/qiskit-aer/pull/161)

### Details and comments


