### PR TITLE
Operator and QuantumChannel classes can simulate circuits

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -8,6 +8,8 @@
 """
 Unitary gate.
 """
+
+from qiskit.exceptions import QiskitError
 from .instruction import Instruction
 
 
@@ -22,3 +24,13 @@ class Gate(Instruction):
         params = list of parameters
         """
         super().__init__(name, num_qubits, 0, params)
+
+    def to_matrix(self):
+        """Return a Numpy.array for the gate unitary matrix.
+
+        Additional Information
+        ----------------------
+        If a Gate subclass does not implement this method an exception
+        will be raised when this base class method is called.
+        """
+        raise QiskitError("to_matrix not defined for this {}".format(type(self)))

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+# pylint: disable=cyclic-import
 """Quantum circuit object."""
 
 from copy import deepcopy

--- a/qiskit/extensions/standard/ccx.py
+++ b/qiskit/extensions/standard/ccx.py
@@ -8,6 +8,9 @@
 """
 Toffoli gate. Controlled-Controlled-X.
 """
+
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -61,6 +64,17 @@ class ToffoliGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return ToffoliGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Toffoli gate."""
+        return numpy.array([[1, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 1],
+                            [0, 0, 0, 0, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 1, 0],
+                            [0, 0, 0, 1, 0, 0, 0, 0]], dtype=complex)
 
 
 @_to_bits(3)

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -10,6 +10,9 @@
 """
 controlled-NOT gate.
 """
+
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -41,6 +44,13 @@ class CnotGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return CnotGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Cx gate."""
+        return numpy.array([[1, 0, 0, 0],
+                            [0, 0, 0, 1],
+                            [0, 0, 1, 0],
+                            [0, 1, 0, 0]], dtype=complex)
 
 
 @_to_bits(2)

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -10,6 +10,9 @@
 """
 controlled-Phase gate.
 """
+
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -44,6 +47,13 @@ class CzGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return CzGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Cz gate."""
+        return numpy.array([[1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, -1]], dtype=complex)
 
 
 @_to_bits(2)

--- a/qiskit/extensions/standard/h.py
+++ b/qiskit/extensions/standard/h.py
@@ -10,6 +10,8 @@
 """
 Hadamard gate.
 """
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -42,6 +44,11 @@ class HGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return HGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the H gate."""
+        return numpy.array([[1, 1],
+                            [1, -1]], dtype=complex) / numpy.sqrt(2)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -10,6 +10,7 @@
 """
 Identity gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -38,6 +39,11 @@ class IdGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return IdGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Id gate."""
+        return numpy.array([[1, 0],
+                            [0, 1]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/s.py
+++ b/qiskit/extensions/standard/s.py
@@ -10,6 +10,7 @@
 """
 S=diag(1,i) Clifford phase gate or its inverse.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -43,6 +44,11 @@ class SGate(Gate):
         """Invert this gate."""
         return SdgGate()
 
+    def to_matrix(self):
+        """Return a Numpy.array for the S gate."""
+        return numpy.array([[1, 0],
+                            [0, 1j]], dtype=complex)
+
 
 class SdgGate(Gate):
     """Sdg=diag(1,-i) Clifford adjoint phase gate."""
@@ -67,6 +73,11 @@ class SdgGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return SGate()
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Sdg gate."""
+        return numpy.array([[1, 0],
+                            [0, -1j]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/swap.py
+++ b/qiskit/extensions/standard/swap.py
@@ -10,6 +10,9 @@
 """
 SWAP gate.
 """
+
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -43,6 +46,13 @@ class SwapGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return SwapGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Swap gate."""
+        return numpy.array([[1, 0, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 0, 1]], dtype=complex)
 
 
 @_to_bits(2)

--- a/qiskit/extensions/standard/t.py
+++ b/qiskit/extensions/standard/t.py
@@ -10,6 +10,7 @@
 """
 T=sqrt(S) phase gate or its inverse.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -43,6 +44,11 @@ class TGate(Gate):
         """Invert this gate."""
         return TdgGate()
 
+    def to_matrix(self):
+        """Return a Numpy.array for the S gate."""
+        return numpy.array([[1, 0],
+                            [0, (1+1j) / numpy.sqrt(2)]], dtype=complex)
+
 
 class TdgGate(Gate):
     """T Gate: -pi/4 rotation around Z axis."""
@@ -67,6 +73,11 @@ class TdgGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return TGate()
+
+    def to_matrix(self):
+        """Return a Numpy.array for the S gate."""
+        return numpy.array([[1, 0],
+                            [0, (1-1j) / numpy.sqrt(2)]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/u0.py
+++ b/qiskit/extensions/standard/u0.py
@@ -10,6 +10,7 @@
 """
 Single qubit gate cycle idle.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -38,6 +39,11 @@ class U0Gate(Gate):
     def inverse(self):
         """Invert this gate."""
         return U0Gate(self.params[0])  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Id gate."""
+        return numpy.array([[1, 0],
+                            [0, 1]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/u1.py
+++ b/qiskit/extensions/standard/u1.py
@@ -10,6 +10,7 @@
 """
 Diagonal single qubit gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -38,6 +39,11 @@ class U1Gate(Gate):
     def inverse(self):
         """Invert this gate."""
         return U1Gate(-self.params[0])
