### PR TITLE
FakePoughkeepsie in qiskit/test/mock.py

### DIFF
--- a/qiskit/test/mock.py
+++ b/qiskit/test/mock.py
@@ -403,6 +403,35 @@ class FakeTokyo(FakeBackend):
         super().__init__(configuration)
 
 
+class FakePoughkeepsie(FakeBackend):
+    """A fake Poughkeepsie backend."""
+
+    def __init__(self):
+        cmap = [[0, 1], [0, 5], [1, 0], [1, 2], [2, 1], [2, 3], [3, 2], [3, 4], [4, 3], [4, 9],
+                [5, 0], [5, 6], [5, 10], [6, 5], [6, 7], [7, 6], [7, 8], [7, 12], [8, 7], [8, 9],
+                [9, 4], [9, 8], [9, 14], [10, 5], [10, 11], [10, 15], [11, 10], [11, 12], [12, 7],
+                [12, 11], [12, 13], [13, 12], [13, 14], [14, 9], [14, 13], [14, 19], [15, 10],
+                [15, 16], [16, 15], [16, 17], [17, 16], [17, 18], [18, 17], [18, 19], [19, 14],
+                [19, 18]]
+
+        configuration = QasmBackendConfiguration(
+            backend_name='fake_poughkeepsie',
+            backend_version='0.0.0',
+            n_qubits=20,
+            basis_gates=['u1', 'u2', 'u3', 'cx', 'id'],
+            simulator=False,
+            local=True,
+            conditional=False,
+            open_pulse=False,
+            memory=True,
+            max_shots=8192,
+            gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
+            coupling_map=cmap,
+        )
+
+        super().__init__(configuration)
+
+
 class FakeJob(BaseJob):
     """Fake simulator job"""
     _executor = futures.ProcessPoolExecutor()


### PR DESCRIPTION
This PR extends the `FakeBackend`s in `qiskit/test/mock.py` with `FakePoughkeepsie`, since sometimes we receive issues in this backend.