### PR TITLE
reduce circuit's tracked variable parameters upon assignment.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -709,6 +709,9 @@ class QuantumCircuit:
         new_circuit = self.copy()
         for variable in value_dict:
             new_circuit.variable_table[variable] = value_dict
+        # clear evaluated expressions
+        for variable in value_dict:
+            del new_circuit.variable_table[variable]
         return new_circuit
 
     @property

--- a/qiskit/circuit/variabletable.py
+++ b/qiskit/circuit/variabletable.py
@@ -42,7 +42,8 @@ class VariableTable(MutableMapping):
             for (instr, param_index) in self._table[key]:
                 params = instr.params
                 if isinstance(value, dict):
-                    params[param_index] = params[param_index].evalf(subs=value)
+                    for param, this_value in value.items():
+                        params[param_index] = params[param_index].subs(param, this_value)
                 else:
                     params[param_index] = value
                 instr.params = params

--- a/test/python/circuit/test_variable_parameters.py
+++ b/test/python/circuit/test_variable_parameters.py
@@ -153,6 +153,24 @@ class TestVariableParameters(QiskitTestCase):
             self.assertEqual(circs[index].data[1][0].params[0], ones + tens)
             self.assertEqual(circs[index].data[2][0].params[0], -ones)
 
+    def test_parameter_reduction(self):
+        """Test circuit parameter reduction upon assignment with partial
+        numeric substitution."""
+        x = sympy.Symbol('x')
+        y = sympy.Symbol('y')
+        z = sympy.Symbol('z')
+        qr1 = QuantumRegister(1, name='qr1')
+        qc1 = QuantumCircuit(qr1)
+        qc1.rx(x, qr1)
+        qc1.ry(y, qr1)
+        qc1.rz(x + z, qr1)
+
+        qc2 = qc1.assign_variables({x: 5, y: 10})
+        self.assertEqual(qc2.variables, {z})
+        self.assertEqual(qc2.data[0][0].params[0], 5)
+        self.assertEqual(qc2.data[1][0].params[0], 10)
+        self.assertEqual(qc2.data[2][0].params[0], z + 5)
+
     def test_parameter_expression_through_composite_instructions(self):
         """Test evaluation of parameters through instruction."""
         x = sympy.Symbol('x')


### PR DESCRIPTION
Previously when assigning a variable to a circuit using the `assign_variables` method the full variable table was preserved in the new circuit. In this PR the generated circuit no longer tracks the substituted expressions.

This PR also corrects a bug where partial expression substitution resulted in no substitution.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


