### PR TITLE
[Stable] For each Acquire, create only one AcquireInstruction with all qubits

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -8,6 +8,7 @@
 """Helper class used to convert a pulse instruction into PulseQobjInstruction."""
 import re
 import math
+import warnings
 
 from sympy.parsing.sympy_parser import (parse_expr, standard_transformations,
                                         implicit_multiplication_application,
@@ -380,44 +381,43 @@ class QobjToInstructionConverter:
         t0 = instruction.t0
         duration = instruction.duration
         qubits = instruction.qubits
+        qubit_channels = [channels.AcquireChannel(qubit, buffer=self.buffer) for qubit in qubits]
+
+        mem_slots = [channels.MemorySlot(instruction.memory_slot[i]) for i in range(len(qubits))]
+
+        if hasattr(instruction, 'register_slot'):
+            register_slots = [channels.RegisterSlot(instruction.register_slot[i])
+                              for i in range(len(qubits))]
+        else:
+            register_slots = None
+
         discriminators = (instruction.discriminators
                           if hasattr(instruction, 'discriminators') else None)
+        if not isinstance(discriminators, list):
+            discriminators = [discriminators]
+        if any(discriminators[i] != discriminators[0] for i in range(len(discriminators))):
+            warnings.warn("Can currently only support one discriminator per acquire. Defaulting "
+                          "to first discriminator entry.")
+        discriminator = discriminators[0]
+        if discriminator:
+            discriminator = commands.Discriminator(name=discriminators[0].name,
+                                                   params=discriminators[0].params)
 
         kernels = (instruction.kernels
                    if hasattr(instruction, 'kernels') else None)
-
-        mem_slots = instruction.memory_slot
-        reg_slots = (instruction.register_slot
-                     if hasattr(instruction, 'register_slot') else None)
-
-        if not isinstance(discriminators, list):
-            discriminators = [discriminators for _ in range(len(qubits))]
-
         if not isinstance(kernels, list):
-            kernels = [kernels for _ in range(len(qubits))]
+            kernels = [kernels]
+        if any(kernels[0] != kernels[i] for i in range(len(kernels))):
+            warnings.warn("Can currently only support one kernel per acquire. Defaulting to first "
+                          "kernel entry.")
+        kernel = kernels[0]
+        if kernel:
+            kernel = commands.Kernel(name=kernels[0].name, params=kernels[0].params)
 
+        cmd = commands.Acquire(duration, discriminator=discriminator, kernel=kernel)
         schedule = Schedule()
-
-        for i, qubit in enumerate(qubits):
-            kernel = kernels[i]
-            if kernel:
-                kernel = commands.Kernel(name=kernel.name,
-                                         params=kernel.params)
-
-            discriminator = discriminators[i]
-            if discriminator:
-                discriminator = commands.Discriminator(name=discriminator.name,
-                                                       params=discriminator.params)
-
-            channel = channels.AcquireChannel(qubit, buffer=self.buffer)
-            if reg_slots:
-                register_slot = channels.RegisterSlot(reg_slots[i])
-            else:
-                register_slot = None
-            memory_slot = channels.MemorySlot(mem_slots[i])
-
-            cmd = commands.Acquire(duration, discriminator=discriminator, kernel=kernel)
-            schedule |= commands.AcquireInstruction(cmd, channel, memory_slot, register_slot) << t0
+        schedule |= commands.AcquireInstruction(cmd, qubit_channels, mem_slots,
+                                                register_slots) << t0
 
         return schedule
 

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -142,13 +142,16 @@ class TestQobjToInstructionConverter(QiskitTestCase):
 
         self.device = DeviceSpecification(
             qubits=[
-                Qubit(0, DriveChannel(0), MeasureChannel(0), AcquireChannel(0))
+                Qubit(0, DriveChannel(0), MeasureChannel(0), AcquireChannel(0)),
+                Qubit(1, DriveChannel(1), MeasureChannel(1), AcquireChannel(1)),
             ],
             registers=[
-                RegisterSlot(0)
+                RegisterSlot(0),
+                RegisterSlot(1)
             ],
             mem_slots=[
-                MemorySlot(0)
+                MemorySlot(0),
+                MemorySlot(1)
             ]
         )
 
@@ -191,8 +194,8 @@ class TestQobjToInstructionConverter(QiskitTestCase):
                       Kernel(name='test_kern', params={'test_params': 'test'}))
         instruction = cmd(self.device.q, self.device.mem, self.device.c)
 
-        qobj = PulseQobjInstruction(name='acquire', t0=0, duration=10, qubits=[0],
-                                    memory_slot=[0], register_slot=[0],
+        qobj = PulseQobjInstruction(name='acquire', t0=0, duration=10, qubits=[0, 1],
+                                    memory_slot=[0, 1], register_slot=[0, 1],
                                     kernels=[QobjMeasurementOption(
                                         name='test_kern', params={'test_params': 'test'})],
                                     discriminators=[QobjMeasurementOption(


### PR DESCRIPTION
### Summary
Fixes #2471

### Details and comments
Join all converted acquire instructions (in qiskit/qobj/converters/pulse_instruction.py) into a single acquire instruction.

Backport of #2484.