### PR TITLE
Only attempt to transpile QuantumCircuit in execute

### DIFF
--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -21,6 +21,7 @@ running quickly we have provided this wrapper module.
 import warnings
 import logging
 
+from qiskit import QuantumCircuit
 from qiskit.compiler import transpile, assemble
 
 logger = logging.getLogger(__name__)
@@ -208,18 +209,23 @@ def execute(experiments, backend,
                       "please use `experiments`, which can handle both circuit "
                       "and pulse Schedules", DeprecationWarning)
 
-    # transpiling the circuits using given transpile options
-    experiments = transpile(experiments,
-                            basis_gates=basis_gates,
-                            coupling_map=coupling_map,
-                            backend_properties=backend_properties,
-                            initial_layout=initial_layout,
-                            seed_transpiler=seed_transpiler,
-                            optimization_level=optimization_level,
-                            backend=backend,
-                            pass_manager=pass_manager,
-                            seed_mapper=seed_mapper,  # deprecated
-                            )
+    if not isinstance(experiments, (list, tuple)):
+        experiments = [experiments]
+
+    # If experiments are QuantumCircuit, transpile.
+    if isinstance(experiments[0], QuantumCircuit):
+        # transpiling the circuits using given transpile options
+        experiments = transpile(experiments,
+                                basis_gates=basis_gates,
+                                coupling_map=coupling_map,
+                                backend_properties=backend_properties,
+                                initial_layout=initial_layout,
+                                seed_transpiler=seed_transpiler,
+                                optimization_level=optimization_level,
+                                backend=backend,
+                                pass_manager=pass_manager,
+                                seed_mapper=seed_mapper,  # deprecated
+                                )
 
     # assembling the circuits into a qobj to be run on the backend
     qobj = assemble(experiments,

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -213,7 +213,7 @@ def execute(experiments, backend,
         experiments = [experiments]
 
     # If experiments are QuantumCircuit, transpile.
-    if isinstance(experiments[0], QuantumCircuit):
+    if any(isinstance(exp, QuantumCircuit) for exp in experiments):
         # transpiling the circuits using given transpile options
         experiments = transpile(experiments,
                                 basis_gates=basis_gates,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR modifies `execute` to only attempt to transpile if the supplied `experiment`s are `QuantumCircuit`s.

Closes #2353.


### Details and comments
This could not be tested as there is no mock result generating pulse backend. This should be added.

