### PR TITLE
For each Acquire, create only one AcquireInstruction with all qubits

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -405,7 +405,8 @@ class QobjToInstructionConverter:
         if not isinstance(discriminators, list):
             discriminators = [discriminators]
         if any(discriminators[i] != discriminators[0] for i in range(len(discriminators))):
-            warnings.warn("Can currently only support one discriminator per acquire.")
+            warnings.warn("Can currently only support one discriminator per acquire. Defaulting "
+                          "to first discriminator entry.")
         discriminator = discriminators[0]
         if discriminator:
             discriminator = commands.Discriminator(name=discriminators[0].name,
@@ -416,7 +417,8 @@ class QobjToInstructionConverter:
         if not isinstance(kernels, list):
             kernels = [kernels]
         if any(kernels[0] != kernels[i] for i in range(len(kernels))):
-            warnings.warn("Can currently only support one kernel per acquire.")
+            warnings.warn("Can currently only support one kernel per acquire. Defaulting to first "
+                          "kernel entry.")
         kernel = kernels[0]
         if kernel:
             kernel = commands.Kernel(name=kernels[0].name, params=kernels[0].params)

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -16,6 +16,7 @@
 
 import re
 import math
+import warnings
 
 from sympy.parsing.sympy_parser import (parse_expr, standard_transformations,
                                         implicit_multiplication_application,
@@ -389,44 +390,41 @@ class QobjToInstructionConverter:
         t0 = instruction.t0
         duration = instruction.duration
         qubits = instruction.qubits
+        qubit_channels = [channels.AcquireChannel(qubit, buffer=self.buffer) for qubit in qubits]
+
+        mem_slots = [channels.MemorySlot(instruction.memory_slot[i]) for i in range(len(qubits))]
+
+        if hasattr(instruction, 'register_slot'):
+            register_slots = [channels.RegisterSlot(instruction.register_slot[i])
+                              for i in range(len(qubits))]
+        else:
+            register_slots = None
+
         discriminators = (instruction.discriminators
                           if hasattr(instruction, 'discriminators') else None)
+        if not isinstance(discriminators, list):
+            discriminators = [discriminators]
+        if any(discriminators[i] != discriminators[0] for i in range(len(discriminators))):
+            warnings.warn("Can currently only support one discriminator per acquire.")
+        discriminator = discriminators[0]
+        if discriminator:
+            discriminator = commands.Discriminator(name=discriminators[0].name,
+                                                   params=discriminators[0].params)
 
         kernels = (instruction.kernels
                    if hasattr(instruction, 'kernels') else None)
-
-        mem_slots = instruction.memory_slot
-        reg_slots = (instruction.register_slot
-                     if hasattr(instruction, 'register_slot') else None)
-
-        if not isinstance(discriminators, list):
-            discriminators = [discriminators for _ in range(len(qubits))]
-
         if not isinstance(kernels, list):
-            kernels = [kernels for _ in range(len(qubits))]
+            kernels = [kernels]
+        if any(kernels[0] != kernels[i] for i in range(len(kernels))):
+            warnings.warn("Can currently only support one kernel per acquire.")
+        kernel = kernels[0]
+        if kernel:
+            kernel = commands.Kernel(name=kernels[0].name, params=kernels[0].params)
 
+        cmd = commands.Acquire(duration, discriminator=discriminator, kernel=kernel)
         schedule = Schedule()
-
-        for i, qubit in enumerate(qubits):
-            kernel = kernels[i]
-            if kernel:
-                kernel = commands.Kernel(name=kernel.name,
-                                         params=kernel.params)
-
-            discriminator = discriminators[i]
-            if discriminator:
-                discriminator = commands.Discriminator(name=discriminator.name,
-                                                       params=discriminator.params)
-
-            channel = channels.AcquireChannel(qubit, buffer=self.buffer)
-            if reg_slots:
-                register_slot = channels.RegisterSlot(reg_slots[i])
-            else:
-                register_slot = None
-            memory_slot = channels.MemorySlot(mem_slots[i])
-
-            cmd = commands.Acquire(duration, discriminator=discriminator, kernel=kernel)
-            schedule |= commands.AcquireInstruction(cmd, channel, memory_slot, register_slot) << t0
+        schedule |= commands.AcquireInstruction(cmd, qubit_channels, mem_slots,
+                                                register_slots) << t0
 
         return schedule
 

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -120,6 +120,36 @@ class TestInstructionToQobjConverter(QiskitTestCase):
 
         self.assertEqual(converter(0, instruction), valid_qobj)
 
+    def test_acquire_multi_q(self):
+        """Test converted qobj from AcquireInstruction with many qubits."""
+        converter = InstructionToQobjConverter(PulseQobjInstruction, meas_level=2)
+        command = Acquire(duration=10)
+        instruction = command(self.device.q, self.device.mem, self.device.c)
+
+        valid_qobj = PulseQobjInstruction(
+            name='acquire',
+            t0=0,
+            duration=10,
+            qubits=[0, 1, 2, 3],
+            memory_slot=[0, 1, 2, 3],
+            register_slot=[0, 1, 2, 3]
+        )
+
+        self.assertEqual(converter(0, instruction), valid_qobj)
+
+        # test without register
+        instruction = command(self.device.q, self.device.mem)
+
+        valid_qobj = PulseQobjInstruction(
+            name='acquire',
+            t0=0,
+            duration=10,
+            qubits=[0],
+            memory_slot=[0]
+        )
+
+        self.assertEqual(converter(0, instruction), valid_qobj)
+
     def test_snapshot(self):
         """Test converted qobj from SnapShot."""
         converter = InstructionToQobjConverter(PulseQobjInstruction, meas_level=2)

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -120,36 +120,6 @@ class TestInstructionToQobjConverter(QiskitTestCase):
 
         self.assertEqual(converter(0, instruction), valid_qobj)
 
-    def test_acquire_multi_q(self):
-        """Test converted qobj from AcquireInstruction with many qubits."""
-        converter = InstructionToQobjConverter(PulseQobjInstruction, meas_level=2)
-        command = Acquire(duration=10)
-        instruction = command(self.device.q, self.device.mem, self.device.c)
-
-        valid_qobj = PulseQobjInstruction(
-            name='acquire',
-            t0=0,
-            duration=10,
-            qubits=[0, 1, 2, 3],
-            memory_slot=[0, 1, 2, 3],
-            register_slot=[0, 1, 2, 3]
-        )
-
-        self.assertEqual(converter(0, instruction), valid_qobj)
-
-        # test without register
-        instruction = command(self.device.q, self.device.mem)
-
-        valid_qobj = PulseQobjInstruction(
-            name='acquire',
-            t0=0,
-            duration=10,
-            qubits=[0],
-            memory_slot=[0]
-        )
-
-        self.assertEqual(converter(0, instruction), valid_qobj)
-
     def test_snapshot(self):
         """Test converted qobj from SnapShot."""
         converter = InstructionToQobjConverter(PulseQobjInstruction, meas_level=2)
@@ -177,13 +147,16 @@ class TestQobjToInstructionConverter(QiskitTestCase):
 
         self.device = DeviceSpecification(
             qubits=[
-                Qubit(0, DriveChannel(0), MeasureChannel(0), AcquireChannel(0))
+                Qubit(0, DriveChannel(0), MeasureChannel(0), AcquireChannel(0)),
+                Qubit(1, DriveChannel(1), MeasureChannel(1), AcquireChannel(1)),
             ],
             registers=[
-                RegisterSlot(0)
+                RegisterSlot(0),
+                RegisterSlot(1)
             ],
             mem_slots=[
-                MemorySlot(0)
+                MemorySlot(0),
+                MemorySlot(1)
             ]
         )
 
@@ -226,8 +199,8 @@ class TestQobjToInstructionConverter(QiskitTestCase):
                       Kernel(name='test_kern', params={'test_params': 'test'}))
         instruction = cmd(self.device.q, self.device.mem, self.device.c)
 
-        qobj = PulseQobjInstruction(name='acquire', t0=0, duration=10, qubits=[0],
-                                    memory_slot=[0], register_slot=[0],
+        qobj = PulseQobjInstruction(name='acquire', t0=0, duration=10, qubits=[0, 1],
+                                    memory_slot=[0, 1, 2], register_slot=[0, 1],
                                     kernels=[QobjMeasurementOption(
                                         name='test_kern', params={'test_params': 'test'})],
                                     discriminators=[QobjMeasurementOption(

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -200,7 +200,7 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         instruction = cmd(self.device.q, self.device.mem, self.device.c)
 
         qobj = PulseQobjInstruction(name='acquire', t0=0, duration=10, qubits=[0, 1],
-                                    memory_slot=[0, 1, 2], register_slot=[0, 1],
+                                    memory_slot=[0, 1], register_slot=[0, 1],
                                     kernels=[QobjMeasurementOption(
                                         name='test_kern', params={'test_params': 'test'})],
                                     discriminators=[QobjMeasurementOption(


### PR DESCRIPTION
…tion for all involved qubits, rather than one per each qubit.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2471 


### Details and comments
Join all converted acquire instructions (in qiskit/qobj/converters/pulse_instruction.py) into a single acquire instruction.