+
+    def to_matrix(self):
+        """Return a Numpy.array for the U3 gate."""
+        lam = self.params[0]
+        return numpy.array([[1, 0], [0, numpy.exp(1j * lam)]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/u2.py
+++ b/qiskit/extensions/standard/u2.py
@@ -6,10 +6,10 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 # pylint: disable=invalid-name
-
 """
 One-pulse single-qubit gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -29,9 +29,7 @@ class U2Gate(Gate):
     def _define(self):
         definition = []
         q = QuantumRegister(1, "q")
-        rule = [
-            (U3Gate(pi/2, self.params[0], self.params[1]), [q[0]], [])
-        ]
+        rule = [(U3Gate(pi / 2, self.params[0], self.params[1]), [q[0]], [])]
         for inst in rule:
             definition.append(inst)
         self.definition = definition
@@ -42,6 +40,17 @@ class U2Gate(Gate):
         u2(phi,lamb)^dagger = u2(-lamb-pi,-phi+pi)
         """
         return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
+
+    def to_matrix(self):
+        """Return a Numpy.array for the U3 gate."""
+        isqrt2 = 1 / numpy.sqrt(2)
+        phi, lam = self.params
+        return numpy.array([[isqrt2, -numpy.exp(1j * lam) * isqrt2],
+                            [
+                                numpy.exp(1j * phi) * isqrt2,
+                                numpy.exp(1j * (phi + lam)) * isqrt2
+                            ]],
+                           dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/u3.py
+++ b/qiskit/extensions/standard/u3.py
@@ -6,10 +6,10 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 # pylint: disable=invalid-name
-
 """
 Two-pulse single-qubit gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -28,9 +28,8 @@ class U3Gate(Gate):
     def _define(self):
         definition = []
         q = QuantumRegister(1, "q")
-        rule = [
-            (UBase(self.params[0], self.params[1], self.params[2]), [q[0]], [])
-        ]
+        rule = [(UBase(self.params[0], self.params[1], self.params[2]), [q[0]],
+                 [])]
         for inst in rule:
             definition.append(inst)
         self.definition = definition
@@ -41,6 +40,20 @@ class U3Gate(Gate):
         u3(theta, phi, lamb)^dagger = u3(-theta, -lam, -phi)
         """
         return U3Gate(-self.params[0], -self.params[2], -self.params[1])
+
+    def to_matrix(self):
+        """Return a Numpy.array for the U3 gate."""
+        theta, phi, lam = self.params
+        return numpy.array(
+            [[
+                numpy.cos(theta / 2),
+                -numpy.exp(1j * lam) * numpy.sin(theta / 2)
+            ],
+             [
+                 numpy.exp(1j * phi) * numpy.sin(theta / 2),
+                 numpy.exp(1j * (phi + lam)) * numpy.cos(theta / 2)
+             ]],
+            dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/ubase.py
+++ b/qiskit/extensions/standard/ubase.py
@@ -10,6 +10,7 @@
 """
 Element of SU(2).
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -28,6 +29,20 @@ class UBase(Gate):  # pylint: disable=abstract-method
         U(theta,phi,lambda)^dagger = U(-theta,-lambda,-phi)
         """
         return UBase(-self.params[0], -self.params[2], -self.params[1])
+
+    def to_matrix(self):
+        """Return a Numpy.array for the U3 gate."""
+        theta, phi, lam = self.params
+        return numpy.array(
+            [[
+                numpy.cos(theta / 2),
+                -numpy.exp(1j * lam) * numpy.sin(theta / 2)
+            ],
+             [
+                 numpy.exp(1j * phi) * numpy.sin(theta / 2),
+                 numpy.exp(1j * (phi + lam)) * numpy.cos(theta / 2)
+             ]],
+            dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -10,6 +10,9 @@
 """
 Pauli X (bit-flip) gate.
 """
+
+import numpy
+
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -44,6 +47,11 @@ class XGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return XGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the X gate."""
+        return numpy.array([[0, 1],
+                            [1, 0]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/y.py
+++ b/qiskit/extensions/standard/y.py
@@ -10,6 +10,7 @@
 """
 Pauli Y (bit-phase-flip) gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -39,6 +40,11 @@ class YGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return YGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the Y gate."""
+        return numpy.array([[0, -1j],
+                            [1j, 0]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/extensions/standard/z.py
+++ b/qiskit/extensions/standard/z.py
@@ -10,6 +10,7 @@
 """
 Pauli Z (phase-flip) gate.
 """
+import numpy
 from qiskit.circuit import CompositeGate
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -39,6 +40,11 @@ class ZGate(Gate):
     def inverse(self):
         """Invert this gate."""
         return ZGate()  # self-inverse
+
+    def to_matrix(self):
+        """Return a Numpy.array for the X gate."""
+        return numpy.array([[1, 0],
+                            [0, -1]], dtype=complex)
 
 
 @_to_bits(1)

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -130,17 +130,17 @@ class BaseOperator(ABC):
             self._output_dims = tuple(output_dims)
         return self
 
-    def input_dims(self, qubits=None):
+    def input_dims(self, qargs=None):
         """Return tuple of input dimension for specified subsystems."""
-        if qubits is None:
+        if qargs is None:
             return self._input_dims
-        return tuple(self._input_dims[i] for i in qubits)
+        return tuple(self._input_dims[i] for i in qargs)
 
-    def output_dims(self, qubits=None):
+    def output_dims(self, qargs=None):
         """Return tuple of output dimension for specified subsystems."""
-        if qubits is None:
+        if qargs is None:
             return self._output_dims
-        return tuple(self._output_dims[i] for i in qubits)
+        return tuple(self._output_dims[i] for i in qargs)
 
     def copy(self):
         """Make a copy of current operator."""
@@ -153,7 +153,7 @@ class BaseOperator(ABC):
         return self.conjugate().transpose()
 
     @abstractmethod
-    def is_unitary(self):
+    def is_unitary(self, atol=None, rtol=None):
         """Return True if operator is a unitary matrix."""
         pass
 
@@ -173,12 +173,12 @@ class BaseOperator(ABC):
         pass
 
     @abstractmethod
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (BaseOperator): an operator object.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -294,12 +294,12 @@ class BaseOperator(ABC):
         pass
 
     @abstractmethod
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the operator.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -71,8 +71,8 @@ class Chi(QuantumChannel):
             if output_dims is None:
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
-        nqubits = int(np.log2(input_dim))
-        if 2**nqubits != input_dim:
+        n_qubits = int(np.log2(input_dim))
+        if 2**n_qubits != input_dim:
             raise QiskitError("Input is not an n-qubit Chi matrix.")
         # Check and format input and output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
@@ -99,12 +99,12 @@ class Chi(QuantumChannel):
         # conjugate channel
         return Chi(Choi(self).transpose())
 
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -116,9 +116,9 @@ class Chi(QuantumChannel):
             QiskitError: if other is not a QuantumChannel subclass, or
             has incompatible dimensions.
         """
-        if qubits is not None:
-            # TODO
-            raise QiskitError("NOT IMPLEMENTED: subsystem composition.")
+        if qargs is not None:
+            return Chi(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
 
         # Convert other to Choi since we convert via Choi
         if not isinstance(other, Choi):
@@ -235,18 +235,18 @@ class Chi(QuantumChannel):
             raise QiskitError("other is not a number")
         return Chi(other * self._data, self._input_dims, self._output_dims)
 
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
         """
-        return Choi(self)._evolve(state, qubits)
+        return Choi(self)._evolve(state, qargs)
 
     def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -26,6 +26,8 @@ from numbers import Number
 
 import numpy as np
 
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.instruction import Instruction
 from qiskit.qiskiterror import QiskitError
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.operators.channel.superop import SuperOp
@@ -37,8 +39,32 @@ class Choi(QuantumChannel):
     """Choi-matrix representation of a quantum channel"""
 
     def __init__(self, data, input_dims=None, output_dims=None):
-        """Initialize a Choi quantum channel operator."""
+        """Initialize a quantum channel Choi matrix operator.
 
+        Args:
+            data (QuantumCircuit or
+                  Instruction or
+                  BaseOperator or
+                  matrix): data to initialize superoperator.
+            input_dims (tuple): the input subsystem dimensions.
+                                [Default: None]
+            output_dims (tuple): the output subsystem dimensions.
+                                 [Default: None]
+
+        Raises:
+            QiskitError: if input data cannot be initialized as a
+            Choi matrix.
+
+        Additional Information
+        ----------------------
+        If the input or output dimensions are None, they will be
+        automatically determined from the input data. If the input data is
+        a Numpy array of shape (4**N, 4**N) qubit systems will be used. If
+        the input operator is not an N-qubit operator, it will assign a
+        single subsystem with dimension specifed by the shape of the input.
+        """
+        # If the input is a raw list or matrix we assume that it is
+        # already a Choi matrix.
         if isinstance(data, (list, np.ndarray)):
             # Initialize from raw numpy or list matrix.
             choi_mat = np.array(data, dtype=complex)
@@ -61,9 +87,18 @@ class Choi(QuantumChannel):
             if input_dim * output_dim != dim_l:
                 raise QiskitError("Invalid shape for input Choi-matrix.")
         else:
-            # Initialize from Qiskit objects
-            data = self._init_transformer(data)
+            # Otherwise we initialize by conversion from another Qiskit
+            # object into the QuantumChannel.
+            if isinstance(data, (QuantumCircuit, Instruction)):
+                # If the input is a Terra QuantumCircuit or Instruction we
+                # convert it to a SuperOp
+                data = SuperOp._instruction_to_superop(data)
+            else:
+                # We use the QuantumChannel init transform to intialize
+                # other objects into a QuantumChannel or Operator object.
+                data = self._init_transformer(data)
             input_dim, output_dim = data.dim
+            # Now that the input is an operator we convert it to a Choi object
             choi_mat = _to_choi(data.rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -96,12 +96,12 @@ class Choi(QuantumChannel):
         return Choi(
             data, input_dims=self.output_dims(), output_dims=self.input_dims())
 
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -113,9 +113,10 @@ class Choi(QuantumChannel):
             QiskitError: if other cannot be converted to a channel or
             has incompatible dimensions.
         """
-        if qubits is not None:
-            # TODO
-            raise QiskitError("NOT IMPLEMENTED: subsystem composition.")
+        if qargs is not None:
+            return Choi(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
+
         # Convert to Choi matrix
         if not isinstance(other, Choi):
             other = Choi(other)
@@ -249,12 +250,12 @@ class Choi(QuantumChannel):
             raise QiskitError("other is not a number")
         return Choi(other * self._data, self._input_dims, self._output_dims)
 
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:
@@ -265,8 +266,8 @@ class Choi(QuantumChannel):
             specified QuantumState subsystem dimensions.
         """
         # If subsystem evolution we use the SuperOp representation
-        if qubits is not None:
-            return SuperOp(self)._evolve(state, qubits)
+        if qargs is not None:
+            return SuperOp(self)._evolve(state, qargs)
         # Otherwise we compute full evolution directly
         state = self._format_state(state, density_matrix=True)
         if state.shape[0] != self._input_dim:

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -126,14 +126,18 @@ class Kraus(QuantumChannel):
             # Otherwise return the tuple of both kraus sets
             return self._data
 
-    def is_cptp(self):
+    def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving."""
         if self._data[1] is not None:
             return False
+        if atol is None:
+            atol = self._atol
+        if rtol is None:
+            rtol = self._rtol
         accum = 0j
         for op in self._data[0]:
             accum += np.dot(np.transpose(np.conj(op)), op)
-        return is_identity_matrix(accum, rtol=self._rtol, atol=self._atol)
+        return is_identity_matrix(accum, rtol=rtol, atol=atol)
 
     def conjugate(self):
         """Return the conjugate of the QuantumChannel."""
@@ -153,12 +157,12 @@ class Kraus(QuantumChannel):
                      input_dims=self.output_dims(),
                      output_dims=self.input_dims())
 
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (QuantumChannel): a quantum channel subclass.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -170,9 +174,9 @@ class Kraus(QuantumChannel):
             QiskitError: if other cannot be converted to a channel, or
             has incompatible dimensions.
         """
-        if qubits is not None:
-            # TODO
-            raise QiskitError("NOT IMPLEMENTED: subsystem composition.")
+        if qargs is not None:
+            return Kraus(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
 
         if not isinstance(other, Kraus):
             other = Kraus(other)
@@ -317,12 +321,12 @@ class Kraus(QuantumChannel):
             kraus_r = [val * k for k in self._data[1]]
         return Kraus((kraus_l, kraus_r), self._input_dim, self._output_dim)
 
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:
@@ -333,8 +337,8 @@ class Kraus(QuantumChannel):
             specified QuantumState subsystem dimensions.
         """
         # If subsystem evolution we use the SuperOp representation
-        if qubits is not None:
-            return SuperOp(self)._evolve(state, qubits)
+        if qargs is not None:
+            return SuperOp(self)._evolve(state, qargs)
 
         # Otherwise we compute full evolution directly
         state = self._format_state(state)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -70,8 +70,8 @@ class PTM(QuantumChannel):
             if output_dims is None:
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
-        nqubits = int(np.log2(input_dim))
-        if 2**nqubits != input_dim:
+        n_qubits = int(np.log2(input_dim))
+        if 2**n_qubits != input_dim:
             raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
         # Check and format input and output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
@@ -98,12 +98,12 @@ class PTM(QuantumChannel):
         # conjugate channel
         return PTM(SuperOp(self).transpose())
 
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -115,9 +115,9 @@ class PTM(QuantumChannel):
             QiskitError: if other cannot be converted to a channel or
             has incompatible dimensions.
         """
-        if qubits is not None:
-            # TODO
-            raise QiskitError("NOT IMPLEMENTED: subsystem composition.")
+        if qargs is not None:
+            return PTM(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
 
         # Convert other to PTM
         if not isinstance(other, PTM):
@@ -240,18 +240,18 @@ class PTM(QuantumChannel):
             raise QiskitError("other is not a number")
         return PTM(other * self._data, self._input_dims, self._output_dims)
 
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:
             DensityMatrix: the output quantum state as a density matrix.
         """
-        return SuperOp(self)._evolve(state, qubits)
+        return SuperOp(self)._evolve(state, qargs)
 
     def _tensor_product(self, other, reverse=False):
         """Return the tensor product channel.

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -102,8 +102,12 @@ class Stinespring(QuantumChannel):
         else:
             return self._data
 
-    def is_cptp(self):
+    def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving."""
+        if atol is None:
+            atol = self._atol
+        if rtol is None:
+            rtol = self._rtol
         if self._data[1] is not None:
             return False
         check = np.dot(np.transpose(np.conj(self._data[0])), self._data[0])
@@ -134,12 +138,12 @@ class Stinespring(QuantumChannel):
             input_dims=self.output_dims(),
             output_dims=self.input_dims())
 
-    def compose(self, other, qubits=None, front=False):
+    def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.
 
         Args:
             other (QuantumChannel): a quantum channel subclass.
-            qubits (list): a list of subsystem positions to compose other on.
+            qargs (list): a list of subsystem positions to compose other on.
             front (bool): If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
@@ -151,9 +155,9 @@ class Stinespring(QuantumChannel):
             QiskitError: if other cannot be converted to a channel or
             has incompatible dimensions.
         """
-        if qubits is not None:
-            # TODO
-            raise QiskitError("NOT IMPLEMENTED: subsystem composition.")
+        if qargs is not None:
+            return Stinespring(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
 
         # Convert other to Kraus
         if not isinstance(other, Kraus):
@@ -285,12 +289,12 @@ class Stinespring(QuantumChannel):
         return Stinespring((stine_l, stine_r), self.input_dims(),
                            self.output_dims())
 
-    def _evolve(self, state, qubits=None):
+    def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the QuantumChannel.
 
         Args:
             state (QuantumState): The input statevector or density matrix.
-            qubits (list): a list of QuantumState subsystem positions to apply
+            qargs (list): a list of QuantumState subsystem positions to apply
                            the operator on.
 
         Returns:
@@ -301,8 +305,8 @@ class Stinespring(QuantumChannel):
             specified QuantumState subsystem dimensions.
         """
         # If subsystem evolution we use the SuperOp representation
-        if qubits is not None:
-            return SuperOp(self)._evolve(state, qubits)
+        if qargs is not None:
+            return SuperOp(self)._evolve(state, qargs)
 
         # Otherwise we compute full evolution directly
         state = self._format_state(state)

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -15,7 +15,6 @@ import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.instruction import Instruction
 from qiskit.qiskiterror import QiskitError
-from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -15,6 +15,7 @@ import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.instruction import Instruction
 from qiskit.qiskiterror import QiskitError
+from qiskit.extensions.exceptions import ExtensionError
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
@@ -412,6 +413,7 @@ class Operator(BaseOperator):
 
     @classmethod
     def _instruction_to_operator(cls, instruction):
+        """Convert a QuantumCircuit or Instruction to an Operator."""
         # Convert circuit to an instruction
         if isinstance(instruction, QuantumCircuit):
             instruction = instruction.to_instruction()
@@ -421,7 +423,7 @@ class Operator(BaseOperator):
         return op
 
     def _append_instruction(self, obj, qargs=None):
-        from qiskit.extensions.exceptions import ExtensionError
+        """Update the current Operator by apply an instruction."""
         if isinstance(obj, Instruction):
             mat = None
             if hasattr(obj, 'to_matrix'):

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -17,7 +17,6 @@ import numpy as np
 from scipy import sparse
 
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info.operators.operator import Operator
 
 
 def _make_np_bool(arr):
@@ -297,6 +296,8 @@ class Pauli:
 
     def to_operator(self):
         """Convert to Operator object."""
+        # Place import here to avoid cyclic import from circuit visualization
+        from qiskit.quantum_info.operators.operator import Operator
         return Operator(self.to_matrix())
 
     def update_z(self, z, indices=None):

--- a/test/python/quantum_info/operators/channel/channel_test_case.py
+++ b/test/python/quantum_info/operators/channel/channel_test_case.py
@@ -10,6 +10,7 @@
 
 import numpy as np
 
+from qiskit.quantum_info.operators.channel import SuperOp
 from ..test_operator import OperatorTestCase
 
 
@@ -46,6 +47,12 @@ class ChannelTestCase(OperatorTestCase):
     ptmY = np.diag([1, -1, 1, -1])
     ptmZ = np.diag([1, -1, -1, 1])
     ptmH = np.array([[1, 0, 0, 0], [0, 0, 0, 1], [0, 0, -1, 0], [0, 1, 0, 0]])
+
+    def simple_circuit_no_measure(self):
+        """Return a unitary circuit and the corresponding unitary array."""
+        # Override OperatorTestCase to return a SuperOp
+        circ, target = super().simple_circuit_no_measure()
+        return circ, SuperOp(target)
 
     # Depolarizing channels
     def depol_kraus(self, p):

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -38,6 +38,18 @@ class TestChi(ChannelTestCase):
         self.assertRaises(
             QiskitError, Chi, np.eye(6) / 2, input_dims=3, output_dims=2)
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = Chi(circuit)
+        target = Chi(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, Chi, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         mat = self.rand_matrix(4, 4, real=True)

--- a/test/python/quantum_info/operators/channel/test_choi.py
+++ b/test/python/quantum_info/operators/channel/test_choi.py
@@ -44,6 +44,18 @@ class TestChoi(ChannelTestCase):
         self.assertRaises(
             QiskitError, Choi, mat8, input_dims=[4], output_dims=[4])
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = Choi(circuit)
+        target = Choi(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, Choi, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         mat = self.rand_matrix(4, 4)

--- a/test/python/quantum_info/operators/channel/test_kraus.py
+++ b/test/python/quantum_info/operators/channel/test_kraus.py
@@ -52,6 +52,18 @@ class TestKraus(ChannelTestCase):
         self.assertRaises(
             QiskitError, Kraus, kraus, input_dims=4, output_dims=4)
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = Kraus(circuit)
+        target = Kraus(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, Kraus, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         kraus = [self.rand_matrix(2, 2) for _ in range(2)]

--- a/test/python/quantum_info/operators/channel/test_ptm.py
+++ b/test/python/quantum_info/operators/channel/test_ptm.py
@@ -38,6 +38,18 @@ class TestPTM(ChannelTestCase):
         self.assertRaises(
             QiskitError, PTM, np.eye(6) / 2, input_dims=3, output_dims=2)
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = PTM(circuit)
+        target = PTM(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, PTM, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         mat = self.rand_matrix(4, 4, real=True)

--- a/test/python/quantum_info/operators/channel/test_stinespring.py
+++ b/test/python/quantum_info/operators/channel/test_stinespring.py
@@ -46,6 +46,18 @@ class TestStinespring(ChannelTestCase):
         self.assertRaises(
             QiskitError, Stinespring, stine_l, input_dims=4, output_dims=4)
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = Stinespring(circuit)
+        target = Stinespring(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, Stinespring, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         stine = tuple(self.rand_matrix(4, 2) for _ in range(2))

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -38,6 +38,18 @@ class TestSuperOp(ChannelTestCase):
         self.assertRaises(
             QiskitError, SuperOp, mat, input_dims=[4], output_dims=[4])
 
+    def test_circuit_init(self):
+        """Test initialization from a circuit."""
+        circuit, target = self.simple_circuit_no_measure()
+        op = SuperOp(circuit)
+        target = SuperOp(target)
+        self.assertEqual(op, target)
+
+    def test_circuit_init_except(self):
+        """Test initialization from circuit with measure raises exception."""
+        circuit = self.simple_circuit_with_measure()
+        self.assertRaises(QiskitError, SuperOp, circuit)
+
     def test_equal(self):
         """Test __eq__ method"""
         mat = self.rand_matrix(4, 4)

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -97,17 +97,17 @@ class TestSuperOp(ChannelTestCase):
         # Evolve on qubit 0
         full_op = id2.tensor(op_a)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[0]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0]), rho_targ)
 
         # Evolve on qubit 1
         full_op = id1.tensor(op_a).tensor(id1)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[1]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[1]), rho_targ)
 
         # Evolve on qubit 2
         full_op = op_a.tensor(id2)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[2]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2]), rho_targ)
 
         # Test 2-qubit evolution
         op = op_b.tensor(op_a)
@@ -115,12 +115,12 @@ class TestSuperOp(ChannelTestCase):
         # Evolve on qubits [0, 2]
         full_op = op_b.tensor(id1).tensor(op_a)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[0, 2]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0, 2]), rho_targ)
 
         # Evolve on qubits [2, 0]
         full_op = op_a.tensor(id1).tensor(op_b)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[2, 0]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2, 0]), rho_targ)
 
         # Test 3-qubit evolution
         op = op_c.tensor(op_b).tensor(op_a)
