### PR TITLE
Do schema validation once at validator init, rather than at every use

### DIFF
--- a/qiskit/validation/jsonschema/schema_validation.py
+++ b/qiskit/validation/jsonschema/schema_validation.py
@@ -88,19 +88,16 @@ def _get_validator(name, schema=None, check_schema=True,
                                         "be provided.")
 
     if name not in _VALIDATORS:
-
         # Resolve JSON spec from schema if needed
         if validator_class is None:
             validator_class = jsonschema.validators.validator_for(schema)
 
         # Generate and store validator in _VALIDATORS
         _VALIDATORS[name] = validator_class(schema, **validator_kwargs)
+        if check_schema:
+            _VALIDATORS[name].check_schema(schema)
 
     validator = _VALIDATORS[name]
-
-    if check_schema:
-        validator.check_schema(schema)
-
     return validator
 
 


### PR DESCRIPTION
This knocks off about 50s from running the test suite on my laptop and should give a huge speed improvement on use cases where there a large number of small circuits, where validation takes the majority of the time. Previously about 75% of the cost of validation was checking the schema against it's meta schema. Since we cache validators, this does not need to be done on every use. This patch changes the validation against meta schema to be a one-time deal at load time.

Possibly we could go further and change `check_schema` to default to `False`. This would speed up `import qiskit` by a tiny amount and any errors should still be caught by the `test_schemas_are_valid` testcase.