### PR TITLE
[Stable] Make assemble_schedule arguments non-optional

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -25,7 +25,7 @@ from qiskit.qobj.converters import InstructionToQobjConverter, LoConfigConverter
 logger = logging.getLogger(__name__)
 
 
-def assemble_schedules(schedules, qobj_id=None, qobj_header=None, run_config=None):
+def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
     """Assembles a list of schedules into a qobj which can be run on the backend.
     Args:
         schedules (list[Schedule]): schedules to assemble


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Makes assemble_schedule arguments non-optional.

### Details and comments
Backport of #2351.
