### PR TITLE
Allow PassManager instances to be reused

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -41,6 +41,7 @@ from .mapping.check_map import CheckMap
 from .mapping.check_cnot_direction import CheckCnotDirection
 from .mapping.cx_direction import CXDirection
 from .mapping.trivial_layout import TrivialLayout
+from .mapping.set_layout import SetLayout
 from .mapping.dense_layout import DenseLayout
 from .mapping.noise_adaptive_layout import NoiseAdaptiveLayout
 from .mapping.basic_swap import BasicSwap

--- a/qiskit/transpiler/passes/mapping/set_layout.py
+++ b/qiskit/transpiler/passes/mapping/set_layout.py
@@ -19,10 +19,10 @@ This pass associates a physical qubit (int) to each virtual qubit
 of the circuit (tuple(QuantumRegister, int)) in increasing order.
 """
 
-from qiskit.transpiler import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 
 class SetLayout(AnalysisPass):
+    """Sets property_set['layout'] to layout."""
     def __init__(self, layout):
         """
         Sets property_set['layout'] to layout.
@@ -35,3 +35,4 @@ class SetLayout(AnalysisPass):
 
     def run(self, dag):
         self.property_set['layout'] = self.layout
+        return dag

--- a/qiskit/transpiler/passes/mapping/set_layout.py
+++ b/qiskit/transpiler/passes/mapping/set_layout.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Sets property_set['layout'] to layout.
+
+This pass associates a physical qubit (int) to each virtual qubit
+of the circuit (tuple(QuantumRegister, int)) in increasing order.
+"""
+
+from qiskit.transpiler import Layout
+from qiskit.transpiler.basepasses import AnalysisPass
+
+class SetLayout(AnalysisPass):
+    def __init__(self, layout):
+        """
+        Sets property_set['layout'] to layout.
+
+        Args:
+            layout (Layout): the layout to set.
+        """
+        super().__init__()
+        self.layout = layout
+
+    def run(self, dag):
+        self.property_set['layout'] = self.layout

--- a/qiskit/transpiler/passes/mapping/set_layout.py
+++ b/qiskit/transpiler/passes/mapping/set_layout.py
@@ -21,8 +21,10 @@ of the circuit (tuple(QuantumRegister, int)) in increasing order.
 
 from qiskit.transpiler.basepasses import AnalysisPass
 
+
 class SetLayout(AnalysisPass):
     """Sets property_set['layout'] to layout."""
+
     def __init__(self, layout):
         """
         Sets property_set['layout'] to layout.

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -139,7 +139,7 @@ class PassManager():
         name = circuit.name
         dag = circuit_to_dag(circuit)
         del circuit
-        self.reset() # Reset passmanager instance before starting
+        self.reset()  # Reset passmanager instance before starting
 
         for passset in self.working_list:
             for pass_ in passset:

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -122,8 +122,8 @@ class PassManager():
         self.working_list.append(
             FlowController.controller_factory(passes, options, **flow_controller_conditions))
 
-
     def reset(self):
+        """ "Resets the pass manager instance """
         self.valid_passes = set()
         self.property_set.clear()
 
@@ -138,16 +138,15 @@ class PassManager():
         """
         name = circuit.name
         dag = circuit_to_dag(circuit)
-        self.reset() # Reset property set before starting
-        circuit = dag_to_circuit(self._run_dag_on_working_list(dag))
-        circuit.name = name
-        return circuit
+        self.reset() # Reset passmanager instance before starting
 
-    def _run_dag_on_working_list(self, dag):
         for passset in self.working_list:
             for pass_ in passset:
                 dag = self._do_pass(pass_, dag, passset.options)
-        return dag
+
+        circuit = dag_to_circuit(dag)
+        circuit.name = name
+        return circuit
 
     def _do_pass(self, pass_, dag, options):
         """Do a pass and its "requires".

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -122,6 +122,11 @@ class PassManager():
         self.working_list.append(
             FlowController.controller_factory(passes, options, **flow_controller_conditions))
 
+
+    def reset(self):
+        self.valid_passes = set()
+        self.property_set.clear()
+
     def run(self, circuit):
         """Run all the passes on a QuantumCircuit
 
@@ -133,13 +138,16 @@ class PassManager():
         """
         name = circuit.name
         dag = circuit_to_dag(circuit)
