### PR TITLE
Add missing optimization level to transpile() docstring

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -109,6 +109,7 @@ def transpile(circuits,
                 0: no optimization
                 1: light optimization
                 2: heavy optimization
+                3: even heavier optimization
 
         pass_manager (PassManager):
             The pass manager to use for a custom pipeline of transpiler passes.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a docstring for optimization level 3 which was missing
from the docstring for the qiskit.compiler.transpile function.

### Details and comments