### PR TITLE
Deprecate DAGCircuit multi_graph access

### DIFF
--- a/qiskit/transpiler/passes/commutation_analysis.py
+++ b/qiskit/transpiler/passes/commutation_analysis.py
@@ -50,7 +50,7 @@ class CommutationAnalysis(AnalysisPass):
 
         # Add edges to the dictionary for each qubit
         for node in dag.topological_op_nodes():
-            for (_, _, edge_data) in dag.multi_graph.edges(node, data=True):
+            for (_, _, edge_data) in dag.edges(node):
 
                 edge_name = edge_data['name']
                 self.property_set['commutation_set'][(node, edge_name)] = -1

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -12,7 +12,6 @@ Visualization function for DAG circuit representation.
 """
 
 import sys
-import copy
 from .exceptions import VisualizationError
 
 
@@ -48,7 +47,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
         raise ImportError("dag_drawer requires nxpd, pydot, and Graphviz. "
                           "Run 'pip install nxpd pydot', and install graphviz")
 
-    G = copy.deepcopy(dag.multi_graph)  # don't modify the original graph attributes
+    G = dag.to_networkx()
     G.graph['dpi'] = 100 * scale
 
     if style == 'plain':

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -109,8 +109,8 @@ class TestDagOperations(QiskitTestCase):
         self.dag.apply_operation_back(XGate(), [self.qubit1], [], condition=self.condition)
         self.dag.apply_operation_back(Measure(), [self.qubit0, self.clbit0], [], condition=None)
         self.dag.apply_operation_back(Measure(), [self.qubit1, self.clbit1], [], condition=None)
-        self.assertEqual(len(self.dag.multi_graph.nodes), 16)
-        self.assertEqual(len(self.dag.multi_graph.edges), 17)
+        self.assertEqual(len(list(self.dag.nodes())), 16)
+        self.assertEqual(len(list(self.dag.edges())), 17)
 
     def test_apply_operation_front(self):
         """The apply_operation_front() method"""
@@ -364,7 +364,7 @@ class TestDagLayers(QiskitTestCase):
 
         name_layers = [
             [node.op.name
-             for node in layer["graph"].multi_graph.nodes()
+             for node in layer["graph"].nodes()
              if node.type == "op"] for layer in layers]
 
         self.assertEqual([


### PR DESCRIPTION
Deprecates direct access to `dagcircuit.multi_graph` in favor of the DAGCircuit API.