### PR TITLE
[Stable] Remove call to CXDirection if necessary

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -105,9 +105,13 @@ def level_3_pass_manager(transpile_config):
 
     _opt = [RemoveResetInZeroState(),
             Collect2qBlocks(), ConsolidateBlocks(),
-            Unroller(basis_gates), CXDirection(coupling_map),  # unroll unitaries and match coupling
+            Unroller(basis_gates),  # unroll unitaries
             Optimize1qGates(), CommutativeCancellation(),
             OptimizeSwapBeforeMeasure(), RemoveDiagonalGatesBeforeMeasure()]
+
+    if coupling_map:
+        _opt.append(CXDirection(coupling_map))
+        # if a coupling map has been provided, match coupling
 
     pm3 = PassManager()
     if coupling_map:


### PR DESCRIPTION
Stable backport of #2434 -- this is needed to make #2509 work on stable. Both PRs are bug fixes. One fixes level0 and one fixes level3.