### PR TITLE
Speed up test_synthesis and fix non-CNOT decompose

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,10 @@ Removed
 - The ``qiskit.qiskiterror`` module has been removed. Please use
   ``qiskit.exceptions`` instead. (#2399)
 
+Fixed
+-----
+-  Possible to decompose SU(4) gate into non-CNOT basis with ``TwoQubitDecomposer``
+
 
 `0.8.0`_ - 2019-05-02
 =====================

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -451,7 +451,7 @@ class TwoQubitBasisDecomposer():
         for i in range(best_nbasis):
             return_circuit.append(U3Gate(*decomposition_angles[2*i]), [q[0]])
             return_circuit.append(U3Gate(*decomposition_angles[2*i+1]), [q[1]])
-            return_circuit.append(CnotGate(), [q[0], q[1]])
+            return_circuit.append(self.gate, [q[0], q[1]])
         return_circuit.append(U3Gate(*decomposition_angles[2*best_nbasis]), [q[0]])
         return_circuit.append(U3Gate(*decomposition_angles[2*best_nbasis+1]), [q[1]])
 


### PR DESCRIPTION
* Change test_synthesis to use operator.compose in most cases instead of UnitarySimulatorPy (gives around a 9x speedup for the tests)
* Fix TwoQubitBasisDecomposer to correctly decompose into non-CNOT basis (and mark relevant test as expected to pass)