@@ -128,12 +128,12 @@ class TestSuperOp(ChannelTestCase):
         # Evolve on qubits [0, 1, 2]
         full_op = op
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[0, 1, 2]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0, 1, 2]), rho_targ)
 
         # Evolve on qubits [2, 1, 0]
         full_op = op_a.tensor(op_b).tensor(op_c)
         rho_targ = full_op._evolve(rho)
-        self.assertAllClose(op._evolve(rho, qubits=[2, 1, 0]), rho_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2, 1, 0]), rho_targ)
 
     def test_is_cptp(self):
         """Test is_cptp method."""
@@ -250,38 +250,38 @@ class TestSuperOp(ChannelTestCase):
         op1 = SuperOp(mat_a)
         op2 = SuperOp(mat_b).tensor(SuperOp(mat_a))
         op3 = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
-        # op3 qubits=[0, 1, 2]
+        # op3 qargs=[0, 1, 2]
         full_op = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op3, qubits=[0, 1, 2]), SuperOp(targ))
-        # op3 qubits=[2, 1, 0]
+        self.assertEqual(op.compose(op3, qargs=[0, 1, 2]), SuperOp(targ))
+        # op3 qargs=[2, 1, 0]
         full_op = SuperOp(mat_a).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_c))
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op3, qubits=[2, 1, 0]), SuperOp(targ))
+        self.assertEqual(op.compose(op3, qargs=[2, 1, 0]), SuperOp(targ))
 
