### PR TITLE
Refactor enhance schedule

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -178,7 +178,7 @@ def assemble_schedules(schedules, qobj_id=None, qobj_header=None, run_config=Non
         # instructions
         qobj_instructions = []
         # Instructions are returned as tuple of shifted time and instruction
-        for shift, instruction in list(schedule.flatten()):
+        for shift, instruction in schedule.instructions:
             # TODO: support conditional gate
             qobj_instructions.append(instruction_converter(shift, instruction))
             if isinstance(instruction, PulseInstruction):

--- a/qiskit/pulse/commands/instruction.py
+++ b/qiskit/pulse/commands/instruction.py
@@ -90,6 +90,11 @@ class Instruction(ScheduleComponent):
         """Instruction has no child nodes. """
         return ()
 
+    @property
+    def instructions(self) -> Tuple[Tuple[int, 'Instruction']]:
+        """Iterable for getting instructions from Schedule tree."""
+        return tuple(self._instructions())
+
     def ch_duration(self, *channels: List[Channel]) -> int:
         """Return duration of the supplied channels in this Instruction.
 
@@ -113,6 +118,22 @@ class Instruction(ScheduleComponent):
             *channels: Supplied channels
         """
         return self.timeslots.ch_stop_time(*channels)
+
+    def _instructions(self, time: int = 0) -> Iterable[Tuple[int, 'Instruction']]:
+        """Iterable for flattening Schedule tree.
+
+        Args:
+            time: Shifted time of this node due to parent
+
+        Yields:
+            Tuple[int, ScheduleComponent]: Tuple containing time `ScheduleComponent` starts
+                at and the flattened `ScheduleComponent`.
+        """
+        yield (time, self)
+
+    def flatten(self) -> 'Instruction':
+        """Return itself as already single instruction."""
+        return self
 
     def union(self, *schedules: List[ScheduleComponent]) -> 'ScheduleComponent':
         """Return a new schedule which is the union of `self` and `schedule`.
@@ -147,18 +168,6 @@ class Instruction(ScheduleComponent):
             schedule: schedule to be appended
         """
         return ops.append(self, schedule)
-
-    def flatten(self, time: int = 0) -> Iterable[Tuple[int, ScheduleComponent]]:
-        """Iterable for flattening Schedule tree.
-
-        Args:
-            time: Shifted time of this node due to parent
-
-        Yields:
-            Tuple[int, ScheduleComponent]: Tuple containing time `ScheduleComponent` starts
-                at and the flattened `ScheduleComponent`.
-        """
-        yield (time, self)
 
     def __add__(self, schedule: ScheduleComponent) -> 'ScheduleComponent':
         """Return a new schedule with `schedule` inserted within `self` at `start_time`."""

--- a/qiskit/pulse/interfaces.py
+++ b/qiskit/pulse/interfaces.py
@@ -9,7 +9,7 @@
 ScheduleComponent, a common interface for components of schedule (Instruction and Schedule).
 """
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, List, Union, Iterable
+from typing import Tuple, List, Union
 
 from qiskit.pulse.channels import Channel
 
@@ -76,12 +76,18 @@ class ScheduleComponent(metaclass=ABCMeta):
         """Child nodes of this schedule component. """
         pass
 
+    @property
     @abstractmethod
-    def flatten(self, time: int = 0) -> Iterable[Tuple[int, 'ScheduleComponent']]:
-        """Iterable for flattening Schedule tree.
+    def instructions(self) -> Tuple[Tuple[int, 'Instructions']]:
+        """Return iterable for all `Instruction`s in `Schedule` tree
         Args:
             time: Initial time of this node
         """
+        pass
+
+    @abstractmethod
+    def flatten(self) -> 'ScheduleComponent':
+        """Return a new schedule which is the flattened schedule contained all `instructions`."""
         pass
 
     @abstractmethod

--- a/qiskit/pulse/interfaces.py
+++ b/qiskit/pulse/interfaces.py
@@ -79,10 +79,7 @@ class ScheduleComponent(metaclass=ABCMeta):
     @property
     @abstractmethod
     def instructions(self) -> Tuple[Tuple[int, 'Instructions']]:
-        """Return iterable for all `Instruction`s in `Schedule` tree
-        Args:
-            time: Initial time of this node
-        """
+        """Return iterable for all `Instruction`s in `Schedule` tree."""
         pass
 
     @abstractmethod

--- a/qiskit/pulse/ops.py
+++ b/qiskit/pulse/ops.py
@@ -38,6 +38,19 @@ def union(*schedules: List[Union[ScheduleComponent, Tuple[int, ScheduleComponent
 # pylint: enable=missing-type-doc
 
 
+def flatten(schedule: ScheduleComponent, name: str = None) -> Schedule:
+    """Create a flattened schedule.
+
+    Args:
+        *schedules: Schedules to take the union of
+        name: Name of the new schedule. Defaults to first element of `schedules`
+    """
+    if name is None:
+            name = schedule.name
+
+    return Schedule(*schedule.instructions, name=name)
+
+
 def shift(schedule: ScheduleComponent, time: int, name: str = None) -> Schedule:
     """Return schedule shifted by `time`.
 

--- a/qiskit/pulse/ops.py
+++ b/qiskit/pulse/ops.py
@@ -42,11 +42,11 @@ def flatten(schedule: ScheduleComponent, name: str = None) -> Schedule:
     """Create a flattened schedule.
 
     Args:
-        *schedules: Schedules to take the union of
+        schedule: Schedules to flatten
         name: Name of the new schedule. Defaults to first element of `schedules`
     """
     if name is None:
-            name = schedule.name
+        name = schedule.name
 
     return Schedule(*schedule.instructions, name=name)
 

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -292,7 +292,7 @@ class TestSchedule(QiskitTestCase):
         gp0 = pulse_lib.gaussian(duration=100, amp=0.7, sigma=3, name='pulse_name')
 
         sched = Schedule()
-        for i in range(10):
+        for _ in range(10):
             sched += gp0(chan)
 
         flat_sched = sched.flatten()

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -177,7 +177,7 @@ class TestSchedule(QiskitTestCase):
         self.assertEqual(0, sched.duration)
         self.assertEqual((), sched.children)
         self.assertEqual(TimeslotCollection(), sched.timeslots)
-        self.assertEqual([], list(sched.flatten()))
+        self.assertEqual([], list(sched.instructions))
 
     def test_flat_instruction_sequence_returns_instructions(self):
         """Test if `flat_instruction_sequence` returns `Instruction`s."""
@@ -186,7 +186,7 @@ class TestSchedule(QiskitTestCase):
 
         # empty schedule with empty schedule
         empty = Schedule().append(Schedule())
-        for _, instr in empty.flatten():
+        for _, instr in empty.instructions:
             self.assertIsInstance(instr, Instruction)
 
         # normal schedule
@@ -197,7 +197,7 @@ class TestSchedule(QiskitTestCase):
         sched = Schedule()
         sched = sched.append(lp0(device.q[0].drive))   # child
         sched = sched.append(subsched)
-        for _, instr in sched.flatten():
+        for _, instr in sched.instructions:
             self.assertIsInstance(instr, Instruction)
 
     def test_absolute_start_time_of_grandchild(self):
@@ -213,7 +213,7 @@ class TestSchedule(QiskitTestCase):
         sched = sched.append(lp0(device.q[0].drive))   # child
         sched = sched.append(subsched)
 
-        start_times = sorted([shft+instr.start_time for shft, instr in sched.flatten()])
+        start_times = sorted([shft+instr.start_time for shft, instr in sched.instructions])
         self.assertEqual([0, 30, 40], start_times)
 
     def test_shift_schedule(self):
@@ -231,7 +231,7 @@ class TestSchedule(QiskitTestCase):
 
         shift = sched.shift(100)
 
-        start_times = sorted([shft+instr.start_time for shft, instr in shift.flatten()])
+        start_times = sorted([shft+instr.start_time for shft, instr in shift.instructions])
 
         self.assertEqual([100, 130, 140], start_times)
 
@@ -242,17 +242,17 @@ class TestSchedule(QiskitTestCase):
         acquire = Acquire(10)
         children = (acquire(device.q[1], device.mem[1]).shift(20) +
                     acquire(device.q[1], device.mem[1]))
-        self.assertEqual(2, len(list(children.flatten())))
+        self.assertEqual(2, len(list(children.instructions)))
 
         sched = acquire(device.q[1], device.mem[1]).append(children)
-        self.assertEqual(3, len(list(sched.flatten())))
+        self.assertEqual(3, len(list(sched.instructions)))
 
         # add 2 instructions to children (2 instructions -> 4 instructions)
         children = children.append(acquire(device.q[1], device.mem[1]))
         children = children.insert(100, acquire(device.q[1], device.mem[1]))
-        self.assertEqual(4, len(list(children.flatten())))
+        self.assertEqual(4, len(list(children.instructions)))
         # sched must keep 3 instructions (must not update to 5 instructions)
-        self.assertEqual(3, len(list(sched.flatten())))
+        self.assertEqual(3, len(list(sched.instructions)))
 
     def test_name_inherited(self):
         """Test that schedule keeps name if an instruction is added."""

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -284,6 +284,23 @@ class TestSchedule(QiskitTestCase):
         sched_snapshot = snapshot | sched1
         self.assertEqual(sched_snapshot.name, 'snapshot_label')
 
+    def test_flatten(self):
+        """Test schedule flattening."""
+
+        device = self.two_qubit_device
+        chan = device.q[0].drive
+        gp0 = pulse_lib.gaussian(duration=100, amp=0.7, sigma=3, name='pulse_name')
+
+        sched = Schedule()
+        for i in range(10):
+            sched += gp0(chan)
+
+        flat_sched = sched.flatten()
+
+        self.assertEqual(len(flat_sched.children), 10)
+
+        self.assertEqual(flat_sched.instructions, sched.instructions)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR refactors the schedule traversal method and replaces `flatten` with `_instruction`, adds a new property `instructions` to `ScheduleComponent` which calls the `_instruction` generator. A new `op` is added `flatten` which returns a new flat schedule of the parent.

Closes #2240.
### Details and comments


