### PR TITLE
Remove redefined-builtin ignores

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -331,7 +331,7 @@ callbacks=cb_,_cb
 
 # List of qualified module names which can have objects that can redefine
 # builtins.
-redefining-builtins-modules=six.moves,future.builtins,tools.compiler
+redefining-builtins-modules=six.moves,future.builtins
 
 
 [CLASSES]

--- a/qiskit/tools/__init__.py
+++ b/qiskit/tools/__init__.py
@@ -12,8 +12,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=redefined-builtin
-
 """Helper module for simplified Qiskit usage.
 
 The functions in this module provide convenience helpers for accessing commonly

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -12,8 +12,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=redefined-builtin
-
 """Compiler Test."""
 
 import unittest

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=redefined-builtin
-
 """Tests basic functionality of the transpile function"""
 
 import math

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -5,8 +5,6 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-# pylint: disable=redefined-builtin
-
 """Converter Test."""
 
 import numpy as np

--- a/test/python/qobj/test_qobj_identifiers.py
+++ b/test/python/qobj/test_qobj_identifiers.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=missing-docstring,redefined-builtin
+# pylint: disable=missing-docstring
 
 """Non-string identifiers for circuit and record identifiers test"""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Small cleanup after #2301, as we are finally able to remove a number of `disable=redefined-builtin` after the `compile()` changes.


### Details and comments


