### PR TITLE
Treat parameterized gates as opaque in Optimize1qGates

### DIFF
--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -18,7 +18,7 @@ class Parameter():
         return self.name
 
     def __eq__(self, other):
-        return self.name == other.name
+        return isinstance(other, Parameter) and self.name == other.name
 
     def __hash__(self):
         return hash(self.name)

--- a/qiskit/compiler/transpile_config.py
+++ b/qiskit/compiler/transpile_config.py
@@ -22,10 +22,7 @@ class TranspileConfig(BaseModel):
         optimization_level (int): a non-negative integer indicating the
             optimization level. 0 means no transformation on the circuit. Higher
             levels may produce more optimized circuits, but may take longer.
-        skip_numeric_passes (bool): if True, do not apply passes containing
-            numerical optimization.
     """
-    def __init__(self, optimization_level, skip_numeric_passes, **kwargs):
+    def __init__(self, optimization_level, **kwargs):
         self.optimization_level = optimization_level
-        self.skip_numeric_passes = skip_numeric_passes
         super().__init__(**kwargs)

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -171,7 +171,6 @@ def _transpile_circuit(circuit_config_tuple):
         pass_manager = default_pass_manager(transpile_config.basis_gates,
                                             transpile_config.coupling_map,
                                             transpile_config.initial_layout,
-                                            transpile_config.skip_numeric_passes,
                                             transpile_config.seed_transpiler)
     else:
         pass_manager = default_pass_manager_simulator(transpile_config.basis_gates)
@@ -211,22 +210,18 @@ def _parse_transpile_args(circuits, backend,
 
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
 
-    is_parametric_circuit = [bool(circuit.parameters) for circuit in circuits]
-
     pass_manager = _parse_pass_manager(pass_manager, num_circuits)
 
     transpile_configs = []
     for args in zip(basis_gates, coupling_map, backend_properties, initial_layout,
-                    seed_transpiler, optimization_level, is_parametric_circuit,
-                    pass_manager):
+                    seed_transpiler, optimization_level, pass_manager):
         transpile_config = TranspileConfig(basis_gates=args[0],
                                            coupling_map=args[1],
                                            backend_properties=args[2],
                                            initial_layout=args[3],
                                            seed_transpiler=args[4],
                                            optimization_level=args[5],
-                                           skip_numeric_passes=args[6],
-                                           pass_manager=args[7])
+                                           pass_manager=args[6])
         transpile_configs.append(transpile_config)
 
     return transpile_configs

--- a/qiskit/transpiler/preset_passmanagers/default.py
+++ b/qiskit/transpiler/preset_passmanagers/default.py
@@ -27,8 +27,7 @@ from qiskit.transpiler.passes.mapping.full_ancilla_allocation import FullAncilla
 from qiskit.transpiler.passes.mapping.enlarge_with_ancilla import EnlargeWithAncilla
 
 
-def default_pass_manager(basis_gates, coupling_map, initial_layout,
-                         skip_numeric_passes, seed_transpiler):
+def default_pass_manager(basis_gates, coupling_map, initial_layout, seed_transpiler):
     """
     The default pass manager that maps to the coupling map.
 
@@ -36,7 +35,6 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout,
         basis_gates (list[str]): list of basis gate names supported by the target.
         coupling_map (CouplingMap): coupling map to target in mapping.
         initial_layout (Layout or None): initial layout of virtual qubits on physical qubits
-        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
         seed_transpiler (int or None): random seed for stochastic passes.
 
     Returns:
@@ -77,12 +75,7 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout,
     pass_manager.append(Unroller(['u1', 'u2', 'u3', 'id', 'cx']))
 
     # Simplify single qubit gates and CXs
-    if not skip_numeric_passes:
-        simplification_passes = [Optimize1qGates(), CXCancellation()]
-    else:
-        simplification_passes = [CXCancellation()]
-
-    simplification_passes += [RemoveResetInZeroState()]
+    simplification_passes = [Optimize1qGates(), CXCancellation(), RemoveResetInZeroState()]
 
     pass_manager.append(simplification_passes + [Depth(), FixedPoint('depth')],
                         do_while=lambda property_set: not property_set['depth_fixed_point'])

