### PR TITLE
Match appveyor requirements install to travis

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,15 +77,9 @@ install:
             throw "There are newer queued builds for this pull request, failing early." }
     - "%PYTHON%\\python.exe -m venv venv"
     - venv\Scripts\activate.bat
-    - pip.exe install -r requirements.txt
-    - pip.exe install vcrpy
-    - pip.exe install jupyter
-    - pip.exe install ipywidgets
-    - pip.exe install cython
-    - pip.exe install stestr
+    - pip.exe install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
     - pip.exe install -e .
-    - pip.exe install "qiskit-ibmq-provider"
-    - pip.exe install PyGithub
+    - pip.exe install "qiskit-ibmq-provider" -c constraints.txt
     - python setup.py build_ext --inplace
 # TODO: uncomment this when testing-cabal/subunit#33 is fixed
 #   - pip.exe install junitxml

--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -7,7 +7,7 @@
 
 # pylint: disable=invalid-name,missing-docstring
 
-import sys
+import os
 import tempfile
 import unittest
 
@@ -36,7 +36,7 @@ class TestMatplotlibDrawer(QiskitTestCase):
 
     @unittest.skipIf(not visualization.HAS_MATPLOTLIB,
                      'matplotlib not available.')
-    @unittest.skipIf(sys.platform == 'nt', 'tempfile fails on appveyor')
+    @unittest.skipIf(os.name == 'nt', 'tempfile fails on appveyor')
     def test_empty_circuit(self):
         qc = QuantumCircuit()
         res = visualization.circuit_drawer(qc, output='mpl')

--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -7,6 +7,7 @@
 
 # pylint: disable=invalid-name,missing-docstring
 
+import sys
 import tempfile
 import unittest
 
@@ -35,6 +36,7 @@ class TestMatplotlibDrawer(QiskitTestCase):
 
     @unittest.skipIf(not visualization.HAS_MATPLOTLIB,
                      'matplotlib not available.')
+    @unittest.skipIf(sys.platform == 'nt', 'tempfile fails on appveyor')
     def test_empty_circuit(self):
         qc = QuantumCircuit()
         res = visualization.circuit_drawer(qc, output='mpl')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2328 tests were added that required nxpd to be installed, but it was
merged before waiting for the results from appveyor. These new tests
don't pass appveyor because the requirements installed were different
from what were installed on travis. This commit fixes this so that we
install the same set of requirements on appveyor and travis jobs to
make sure when people take shortcuts in the future there are less
surprises.

### Details and comments