### PR TITLE
optimization_level=0 without coupling map

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -85,8 +85,6 @@ def level_0_pass_manager(transpile_config):
     def _direction_condition(property_set):
         return not coupling_map.is_symmetric and not property_set['is_direction_mapped']
 
-    _direction = [CXDirection(coupling_map)]
-
     # 6. Remove zero-state reset
     _reset = RemoveResetInZeroState()
 
@@ -99,9 +97,9 @@ def level_0_pass_manager(transpile_config):
     if coupling_map:
         pm0.append(_swap_check)
         pm0.append(_swap, condition=_swap_condition)
-        # pm0.append(_direction_check)  # TODO
-        pm0.append(_direction, condition=_direction_condition)
+        pm0.append(CXDirection(coupling_map), condition=_direction_condition)
     pm0.append(_reset)
-    pm0.append(_direction)
+    if coupling_map:
+        pm0.append(CXDirection(coupling_map))
 
     return pm0

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -85,6 +85,8 @@ def level_0_pass_manager(transpile_config):
     def _direction_condition(property_set):
         return not coupling_map.is_symmetric and not property_set['is_direction_mapped']
 
+    _direction = [CXDirection(coupling_map)]
+
     # 6. Remove zero-state reset
     _reset = RemoveResetInZeroState()
 
@@ -97,9 +99,8 @@ def level_0_pass_manager(transpile_config):
     if coupling_map:
         pm0.append(_swap_check)
         pm0.append(_swap, condition=_swap_condition)
-        pm0.append(CXDirection(coupling_map), condition=_direction_condition)
+        # pm0.append(_direction_check)  # TODO
+        pm0.append(_direction, condition=_direction_condition)
     pm0.append(_reset)
-    if coupling_map:
-        pm0.append(CXDirection(coupling_map))
 
     return pm0

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests preset pass manager functionalities"""
+
+from qiskit.test import QiskitTestCase
+from qiskit.compiler import transpile
+from qiskit import QuantumCircuit, QuantumRegister
+
+
+class TestPresetPassManager(QiskitTestCase):
+    """Test preset passmanagers work as expected."""
+
+    def test_no_coupling_map(self):
+        """Test that coupling_map can be None"""
+        q = QuantumRegister(2, name='q')
+        test = QuantumCircuit(q)
+        test.cz(q[0],q[1])
+        for level in [0, 1, 2, 3]:
+            with self.subTest(level=level):
+                test2 = transpile(test, basis_gates=['u1','u2','u3','cx'],
+                                  optimization_level=level)
+                self.assertIsInstance(test2, QuantumCircuit)

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -26,9 +26,9 @@ class TestPresetPassManager(QiskitTestCase):
         """Test that coupling_map can be None"""
         q = QuantumRegister(2, name='q')
         test = QuantumCircuit(q)
-        test.cz(q[0],q[1])
+        test.cz(q[0], q[1])
         for level in [0, 1, 2, 3]:
             with self.subTest(level=level):
-                test2 = transpile(test, basis_gates=['u1','u2','u3','cx'],
+                test2 = transpile(test, basis_gates=['u1', 'u2', 'u3', 'cx'],
                                   optimization_level=level)
                 self.assertIsInstance(test2, QuantumCircuit)


### PR DESCRIPTION
The following code was failing because the same reason as https://github.com/Qiskit/qiskit-terra/issues/2421 in level 0.
```
backend = BasicAer.get_backend('qasm_simulator')

qr = QuantumRegister(3, 'q')
cr = ClassicalRegister(3, 'c')
circuit = QuantumCircuit(qr, cr, name='a_cx_to_map')
circuit.h(qr[1])
circuit.cx(qr[1], qr[2])
circuit.measure(qr, cr)

job_device = execute(circuit, backend, optimization_level=0)
```
The fixed is this PR.