### PR TITLE
[Stable[ Update expression math sanitization

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -227,7 +227,9 @@ _math_ops = [math_op for math_op in math.__dict__ if not math_op.startswith('__'
 _math_ops_regex = r"(" + ")|(".join(_math_ops) + ")"
 # match consecutive alphanumeric, and single consecutive math ops +-/.()
 # and multiple * for exponentiation
-_allowedchars = re.compile(r'([+\/\-\(\)\.])?([\sa-zA-Z\d]+[+\/\-\(\)\.]?\*{0,2})*')
+_allowedchars = re.compile(r'(([+\/\-]?|\*{0,2})?[\(\)\s]*'  # allow to start with math/bracket
+                            '([a-zA-Z][a-zA-Z\d]*|'  # match word
+                            '[\d]+(\.\d*)?)[\(\)\s]*)*')  # match decimal and bracket
 # match any sequence of chars and numbers
 _expr_regex = r'([a-zA-Z]+\d*)'
 # and valid params
@@ -263,6 +265,7 @@ def _is_math_expr_safe(expr):
     sub_expressions = re.findall(_expr_regex, expr)
     if not all([_valid_sub_expr.match(sub_exp) for sub_exp in sub_expressions]):
         return False
+
     return True
 
 

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -228,8 +228,8 @@ _math_ops_regex = r"(" + ")|(".join(_math_ops) + ")"
 # match consecutive alphanumeric, and single consecutive math ops +-/.()
 # and multiple * for exponentiation
 _allowedchars = re.compile(r'(([+\/\-]?|\*{0,2})?[\(\)\s]*'  # allow to start with math/bracket
-                            '([a-zA-Z][a-zA-Z\d]*|'  # match word
-                            '[\d]+(\.\d*)?)[\(\)\s]*)*')  # match decimal and bracket
+                           r'([a-zA-Z][a-zA-Z\d]*|'  # match word
+                           r'[\d]+(\.\d*)?)[\(\)\s]*)*')  # match decimal and bracket
 # match any sequence of chars and numbers
 _expr_regex = r'([a-zA-Z]+\d*)'
 # and valid params

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -260,6 +260,9 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         self.assertTrue(_is_math_expr_safe('pi*2'))
         self.assertTrue(_is_math_expr_safe('-P1*cos(P2)'))
         self.assertTrue(_is_math_expr_safe('-P1*P2*P3'))
+        self.assertTrue(_is_math_expr_safe('-P1'))
+        self.assertTrue(_is_math_expr_safe('-1 (P1)'))
+        self.assertTrue(_is_math_expr_safe('-(P1)'))
 
 
 class TestLoConverter(QiskitTestCase):

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -249,6 +249,9 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         self.assertFalse(_is_math_expr_safe('INSERT INTO students VALUES (?,?)'))
         self.assertFalse(_is_math_expr_safe('import math'))
         self.assertFalse(_is_math_expr_safe('complex'))
+        self.assertFalse(_is_math_expr_safe('__import__("os").system("clear")'))
+        self.assertFalse(_is_math_expr_safe('eval("()._" + "_class_" + "_._" +'
+                                            ' "_bases_" + "_[0]")'))
         self.assertFalse(_is_math_expr_safe('2***2'))
         self.assertFalse(_is_math_expr_safe('avdfd*3'))
         self.assertFalse(_is_math_expr_safe('Cos(1+2)'))
@@ -259,7 +262,6 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         self.assertFalse(_is_math_expr_safe('print(1.0)'))
         self.assertFalse(_is_math_expr_safe('1.1.1.1'))
         self.assertFalse(_is_math_expr_safe('abc.1'))
-
 
         self.assertTrue(_is_math_expr_safe('1+1*2*3.2+8*cos(1)**2'))
         self.assertTrue(_is_math_expr_safe('pi*2'))

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -261,7 +261,8 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         self.assertTrue(_is_math_expr_safe('-P1*cos(P2)'))
         self.assertTrue(_is_math_expr_safe('-P1*P2*P3'))
         self.assertTrue(_is_math_expr_safe('-P1'))
-        self.assertTrue(_is_math_expr_safe('-1 (P1)'))
+        self.assertTrue(_is_math_expr_safe('-1.*P1'))
+        self.assertTrue(_is_math_expr_safe('-1.*P1*P2'))
         self.assertTrue(_is_math_expr_safe('-(P1)'))
 
 

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -252,9 +252,14 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         self.assertFalse(_is_math_expr_safe('2***2'))
         self.assertFalse(_is_math_expr_safe('avdfd*3'))
         self.assertFalse(_is_math_expr_safe('Cos(1+2)'))
+        self.assertFalse(_is_math_expr_safe('hello'))
         self.assertFalse(_is_math_expr_safe('hello_world'))
         self.assertFalse(_is_math_expr_safe('1_2'))
         self.assertFalse(_is_math_expr_safe('2+-2'))
+        self.assertFalse(_is_math_expr_safe('print(1.0)'))
+        self.assertFalse(_is_math_expr_safe('1.1.1.1'))
+        self.assertFalse(_is_math_expr_safe('abc.1'))
+
 
         self.assertTrue(_is_math_expr_safe('1+1*2*3.2+8*cos(1)**2'))
         self.assertTrue(_is_math_expr_safe('pi*2'))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As noted in #2346, expression sanitization was too strict and was failing on strings of form `-(P1)`. This update the sanitization to allow strings of this form to pass.

Closes #2346.


### Details and comments

Backported from: #2376
