### PR TITLE
[Stable] Use pip install -U when installing twine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,8 @@ jobs:
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       if: tag IS present
       script:
-        - sudo pip install cibuildwheel==0.10.1 twine
+        - sudo pip install cibuildwheel==0.10.1
+        - sudo pip install -U twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
     - os: osx
@@ -115,7 +116,8 @@ jobs:
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       script:
-        - sudo pip2 install cibuildwheel==0.10.1 twine
+        - sudo pip2 install cibuildwheel==0.10.1
+        - sudo pip2 install -U twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,9 +59,10 @@ deploy: false
 skip_branch_with_pr: true
 
 build_script:
-  - if defined WHEEL (pip install cibuildwheel==0.10.1 twine)
+  - if defined WHEEL (pip install cibuildwheel==0.10.1)
+  - if defined WHEEL (pip install -U twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
-  - if defined WHEEL {twine upload wheelhouse\*}
+  - if defined WHEEL (twine upload wheelhouse\*)
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In using a very similar ci wheel build automation setup in
[mtreinish/retworkx](https://github.com/mtreinish/retworkx) the linux ci failed to upload the built wheels on the
0.0.2 release because the system install version of six was too old and
pip's lack of a dep solver failed to upgrade that. [1] This commit address
this so it's not an issue when we push a bugfix release on the stable
branch by making twine install a separate command with -U to avoid this
in all 3 ci envs.

[1] https://travis-ci.com/mtreinish/retworkx/jobs/199756375#L1116

### Details and comments

This is being pushed to the stable branch since it effects CI setup and doesn't apply to master yet (although #2292 will address it on master).