-        # op2 qubits=[0, 1]
+        # op2 qargs=[0, 1]
         full_op = iden.tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op2, qubits=[0, 1]), SuperOp(targ))
-        # op2 qubits=[2, 0]
+        self.assertEqual(op.compose(op2, qargs=[0, 1]), SuperOp(targ))
+        # op2 qargs=[2, 0]
         full_op = SuperOp(mat_a).tensor(iden).tensor(SuperOp(mat_b))
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op2, qubits=[2, 0]), SuperOp(targ))
+        self.assertEqual(op.compose(op2, qargs=[2, 0]), SuperOp(targ))
 
-        # op1 qubits=[0]
+        # op1 qargs=[0]
         full_op = iden.tensor(iden).tensor(SuperOp(mat_a))
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op1, qubits=[0]), SuperOp(targ))
+        self.assertEqual(op.compose(op1, qargs=[0]), SuperOp(targ))
 
-        # op1 qubits=[1]
+        # op1 qargs=[1]
         full_op = iden.tensor(SuperOp(mat_a)).tensor(iden)
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op1, qubits=[1]), SuperOp(targ))
+        self.assertEqual(op.compose(op1, qargs=[1]), SuperOp(targ))
 
-        # op1 qubits=[2]
+        # op1 qargs=[2]
         full_op = SuperOp(mat_a).tensor(iden).tensor(iden)
         targ = np.dot(full_op.data, mat)
