### PR TITLE
Improve style for Matplotlib circuit drawer

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -24,6 +24,7 @@ import logging
 import math
 
 import numpy as np
+import sympy
 
 try:
     from matplotlib import patches
@@ -203,11 +204,11 @@ class MatplotlibDrawer:
         if text:
             disp_text = text
             if subtext:
-                self.ax.text(xpos, ypos + 0.15 * height, disp_text, ha='center',
+                self.ax.text(xpos, ypos + 0.5 * height, disp_text, ha='center',
                              va='center', fontsize=self._style.fs,
                              color=self._style.gt, clip_on=True,
                              zorder=PORDER_TEXT)
-                self.ax.text(xpos, ypos - 0.3 * height, subtext, ha='center',
+                self.ax.text(xpos, ypos + 0.3 * height, subtext, ha='center',
                              va='center', fontsize=self._style.sfs,
                              color=self._style.sc, clip_on=True,
                              zorder=PORDER_TEXT)
@@ -583,6 +584,20 @@ class MatplotlibDrawer:
                                      'noise', 'cswap', 'swap', 'measure'] and len(
                                          op.name) >= 4:
                     box_width = round(len(op.name) / 8)
+                    # handle params/subtext longer than op names
+                    if op.type == 'op' and hasattr(op.op, 'params'):
+                        param = self.param_parse(op.op.params, self._style.pimode)
+                        if len(param) > len(op.name):
+                            box_width = round(len(param) / 8)
+                            # If more than 4 characters min width is 2
+                            if box_width <= 1:
+                                box_width = 2
+                            if layer_width < box_width:
+                                if box_width > 2:
+                                    layer_width = box_width * 2
+                                else:
+                                    layer_width = 2
+                            continue
                     # If more than 4 characters min width is 2
                     if box_width <= 1:
                         box_width = 2
@@ -699,13 +714,23 @@ class MatplotlibDrawer:
                     else:
                         # this stop there being blank lines plotted in place of barriers
                         this_anc -= 1
+                elif op.name == 'initialize':
+                    vec = '[%s]' % param
+                    self._custom_multiqubit_gate(q_xy, wide=_iswide,
+                                                 text="|psi>",
+                                                 subtext=vec)
+                elif op.name == 'unitary':
+                    # TODO(mtreinish): Look into adding the unitary to the
+                    # subtext
+                    self._custom_multiqubit_gate(q_xy, wide=_iswide,
+                                                 text="U")
                 #
                 # draw single qubit gates
                 #
                 elif len(q_xy) == 1:
                     disp = op.name
                     if param:
-                        prm = '{}'.format(param)
+                        prm = '({})'.format(param)
                         if len(prm) < 20:
                             self._gate(q_xy[0], wide=_iswide, text=disp,
                                        subtext=prm)
@@ -840,11 +865,9 @@ class MatplotlibDrawer:
 
     @staticmethod
     def param_parse(v, pimode=False):
-
         # create an empty list to store the parameters in
         param_parts = [None] * len(v)
         for i, e in enumerate(v):
-
             if pimode:
                 try:
                     param_parts[i] = MatplotlibDrawer.format_pi(e)
@@ -884,6 +907,10 @@ class MatplotlibDrawer:
 
     @staticmethod
     def format_numeric(val, tol=1e-5):
+        if isinstance(val, complex):
+            return str(val)
+        elif complex(val).imag != 0:
+            val = complex(val)
         abs_val = abs(val)
         if math.isclose(abs_val, 0.0, abs_tol=1e-100):
             return '0'

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -24,7 +24,6 @@ import logging
 import math
 
 import numpy as np
-import sympy
 
 try:
     from matplotlib import patches

--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -33,7 +33,7 @@ class DefaultStyle:
         self.fs = 13
         self.sfs = 8
         self.disptex = {
-            'id': 'id',
+            'id': 'Id',
             'u0': 'U_0',
             'u1': 'U_1',
             'u2': 'U_2',
@@ -123,7 +123,7 @@ class BWStyle:
         self.fs = 13
         self.sfs = 8
         self.disptex = {
-            'id': 'id',
+            'id': 'Id',
             'u0': 'U_0',
             'u1': 'U_1',
             'u2': 'U_2',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit addresses some of the style issues with the mpl drawer
outlined in #2319. There are 5 small style issues addressed by this
commit. The first is the subtext for parameters are now placed in
brackets. Secondly the label for the id gates is changed to have a
leading capital letter and read 'Id'. Then the output for the initialize
instruction is change to read '|psi>' instead of initialize and the
vector being used is printed. The unitary gate's label is also changed
to read 'U'. However, unlike the initialize instruction, the unitary
does not print the unitary matrix being used. This is because of spacing
concerns since the unitaries are typically going to be much larger (being
a square matrix). However, this may be addressed in a future commit. The
last style issue addressed by this is that the reset gate is updated to
not draw a box around the |0> anymore. Unlike the suggestion in the
issue on this change, the box is removed but the background is shaded
where the reset is on the circuit. Without this the reset looked like an
odd discontinuity in the circuit.

### Details and comments

Partially-addresses #2319
