### PR TITLE
Add Job names to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,11 +87,13 @@ jobs:
     ###########################################################################
     # Linter and style check (GNU/Linux, Python 3.5)
     - stage: lint and pure python test
+      name: Python Style and Linter
       <<: *stage_linux
       script: make style && make lint
 
     # Run the tests against without compilation (GNU/Linux, Python 3.5)
     - stage: lint and pure python test
+      name: Python 3.5 Tests Linux
       <<: *stage_linux
 
     # "test" stage
@@ -99,11 +101,13 @@ jobs:
 
     # GNU/Linux, Python 3.6
     - stage: test
+      name: Python 3.6 Tests Linux
       <<: *stage_linux
       python: 3.6
 
     # GNU/Linux, Python 3.7
     - stage: test
+      name: Python 3.7 Tests Linux
       <<: *stage_linux
       # Compiling Python 3.7 requires an Ubuntu Xenial distribution
       # and sudo set to true
@@ -116,12 +120,14 @@ jobs:
     # OSX, Python 3.5.6 (via pyenv)
     - stage: test
       <<: *stage_osx
+      name: Python 3.5 Tests OSX
       env:
         - MPLBACKEND=ps
         - PYTHON_VERSION=3.5.6
 
     # OSX, Python 3.6.5 (via pyenv)
     - stage: test
+      name: Python 3.6 Tests OSX
       <<: *stage_osx
       env:
         - MPLBACKEND=ps
@@ -129,6 +135,7 @@ jobs:
 
     # OSX, Python 3.7.2 (via pyenv)
     - stage: test
+      name: Python 3.7 Tests OSX
       <<: *stage_osx
       env:
         - MPLBACKEND=ps


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now the jobs listed in travis don't have explicit names. You can
pretty easily figure out which jobs do what based on the OS icon and the
environment variables set for each job. But to make it a bit easier just
name each job with a descriptive human readable name so we're explicit
about which each job is doing.

### Details and comments
