### PR TITLE
Fix typo in QuantumChannel init

### DIFF
--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -139,7 +139,7 @@ class QuantumChannel(BaseOperator):
             # preference to a 'to_quantumchannel' attribute that allows
             # an arbitrary object to define its own conversion to any
             # quantum channel subclass.
-            return data.to_channel()
+            return data.to_quantumchannel()
         if hasattr(data, 'to_channel'):
             # TODO: this 'to_channel' method is the same case as the above
             # but is used by current version of Aer. It should be removed


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fix typo where `to_channel` should have been `to_quantumchannel`

### Details and comments


