### PR TITLE
Input type in qiskit.validation.exceptions.ModelValidationError

### DIFF
--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -84,7 +84,7 @@ class ModelTypeValidator(_fields.Field):
         else:
             body = 'is not the expected type {}'.format(type_)
 
-        message = 'Value \'{}\' {}'.format(value, body)
+        message = 'Value \'{}\' {}: {}'.format(value, type(value), body)
         return ValidationError(message, **kwargs)
 
 


### PR DESCRIPTION
Fixes #2151 

When `qiskit.validation.exceptions.ModelValidationError` raises because the input type does not match the expected type, the expected type was part of the error message but not the input type.

```
qiskit.validation.exceptions.ModelValidationError: {'n_qubits': ["Value '2' is not the expected type <class 'int'>"]}
```

With this PR the error looks like this:

```
qiskit.validation.exceptions.ModelValidationError: {'n_qubits': ["Value '2' <class 'numpy.int64'>: is not the expected type <class 'int'>"]}
```

(the example is descriptive, not a real example, see https://github.com/Qiskit/qiskit-terra/issues/2151#issuecomment-491292005)