### PR TITLE
Fix issue #2449 - Pulse figure not closed before return

### DIFF
--- a/qiskit/visualization/pulse_visualization.py
+++ b/qiskit/visualization/pulse_visualization.py
@@ -66,6 +66,9 @@ def pulse_drawer(data, dt=1, style=None, filename=None,
     if filename:
         image.savefig(filename, dpi=drawer.style.dpi, bbox_inches='tight')
 
+    _matplotlib.plt.close(image)
+        
     if image and interactive:
         image.show()
+        
     return image


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We need to close the figure before return it.

### Details and comments


