### PR TITLE
Fix graphviz check in pass manager visualization

### DIFF
--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -23,9 +23,14 @@ DEFAULT_STYLE = {AnalysisPass: 'red',
 
 try:
     import subprocess
-    print(subprocess.check_output(['dot', '-V']))
-    HAS_GRAPHVIZ = True
-except FileNotFoundError:
+    proc = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE)
+    proc.communicate()
+    if proc.returncode != 0:
+        HAS_GRAPHVIZ = False
+    else:
+        HAS_GRAPHVIZ = True
+except Exception:
     # this is raised when the dot command cannot be found, which means GraphViz
     # isn't installed
     HAS_GRAPHVIZ = False

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -23,14 +23,14 @@ DEFAULT_STYLE = {AnalysisPass: 'red',
 
 try:
     import subprocess
-    proc = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
-    proc.communicate()
-    if proc.returncode != 0:
+    _PROC = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+    _PROC.communicate()
+    if _PROC.returncode != 0:
         HAS_GRAPHVIZ = False
     else:
         HAS_GRAPHVIZ = True
-except Exception:
+except Exception:  # pylint: disable=broad-except
     # this is raised when the dot command cannot be found, which means GraphViz
     # isn't installed
     HAS_GRAPHVIZ = False


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the graphviz check in the pass manager visualization
added recently in #2445. The check was added to determine if the dot
command was in the default PATH by trying to subprocess out and run
'dot -V' however the way in which subprocess was called results in both
the dot version string and a blank line being printed if graphviz is
actually installed. This happens on import time which we definitely
don't want to do (and breaks test discovery in stestr). This commit addresses
that by updating the subprocess call to redirect stdout and stderr, but it also
loosens the exception catch to never raise, if anything fails during the attempt
to run dot we should not treat that as fatal, instead just say we don't have
graphviz.

### Details and comments


