### PR TITLE
Handle symbolic parameters in mpl circuit drawer

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -787,9 +787,15 @@ class MatplotlibDrawer:
     def param_parse(v, pimode=False):
         for i, e in enumerate(v):
             if pimode:
-                v[i] = MatplotlibDrawer.format_pi(e)
+                try:
+                    v[i] = MatplotlibDrawer.format_pi(e)
+                except TypeError:
+                    v[i] = str(e)
             else:
-                v[i] = MatplotlibDrawer.format_numeric(e)
+                try:
+                    v[i] = MatplotlibDrawer.format_numeric(e)
+                except TypeError:
+                    v[i] = str(e)
             if v[i].startswith('-'):
                 v[i] = '$-$' + v[i][1:]
         param = ', '.join(v)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds support for sympy symbols as parameters to gates. These
are encountered in parametric circuits. Previously the mpl drawer
assumed all gate parameters would be numeric and thus try to format
(and/or convert) them the same way. However, if it is a sympy symbol
that can't be resolved to a numeric value then we have to just use the
symbol name instead of a numeric value.

### Details and comments

Fixes #2144
