### PR TITLE
Instruction shallow copy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -160,6 +160,7 @@ Changed
 - Not specifying a basis in ``execute()`` or ``transpile()`` no longer defaults to unrolling
   to the ['u1', 'u2', 'u3', 'cx'] basis. Instead the default behavior is to not unroll,
   unless specifically requested (#2166).
+- Instruction.copy() is now a shallow copy instead of deep (#2214)
 
 Deprecated
 ----------

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -27,7 +27,7 @@ Instructions are identified by the following:
 Instructions do not have any context about where they are in a circuit (which qubits/clbits).
 The circuit itself keeps this context.
 """
-from copy import deepcopy
+import copy
 import sympy
 import numpy
 
@@ -208,17 +208,17 @@ class Instruction:
 
     def copy(self, name=None):
         """
-        deepcopy of the instruction.
+        shallow copy of the instruction.
 
         Args:
           name (str): name to be given to the copied circuit,
             if None then the name stays the same
 
         Returns:
-          Instruction: a deepcopy of the current instruction, with the name
+          Instruction: a shallow copy of the current instruction, with the name
             updated if it was provided
         """
-        cpy = deepcopy(self)
+        cpy = copy.copy(self)
         if name:
             cpy.name = name
         return cpy

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -34,7 +34,6 @@ def circuit_to_dag(circuit):
         else:
             control = (instruction.control[0], instruction.control[1])
 
-        
         dagcircuit.apply_operation_back(instruction.copy(),
                                         qargs, cargs, control)
 

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -6,12 +6,11 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Helper function for converting a dag to a circuit"""
+import copy
 import collections
 
-from qiskit.circuit import ClassicalRegister
-from qiskit.circuit import Instruction
-from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import ClassicalRegister
 from qiskit.circuit import QuantumRegister
 
 
@@ -51,38 +50,7 @@ def dag_to_circuit(dag):
         else:
             control = (node.condition[0], node.condition[1])
 
-        def duplicate_instruction(inst):
-            """Create a fresh instruction from an input instruction."""
-            if issubclass(inst.__class__,
-                          Instruction) and inst.__class__ not in [
-                              Instruction, Gate]:
-                if inst.name == 'barrier':
-                    new_inst = inst.__class__(inst.num_qubits)
-                elif inst.name == 'initialize':
-                    params = getattr(inst, 'params', [])
-                    new_inst = inst.__class__(params)
-                elif inst.name == 'snapshot':
-                    label = inst.params[0]
-                    snap_type = inst.params[1]
-                    new_inst = inst.__class__(inst.num_qubits,
-                                              inst.num_clbits,
-                                              label, snap_type)
-                else:
-                    params = getattr(inst, 'params', [])
-                    new_inst = inst.__class__(*params)
-            else:
-                if isinstance(inst, Gate):
-                    new_inst = Gate(inst.name, inst.num_qubits,
-                                    inst.params)
-                else:
-                    new_inst = Instruction(name=inst.name,
-                                           num_qubits=inst.num_qubits,
-                                           num_clbits=inst.num_clbits,
-                                           params=inst.params)
-                new_inst.definition = inst.definition
-            return new_inst
-
-        inst = duplicate_instruction(node.op)
+        inst = node.op.copy()
         inst.control = control
         circuit.append(inst, qubits, clbits)
     return circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
This PR changes the instruction.copy() to return a shallow copy. This works because after #1816, the instruction no longer has recursive references.

So it simplifies the duplication of instructions found in `converters.circuit_to_dag`/`dag_to_circuit`, which hardcoded special cases to handle special instructions.