-        self.assertEqual(op.compose(op1, qubits=[2]), SuperOp(targ))
+        self.assertEqual(op.compose(op1, qargs=[2]), SuperOp(targ))
 
     def test_compose_front_subsystem(self):
         """Test subsystem front compose method."""
@@ -296,45 +296,45 @@ class TestSuperOp(ChannelTestCase):
         op2 = SuperOp(mat_b).tensor(SuperOp(mat_a))
         op3 = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
 
-        # op3 qubits=[0, 1, 2]
+        # op3 qargs=[0, 1, 2]
         full_op = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op3, qubits=[0, 1, 2], front=True), SuperOp(targ))
-        # op3 qubits=[2, 1, 0]
+            op.compose(op3, qargs=[0, 1, 2], front=True), SuperOp(targ))
+        # op3 qargs=[2, 1, 0]
         full_op = SuperOp(mat_a).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_c))
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op3, qubits=[2, 1, 0], front=True), SuperOp(targ))
+            op.compose(op3, qargs=[2, 1, 0], front=True), SuperOp(targ))
 
-        # op2 qubits=[0, 1]
+        # op2 qargs=[0, 1]
         full_op = iden.tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op2, qubits=[0, 1], front=True), SuperOp(targ))
-        # op2 qubits=[2, 0]
+            op.compose(op2, qargs=[0, 1], front=True), SuperOp(targ))
+        # op2 qargs=[2, 0]
         full_op = SuperOp(mat_a).tensor(iden).tensor(SuperOp(mat_b))
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op2, qubits=[2, 0], front=True), SuperOp(targ))
+            op.compose(op2, qargs=[2, 0], front=True), SuperOp(targ))
 
