### PR TITLE
Fix color reset on use of style dict

### DIFF
--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -95,8 +95,6 @@ class DefaultStyle:
         self.fs = dic.get('fontsize', self.fs)
         self.sfs = dic.get('subfontsize', self.sfs)
         self.disptex = dic.get('displaytext', self.disptex)
-        for key in self.dispcol.keys():
-            self.dispcol[key] = self.gc
         self.dispcol = dic.get('displaycolor', self.dispcol)
         self.latexmode = dic.get('latexdrawerstyle', self.latexmode)
         self.pimode = dic.get('usepiformat', self.pimode)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2344 we made the default mpl style have colored gates. However in
that change we incorrectly reset the gate colors to white when a style
dict was passed in. This was likely just a copy and paste error, because
the black and white style class did the same thing. This commit fixes
this by removing that and letting the default colors be used when a
style dict is used.

### Details and comments