-        del circuit
+        self.reset() # Reset property set before starting
+        circuit = dag_to_circuit(self._run_dag_on_working_list(dag))
+        circuit.name = name
+        return circuit
+
+    def _run_dag_on_working_list(self, dag):
         for passset in self.working_list:
             for pass_ in passset:
                 dag = self._do_pass(pass_, dag, passset.options)
-        circuit = dag_to_circuit(dag)
-        circuit.name = name
-        return circuit
+        return dag
 
     def _do_pass(self, pass_, dag, options):
         """Do a pass and its "requires".

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -138,6 +138,7 @@ class PassManager():
         """
         name = circuit.name
         dag = circuit_to_dag(circuit)
+        del circuit
         self.reset() # Reset passmanager instance before starting
 
         for passset in self.working_list:

--- a/qiskit/transpiler/preset_passmanagers/default.py
+++ b/qiskit/transpiler/preset_passmanagers/default.py
@@ -22,6 +22,7 @@ from qiskit.transpiler.passes.mapping.check_map import CheckMap
 from qiskit.transpiler.passes.mapping.cx_direction import CXDirection
 from qiskit.transpiler.passes.mapping.dense_layout import DenseLayout
 from qiskit.transpiler.passes.mapping.trivial_layout import TrivialLayout
+from qiskit.transpiler.passes.mapping.set_layout import SetLayout
 from qiskit.transpiler.passes.mapping.legacy_swap import LegacySwap
 from qiskit.transpiler.passes.mapping.full_ancilla_allocation import FullAncillaAllocation
 from qiskit.transpiler.passes.mapping.enlarge_with_ancilla import EnlargeWithAncilla
@@ -41,8 +42,7 @@ def default_pass_manager(basis_gates, coupling_map, initial_layout, seed_transpi
         PassManager: A pass manager to map and optimize.
     """
     pass_manager = PassManager()
-    pass_manager.property_set['layout'] = initial_layout
-
+    pass_manager.append(SetLayout(initial_layout))
     pass_manager.append(Unroller(basis_gates))
 
     # Use the trivial layout if no layout is found

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -78,7 +78,7 @@ import os
 from qiskit import execute
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, BasicAer
 from qiskit.transpiler import PassManager, transpile
-from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, StochasticSwap, LegacySwap
+from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, StochasticSwap, LegacySwap, SetLayout
 from qiskit.mapper import CouplingMap, Layout
 
 from qiskit.test import QiskitTestCase
@@ -100,15 +100,15 @@ class CommonUtilitiesMixin:
     seed = 42
     seed_mapper = 42
     additional_args = {}
-    pass_class = None
+    pass_class = lambda *args: None
 
     def create_passmanager(self, coupling_map, initial_layout=None):
         """Returns a PassManager using self.pass_class(coupling_map, initial_layout)"""
-        passmanager = PassManager(
-            self.pass_class(CouplingMap(coupling_map),  # pylint: disable=not-callable
-                            **self.additional_args))
+        passmanager = PassManager()
         if initial_layout:
-            passmanager.property_set['layout'] = Layout(initial_layout)
+            passmanager.append(SetLayout(Layout(initial_layout)))
+
+        passmanager.append(self.pass_class(CouplingMap(coupling_map), **self.additional_args))
         return passmanager
 
     def create_backend(self):

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -100,7 +100,7 @@ class CommonUtilitiesMixin:
     seed = 42
     seed_mapper = 42
     additional_args = {}
-    pass_class = lambda *args: None
+    pass_class = None
 
     def create_passmanager(self, coupling_map, initial_layout=None):
         """Returns a PassManager using self.pass_class(coupling_map, initial_layout)"""
@@ -108,6 +108,7 @@ class CommonUtilitiesMixin:
         if initial_layout:
             passmanager.append(SetLayout(Layout(initial_layout)))
 
+        # pylint: disable=not-callable
         passmanager.append(self.pass_class(CouplingMap(coupling_map), **self.additional_args))
         return passmanager
 


### PR DESCRIPTION
This PR introduces the method `PassManager.reset`  to allow the reuse of pass manager instances. 

Because the reset includes cleaning the property set associated, a new pass is introduced to set the layout and avoid handling the property set manually.