### PR TITLE
Remove buffer from first pulse on channel

### DIFF
--- a/qiskit/pulse/ops.py
+++ b/qiskit/pulse/ops.py
@@ -82,7 +82,7 @@ def insert(parent: ScheduleComponent, time: int, child: ScheduleComponent, buffe
         buffer: Obey buffer when inserting
         name: Name of the new schedule. Defaults to name of parent
     """
-    if buffer and child.buffer:
+    if buffer and child.buffer and time > 0:
         time += parent.buffer
     return union(parent, (time, child), name=name)
 
@@ -102,8 +102,9 @@ def append(parent: ScheduleComponent, child: ScheduleComponent, buffer: bool = T
         name: Name of the new schedule. Defaults to name of parent
     """
     common_channels = set(parent.channels) & set(child.channels)
+
     time = parent.ch_stop_time(*common_channels)
-    if buffer and child.buffer:
+    if buffer and child.buffer and time > 0:
         time += parent.buffer
 
     return insert(parent, time, child, name=name)

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -303,7 +303,9 @@ class TestSchedule(QiskitTestCase):
     def test_buffering(self):
         """Test channel buffering."""
         buffer_chan = DriveChannel(0, buffer=5)
-
+        measure_chan = MeasureChannel(0, buffer=10)
+        acquire_chan = AcquireChannel(0, buffer=10)
+        memory_slot = MemorySlot(0)
         gp0 = pulse_lib.gaussian(duration=10, amp=0.7, sigma=3)
         fc_pi_2 = FrameChange(phase=1.57)
 
@@ -327,6 +329,12 @@ class TestSchedule(QiskitTestCase):
         sched = sched.insert(sched.duration, gp0(buffer_chan), buffer=True)
 
         self.assertEqual(sched.duration, 40)
+
+        sched = Schedule()
+
+        sched = gp0(measure_chan) + Acquire(duration=10)(acquire_chan, memory_slot)
+
+        self.assertEqual(sched.duration, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Small bug in timing of appends with buffer. Currently a buffer will be inserted for first pulse on channel, which is not required.


### Details and comments


