### PR TITLE
make rep_times an integer and not a float

### DIFF
--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -120,7 +120,7 @@ class PulseBackendConfigurationSchema(QasmBackendConfigurationSchema):
                               validate=Length(equal=2)), required=True)
     dt = Float(required=True, validate=Range(min=0))  # pylint: disable=invalid-name
     dtm = Float(required=True, validate=Range(min=0))
-    rep_times = List(Float(validate=Range(min=0)), required=True)
+    rep_times = List(Integer(validate=Range(min=0)), required=True)
     meas_kernels = List(String(), required=True)
     discriminators = List(String(), required=True)
 

--- a/qiskit/test/mock.py
+++ b/qiskit/test/mock.py
@@ -173,7 +173,7 @@ class FakeOpenPulse2Q(FakeBackend):
             meas_lo_range=[[6.0, 7.0], [6.0, 7.0]],
             dt=1.3333,
             dtm=10.5,
-            rep_times=[100., 250., 500., 1000.],
+            rep_times=[100, 250, 500, 1000],
             meas_map=[[0], [1, 2]],
             channel_bandwidth=[
                 [-0.2, 0.4], [-0.3, 0.3], [-0.3, 0.3],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR sets `rep_times` in the pulse backend configuration model to `Integer` rather than `Float` to be in line with the specification.


### Details and comments
Closes #2409.