-        # op1 qubits=[0]
+        # op1 qargs=[0]
         full_op = iden.tensor(iden).tensor(SuperOp(mat_a))
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op1, qubits=[0], front=True), SuperOp(targ))
+            op.compose(op1, qargs=[0], front=True), SuperOp(targ))
 
-        # op1 qubits=[1]
+        # op1 qargs=[1]
         full_op = iden.tensor(SuperOp(mat_a)).tensor(iden)
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op1, qubits=[1], front=True), SuperOp(targ))
+            op.compose(op1, qargs=[1], front=True), SuperOp(targ))
 
-        # op1 qubits=[2]
+        # op1 qargs=[2]
         full_op = SuperOp(mat_a).tensor(iden).tensor(iden)
         targ = np.dot(mat, full_op.data)
         self.assertEqual(
-            op.compose(op1, qubits=[2], front=True), SuperOp(targ))
+            op.compose(op1, qargs=[2], front=True), SuperOp(targ))
 
     def test_expand(self):
         """Test expand method."""

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -140,24 +140,24 @@ class TestOperator(OperatorTestCase):
         op = Operator(self.rand_matrix(2 * 3 * 4, 4 * 5),
                       input_dims=[4, 5], output_dims=[2, 3, 4])
         self.assertEqual(op.input_dims(), (4, 5))
-        self.assertEqual(op.input_dims(qubits=[0, 1]), (4, 5))
-        self.assertEqual(op.input_dims(qubits=[1, 0]), (5, 4))
-        self.assertEqual(op.input_dims(qubits=[0]), (4,))
-        self.assertEqual(op.input_dims(qubits=[1]), (5,))
+        self.assertEqual(op.input_dims(qargs=[0, 1]), (4, 5))
+        self.assertEqual(op.input_dims(qargs=[1, 0]), (5, 4))
+        self.assertEqual(op.input_dims(qargs=[0]), (4,))
+        self.assertEqual(op.input_dims(qargs=[1]), (5,))
 
     def test_output_dims(self):
         """Test Operator output_dims method."""
         op = Operator(self.rand_matrix(2 * 3 * 4, 4 * 5),
                       input_dims=[4, 5], output_dims=[2, 3, 4])
         self.assertEqual(op.output_dims(), (2, 3, 4))
-        self.assertEqual(op.output_dims(qubits=[0, 1, 2]), (2, 3, 4))
-        self.assertEqual(op.output_dims(qubits=[2, 1, 0]), (4, 3, 2))
-        self.assertEqual(op.output_dims(qubits=[2, 0, 1]), (4, 2, 3))
-        self.assertEqual(op.output_dims(qubits=[0]), (2,))
-        self.assertEqual(op.output_dims(qubits=[1]), (3,))
-        self.assertEqual(op.output_dims(qubits=[2]), (4,))
-        self.assertEqual(op.output_dims(qubits=[0, 2]), (2, 4))
-        self.assertEqual(op.output_dims(qubits=[2, 0]), (4, 2))
+        self.assertEqual(op.output_dims(qargs=[0, 1, 2]), (2, 3, 4))
+        self.assertEqual(op.output_dims(qargs=[2, 1, 0]), (4, 3, 2))
+        self.assertEqual(op.output_dims(qargs=[2, 0, 1]), (4, 2, 3))
+        self.assertEqual(op.output_dims(qargs=[0]), (2,))
+        self.assertEqual(op.output_dims(qargs=[1]), (3,))
+        self.assertEqual(op.output_dims(qargs=[2]), (4,))
+        self.assertEqual(op.output_dims(qargs=[0, 2]), (2, 4))
+        self.assertEqual(op.output_dims(qargs=[2, 0]), (4, 2))
 
     def test_reshape(self):
         """Test Operator _reshape method."""
