### PR TITLE
Update BackendConfiguration signature

### DIFF
--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -80,9 +80,9 @@ class BackendConfigurationSchema(BaseSchema):
     local = Boolean(required=True)
     simulator = Boolean(required=True)
     conditional = Boolean(required=True)
+    open_pulse = Boolean(required=True)
     memory = Boolean(required=True)
     max_shots = Integer(required=True, validate=Range(min=1))
-    open_pulse = Boolean(required=True)
 
     # Optional properties.
     max_experiments = Integer(validate=Range(min=1))
@@ -189,13 +189,13 @@ class BackendConfiguration(BaseModel):
         local (bool): backend is local or remote.
         simulator (bool): backend is a simulator.
         conditional (bool): backend supports conditional operations.
-        memory (bool): backend supports memory.
         open_pulse (bool): backend supports open pulse.
+        memory (bool): backend supports memory.
         max_shots (int): maximum number of shots supported.
     """
 
     def __init__(self, backend_name, backend_version, n_qubits, basis_gates,
-                 gates, local, simulator, conditional, memory, open_pulse,
+                 gates, local, simulator, conditional, open_pulse, memory,
                  max_shots, **kwargs):
 
         self.backend_name = backend_name
@@ -206,8 +206,8 @@ class BackendConfiguration(BaseModel):
         self.local = local
         self.simulator = simulator
         self.conditional = conditional
-        self.memory = memory
         self.open_pulse = open_pulse
+        self.memory = memory
         self.max_shots = max_shots
 
         super().__init__(**kwargs)
@@ -237,8 +237,6 @@ class QasmBackendConfiguration(BackendConfiguration):
     def __init__(self, backend_name, backend_version, n_qubits, basis_gates,
                  gates, local, simulator, conditional, open_pulse, memory,
                  max_shots, **kwargs):
-
-        self.open_pulse = open_pulse
 
         super().__init__(backend_name=backend_name, backend_version=backend_version,
                          n_qubits=n_qubits, basis_gates=basis_gates, gates=gates,


### PR DESCRIPTION
Follow up to #2216 

Update the order of the arguments in `BackendConfiguration` for making it consistent with `QasmBackendConfiguration` and prevent confusiong when instantiating without named args - the `open_pulse` parameter ended up in a different place in the signature.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


