### PR TITLE
[Stable] Framechange instruction as_dict bug

### DIFF
--- a/qiskit/qobj/models/pulse.py
+++ b/qiskit/qobj/models/pulse.py
@@ -46,7 +46,7 @@ class PulseQobjInstructionSchema(QobjInstructionSchema):
     ch = String(validate=Regexp('[dum]([0-9])+'))
     conditional = Integer(validate=Range(min=0))
     val = ByType([Complex(), String()])
-    phase = ByType([String(), Number()])
+    phase = ByType([Number(), String()])
     duration = Integer(validate=Range(min=1))
     qubits = List(Integer(validate=Range(min=0)), validate=Length(min=1))
     memory_slot = List(Integer(validate=Range(min=0)), validate=Length(min=1))

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -210,7 +210,7 @@ class TestPulseQobj(QiskitTestCase):
             self.fail(str(validation_error))
 
     def test_from_dict_per_class(self):
-        """Test Qobj and its subclass representations given a dictionary."""
+        """Test converting to Qobj and its subclass representations given a dictionary."""
         test_parameters = {
             PulseQobj: (
                 self.valid_qobj,
@@ -251,6 +251,49 @@ class TestPulseQobj(QiskitTestCase):
         for qobj_class, (qobj_item, expected_dict) in test_parameters.items():
             with self.subTest(msg=str(qobj_class)):
                 self.assertEqual(qobj_item, qobj_class.from_dict(expected_dict))
+
+    def test_as_dict_per_class(self):
+            """Test converting from Qobj and its subclass representations given a dictionary."""
+            test_parameters = {
+                PulseQobj: (
+                    self.valid_qobj,
+                    self.valid_dict
+                ),
+                PulseQobjConfig: (
+                    PulseQobjConfig(meas_level=1,
+                                    memory_slot_size=8192,
+                                    meas_return='avg',
+                                    pulse_library=[
+                                        PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j])
+                                    ],
+                                    qubit_lo_freq=[4.9], meas_lo_freq=[6.9],
+                                    rep_time=1000),
+                    {'meas_level': 1,
+                     'memory_slot_size': 8192,
+                     'meas_return': 'avg',
+                     'pulse_library': [{'name': 'pulse0', 'samples': [[0.1, 0.0]]}],
+                     'qubit_lo_freq': [4.9],
+                     'meas_lo_freq': [6.9],
+                     'rep_time': 1000},
+                ),
+                PulseLibraryItem: (
+                    PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j]),
+                    {'name': 'pulse0', 'samples': [[0.1, 0.0]]}
+                ),
+                PulseQobjExperiment: (
+                    PulseQobjExperiment(
+                        instructions=[PulseQobjInstruction(name='pulse0', t0=0, ch='d0')]),
+                    {'instructions': [{'name': 'pulse0', 't0': 0, 'ch': 'd0'}]}
+                ),
+                PulseQobjInstruction: (
+                    PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
+                    {'name': 'pulse0', 't0': 0, 'ch': 'd0'}
+                )
+            }
+
+            for qobj_class, (qobj_item, expected_dict) in test_parameters.items():
+                with self.subTest(msg=str(qobj_class)):
+                    self.assertEqual(qobj_item.as_dict(), expected_dict)
 
 
 def _nop():

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -158,7 +158,11 @@ class TestPulseQobj(QiskitTestCase):
                 PulseQobjExperiment(instructions=[
                     PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
                     PulseQobjInstruction(name='fc', t0=5, ch='d0', phase=1.57),
+                    PulseQobjInstruction(name='fc', t0=5, ch='d0', phase='1.57'),
+                    PulseQobjInstruction(name='fc', t0=5, ch='d0', phase='P1'),
                     PulseQobjInstruction(name='pv', t0=10, ch='d0', val=0.1 + 0.0j),
+                    PulseQobjInstruction(name='pv', t0=10, ch='d0', val='0.1 + 0.0j'),
+                    PulseQobjInstruction(name='pv', t0=10, ch='d0', val='P1'),
                     PulseQobjInstruction(name='acquire', t0=15, duration=5,
                                          qubits=[0], memory_slot=[0],
                                          kernels=[
@@ -190,7 +194,11 @@ class TestPulseQobj(QiskitTestCase):
                 {'instructions': [
                     {'name': 'pulse0', 't0': 0, 'ch': 'd0'},
                     {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 1.57},
+                    {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': '1.57'},
+                    {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 'P1'},
                     {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': [0.1, 0.0]},
+                    {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': '0.1 + 0.0j'},
+                    {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': 'P1'},
                     {'name': 'acquire', 't0': 15, 'duration': 5,
                      'qubits': [0], 'memory_slot': [0],
                      'kernels': [{'name': 'boxcar',

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -257,47 +257,47 @@ class TestPulseQobj(QiskitTestCase):
                 self.assertEqual(qobj_item, qobj_class.from_dict(expected_dict))
 
     def test_as_dict_per_class(self):
-            """Test converting from Qobj and its subclass representations given a dictionary."""
-            test_parameters = {
-                PulseQobj: (
-                    self.valid_qobj,
-                    self.valid_dict
-                ),
-                PulseQobjConfig: (
-                    PulseQobjConfig(meas_level=1,
-                                    memory_slot_size=8192,
-                                    meas_return='avg',
-                                    pulse_library=[
-                                        PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j])
-                                    ],
-                                    qubit_lo_freq=[4.9], meas_lo_freq=[6.9],
-                                    rep_time=1000),
-                    {'meas_level': 1,
-                     'memory_slot_size': 8192,
-                     'meas_return': 'avg',
-                     'pulse_library': [{'name': 'pulse0', 'samples': [[0.1, 0.0]]}],
-                     'qubit_lo_freq': [4.9],
-                     'meas_lo_freq': [6.9],
-                     'rep_time': 1000},
-                ),
-                PulseLibraryItem: (
-                    PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j]),
-                    {'name': 'pulse0', 'samples': [[0.1, 0.0]]}
-                ),
-                PulseQobjExperiment: (
-                    PulseQobjExperiment(
-                        instructions=[PulseQobjInstruction(name='pulse0', t0=0, ch='d0')]),
-                    {'instructions': [{'name': 'pulse0', 't0': 0, 'ch': 'd0'}]}
-                ),
-                PulseQobjInstruction: (
-                    PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
-                    {'name': 'pulse0', 't0': 0, 'ch': 'd0'}
-                )
-            }
+        """Test converting from Qobj and its subclass representations given a dictionary."""
+        test_parameters = {
+            PulseQobj: (
+                self.valid_qobj,
+                self.valid_dict
+            ),
+            PulseQobjConfig: (
+                PulseQobjConfig(meas_level=1,
+                                memory_slot_size=8192,
+                                meas_return='avg',
+                                pulse_library=[
+                                    PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j])
+                                ],
+                                qubit_lo_freq=[4.9], meas_lo_freq=[6.9],
+                                rep_time=1000),
+                {'meas_level': 1,
+                 'memory_slot_size': 8192,
+                 'meas_return': 'avg',
+                 'pulse_library': [{'name': 'pulse0', 'samples': [[0.1, 0.0]]}],
+                 'qubit_lo_freq': [4.9],
+                 'meas_lo_freq': [6.9],
+                 'rep_time': 1000},
+            ),
+            PulseLibraryItem: (
+                PulseLibraryItem(name='pulse0', samples=[0.1 + 0.0j]),
+                {'name': 'pulse0', 'samples': [[0.1, 0.0]]}
+            ),
+            PulseQobjExperiment: (
+                PulseQobjExperiment(
+                    instructions=[PulseQobjInstruction(name='pulse0', t0=0, ch='d0')]),
+                {'instructions': [{'name': 'pulse0', 't0': 0, 'ch': 'd0'}]}
+            ),
+            PulseQobjInstruction: (
+                PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
+                {'name': 'pulse0', 't0': 0, 'ch': 'd0'}
+            )
+        }
 
-            for qobj_class, (qobj_item, expected_dict) in test_parameters.items():
-                with self.subTest(msg=str(qobj_class)):
-                    self.assertEqual(qobj_item.as_dict(), expected_dict)
+        for qobj_class, (qobj_item, expected_dict) in test_parameters.items():
+            with self.subTest(msg=str(qobj_class)):
+                self.assertEqual(qobj_item.as_dict(), expected_dict)
 
 
 def _nop():

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -158,10 +158,8 @@ class TestPulseQobj(QiskitTestCase):
                 PulseQobjExperiment(instructions=[
                     PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
                     PulseQobjInstruction(name='fc', t0=5, ch='d0', phase=1.57),
-                    PulseQobjInstruction(name='fc', t0=5, ch='d0', phase='1.57'),
                     PulseQobjInstruction(name='fc', t0=5, ch='d0', phase='P1'),
                     PulseQobjInstruction(name='pv', t0=10, ch='d0', val=0.1 + 0.0j),
-                    PulseQobjInstruction(name='pv', t0=10, ch='d0', val='0.1 + 0.0j'),
                     PulseQobjInstruction(name='pv', t0=10, ch='d0', val='P1'),
                     PulseQobjInstruction(name='acquire', t0=15, duration=5,
                                          qubits=[0], memory_slot=[0],
@@ -194,10 +192,8 @@ class TestPulseQobj(QiskitTestCase):
                 {'instructions': [
                     {'name': 'pulse0', 't0': 0, 'ch': 'd0'},
                     {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 1.57},
-                    {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': '1.57'},
                     {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 'P1'},
                     {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': [0.1, 0.0]},
-                    {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': '0.1 + 0.0j'},
                     {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': 'P1'},
                     {'name': 'acquire', 't0': 15, 'duration': 5,
                      'qubits': [0], 'memory_slot': [0],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR rearranges the order in which `ByType` is applied in the `PulseQobInstruction` schema. As String was first in the list, floats were being converted to a string when `as_dict` was called. A set of tests have also been added converted from marshmallow models to dicts. 

### Details and comments
The alternative to the approach in this PR is to create a new type of `CmdDefPulseQobjInstruction` that inherits from `PulseQobjInstruction`. This would allow `PulseQobjInstruction` to not accept a string as a valid option. See [this branch](https://github.com/taalexander/qiskit-terra/tree/issue-2411-framechange-instruction-as-dict-new-model) for the implementation.

Backport of #2413.

