### PR TITLE
Add parameterized circuits support in RunConfig and execute

### DIFF
--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -22,3 +22,6 @@ class Parameter():
 
     def __hash__(self):
         return hash(self.name)
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__, self.name)

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -25,36 +25,19 @@ class ParameterTable(MutableMapping):
     def __getitem__(self, key):
         return self._table[key]
 
-    def __setitem__(self, parameter, value):
-        """set the value of parameter
-
-        If the parameter is not already in the table, value should be a list of
-        (Instruction, param_index) tuples. __setitem__ will record in the
-        ParameterTable that Instruction is dependent on parameter at param_index.
-
-        If the parameter is in the table, value should be either a Number, or a
-        { Parameter: value } dict. __setitem__ will update all instructions in
-        the ParameterTable with the set value of Parameter.
+    def __setitem__(self, parameter, instr_params):
+        """Sets list of Instructions that depend on Parameter.
 
         Args:
             parameter (Parameter): the parameter to set
-            value (Number or dict or list): numeric constant or dictionary of
-                (Parameter: value) pairs or list of (Instruction, int) tuples
+            instr_params (list): List of (Instruction, int) tuples. Int is the
+              parameter index at which the parameter appears in the instruction.
         """
-        if parameter not in self._table:
-            for instruction, param_index in value:
-                assert isinstance(instruction, Instruction)
-                assert isinstance(param_index, int)
-            self._table[parameter] = value
-        else:
-            for (instr, param_index) in self._table[parameter]:
-                params = instr.params
-                if isinstance(value, dict):
-                    for _, this_value in value.items():
-                        params[param_index] = this_value
-                else:
-                    params[param_index] = value
-                instr.params = params
+
+        for instruction, param_index in instr_params:
+            assert isinstance(instruction, Instruction)
+            assert isinstance(param_index, int)
+        self._table[parameter] = instr_params
 
     def __delitem__(self, key):
         del self._table[key]

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -703,10 +703,18 @@ class QuantumCircuit:
         Args:
             value_dict (dict): {parameter: value, ...}
 
+        Raises:
+            QiskitError: If value_dict contains parameters not present in the circuit
+
         Returns:
             QuantumCircuit: copy of self with assignment substitution.
         """
         new_circuit = self.copy()
+
+        if value_dict.keys() > self.parameters:
+            raise QiskitError('Cannot bind parameters ({}) not present in the circuit.'.format(
+                [str(p) for p in value_dict.keys() - self.parameters]))
+
         for parameter, value in value_dict.items():
             new_circuit._bind_parameter(parameter, value)
         # clear evaluated expressions

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -707,12 +707,17 @@ class QuantumCircuit:
             QuantumCircuit: copy of self with assignment substitution.
         """
         new_circuit = self.copy()
-        for parameter in value_dict:
-            new_circuit._parameter_table[parameter] = value_dict
+        for parameter, value in value_dict.items():
+            new_circuit._bind_parameter(parameter, value)
         # clear evaluated expressions
         for parameter in value_dict:
             del new_circuit._parameter_table[parameter]
         return new_circuit
+
+    def _bind_parameter(self, parameter, value):
+        """Assigns a parameter value to matching instructions in-place."""
+        for (instr, param_index) in self._parameter_table[parameter]:
+            instr.params[param_index] = value
 
 
 def _circuit_from_qasm(qasm):

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -9,6 +9,7 @@
 import warnings
 import uuid
 import logging
+import copy
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
@@ -257,7 +258,7 @@ def assemble(experiments,
              shots=1024, memory=False, max_credits=None, seed_simulator=None,
              default_qubit_los=None, default_meas_los=None,  # schedule run options
              schedule_los=None, meas_level=2, meas_return='avg',
-             memory_slots=None, memory_slot_size=100, rep_time=None,
+             memory_slots=None, memory_slot_size=100, rep_time=None, parameter_binds=None,
              config=None, seed=None,  # deprecated
              **run_config):
     """Assemble a list of circuits or pulse schedules into a Qobj.
