### PR TITLE
[Stable] Determine row spacing properly

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -222,6 +222,18 @@ class QCircuitImage:
         """
 
         max_column_widths = []
+        # Determine row spacing before image depth
+        for layer in self.ops:
+            for op in layer:
+                # useful information for determining row spacing
+                boxed_gates = ['u0', 'u1', 'u2', 'u3', 'x', 'y', 'z', 'h', 's',
+                               'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'ch', 'cy',
+                               'crz', 'cu3', 'id']
+                target_gates = ['cx', 'ccx']
+                if op.name in boxed_gates:
+                    self.has_box = True
+                if op.name in target_gates:
+                    self.has_target = True
 
         for layer in self.ops:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the large refactor adding column justification to the latex
drawer in #1977 the function used to determine the image depth was
greatly simplified since most of the work was offset to the dag
processing prior to the latex drawer. However, one piece of critical
code was removed inadvertently which was used for determining the row
spacing. This section looked at every operation and determined if we
should increase or decrease the row spacing depending on what time of
operations were being drawn. The result of this check end up directly
setting a value in the output latex call to \Qcircuit. Without this code
the calculations which are done to determine the output page size are
off by the spacing factor and result in the output circuit exceeding the
single page size. This causes a blank image to be output since the first
is blank and that leads pdf to png conversion to return a blank image.

This commit fixes this by adding back the previously removed row spacing
check before we determine the image depth. This way we properly set the
output row spacing in the latex and avoid page wraps.

(cherry picked from commit 8609f7ae36d08e4f7d7173e26131896ae75ddc6b)

### Details and comments

Fixes #2155

Backported from #2299