### PR TITLE
Fix unconditional pillow import

### DIFF
--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -14,10 +14,15 @@
 
 """Common visualization utilities."""
 
-import PIL
 import numpy as np
 from qiskit.converters import circuit_to_dag
 from qiskit.visualization.exceptions import VisualizationError
+
+try:
+    import PIL
+    HAS_PIL = True
+except ImportError:
+    HAS_PIL = False
 
 
 def _validate_input_state(quantum_state):
@@ -46,6 +51,10 @@ def _validate_input_state(quantum_state):
 
 def _trim(image):
     """Trim a PIL image and remove white space."""
+    if not HAS_PIL:
+        raise ImportError('The latex drawer needs pillow installed. '
+                          'Run "pip install pillow" before using the '
+                          'latex drawer.')
     background = PIL.Image.new(image.mode, image.size, image.getpixel((0, 0)))
     diff = PIL.ImageChops.difference(image, background)
     diff = PIL.ImageChops.add(diff, diff, 2.0, -100)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2451 we made both pillow and pylatexenc optional requirements just
for users who wanted to use latex visualizations. However in that patch
we missed a place where pillow was being imported unconditionally at the
module level. This causes an exception to be raised whenever someone
import's qiskit without pillow installed. This commit fixes this by
handling the ImportError raised by a missing pillow and raising a more
detailed ImportError if/when a user tries to use the sole function that
needs pillow.

### Details and comments