@@ -328,6 +329,14 @@ def assemble(experiments,
             The delay between experiments will be rep_time.
             Must be from the list provided by the device.
 
+        parameter_binds (list[dict{Parameter: Value}]):
+            List of Parameter bindings over which the set of experiments will be
+            executed. Each list element (bind) should be of the form
+            {Parameter1: value1, Parameter2: value2, ...}. All binds will be
+            executed across all experiments, e.g. if parameter_binds is a
+            length-n list, and there are m experiments, a total of m x n
+            experiments will be run (one for each experiment/bind pair).
+
         seed (int):
             DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
 
@@ -361,11 +370,14 @@ def assemble(experiments,
                                                        default_qubit_los, default_meas_los,
                                                        schedule_los, meas_level, meas_return,
                                                        memory_slots, memory_slot_size, rep_time,
-                                                       **run_config)
+                                                       parameter_binds, **run_config)
 
     # assemble either circuits or schedules
     if all(isinstance(exp, QuantumCircuit) for exp in experiments):
-        return assemble_circuits(circuits=experiments, qobj_id=qobj_id,
+        # If circuits are parameterized, bind parameters and remove from run_config
+        bound_experiments, run_config = _expand_parameters(circuits=experiments,
+                                                           run_config=run_config)
+        return assemble_circuits(circuits=bound_experiments, qobj_id=qobj_id,
                                  qobj_header=qobj_header, run_config=run_config)
 
     elif all(isinstance(exp, Schedule) for exp in experiments):
@@ -383,7 +395,7 @@ def _parse_run_args(backend, qobj_id, qobj_header,
                     default_qubit_los, default_meas_los,
                     schedule_los, meas_level, meas_return,
                     memory_slots, memory_slot_size, rep_time,
-                    **run_config):
+                    parameter_binds, **run_config):
     """Resolve the various types of args allowed to the assemble() function through
     duck typing, overriding args, etc. Refer to the assemble() docstring for details on
     what types of inputs are allowed.
@@ -417,6 +429,8 @@ def _parse_run_args(backend, qobj_id, qobj_header,
     rep_time = rep_time or getattr(backend_config, 'rep_times', None)
     if isinstance(rep_time, list):
         rep_time = rep_time[-1]
+
+    parameter_binds = parameter_binds or []
 
     # add default empty lo config
     schedule_los = schedule_los or []
@@ -458,7 +472,60 @@ def _parse_run_args(backend, qobj_id, qobj_header,
                            memory_slots=memory_slots,
                            memory_slot_size=memory_slot_size,
                            rep_time=rep_time,
+                           parameter_binds=parameter_binds,
                            **run_config)
     run_config = RunConfig(**{k: v for k, v in run_config_dict.items() if v is not None})
 
     return qobj_id, qobj_header, run_config
+
+
+def _expand_parameters(circuits, run_config):
+    """Verifies that there is a single common set of parameters shared between
+    all circuits and all parameter binds in the run_config. Returns an expanded
+    list of circuits (if parameterized) with all parameters bound, and a copy of
+    the run_config with parameter_binds cleared.
+
+    If neither the circuits nor the run_config specify parameters, the two are
+    returned unmodified.
+
+    Raises:
+        QiskitError: if run_config parameters are not compatible with circuit parameters
+
+    Returns:
+        Tuple(List[QuantumCircuit], RunConfig):
+          - List of input circuits expanded and with parameters bound
+          - RunConfig with parameter_binds removed
+    """
+
+    parameter_binds = run_config.parameter_binds
+    if parameter_binds or \
+       any(circuit.parameters for circuit in circuits):
+
+        all_bind_parameters = [bind.keys()
+                               for bind in parameter_binds]
+        all_circuit_parameters = [circuit.parameters for circuit in circuits]
+
+        # Collect set of all unique parameters across all circuits and binds
+        unique_parameters = set(param
+                                for param_list in all_bind_parameters + all_circuit_parameters
+                                for param in param_list)
+
+        # Check that all parameters are common to all circuits and binds
+        if not all_bind_parameters \
+           or not all_circuit_parameters \
+           or any(unique_parameters != bind_params for bind_params in all_bind_parameters) \
+           or any(unique_parameters != parameters for parameters in all_circuit_parameters):
+            raise QiskitError(
+                ('Mismatch between run_config.parameter_binds and all circuit parameters. ' +
+                 'Parameter binds: {} ' +
+                 'Circuit parameters: {}').format(all_bind_parameters, all_circuit_parameters))
+
+        circuits = [circuit.bind_parameters(binds)
+                    for circuit in circuits
+                    for binds in parameter_binds]
+
+        # All parameters have been expanded and bound, so remove from run_config
+        run_config = copy.deepcopy(run_config)
+        run_config.parameter_binds = []
+
+    return circuits, run_config

--- a/qiskit/compiler/run_config.py
+++ b/qiskit/compiler/run_config.py
@@ -23,4 +23,5 @@ class RunConfig(BaseModel):
         max_credits (int): the max_credits to use on the IBMQ public devices.
         seed_simulator (int): the seed to use in the simulator
         memory (bool): whether to request memory from backend (per-shot readouts)
+        parameter_binds (list[dict]): List of parameter bindings
     """

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -27,7 +27,7 @@ def execute(experiments, backend,
             memory=False, max_credits=10, seed_simulator=None,
             default_qubit_los=None, default_meas_los=None,  # schedule run options
             schedule_los=None, meas_level=2, meas_return='avg',
-            memory_slots=None, memory_slot_size=100, rep_time=None,
+            memory_slots=None, memory_slot_size=100, rep_time=None, parameter_binds=None,
             seed=None, seed_mapper=None,  # deprecated
             config=None, circuits=None,
             **run_config):
