### PR TITLE
Improve error message when unrolling parameterized CU1.

### DIFF
--- a/qiskit/transpiler/passes/unroller.py
+++ b/qiskit/transpiler/passes/unroller.py
@@ -10,6 +10,7 @@
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.exceptions import QiskitError
+from qiskit.circuit import Parameter
 
 
 class Unroller(TransformationPass):
@@ -51,7 +52,15 @@ class Unroller(TransformationPass):
                 continue
 
             # TODO: allow choosing other possible decompositions
-            rule = node.op.definition
+            try:
+                rule = node.op.definition
+            except TypeError as err:
+                if any(isinstance(p, Parameter) for p in node.op.params):
+                    raise QiskitError('Unrolling gates parameterized by expressions '
+                                      'is currently unsupported.')
+                else:
+                    raise QiskitError('Error decomposing node {}: {}'.format(node.name, err))
+
             if not rule:
                 raise QiskitError("Cannot unroll the circuit to the given basis, %s. "
                                   "No rule to expand instruction %s." %

--- a/test/python/transpiler/test_unroller.py
+++ b/test/python/transpiler/test_unroller.py
@@ -17,6 +17,7 @@ from qiskit.transpiler.passes import Unroller
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
 from qiskit.exceptions import QiskitError
+from qiskit.circuit import Parameter
 
 
 class TestUnroller(QiskitTestCase):
@@ -229,3 +230,34 @@ class TestUnroller(QiskitTestCase):
         ref_circuit.measure(qr, cr)
         ref_dag = circuit_to_dag(ref_circuit)
         self.assertEqual(unrolled_dag, ref_dag)
+
+    def test_unroll_parameterized_without_expressions(self):
+        """Verify unrolling parameterized gates without expressions."""
+        qr = QuantumRegister(1)
+        qc = QuantumCircuit(qr)
+
+        theta = Parameter('theta')
+
+        qc.rz(theta, qr[0])
+        dag = circuit_to_dag(qc)
+
+        unrolled_dag = Unroller(['u1', 'cx']).run(dag)
+
+        expected = QuantumCircuit(qr)
+        expected.u1(theta, qr[0])
+
+        self.assertEqual(circuit_to_dag(expected), unrolled_dag)
+
+    def test_unroll_parameterized_with_expressions(self):
+        """Verify that unrolling parameterized gates with expressions raises."""
+        qr = QuantumRegister(2)
+        qc = QuantumCircuit(qr)
+
+        theta = Parameter('theta')
+
+        qc.cu1(theta, qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        with self.assertRaisesRegex(QiskitError, 'unsupported'):
+            Unroller(['u1', 'cx']).run(dag)
+            raise QiskitError('unsupported')


### PR DESCRIPTION
Currently, `Parameter`s do not support any math operations. Unrolling gates defined in terms of expressions will fail if the param is a `Parameter` (in the standard gate set, this includes cu1 and cu3). This PR improves the error message raised from
```
TypeError: unsupported operand type(s) for /: 'Parameter' and 'int'
```
to
```
qiskit.exceptions.QiskitError: 'Unrolling gates parameterized by expressions is currently unsupported.'
```