### PR TITLE
Fix cycles in several modules

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -562,15 +562,16 @@ class QuantumCircuit:
         Raises:
             VisualizationError: when an invalid output method is selected
         """
-        from qiskit.tools import visualization
-        return visualization.circuit_drawer(self, scale=scale,
-                                            filename=filename, style=style,
-                                            output=output,
-                                            interactive=interactive,
-                                            line_length=line_length,
-                                            plot_barriers=plot_barriers,
-                                            reverse_bits=reverse_bits,
-                                            justify=justify)
+        # pylint: disable=cyclic-import
+        from qiskit.visualization import circuit_drawer
+        return circuit_drawer(self, scale=scale,
+                              filename=filename, style=style,
+                              output=output,
+                              interactive=interactive,
+                              line_length=line_length,
+                              plot_barriers=plot_barriers,
+                              reverse_bits=reverse_bits,
+                              justify=justify)
 
     def size(self):
         """Returns total number of gate operations in circuit.

--- a/qiskit/pulse/ops.py
+++ b/qiskit/pulse/ops.py
@@ -19,7 +19,7 @@ import logging
 from typing import List, Union, Tuple
 
 from .interfaces import ScheduleComponent
-from .schedule import Schedule
+from .schedule import Schedule  # pylint: disable=cyclic-import
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -11,9 +11,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-"""
-Schedule.
-"""
+
+"""Schedule."""
+
 import itertools
 import logging
 from typing import List, Tuple, Iterable, Union, Dict, Callable

--- a/qiskit/qobj/converters/lo_config.py
+++ b/qiskit/qobj/converters/lo_config.py
@@ -7,7 +7,8 @@
 
 """Helper class used to convert a user lo configuration into a list of frequencies."""
 
-from qiskit.pulse import DriveChannel, MeasureChannel, LoConfig
+from qiskit.pulse.channels.pulse_channels import DriveChannel, MeasureChannel
+from qiskit.pulse.configuration import LoConfig
 
 
 class LoConfigConverter:

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -6,6 +6,7 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 """Helper class used to convert a pulse instruction into PulseQobjInstruction."""
+
 import re
 import math
 
@@ -14,11 +15,11 @@ from sympy.parsing.sympy_parser import (parse_expr, standard_transformations,
                                         function_exponentiation)
 from sympy import Symbol
 
-from qiskit.pulse import commands, channels, Schedule
-from qiskit.pulse.schedule import ParameterizedSchedule
+from qiskit.pulse import commands, channels
+from qiskit.pulse.schedule import ParameterizedSchedule, Schedule
 from qiskit.pulse.exceptions import PulseError
 from qiskit.qobj import QobjMeasurementOption
-from qiskit import QiskitError
+from qiskit.exceptions import QiskitError
 
 
 class ConversionMethodBinder:

--- a/qiskit/transpiler/passes/mapping/basic_swap.py
+++ b/qiskit/transpiler/passes/mapping/basic_swap.py
@@ -23,7 +23,7 @@ compatible.
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.extensions.standard import SwapGate
 
 

--- a/qiskit/transpiler/passes/mapping/check_cx_direction.py
+++ b/qiskit/transpiler/passes/mapping/check_cx_direction.py
@@ -18,7 +18,7 @@ direction with respect to the coupling map.
 """
 
 from qiskit.transpiler.basepasses import AnalysisPass
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.extensions.standard.cx import CnotGate
 from qiskit.extensions.standard.cxbase import CXBase
 

--- a/qiskit/transpiler/passes/mapping/check_map.py
+++ b/qiskit/transpiler/passes/mapping/check_map.py
@@ -18,7 +18,7 @@ It checks that all 2-qubit interactions are laid out to be physically close.
 """
 
 from qiskit.transpiler.basepasses import AnalysisPass
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 
 
 class CheckMap(AnalysisPass):

--- a/qiskit/transpiler/passes/mapping/cx_direction.py
+++ b/qiskit/transpiler/passes/mapping/cx_direction.py
@@ -22,7 +22,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
 from qiskit.dagcircuit import DAGCircuit
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.extensions.standard import U2Gate
 
 

--- a/qiskit/transpiler/passes/mapping/dense_layout.py
+++ b/qiskit/transpiler/passes/mapping/dense_layout.py
@@ -26,7 +26,7 @@ import numpy as np
 import scipy.sparse as sp
 import scipy.sparse.csgraph as cs
 
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 

--- a/qiskit/transpiler/passes/mapping/lookahead_swap.py
+++ b/qiskit/transpiler/passes/mapping/lookahead_swap.py
@@ -49,7 +49,7 @@ https://medium.com/qiskit/improving-a-quantum-compiler-48410d7a7084
 
 from copy import deepcopy
 
-from qiskit import QuantumRegister
+from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.extensions.standard import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass

--- a/qiskit/transpiler/passes/mapping/lookahead_swap.py
+++ b/qiskit/transpiler/passes/mapping/lookahead_swap.py
@@ -54,7 +54,7 @@ from qiskit.dagcircuit import DAGCircuit
 from qiskit.extensions.standard import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.dagcircuit import DAGNode
 
 

--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -40,7 +40,7 @@ being set in `property_set`.
 import math
 import networkx as nx
 
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 

--- a/qiskit/transpiler/passes/mapping/stochastic_swap.py
+++ b/qiskit/transpiler/passes/mapping/stochastic_swap.py
@@ -25,7 +25,7 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.extensions.standard import SwapGate
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 # pylint: disable=no-name-in-module
 from .cython.stochastic_swap.utils import nlayout_from_layout
 # pylint: disable=no-name-in-module

--- a/qiskit/transpiler/passes/mapping/trivial_layout.py
+++ b/qiskit/transpiler/passes/mapping/trivial_layout.py
@@ -19,7 +19,7 @@ This pass associates a physical qubit (int) to each virtual qubit
 of the circuit (tuple(QuantumRegister, int)) in increasing order.
 """
 
-from qiskit.transpiler import Layout
+from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As @levbishop helpfully pointed out in #2400, more measures were need for  handling the `cyclic-import` disables - actually, they needed ... solving!

It turns out the _module-level_ `disable=cyclic-import` at `qiskit/circuit/quantumcircuit.py` and at `qiskit/pulse/schedule.py` were obscuring a number of import cycles inadvertently.  A `disable` at a wide scope prevents finer-level warnings to be raised, and that is the reason why we recommend being mindful when using `pylint: disable` in general (and in particular with "dangerous" ignores): it should not be used as a systematic way of appeasing the linter but in a controlled way and ideally in the smallest scope possible, in order to help the team and keep maintainability and good practices at a high level.

A summary of the changes:
* solves cycles in `qiskit.transpiler`, mostly related to individual passes and `Layout`
* solves cycles in `qobj.converter`, related to `QiskitError` and other misc tweaks
* moves the `QuantumCircuit` disable to the smallest scope at `.draw()`, in the same spirit as other methods - does *not* solve the cycles we have with visualization, which are also in other places.
* moves the pulse disable to a smaller scope `pulse.ops` - does *not* solve the cycle (follow-up)

### Details and comments