@@ -163,6 +163,14 @@ def execute(experiments, backend,
             The delay between experiments will be rep_time.
             Must be from the list provided by the device.
 
+        parameter_binds (list[dict{Parameter: Value}]):
+            List of Parameter bindings over which the set of experiments will be
+            executed. Each list element (bind) should be of the form
+            {Parameter1: value1, Parameter2: value2, ...}. All binds will be
+            executed across all experiments, e.g. if parameter_binds is a
+            length-n list, and there are m experiments, a total of m x n
+            experiments will be run (one for each experiment/bind pair).
+
         seed (int):
             DEPRECATED in 0.8: use ``seed_simulator`` kwarg instead
 
@@ -222,6 +230,7 @@ def execute(experiments, backend,
                     memory_slots=memory_slots,
                     memory_slot_size=memory_slot_size,
                     rep_time=rep_time,
+                    parameter_binds=parameter_binds,
                     backend=backend,
                     config=config,  # deprecated
                     seed=seed,  # deprecated

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -58,12 +58,12 @@ class TestParameters(QiskitTestCase):
         qc = QuantumCircuit(qr)
         qc.rx(theta, qr)
         qc.u3(0, theta, 0, qr)
-        qc._parameter_table[theta] = 0.5
-        self.assertEqual(qc._parameter_table[theta][0][0].params[0], 0.5)
-        self.assertEqual(qc._parameter_table[theta][1][0].params[1], 0.5)
-        qc._parameter_table[theta] = 0.6
-        self.assertEqual(qc._parameter_table[theta][0][0].params[0], 0.6)
-        self.assertEqual(qc._parameter_table[theta][1][0].params[1], 0.6)
+        bqc = qc.bind_parameters({theta: 0.5})
+        self.assertEqual(bqc.data[0][0].params[0], 0.5)
+        self.assertEqual(bqc.data[1][0].params[1], 0.5)
+        bqc = qc.bind_parameters({theta: 0.6})
+        self.assertEqual(bqc.data[0][0].params[0], 0.6)
+        self.assertEqual(bqc.data[1][0].params[1], 0.6)
 
     def test_multiple_parameters(self):
         """Test setting multiple parameters"""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -15,6 +15,7 @@ from qiskit.circuit import Gate, Parameter
 from qiskit.transpiler import transpile
 from qiskit.compiler import assemble
 from qiskit.test import QiskitTestCase
+from qiskit.exceptions import QiskitError
 
 
 class TestParameters(QiskitTestCase):
@@ -74,6 +75,19 @@ class TestParameters(QiskitTestCase):
         qc.rx(theta, qr)
         qc.u3(0, theta, x, qr)
         self.assertEqual(qc.parameters, {theta, x})
+
+    def test_raise_if_assigning_params_not_in_circuit(self):
+        """Verify binding parameters which are not present in the circuit raises an error."""
+        x = Parameter('x')
+        y = Parameter('y')
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+
+        qc.u1(0.1, qr[0])
+        self.assertRaises(QiskitError, qc.bind_parameters, {x: 1})
+
+        qc.u1(x, qr[0])
+        self.assertRaises(QiskitError, qc.bind_parameters, {x: 1, y: 2})
 
     def test_circuit_generation(self):
         """Test creating a series of circuits parametrically"""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -76,6 +76,22 @@ class TestParameters(QiskitTestCase):
         qc.u3(0, theta, x, qr)
         self.assertEqual(qc.parameters, {theta, x})
 
+    def test_partial_binding(self):
+        """Test that binding a subset of circuit parameters returns a new parameterized circuit."""
+        theta = Parameter('θ')
+        x = Parameter('x')
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+        qc.rx(theta, qr)
+        qc.u3(0, theta, x, qr)
+
+        pqc = qc.bind_parameters({theta: 2})
+
+        self.assertEqual(pqc.parameters, {x})
+
+        self.assertEqual(pqc.data[0][0].params[0], 2)
+        self.assertEqual(pqc.data[1][0].params[1], 2)
+
     def test_raise_if_assigning_params_not_in_circuit(self):
         """Verify binding parameters which are not present in the circuit raises an error."""
         x = Parameter('x')

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -36,8 +36,7 @@ class TestParameters(QiskitTestCase):
         qc.rx(theta, qr)
         backend = BasicAer.get_backend('qasm_simulator')
         qc_aer = transpile(qc, backend)
-        qobj = assemble(qc_aer)
-        self.assertIn(theta, qobj.experiments[0].instructions[0].params)
+        self.assertIn(theta, qc_aer.parameters)
 
     def test_get_parameters(self):
         """Test instantiating gate with variable parmeters"""

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -12,7 +12,7 @@ import unittest
 import numpy as np
 
 import qiskit.pulse as pulse
-from qiskit.circuit import Instruction
+from qiskit.circuit import Instruction, Parameter
 from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler.assembler import assemble
 from qiskit.exceptions import QiskitError
@@ -174,6 +174,80 @@ class TestCircuitAssembler(QiskitTestCase):
 
         self.assertTrue(hasattr(h_op, 'conditional'))
         self.assertEqual(bfunc_op.register, h_op.conditional)
+
+    def test_assemble_circuits_raises_for_bind_circuit_mismatch(self):
+        """Verify assemble_circuits raise error for parametized circuits without matching binds."""
+        qr = QuantumRegister(2)
+        x = Parameter('x')
+        y = Parameter('y')
+
+        full_bound_circ = QuantumCircuit(qr)
+        full_param_circ = QuantumCircuit(qr)
+        partial_param_circ = QuantumCircuit(qr)
+
+        partial_param_circ.u1(x, qr[0])
+
+        full_param_circ.u1(x, qr[0])
+        full_param_circ.u1(y, qr[1])
+
+        partial_bind_args = {'parameter_binds': [{x: 1}, {x: 0}]}
+        full_bind_args = {'parameter_binds': [{x: 1, y: 1}, {x: 0, y: 0}]}
+        inconsistent_bind_args = {'parameter_binds': [{x: 1}, {x: 0, y: 0}]}
+
+        # Raise when parameters passed for non-parametric circuit
+        self.assertRaises(QiskitError, assemble,
+                          full_bound_circ, **partial_bind_args)
+
+        # Raise when no parameters passed for parametric circuit
+        self.assertRaises(QiskitError, assemble, partial_param_circ)
+        self.assertRaises(QiskitError, assemble, full_param_circ)
+
+        # Raise when circuit has more parameters than run_config
+        self.assertRaises(QiskitError, assemble,
+                          full_param_circ, **partial_bind_args)
+
+        # Raise when not all circuits have all parameters
+        self.assertRaises(QiskitError, assemble,
+                          [full_param_circ, partial_param_circ], **full_bind_args)
+
+        # Raise when not all binds have all circuit params
+        self.assertRaises(QiskitError, assemble,
+                          full_param_circ, **inconsistent_bind_args)
+
+    def test_assemble_circuits_binds_parameters(self):
+        """Verify assemble_circuits applies parameter bindings and output circuits are bound."""
+        qr = QuantumRegister(1)
+        qc1 = QuantumCircuit(qr)
+        qc2 = QuantumCircuit(qr)
+
+        x = Parameter('x')
+        y = Parameter('y')
+
+        qc1.u2(x, y, qr[0])
+
+        qc2.rz(x, qr[0])
+        qc2.rz(y, qr[0])
+
+        bind_args = {'parameter_binds': [{x: 0, y: 0},
+                                         {x: 1, y: 0},
+                                         {x: 1, y: 1}]}
+
+        qobj = assemble([qc1, qc2], **bind_args)
+
+        self.assertEqual(len(qobj.experiments), 6)
+        self.assertEqual([len(expt.instructions) for expt in qobj.experiments],
+                         [1, 1, 1, 2, 2, 2])
+
+        self.assertEqual(qobj.experiments[0].instructions[0].params, [0, 0])
+        self.assertEqual(qobj.experiments[1].instructions[0].params, [1, 0])
+        self.assertEqual(qobj.experiments[2].instructions[0].params, [1, 1])
+
+        self.assertEqual(qobj.experiments[3].instructions[0].params, [0])
+        self.assertEqual(qobj.experiments[3].instructions[1].params, [0])
+        self.assertEqual(qobj.experiments[4].instructions[0].params, [1])
+        self.assertEqual(qobj.experiments[4].instructions[1].params, [0])
+        self.assertEqual(qobj.experiments[5].instructions[0].params, [1])
+        self.assertEqual(qobj.experiments[5].instructions[1].params, [1])
 
 
 class TestPulseAssembler(QiskitTestCase):


### PR DESCRIPTION
Follows #2204 , add support for specifying a list of parameter bindings to `execute` or in `RunConfig` to `assemble_circuits`.  

Example:
```
x = Parameter('x')
y = Parameter('y')
param_qc = ... # circuit over theta, phi

job = execute(param_qc, parameter_binds=[{x: 0, y: 0}, {x: 0, y: 1}, {x: 1, y: 0}, {x: 1, y: 1}])
```
will generate and run a qobj with four circuits: `param_qc(x=0,y=0)`, `param_qc(x=0,y=1)`, `param_qc(x=1,y=0)`, and `param_qc(x=1,y=1)`.

Additionally:
- Moves internal in-place parameter binding from `ParameterTable` to `QuantumCircuit`
- Raises an error when attempting to bind a parameter not found in the circuit
- Adds `Parameter.__repr__`

Needs to be rebased after #2166 , and a full model definition in run_config.