### PR TITLE
[Stable] Add cython files to manifest to enable sdist compilation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include qiskit/qasm/libs/*.inc
 include qiskit/schemas/*json
 include qiskit/VERSION.txt
-include setup.py.in
+include qiskit/transpiler/passes/mapping/cython/stochastic_swap/*pyx
+include qiskit/transpiler/passes/mapping/cython/stochastic_swap/*pxd


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with our published sdists. We are not
including the cython source files in the sdist. While the generated cpp
files get included the pyx files are required because we unconditionally
call cythonize in the setup.py. This causes building from sdist to fail
because it can't find the required files.

Fixes Qiskit/qiskit#278

(cherry picked from commit fdc59cfacb331fa4dac79e46adb3adc0bf094238)

### Details and comments

Backported from #2436