### PR TITLE
Remove profile testing loader

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -14,7 +14,6 @@ IF "%target%"=="env" GOTO :env
 IF "%target%"=="run" GOTO :run
 IF "%target%"=="lint" GOTO :lint
 IF "%target%"=="test" GOTO :test
-IF "%target%"=="profile" GOTO :profile
 IF "%target%"=="clean" GOTO :clean
 :usage
 ECHO.
@@ -50,11 +49,6 @@ GOTO :next
 pip install -r requirements.txt
 IF errorlevel 9009 GOTO :error
 python -m unittest discover -v
-IF errorlevel 9009 GOTO :error
-GOTO :next
-
-:profile
-python -m unittest discover -p "profile*.py" -v
 IF errorlevel 9009 GOTO :error
 GOTO :next
 

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,6 @@ test_ci:
 	echo "Detected $(NPROCS) CPUs running with $(CONCURRENCY) workers"
 	stestr run --concurrency $(CONCURRENCY)
 
-profile:
-	python3 -m unittest discover -p "profile*.py" -v
-
 coverage:
 	coverage3 run --source qiskit -m unittest discover -s test -q
 	coverage3 report

--- a/test/python/__init__.py
+++ b/test/python/__init__.py
@@ -13,20 +13,3 @@
 # that they have been altered from the originals.
 
 """Qiskit unit tests."""
-
-import os
-
-
-def load_tests(loader, standard_tests, pattern):
-    """
-    test suite for unittest discovery
-    """
-    this_dir = os.path.dirname(__file__)
-    if pattern in ['test*.py', '*_test.py']:
-        package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
-        standard_tests.addTests(package_tests)
-    elif pattern in ['profile*.py', '*_profile.py']:
-        loader.testMethodPrefix = 'profile'
-        package_tests = loader.discover(start_dir=this_dir, pattern='test*.py')
-        standard_tests.addTests(package_tests)
-    return standard_tests

--- a/tox.ini
+++ b/tox.ini
@@ -25,10 +25,6 @@ setenv = {[testenv]setenv}
 setenv = {[testenv]setenv}
          QISKIT_TESTS=rec
 
-[testenv:profile]
-commands =
-  stestr run "profile*" {posargs}
-
 [testenv:lint]
 commands =
   pycodestyle --max-line-length=100 qiskit test


### PR DESCRIPTION
✅ I have read the CONTRIBUTING document.

There were unused vestiges of a profiling environment. The way it was implemented interfered with some tools. In particular the VS Code automatic test discovery and running were broken by the `load_tests()` override in `tests/python/__init__.py`.

This patch removes all traces of the profiling, since anything like that probably belongs in the Qiskit/qiskit repo's benchmarking folder.