### PR TITLE
Fixed mpl style by adding in the default style dict

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -139,6 +139,8 @@ class MatplotlibDrawer:
             self._style = DefaultStyle()
         elif style is False:
             self._style = BWStyle()
+        else :
+            self._style = DefaultStyle()
 
         self.plot_barriers = plot_barriers
         self.reverse_bits = reverse_bits

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -135,11 +135,9 @@ class MatplotlibDrawer:
                 self._style = DefaultStyle()
             elif config_style == 'bw':
                 self._style = BWStyle()
-        if not config and style is None:
-            self._style = DefaultStyle()
         elif style is False:
             self._style = BWStyle()
-        else :
+        else:
             self._style = DefaultStyle()
 
         self.plot_barriers = plot_barriers


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2422 

This simply sets the style to be `DefaultStyle()` before it is then updated with any parameters given by the user. This needs to be done otherwise it attempts to update the style dict before it has been initialised. 