### PR TITLE
Revert pylint execution to non-parallel behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ env:
 
 # Ignoring generated ones with .py extension.
 lint:
-	pylint -j 2 -rn qiskit test
+	pylint -rn qiskit test
 
 style:
 	pycodestyle --max-line-length=100 qiskit test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

During #2211, the invocation of `make lint` was changed to parallelized execution via `-j 2` for a (reasonable!) performance gain during the travis linting job. However, as @levbishop noted in https://github.com/Qiskit/qiskit-terra/pull/2400#issuecomment-491507733 and inferred [from the docs](https://pylint.readthedocs.io/en/latest/user_guide/run.html#parallel-execution) and from usage, there are some limitations when running pylint in parallel mode - in practice, it prevents some checks to be performed, such as the `cyclic-import`, which might obscure problems in the codebase if we rely solely on the paralellized execution.

This PR proposes reverting back to the non-parallel behaviour, with the thinking that the ` Lint and pure python test` would _probably_ still be dominated by the 3.5 tests (6'28'' vs 5' + x, based on [the most recent master](https://travis-ci.com/Qiskit/qiskit-terra/builds/111449872)), and that the trade-off between performance and "code QA bonus gain" would make sense. 

Pinging @1ucian0 @kdk for thoughts, as they probably have better numbers and insight! 

### Details and comments