@@ -220,23 +220,23 @@ class TestOperator(OperatorTestCase):
         # Evolve on qubit 0
         mat0 = np.kron(np.eye(4), mat)
         psi0_targ = np.dot(mat0, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[0]), psi0_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[0]), psi0_targ)
         rho0_targ = np.dot(np.dot(mat0, rho), np.conj(mat0.T))
-        self.assertAllClose(op._evolve(rho, qubits=[0]), rho0_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0]), rho0_targ)
 
         # Evolve on qubit 1
         mat1 = np.kron(np.kron(np.eye(2), mat), np.eye(2))
         psi1_targ = np.dot(mat1, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[1]), psi1_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[1]), psi1_targ)
         rho1_targ = np.dot(np.dot(mat1, rho), np.conj(mat1.T))
-        self.assertAllClose(op._evolve(rho, qubits=[1]), rho1_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[1]), rho1_targ)
 
         # Evolve on qubit 2
         mat2 = np.kron(mat, np.eye(4))
         psi2_targ = np.dot(mat2, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[2]), psi2_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[2]), psi2_targ)
         rho2_targ = np.dot(np.dot(mat2, rho), np.conj(mat2.T))
-        self.assertAllClose(op._evolve(rho, qubits=[2]), rho2_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2]), rho2_targ)
 
         # Test 2-qubit evolution
         mat_a = self.rand_matrix(2, 2)
@@ -248,16 +248,16 @@ class TestOperator(OperatorTestCase):
         # Evolve on qubits [0, 2]
         mat02 = np.kron(mat_b, np.kron(np.eye(2), mat_a))
         psi02_targ = np.dot(mat02, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[0, 2]), psi02_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[0, 2]), psi02_targ)
         rho02_targ = np.dot(np.dot(mat02, rho), np.conj(mat02.T))
-        self.assertAllClose(op._evolve(rho, qubits=[0, 2]), rho02_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0, 2]), rho02_targ)
 
         # Evolve on qubits [2, 0]
         mat20 = np.kron(mat_a, np.kron(np.eye(2), mat_b))
         psi20_targ = np.dot(mat20, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[2, 0]), psi20_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[2, 0]), psi20_targ)
         rho20_targ = np.dot(np.dot(mat20, rho), np.conj(mat20.T))
-        self.assertAllClose(op._evolve(rho, qubits=[2, 0]), rho20_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2, 0]), rho20_targ)
 
         # Test evolve on 3-qubits
         mat_a = self.rand_matrix(2, 2)
@@ -270,16 +270,16 @@ class TestOperator(OperatorTestCase):
         # Evolve on qubits [0, 1, 2]
         mat012 = np.kron(mat_c, np.kron(mat_b, mat_a))
         psi012_targ = np.dot(mat012, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[0, 1, 2]), psi012_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[0, 1, 2]), psi012_targ)
         rho012_targ = np.dot(np.dot(mat012, rho), np.conj(mat012.T))
-        self.assertAllClose(op._evolve(rho, qubits=[0, 1, 2]), rho012_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[0, 1, 2]), rho012_targ)
 
         # Evolve on qubits [2, 1, 0]
         mat210 = np.kron(mat_a, np.kron(mat_b, mat_c))
         psi210_targ = np.dot(mat210, psi)
-        self.assertAllClose(op._evolve(psi, qubits=[2, 1, 0]), psi210_targ)
+        self.assertAllClose(op._evolve(psi, qargs=[2, 1, 0]), psi210_targ)
         rho210_targ = np.dot(np.dot(mat210, rho), np.conj(mat210.T))
-        self.assertAllClose(op._evolve(rho, qubits=[2, 1, 0]), rho210_targ)
+        self.assertAllClose(op._evolve(rho, qargs=[2, 1, 0]), rho210_targ)
 
     def test_evolve_rand(self):
         """Test evolve method on random state."""
@@ -357,31 +357,31 @@ class TestOperator(OperatorTestCase):
         op2 = Operator(np.kron(mat_b, mat_a))
         op3 = Operator(np.kron(mat_c, np.kron(mat_b, mat_a)))
 
-        # op3 qubits=[0, 1, 2]
+        # op3 qargs=[0, 1, 2]
         targ = np.dot(np.kron(mat_c, np.kron(mat_b, mat_a)), mat)
-        self.assertEqual(op.compose(op3, qubits=[0, 1, 2]), Operator(targ))
-        # op3 qubits=[2, 1, 0]
+        self.assertEqual(op.compose(op3, qargs=[0, 1, 2]), Operator(targ))
+        # op3 qargs=[2, 1, 0]
         targ = np.dot(np.kron(mat_a, np.kron(mat_b, mat_c)), mat)
-        self.assertEqual(op.compose(op3, qubits=[2, 1, 0]), Operator(targ))
+        self.assertEqual(op.compose(op3, qargs=[2, 1, 0]), Operator(targ))
 
-        # op2 qubits=[0, 1]
+        # op2 qargs=[0, 1]
         targ = np.dot(np.kron(np.eye(2), np.kron(mat_b, mat_a)), mat)
-        self.assertEqual(op.compose(op2, qubits=[0, 1]), Operator(targ))
-        # op2 qubits=[2, 0]
+        self.assertEqual(op.compose(op2, qargs=[0, 1]), Operator(targ))
+        # op2 qargs=[2, 0]
         targ = np.dot(np.kron(mat_a, np.kron(np.eye(2), mat_b)), mat)
