### PR TITLE
interface to execute(), transpile() and assemble()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -180,8 +180,9 @@ Deprecated
   ``QuantumCircuit`` objects from a compiled qobj. (#2137)
 - The ``qiskit.transpiler.transpile()`` function is deprecated in favor of
   ``qiskit.compiler.transpile()`` (#2166).
-- The ``seed_mapper`` argument in ``transpile()`` is deprecated in favor of
+- The ``seed_mapper`` argument in ``transpile()`` and ``execute()`` is deprecated in favor of
   ``seed_transpile()``, which sets the seed for all stochastic stages of the transpiler (#2166).
+- The ``seed`` argument is ``execute()`` is deprecated in favor of ``seed_simulator`` (#2166).
 - The ``pass_manager`` argument in ``transpile()`` is deprecated. Instead, the
   ``pass_manager.run()`` methdod can be used directly to transform the circuit (#2166).
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,7 +28,7 @@ Added
 - Builtin library of continuous pulses and builtin library of discrete pulses which are obtained
   by sampling continuous pulses with default sampling strategy.
 - Sampler decorator and standard sampler library for conversion of continuous pulses
-  to discrete `SamplePulse`s (#2042).
+  to discrete ``SamplePulse`` (#2042).
 - Core StochasticSwap routine implimented in Cython (#1789).
 - Added QuantumChannel classes SuperOp, Choi, Kraus, Stinespring, PTM, Chi to
   quantum_info for manipulating quantum channels and CPTP maps.
@@ -54,13 +54,12 @@ Added
   circuits (e.g. basis_gates, coupling_map, initial_layout) (#1856)
 - Added a ``qiskit.compiler`` namespace for all functions that transpile, schedule
   and assemble circuits and pulses (#1856)
+- Added support for passing a list of ``basis_gates``, ``coupling_map`` etc. to the
+  ``qiskit.compiler.transpile()`` function, each corresponding to one of the circuits (#2163)
 - Added a ``qiskit.compiler.assemble_circuits()`` function to generate qobj from some
   circuits and a RunConfig (#1856)
-- Added an ``execute_circuits()`` function that takes a list of circuits along with a
-  TranspileConfig and RunConfig. The ``execute()`` function remains as a wrapper of this,
-  and later as a wrapper of ``execute_pulses()``.
-- ``execute_circuits()`` and ``assemble_circuits()`` allow setting a qobj_header of type
-  QobjHeader to add extra information to the qobj (and thus result).
+- ``execute()`` and ``assemble()`` allow setting a qobj_header, of type
+  QobjHeader or dict, to add extra information to the qobj (and thus result).
 - Register indexing supports negative indices (#1875)
 - Added new resource estimation passes: ``Depth``, ``Width``, ``Size``, ``CountOps``, and
   ``NumTensorFactors``, all grouped in the ``ResourceEstimation`` analysis pass.
@@ -158,6 +157,9 @@ Changed
   (#1878)
 - Layout object can now only be constructed from a dictionary, and must be bijective (#2157).
 - ``transpile()`` accepts ``initial_layout`` in the form of dict, list or Layout (#2157).
+- Not specifying a basis in ``execute()`` or ``transpile()`` no longer defaults to unrolling
+  to the ['u1', 'u2', 'u3', 'cx'] basis. Instead the default behavior is to not unroll,
+  unless specifically requested (#2166).
 
 Deprecated
 ----------
@@ -171,12 +173,17 @@ Deprecated
 - The ``qiskit.tools.qcvv`` package is deprecated in favor of Qiskit Ignis (#1884).
 - The ``qiskit.compile()`` function is now deprecated in favor of explicitly
   using the ``qiskit.compiler.transpile()`` function to transform a circuit followed
-  by ``qiskit.compiler.assemble_circuits()`` to make a qobj out of it.
+  by ``qiskit.compiler.assemble()`` to make a qobj out of it.
 - ``qiskit.converters.qobj_to_circuits()`` has been deprecated and will be
   removed in a future release. Instead
   ``qiskit.compiler.disassemble_circuits()`` should be used to extract
   ``QuantumCircuit`` objects from a compiled qobj. (#2137)
-
+- The ``qiskit.transpiler.transpile()`` function is deprecated in favor of
+  ``qiskit.compiler.transpile()`` (#2166).
+- The ``seed_mapper`` argument in ``transpile()`` is deprecated in favor of
+  ``seed_transpile()``, which sets the seed for all stochastic stages of the transpiler (#2166).
+- The ``pass_manager`` argument in ``transpile()`` is deprecated. Instead, the
+  ``pass_manager.run()`` methdod can be used directly to transform the circuit (#2166).
 
 Fixed
 -----

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -24,8 +24,9 @@ from qiskit.circuit import QuantumRegister
 from qiskit.circuit import QuantumCircuit
 # pylint: disable=redefined-builtin
 from qiskit.tools.compiler import compile  # TODO remove after 0.8
-from qiskit.execute import (execute_circuits, execute_schedules, execute)
-from qiskit.compiler.assembler import (assemble_circuits, assemble_schedules)
+from qiskit.execute import execute
+from qiskit.compiler.transpiler import transpile
+from qiskit.compiler.assembler import assemble
 
 # The qiskit.extensions.x imports needs to be placed here due to the
 # mechanism for adding gates dynamically.

--- a/qiskit/compiler/__init__.py
+++ b/qiskit/compiler/__init__.py
@@ -11,6 +11,6 @@
 
 from .run_config import RunConfig
 from .transpile_config import TranspileConfig
-from .assembler import assemble_circuits, assemble_schedules
+from .assembler import assemble
 from .disassembler import disassemble
 from .transpiler import transpile

--- a/qiskit/compiler/__init__.py
+++ b/qiskit/compiler/__init__.py
@@ -9,8 +9,6 @@
 
 """
 
-from .run_config import RunConfig
-from .transpile_config import TranspileConfig
 from .assembler import assemble
 from .disassembler import disassemble
 from .transpiler import transpile

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=unused-import
-
 """Assemble function for converting a list of circuits into a qobj"""
 import warnings
 import uuid
@@ -23,92 +21,28 @@ from qiskit.qobj import (QasmQobj, PulseQobj, QobjExperimentHeader, QobjHeader,
                          QasmQobjConfig, PulseQobjInstruction, PulseQobjExperimentConfig,
                          PulseQobjExperiment, PulseQobjConfig, QobjPulseLibrary)
 from qiskit.qobj.converters import PulseQobjConverter, LoConfigConverter
+from qiskit.validation.exceptions import ModelValidationError
 
 logger = logging.getLogger(__name__)
 
 
-def assemble_circuits(circuits, qobj_id=None, qobj_header=None,
-                      shots=None, memory=None, max_credits=None,
-                      seed_simulator=None, run_config=None,
-                      config=None, seed=None):  # deprecated
+def assemble_circuits(circuits, qobj_id=None, qobj_header=None, run_config=None):
     """Assembles a list of circuits into a qobj which can be run on the backend.
 
-    This function serializes the circuits to create Qobj "experiments", and
-    annotates the experiment payload with header and configurations.
-
     Args:
-        circuits (list[QuantumCircuits] or QuantumCircuit):
-            circuit(s) to assemble
-
-        qobj_id (str):
-            String identifier to annotate the Qobj
-
-        qobj_header (QobjHeader or dict):
-            User input that will be inserted in Qobj header, and will also be
-            copied to the corresponding Result header. Headers do not affect the run.
-
-        shots (int):
-            number of repetitions of each circuit, for sampling. Default: 2014
-
-        memory (bool):
-            if True, per-shot measurement bitstrings are returned as well
-            (provided the backend supports it). Default: False
-
-        max_credits (int):
-            maximum credits to spend on job. Default: 10
-
-        seed_simulator (int):
-            random seed to control sampling, for when backend is a simulator
-
-        config (dict):
-            DEPRECATED in 0.8: use run_config instead
-
-        run_config (RunConfig):
-            Qobj runtime configuration, containing some or all of the above options.
-            If any other option is explicitly set (e.g. shots), it
-            will override the run_config's.
-
-        seed (int):
-            DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
+        circuits (list[QuantumCircuits]): circuit(s) to assemble
+        qobj_id (int): identifier for the generated qobj
+        qobj_header (QobjHeader): header to pass to the results
+        run_config (RunConfig): configuration of the runtime environment
 
     Returns:
         QasmQobj: the Qobj to be run on the backends
     """
-    # deprecation matter
-    if config:
-        warnings.warn('config is not used anymore. Set all configs in '
-                      'run_config.', DeprecationWarning)
-        run_config = run_config or config
-    if seed:
-        warnings.warn('seed is deprecated in favor of seed_simulator.', DeprecationWarning)
-        seed_simulator = seed_simulator or seed
-
-    # The header that goes at the top of the Qobj (and later Result)
-    qobj_header = qobj_header or QobjHeader()
-    if isinstance(qobj_header, dict):
-        qobj_header = QobjHeader(**qobj_header)
-
-    # Get RunConfig(s) to configure each QASM experiment
-    run_config = run_config or RunConfig()
-    shots = shots or getattr(run_config, 'shots', None)
-    memory = memory or getattr(run_config, 'memory', None)
-    max_credits = max_credits or getattr(run_config, 'max_credits', None)
-    seed_simulator = (seed_simulator or
-                      getattr(run_config, 'seed_simulator', None) or
-                      getattr(run_config, 'seed', None))  # deprecated
-    # this ensures that None values are not set, otherwise
-    # validation fails when 'null' is not acceptable
-    run_config_dict = dict(shots=shots,
-                           memory=memory,
-                           max_credits=max_credits,
-                           seed_simulator=seed_simulator,
-                           seed=seed_simulator)  # deprecated
-    run_config = RunConfig(**{k: v for k, v in run_config_dict.items() if v is not None})
+    qobj_config = QasmQobjConfig()
+    if run_config:
+        qobj_config = QasmQobjConfig(**run_config.to_dict())
 
     # Pack everything into the Qobj
-    circuits = circuits if isinstance(circuits, list) else [circuits]
-
-    userconfig = QasmQobjConfig(**run_config.to_dict())
     experiments = []
     max_n_qubits = 0
     max_memory_slots = 0
@@ -222,48 +156,23 @@ def assemble_circuits(circuits, qobj_id=None, qobj_header=None,
         if memory_slots > max_memory_slots:
             max_memory_slots = memory_slots
 
-    userconfig.memory_slots = max_memory_slots
-    userconfig.n_qubits = max_n_qubits
+    qobj_config.memory_slots = max_memory_slots
+    qobj_config.n_qubits = max_n_qubits
 
-    return QasmQobj(qobj_id=qobj_id or str(uuid.uuid4()),
-                    config=userconfig,
+    return QasmQobj(qobj_id=qobj_id,
+                    config=qobj_config,
                     experiments=experiments,
                     header=qobj_header)
 
 
-def assemble_schedules(schedules, default_qubit_los, default_meas_los,
-                       schedule_los=None, shots=1024, qobj_id=None,
-                       meas_level=2, meas_return='avg', memory=None,
-                       memory_slots=None, memory_slot_size=100,
-                       rep_time=None, max_credits=10, seed=None,
-                       qobj_header=None, instruction_converter=PulseQobjConverter,
-                       **run_config):
-    """Assembles a list of circuits into a qobj which can be run on the backend.
+def assemble_schedules(schedules, qobj_id=None, qobj_header=None, run_config=None):
+    """Assembles a list of schedules into a qobj which can be run on the backend.
 
     Args:
-        schedules (list[Schedule] or Schedule): schedules to assemble
-        default_qubit_los (list): List of default qubit lo frequencies
-        default_meas_los (list): List of default meas lo frequencies
-        qobj_header (QobjHeader or dict): header to pass to the results
-        schedule_los(None or list[Union[Dict[OutputChannel, float], LoConfig]] or
-                        Union[Dict[OutputChannel, float], LoConfig]): Experiment LO configurations
-        shots (int): number of repetitions of each circuit, for sampling
+        schedules (list[Schedule]): schedules to assemble
         qobj_id (int): identifier for the generated qobj
-        meas_level (int): set the appropriate level of the measurement output.
-        meas_return (str): indicates the level of measurement data for the backend to return
-            for `meas_level` 0 and 1:
-                "single" returns information from every shot of the experiment.
-                "avg" returns the average measurement output (averaged over the number of shots).
-        memory (bool or None): For `meas_level` 2, return the individual shot results.
-        memory_slots (int): number of classical memory slots used in this job.
-        memory_slot_size (int): size of each memory slot if the output is Level 0.
-        rep_time (int): repetition time of the experiment in μs.
-            The delay between experiments will be rep_time.
-            Must be from the list provided by the device.
-        max_credits (int): maximum credits to use
-        seed (int): random seed for simulators
-        instruction_converter (PulseQobjConverter): converter for pulse instruction
-        run_config: Additional keyword arguments to be inserted in the Qobj configuration.
+        qobj_header (QobjHeader): header to pass to the results
+        run_config (RunConfig): configuration of the runtime environment
 
     Returns:
         PulseQobj: the Qobj to be run on the backends
@@ -271,59 +180,19 @@ def assemble_schedules(schedules, default_qubit_los, default_meas_los,
     Raises:
         QiskitError: when invalid schedules or configs are provided
     """
-    # add default empty lo config
-    if schedule_los is None:
-        schedule_los = []
+    qobj_config = QasmQobjConfig()
+    if run_config:
+        qobj_config = QasmQobjConfig(**run_config.to_dict())
 
-    if isinstance(schedule_los, (LoConfig, dict)):
-        schedule_los = [schedule_los]
-
-    if qobj_id is None:
-        qobj_id = str(uuid.uuid4())
-
-    # Convert to LoConfig if lo configuration supplied as dictionary
-    schedule_los = [lo_config if isinstance(lo_config, LoConfig) else LoConfig(lo_config)
-                    for lo_config in schedule_los]
-
-    user_pulselib = set()
-
-    qobj_header = qobj_header or QobjHeader()
-    if isinstance(qobj_header, dict):
-        qobj_header = QobjHeader(**qobj_header)
-    # create run configuration and populate
-    run_config['qubit_lo_freq'] = default_qubit_los
-    run_config['meas_lo_freq'] = default_meas_los
-    run_config['shots'] = shots
-    run_config['max_credits'] = max_credits
-    run_config['meas_level'] = meas_level
-
-    if meas_level == 2:
-        if meas_return == 'avg':
-            logger.warning('"meas_return=avg" is not a supported option for "meas_level=2".'
-                           'If you wish to obtain the binned counts please use "meas_level=2" and'
-                           'if you wish to obtain the individual shot results, set "memory=True".')
-        memory = True
-
-        run_config['memory'] = memory
-        run_config['meas_return'] = 'single'
-    else:
-        run_config['meas_return'] = meas_return
-        if memory:
-            logger.warning('Setting "memory" does not have an effect for "meas_level=0/1".')
-
-    run_config['memory_slot'] = memory_slots
-    run_config['memory_slot_size'] = memory_slot_size
-    run_config['rep_time'] = rep_time
-    if seed:
-        run_config['seed'] = seed
-
-    instruction_converter = instruction_converter(PulseQobjInstruction, **run_config)
-    lo_converter = LoConfigConverter(PulseQobjExperimentConfig, default_qubit_los,
-                                     default_meas_los, **run_config)
+    # Get appropriate convertors
+    instruction_converter = PulseQobjConverter
+    instruction_converter = instruction_converter(PulseQobjInstruction, **run_config.to_dict())
+    lo_converter = LoConfigConverter(PulseQobjExperimentConfig, run_config.qubit_lo_freq,
+                                     run_config.meas_lo_freq, **run_config.to_dict())
 
     # Pack everything into the Qobj
-    schedules = schedules if isinstance(schedules, list) else [schedules]
     qobj_schedules = []
+    user_pulselib = set()
     for idx, schedule in enumerate(schedules):
         # instructions
         qobj_instructions = []
@@ -344,34 +213,34 @@ def assemble_schedules(schedules, default_qubit_los, default_meas_los,
         })
 
     # setup pulse_library
-    run_config['pulse_library'] = [QobjPulseLibrary(name=pulse.name, samples=pulse.samples)
-                                   for pulse in user_pulselib]
+    run_config.pulse_library = [QobjPulseLibrary(name=pulse.name, samples=pulse.samples)
+                                for pulse in user_pulselib]
 
     # create qob experiment field
     experiments = []
-    if len(schedule_los) == 1:
-        lo_dict = schedule_los.pop()
+    if len(run_config.schedule_los) == 1:
+        lo_dict = run_config.schedule_los.pop()
         # update global config
         q_los = lo_converter.get_qubit_los(lo_dict)
         if q_los:
-            run_config['qubit_lo_freq'] = q_los
+            run_config.qubit_lo_freq = q_los
         m_los = lo_converter.get_meas_los(lo_dict)
         if m_los:
-            run_config['meas_lo_freq'] = m_los
+            run_config.meas_lo_freq = m_los
 
-    if schedule_los:
+    if run_config.schedule_los:
         # multiple frequency setups
         if len(qobj_schedules) == 1:
             # frequency sweep
-            for lo_dict in schedule_los:
+            for lo_dict in run_config.schedule_los:
                 experiments.append(PulseQobjExperiment(
                     instructions=qobj_schedules[0]['instructions'],
                     experimentheader=qobj_schedules[0]['header'],
                     experimentconfig=lo_converter(lo_dict)
                 ))
-        elif len(qobj_schedules) == len(schedule_los):
+        elif len(qobj_schedules) == len(run_config.schedule_los):
             # n:n setup
-            for lo_dict, schedule in zip(schedule_los, qobj_schedules):
+            for lo_dict, schedule in zip(run_config.schedule_los, qobj_schedules):
                 experiments.append(PulseQobjExperiment(
                     instructions=schedule['instructions'],
                     experimentheader=schedule['header'],
@@ -391,7 +260,7 @@ def assemble_schedules(schedules, default_qubit_los, default_meas_los,
                 experimentheader=schedule['header'],
             ))
 
-    qobj_config = PulseQobjConfig(**run_config)
+    qobj_config = PulseQobjConfig(**run_config.to_dict())
 
     return PulseQobj(qobj_id=qobj_id,
                      config=qobj_config,
@@ -399,82 +268,92 @@ def assemble_schedules(schedules, default_qubit_los, default_meas_los,
                      header=qobj_header)
 
 
+# TODO: parallelize over the experiments (serialize each separately, then add global header/config)
 def assemble(experiments,
              qobj_id=None, qobj_header=None,  # common run options
              shots=None, memory=None, max_credits=None,
-             seed_simulator=None, run_config=None,
+             seed_simulator=None,
              default_qubit_los=None, default_meas_los=None,  # schedule run options
              schedule_los=None, meas_level=2, meas_return='avg',
              memory_slots=None, memory_slot_size=100, rep_time=None,
              config=None, seed=None,  # deprecated
-             **kwargs):
+             backend=None, **run_config):
     """Assemble a list of circuits or pulse schedules into a Qobj.
 
-    This is a wrapper around either ``assemble_circuits()`` or ``assemble_schedules()``.
-    Refer to those functions for more details.
+    This function serializes the payloads, which could be either circuits or schedules,
+    to create Qobj "experiments". It further annotates the experiment payload with
+    header and configurations.
 
-    qobj_id (str):
-        String identifier to annotate the Qobj
+    Args:
+        experiments (QuantumCircuit or list[QuantumCircuit] or Schedule or list[Schedule]):
+            Circuit(s) or pulse schedule(s) to execute
 
-    qobj_header (QobjHeader or dict):
-        User input that will be inserted in Qobj header, and will also be
-        copied to the corresponding Result header. Headers do not affect the run.
+        qobj_id (str):
+            String identifier to annotate the Qobj
 
-    shots (int):
-        Number of repetitions of each circuit, for sampling. Default: 2014
+        qobj_header (QobjHeader or dict):
+            User input that will be inserted in Qobj header, and will also be
+            copied to the corresponding Result header. Headers do not affect the run.
 
-    memory (bool):
-        If True, per-shot measurement bitstrings are returned as well
-        (provided the backend supports it). For OpenPulse jobs, only
-        measurement level 2 supports this option. Default: False
+        shots (int):
+            Number of repetitions of each circuit, for sampling. Default: 2014
 
-    max_credits (int):
-        Maximum credits to spend on job. Default: 10
+        memory (bool):
+            If True, per-shot measurement bitstrings are returned as well
+            (provided the backend supports it). For OpenPulse jobs, only
+            measurement level 2 supports this option. Default: False
 
-    seed_simulator (int):
-        Random seed to control sampling, for when backend is a simulator
+        max_credits (int):
+            Maximum credits to spend on job. Default: 10
 
-    default_qubit_los (list):
-        List of default qubit lo frequencies
+        seed_simulator (int):
+            Random seed to control sampling, for when backend is a simulator
 
-    default_meas_los (list):
-        List of default meas lo frequencies
+        default_qubit_los (list):
+            List of default qubit lo frequencies
 
-    schedule_los (None or list[Union[Dict[OutputChannel, float], LoConfig]] or
-                  Union[Dict[OutputChannel, float], LoConfig]):
-        Experiment LO configurations
+        default_meas_los (list):
+            List of default meas lo frequencies
 
-    meas_level (int):
-        Set the appropriate level of the measurement output for pulse experiments.
+        schedule_los (None or list[Union[Dict[OutputChannel, float], LoConfig]] or
+                      Union[Dict[OutputChannel, float], LoConfig]):
+            Experiment LO configurations
 
-    meas_return (str):
-        Level of measurement data for the backend to return
-        For `meas_level` 0 and 1:
-            "single" returns information from every shot.
-            "avg" returns average measurement output (averaged over number of shots).
+        meas_level (int):
+            Set the appropriate level of the measurement output for pulse experiments.
 
-    memory_slots (int):
-        Number of classical memory slots used in this job.
+        meas_return (str):
+            Level of measurement data for the backend to return
+            For `meas_level` 0 and 1:
+                "single" returns information from every shot.
+                "avg" returns average measurement output (averaged over number of shots).
 
-    memory_slot_size (int):
-        Size of each memory slot if the output is Level 0.
+        memory_slots (int):
+            Number of classical memory slots used in this job.
 
-    rep_time (int): repetition time of the experiment in μs.
-        The delay between experiments will be rep_time.
-        Must be from the list provided by the device.
+        memory_slot_size (int):
+            Size of each memory slot if the output is Level 0.
 
-    run_config (RunConfig):
-        Qobj runtime configuration, containing some or all of the above options.
-        If any other option is explicitly set (e.g. shots), it
-        will override the run_config's.
+        rep_time (int): repetition time of the experiment in μs.
+            The delay between experiments will be rep_time.
+            Must be from the list provided by the device.
 
-    seed (int):
-        DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
+        backend (BaseBackend):
+            If set, some runtime options are automatically grabbed from
+            backend.configuration() and backend.defaults().
+            If any other option is explicitly set (e.g. rep_rate), it
+            will override the backend's.
+            If any other options is set in the run_config, it will
+            also override the backend's.
 
-    config (dict):
-        DEPRECATED in 0.8: use run_config instead
+        seed (int):
+            DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
 
-    kwargs: extra arguments used by Aer for running configurable backends.
+        config (dict):
+            DEPRECATED in 0.8: use run_config instead
+
+        run_config (dict):
+            extra arguments used to configure the run (e.g. for Aer configurable backends)
             Refer to the backend documentation for details on these arguments
 
     Returns:
@@ -484,42 +363,131 @@ def assemble(experiments,
     Raises:
         QiskitError: if the input cannot be interpreted as either circuits or schedules
     """
-    if (isinstance(experiments, QuantumCircuit) or
-            (isinstance(experiments, list) and
-             all(isinstance(c, QuantumCircuit) for c in experiments))):
-        return assemble_circuits(circuits=experiments,
-                                 qobj_id=qobj_id,
-                                 qobj_header=qobj_header,
-                                 shots=shots,
-                                 memory=memory,
-                                 max_credits=max_credits,
-                                 seed_simulator=seed_simulator,
-                                 run_config=run_config,
-                                 seed=seed,  # deprecated
-                                 config=config,
-                                 **kwargs)
+    # deprecation matter
+    if config:
+        warnings.warn('config is not used anymore. Set all configs in '
+                      'run_config.', DeprecationWarning)
+        run_config = run_config or config
+    if seed:
+        warnings.warn('seed is deprecated in favor of seed_simulator.', DeprecationWarning)
+        seed_simulator = seed_simulator or seed
 
-    elif (isinstance(experiments, Schedule) or
-          (isinstance(experiments, list) and
-           all(isinstance(c, Schedule) for c in experiments))):
-        return assemble_schedules(schedules=experiments,
-                                  default_qubit_los=default_qubit_los,
-                                  default_meas_los=default_meas_los,
-                                  qobj_id=qobj_id,
-                                  qobj_header=qobj_header,
-                                  shots=shots,
-                                  memory=memory,
-                                  max_credits=max_credits,
-                                  seed_simulator=seed_simulator,
-                                  schedule_los=schedule_los,
-                                  meas_level=meas_level,
-                                  meas_return=meas_return,
-                                  memory_slots=memory_slots,
-                                  memory_slot_size=memory_slot_size,
-                                  rep_time=rep_time,
-                                  run_config=run_config,
-                                  seed=seed,  # deprecated
-                                  **kwargs)
+    # Get RunConfig(s) that will be inserted in Qobj to configure the run
+    experiments = experiments if isinstance(experiments, list) else [experiments]
+    qobj_id, qobj_header, run_config = _parse_run_args(qobj_id, qobj_header,
+                                                       shots, memory, max_credits, seed_simulator,
+                                                       default_qubit_los, default_meas_los,
+                                                       schedule_los, meas_level, meas_return,
+                                                       memory_slots, memory_slot_size, rep_time,
+                                                       backend, **run_config)
+
+    # assemble either circuits or schedules
+    if all(isinstance(exp, QuantumCircuit) for exp in experiments):
+        return assemble_circuits(circuits=experiments, qobj_id=qobj_id,
+                                 qobj_header=qobj_header, run_config=run_config)
+
+    elif all(isinstance(exp, Schedule) for exp in experiments):
+        return assemble_schedules(schedules=experiments, qobj_id=qobj_id,
+                                  qobj_header=qobj_header, run_config=run_config)
 
     else:
-        raise QiskitError("bad input to assemble() function; must be either circuits or schedules")
+        raise QiskitError("bad input to assemble() function; "
+                          "must be either circuits or schedules")
+
+
+# TODO: rework to return a list of RunConfigs (one for each experiments), and a global one
+def _parse_run_args(qobj_id, qobj_header,
+                    shots, memory, max_credits, seed_simulator,
+                    default_qubit_los, default_meas_los,
+                    schedule_los, meas_level, meas_return,
+                    memory_slots, memory_slot_size, rep_time,
+                    backend, **run_config):
+    """Resolve the various types of args allowed to the assemble() function through
+    duck typing, overriding args, etc. Refer to the assemble() docstring for details on
+    what types of inputs are allowed.
+
+    Here the args are resolved by converting them to standard instances, and prioritizing
+    them in case a run option is passed through multiple args (explicitly setting an arg
+    has more priority than the arg set by backend)
+
+    Returns:
+        RunConfig: a run config, which is a standardized object that configures the qobj
+            and determines the runtime environment.
+    """
+    # grab relevant info from backend if it exists
+    backend_config = None
+    backend_default = None
+    if backend:
+        backend_config = backend.configuration()
+        # TODO : Remove usage of config.defaults when backend.defaults() is updated.
+        try:
+            backend_default = backend.defaults()
+        except (ModelValidationError, AttributeError):
+            from collections import namedtuple
+            backend_config_defaults = getattr(backend_config, 'defaults', {})
+            BackendDefault = namedtuple('BackendDefault', ('qubit_freq_est', 'meas_freq_est'))
+            backend_default = BackendDefault(
+                qubit_freq_est=backend_config_defaults.get('qubit_freq_est'),
+                meas_freq_est=backend_config_defaults.get('meas_freq_est')
+            )
+
+    memory_slots = memory_slots or getattr(backend_config, 'memory_slots', None)
+    rep_time = rep_time or getattr(backend_config, 'rep_times', None)
+    if isinstance(rep_time, list):
+        rep_time = rep_time[-1]
+
+    # add default empty lo config
+    schedule_los = schedule_los or []
+    if isinstance(schedule_los, (LoConfig, dict)):
+        schedule_los = [schedule_los]
+
+    # Convert to LoConfig if lo configuration supplied as dictionary
+    schedule_los = [lo_config if isinstance(lo_config, LoConfig) else LoConfig(lo_config)
+                    for lo_config in schedule_los]
+
+    qubit_lo_freq = default_qubit_los or getattr(backend_default, 'qubit_freq_est', [])
+    meas_lo_freq = default_meas_los or getattr(backend_default, 'meas_freq_est', [])
+
+    if meas_level == 2:
+        if meas_return == 'avg':
+            logger.warning('"meas_return=avg" is not a supported option for "meas_level=2".'
+                           'If you wish to obtain the binned counts please use "meas_level=2" and'
+                           'if you wish to obtain the individual shot results, set "memory=True".')
+        memory = True
+        meas_return = 'single'
+    else:
+        if memory:
+            logger.warning('Setting "memory" does not have an effect for "meas_level=0/1".')
+
+    # an identifier for the Qobj
+    qobj_id = qobj_id or str(uuid.uuid4())
+
+    # The header that goes at the top of the Qobj (and later Result)
+    # we process it as dict, then write entries that are not None to a QobjHeader object
+    qobj_header = qobj_header or {}
+    if isinstance(qobj_header, QobjHeader):
+        qobj_header = qobj_header.to_dict()
+    backend_name = getattr(backend_config, 'backend_name', None)
+    backend_version = getattr(backend_config, 'backend_version', None)
+    qobj_header = {**dict(backend_name=backend_name, backend_version=backend_version),
+                   **qobj_header}
+    qobj_header = QobjHeader(**{k: v for k, v in qobj_header.items() if v is not None})
+
+    # create run configuration and populate
+    run_config_dict = dict(shots=shots,
+                           memory=memory,
+                           max_credits=max_credits,
+                           seed_simulator=seed_simulator,
+                           seed=seed_simulator,  # deprecated
+                           qubit_lo_freq=qubit_lo_freq,
+                           meas_lo_freq=meas_lo_freq,
+                           schedule_los=schedule_los,
+                           meas_level=meas_level,
+                           meas_return=meas_return,
+                           memory_slots=memory_slots,
+                           memory_slot_size=memory_slot_size,
+                           rep_time=rep_time,
+                           **run_config)
+    run_config = RunConfig(**{k: v for k, v in run_config_dict.items() if v is not None})
+
+    return qobj_id, qobj_header, run_config

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -271,7 +271,7 @@ def assemble_schedules(schedules, qobj_id=None, qobj_header=None, run_config=Non
 # TODO: parallelize over the experiments (serialize each separately, then add global header/config)
 def assemble(experiments,
              qobj_id=None, qobj_header=None,  # common run options
-             shots=None, memory=None, max_credits=None,
+             shots=1024, memory=False, max_credits=None,
              seed_simulator=None,
              default_qubit_los=None, default_meas_los=None,  # schedule run options
              schedule_los=None, meas_level=2, meas_return='avg',
@@ -447,17 +447,6 @@ def _parse_run_args(qobj_id, qobj_header,
 
     qubit_lo_freq = default_qubit_los or getattr(backend_default, 'qubit_freq_est', [])
     meas_lo_freq = default_meas_los or getattr(backend_default, 'meas_freq_est', [])
-
-    if meas_level == 2:
-        if meas_return == 'avg':
-            logger.warning('"meas_return=avg" is not a supported option for "meas_level=2".'
-                           'If you wish to obtain the binned counts please use "meas_level=2" and'
-                           'if you wish to obtain the individual shot results, set "memory=True".')
-        memory = True
-        meas_return = 'single'
-    else:
-        if memory:
-            logger.warning('Setting "memory" does not have an effect for "meas_level=0/1".')
 
     # an identifier for the Qobj
     qobj_id = qobj_id or str(uuid.uuid4())

--- a/qiskit/compiler/models.py
+++ b/qiskit/compiler/models.py
@@ -5,19 +5,15 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Models for RunConfig and its related components."""
-
-from marshmallow.validate import Range
+"""Models for TranspileConfig and RunConfig."""
 
 from qiskit.validation import BaseSchema
-from qiskit.validation.fields import Boolean, Integer
 
 
 class TranspileConfigSchema(BaseSchema):
     """Schema for TranspileConfig."""
 
     # Required properties.
-    # None
 
     # Optional properties.
 
@@ -29,7 +25,3 @@ class RunConfigSchema(BaseSchema):
     # None
 
     # Optional properties.
-    shots = Integer(validate=Range(min=1))
-    max_credits = Integer(validate=Range(min=3, max=10))  # TODO: can we check the range
-    seed = Integer()
-    memory = Boolean()  # set default to be False

--- a/qiskit/compiler/models.py
+++ b/qiskit/compiler/models.py
@@ -7,32 +7,15 @@
 
 """Models for TranspileConfig and RunConfig."""
 
-from marshmallow.validate import Length, Range, OneOf
-
 from qiskit.validation import BaseSchema
-from qiskit.validation.fields import Boolean, Integer, List, String, Number, Nested
-from qiskit.providers.models import BackendProperties
-from qiskit.qobj.models.base import QobjHeader
-from qiskit.mapper import Layout, CouplingMap
 
 
 class TranspileConfigSchema(BaseSchema):
     """Schema for TranspileConfig."""
 
     # Required properties.
-    """
-    optimization_level = Integer(validate=Range(min=0, max=2), required=True)
-    skip_numeric_passes = Boolean()
-    """
 
     # Optional properties.
-    """
-    basis_gates = List(String())
-    coupling_map = Nested(CouplingMap)
-    backend_properties = Nested(BackendProperties, many=True)
-    initial_layout = Nested(Layout)
-    seed_transpiler = Integer()
-    """
 
 
 class RunConfigSchema(BaseSchema):
@@ -42,19 +25,3 @@ class RunConfigSchema(BaseSchema):
     # None
 
     # Optional properties.
-    """
-    qobj_id = String()
-    qobj_header = Nested(QobjHeader)
-    shots = Integer(validate=Range(min=1))
-    memory = Boolean()  # TODO: if True, meas_level MUST be 2
-    max_credits = Integer(validate=Range(min=3, max=10))
-    seed_simulator = Integer()
-    default_qubit_los = List(Number())
-    default_meas_los = List(Number())
-    schedule_los = List(Number())  # FIXME: double check this with assembler docstring
-    meas_level = Integer(required=True, validate=Range(min=0, max=2))
-    meas_return = String(validate=OneOf(['single', 'avg']))
-    memory_slots = Integer(validate=Range(min=0))
-    memory_slot_size = Integer(validate=Range(min=1))
-    rep_time = Integer()
-    """

--- a/qiskit/compiler/models.py
+++ b/qiskit/compiler/models.py
@@ -7,15 +7,32 @@
 
 """Models for TranspileConfig and RunConfig."""
 
+from marshmallow.validate import Length, Range, OneOf
+
 from qiskit.validation import BaseSchema
+from qiskit.validation.fields import Boolean, Integer, List, String, Number, Nested
+from qiskit.providers.models import BackendProperties
+from qiskit.qobj.models.base import QobjHeader
+from qiskit.mapper import Layout, CouplingMap
 
 
 class TranspileConfigSchema(BaseSchema):
     """Schema for TranspileConfig."""
 
     # Required properties.
+    """
+    optimization_level = Integer(validate=Range(min=0, max=2), required=True)
+    skip_numeric_passes = Boolean()
+    """
 
     # Optional properties.
+    """
+    basis_gates = List(String())
+    coupling_map = Nested(CouplingMap)
+    backend_properties = Nested(BackendProperties, many=True)
+    initial_layout = Nested(Layout)
+    seed_transpiler = Integer()
+    """
 
 
 class RunConfigSchema(BaseSchema):
@@ -25,3 +42,19 @@ class RunConfigSchema(BaseSchema):
     # None
 
     # Optional properties.
+    """
+    qobj_id = String()
+    qobj_header = Nested(QobjHeader)
+    shots = Integer(validate=Range(min=1))
+    memory = Boolean()  # TODO: if True, meas_level MUST be 2
+    max_credits = Integer(validate=Range(min=3, max=10))
+    seed_simulator = Integer()
+    default_qubit_los = List(Number())
+    default_meas_los = List(Number())
+    schedule_los = List(Number())  # FIXME: double check this with assembler docstring
+    meas_level = Integer(required=True, validate=Range(min=0, max=2))
+    meas_return = String(validate=OneOf(['single', 'avg']))
+    memory_slots = Integer(validate=Range(min=0))
+    memory_slot_size = Integer(validate=Range(min=1))
+    rep_time = Integer()
+    """

--- a/qiskit/compiler/run_config.py
+++ b/qiskit/compiler/run_config.py
@@ -21,6 +21,6 @@ class RunConfig(BaseModel):
     Attributes:
         shots (int): the number of shots.
         max_credits (int): the max_credits to use on the IBMQ public devices.
-        seed (int): the seed to use in the simulator for the first experiment.
-        memory (bool): to use memory.
+        seed_simulator (int): the seed to use in the simulator
+        memory (bool): whether to request memory from backend (per-shot readouts)
     """

--- a/qiskit/compiler/transpile_config.py
+++ b/qiskit/compiler/transpile_config.py
@@ -19,5 +19,13 @@ class TranspileConfig(BaseModel):
     full description of the model, please check ``TranspileConfigSchema``.
 
     Attributes:
-
+        optimization_level (int): a non-negative integer indicating the
+            optimization level. 0 means no transformation on the circuit. Higher
+            levels may produce more optimized circuits, but may take longer.
+        skip_numeric_passes (bool): if True, do not apply passes containing
+            numerical optimization.
     """
+    def __init__(self, optimization_level, skip_numeric_passes, **kwargs):
+        self.optimization_level = optimization_level
+        self.skip_numeric_passes = skip_numeric_passes
+        super().__init__(**kwargs)

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -8,11 +8,8 @@
 """Circuit transpile function"""
 import warnings
 
-from qiskit.circuit import QuantumCircuit
-from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.mapper import Layout, CouplingMap
 from qiskit.tools.parallel import parallel_map
-from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
                                                    default_pass_manager)
 from qiskit.compiler.transpile_config import TranspileConfig
@@ -222,7 +219,7 @@ def _parse_transpile_args(circuits,
     optimization_level = _parse_optimization_level(optimization_level,
                                                    transpile_config, num_circuits)
 
-    is_parametric_circuit=[bool(circuit.variables) for circuit in circuits]
+    is_parametric_circuit = [bool(circuit.variables) for circuit in circuits]
 
     transpile_configs = []
     for args in zip(basis_gates, coupling_map, backend_properties, initial_layout,
@@ -304,26 +301,26 @@ def _parse_initial_layout(initial_layout, transpile_config, circuits):
     initial_layout = initial_layout or getattr(transpile_config, 'initial_layout', None)
     # multiple layouts?
     if isinstance(initial_layout, list) and \
-       not any(isinstance(i, (int, dict)) for i in initial_layout):
+       any(isinstance(i, (list, dict)) for i in initial_layout):
         initial_layout = [_layout_from_raw(lo, circ) if isinstance(lo, (list, dict)) else lo
                           for lo, circ in zip(initial_layout, circuits)]
     else:
-        # even if one layout, but multiple circuits, the layout need to be adapted for each
+        # even if one layout, but multiple circuits, the layout needs to be adapted for each
         initial_layout = [_layout_from_raw(initial_layout, circ) for circ in circuits]
     if not isinstance(initial_layout, list):
-        initial_layout = [initial_layout] * num_circuits
+        initial_layout = [initial_layout] * len(circuits)
     return initial_layout
 
 
 def _parse_seed_transpiler(seed_transpiler, transpile_config, num_circuits):
     seed_transpiler = seed_transpiler or getattr(transpile_config, 'seed_transpiler', None)
     if not isinstance(seed_transpiler, list):
-        seed_transpiler = [seed_transpiler, num_circuits]
+        seed_transpiler = [seed_transpiler] * num_circuits
     return seed_transpiler
 
 
 def _parse_optimization_level(optimization_level, transpile_config, num_circuits):
     optimization_level = optimization_level or getattr(transpile_config, 'seed_transpiler', None)
     if not isinstance(optimization_level, list):
-        optimization_level = [optimization_level, num_circuits]
+        optimization_level = [optimization_level] * num_circuits
     return optimization_level

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -5,7 +5,8 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Circuit transpile function """
+"""Circuit transpile function"""
+
 import logging
 
 from qiskit import transpiler
@@ -15,15 +16,69 @@ from qiskit.mapper import Layout
 logger = logging.getLogger(__name__)
 
 
-def transpile(circuits, transpile_config=None):
-    """Compile a list of circuits into a list of optimized circuits.
+def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
+              backend_properties=None, initial_layout=None,
+              seed_transpiler=None, seed_mapper=None):
+    """transpile one or more circuits, according to some desired
+    transpilation targets.
 
     Args:
-        circuits (QuantumCircuit or list[QuantumCircuit]): circuits to compile
-        transpile_config (TranspileConfig): configuration for the transpiler
+        circuits (QuantumCircuit or list[QuantumCircuit]):
+            Circuit(s) to transpile
+
+        backend (BaseBackend):
+            If set, transpiler options are automatically grabbed from
+            backend.configuration() and backend.properties().
+            If any other option is explicitly set (e.g. coupling_map), it
+            will override the backend's.
+            Note: the backend arg is purely for convenience. The resulting
+                circuit may be run on any backend as long as it is compatible.
+
+        basis_gates (list[str]):
+            List of basis gate names to unroll to.
+            e.g:
+                ['u1', 'u2', 'u3', 'cx']
+            If None, do not unroll.
+
+        coupling_map (list):
+            Coupling map (perhaps custom) to target in mapping.
+            Must be given as an adjacency matrix, where each entry
+            specifies all two-qubit interactions supported by backend
+            e.g:
+                [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
+
+        backend_properties (BackendProperties):
+            properties returned by a backend, including information on gate
+            errors, readout errors, qubit coherence times, etc. For a backend
+            that provides this information, it can be obtained with:
+            ``backend.properties()``
+
+        initial_layout (list or dict):
+            Initial layout of virtual qubits onto the physical qubits
+            If this layout makes the circuit compatible with the coupling_map
+            constraints, it will be used.
+            The final layout will not necessarily be the same, since swaps may
+            permute the location of qubits.
+            e.g:
+                [q[0], None, None, q[1], None]
+                {q[0]: 0, q[1]: 3}
+            N.B. These layouts are not identical. In the first case, it is
+            signaled to the transpiler that three unspecified virtual qubits
+            must exist on physical qubits 1, 2 and 4. The transpiler will
+            expand the original circuit with extra virtual ancilla qubits
+            to accomodate this layout.
+
+        seed_transpiler (int):
+            sets random seed for the stochastic parts of the transpiler
+
+        seed_mapper (int):
+            DEPRECATED in 0.8: use ``seed_transpiler`` kwarg instead
+
+        pass_manager (PassManager):
+            DEPRECATED in 0.8: use ``pass_manager.run(circuits)`` directly
 
     Returns:
-        circuits: the optimized circuits
+        QuantumCircuit or list[QuantumCircuit]: transpiled circuit(s).
     """
 
     # ------------

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -6,33 +6,27 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Circuit transpile function"""
+import warnings
 
-import logging
+from qiskit.circuit import QuantumCircuit
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.mapper import Layout, CouplingMap
+from qiskit.tools.parallel import parallel_map
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
+                                                   default_pass_manager)
 
-from qiskit import transpiler
-from qiskit.mapper import Layout
-
-
-logger = logging.getLogger(__name__)
-
-
-def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
-              backend_properties=None, initial_layout=None,
-              seed_transpiler=None, seed_mapper=None):
+def transpile(circuits,
+              basis_gates=None, coupling_map=None, backend_properties=None,
+              initial_layout=None, seed_transpiler=None, optimization_level=None,
+              transpile_config=None, backend=None,
+              seed_mapper=None, pass_manager=None):
     """transpile one or more circuits, according to some desired
     transpilation targets.
 
     Args:
         circuits (QuantumCircuit or list[QuantumCircuit]):
             Circuit(s) to transpile
-
-        backend (BaseBackend):
-            If set, transpiler options are automatically grabbed from
-            backend.configuration() and backend.properties().
-            If any other option is explicitly set (e.g. coupling_map), it
-            will override the backend's.
-            Note: the backend arg is purely for convenience. The resulting
-                circuit may be run on any backend as long as it is compatible.
 
         basis_gates (list[str]):
             List of basis gate names to unroll to.
@@ -53,23 +47,59 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
             that provides this information, it can be obtained with:
             ``backend.properties()``
 
-        initial_layout (list or dict):
-            Initial layout of virtual qubits onto the physical qubits
+        initial_layout (Layout or dict or list):
+            Initial position of virtual qubits on physical qubits.
             If this layout makes the circuit compatible with the coupling_map
             constraints, it will be used.
-            The final layout will not necessarily be the same, since swaps may
-            permute the location of qubits.
-            e.g:
-                [q[0], None, None, q[1], None]
-                {q[0]: 0, q[1]: 3}
-            N.B. These layouts are not identical. In the first case, it is
-            signaled to the transpiler that three unspecified virtual qubits
-            must exist on physical qubits 1, 2 and 4. The transpiler will
-            expand the original circuit with extra virtual ancilla qubits
-            to accomodate this layout.
+            The final layout is not guaranteed to be the same, as the transpiler
+            may permute qubits through swaps or other means.
+
+            Multiple formats are supported:
+            a. Layout instance
+
+            b. dict
+                virtual to physical:
+                    {qr[0]: 0,
+                     qr[1]: 3,
+                     qr[2]: 5}
+
+                physical to virtual:
+                    {0: qr[0],
+                     3: qr[1],
+                     5: qr[2]}
+
+            c. list
+                virtual to physical:
+                    [0, 3, 5]  # virtual qubits are ordered (in addition to named)
+
+                physical to virtual:
+                    [qr[0], None, None, qr[1], None, qr[2]]
 
         seed_transpiler (int):
             sets random seed for the stochastic parts of the transpiler
+
+        optimization_level (int):
+            How much optimization to perform on the circuits.
+            Higher levels generate more optimized circuits,
+            at the expense of longer transpilation time.
+                0: no optimization
+                1: light optimization
+                2: heavy optimization
+
+        transpile_config (TranspileConfig):
+            transpiler configuration, containing some or all of the above options.
+            If any other options is explicitly set (e.g. coupling_map), it
+            will override the transpile_config's.
+
+        backend (BaseBackend):
+            If set, transpiler options are automatically grabbed from
+            backend.configuration() and backend.properties().
+            If any other option is explicitly set (e.g. coupling_map), it
+            will override the backend's.
+            If any other options is set in the transpile_config, it will
+            also override the backend's.
+            Note: the backend arg is purely for convenience. The resulting
+                circuit may be run on any backend as long as it is compatible.
 
         seed_mapper (int):
             DEPRECATED in 0.8: use ``seed_transpiler`` kwarg instead
@@ -79,27 +109,175 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
 
     Returns:
         QuantumCircuit or list[QuantumCircuit]: transpiled circuit(s).
+
+    Raises:
+        TranspilerError: in case of bad inputs to transpiler or errors in passes
     """
+    # Deprecated matter
+    if seed_mapper:
+        warnings.warn("seed_mapper has been deprecated and will be removed in the "
+                      "0.9 release. Instead use seed_transpiler to set the seed "
+                      "for all stochastic parts of the.", DeprecationWarning)
+        seed_transpiler = seed_mapper
 
-    # ------------
-    # TODO: This is a hack while we are still using the old transpiler.
-    initial_layout = getattr(transpile_config, 'initial_layout', None)
-    basis_gates = getattr(transpile_config, 'basis_gates', None)
-    coupling_map = getattr(transpile_config, 'coupling_map', None)
-    seed_mapper = getattr(transpile_config, 'seed_mapper', None)
+    if pass_manager:
+        warnings.warn("After the 0.9 release, the transpile() function no longer accepts "
+                      "a pass_manager arg. Instead use pass_manager.run(circuits) directly "
+                      "to run a custom pipeline of passes.", DeprecationWarning)
+        return pass_manager.run(circuits)
 
-    if initial_layout is not None and not isinstance(initial_layout, Layout):
+    # Parse transpile options. the priority is:
+    # 1. kwarg    2. transpile_config    3. backend
+    if basis_gates is None:
+        basis_gate = getattr(transpile_config, 'basis_gates', None) or \
+                     getattr(backend.configuration(), 'basis_gates', None)
+
+    if coupling_map is None:
+        coupling_map = getattr(transpile_config, 'coupling_map', None) or \
+                       getattr(backend.configuration(), 'coupling_map', None)
+
+    if backend_properties is None:
+        backend_properties = getattr(transpile_config, 'backend_properties', None) or \
+                             backend.properties()
+
+    # TODO: (Ali) allow partial layout specifications
+    initial_layout = initial_layout or getattr(transpile_config, 'initial_layout', None)
+    if isinstance(initial_layout, list):
+        if all(isinstance(elem, int) for elem in initial_layout):
+            # FIXME: (Ali) must allow a list of initial layouts
+            initial_layout = Layout.from_intlist(initial_layout, *circuits[0].qregs)
+        elif all(elem is None or isinstance(elem, tuple) for elem in initial_layout):
+            initial_layout = Layout.from_tuplelist(initial_layout)
+        else:
+            raise TranspilerError("bad format for initial_layout")
+    elif isinstance(initial_layout, dict):
         initial_layout = Layout(initial_layout)
 
-    pass_manager = None
-    backend = getattr(transpile_config, 'backend', None)
-    new_circuits = transpiler.transpile(circuits, backend, basis_gates, coupling_map,
-                                        initial_layout, seed_mapper, pass_manager)
-    # ---------
+    seed_transpiler = seed_transpiler or getattr(transpile_config, 'seed_transpiler', None)
 
-    # THE IDEAL CODE HERE WILL BE.
-    # 1 set up the pass_manager using transpile_config options
-    # pass_manager = PassManager(TranspileConig)
-    # run the passes
-    # new_circuits = pass_manager.run(circuits)
-    return new_circuits
+    return_form_is_single = False
+    if isinstance(circuits, QuantumCircuit):
+        circuits = [circuits]
+        return_form_is_single = True
+
+    # pass manager overrides explicit transpile options (basis_gates, coupling_map)
+    # explicit transpile options override options gotten from a backend
+    if not pass_manager and backend:
+        basis_gates = basis_gates or getattr(backend.configuration(), 'basis_gates', None)
+        # This needs to be removed once Aer 0.2 is out
+        coupling_map = coupling_map or getattr(backend.configuration(), 'coupling_map', None)
+
+    circuits = parallel_map(_transpilation, circuits,
+                            task_kwargs={'basis_gates': basis_gates,
+                                         'coupling_map': coupling_map,
+                                         'initial_layout': initial_layout,
+                                         'seed_mapper': seed_mapper,
+                                         'pass_manager': pass_manager})
+    if return_form_is_single:
+        return circuits[0]
+    return circuits
+
+
+def _transpilation(circuit, basis_gates=None, coupling_map=None,
+                   initial_layout=None, seed_mapper=None,
+                   pass_manager=None):
+    """Perform transpilation of a single circuit.
+
+    Args:
+        circuit (QuantumCircuit): A circuit to transpile.
+        basis_gates (list[str]): list of basis gate names supported by the
+            target. Default: ['u1','u2','u3','cx','id']
+        coupling_map (CouplingMap): coupling map (perhaps custom) to target in mapping
+        initial_layout (Layout): initial layout of qubits in mapping
+        seed_mapper (int): random seed for the swap_mapper
+        pass_manager (PassManager): a pass_manager for the transpiler stage
+
+    Returns:
+        QuantumCircuit: A transpiled circuit.
+
+    Raises:
+        TranspilerError: If the Layout does not matches the circuit
+    """
+    if initial_layout is not None and set(circuit.qregs) != initial_layout.get_registers():
+        raise TranspilerError('The provided initial layout does not match the registers in '
+                              'the circuit "%s"' % circuit.name)
+
+    if pass_manager and not pass_manager.working_list:
+        return circuit
+
+    is_parametric_circuit = bool(circuit.variables)
+
+    dag = circuit_to_dag(circuit)
+    del circuit
+
+    final_dag = _transpile_dag(dag, basis_gates=basis_gates,
+                               coupling_map=coupling_map,
+                               initial_layout=initial_layout,
+                               skip_numeric_passes=is_parametric_circuit,
+                               seed_mapper=seed_mapper,
+                               pass_manager=pass_manager)
+
+    out_circuit = dag_to_circuit(final_dag)
+
+    return out_circuit
+
+
+def _transpile_dag(dag, basis_gates=None, coupling_map=None,
+                   initial_layout=None, skip_numeric_passes=None,
+                   seed_mapper=None, pass_manager=None):
+    """Transform a dag circuit into another dag circuit (transpile), through
+    consecutive passes on the dag.
+
+    Args:
+        dag (DAGCircuit): dag circuit to transform via transpilation
+        basis_gates (list[str]): list of basis gate names supported by the
+            target. Default: ['u1','u2','u3','cx','id']
+        coupling_map (list): A graph of coupling::
+
+            [
+             [control0(int), target0(int)],
+             [control1(int), target1(int)],
+            ]
+
+            eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
+
+        initial_layout (Layout or None): A layout object
+        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
+        seed_mapper (int): random seed_mapper for the swap mapper
+        pass_manager (PassManager): pass manager instance for the transpilation process
+            If None, a default set of passes are run.
+            Otherwise, the passes defined in it will run.
+            If contains no passes in it, no dag transformations occur.
+
+    Returns:
+        DAGCircuit: transformed dag
+    """
+    if basis_gates is None:
+        basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']
+    if isinstance(basis_gates, str):
+        warnings.warn("The parameter basis_gates is now a list of strings. "
+                      "For example, this basis ['u1','u2','u3','cx'] should be used "
+                      "instead of 'u1,u2,u3,cx'. The string format will be "
+                      "removed after 0.9", DeprecationWarning, 2)
+        basis_gates = basis_gates.split(',')
+
+    if pass_manager is None:
+        # default set of passes
+
+        # if a coupling map is given compile to the map
+        if coupling_map:
+            pass_manager = default_pass_manager(basis_gates,
+                                                CouplingMap(coupling_map),
+                                                initial_layout,
+                                                skip_numeric_passes,
+                                                seed_mapper=seed_mapper)
+        else:
+            pass_manager = default_pass_manager_simulator(basis_gates)
+
+    # run the passes specified by the pass manager
+    # TODO return the property set too. See #1086
+    name = dag.name
+    dag = pass_manager.run_passes(dag)
+    dag.name = name
+
+    return dag

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -167,6 +167,11 @@ def _transpile_circuit(circuit_config_tuple):
         QuantumCircuit: transpiled circuit
     """
     circuit, transpile_config = circuit_config_tuple
+
+    # no basis means don't unroll (all circuit gates are valid basis)
+    if transpile_config.basis_gates is None:
+        transpile_config.basis_gates = [inst.name for inst, _, _ in circuit.data]
+
     if transpile_config.coupling_map:
         pass_manager = default_pass_manager(transpile_config.basis_gates,
                                             transpile_config.coupling_map,

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -19,7 +19,8 @@ from qiskit.pulse import Schedule
 def transpile(circuits,
               backend=None,
               basis_gates=None, coupling_map=None, backend_properties=None,
-              initial_layout=None, seed_transpiler=None, optimization_level=None,
+              initial_layout=None, seed_transpiler=None,
+              optimization_level=None,
               pass_manager=None,
               seed_mapper=None):  # deprecated
     """transpile one or more circuits, according to some desired
@@ -163,15 +164,17 @@ def _transpile_circuit(circuit_config_tuple):
     circuit, transpile_config = circuit_config_tuple
 
     # if the pass manager is not already selected, choose an appropriate one.
-    if not transpile_config.pass_manager:
-        if transpile_config.coupling_map:
-            pass_manager = default_pass_manager(transpile_config.basis_gates,
-                                                transpile_config.coupling_map,
-                                                transpile_config.initial_layout,
-                                                transpile_config.skip_numeric_passes,
-                                                transpile_config.seed_transpiler)
-        else:
-            pass_manager = default_pass_manager_simulator(transpile_config.basis_gates)
+    if transpile_config.pass_manager:
+        pass_manager = transpile_config.pass_manager
+
+    elif transpile_config.coupling_map:
+        pass_manager = default_pass_manager(transpile_config.basis_gates,
+                                            transpile_config.coupling_map,
+                                            transpile_config.initial_layout,
+                                            transpile_config.skip_numeric_passes,
+                                            transpile_config.seed_transpiler)
+    else:
+        pass_manager = default_pass_manager_simulator(transpile_config.basis_gates)
 
     return pass_manager.run(circuit)
 

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -15,6 +15,8 @@ from qiskit.tools.parallel import parallel_map
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
                                                    default_pass_manager)
+from qiskit.compiler.transpile_config import TranspileConfig
+
 
 def transpile(circuits,
               basis_gates=None, coupling_map=None, backend_properties=None,
@@ -23,6 +25,11 @@ def transpile(circuits,
               seed_mapper=None, pass_manager=None):
     """transpile one or more circuits, according to some desired
     transpilation targets.
+
+    All arguments may be given as either singleton or list. In case of list,
+    the length must be equal to the number of circuits being transpiled.
+
+    Transpilation is done in parallel using multiprocessing.
 
     Args:
         circuits (QuantumCircuit or list[QuantumCircuit]):
@@ -34,12 +41,16 @@ def transpile(circuits,
                 ['u1', 'u2', 'u3', 'cx']
             If None, do not unroll.
 
-        coupling_map (list):
+        coupling_map (CouplingMap or list):
             Coupling map (perhaps custom) to target in mapping.
-            Must be given as an adjacency matrix, where each entry
-            specifies all two-qubit interactions supported by backend
-            e.g:
-                [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
+            Multiple formats are supported:
+            a. CouplingMap instance
+
+            b. list
+                Must be given as an adjacency matrix, where each entry
+                specifies all two-qubit interactions supported by backend
+                e.g:
+                    [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
 
         backend_properties (BackendProperties):
             properties returned by a backend, including information on gate
@@ -113,7 +124,7 @@ def transpile(circuits,
     Raises:
         TranspilerError: in case of bad inputs to transpiler or errors in passes
     """
-    # Deprecated matter
+    # Deprecation matter
     if seed_mapper:
         warnings.warn("seed_mapper has been deprecated and will be removed in the "
                       "0.9 release. Instead use seed_transpiler to set the seed "
@@ -126,158 +137,188 @@ def transpile(circuits,
                       "to run a custom pipeline of passes.", DeprecationWarning)
         return pass_manager.run(circuits)
 
-    # Parse transpile options. the priority is:
-    # 1. kwarg    2. transpile_config    3. backend
-    if basis_gates is None:
-        basis_gate = getattr(transpile_config, 'basis_gates', None) or \
-                     getattr(backend.configuration(), 'basis_gates', None)
+    # Get TranspileConfig(s) to configure the circuit transpilation job(s)
+    circuits = circuits if isinstance(circuits, list) else [circuits]
+    transpile_configs = _parse_transpile_args(circuits, basis_gates, coupling_map,
+                                              backend_properties, initial_layout,
+                                              seed_transpiler, optimization_level,
+                                              transpile_config, backend)
 
-    if coupling_map is None:
-        coupling_map = getattr(transpile_config, 'coupling_map', None) or \
-                       getattr(backend.configuration(), 'coupling_map', None)
+    # Transpile circuits in parallel
+    circuits = parallel_map(_transpile_circuit, list(zip(circuits, transpile_configs)))
 
-    if backend_properties is None:
-        backend_properties = getattr(transpile_config, 'backend_properties', None) or \
-                             backend.properties()
-
-    # TODO: (Ali) allow partial layout specifications
-    initial_layout = initial_layout or getattr(transpile_config, 'initial_layout', None)
-    if isinstance(initial_layout, list):
-        if all(isinstance(elem, int) for elem in initial_layout):
-            # FIXME: (Ali) must allow a list of initial layouts
-            initial_layout = Layout.from_intlist(initial_layout, *circuits[0].qregs)
-        elif all(elem is None or isinstance(elem, tuple) for elem in initial_layout):
-            initial_layout = Layout.from_tuplelist(initial_layout)
-        else:
-            raise TranspilerError("bad format for initial_layout")
-    elif isinstance(initial_layout, dict):
-        initial_layout = Layout(initial_layout)
-
-    seed_transpiler = seed_transpiler or getattr(transpile_config, 'seed_transpiler', None)
-
-    return_form_is_single = False
-    if isinstance(circuits, QuantumCircuit):
-        circuits = [circuits]
-        return_form_is_single = True
-
-    # pass manager overrides explicit transpile options (basis_gates, coupling_map)
-    # explicit transpile options override options gotten from a backend
-    if not pass_manager and backend:
-        basis_gates = basis_gates or getattr(backend.configuration(), 'basis_gates', None)
-        # This needs to be removed once Aer 0.2 is out
-        coupling_map = coupling_map or getattr(backend.configuration(), 'coupling_map', None)
-
-    circuits = parallel_map(_transpilation, circuits,
-                            task_kwargs={'basis_gates': basis_gates,
-                                         'coupling_map': coupling_map,
-                                         'initial_layout': initial_layout,
-                                         'seed_mapper': seed_mapper,
-                                         'pass_manager': pass_manager})
-    if return_form_is_single:
+    if len(circuits) == 1:
         return circuits[0]
     return circuits
 
 
-def _transpilation(circuit, basis_gates=None, coupling_map=None,
-                   initial_layout=None, seed_mapper=None,
-                   pass_manager=None):
-    """Perform transpilation of a single circuit.
+# FIXME: (Ali) This function should really be public and have the
+# signature (circuit, transpile_config). It is currently written like this
+# because our parallel tool can only parallelize functions over one variable.
+def _transpile_circuit(circuit_config_tuple):
+    """Select a PassManager and run a single circuit through it.
 
     Args:
-        circuit (QuantumCircuit): A circuit to transpile.
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
-        coupling_map (CouplingMap): coupling map (perhaps custom) to target in mapping
-        initial_layout (Layout): initial layout of qubits in mapping
-        seed_mapper (int): random seed for the swap_mapper
-        pass_manager (PassManager): a pass_manager for the transpiler stage
+        circuit_config_tuple (tuple):
+            circuit (QuantumCircuit): circuit to transpile
+            transpile_config (TranspileConfig): configuration dictating how to transpile
 
     Returns:
-        QuantumCircuit: A transpiled circuit.
-
-    Raises:
-        TranspilerError: If the Layout does not matches the circuit
+        QuantumCircuit: transpiled circuit
     """
-    if initial_layout is not None and set(circuit.qregs) != initial_layout.get_registers():
-        raise TranspilerError('The provided initial layout does not match the registers in '
-                              'the circuit "%s"' % circuit.name)
+    circuit, transpile_config = circuit_config_tuple
+    if transpile_config.coupling_map:
+        pass_manager = default_pass_manager(transpile_config.basis_gates,
+                                            transpile_config.coupling_map,
+                                            transpile_config.initial_layout,
+                                            transpile_config.skip_numeric_passes,
+                                            transpile_config.seed_transpiler)
+    else:
+        pass_manager = default_pass_manager_simulator(transpile_config.basis_gates)
 
-    if pass_manager and not pass_manager.working_list:
-        return circuit
-
-    is_parametric_circuit = bool(circuit.variables)
-
-    dag = circuit_to_dag(circuit)
-    del circuit
-
-    final_dag = _transpile_dag(dag, basis_gates=basis_gates,
-                               coupling_map=coupling_map,
-                               initial_layout=initial_layout,
-                               skip_numeric_passes=is_parametric_circuit,
-                               seed_mapper=seed_mapper,
-                               pass_manager=pass_manager)
-
-    out_circuit = dag_to_circuit(final_dag)
-
-    return out_circuit
+    return pass_manager.run(circuit)
 
 
-def _transpile_dag(dag, basis_gates=None, coupling_map=None,
-                   initial_layout=None, skip_numeric_passes=None,
-                   seed_mapper=None, pass_manager=None):
-    """Transform a dag circuit into another dag circuit (transpile), through
-    consecutive passes on the dag.
+def _parse_transpile_args(circuits,
+                          basis_gates=None, coupling_map=None, backend_properties=None,
+                          initial_layout=None, seed_transpiler=None, optimization_level=None,
+                          transpile_config=None, backend=None):
+    """Resolve the various types of args allowed to the transpile() function through
+    duck typing, overriding args, etc. Refer to the transpile() docstring for details on
+    what types of inputs are allowed.
 
-    Args:
-        dag (DAGCircuit): dag circuit to transform via transpilation
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
-        coupling_map (list): A graph of coupling::
+    Here the args are resolved by converting them to standard instances, and prioritizing
+    them in case a transpile option is passed through multiple args.
 
-            [
-             [control0(int), target0(int)],
-             [control1(int), target1(int)],
-            ]
-
-            eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
-
-        initial_layout (Layout or None): A layout object
-        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
-        seed_mapper (int): random seed_mapper for the swap mapper
-        pass_manager (PassManager): pass manager instance for the transpilation process
-            If None, a default set of passes are run.
-            Otherwise, the passes defined in it will run.
-            If contains no passes in it, no dag transformations occur.
+    The priority is:
+        1. kwarg
+        2. transpile_config
+        3. backend
 
     Returns:
-        DAGCircuit: transformed dag
+        list[TranspileConfig]: a transpile config for each circuit, which is a standardized
+            object that configures the transpiler and determines the pass manager to use.
     """
+    # Each arg could be single or a list. If list, it must be the same size as
+    # number of circuits. If single, duplicate to create a list of that size.
+    num_circuits = len(circuits)
+
+    basis_gates = _parse_basis_gates(basis_gates, transpile_config, backend, num_circuits)
+
+    coupling_map = _parse_coupling_map(coupling_map, transpile_config, backend, num_circuits)
+
+    backend_properties = _parse_backend_properties(backend_properties, transpile_config,
+                                                   backend, num_circuits)
+
+    initial_layout = _parse_initial_layout(initial_layout, transpile_config, circuits)
+
+    seed_transpiler = _parse_seed_transpiler(seed_transpiler, transpile_config, num_circuits)
+
+    optimization_level = _parse_optimization_level(optimization_level,
+                                                   transpile_config, num_circuits)
+
+    is_parametric_circuit=[bool(circuit.variables) for circuit in circuits]
+
+    transpile_configs = []
+    for args in zip(basis_gates, coupling_map, backend_properties, initial_layout,
+                    seed_transpiler, optimization_level, is_parametric_circuit):
+        transpile_config = TranspileConfig(basis_gates=args[0],
+                                           coupling_map=args[1],
+                                           backend_properties=args[2],
+                                           initial_layout=args[3],
+                                           seed_transpiler=args[4],
+                                           optimization_level=args[5],
+                                           skip_numeric_passes=args[6])
+        transpile_configs.append(transpile_config)
+
+    return transpile_configs
+
+
+def _parse_basis_gates(basis_gates, transpile_config, backend, num_circuits):
+    # try getting basis_gates from user, else transpile_config, else backend
     if basis_gates is None:
-        basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']
+        basis_gates = getattr(transpile_config, 'basis_gates', None)
+    if basis_gates is None:
+        if getattr(backend, 'configuration', None):
+            basis_gates = getattr(backend.configuration(), 'basis_gates', None)
+    # basis_gates could be None, or a list of basis, e.g. ['u3', 'cx']
     if isinstance(basis_gates, str):
         warnings.warn("The parameter basis_gates is now a list of strings. "
                       "For example, this basis ['u1','u2','u3','cx'] should be used "
                       "instead of 'u1,u2,u3,cx'. The string format will be "
                       "removed after 0.9", DeprecationWarning, 2)
         basis_gates = basis_gates.split(',')
+    if basis_gates is None or (isinstance(basis_gates, list) and
+                               all(isinstance(i, str) for i in basis_gates)):
+        basis_gates = [basis_gates] * num_circuits
+    return basis_gates
 
-    if pass_manager is None:
-        # default set of passes
 
-        # if a coupling map is given compile to the map
-        if coupling_map:
-            pass_manager = default_pass_manager(basis_gates,
-                                                CouplingMap(coupling_map),
-                                                initial_layout,
-                                                skip_numeric_passes,
-                                                seed_mapper=seed_mapper)
-        else:
-            pass_manager = default_pass_manager_simulator(basis_gates)
+def _parse_coupling_map(coupling_map, transpile_config, backend, num_circuits):
+    # try getting coupling_map from user, else transpile_config, else backend
+    if coupling_map is None:
+        coupling_map = getattr(transpile_config, 'coupling_map', None)
+    if coupling_map is None:
+        if getattr(backend, 'configuration', None):
+            coupling_map = getattr(backend.configuration(), 'coupling_map', None)
+    # coupling_map could be None, or a list of lists, e.g. [[0, 1], [2, 1]]
+    if coupling_map is None or isinstance(coupling_map, CouplingMap):
+        coupling_map = [coupling_map] * num_circuits
+    elif isinstance(coupling_map, list) and all(isinstance(i, list) and len(i) == 2
+                                                for i in coupling_map):
+        coupling_map = [coupling_map] * num_circuits
+    coupling_map = [CouplingMap(cm) if isinstance(cm, list) else cm for cm in coupling_map]
+    return coupling_map
 
-    # run the passes specified by the pass manager
-    # TODO return the property set too. See #1086
-    name = dag.name
-    dag = pass_manager.run_passes(dag)
-    dag.name = name
 
-    return dag
+def _parse_backend_properties(backend_properties, transpile_config, backend, num_circuits):
+    # try getting backend_properties from user, else transpile_config, else backend
+    if backend_properties is None:
+        backend_properties = getattr(transpile_config, 'backend_properties', None)
+    if backend_properties is None:
+        if getattr(backend, 'properties', None):
+            backend_properties = backend.properties()
+    if not isinstance(backend_properties, list):
+        backend_properties = [backend_properties] * num_circuits
+    return backend_properties
+
+
+def _parse_initial_layout(initial_layout, transpile_config, circuits):
+    # initial_layout could be None, or a list of ints, e.g. [0, 5, 14]
+    # or a list of tuples/None e.g. [qr[0], None, qr[1]] or a dict e.g. {qr[0]: 0}
+    def _layout_from_raw(initial_layout, circuit):
+        if isinstance(initial_layout, list):
+            if all(isinstance(elem, int) for elem in initial_layout):
+                initial_layout = Layout.from_intlist(initial_layout, *circuit.qregs)
+            elif all(elem is None or isinstance(elem, tuple) for elem in initial_layout):
+                initial_layout = Layout.from_tuplelist(initial_layout)
+        elif isinstance(initial_layout, dict):
+            initial_layout = Layout(initial_layout)
+        return initial_layout
+    # try getting initial_layout from user, else transpile_config
+    initial_layout = initial_layout or getattr(transpile_config, 'initial_layout', None)
+    # multiple layouts?
+    if isinstance(initial_layout, list) and \
+       not any(isinstance(i, (int, dict)) for i in initial_layout):
+        initial_layout = [_layout_from_raw(lo, circ) if isinstance(lo, (list, dict)) else lo
+                          for lo, circ in zip(initial_layout, circuits)]
+    else:
+        # even if one layout, but multiple circuits, the layout need to be adapted for each
+        initial_layout = [_layout_from_raw(initial_layout, circ) for circ in circuits]
+    if not isinstance(initial_layout, list):
+        initial_layout = [initial_layout] * num_circuits
+    return initial_layout
+
+
+def _parse_seed_transpiler(seed_transpiler, transpile_config, num_circuits):
+    seed_transpiler = seed_transpiler or getattr(transpile_config, 'seed_transpiler', None)
+    if not isinstance(seed_transpiler, list):
+        seed_transpiler = [seed_transpiler, num_circuits]
+    return seed_transpiler
+
+
+def _parse_optimization_level(optimization_level, transpile_config, num_circuits):
+    optimization_level = optimization_level or getattr(transpile_config, 'seed_transpiler', None)
+    if not isinstance(optimization_level, list):
+        optimization_level = [optimization_level, num_circuits]
+    return optimization_level

--- a/qiskit/converters/circuits_to_qobj.py
+++ b/qiskit/converters/circuits_to_qobj.py
@@ -12,7 +12,7 @@ from qiskit.qobj import QobjHeader
 from qiskit.compiler import assemble_circuits
 
 
-def circuits_to_qobj(circuits, qobj_header=None, run_config=None,
+def circuits_to_qobj(circuits, qobj_header=None,
                      qobj_id=None, backend_name=None,
                      config=None, shots=None, max_credits=None,
                      basis_gates=None,
@@ -22,8 +22,6 @@ def circuits_to_qobj(circuits, qobj_header=None, run_config=None,
     Args:
         circuits (list[QuantumCircuits] or QuantumCircuit): circuits to compile
         qobj_header (QobjHeader): header to pass to the results
-        run_config (RunConfig): RunConfig object
-
         qobj_id (int): TODO: delete after qiskit-terra 0.8
         backend_name (str): TODO: delete after qiskit-terra 0.8
         config (dict): TODO: delete after qiskit-terra 0.8
@@ -44,30 +42,19 @@ def circuits_to_qobj(circuits, qobj_header=None, run_config=None,
     qobj_header = qobj_header or QobjHeader()
 
     if backend_name:
-        warnings.warn('backend_name is not required anymore', DeprecationWarning)
         qobj_header.backend_name = backend_name
-    if config:
-        warnings.warn('config is not used anymore. Set all configs in '
-                      'run_config.', DeprecationWarning)
-    if shots:
-        warnings.warn('shots is not used anymore. Set it via run_config.', DeprecationWarning)
-        run_config.shots = shots
     if basis_gates:
         warnings.warn('basis_gates was unused and will be removed.', DeprecationWarning)
     if coupling_map:
         warnings.warn('coupling_map was unused and will be removed.', DeprecationWarning)
-    if seed:
-        warnings.warn('seed is not used anymore. Set it via run_config', DeprecationWarning)
-        run_config.seed = seed
-    if memory:
-        warnings.warn('memory is not used anymore. Set it via run_config', DeprecationWarning)
-        run_config.memory = memory
-    if max_credits:
-        warnings.warn('max_credits is not used anymore. Set it via run_config', DeprecationWarning)
-        run_config.max_credits = max_credits
-    if qobj_id:
-        warnings.warn('qobj_id is not used anymore', DeprecationWarning)
 
-    qobj = assemble_circuits(circuits, qobj_header, run_config)
+    qobj = assemble_circuits(circuits=circuits,
+                             qobj_id=qobj_id,
+                             qobj_header=qobj_header,
+                             shots=shots,
+                             memory=memory,
+                             max_credits=max_credits,
+                             seed_simulator=seed,
+                             config=config)
 
     return qobj

--- a/qiskit/converters/circuits_to_qobj.py
+++ b/qiskit/converters/circuits_to_qobj.py
@@ -9,7 +9,7 @@
 import warnings
 
 from qiskit.qobj import QobjHeader
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 
 
 def circuits_to_qobj(circuits, qobj_header=None,
@@ -36,7 +36,7 @@ def circuits_to_qobj(circuits, qobj_header=None,
         Qobj: the Qobj to be run on the backends
     """
     warnings.warn('circuits_to_qobj is deprecated and will be removed in Qiskit Terra 0.9. '
-                  'Use qiskit.compiler.assemble_circuits() to serialize circuits into a qobj.',
+                  'Use qiskit.compiler.assemble() to serialize circuits into a qobj.',
                   DeprecationWarning)
 
     qobj_header = qobj_header or QobjHeader()
@@ -48,13 +48,13 @@ def circuits_to_qobj(circuits, qobj_header=None,
     if coupling_map:
         warnings.warn('coupling_map was unused and will be removed.', DeprecationWarning)
 
-    qobj = assemble_circuits(circuits=circuits,
-                             qobj_id=qobj_id,
-                             qobj_header=qobj_header,
-                             shots=shots,
-                             memory=memory,
-                             max_credits=max_credits,
-                             seed_simulator=seed,
-                             config=config)
+    qobj = assemble(circuits=circuits,
+                    qobj_id=qobj_id,
+                    qobj_header=qobj_header,
+                    shots=shots,
+                    memory=memory,
+                    max_credits=max_credits,
+                    seed_simulator=seed,
+                    config=config)
 
     return qobj

--- a/qiskit/converters/circuits_to_qobj.py
+++ b/qiskit/converters/circuits_to_qobj.py
@@ -48,7 +48,7 @@ def circuits_to_qobj(circuits, qobj_header=None,
     if coupling_map:
         warnings.warn('coupling_map was unused and will be removed.', DeprecationWarning)
 
-    qobj = assemble(circuits=circuits,
+    qobj = assemble(experiments=circuits,
                     qobj_id=qobj_id,
                     qobj_header=qobj_header,
                     shots=shots,

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -8,298 +8,29 @@
 """
 Helper module for simplified Qiskit usage.
 
-This module includes
-    execute_circuits: compile and run a list of quantum circuits.
-    execute_schedules: compile and run a list of pulse schedules.
-    execute: legacy wrapper that automatically selects
-        execute_circuits or execute_schedules based on input
-
 In general we recommend using the SDK modules directly. However, to get something
 running quickly we have provided this wrapper module.
 """
 import warnings
 import logging
 
-from qiskit.circuit import QuantumCircuit
-from qiskit.pulse import Schedule
-from qiskit.compiler import assemble_circuits, assemble_schedules, transpile
-from qiskit.qobj import QobjHeader
-from qiskit.validation.exceptions import ModelValidationError
-from qiskit.exceptions import QiskitError
+from qiskit.compiler import transpile, assemble
 
 logger = logging.getLogger(__name__)
-
-
-def execute_circuits(circuits, backend,
-                     basis_gates=None, coupling_map=None,  # transpile options
-                     backend_properties=None, initial_layout=None,
-                     seed_transpiler=None, optimization_level=None, transpile_config=None,
-                     qobj_id=None, qobj_header=None, shots=1024,  # run options
-                     memory=False, max_credits=10, seed_simulator=None, run_config=None,
-                     seed=None, seed_mapper=None,  # deprecated
-                     config=None, pass_manager=None,
-                     **kwargs):
-    """Executes a list of circuits on a backend.
-
-    The execution is asynchronous, and a handle to a job instance is returned.
-
-    This is a wrapper function around the following 3 stages:
-    1. new_circuits = compiler.transpile(circuits)
-    2. qobj = compiler.assemble_circuits(new_circuits)
-    3. job = backend.run(qobj)
-
-    Args:
-        circuits (QuantumCircuit or list[QuantumCircuit]):
-            Circuit(s) to execute
-
-        backend (BaseBackend):
-            Backend to execute circuits on.
-            Transpiler options are automatically grabbed from
-            backend.configuration() and backend.properties().
-            If any other option is explicitly set (e.g. coupling_map), it
-            will override the backend's.
-            If any other options is set in the transpile_config, it will
-            also override the backend's.
-
-        basis_gates (list[str]):
-            List of basis gate names to unroll to.
-            e.g:
-                ['u1', 'u2', 'u3', 'cx']
-            If None, do not unroll.
-
-        coupling_map (CouplingMap or list):
-            Coupling map (perhaps custom) to target in mapping.
-            Multiple formats are supported:
-            a. CouplingMap instance
-
-            b. list
-                Must be given as an adjacency matrix, where each entry
-                specifies all two-qubit interactions supported by backend
-                e.g:
-                    [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
-
-        backend_properties (BackendProperties):
-            properties returned by a backend, including information on gate
-            errors, readout errors, qubit coherence times, etc. For a backend
-            that provides this information, it can be obtained with:
-            ``backend.properties()``
-
-        initial_layout (Layout or dict or list):
-            Initial position of virtual qubits on physical qubits.
-            If this layout makes the circuit compatible with the coupling_map
-            constraints, it will be used.
-            The final layout is not guaranteed to be the same, as the transpiler
-            may permute qubits through swaps or other means.
-
-            Multiple formats are supported:
-            a. Layout instance
-
-            b. dict
-                virtual to physical:
-                    {qr[0]: 0,
-                     qr[1]: 3,
-                     qr[2]: 5}
-
-                physical to virtual:
-                    {0: qr[0],
-                     3: qr[1],
-                     5: qr[2]}
-
-            c. list
-                virtual to physical:
-                    [0, 3, 5]  # virtual qubits are ordered (in addition to named)
-
-                physical to virtual:
-                    [qr[0], None, None, qr[1], None, qr[2]]
-
-        seed_transpiler (int):
-            sets random seed for the stochastic parts of the transpiler
-
-        optimization_level (int):
-            How much optimization to perform on the circuits.
-            Higher levels generate more optimized circuits,
-            at the expense of longer transpilation time.
-                0: no optimization
-                1: light optimization
-                2: heavy optimization
-
-        transpile_config (TranspileConfig):
-            Transpiler configuration, containing some or all of the above options.
-            If any other option is explicitly set (e.g. coupling_map), it
-            will override the transpile_config's.
-
-        qobj_id (str):
-            String identifier to annotate the Qobj
-
-        qobj_header (QobjHeader or dict):
-            User input that will be inserted in Qobj header, and will also be
-            copied to the corresponding Result header. Headers do not affect the run.
-
-        shots (int):
-            number of repetitions of each circuit, for sampling. Default: 2014
-
-        memory (bool):
-            if True, per-shot measurement bitstrings are returned as well
-            (provided the backend supports it). Default: False
-
-        max_credits (int):
-            maximum credits to spend on job. Default: 10
-
-        seed_simulator (int):
-            random seed to control sampling, for when backend is a simulator
-
-        run_config (RunConfig):
-            Qobj runtime configuration, containing some or all of the above options.
-            If any other option is explicitly set (e.g. shots), it
-            will override the run_config's.
-
-        seed (int):
-            DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
-
-        seed_mapper (int):
-            DEPRECATED in 0.8: use ``seed_transpiler`` kwarg instead
-
-        config (dict):
-            DEPRECATED in 0.8: use run_config instead
-
-        pass_manager (PassManager):
-            DEPRECATED in 0.8: use pass_manager.run() to transpile the circuit,
-            then assemble and run it.
-
-        kwargs: extra arguments used by Aer for running configurable backends.
-                Refer to the backend documentation for details on these arguments
-
-    Returns:
-        BaseJob: returns job instance derived from BaseJob
-    """
-    # transpiling the circuits using given transpile options
-    new_circuits = transpile(circuits,
-                             basis_gates=basis_gates,
-                             coupling_map=coupling_map,
-                             backend_properties=backend_properties,
-                             initial_layout=initial_layout,
-                             seed_transpiler=seed_transpiler,
-                             optimization_level=optimization_level,
-                             transpile_config=transpile_config,
-                             backend=backend,
-                             seed_mapper=seed_mapper,  # deprecated
-                             pass_manager=pass_manager  # deprecated
-                             )
-
-    # filling in the header with the backend name the qobj was run on
-    backend_config = backend.configuration()
-    qobj_header = qobj_header or QobjHeader()
-    if isinstance(qobj_header, dict):
-        qobj_header = QobjHeader(**qobj_header)
-    qobj_header.backend_name = backend_config.backend_name
-    qobj_header.backend_version = backend_config.backend_version
-
-    # assembling the circuits into a qobj to be run on the backend
-    qobj = assemble_circuits(new_circuits,
-                             qobj_id=qobj_id,
-                             qobj_header=qobj_header,
-                             shots=shots,
-                             memory=memory,
-                             max_credits=max_credits,
-                             seed_simulator=seed_simulator,
-                             run_config=run_config,
-                             config=config,  # deprecated
-                             seed=seed  # deprecated
-                             )
-
-    # executing the circuits on the backend and returning the job
-    return backend.run(qobj, **kwargs)
-
-
-def execute_schedules(schedules, backend, schedule_los=None, shots=1024,
-                      meas_level=2, meas_return='avg', memory=None,
-                      memory_slots=None, memory_slot_size=100,
-                      rep_time=None, max_credits=10, seed=None,
-                      qobj_header=None, run_config=None,
-                      **kwargs):
-    """Executes a list of schedules.
-
-    Args:
-        schedules (Schedule or List[Schedule]): schedules to execute
-        backend (BaseBackend): a backend to execute the schedules on
-        schedule_los(None or list[Union[Dict[OutputChannel, float], LoConfig]] or
-                        Union[Dict[OutputChannel, float], LoConfig]): Experiment LO configurations
-        shots (int): number of repetitions of each circuit, for sampling
-        meas_level (int): set the appropriate level of the measurement output.
-        meas_return (str): indicates the level of measurement data for the backend to return
-            for `meas_level` 0 and 1:
-                "single" returns information from every shot of the experiment.
-                "avg" returns the average measurement output (averaged over the number of shots).
-        memory (bool or None): For `meas_level` 2, return the individual shot results.
-        memory_slots (int): number of classical memory slots used in this job.
-        memory_slot_size (int): size of each memory slot if the output is Level 0.
-        rep_time (int): repetition time of the experiment in μs.
-            The delay between experiments will be rep_time.
-            Must be from the list provided by the device.
-        max_credits (int): maximum credits to use
-        seed (int): random seed for simulators
-        qobj_header (QobjHeader or dict): user input to go into the header
-        run_config (dict): Additional run time configuration arguments to be inserted
-                    in the qobj configuration.
-        kwargs: extra arguments to configure backend
-
-    Returns:
-        BaseJob: returns job instance derived from BaseJob
-    """
-    backend_config = backend.configuration()
-
-    # TODO : Remove usage of config.defaults when backend.defaults() is updated.
-    try:
-        backend_default = backend.defaults()
-    except ModelValidationError:
-        from collections import namedtuple
-        BackendDefault = namedtuple('BackendDefault', ('qubit_freq_est', 'meas_freq_est'))
-
-        backend_default = BackendDefault(
-            qubit_freq_est=backend_config.defaults['qubit_freq_est'],
-            meas_freq_est=backend_config.defaults['meas_freq_est']
-        )
-
-    memory_slots = memory_slots if memory_slots else backend_config.n_qubits
-    rep_time = rep_time if rep_time else backend_config.rep_times[-1]
-
-    # filling in the header with the backend name the qobj was run on
-    qobj_header = qobj_header or QobjHeader()
-    if isinstance(qobj_header, dict):
-        qobj_header = QobjHeader(**qobj_header)
-
-    qobj_header.backend_name = backend.name()
-    qobj_header.backend_version = backend_config.backend_version
-
-    if run_config is None:
-        run_config = {}
-
-    qobj = assemble_schedules(schedules,
-                              backend_default.qubit_freq_est,
-                              backend_default.meas_freq_est,
-                              schedule_los=schedule_los, shots=shots,
-                              meas_level=meas_level, meas_return=meas_return,
-                              memory=memory, memory_slots=memory_slots,
-                              memory_slot_size=memory_slot_size,
-                              rep_time=rep_time, max_credits=max_credits,
-                              seed=seed, qobj_header=qobj_header,
-                              **run_config)
-
-    # executing the schedules on the backend and returning the job
-    return backend.run(qobj, **kwargs)
 
 
 def execute(experiments, backend,
             basis_gates=None, coupling_map=None,  # circuit transpile options
             backend_properties=None, initial_layout=None,
-            seed_transpiler=None, optimization_level=None, transpile_config=None,
+            seed_transpiler=None, optimization_level=None,
             qobj_id=None, qobj_header=None, shots=1024,  # common run options
-            memory=False, max_credits=10, seed_simulator=None, run_config=None,
-            schedule_los=None, meas_level=2, meas_return='avg',  # schedule run options
+            memory=False, max_credits=10, seed_simulator=None,
+            default_qubit_los=None, default_meas_los=None,  # schedule run options
+            schedule_los=None, meas_level=2, meas_return='avg',
             memory_slots=None, memory_slot_size=100, rep_time=None,
             seed=None, seed_mapper=None,  # deprecated
             config=None, pass_manager=None, circuits=None,
-            **kwargs):
+            **run_config):
     """Execute a list of circuits or pulse schedules on a backend.
 
     The execution is asynchronous, and a handle to a job instance is returned.
@@ -314,8 +45,6 @@ def execute(experiments, backend,
             backend.configuration() and backend.properties().
             If any other option is explicitly set (e.g. coupling_map), it
             will override the backend's.
-            If any other options is set in the transpile_config, it will
-            also override the backend's.
 
         basis_gates (list[str]):
             List of basis gate names to unroll to.
@@ -379,11 +108,6 @@ def execute(experiments, backend,
                 1: light optimization
                 2: heavy optimization
 
-        transpile_config (TranspileConfig):
-            Transpiler configuration, containing some or all of the above options.
-            If any other option is explicitly set (e.g. coupling_map), it
-            will override the transpile_config's.
-
         qobj_id (str):
             String identifier to annotate the Qobj
 
@@ -404,6 +128,12 @@ def execute(experiments, backend,
 
         seed_simulator (int):
             Random seed to control sampling, for when backend is a simulator
+
+        default_qubit_los (list):
+            List of default qubit lo frequencies
+
+        default_meas_los (list):
+            List of default meas lo frequencies
 
         schedule_los (None or list[Union[Dict[OutputChannel, float], LoConfig]] or
                       Union[Dict[OutputChannel, float], LoConfig]):
@@ -428,11 +158,6 @@ def execute(experiments, backend,
             The delay between experiments will be rep_time.
             Must be from the list provided by the device.
 
-        run_config (RunConfig):
-            Qobj runtime configuration, containing some or all of the above options.
-            If any other option is explicitly set (e.g. shots), it
-            will override the run_config's.
-
         seed (int):
             DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
 
@@ -449,8 +174,11 @@ def execute(experiments, backend,
         circuits (QuantumCircuit or list[QuantumCircuit]):
             DEPRECATED in 0.8: use ``experiments`` kwarg instead.
 
-        kwargs: extra arguments used by Aer for running configurable backends.
-                Refer to the backend documentation for details on these arguments
+        run_config (dict):
+            Extra arguments used to configure the run (e.g. for Aer configurable backends)
+            Refer to the backend documentation for details on these arguments
+            Note: for now, these keyword arguments will both be copied to the
+            Qobj config, and passed to backend.run()
 
     Returns:
         BaseJob: returns job instance derived from BaseJob
@@ -464,51 +192,40 @@ def execute(experiments, backend,
                       "please use `experiments`, which can handle both circuit "
                       "and pulse Schedules", DeprecationWarning)
 
-    if (isinstance(experiments, QuantumCircuit) or
-            (isinstance(experiments, list) and
-             all(isinstance(c, QuantumCircuit) for c in experiments))):
-        return execute_circuits(circuits=experiments,
-                                backend=backend,
-                                basis_gates=basis_gates,  # transpile options
-                                coupling_map=coupling_map,
-                                backend_properties=backend_properties,
-                                initial_layout=initial_layout,
-                                seed_transpiler=seed_transpiler,
-                                optimization_level=optimization_level,
-                                transpile_config=transpile_config,
-                                qobj_id=qobj_id,  # run options
-                                qobj_header=qobj_header,
-                                shots=shots,
-                                memory=memory,
-                                max_credits=max_credits,
-                                seed_simulator=seed_simulator,
-                                run_config=run_config,
-                                seed=seed,  # deprecated
-                                seed_mapper=seed_mapper,
-                                config=config,
-                                pass_manager=pass_manager,
-                                **kwargs)
+    # transpiling the circuits using given transpile options
+    experiments = transpile(experiments,
+                            basis_gates=basis_gates,
+                            coupling_map=coupling_map,
+                            backend_properties=backend_properties,
+                            initial_layout=initial_layout,
+                            seed_transpiler=seed_transpiler,
+                            optimization_level=optimization_level,
+                            backend=backend,
+                            seed_mapper=seed_mapper,  # deprecated
+                            pass_manager=pass_manager  # deprecated
+                            )
 
-    elif (isinstance(experiments, Schedule) or
-          (isinstance(experiments, list) and
-           all(isinstance(c, Schedule) for c in experiments))):
-        return execute_schedules(schedules=experiments,
-                                 backend=backend,
-                                 qobj_id=qobj_id,  # run options
-                                 qobj_header=qobj_header,
-                                 shots=shots,
-                                 memory=memory,
-                                 max_credits=max_credits,
-                                 seed_simulator=seed_simulator,
-                                 schedule_los=schedule_los,
-                                 meas_level=meas_level,
-                                 meas_return=meas_return,
-                                 memory_slots=memory_slots,
-                                 memory_slot_size=memory_slot_size,
-                                 rep_time=rep_time,
-                                 run_config=run_config,
-                                 seed=seed,  # deprecated
-                                 **kwargs)
+    # assembling the circuits into a qobj to be run on the backend
+    qobj = assemble(experiments,
+                    qobj_id=qobj_id,
+                    qobj_header=qobj_header,
+                    shots=shots,
+                    memory=memory,
+                    max_credits=max_credits,
+                    seed_simulator=seed_simulator,
+                    default_qubit_los=default_qubit_los,
+                    default_meas_los=default_meas_los,
+                    schedule_los=schedule_los,
+                    meas_level=meas_level,
+                    meas_return=meas_return,
+                    memory_slots=memory_slots,
+                    memory_slot_size=memory_slot_size,
+                    rep_time=rep_time,
+                    backend=backend,
+                    config=config,  # deprecated
+                    seed=seed,  # deprecated
+                    run_config=run_config
+                    )
 
-    else:
-        raise QiskitError("bad input to execute() function; must be either circuits or schedules")
+    # executing the circuits on the backend and returning the job
+    return backend.run(qobj, **run_config)

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -22,14 +22,14 @@ logger = logging.getLogger(__name__)
 def execute(experiments, backend,
             basis_gates=None, coupling_map=None,  # circuit transpile options
             backend_properties=None, initial_layout=None,
-            seed_transpiler=None, optimization_level=None,
+            seed_transpiler=None, optimization_level=None, pass_manager=None,
             qobj_id=None, qobj_header=None, shots=1024,  # common run options
             memory=False, max_credits=10, seed_simulator=None,
             default_qubit_los=None, default_meas_los=None,  # schedule run options
             schedule_los=None, meas_level=2, meas_return='avg',
             memory_slots=None, memory_slot_size=100, rep_time=None,
             seed=None, seed_mapper=None,  # deprecated
-            config=None, pass_manager=None, circuits=None,
+            config=None, circuits=None,
             **run_config):
     """Execute a list of circuits or pulse schedules on a backend.
 
@@ -108,6 +108,11 @@ def execute(experiments, backend,
                 1: light optimization
                 2: heavy optimization
 
+        pass_manager (PassManager):
+            The pass manager to use during transpilation. If this arg is present,
+            auto-selection of pass manager based on the transpile options will be
+            turned off and this pass manager will be used directly.
+
         qobj_id (str):
             String identifier to annotate the Qobj
 
@@ -167,10 +172,6 @@ def execute(experiments, backend,
         config (dict):
             DEPRECATED in 0.8: use run_config instead
 
-        pass_manager (PassManager):
-            DEPRECATED in 0.8: use pass_manager.run() to transpile the circuit,
-            then assemble and run it.
-
         circuits (QuantumCircuit or list[QuantumCircuit]):
             DEPRECATED in 0.8: use ``experiments`` kwarg instead.
 
@@ -201,8 +202,8 @@ def execute(experiments, backend,
                             seed_transpiler=seed_transpiler,
                             optimization_level=optimization_level,
                             backend=backend,
+                            pass_manager=pass_manager,
                             seed_mapper=seed_mapper,  # deprecated
-                            pass_manager=pass_manager  # deprecated
                             )
 
     # assembling the circuits into a qobj to be run on the backend

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -22,7 +22,6 @@ import logging
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.pulse import Schedule
-from qiskit.compiler import transpile, assemble_circuits
 from qiskit.compiler import assemble_circuits, assemble_schedules, transpile
 from qiskit.qobj import QobjHeader
 from qiskit.validation.exceptions import ModelValidationError
@@ -35,9 +34,9 @@ def execute_circuits(circuits, backend,
                      basis_gates=None, coupling_map=None,  # transpile options
                      backend_properties=None, initial_layout=None,
                      seed_transpiler=None, optimization_level=None, transpile_config=None,
-                     qobj_header=None, shots=1024, memory=False,  # run options
-                     max_credits=10, seed_simulator=None, run_config=None,
-                     seed=None, seed_mapper=None, qobj_id=None,  # deprecated
+                     qobj_id=None, qobj_header=None, shots=1024,  # run options
+                     memory=False, max_credits=10, seed_simulator=None, run_config=None,
+                     seed=None, seed_mapper=None,  # deprecated
                      config=None, pass_manager=None,
                      **kwargs):
     """Executes a list of circuits on a backend.
@@ -129,6 +128,9 @@ def execute_circuits(circuits, backend,
             If any other option is explicitly set (e.g. coupling_map), it
             will override the transpile_config's.
 
+        qobj_id (str):
+            String identifier to annotate the Qobj
+
         qobj_header (QobjHeader or dict):
             User input that will be inserted in Qobj header, and will also be
             copied to the corresponding Result header. Headers do not affect the run.
@@ -145,11 +147,11 @@ def execute_circuits(circuits, backend,
 
         seed_simulator (int):
             random seed to control sampling, for when backend is a simulator
-            
+
         run_config (RunConfig):
             Qobj runtime configuration, containing some or all of the above options.
             If any other option is explicitly set (e.g. shots), it
-            will override the run_config's.            
+            will override the run_config's.
 
         seed (int):
             DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
@@ -157,11 +159,8 @@ def execute_circuits(circuits, backend,
         seed_mapper (int):
             DEPRECATED in 0.8: use ``seed_transpiler`` kwarg instead
 
-        qobj_id (int):
-            DEPRECATED in 0.8: use qobj_header instead
-
         config (dict):
-            DEPRECATED in 0.8: use **kwargs instead
+            DEPRECATED in 0.8: use run_config instead
 
         pass_manager (PassManager):
             DEPRECATED in 0.8: use pass_manager.run() to transpile the circuit,
@@ -197,14 +196,15 @@ def execute_circuits(circuits, backend,
 
     # assembling the circuits into a qobj to be run on the backend
     qobj = assemble_circuits(new_circuits,
+                             qobj_id=qobj_id,
                              qobj_header=qobj_header,
                              shots=shots,
                              memory=memory,
                              max_credits=max_credits,
                              seed_simulator=seed_simulator,
                              run_config=run_config,
-                             qobj_id=qobj_id,  # deprecated
-                             seed=seed,  # deprecated
+                             config=config,  # deprecated
+                             seed=seed  # deprecated
                              )
 
     # executing the circuits on the backend and returning the job
@@ -293,10 +293,10 @@ def execute(circuits, backend,
             basis_gates=None, coupling_map=None,  # transpile options
             backend_properties=None, initial_layout=None,
             seed_transpiler=None, optimization_level=None, transpile_config=None,
-            qobj_header=None, shots=1024, memory=False,  # run options
-            max_credits=10, seed_simulator=None, run_config=None,
-            seed=None, seed_mapper=None, qobj_id=None,  # deprecated
-            config=None,  pass_manager=None,
+            qobj_id=None, qobj_header=None, shots=1024,  # run options
+            memory=False, max_credits=10, seed_simulator=None, run_config=None,
+            seed=None, seed_mapper=None,  # deprecated
+            config=None, pass_manager=None,
             **kwargs):
     """Execute a list of circuits or pulse schedules on a backend.
 
@@ -306,29 +306,135 @@ def execute(circuits, backend,
     The execution is asynchronous, and a handle to a job instance is returned.
 
     Args:
-        circuits (QuantumCircuit or list[QuantumCircuit])
-        backend (BaseBackend)
-        basis_gates (list[str])
-        coupling_map (CouplingMap or list)
-        backend_properties (BackendProperties)
-        initial_layout (Layout or dict or list)
-        seed_transpiler (int)
-        optimization_level (int)
-        transpile_config (TranspileConfig)
-        qobj_header (QobjHeader or dict)
-        shots (int)
-        memory (bool)
-        max_credits (int)
-        seed_simulator (int)
-        run_config (RunConfig)
-        seed (int): DEPRECATED
-        seed_mapper (int): DEPRECATED
-        qobj_id (int): DEPRECATED
-        config (dict): DEPRECATED
-        pass_manager (PassManager): DEPRECATED
+        circuits (QuantumCircuit or list[QuantumCircuit]):
+            Circuit(s) to execute
+
+        backend (BaseBackend):
+            Backend to execute circuits on.
+            Transpiler options are automatically grabbed from
+            backend.configuration() and backend.properties().
+            If any other option is explicitly set (e.g. coupling_map), it
+            will override the backend's.
+            If any other options is set in the transpile_config, it will
+            also override the backend's.
+
+        basis_gates (list[str]):
+            List of basis gate names to unroll to.
+            e.g:
+                ['u1', 'u2', 'u3', 'cx']
+            If None, do not unroll.
+
+        coupling_map (CouplingMap or list):
+            Coupling map (perhaps custom) to target in mapping.
+            Multiple formats are supported:
+            a. CouplingMap instance
+
+            b. list
+                Must be given as an adjacency matrix, where each entry
+                specifies all two-qubit interactions supported by backend
+                e.g:
+                    [[0, 1], [0, 3], [1, 2], [1, 5], [2, 5], [4, 1], [5, 3]]
+
+        backend_properties (BackendProperties):
+            properties returned by a backend, including information on gate
+            errors, readout errors, qubit coherence times, etc. For a backend
+            that provides this information, it can be obtained with:
+            ``backend.properties()``
+
+        initial_layout (Layout or dict or list):
+            Initial position of virtual qubits on physical qubits.
+            If this layout makes the circuit compatible with the coupling_map
+            constraints, it will be used.
+            The final layout is not guaranteed to be the same, as the transpiler
+            may permute qubits through swaps or other means.
+
+            Multiple formats are supported:
+            a. Layout instance
+
+            b. dict
+                virtual to physical:
+                    {qr[0]: 0,
+                     qr[1]: 3,
+                     qr[2]: 5}
+
+                physical to virtual:
+                    {0: qr[0],
+                     3: qr[1],
+                     5: qr[2]}
+
+            c. list
+                virtual to physical:
+                    [0, 3, 5]  # virtual qubits are ordered (in addition to named)
+
+                physical to virtual:
+                    [qr[0], None, None, qr[1], None, qr[2]]
+
+        seed_transpiler (int):
+            sets random seed for the stochastic parts of the transpiler
+
+        optimization_level (int):
+            How much optimization to perform on the circuits.
+            Higher levels generate more optimized circuits,
+            at the expense of longer transpilation time.
+                0: no optimization
+                1: light optimization
+                2: heavy optimization
+
+        transpile_config (TranspileConfig):
+            Transpiler configuration, containing some or all of the above options.
+            If any other option is explicitly set (e.g. coupling_map), it
+            will override the transpile_config's.
+
+        qobj_id (str):
+            String identifier to annotate the Qobj
+
+        qobj_header (QobjHeader):
+            User input that will be inserted in Qobj header, and will also be
+            copied to the corresponding Result header. Headers do not affect the run.
+
+        shots (int):
+            number of repetitions of each circuit, for sampling. Default: 2014
+
+        memory (bool):
+            if True, per-shot measurement bitstrings are returned as well
+            (provided the backend supports it). Default: False
+
+        max_credits (int):
+            maximum credits to spend on job. Default: 10
+
+        seed_simulator (int):
+            random seed to control sampling, for when backend is a simulator
+
+        run_config (RunConfig):
+            Qobj runtime configuration, containing some or all of the above options.
+            If any other option is explicitly set (e.g. shots), it
+            will override the run_config's.
+
+        seed (int):
+            DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
+
+        seed_mapper (int):
+            DEPRECATED in 0.8: use ``seed_transpiler`` kwarg instead
+
+        config (dict):
+            DEPRECATED in 0.8: use run_config instead
+
+        pass_manager (PassManager):
+            DEPRECATED in 0.8: use pass_manager.run() to transpile the circuit,
+            then assemble and run it.
+
+        kwargs: extra arguments used by Aer for running configurable backends.
+                Refer to the backend documentation for details on these arguments
+
+    Returns:
+        BaseJob: returns job instance derived from BaseJob
+
+    Raises:
+        QiskitError: if the execution cannot be interpreted as either circuits or pulses
     """
-    if isinstance(circuits, QuantumCircuit) or \
-       (isinstance(circuits, list) and all(isinstance(c, QuantumCircuit) for c in circuits)):
+    if (isinstance(circuits, QuantumCircuit) or
+            (isinstance(circuits, list) and
+             all(isinstance(c, QuantumCircuit) for c in circuits))):
         return execute_circuits(circuits=circuits,
                                 backend=backend,
                                 basis_gates=basis_gates,  # transpile options
@@ -338,7 +444,8 @@ def execute(circuits, backend,
                                 seed_transpiler=seed_transpiler,
                                 optimization_level=optimization_level,
                                 transpile_config=transpile_config,
-                                qobj_header=qobj_header,  # run options
+                                qobj_id=qobj_id,  # run options
+                                qobj_header=qobj_header,
                                 shots=shots,
                                 memory=memory,
                                 max_credits=max_credits,
@@ -346,14 +453,14 @@ def execute(circuits, backend,
                                 run_config=run_config,
                                 seed=seed,  # deprecated
                                 seed_mapper=seed_mapper,
-                                qobj_id=qobj_id,
                                 config=config,
                                 pass_manager=pass_manager,
                                 **kwargs)
 
-    elif isinstance(circuits, Schedule) or \
-       (isinstance(circuits, list) and all(isinstance(c, Schedule) for c in circuits)):
-        return execute_schedules(circuits)
+    elif (isinstance(circuits, Schedule) or
+          (isinstance(circuits, list) and
+           all(isinstance(c, Schedule) for c in circuits))):
+        return execute_schedules()
 
     else:
         raise QiskitError("bad input to execute function; must be either circuits or schedules")

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -460,7 +460,8 @@ def execute(circuits, backend,
     elif (isinstance(circuits, Schedule) or
           (isinstance(circuits, list) and
            all(isinstance(c, Schedule) for c in circuits))):
-        return execute_schedules()
+        return execute_schedules(schedules=circuits,
+                                 backend=backend)
 
     else:
         raise QiskitError("bad input to execute function; must be either circuits or schedules")

--- a/qiskit/tools/compiler.py
+++ b/qiskit/tools/compiler.py
@@ -5,12 +5,12 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Helper module for simplified Qiskit usage. THIS WILL BE REMOVED IN AFTER 0.8."""
+"""DEPRECATED: WILL BE REMOVED AFTER 0.8."""
 import warnings
 import logging
 
 from qiskit.compiler.transpiler import transpile
-from qiskit.compiler.assembler import assemble_circuits
+from qiskit.compiler.assembler import assemble
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +45,11 @@ def compile(circuits, backend,
         QiskitError: if the desired options are not supported by backend
     """
     warnings.warn('qiskit.compile() is deprecated and will be removed in Qiskit Terra 0.9. '
-                  'Please use qiskit.transpile() to transform circuits '
-                  'and qiskit.assemble_circuits() to produce qobj.',
+                  'Please use qiskit.compiler.transpile() to transform circuits '
+                  'and qiskit.compiler.assemble() to produce a runnable qobj.',
                   DeprecationWarning)
 
-    new_circuits = transpile(circuits=circuits,
+    new_circuits = transpile(circuits,
                              basis_gates=basis_gates,
                              coupling_map=coupling_map,
                              initial_layout=initial_layout,
@@ -57,13 +57,13 @@ def compile(circuits, backend,
                              backend=backend,
                              pass_manager=pass_manager)
 
-    qobj = assemble_circuits(circuits=new_circuits,
-                             qobj_header=None,
-                             shots=shots,
-                             max_credits=max_credits,
-                             seed_simulator=seed,
-                             memory=memory,
-                             qobj_id=qobj_id,
-                             config=config)  # deprecated
+    qobj = assemble(new_circuits,
+                    qobj_header=None,
+                    shots=shots,
+                    max_credits=max_credits,
+                    seed_simulator=seed,
+                    memory=memory,
+                    qobj_id=qobj_id,
+                    config=config)  # deprecated
 
     return qobj

--- a/qiskit/tools/compiler.py
+++ b/qiskit/tools/compiler.py
@@ -9,9 +9,8 @@
 import warnings
 import logging
 
+from qiskit.compiler.transpiler import transpile
 from qiskit.compiler.assembler import assemble_circuits
-from qiskit.compiler.run_config import RunConfig
-from qiskit import transpiler
 
 logger = logging.getLogger(__name__)
 
@@ -50,24 +49,21 @@ def compile(circuits, backend,
                   'and qiskit.assemble_circuits() to produce qobj.',
                   DeprecationWarning)
 
-    run_config = RunConfig()
+    new_circuits = transpile(circuits=circuits,
+                             basis_gates=basis_gates,
+                             coupling_map=coupling_map,
+                             initial_layout=initial_layout,
+                             seed_transpiler=seed_mapper,
+                             backend=backend,
+                             pass_manager=pass_manager)
 
-    if config:
-        warnings.warn('config is not used anymore. Set all configs in '
-                      'run_config.', DeprecationWarning)
-    if shots:
-        run_config.shots = shots
-    if max_credits:
-        run_config.max_credits = max_credits
-    if seed:
-        run_config.seed = seed
-    if memory:
-        run_config.memory = memory
-
-    new_circuits = transpiler.transpile(circuits, backend, basis_gates, coupling_map,
-                                        initial_layout, seed_mapper, pass_manager)
-
-    qobj = assemble_circuits(new_circuits, qobj_header=None, run_config=run_config,
-                             qobj_id=qobj_id)
+    qobj = assemble_circuits(circuits=new_circuits,
+                             qobj_header=None,
+                             shots=shots,
+                             max_credits=max_credits,
+                             seed_simulator=seed,
+                             memory=memory,
+                             qobj_id=qobj_id,
+                             config=config)  # deprecated
 
     return qobj

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -69,7 +69,7 @@ def parallel_map(task, values, task_args=tuple(), task_kwargs={},  # pylint: dis
     overhead from spawning processes in Windows.
 
     Args:
-        task (func): Function that is to be called for each value in ``task_vec``.
+        task (func): Function that is to be called for each value in ``values``.
         values (array_like): List or array of values for which the ``task``
                             function is to be evaluated.
         task_args (list): Optional additional arguments to the ``task`` function.

--- a/qiskit/transpiler/passes/unroller.py
+++ b/qiskit/transpiler/passes/unroller.py
@@ -29,7 +29,6 @@ class Unroller(TransformationPass):
     def run(self, dag):
         """Expand all op nodes to the given basis.
 
-
         Args:
             dag(DAGCircuit): input dag
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -115,20 +115,6 @@ class PassManager():
         self.working_list.append(
             FlowController.controller_factory(passes, options, **flow_controller_conditions))
 
-    def run_passes(self, dag):
-        """Run all the passes on a DAG.
-
-        Args:
-            dag (DAGCircuit): DAG circuit to transform via all the registered passes
-
-        Returns:
-            DAGCircuit: Transformed DAG.
-        """
-        for passset in self.working_list:
-            for pass_ in passset:
-                dag = self._do_pass(pass_, dag, passset.options)
-        return dag
-
     def run(self, circuit):
         """Run all the passes on a QuantumCircuit
 
@@ -141,7 +127,10 @@ class PassManager():
         name = circuit.name
         dag = circuit_to_dag(circuit)
         del circuit
-        circuit = dag_to_circuit(self.run_passes(dag))
+        for passset in self.working_list:
+            for pass_ in passset:
+                dag = self._do_pass(pass_, dag, passset.options)
+        circuit = dag_to_circuit(dag)
         circuit.name = name
         return circuit
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -17,7 +17,7 @@ from .exceptions import TranspilerError
 
 
 class PassManager():
-    """ A PassManager schedules the passes """
+    """A PassManager schedules the passes"""
 
     def __init__(self, passes=None,
                  ignore_requires=None,
@@ -57,7 +57,7 @@ class PassManager():
             self.append(passes)
 
     def _join_options(self, passset_options):
-        """ Set the options of each passset, based on precedence rules:
+        """Set the options of each passset, based on precedence rules:
         passset options (set via ``PassManager.append()``) override
         passmanager options (set via ``PassManager.__init__()``), which override Default.
         .
@@ -131,12 +131,15 @@ class PassManager():
 
     def run(self, circuit):
         """Run all the passes on a QuantumCircuit
+
         Args:
             circuit (QuantumCircuit): circuit to transform via all the registered passes
+
         Returns:
             QuantumCircuit: Transformed circuit.
         """
         dag = circuit_to_dag(circuit)
+        del circuit
         for passset in self.working_list:
             for pass_ in passset:
                 dag = self._do_pass(pass_, dag, passset.options)
@@ -286,7 +289,7 @@ class FlowController():
 
 
 class FlowControllerLinear(FlowController):
-    """ The basic controller run the passes one after the other one. """
+    """The basic controller runs the passes one after the other."""
 
     def __init__(self, passes, options):  # pylint: disable=super-init-not-called
         self.passes = self._passes = passes
@@ -294,7 +297,7 @@ class FlowControllerLinear(FlowController):
 
 
 class DoWhileController(FlowController):
-    """Implements a set of passes in a do while loop. """
+    """Implements a set of passes in a do-while loop."""
 
     def __init__(self, passes, options, do_while=None,
                  **partial_controller):
@@ -314,7 +317,7 @@ class DoWhileController(FlowController):
 
 
 class ConditionalController(FlowController):
-    """Implements a set of passes under certain condition. """
+    """Implements a set of passes under a certain condition."""
 
     def __init__(self, passes, options, condition=None,
                  **partial_controller):

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -141,10 +141,7 @@ class PassManager():
         name = circuit.name
         dag = circuit_to_dag(circuit)
         del circuit
-        for passset in self.working_list:
-            for pass_ in passset:
-                dag = self._do_pass(pass_, dag, passset.options)
-        circuit = dag_to_circuit(dag)
+        circuit = dag_to_circuit(self.run_passes(dag))
         circuit.name = name
         return circuit
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -138,12 +138,14 @@ class PassManager():
         Returns:
             QuantumCircuit: Transformed circuit.
         """
+        name = circuit.name
         dag = circuit_to_dag(circuit)
         del circuit
         for passset in self.working_list:
             for pass_ in passset:
                 dag = self._do_pass(pass_, dag, passset.options)
         circuit = dag_to_circuit(dag)
+        circuit.name = name
         return circuit
 
     def _do_pass(self, pass_, dag, options):

--- a/qiskit/transpiler/preset_passmanagers/default.py
+++ b/qiskit/transpiler/preset_passmanagers/default.py
@@ -11,6 +11,7 @@ from qiskit.transpiler.passmanager import PassManager
 from qiskit.extensions.standard import SwapGate
 
 from qiskit.transpiler.passes.unroller import Unroller
+from qiskit.transpiler.passes.unroll_3q_or_more import Unroll3qOrMore
 from qiskit.transpiler.passes.cx_cancellation import CXCancellation
 from qiskit.transpiler.passes.decompose import Decompose
 from qiskit.transpiler.passes.optimize_1q_gates import Optimize1qGates
@@ -45,7 +46,7 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout,
 
     pass_manager.append(Unroller(basis_gates))
 
-    # Use the trivial layout if no layouto is found
+    # Use the trivial layout if no layout is found
     pass_manager.append(TrivialLayout(coupling_map),
                         condition=lambda property_set: not property_set['layout'])
 
@@ -58,6 +59,9 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout,
     # Extend the the dag/layout with ancillas using the full coupling map
     pass_manager.append(FullAncillaAllocation(coupling_map))
     pass_manager.append(EnlargeWithAncilla())
+
+    # Circuit must only contain 1- or 2-qubit interactions for swapper to work
+    pass_manager.append(Unroll3qOrMore())
 
     # Swap mapper
     pass_manager.append(LegacySwap(coupling_map, trials=20, seed=seed_transpiler))

--- a/qiskit/transpiler/preset_passmanagers/default.py
+++ b/qiskit/transpiler/preset_passmanagers/default.py
@@ -26,18 +26,16 @@ from qiskit.transpiler.passes.mapping.enlarge_with_ancilla import EnlargeWithAnc
 
 
 def default_pass_manager(basis_gates, coupling_map, initial_layout,
-                         skip_numeric_passes, seed_mapper):
+                         skip_numeric_passes, seed_transpiler):
     """
     The default pass manager that maps to the coupling map.
 
     Args:
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
-        initial_layout (Layout or None): If None, trivial layout will be chosen.
+        basis_gates (list[str]): list of basis gate names supported by the target.
+        coupling_map (CouplingMap): coupling map to target in mapping.
+        initial_layout (Layout or None): initial layout of virtual qubits on physical qubits
         skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
-        coupling_map (CouplingMap): coupling map (perhaps custom) to target
-            in mapping.
-        seed_mapper (int or None): random seed for the swap_mapper.
+        seed_transpiler (int or None): random seed for stochastic passes.
 
     Returns:
         PassManager: A pass manager to map and optimize.
@@ -62,7 +60,7 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout,
     pass_manager.append(EnlargeWithAncilla())
 
     # Swap mapper
-    pass_manager.append(LegacySwap(coupling_map, trials=20, seed=seed_mapper))
+    pass_manager.append(LegacySwap(coupling_map, trials=20, seed=seed_transpiler))
 
     # Expand swaps
     pass_manager.append(Decompose(SwapGate))
@@ -90,11 +88,10 @@ def default_pass_manager_simulator(basis_gates):
     The default pass manager without a coupling map.
 
     Args:
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
+        basis_gates (list[str]): list of basis gate names to unroll to.
 
     Returns:
-        PassManager: A passmanager without any optimization
+        PassManager: A passmanager that just unrolls, without any optimization.
     """
     pass_manager = PassManager()
     pass_manager.append(Unroller(basis_gates))

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -108,7 +108,7 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
                                                 CouplingMap(coupling_map),
                                                 initial_layout,
                                                 skip_numeric_passes,
-                                                seed_mapper=seed_mapper)
+                                                seed_transpiler=seed_mapper)
         else:
             pass_manager = default_pass_manager_simulator(basis_gates)
 

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -9,6 +9,7 @@
 """
 import warnings
 
+from qiskit.converters import dag_to_circuit, circuit_to_dag
 from qiskit.mapper import CouplingMap
 from qiskit import compiler
 from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
@@ -104,7 +105,9 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
     # run the passes specified by the pass manager
     # TODO return the property set too. See #1086
     name = dag.name
-    dag = pass_manager.run_passes(dag)
+    circuit = dag_to_circuit(dag)
+    circuit = pass_manager.run(circuit)
+    dag = circuit_to_dag(circuit)
     dag.name = name
 
     return dag

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -5,9 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Tools for compiling a batch of quantum circuits.
-
-This file is deprecated and should be removed after the 0.8 release.
+"""THIS FILE IS DEPRECATED AND WILL BE REMOVED IN RELEASE 0.9.
 """
 import warnings
 

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -5,21 +5,16 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-"""Tools for compiling a batch of quantum circuits."""
-import logging
+"""Tools for compiling a batch of quantum circuits.
+
+This file is deprecated and should be removed after the 0.8 release.
+"""
 import warnings
 
-from qiskit.circuit import QuantumCircuit
 from qiskit.mapper import CouplingMap
-from qiskit.tools.parallel import parallel_map
-from qiskit.converters import circuit_to_dag
-from qiskit.converters import dag_to_circuit
-from qiskit.mapper.layout import Layout
-from qiskit.transpiler.exceptions import TranspilerError
+from qiskit import compiler
 from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
                                                    default_pass_manager)
-
-logger = logging.getLogger(__name__)
 
 
 def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
@@ -38,28 +33,6 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
             layout is not guaranteed to be the same, as the transpiler may permute
             qubits through swaps or other means.
 
-            Multiple formats are supported:
-            a. Layout instance
-
-            b. dict
-                virtual to physical:
-                    {qr[0]: 0,
-                     qr[1]: 3,
-                     qr[2]: 5}
-
-                physical to virtual:
-                    {0: qr[0],
-                     3: qr[1],
-                     5: qr[2]}
-
-            c. list
-                virtual to physical:
-                    [0, 3, 5]  # virtual qubits are ordered (in addition to named)
-
-                physical to virtual:
-                    [qr[0], None, None, qr[1], None, qr[2]]
-
-
         seed_mapper (int): random seed for the swap_mapper
         pass_manager (PassManager): a pass_manager for the transpiler stages
 
@@ -69,90 +42,26 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
     Raises:
         TranspilerError: in case of bad inputs to transpiler or errors in passes
     """
-    return_form_is_single = False
-    if isinstance(circuits, QuantumCircuit):
-        circuits = [circuits]
-        return_form_is_single = True
-
-    # pass manager overrides explicit transpile options (basis_gates, coupling_map)
-    # explicit transpile options override options gotten from a backend
-    if not pass_manager and backend:
-        basis_gates = basis_gates or getattr(backend.configuration(), 'basis_gates', None)
-        # This needs to be removed once Aer 0.2 is out
-        coupling_map = coupling_map or getattr(backend.configuration(), 'coupling_map', None)
-
-    # Accomodate initial_layout in the form of Layout, or dict, or list
-    # TODO: (Ali) allow partial layout specifications
-    if isinstance(initial_layout, list):
-        if all(isinstance(elem, int) for elem in initial_layout):
-            # FIXME: (Ali) must allow a list of initial layouts
-            initial_layout = Layout.from_intlist(initial_layout, *circuits[0].qregs)
-        elif all(elem is None or isinstance(elem, tuple) for elem in initial_layout):
-            initial_layout = Layout.from_tuplelist(initial_layout)
-        else:
-            raise TranspilerError("bad format for initial_layout")
-    elif isinstance(initial_layout, dict):
-        initial_layout = Layout(initial_layout)
-
-    circuits = parallel_map(_transpilation, circuits,
-                            task_kwargs={'basis_gates': basis_gates,
-                                         'coupling_map': coupling_map,
-                                         'initial_layout': initial_layout,
-                                         'seed_mapper': seed_mapper,
-                                         'pass_manager': pass_manager})
-    if return_form_is_single:
-        return circuits[0]
-    return circuits
-
-
-def _transpilation(circuit, basis_gates=None, coupling_map=None,
-                   initial_layout=None, seed_mapper=None,
-                   pass_manager=None):
-    """Perform transpilation of a single circuit.
-
-    Args:
-        circuit (QuantumCircuit): A circuit to transpile.
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
-        coupling_map (CouplingMap): coupling map (perhaps custom) to target in mapping
-        initial_layout (Layout): initial layout of qubits in mapping
-        seed_mapper (int): random seed for the swap_mapper
-        pass_manager (PassManager): a pass_manager for the transpiler stage
-
-    Returns:
-        QuantumCircuit: A transpiled circuit.
-
-    Raises:
-        TranspilerError: If the Layout does not matches the circuit
-    """
-    if initial_layout is not None and set(circuit.qregs) != initial_layout.get_registers():
-        raise TranspilerError('The provided initial layout does not match the registers in '
-                              'the circuit "%s"' % circuit.name)
-
-    if pass_manager and not pass_manager.working_list:
-        return circuit
-
-    is_parametric_circuit = bool(circuit.variables)
-
-    dag = circuit_to_dag(circuit)
-    del circuit
-
-    final_dag = _transpile_dag(dag, basis_gates=basis_gates,
-                               coupling_map=coupling_map,
-                               initial_layout=initial_layout,
-                               skip_numeric_passes=is_parametric_circuit,
-                               seed_mapper=seed_mapper,
-                               pass_manager=pass_manager)
-
-    out_circuit = dag_to_circuit(final_dag)
-
-    return out_circuit
+    warnings.warn("qiskit.transpiler.transpile() has been deprecated and will be "
+                  "removed in the 0.9 release. Use qiskit.compiler.transpile() instead.",
+                  DeprecationWarning)
+    if pass_manager:
+        warnings.warn("The transpile() function will no longer accept a pass_manager "
+                      "argument after the 0.9 release. Instead, call pass_manager.run() "
+                      "on circuit(s) directly.", DeprecationWarning)
+        return pass_manager.run(circuits)
+    else:
+        return compiler.transpile(circuits=circuits, backend=backend,
+                                  basis_gates=basis_gates, coupling_map=coupling_map,
+                                  initial_layout=initial_layout, seed_transpiler=seed_mapper)
 
 
 def transpile_dag(dag, basis_gates=None, coupling_map=None,
                   initial_layout=None, skip_numeric_passes=None,
                   seed_mapper=None, pass_manager=None):
-    """Deprecated - Transform a dag circuit into another dag circuit
+    """Deprecated - Use qiskit.compiler.transpile for transpiling from
+    circuits to circuits.
+    Transform a dag circuit into another dag circuit
     (transpile), through consecutive passes on the dag.
 
     Args:
@@ -179,46 +88,9 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
     Returns:
         DAGCircuit: transformed dag
     """
-
     warnings.warn("transpile_dag has been deprecated and will be removed in the "
                   "0.9 release. Circuits can be transpiled directly to other "
                   "circuits with the transpile function.", DeprecationWarning)
-    return _transpile_dag(dag, basis_gates, coupling_map, initial_layout,
-                          skip_numeric_passes, seed_mapper, pass_manager)
-
-
-def _transpile_dag(dag, basis_gates=None, coupling_map=None,
-                   initial_layout=None, skip_numeric_passes=None,
-                   seed_mapper=None, pass_manager=None):
-    """Transform a dag circuit into another dag circuit (transpile), through
-    consecutive passes on the dag.
-
-    Args:
-        dag (DAGCircuit): dag circuit to transform via transpilation
-        basis_gates (list[str]): list of basis gate names supported by the
-            target. Default: ['u1','u2','u3','cx','id']
-        coupling_map (list): A graph of coupling::
-
-            [
-             [control0(int), target0(int)],
-             [control1(int), target1(int)],
-            ]
-
-            eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
-
-        initial_layout (Layout or None): A layout object
-        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
-        seed_mapper (int): random seed_mapper for the swap mapper
-        pass_manager (PassManager): pass manager instance for the transpilation process
-            If None, a default set of passes are run.
-            Otherwise, the passes defined in it will run.
-            If contains no passes in it, no dag transformations occur.
-
-    Returns:
-        DAGCircuit: transformed dag
-    """
-    # TODO: `basis_gates` will be removed after we have the unroller pass.
-    # TODO: `coupling_map`, `initial_layout`, `seed_mapper` removed after mapper pass.
 
     if basis_gates is None:
         basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -43,15 +43,10 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
     warnings.warn("qiskit.transpiler.transpile() has been deprecated and will be "
                   "removed in the 0.9 release. Use qiskit.compiler.transpile() instead.",
                   DeprecationWarning)
-    if pass_manager:
-        warnings.warn("The transpile() function will no longer accept a pass_manager "
-                      "argument after the 0.9 release. Instead, call pass_manager.run() "
-                      "on circuit(s) directly.", DeprecationWarning)
-        return pass_manager.run(circuits)
-    else:
-        return compiler.transpile(circuits=circuits, backend=backend,
-                                  basis_gates=basis_gates, coupling_map=coupling_map,
-                                  initial_layout=initial_layout, seed_transpiler=seed_mapper)
+    return compiler.transpile(circuits=circuits, backend=backend,
+                              basis_gates=basis_gates, coupling_map=coupling_map,
+                              initial_layout=initial_layout, seed_transpiler=seed_mapper,
+                              pass_manager=pass_manager)
 
 
 def transpile_dag(dag, basis_gates=None, coupling_map=None,
@@ -92,12 +87,6 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
 
     if basis_gates is None:
         basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']
-    if isinstance(basis_gates, str):
-        warnings.warn("The parameter basis_gates is now a list of strings. "
-                      "For example, this basis ['u1','u2','u3','cx'] should be used "
-                      "instead of 'u1,u2,u3,cx'. The string format will be "
-                      "removed after 0.9", DeprecationWarning, 2)
-        basis_gates = basis_gates.split(',')
 
     if pass_manager is None:
         # default set of passes

--- a/test/python/aer_provider_integration_test/test_aer_qobj_headers.py
+++ b/test/python/aer_provider_integration_test/test_aer_qobj_headers.py
@@ -12,8 +12,7 @@ import unittest
 
 import qiskit
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import transpile, assemble_circuits
-from qiskit.compiler import TranspileConfig, RunConfig
+from qiskit.compiler import transpile, assemble
 from qiskit.qobj import QobjHeader
 from qiskit.test import QiskitTestCase, requires_aer_provider
 
@@ -35,8 +34,8 @@ class TestBasicAerQobj(QiskitTestCase):
         custom_qobj_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
         for backend in qiskit.providers.aer.Aer.backends():
             with self.subTest(backend=backend):
-                qc1_new = transpile(self.qc1, TranspileConfig(backend=backend))
-                qobj = assemble_circuits(qc1_new, RunConfig(shots=1000))
+                qc1_new = transpile(self.qc1, backend=backend)
+                qobj = assemble(qc1_new, shots=1000)
 
                 # Update the Qobj header.
                 qobj.header = QobjHeader.from_dict(custom_qobj_header)
@@ -53,8 +52,8 @@ class TestBasicAerQobj(QiskitTestCase):
         """Test job.qobj()."""
         for backend in qiskit.providers.aer.Aer.backends():
             with self.subTest(backend=backend):
-                qc1_new = transpile(self.qc1, TranspileConfig(backend=backend))
-                qobj = assemble_circuits(qc1_new, RunConfig(shots=1000))
+                qc1_new = transpile(self.qc1, backend=backend)
+                qobj = assemble(qc1_new, shots=1000)
 
                 job = backend.run(qobj)
                 self.assertEqual(job.qobj(), qobj)

--- a/test/python/basicaer/test_basicaer_qobj_headers.py
+++ b/test/python/basicaer/test_basicaer_qobj_headers.py
@@ -9,8 +9,8 @@
 
 from qiskit import BasicAer
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import transpile, TranspileConfig
-from qiskit.compiler import assemble_circuits, RunConfig
+from qiskit.compiler import transpile
+from qiskit.compiler import assemble_circuits
 from qiskit.qobj import QobjHeader
 from qiskit.test import QiskitTestCase
 
@@ -32,8 +32,8 @@ class TestBasicAerQobj(QiskitTestCase):
 
         for backend in BasicAer.backends():
             with self.subTest(backend=backend):
-                new_circ = transpile(self.qc1, TranspileConfig(backend=backend))
-                qobj = assemble_circuits(new_circ, RunConfig(shots=1024))
+                new_circ = transpile(self.qc1, backend=backend)
+                qobj = assemble_circuits(new_circ, shots=1024)
 
                 # Update the Qobj header.
                 qobj.header = QobjHeader.from_dict(custom_qobj_header)
@@ -48,6 +48,6 @@ class TestBasicAerQobj(QiskitTestCase):
         """Test job.qobj()."""
         for backend in BasicAer.backends():
             with self.subTest(backend=backend):
-                qobj = assemble_circuits(self.qc1, TranspileConfig(backend=backend))
+                qobj = assemble_circuits(self.qc1)
                 job = backend.run(qobj)
                 self.assertEqual(job.qobj(), qobj)

--- a/test/python/basicaer/test_basicaer_qobj_headers.py
+++ b/test/python/basicaer/test_basicaer_qobj_headers.py
@@ -10,7 +10,7 @@
 from qiskit import BasicAer
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import transpile
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.qobj import QobjHeader
 from qiskit.test import QiskitTestCase
 
@@ -33,7 +33,7 @@ class TestBasicAerQobj(QiskitTestCase):
         for backend in BasicAer.backends():
             with self.subTest(backend=backend):
                 new_circ = transpile(self.qc1, backend=backend)
-                qobj = assemble_circuits(new_circ, shots=1024)
+                qobj = assemble(new_circ, shots=1024)
 
                 # Update the Qobj header.
                 qobj.header = QobjHeader.from_dict(custom_qobj_header)
@@ -48,6 +48,6 @@ class TestBasicAerQobj(QiskitTestCase):
         """Test job.qobj()."""
         for backend in BasicAer.backends():
             with self.subTest(backend=backend):
-                qobj = assemble_circuits(self.qc1)
+                qobj = assemble(self.qc1)
                 job = backend.run(qobj)
                 self.assertEqual(job.qobj(), qobj)

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -13,8 +13,8 @@ import numpy as np
 
 from qiskit import execute
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import transpile, TranspileConfig
-from qiskit.compiler import assemble_circuits, RunConfig
+from qiskit.compiler import transpile
+from qiskit.compiler import assemble_circuits
 from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.test import Path
 from qiskit.test import providers
@@ -32,8 +32,8 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         qasm_filename = self._get_resource_path('example.qasm', Path.QASMS)
         transpiled_circuit = QuantumCircuit.from_qasm_file(qasm_filename)
         transpiled_circuit.name = 'test'
-        transpiled_circuit = transpile(transpiled_circuit, TranspileConfig(backend=self.backend))
-        self.qobj = assemble_circuits(transpiled_circuit, RunConfig(shots=1000))
+        transpiled_circuit = transpile(transpiled_circuit, backend=self.backend)
+        self.qobj = assemble_circuits(transpiled_circuit, shots=1000)
 
     def test_qasm_simulator_single_shot(self):
         """Test single shot run."""
@@ -79,7 +79,7 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         circuit_if_false.measure(qr[1], cr[1])
         circuit_if_false.measure(qr[2], cr[2])
         job = execute([circuit_if_true, circuit_if_false],
-                      backend=self.backend, shots=shots, seed=self.seed)
+                      backend=self.backend, shots=shots, seed_simulator=self.seed)
 
         result = job.result()
         counts_if_true = result.get_counts(circuit_if_true)
@@ -108,7 +108,7 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         circuit.z(qr[2]).c_if(cr0, 1)
         circuit.x(qr[2]).c_if(cr1, 1)
         circuit.measure(qr[2], cr2[0])
-        job = execute(circuit, backend=self.backend, shots=shots, seed=self.seed)
+        job = execute(circuit, backend=self.backend, shots=shots, seed_simulator=self.seed)
         results = job.result()
         data = results.get_counts('teleport')
         alice = {

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from qiskit import execute
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import transpile
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import transpile, assemble
 from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.test import Path
 from qiskit.test import providers
@@ -33,7 +32,7 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         transpiled_circuit = QuantumCircuit.from_qasm_file(qasm_filename)
         transpiled_circuit.name = 'test'
         transpiled_circuit = transpile(transpiled_circuit, backend=self.backend)
-        self.qobj = assemble_circuits(transpiled_circuit, shots=1000)
+        self.qobj = assemble(transpiled_circuit, shots=1000)
 
     def test_qasm_simulator_single_shot(self):
         """Test single shot run."""

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -122,7 +122,6 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
             '1': data['1 0 0'] + data['1 1 0'] + data['1 0 1'] + data['1 1 1']
         }
         self.log.info('test_teleport: circuit:')
-        self.log.info('test_teleport: circuit:')
         self.log.info(circuit.qasm())
         self.log.info('test_teleport: data %s', data)
         self.log.info('test_teleport: alice %s', alice)

--- a/test/python/circuit/test_variable_parameters.py
+++ b/test/python/circuit/test_variable_parameters.py
@@ -13,7 +13,7 @@ from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Gate, Parameter
 from qiskit.transpiler import transpile
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.test import QiskitTestCase
 
 
@@ -35,7 +35,7 @@ class TestVariableParameters(QiskitTestCase):
         qc.rx(theta, qr)
         backend = BasicAer.get_backend('qasm_simulator')
         qc_aer = transpile(qc, backend)
-        qobj = assemble_circuits(qc_aer)
+        qobj = assemble(qc_aer)
         self.assertIn(theta, qobj.experiments[0].instructions[0].params)
 
     def test_get_variables(self):
@@ -89,7 +89,7 @@ class TestVariableParameters(QiskitTestCase):
         theta_list = numpy.linspace(0, numpy.pi, 20)
         for theta_i in theta_list:
             circs.append(qc_aer.assign_variables({theta: theta_i}))
-        qobj = assemble_circuits(circs)
+        qobj = assemble(circs)
         for index, theta_i in enumerate(theta_list):
             self.assertEqual(qobj.experiments[index].instructions[0].params[0],
                              theta_i)

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -65,7 +65,7 @@ class TestAssembler(QiskitTestCase):
         run_config = RunConfig(shots=100, memory=False, seed=6)
         qobj = assemble_circuits([circ0, circ1], run_config=run_config)
         self.assertIsInstance(qobj, QasmQobj)
-        self.assertEqual(qobj.config.seed, 6)
+        self.assertEqual(qobj.config.seed_simulator, 6)
         self.assertEqual(len(qobj.experiments), 2)
         self.assertEqual(qobj.experiments[1].config.n_qubits, 3)
         self.assertEqual(len(qobj.experiments), 2)

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -79,7 +79,7 @@ class TestCircuitAssembler(QiskitTestCase):
 
         qobj = assemble(circ)
         self.assertIsInstance(qobj, QasmQobj)
-        self.assertIsNone(getattr(qobj.config, 'shots', None))
+        self.assertEqual(qobj.config.shots, 1024)
 
     def test_assemble_initialize(self):
         """Test assembling a circuit with an initialize.

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -15,8 +15,8 @@ import qiskit.pulse as pulse
 from qiskit.circuit import Instruction
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler import RunConfig
-from qiskit.compiler import assemble_circuits
-from qiskit.compiler import assemble_schedules
+from qiskit.compiler.assembler import assemble_circuits
+from qiskit.compiler.assembler import assemble_schedules
 from qiskit.exceptions import QiskitError
 from qiskit.qobj import QasmQobj
 from qiskit.test import QiskitTestCase

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -84,7 +84,7 @@ class TestCompiler(QiskitTestCase):
 
         qr = QuantumRegister(3, 'qr')
         cr = ClassicalRegister(3, 'cr')
-        qc = QuantumCircuit(qr, cr)
+        qc = QuantumCircuit(qr, cr, name='qccccccc')
         qc.h(qr[0])
         qc.cx(qr[0], qr[1])
         qc.cx(qr[0], qr[2])

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2018, IBM.
+# Copyright 2019, IBM.
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
@@ -25,86 +25,10 @@ from qiskit.mapper import Layout
 from qiskit.circuit import Parameter
 
 
-class TestTranspileDag(QiskitTestCase):
+class TestTranspile(QiskitTestCase):
     """Test transpile function."""
 
     barrier_pass = BarrierBeforeFinalMeasurements()
-
-    @patch.object(BarrierBeforeFinalMeasurements, 'run', wraps=barrier_pass.run)
-    def test_final_measurement_barrier_for_devices(self, mock_pass):
-        """Verify BarrierBeforeFinalMeasurements pass is called in default pipeline for devices."""
-
-        circ = QuantumCircuit.from_qasm_file(self._get_resource_path('example.qasm', Path.QASMS))
-        layout = Layout.generate_trivial_layout(*circ.qregs)
-        transpile(circ, coupling_map=FakeRueschlikon().configuration().coupling_map,
-                  initial_layout=layout)
-
-        self.assertTrue(mock_pass.called)
-
-    def test_optimize_to_nothing(self):
-        """ Optimze gates up to fixed point in the default pipeline
-        See https://github.com/Qiskit/qiskit-terra/issues/2035 """
-        qr = QuantumRegister(2)
-        circ = QuantumCircuit(qr)
-        circ.h(qr[0])
-        circ.cx(qr[0], qr[1])
-        circ.x(qr[0])
-        circ.y(qr[0])
-        circ.z(qr[0])
-        circ.cx(qr[0], qr[1])
-        circ.h(qr[0])
-        circ.cx(qr[0], qr[1])
-        circ.cx(qr[0], qr[1])
-
-        after = transpile(circ, coupling_map=[[0, 1], [1, 0]])
-
-        expected = QuantumCircuit(QuantumRegister(2, 'q'))
-        self.assertEqual(after, expected)
-
-    def test_pass_manager_empty(self):
-        """Test passing an empty PassManager() to the transpiler.
-
-        It should perform no transformations on the circuit.
-        """
-        qr = QuantumRegister(2)
-        circuit = QuantumCircuit(qr)
-        circuit.h(qr[0])
-        circuit.h(qr[0])
-        circuit.cx(qr[0], qr[1])
-        circuit.cx(qr[0], qr[1])
-        circuit.cx(qr[0], qr[1])
-        circuit.cx(qr[0], qr[1])
-        resources_before = circuit.count_ops()
-
-        pass_manager = PassManager()
-        out_circuit = transpile(circuit, pass_manager=pass_manager)
-        resources_after = out_circuit.count_ops()
-
-        self.assertDictEqual(resources_before, resources_after)
-
-    def test_move_measurements(self):
-        """Measurements applied AFTER swap mapping.
-        """
-        backend = FakeRueschlikon()
-        cmap = backend.configuration().coupling_map
-        circ = QuantumCircuit.from_qasm_file(
-            self._get_resource_path('move_measurements.qasm', Path.QASMS))
-
-        lay = Layout({('qa', 0): ('q', 0), ('qa', 1): ('q', 1), ('qb', 0): ('q', 15),
-                      ('qb', 1): ('q', 2), ('qb', 2): ('q', 14), ('qN', 0): ('q', 3),
-                      ('qN', 1): ('q', 13), ('qN', 2): ('q', 4), ('qc', 0): ('q', 12),
-                      ('qNt', 0): ('q', 5), ('qNt', 1): ('q', 11), ('qt', 0): ('q', 6)})
-        out = transpile(circ, initial_layout=lay, coupling_map=cmap)
-        out_dag = circuit_to_dag(out)
-        meas_nodes = out_dag.named_nodes('measure')
-        for meas_node in meas_nodes:
-            is_last_measure = all([after_measure.type == 'out'
-                                   for after_measure in out_dag.quantum_successors(meas_node)])
-            self.assertTrue(is_last_measure)
-
-
-class TestTranspile(QiskitTestCase):
-    """Test transpile function."""
 
     def test_pass_manager_none(self):
         """Test passing the default (None) pass manager to the transpiler.
@@ -500,3 +424,75 @@ class TestTranspile(QiskitTestCase):
         expected_qc.u1(theta, qr[0])
 
         self.assertEqual(expected_qc, transpiled_qc)
+
+    @patch.object(BarrierBeforeFinalMeasurements, 'run', wraps=barrier_pass.run)
+    def test_final_measurement_barrier_for_devices(self, mock_pass):
+        """Verify BarrierBeforeFinalMeasurements pass is called in default pipeline for devices."""
+
+        circ = QuantumCircuit.from_qasm_file(self._get_resource_path('example.qasm', Path.QASMS))
+        layout = Layout.generate_trivial_layout(*circ.qregs)
+        transpile(circ, coupling_map=FakeRueschlikon().configuration().coupling_map,
+                  initial_layout=layout)
+
+        self.assertTrue(mock_pass.called)
+
+    def test_optimize_to_nothing(self):
+        """ Optimze gates up to fixed point in the default pipeline
+        See https://github.com/Qiskit/qiskit-terra/issues/2035 """
+        qr = QuantumRegister(2)
+        circ = QuantumCircuit(qr)
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.x(qr[0])
+        circ.y(qr[0])
+        circ.z(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.h(qr[0])
+        circ.cx(qr[0], qr[1])
+        circ.cx(qr[0], qr[1])
+
+        after = transpile(circ, coupling_map=[[0, 1], [1, 0]])
+
+        expected = QuantumCircuit(QuantumRegister(2, 'q'))
+        self.assertEqual(after, expected)
+
+    def test_pass_manager_empty(self):
+        """Test passing an empty PassManager() to the transpiler.
+
+        It should perform no transformations on the circuit.
+        """
+        qr = QuantumRegister(2)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[0])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[0], qr[1])
+        resources_before = circuit.count_ops()
+
+        pass_manager = PassManager()
+        out_circuit = transpile(circuit, pass_manager=pass_manager)
+        resources_after = out_circuit.count_ops()
+
+        self.assertDictEqual(resources_before, resources_after)
+
+    def test_move_measurements(self):
+        """Measurements applied AFTER swap mapping.
+        """
+        backend = FakeRueschlikon()
+        cmap = backend.configuration().coupling_map
+        circ = QuantumCircuit.from_qasm_file(
+            self._get_resource_path('move_measurements.qasm', Path.QASMS))
+
+        lay = Layout({('qa', 0): ('q', 0), ('qa', 1): ('q', 1), ('qb', 0): ('q', 15),
+                      ('qb', 1): ('q', 2), ('qb', 2): ('q', 14), ('qN', 0): ('q', 3),
+                      ('qN', 1): ('q', 13), ('qN', 2): ('q', 4), ('qc', 0): ('q', 12),
+                      ('qNt', 0): ('q', 5), ('qNt', 1): ('q', 11), ('qt', 0): ('q', 6)})
+        out = transpile(circ, initial_layout=lay, coupling_map=cmap)
+        out_dag = circuit_to_dag(out)
+        meas_nodes = out_dag.named_nodes('measure')
+        for meas_node in meas_nodes:
+            is_last_measure = all([after_measure.type == 'out'
+                                   for after_measure in out_dag.quantum_successors(meas_node)])
+            self.assertTrue(is_last_measure)

--- a/test/python/converters/test_qobj_to_circuits.py
+++ b/test/python/converters/test_qobj_to_circuits.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import BasicAer
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.converters import qobj_to_circuits
 
 from qiskit.qobj import QasmQobj, QasmQobjConfig, QobjHeader
@@ -38,7 +38,7 @@ class TestQobjToCircuits(QiskitTestCase):
 
     def test_qobj_to_circuits_single(self):
         """Check that qobj_to_circuits's result matches the qobj ini."""
-        qobj_in = assemble_circuits(self.circuit)
+        qobj_in = assemble(self.circuit)
         out_circuit = qobj_to_circuits(qobj_in)
         self.assertEqual(circuit_to_dag(out_circuit[0]), self.dag)
 
@@ -53,7 +53,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circuit_b.h(qreg2)
         circuit_b.measure(qreg1, creg1)
         circuit_b.measure(qreg2[0], creg2[1])
-        qobj = assemble_circuits([self.circuit, circuit_b])
+        qobj = assemble([self.circuit, circuit_b])
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
 
@@ -69,7 +69,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circuit_b.u2(0.2, 0.57, qreg2[1])
         circuit_b.measure(qreg1, creg1)
         circuit_b.measure(qreg2[0], creg2[1])
-        qobj = assemble_circuits(circuit_b)
+        qobj = assemble(circuit_b)
         out_circuit = qobj_to_circuits(qobj)
         self.assertEqual(circuit_to_dag(out_circuit[0]),
                          circuit_to_dag(circuit_b))
@@ -83,7 +83,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circuit.snapshot(1)
         circuit.measure(qr, cr)
         dag = circuit_to_dag(circuit)
-        qobj_in = assemble_circuits(circuit)
+        qobj_in = assemble(circuit)
         out_circuit = qobj_to_circuits(qobj_in)
         self.assertEqual(circuit_to_dag(out_circuit[0]), dag)
 
@@ -97,7 +97,7 @@ class TestQobjToCircuits(QiskitTestCase):
 
     def test_qobj_to_circuits_single_no_qasm(self):
         """Check that qobj_to_circuits's result matches the qobj ini."""
-        qobj_in = assemble_circuits(self.circuit)
+        qobj_in = assemble(self.circuit)
         out_circuit = qobj_to_circuits(qobj_in)
         self.assertEqual(circuit_to_dag(out_circuit[0]), self.dag)
 
@@ -112,7 +112,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circuit_b.h(qreg2)
         circuit_b.measure(qreg1, creg1)
         circuit_b.measure(qreg2[0], creg2[1])
-        qobj = assemble_circuits([self.circuit, circuit_b])
+        qobj = assemble([self.circuit, circuit_b])
 
         dag_list = [circuit_to_dag(x) for x in qobj_to_circuits(qobj)]
         self.assertEqual(dag_list, [self.dag, circuit_to_dag(circuit_b)])
@@ -123,7 +123,7 @@ class TestQobjToCircuits(QiskitTestCase):
         circ = QuantumCircuit(q, name='circ')
         circ.initialize([1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)], q[:])
         dag = circuit_to_dag(circ)
-        qobj = assemble_circuits(circ)
+        qobj = assemble(circ)
         out_circuit = qobj_to_circuits(qobj)[0]
         self.assertEqual(circuit_to_dag(out_circuit), dag)
 

--- a/test/python/notebooks/test_pbar_status.ipynb
+++ b/test/python/notebooks/test_pbar_status.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "from qiskit import BasicAer, execute\n",
     "from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit\n",
-    "from qiskit.compiler import transpile, TranspileConfig\n",
+    "from qiskit.compiler import transpile\n",
     "from qiskit.tools.parallel import parallel_map\n",
     "from qiskit.tools.monitor import job_monitor\n",
     "from qiskit.tools.events import TextProgressBar\n",
@@ -157,7 +157,7 @@
     "qc.measure(q, c)\n",
     "\n",
     "HTMLProgressBar()\n",
-    "qobj = transpile([qc]*20, TranspileConfig(backend=sim_backend))"
+    "qobj = transpile([qc]*20, backend=sim_backend)"
    ]
   },
   {

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -13,9 +13,8 @@ import uuid
 
 import jsonschema
 
-from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.compiler import assemble_circuits, RunConfig
+from qiskit.compiler import assemble_circuits
 from qiskit.providers.basicaer import basicaerjob
 
 from qiskit.qobj import (QasmQobj, PulseQobj, QobjHeader,
@@ -120,8 +119,7 @@ class TestQASMQobj(QiskitTestCase):
         qc1.measure(qr, cr)
         qc2.measure(qr, cr)
         circuits = [qc1, qc2]
-        backend = BasicAer.get_backend('qasm_simulator')
-        qobj1 = assemble_circuits(circuits, RunConfig(backend=backend, shots=1024, seed=88))
+        qobj1 = assemble_circuits(circuits, shots=1024, seed=88)
         qobj1.experiments[0].config.shots = 50
         qobj1.experiments[1].config.shots = 1
         self.assertTrue(qobj1.experiments[0].config.shots == 50)

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -14,7 +14,7 @@ import uuid
 import jsonschema
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.providers.basicaer import basicaerjob
 
 from qiskit.qobj import (QasmQobj, PulseQobj, QobjHeader,
@@ -119,7 +119,7 @@ class TestQASMQobj(QiskitTestCase):
         qc1.measure(qr, cr)
         qc2.measure(qr, cr)
         circuits = [qc1, qc2]
-        qobj1 = assemble_circuits(circuits, shots=1024, seed=88)
+        qobj1 = assemble(circuits, shots=1024, seed=88)
         qobj1.experiments[0].config.shots = 50
         qobj1.experiments[1].config.shots = 1
         self.assertTrue(qobj1.experiments[0].config.shots == 50)

--- a/test/python/qobj/test_qobj_identifiers.py
+++ b/test/python/qobj/test_qobj_identifiers.py
@@ -12,7 +12,7 @@
 import unittest
 
 from qiskit.circuit import ClassicalRegister, QuantumCircuit, QuantumRegister
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.test import QiskitTestCase
 
 
@@ -30,19 +30,19 @@ class TestQobjIdentifiers(QiskitTestCase):
         self.circuits = [qc]
 
     def test_builtin_qasm_simulator_py(self):
-        qobj = assemble_circuits(self.circuits)
+        qobj = assemble(self.circuits)
         exp = qobj.experiments[0]
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))
 
     def test_builtin_qasm_simulator(self):
-        qobj = assemble_circuits(self.circuits)
+        qobj = assemble(self.circuits)
         exp = qobj.experiments[0]
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))
 
     def test_builtin_unitary_simulator_py(self):
-        qobj = assemble_circuits(self.circuits)
+        qobj = assemble(self.circuits)
         exp = qobj.experiments[0]
         self.assertIn(self.qr_name, map(lambda x: x[0], exp.header.qubit_labels))
         self.assertIn(self.cr_name, map(lambda x: x[0], exp.header.clbit_labels))

--- a/test/python/quantum_info/test_unitary.py
+++ b/test/python/quantum_info/test_unitary.py
@@ -202,7 +202,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         uni = Unitary(matrix)
         qc.append(uni, [qr[0], qr[1], qr[3]])
         qc.cx(qr[3], qr[2])
-        qobj = qiskit.compiler.assemble_circuits(qc)
+        qobj = qiskit.compiler.assemble(qc)
         instr = qobj.experiments[0].instructions[1]
         self.assertEqual(instr.name, 'unitary')
         self.assertTrue(numpy.allclose(
@@ -222,7 +222,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         matrix = numpy.kron(sigmax, sigmay)
         uni = Unitary(matrix, label='xy')
         qc.append(uni, [qr[0], qr[1]])
-        qobj = qiskit.compiler.assemble_circuits(qc)
+        qobj = qiskit.compiler.assemble(qc)
         instr = qobj.experiments[0].instructions[0]
         self.assertEqual(instr.name, 'unitary')
         self.assertEqual(instr.label, 'xy')

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -16,11 +16,10 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import compile, BasicAer
 from qiskit.extensions.standard import CnotGate
 from qiskit.transpiler import PassManager, transpile
-from qiskit.compiler import assemble_circuits
+from qiskit.compiler import assemble
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase, Path
 from qiskit.test.mock import FakeMelbourne, FakeRueschlikon
-from qiskit.compiler import RunConfig
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
 from qiskit.mapper import Layout
 from qiskit.circuit import Parameter
@@ -131,8 +130,7 @@ class TestTranspile(QiskitTestCase):
                              pass_manager=None)
 
         qobj = compile(circuit, backend=backend, coupling_map=coupling_map, basis_gates=basis_gates)
-        run_config = RunConfig(shots=1024, max_credits=10)
-        qobj2 = assemble_circuits(circuit2, qobj_id=qobj.qobj_id, run_config=run_config)
+        qobj2 = assemble(circuit2, qobj_id=qobj.qobj_id, shots=1024, max_credits=10)
         self.assertEqual(qobj, qobj2)
 
     def test_transpile_basis_gates_no_backend_no_coupling_map(self):

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -126,8 +126,8 @@ class TestTranspile(QiskitTestCase):
         basis_gates = ['u1', 'u2', 'u3', 'cx', 'id']
 
         backend = BasicAer.get_backend('qasm_simulator')
-        circuit2 = transpile(circuit, backend, coupling_map=coupling_map, basis_gates=basis_gates,
-                             pass_manager=None)
+        circuit2 = transpile(circuit, backend=backend, coupling_map=coupling_map,
+                             basis_gates=basis_gates, pass_manager=None)
 
         qobj = compile(circuit, backend=backend, coupling_map=coupling_map, basis_gates=basis_gates)
         qobj2 = assemble(circuit2, qobj_id=qobj.qobj_id, shots=1024, max_credits=10)

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -42,25 +42,6 @@ class TestTranspileDag(QiskitTestCase):
 
         self.assertTrue(mock_pass.called)
 
-    def test_wrong_initial_layout(self):
-        """Test transpile with a bad initial layout.
-        """
-        backend = BasicAer.get_backend('qasm_simulator')
-
-        qubit_reg = QuantumRegister(2, name='q')
-        clbit_reg = ClassicalRegister(2, name='c')
-        qc = QuantumCircuit(qubit_reg, clbit_reg, name="bell")
-        qc.h(qubit_reg[0])
-        qc.cx(qubit_reg[0], qubit_reg[1])
-        qc.measure(qubit_reg, clbit_reg)
-
-        bad_initial_layout = [(QuantumRegister(3, 'q'), 0),
-                              (QuantumRegister(3, 'q'), 1),
-                              (QuantumRegister(3, 'q'), 2)]
-
-        self.assertRaises(TranspilerError, transpile,
-                          qc, backend, initial_layout=bad_initial_layout)
-
     def test_optimize_to_nothing(self):
         """ Optimze gates up to fixed point in the default pipeline
         See https://github.com/Qiskit/qiskit-terra/issues/2035 """

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import compile, BasicAer
 from qiskit.extensions.standard import CnotGate
-from qiskit.transpiler import PassManager, transpile, TranspilerError
+from qiskit.transpiler import PassManager, transpile
 from qiskit.compiler import assemble_circuits
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase, Path

--- a/test/python/transpiler/test_transpile.py
+++ b/test/python/transpiler/test_transpile.py
@@ -456,7 +456,7 @@ class TestTranspile(QiskitTestCase):
     def test_wrong_initial_layout(self):
         """Test transpile with a bad initial layout.
         """
-        backend = BasicAer.get_backend('qasm_simulator')
+        backend = FakeMelbourne()
 
         qubit_reg = QuantumRegister(2, name='q')
         clbit_reg = ClassicalRegister(2, name='c')
@@ -469,7 +469,7 @@ class TestTranspile(QiskitTestCase):
                               (QuantumRegister(3, 'q'), 1),
                               (QuantumRegister(3, 'q'), 2)]
 
-        self.assertRaises(TranspilerError, transpile,
+        self.assertRaises(KeyError, transpile,
                           qc, backend, initial_layout=bad_initial_layout)
 
     def test_parameterized_circuit_for_simulator(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
### Summary
This is a refactoring of `qiskit.compiler` to define the user interfaces and the internal method interfaces.

There are 3 main user-facing functions: `transpile()`, `assemble()`, and `execute()`.
All 3 can handle both circuits and pulse schedules. All have an expansive set of arguments, which are overloaded heavily in certain cases for convenience (e.g. an initial_layout can be passed as a dict, or list, or Layout object).

A parsing stage separates this from the internal methods and data-structures.

Internally we have well-defined methods (e.g. `transpile_circuit()` takes a `QuantumCircuit` and a `TranspileConfig`. The TranspileConfig has a model defined whereby it only allows initial_layout to be of type Layout, etc. etc.)

### Details
- Deprecates and moves the ``transpile()`` function from the ``qiskit.transpiler`` namespace to the ``qiskit.compiler`` namespace, which is where all transpilation, scheduling and assembling functions will reside.

- `transpile()` (and therefore `execute()`) functions now accept a list for all kwargs, similar to how they accept a list of circuits. This is so each circuit's transpilation can be configured independently, yet all run together. (Fixes #1945, Fixes #2178, Fixes #2190. Closes #1953 by making it moot.)

- Internally, Qiskit parses and creates a TranspileConfig from these, and then selects an appropriate PassManager based on that TranspileConfig (Closes #1953 by making it moot).

- Extensive documentation for the `transpile()` , `assemble` and `execute()` functions.

- Several modes of input are now supported to the `assemble_circuits()` function, including via individual kwargs (e.g. shots), or from a RunConfig. Refer to documentation for more details.

- `execute()` is now a thin wrapper (3 lines) around `transpile()`, `assemble()`, `backend.run()`

- `seed_mapper` is deprecated --> use `seed_transpiler`
- `seed` is deprecated --> use `seed_simulator`

### Follow-ups
I have made TODO comments for these:
- The TranspileConfig and RunConfig models have to be formalized based on Marshmallow. I did this in but I reverted it due to a few bugs.

- The `optimization_level` field of transpile_config has to be tied to choosing a pass manager. I'll do this next.

- The `transpile_circuit` function is a bit awkward now as it accepts a tuple of `(circuit, transpile_config)`. This was so that it could be parallelized. In general we should make the `parallel_map` function be able to handle multi-variable parallelizations (essentially like a zip).