### PR TITLE
[stable] DeprecationWarning message to replace qobj_to_circuit

### DIFF
--- a/qiskit/converters/qobj_to_circuits.py
+++ b/qiskit/converters/qobj_to_circuits.py
@@ -30,7 +30,7 @@ def qobj_to_circuits(qobj):
     """
     warnings.warn('qiskit.converters.qobj_to_circuit() is deprecated and will '
                   'be removed in Qiskit Terra 0.9. Please use '
-                  'qiskit.compiler.disassemble_circuits() to convert a qobj '
+                  'qiskit.assembler.disassemble() to convert a qobj '
                   'to list of circuits.', DeprecationWarning)
 
     variables = disassemble(qobj)


### PR DESCRIPTION
Fixes #2334 in stable

This PR fixes the deprecation warning for `qobj_to_circuit`.