### PR TITLE
[Stable] Add framechange phase casting to float

### DIFF
--- a/qiskit/pulse/commands/frame_change.py
+++ b/qiskit/pulse/commands/frame_change.py
@@ -25,7 +25,7 @@ class FrameChange(Command):
                 The allowable precision is device specific.
         """
         super().__init__(duration=0)
-        self._phase = phase
+        self._phase = float(phase)
 
     @property
     def phase(self):

--- a/qiskit/qobj/models/pulse.py
+++ b/qiskit/qobj/models/pulse.py
@@ -11,7 +11,7 @@ from marshmallow.validate import Range, Regexp, Length, OneOf
 
 from qiskit.qobj.utils import MeasReturnType
 from qiskit.validation import BaseSchema, bind_schema, BaseModel
-from qiskit.validation.fields import (Integer, String, Number, Complex, List,
+from qiskit.validation.fields import (Integer, String, Number, Float, Complex, List,
                                       Nested, DictParameters, ByType)
 from .base import (QobjInstructionSchema, QobjExperimentConfigSchema, QobjExperimentSchema,
                    QobjConfigSchema, QobjInstruction, QobjExperimentConfig,
@@ -46,7 +46,7 @@ class PulseQobjInstructionSchema(QobjInstructionSchema):
     ch = String(validate=Regexp('[dum]([0-9])+'))
     conditional = Integer(validate=Range(min=0))
     val = ByType([Complex(), String()])
-    phase = ByType([Number(), String()])
+    phase = ByType([Float(), String()])
     duration = Integer(validate=Range(min=1))
     qubits = List(Integer(validate=Range(min=0)), validate=Length(min=1))
     memory_slot = List(Integer(validate=Range(min=0)), validate=Length(min=1))

--- a/test/python/pulse/test_commands.py
+++ b/test/python/pulse/test_commands.py
@@ -60,9 +60,9 @@ class TestFrameChange(QiskitTestCase):
     def test_default(self):
         """Test default frame change.
         """
-        fc_command = FrameChange(phase=1.57 - 0.785j)
+        fc_command = FrameChange(phase=1.57)
 
-        self.assertEqual(fc_command.phase, 1.57-0.785j)
+        self.assertEqual(fc_command.phase, 1.57)
         self.assertEqual(fc_command.duration, 0)
 
 

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -158,6 +158,7 @@ class TestPulseQobj(QiskitTestCase):
                 PulseQobjExperiment(instructions=[
                     PulseQobjInstruction(name='pulse0', t0=0, ch='d0'),
                     PulseQobjInstruction(name='fc', t0=5, ch='d0', phase=1.57),
+                    PulseQobjInstruction(name='fc', t0=5, ch='d0', phase=0.),
                     PulseQobjInstruction(name='fc', t0=5, ch='d0', phase='P1'),
                     PulseQobjInstruction(name='pv', t0=10, ch='d0', val=0.1 + 0.0j),
                     PulseQobjInstruction(name='pv', t0=10, ch='d0', val='P1'),
@@ -192,6 +193,7 @@ class TestPulseQobj(QiskitTestCase):
                 {'instructions': [
                     {'name': 'pulse0', 't0': 0, 'ch': 'd0'},
                     {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 1.57},
+                    {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 0},
                     {'name': 'fc', 't0': 5, 'ch': 'd0', 'phase': 'P1'},
                     {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': [0.1, 0.0]},
                     {'name': 'pv', 't0': 10, 'ch': 'd0', 'val': 'P1'},


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->
### Summary
This PR adds casting of the framechange instruction to a phase.


### Details and comments
This is required because the marshmallow schema will error out if the phase is passed as an integer. The typical edge case for this is if the user passes in a framechange of `0`.

Backport of #2432.


