### PR TITLE
Fix json schema for Qasm qobj snapshot

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -122,7 +122,7 @@ def assemble_circuits(circuits, run_config=None, qobj_header=None, qobj_id=None)
                 current_instruction.params = params
             # TODO: I really dont like this for snapshot. I also think we should change
             # type to snap_type
-            if op.name == "snapshot":
+            if op.name == 'snapshot':
                 current_instruction.label = str(op.params[0])
                 current_instruction.snapshot_type = str(op.params[1])
             if op.name == 'unitary':

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -18,22 +18,22 @@ from qiskit.extensions.exceptions import ExtensionError
 class Snapshot(Instruction):
     """Simulator snapshot instruction."""
 
-    def __init__(self, num_qubits, num_clbits, label, snap_type):
+    def __init__(self, num_qubits, num_clbits, label, snapshot_type):
         """Create new snapshot instruction."""
-        super().__init__("snapshot", num_qubits, num_clbits, [label, snap_type])
+        super().__init__('snapshot', num_qubits, num_clbits, [label, snapshot_type])
 
     def inverse(self):
         """Special case. Return self."""
         return Snapshot(self.num_qubits, self.num_clbits, self.params[0], self.params[1])
 
 
-def snapshot(self, label, snap_type='statevector'):
+def snapshot(self, label, snapshot_type='statevector'):
     """Take a snapshot of the internal simulator representation (statevector)
     Works on all qubits, and prevents reordering (like barrier).
 
     Args:
         label (str): a snapshot label to report the result
-        snap_type (str): a snapshot type (only supports statevector)
+        snapshot_type (str): a snapshot type (only supports statevector)
 
     Returns:
         QuantumCircuit: with attached command
@@ -46,9 +46,9 @@ def snapshot(self, label, snap_type='statevector'):
         for register in self.qregs:
             tuples.append(register)
     if not tuples:
-        raise ExtensionError("no qubits for snapshot")
+        raise ExtensionError('no qubits for snapshot')
     if label is None:
-        raise ExtensionError("no snapshot label passed")
+        raise ExtensionError('no snapshot label passed')
     qubits = []
     for tuple_element in tuples:
         if isinstance(tuple_element, QuantumRegister):
@@ -56,7 +56,7 @@ def snapshot(self, label, snap_type='statevector'):
                 qubits.append((tuple_element, j))
         else:
             qubits.append(tuple_element)
-    return self.append(Snapshot(len(qubits), 0, label, snap_type), qubits, [])
+    return self.append(Snapshot(len(qubits), 0, label, snapshot_type), qubits, [])
 
 
 # Add to QuantumCircuit and CompositeGate classes

--- a/qiskit/schemas/examples/qobj_openqasm_example.json
+++ b/qiskit/schemas/examples/qobj_openqasm_example.json
@@ -22,7 +22,7 @@
             {"name": "u1", "qubits": [1], "params": [0.4]},
             {"name": "u2", "qubits": [1], "params": [0.4,0.2]},
             {"name": "u3", "qubits": [1], "params": [0.4,0.2,-0.3]},
-            {"name": "snapshot", "label": "snapstate1", "type": "state"},
+            {"name": "snapshot", "label": "snapstate1", "snapshot_type": "statevector"},
             {"name": "cx", "qubits": [1,2]},
             {"name": "barrier", "qubits": [1]},
             {"name": "measure", "qubits": [1], "register": [2], "memory": [0]},
@@ -40,7 +40,7 @@
         "instructions": [
             {"name": "u1", "qubits": [1], "params": [0.4]},
             {"name": "cx", "qubits": [1,2]},
-            {"name": "snapshot", "label": "snapstate1", "type": "state"},
+            {"name": "snapshot", "label": "snapstate1", "snapshot_type": "statevector"},
             {"name": "cx", "qubits": [1,2]},
             {"name": "barrier", "qubits": [1]},
             {"name": "measure", "qubits": [1], "register": [2], "memory": [0]},

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -618,23 +618,27 @@
                             "type": "string"
                         },
                         "memory": {
-			    "type": "array",
-                            "maxItems": 0
+			                "type": "array"
                         },
                         "name": {
                             "enum": [
                                 "snapshot"
                             ]
                         },
+                        "params": {
+                            "type": "array"
+                        },
+                        "qubits": {
+                            "type": "array"
+                        },
                         "register": {
-			    "type": "array",
-                            "maxItems": 0
+			                "type": "array"
+                        },
+                        "snapshot_type": {
+                            "type": "string"
                         },
                         "texparams": {
                             "maxItems": 0
-                        },
-                        "type": {
-                            "type": "string"
                         }
                     },
                     "required": [

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -639,7 +639,7 @@
                     },
                     "required": [
                         "label",
-                        "type"
+                        "snapshot_type"
                     ],
                     "title": "snapshot"
                 },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

PR #2164 changed the qasm qobj field for snapshots from `"type"` to `"snapshot_type"`, but didn't update the JSON schema so circuits with snapshots fail validation. This PR updates the schema to correct format.


### Details and comments


