### PR TITLE
[Stable] Transpiler add passes that might be out of the default basis

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -234,10 +234,14 @@ def _parse_basis_gates(basis_gates, backend, circuits):
     if basis_gates is None or (isinstance(basis_gates, list) and
                                all(isinstance(i, str) for i in basis_gates)):
         basis_gates = [basis_gates] * len(circuits)
-    # no basis means don't unroll (all circuit gates are valid basis)
-    basis_gates = [[inst.name for inst, _, _ in circuit.data] if basis is None
-                   else basis for basis, circuit in zip(basis_gates, circuits)]
 
+    # no basis means don't unroll (all circuit gates are valid basis)
+    for index, circuit in enumerate(circuits):
+        basis = basis_gates[index]
+        if basis is None:
+            gates_in_circuit = set(inst.name for inst, _, _ in circuit.data)
+            # Other passes might add new gates that need to be supported
+            basis_gates[index] = list(gates_in_circuit.union(['u3', 'cx']))
     return basis_gates
 
 


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #2349

When a basis is not defined for a circuit, the default basis set is the
set of gates used in the circuit. This makes total sense to me.

However, passes might add gates and the might be out of that bases. For
this reason, I'm suggesting to add the base basis (UBase and CXBase) as
part of the default basis set. If I understand correctly, the base
basis (is that their name?) is supported by every backend by
definition, so the gates that are added by the transpiler can run in
the backend.

(cherry picked from commit 4bfcc5d44771beb0549ad5b5b604b0e9563d735b)

### Details and comments

Backported from: #2357
