### PR TITLE
Update import path for MutableMapping in variabletable

### DIFF
--- a/qiskit/circuit/variabletable.py
+++ b/qiskit/circuit/variabletable.py
@@ -7,7 +7,7 @@
 """
 Look-up table for varaible parameters in QuantumCircuit.
 """
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 from .instruction import Instruction
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the import path for the MutableMapping. We currently
import from collections in stdlib. However that import is deprecated and
will be removed in 3.8, this raises a warning on python 3.7. To address
this and prevent breakage when python 3.8 is released, this commit
updates the path to collections.abc which is the supported path.

### Details and comments