### PR TITLE
mpl label only shows shorter parameters

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -658,8 +658,12 @@ class MatplotlibDrawer:
                 elif len(q_xy) == 1:
                     disp = op.name
                     if param:
-                        self._gate(q_xy[0], wide=_iswide, text=disp,
-                                   subtext='{}'.format(param))
+                        prm = '{}'.format(param)
+                        if len(prm) < 20:
+                            self._gate(q_xy[0], wide=_iswide, text=disp,
+                                       subtext=prm)
+                        else:
+                            self._gate(q_xy[0], wide=_iswide, text=disp)
                     else:
                         self._gate(q_xy[0], wide=_iswide, text=disp)
                 #


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2233 

The label is only added if it is short enough.

For example for the following circuit
```
qr = QuantumRegister(1)
qc = QuantumCircuit(qr)
U1 = random_unitary(2)
qc.u3(pi/2, pi/2, pi/2, qr[0])
qc.append(U1, [qr[0]])
```
This image is generated : 
![image](https://user-images.githubusercontent.com/40489777/56906187-a5759d80-6a99-11e9-8ad8-785ceaeda7be.png)

