### PR TITLE
Install twine in wheel build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       if: tag IS present
       script:
-        - sudo pip install cibuildwheel==0.10.1
+        - sudo pip install cibuildwheel==0.10.1 twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - os: osx
@@ -115,7 +115,7 @@ jobs:
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       script:
-        - sudo pip2 install cibuildwheel==0.10.1
+        - sudo pip2 install cibuildwheel==0.10.1 twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ deploy: false
 skip_branch_with_pr: true
 
 build_script:
-  - if defined WHEEL (pip install cibuildwheel==0.10.1)
+  - if defined WHEEL (pip install cibuildwheel==0.10.1 twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
   - if defined WHEEL {twine upload wheelhouse\*}
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,11 @@ version: 1.0.{build}
 environment:
     matrix:
         - PYTHON: C:\Python35
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - PYTHON: C:\Python36
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - PYTHON: C:\Python37
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
         - WHEEL: 1
           PYTHON: C:\Python35
           CIBW_BEFORE_BUILD: pip install -U Cython
@@ -27,7 +27,7 @@ environment:
           TWINE_USERNAME: qiskit
           TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
 
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
@@ -61,7 +61,7 @@ skip_branch_with_pr: true
 build_script:
   - if defined WHEEL (pip install cibuildwheel==0.10.1 twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
-  - if defined WHEEL {twine upload wheelhouse\*}
+#  - if defined WHEEL {twine upload wheelhouse\*}
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,11 @@ version: 1.0.{build}
 environment:
     matrix:
         - PYTHON: C:\Python35
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - PYTHON: C:\Python36
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - PYTHON: C:\Python37
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
         - WHEEL: 1
           PYTHON: C:\Python35
           CIBW_BEFORE_BUILD: pip install -U Cython
@@ -27,7 +27,7 @@ environment:
           TWINE_USERNAME: qiskit
           TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
 
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
@@ -61,7 +61,7 @@ skip_branch_with_pr: true
 build_script:
   - if defined WHEEL (pip install cibuildwheel==0.10.1 twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
-#  - if defined WHEEL {twine upload wheelhouse\*}
+  - if defined WHEEL {twine upload wheelhouse\*}
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The wheel build jobs failed to install twine so when the jobs completed
and went to upload the wheels this failed because the command wasn't
found. This commit fixes the issue by installing twine as part of the
wheel build job set ups so that we can actually upload our built
binaries.

### Details and comments


