### PR TITLE
Remove warning from qiskit._util and rely on a comment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,6 +192,8 @@ Deprecated
 - The ``seed`` argument is ``execute()`` is deprecated in favor of ``seed_simulator`` (#2166).
 - The ``pass_manager`` argument in ``transpile()`` is deprecated. Instead, the
   ``pass_manager.run()`` methdod can be used directly to transform the circuit (#2166).
+- The ``qiskit._util`` module is deprecated and replaced by ``qiskit.util``.
+  ``qiskit._util`` will be removed in the 0.9 release. (#2154)
 
 Fixed
 -----

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -16,17 +16,8 @@
 
 """Compat shim for backwards compatability with qiskit.util."""
 
-import warnings
+# The 'qiskit._util' module is deprecated and has been renamed
+# 'qiskit.util'. Please update your imports as 'qiskit._util'
+# will be removed in Qiskit Terra 0.9.
 
-from qiskit import util
-
-def __getattr__(name):
-    warnings.warn('The qiskit._util module is deprecated and has been renamed '
-                  'qiskit.util. Please update your imports as qiskit._util '
-                  'will be removed in Qiskit Terra 0.9.', DeprecationWarning)
-    res = getattr(util, name, None)
-    if res is None:
-        raise AttributeError("module: 'qiskit._util' has no attribute: '%s'"
-                             % name)
-    return res
-
+from qiskit.util import *

--- a/qiskit/_util.py
+++ b/qiskit/_util.py
@@ -18,8 +18,15 @@
 
 import warnings
 
-from qiskit.util import *
+from qiskit import util
 
-warnings.warn('The qiskit._util module is deprecated and has been renamed '
-              'qiskit.util. Please update your imports as qiskit._util will be'
-              'removed in Qiskit Terra 0.9.', DeprecationWarning)
+def __getattr__(name):
+    warnings.warn('The qiskit._util module is deprecated and has been renamed '
+                  'qiskit.util. Please update your imports as qiskit._util '
+                  'will be removed in Qiskit Terra 0.9.', DeprecationWarning)
+    res = getattr(util, name, None)
+    if res is None:
+        raise AttributeError("module: 'qiskit._util' has no attribute: '%s'"
+                             % name)
+    return res
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since the warning was too noisy and gets emitted on every qiskit import
this commit just removes it. The _util module is still deprecated, and
listed as such in the module and in the changelog (and the future
release notes). But, since it was marked as private previously weighing
the noise of advertising the deprecation with a warning against the
potential of an external user using it removing the warning seems the
better option.

### Details and comments

Fixes #2252