--- a/qiskit/transpiler/transpiler.py
+++ b/qiskit/transpiler/transpiler.py
@@ -51,8 +51,7 @@ def transpile(circuits, backend=None, basis_gates=None, coupling_map=None,
 
 
 def transpile_dag(dag, basis_gates=None, coupling_map=None,
-                  initial_layout=None, skip_numeric_passes=None,
-                  seed_mapper=None, pass_manager=None):
+                  initial_layout=None, seed_mapper=None, pass_manager=None):
     """Deprecated - Use qiskit.compiler.transpile for transpiling from
     circuits to circuits.
     Transform a dag circuit into another dag circuit
@@ -72,7 +71,6 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
             eg. [[0, 2], [1, 2], [1, 3], [3, 4]}
 
         initial_layout (Layout or None): A layout object
-        skip_numeric_passes (bool): If true, skip passes which require fixed parameter values
         seed_mapper (int): random seed_mapper for the swap mapper
         pass_manager (PassManager): pass manager instance for the transpilation process
             If None, a default set of passes are run.
@@ -97,7 +95,6 @@ def transpile_dag(dag, basis_gates=None, coupling_map=None,
             pass_manager = default_pass_manager(basis_gates,
                                                 CouplingMap(coupling_map),
                                                 initial_layout,
-                                                skip_numeric_passes,
                                                 seed_transpiler=seed_mapper)
         else:
             pass_manager = default_pass_manager_simulator(basis_gates)

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -10,6 +10,7 @@
 import unittest
 
 from qiskit.circuit import Gate
+from qiskit.circuit import Parameter
 from qiskit.circuit import Instruction
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister, ClassicalRegister
@@ -23,8 +24,7 @@ class TestInstructions(QiskitTestCase):
     """Instructions tests."""
 
     def test_instructions_equal(self):
-        """Test equality of two instructions.
-        """
+        """Test equality of two instructions."""
         hop1 = Instruction('h', 1, 0, [])
         hop2 = Instruction('s', 1, 0, [])
         hop3 = Instruction('h', 1, 0, [])
@@ -41,6 +41,27 @@ class TestInstructions(QiskitTestCase):
         self.assertTrue(HGate() == HGate())
         self.assertFalse(HGate() == CnotGate())
         self.assertFalse(hop1 == HGate())
+
+    def test_instructions_equal_with_parameters(self):
+        """Test equality of instructions for cases with Parameters."""
+        theta = Parameter('theta')
+        phi = Parameter('phi')
+
+        # Verify we can check params including parameters
+        self.assertEqual(Instruction('u', 1, 0, [theta, phi, 0.4]),
+                         Instruction('u', 1, 0, [theta, phi, 0.4]))
+
+        # Verify we can test for correct parameter order
+        self.assertNotEqual(Instruction('u', 1, 0, [theta, phi, 0]),
+                            Instruction('u', 1, 0, [phi, theta, 0]))
+
+        # Verify we can still find a wrong fixed param if we use parameters
+        self.assertNotEqual(Instruction('u', 1, 0, [theta, phi, 0.4]),
+                            Instruction('u', 1, 0, [theta, phi, 0.5]))
+
+        # Verify we can find cases when param != float
+        self.assertNotEqual(Instruction('u', 1, 0, [0.3, phi, 0.4]),
+                            Instruction('u', 1, 0, [theta, phi, 0.5]))
 
     def circuit_instruction_circuit_roundtrip(self):
         """test converting between circuit and instruction and back

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -17,6 +17,7 @@ from qiskit.transpiler.passes import Optimize1qGates
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeRueschlikon
+from qiskit.circuit import Parameter
 
 
 class TestOptimize1qGates(QiskitTestCase):
@@ -162,6 +163,56 @@ class TestOptimize1qGates(QiskitTestCase):
 
         pass_ = Optimize1qGates()
         after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+    def test_single_parameterized_circuit(self):
+        """Parameters should be treated as opaque gates."""
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+        theta = Parameter('theta')
+
+        qc.u1(0.3, qr)
+        qc.u1(0.4, qr)
+        qc.u1(theta, qr)
+        qc.u1(0.1, qr)
+        qc.u1(0.2, qr)
+        dag = circuit_to_dag(qc)
+
+        expected = QuantumCircuit(qr)
+        expected.u1(0.7, qr)
+        expected.u1(theta, qr)
+        expected.u1(0.3, qr)
+
+        after = Optimize1qGates().run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
+    def test_parameterized_circuits(self):
+        """Parameters should be treated as opaque gates."""
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+        theta = Parameter('theta')
+
+        qc.u1(0.3, qr)
+        qc.u1(0.4, qr)
+        qc.u1(theta, qr)
+        qc.u1(0.1, qr)
+        qc.u1(0.2, qr)
+        qc.u1(theta, qr)
+        qc.u1(0.3, qr)
+        qc.u1(0.2, qr)
+
+        dag = circuit_to_dag(qc)
+
+        expected = QuantumCircuit(qr)
+        expected.u1(0.7, qr)
+        expected.u1(theta, qr)
+        expected.u1(0.3, qr)
+        expected.u1(theta, qr)
+        expected.u1(0.5, qr)
+
+        after = Optimize1qGates().run(dag)
 
         self.assertEqual(circuit_to_dag(expected), after)
 


### PR DESCRIPTION
Currently, if a circuit contains a parameterized gate, we skip Optimize1qGates in the default set of transpiler passes, even though would be possible to optimize 1q gates over runs where all of the parameters are bound. This PR updates Optimize1qGates to treat parameterized gates as opaque (so they are not optimized over) and returns Optimize1qGates to the default set of transpiler passes for parameterized circuits.