-        self.assertEqual(op.compose(op2, qubits=[2, 0]), Operator(targ))
+        self.assertEqual(op.compose(op2, qargs=[2, 0]), Operator(targ))
 
-        # op1 qubits=[0]
+        # op1 qargs=[0]
         targ = np.dot(np.kron(np.eye(4), mat_a), mat)
-        self.assertEqual(op.compose(op1, qubits=[0]), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[0]), Operator(targ))
 
-        # op1 qubits=[1]
+        # op1 qargs=[1]
         targ = np.dot(np.kron(np.eye(2), np.kron(mat_a, np.eye(2))), mat)
-        self.assertEqual(op.compose(op1, qubits=[1]), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[1]), Operator(targ))
 
-        # op1 qubits=[2]
+        # op1 qargs=[2]
         targ = np.dot(np.kron(mat_a, np.eye(4)), mat)
-        self.assertEqual(op.compose(op1, qubits=[2]), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[2]), Operator(targ))
 
     def test_compose_front_subsystem(self):
         """Test subsystem front compose method."""
@@ -395,31 +395,31 @@ class TestOperator(OperatorTestCase):
         op2 = Operator(np.kron(mat_b, mat_a))
         op3 = Operator(np.kron(mat_c, np.kron(mat_b, mat_a)))
 
-        # op3 qubits=[0, 1, 2]
+        # op3 qargs=[0, 1, 2]
         targ = np.dot(mat, np.kron(mat_c, np.kron(mat_b, mat_a)))
-        self.assertEqual(op.compose(op3, qubits=[0, 1, 2], front=True), Operator(targ))
-        # op3 qubits=[2, 1, 0]
+        self.assertEqual(op.compose(op3, qargs=[0, 1, 2], front=True), Operator(targ))
+        # op3 qargs=[2, 1, 0]
         targ = np.dot(mat, np.kron(mat_a, np.kron(mat_b, mat_c)))
-        self.assertEqual(op.compose(op3, qubits=[2, 1, 0], front=True), Operator(targ))
+        self.assertEqual(op.compose(op3, qargs=[2, 1, 0], front=True), Operator(targ))
 
-        # op2 qubits=[0, 1]
+        # op2 qargs=[0, 1]
         targ = np.dot(mat, np.kron(np.eye(2), np.kron(mat_b, mat_a)))
-        self.assertEqual(op.compose(op2, qubits=[0, 1], front=True), Operator(targ))
-        # op2 qubits=[2, 0]
+        self.assertEqual(op.compose(op2, qargs=[0, 1], front=True), Operator(targ))
+        # op2 qargs=[2, 0]
         targ = np.dot(mat, np.kron(mat_a, np.kron(np.eye(2), mat_b)))
-        self.assertEqual(op.compose(op2, qubits=[2, 0], front=True), Operator(targ))
+        self.assertEqual(op.compose(op2, qargs=[2, 0], front=True), Operator(targ))
 
-        # op1 qubits=[0]
+        # op1 qargs=[0]
         targ = np.dot(mat, np.kron(np.eye(4), mat_a))
-        self.assertEqual(op.compose(op1, qubits=[0], front=True), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[0], front=True), Operator(targ))
 
-        # op1 qubits=[1]
+        # op1 qargs=[1]
         targ = np.dot(mat, np.kron(np.eye(2), np.kron(mat_a, np.eye(2))))
-        self.assertEqual(op.compose(op1, qubits=[1], front=True), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[1], front=True), Operator(targ))
 
-        # op1 qubits=[2]
+        # op1 qargs=[2]
         targ = np.dot(mat, np.kron(mat_a, np.eye(4)))
-        self.assertEqual(op.compose(op1, qubits=[2], front=True), Operator(targ))
+        self.assertEqual(op.compose(op1, qargs=[2], front=True), Operator(targ))
 
     def test_power(self):
         """Test power method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allows `Operator` and `QuantumChannel` classes (`SuperOp` etc) to simulate quantum circuits.

### Details and comments

* adds `to_matrix` property to `Gate` base class that raises exception. Derived gate classes may implement this to define a matrix representation needed for simulation. This is done for most (but not all) of the standard gates. The ones that aren't implemented can be turned into a matrix using their `definition` list.

* Changes `qubits` kwarg of `BaseChannel` compose and evolve functions to be `qargs` to match `QuantumCircuit.append` method.

* `Operator` classes can initialize from a `QuantumCircuit` or `Instruction` object if it contains only non-conditional gate operations. The output should be equivalent to if this was executed on the unitary simulator, however it does not get compiled and the simulation is done directly from the `Instruction` objects. Circuits are treated as having a single flat register by calling the `to_instruction` method to flatten the circuit.

* `SuperOp` classes can initialize from a `QuantumCircuit` or `Instruction` object if it contains only non-conditional gates, Kraus, or reset operations. The other `QuantumChannel` subclasses can also simulate but this is done by simulating as a superoperator and then converting the output into the required representation.

* Because of how the classes work, this also means that `QuantumCircuits` can be passed to `Operator` and `QuantumChannel` objects as arguments for `expand, tensor, compose` which will convert their inputs into the current class.

### Example

```python
from qiskit import *
from qiskit.quantum_info.operators import *

qr = QuantumRegister(2)
circ = QuantumCircuit(qr)
circ.x(qr[0])
circ.cx(qr[0], qr[1])
unitary = Operator(circ)

# unitary = 
Operator([[0.+0.j 1.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 1.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 1.+0.j]
 [1.+0.j 0.+0.j 0.+0.j 0.+0.j]], input_dims=(2, 2), output_dims=(2, 2))
```

```python
from qiskit import *
from qiskit.quantum_info.operators import *

qr = QuantumRegister(1)
circ = QuantumCircuit(qr)
circ.x(qr)
circ.reset(qr)
superop = SuperOp(circ)

# superop = 
SuperOp([[1.+0.j 0.+0.j 0.+0.j 1.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j]], input_dims=(2,), output_dims=(2,))
```