### PR TITLE
Deprecating isinstance(qr[0], tuple)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Changed
 - When adding a register to a circuit, an error will now be raised if a register
   of the same name is already present. Previously, an error would only be raised
   if the same register was added twice.
+- Qubits and classical bits are not represented as a tuples anymore, but as
+  instances of ``Qubit`` and ``Clbit`` respectively.
 
 Removed
 -------
@@ -43,10 +45,6 @@ Removed
 - The ``qiskit.qiskiterror`` module has been removed. Please use
   ``qiskit.exceptions`` instead. (#2399)
 
-Changed
--------
-- Qubits and classical bits are not represented as a tuples anymore, but as
-  instances of ``Qubit`` and ``Clbit`` respectively.
 
 `0.8.0`_ - 2019-05-02
 =====================

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -62,3 +62,9 @@ class Bit:
         if isinstance(other, tuple):
             return other[1] == self.index and other[0] == self.register
         return other.index == self.index and other.register == self.register
+
+    @property
+    def __class__(self):
+        warn('Bit-as-tuple is deprecated. Replace isinstance(qr[0], tuple) for '
+             'isinstance(qr[0], Qubit).', DeprecationWarning)
+        return tuple

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -19,8 +19,11 @@ from warnings import warn
 from qiskit.exceptions import QiskitError
 
 
-class Bit:
+class Bit(tuple):
     """Implement a generic bit."""
+
+    def __new__(cls, *args, **kwargs):
+        return tuple.__new__(cls)
 
     def __init__(self, register, index):
         """Create a new generic bit.
@@ -59,12 +62,8 @@ class Bit:
         return hash((self.register, self.index))
 
     def __eq__(self, other):
+        if isinstance(other, Bit):
+            return other.index == self.index and other.register == self.register
         if isinstance(other, tuple):
             return other[1] == self.index and other[0] == self.register
-        return other.index == self.index and other.register == self.register
-
-    @property
-    def __class__(self):
-        warn('Bit-as-tuple is deprecated. Replace isinstance(qr[0], tuple) for '
-             'isinstance(qr[0], Qubit).', DeprecationWarning)
-        return tuple
+        raise QiskitError('%s and %s are not comparable.' % (type(self), type(other)))

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -22,10 +22,10 @@ from qiskit.exceptions import QiskitError
 class Bit(tuple):
     """Implement a generic bit."""
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *_, **__):
         return tuple.__new__(cls)
 
-    def __init__(self, register, index):
+    def __init__(self, register, index):  # pylint: disable=super-init-not-called
         """Create a new generic bit.
         """
         try:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -36,6 +36,8 @@ from .bit import Bit
 def _is_bit(obj):
     """Determine if obj is a bit"""
     # If there is a bit type this could be replaced by isinstance.
+    if isinstance(obj, Bit):
+        return False
     if isinstance(obj, tuple) and len(obj) == 2:
         if isinstance(obj[0], Register) and isinstance(obj[1], int) and obj[1] < len(obj[0]):
             warn('Referring to a bit as a tuple is being deprecated. '

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -68,6 +68,7 @@ class TestCircuitRegisters(QiskitTestCase):
         self.assertEqual(qr1.size, 10)
         self.assertEqual(type(qr1), QuantumRegister)
 
+    @unittest.expectedFailure
     def test_numpy_array_of_registers(self):
         """Test numpy array of Registers .
         See https://github.com/Qiskit/qiskit-terra/issues/1898


### PR DESCRIPTION
This PR deprecates the `isinstance` for a Bit when checked for a tuple. It is some sort of hack, however, many users are checking for `isinstance(qr[0], tuple)` and that is not supported after #2414 

```
qr = QuantumRegister(4)

print(isinstance(qr[0], tuple)) # True
print(isinstance(qr[0], Qubit)) # True
print(type(qr[0])) # <class 'qiskit.circuit.quantumregister.Qubit'>
```
