### PR TITLE
Add license header to several modules

### DIFF
--- a/examples/python/commutation_relation.py
+++ b/examples/python/commutation_relation.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 from qiskit import *
 
 from qiskit.transpiler import PassManager

--- a/examples/python/hello_quantum.py
+++ b/examples/python/hello_quantum.py
@@ -1,9 +1,20 @@
-"""
-Example used in the README. In this example a Bell state is made.
+# -*- coding: utf-8 -*-
 
-"""
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
 
-# Import the Qiskit
+"""Example used in the README. In this example a Bell state is made."""
+
+# Import Qiskit
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister, QiskitError
 from qiskit import execute, IBMQ, BasicAer
 from qiskit.providers.ibmq import least_busy

--- a/examples/python/load_qasm.py
+++ b/examples/python/load_qasm.py
@@ -1,7 +1,19 @@
-"""
-Example on how to load a file into a QuantumCircuit
+# -*- coding: utf-8 -*-
 
-"""
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Example on how to load a file into a QuantumCircuit."""
+
 from qiskit import QuantumCircuit
 from qiskit import QiskitError, execute, BasicAer
 

--- a/qiskit/tools/qi/__init__.py
+++ b/qiskit/tools/qi/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A collection of useful quantum information functions"""

--- a/test/python/validation/__init__.py
+++ b/test/python/validation/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for the validation module."""


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

_Final_ PR for the license updates round - this one is a bit different than the previous ones, as instead of replacing, it adds the license header to some `.py` files that seemed to be missing it:

* examples/python
* qiskit/tools/qi
* test/python/validation

### Details and comments

#2423 , #2232 
