### PR TITLE
Added utility function backend_get_qubit_params

### DIFF
--- a/qiskit/tools/monitor/backend_overview.py
+++ b/qiskit/tools/monitor/backend_overview.py
@@ -216,6 +216,7 @@ def backend_get_qubit_params(backend):
     if config['simulator']:
         print('Warning: A simulator backend was passed in place of a device backend.\
               These backend properties only apply to devices and not to simulators.')
+        return
     
     # Extract relevant properties
     RES  = OrderedDict()
@@ -225,7 +226,7 @@ def backend_get_qubit_params(backend):
         for prop in props['qubits'][qnum]:
             # T1, T2, freq, ro_err
             RES[qnum][prop['name']] = prop['value']
-            # Gate error -- asumes structure is u1, u2, u3 first for all single q gates
+            # Gate error -- assumes structure is u1, u2, u3 first for all single q gates
             gates = props['gates'][3*qnum:3*qnum+3]
             for gate in gates:
                 RES[qnum][gate['gate']+'_err'] = gate['parameters'][0]['value']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Added utility to return all relevant single-qubit parameters as a pandas DataFrame object, which can easily be manipulated, sorted, queried.


### Details and comments

Example use 
```python 
### Standard import 
from qiskit import IBMQ
IBMQ.load_accounts()
backend = IBMQ.get_backend('ibmq_16_melbourne')

### Example use 
df = backend_get_qubit_params_df(backend)
df.sort_values('T2', ascending=False).style.set_precision(3)
```

Example output of qubit data sorted by T2:
![image](https://user-images.githubusercontent.com/15937254/58752998-3b7c5980-8486-11e9-8dcf-39ff06110418.png)

