### PR TITLE
Adding the split_statevector_simulator to the available backends.

### DIFF
--- a/qiskit/providers/basicaer/basicaerprovider.py
+++ b/qiskit/providers/basicaer/basicaerprovider.py
@@ -26,6 +26,7 @@ from qiskit.providers.providerutils import resolve_backend_name, filter_backends
 from .qasm_simulator import QasmSimulatorPy
 from .statevector_simulator import StatevectorSimulatorPy
 from .unitary_simulator import UnitarySimulatorPy
+from .split_statevector_simulator import SplitStatevectorSimulatorPy
 
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,8 @@ logger = logging.getLogger(__name__)
 SIMULATORS = [
     QasmSimulatorPy,
     StatevectorSimulatorPy,
-    UnitarySimulatorPy
+    UnitarySimulatorPy,
+    SplitStatevectorSimulatorPy
 ]
 
 

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -139,7 +139,8 @@ class QasmSimulatorPy(BaseBackend):
         self._sample_measure = False
 
         if self.SPLIT_STATES:
-            # _substates field will contain 2 statevectors corresponding to measurement results 0 and 1
+            # _substates field will contain 2 statevectors corresponding to 
+            # measurement results 0 and 1
             self._substates = []
             self._substate_probabilities = []
 

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -139,7 +139,7 @@ class QasmSimulatorPy(BaseBackend):
         self._sample_measure = False
 
         if self.SPLIT_STATES:
-            # _substates field will contain 2 statevectors corresponding to 
+            # _substates field will contain 2 statevectors corresponding to
             # measurement results 0 and 1
             self._substates = []
             self._substate_probabilities = []

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -117,12 +117,11 @@ class QasmSimulatorPy(BaseBackend):
     # This should be set to True for the split_statevector_simulator
     SPLIT_STATES = False
 
-
     def __init__(self, configuration=None, provider=None):
         super().__init__(configuration=(
             configuration or QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
-        
+
         # Define attributes in __init__.
         self._local_random = np.random.RandomState()
         self._classical_memory = 0
@@ -135,10 +134,8 @@ class QasmSimulatorPy(BaseBackend):
         self._initial_statevector = self.DEFAULT_OPTIONS["initial_statevector"]
         self._chop_threshold = self.DEFAULT_OPTIONS["chop_threshold"]
         self._qobj_config = None
-
         # TEMP
         self._sample_measure = False
-            
 
     def _add_unitary_single(self, gate, qubit):
         """Apply an arbitrary 1-qubit unitary matrix.
@@ -266,7 +263,7 @@ class QasmSimulatorPy(BaseBackend):
         This is done by doing a simulating a measurement
         outcome and projecting onto the outcome state while
         renormalizing.
-        """    
+        """
         # update classical state
         membit = 1 << cmembit
         self._classical_memory = (self._classical_memory & (~membit)) | (int(outcome) << cmembit)
@@ -566,7 +563,7 @@ class QasmSimulatorPy(BaseBackend):
                 'time_taken': (end - start),
                 'header': experiment.header.as_dict()}
 
-    def _run_single_shot(self, experiment, memory, measure_sample_ops, op_idx = 0):
+    def _run_single_shot(self, experiment, memory, measure_sample_ops, op_idx=0):
         """Run a single shot of the experiment circuit.
 
         Args:
@@ -577,7 +574,6 @@ class QasmSimulatorPy(BaseBackend):
         """
         for i in range(op_idx, len(experiment.instructions)):
             operation = experiment.instructions[i]
-            #for operation in experiment.instructions:
             conditional = getattr(operation, 'conditional', None)
             if isinstance(conditional, int):
                 conditional_bit_set = (self._classical_register >> conditional) & 1
@@ -669,8 +665,10 @@ class QasmSimulatorPy(BaseBackend):
                 raise BasicAerError(err_msg.format(backend, operation.name))
 
         if self.SPLIT_STATES and len(self._substates) != 0:
-            self._substates[0]._run_single_shot(experiment, memory, measure_sample_ops, op_idx = i + 1)
-            self._substates[1]._run_single_shot(experiment, memory, measure_sample_ops, op_idx = i + 1)
+            self._substates[0]._run_single_shot(experiment, memory,
+                                                measure_sample_ops, op_idx=i + 1)
+            self._substates[1]._run_single_shot(experiment, memory,
+                                                measure_sample_ops, op_idx=i + 1)
         # Add final creg data to memory list
         if self._number_of_cmembits > 0:
             if self._sample_measure:
@@ -680,7 +678,7 @@ class QasmSimulatorPy(BaseBackend):
                 # Turn classical_memory (int) into bit string and pad zero for unused cmembits
                 outcome = bin(self._classical_memory)[2:]
                 memory.append(hex(int(outcome, 2)))
-    
+
     def _validate(self, qobj):
         """Semantic validations of the qobj which cannot be done via schemas."""
         n_qubits = qobj.config.n_qubits

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -113,7 +113,7 @@ class QasmSimulatorPy(BaseBackend):
     # This should be set to True for the statevector simulator
     SHOW_FINAL_STATE = False
 
-    # SSS: Class level variable to determine whether to split the statevector upon measurement
+    # Class level variable to determine whether to split the statevector upon measurement
     # This should be set to True for the split_statevector_simulator
     SPLIT_STATES = False
 
@@ -242,22 +242,20 @@ class QasmSimulatorPy(BaseBackend):
             cmembit (int): is the classical memory bit to store outcome in.
             cregbit (int, optional): is the classical register bit to store outcome in.
         """
-        # SSS: Checking whether the probabilities are nonzero in order to run the split
+        # Checking whether the probabilities are nonzero in order to run the split
         axis = list(range(self._number_of_qubits))
         axis.remove(self._number_of_qubits - 1 - qubit)
         probabilities = np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis))
         if (self.SPLIT_STATES and probabilities[0] != 0 and probabilities[1] != 0):
             self._split_statevector(qubit, probabilities, cmembit, cregbit)
         else:
-            # SSS: moved this part into the refactored function _update_after_measure
             # get measure outcome
             outcome, probability = self._get_measure_outcome(qubit)
             # update classical state
             self._update_state_after_measure(qubit, cmembit, outcome, probability, cregbit)
 
-    # SSS: Refactor of _add_qasm_measure
     def _update_state_after_measure(self, qubit, cmembit, outcome, probability, cregbit):
-        """Apply a reset instruction to a qubit.
+        """Update the statevector to the collapsed measured state.
 
         Args:
             qubit (int): qubit is the qubit measured.
@@ -472,7 +470,6 @@ class QasmSimulatorPy(BaseBackend):
 
         return Result.from_dict(result)
 
-    # SSS: Refactored _run_single_shot
     def run_experiment(self, experiment):
         """Run an experiment (circuit) and return a single experiment result.
 
@@ -528,12 +525,9 @@ class QasmSimulatorPy(BaseBackend):
 
         # Store (qubit, cmembit) pairs for all measure ops in circuit to
         # be sampled
-        # SSS: Moved the assignment into measure_sample_ops out of the condition in order to accomodate the refactor into
-        # _run_single_shot method
         measure_sample_ops = []
         if self._sample_measure:
             shots = 1
-
         else:
             shots = self._shots
         for _ in range(shots):
@@ -572,7 +566,6 @@ class QasmSimulatorPy(BaseBackend):
                 'time_taken': (end - start),
                 'header': experiment.header.as_dict()}
 
-    # SSS: Refactored from existing code to allow flexibility
     def _run_single_shot(self, experiment, memory, measure_sample_ops, op_idx = 0):
         """Run a single shot of the experiment circuit.
 
@@ -582,7 +575,6 @@ class QasmSimulatorPy(BaseBackend):
         Raises:
             BasicAerError: if an error occurred.
         """
-        # SSS: Changing to run with index parameter
         for i in range(op_idx, len(experiment.instructions)):
             operation = experiment.instructions[i]
             #for operation in experiment.instructions:
@@ -635,7 +627,7 @@ class QasmSimulatorPy(BaseBackend):
                 else:
                     # If not sampling perform measurement as normal
                     self._add_qasm_measure(qubit, cmembit, cregbit)
-                # SSS: Checking whether the statevector was split
+                # Checking whether the statevector was split
                 if self.SPLIT_STATES and len(self._substates) != 0:
                     break
             elif operation.name == 'bfunc':

--- a/qiskit/providers/basicaer/split_statevector_simulator.py
+++ b/qiskit/providers/basicaer/split_statevector_simulator.py
@@ -94,7 +94,7 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         ]
     }
 
-    # SSS: This should be set to True to use multiverse reperesentation for measurments
+    # This should be set to True to use the split statevector reperesentation for measurments
     SPLIT_STATES = True
 
     
@@ -102,7 +102,7 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         super().__init__(configuration=(
             configuration or QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
-        # SSS: Substates field will contain 2 sons to split the statevector into two (parallel universe) statevectors.
+        # _substates field will contain 2 statevectors corresponding to measurement results 0 and 1
         self._substates = []
         self._substate_probabilities = []
 
@@ -140,7 +140,6 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         """
         return super().run(qobj, backend_options=backend_options)
 
-    # SSS: Getting only the desired result (0 or 1)
     def _get_single_outcome(self, qubit, wanted_state):
         """Simulate the outcome of a determined measurement of a qubit. 
         This function mainly exists to perserve the existing function division, 

--- a/qiskit/providers/basicaer/split_statevector_simulator.py
+++ b/qiskit/providers/basicaer/split_statevector_simulator.py
@@ -13,8 +13,9 @@
 # that they have been altered from the originals.
 
 
-"""Contains a (slow) python statevector simulator which splits for every non-zero probability measurement
+"""Contains a (slow) python split statevector simulator.
 
+The simulator splits for every non-zero probability measurement.
 It simulates the statevector through a quantum circuit. It is exponential in
 the number of qubits, and in the number of non-zero probability measurements within the circuit.
 
@@ -24,7 +25,8 @@ The input is a qobj dictionary and the output is a Result object.
 
 The input qobj to this simulator has no shots, no reset, no noise.
 
-The final result is a dictionary containing a binary tree data structure for the different splits, kept under statevector_tree
+The final result is a dictionary containing a binary tree data structure
+for the different splits, kept under statevector_tree
 """
 
 import logging
@@ -97,7 +99,6 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
     # This should be set to True to use the split statevector reperesentation for measurments
     SPLIT_STATES = True
 
-    
     def __init__(self, configuration=None, provider=None):
         super().__init__(configuration=(
             configuration or QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
@@ -141,8 +142,8 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         return super().run(qobj, backend_options=backend_options)
 
     def _get_single_outcome(self, qubit, wanted_state):
-        """Simulate the outcome of a determined measurement of a qubit. 
-        This function mainly exists to perserve the existing function division, 
+        """Simulate the outcome of a determined measurement of a qubit.
+        This function mainly exists to perserve the existing function division,
         replacing _get_measure_outcome which is called for the other simulators
 
         Args:
@@ -185,8 +186,10 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         self._substate_probabilities.append(probabilities[1])
 
         # Updating the states after the split
-        self._substates[0]._update_state_after_measure(qubit, cmembit, outcome0, probability0, cregbit)
-        self._substates[1]._update_state_after_measure(qubit, cmembit, outcome1, probability1, cregbit)
+        self._substates[0]._update_state_after_measure(qubit, cmembit,
+                                                       outcome0, probability0, cregbit)
+        self._substates[1]._update_state_after_measure(qubit, cmembit,
+                                                       outcome1, probability1, cregbit)
 
     def _generate_data(self):
         """Run an experiment (circuit) and return a single experiment result.
@@ -195,18 +198,18 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
             experiment (QobjExperiment): experiment from qobj experiments list
 
         Returns:
-             data: A result dictionary in the form of a binary tree which looks something like::
+             data: A result dictionary in the form of a binary tree which looks something like:
 
                 {
                 "value": The statevector of the state at the first measurement
                 "prob_0": The probability to get a measurement of 0 at the first measurement
                 "prob_1": The probability to get a measurement of 1 at the first measurement
-                "path_0": 
+                "path_0":
                     {
                         "value": The statevector evolved from result 0 in the first measurement,
                                  at the second measurement or at the end of the circuit
-                        "prob_0": The probability to get a measurement of 0 at the second measurement
-                        "prob_1": The probability to get a measurement of 1 at the second measurement
+                        "prob_0": The probability for a measurement of 0 at the second measurement
+                        "prob_1": The probability for a measurement of 1 at the second measurement
                         "path_0":
                             {
                                 ...
@@ -223,13 +226,16 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
                 }
         Raises:
             BasicAerError: if an error occurred.
-        """    
+        """
         if len(self._substates) != 0:
             data = {'value': self._get_statevector(),
-                    'path_0': self._substates[0]._generate_data(), 'path_0_probability': self._substate_probabilities[0],
-                    'path_1': self._substates[1]._generate_data(), 'path_1_probability': self._substate_probabilities[1]}
+                    'path_0': self._substates[0]._generate_data(),
+                    'path_0_probability': self._substate_probabilities[0],
+                    'path_1': self._substates[1]._generate_data(),
+                    'path_1_probability': self._substate_probabilities[1]}
         else:
             data = {'value': self._get_statevector()}
         
         return data
+
     # TODO: Add a _validate method

--- a/qiskit/providers/basicaer/split_statevector_simulator.py
+++ b/qiskit/providers/basicaer/split_statevector_simulator.py
@@ -30,13 +30,9 @@ for the different splits, kept under statevector_tree
 """
 
 import logging
-import copy
 from math import log2
-import numpy as np
 from qiskit.util import local_hardware_info
-from qiskit.providers.basicaer.exceptions import BasicAerError
 from qiskit.providers.models import QasmBackendConfiguration
-from .qasm_simulator import QasmSimulatorPy
 from .statevector_simulator import StatevectorSimulatorPy
 
 logger = logging.getLogger(__name__)
@@ -103,9 +99,6 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         super().__init__(configuration=(
             configuration or QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
                          provider=provider)
-        # _substates field will contain 2 statevectors corresponding to measurement results 0 and 1
-        self._substates = []
-        self._substate_probabilities = []
 
     def run(self, qobj, backend_options=None):
         """Run qobj asynchronously.
@@ -140,102 +133,5 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
                 }
         """
         return super().run(qobj, backend_options=backend_options)
-
-    def _get_single_outcome(self, qubit, wanted_state):
-        """Simulate the outcome of a determined measurement of a qubit.
-        This function mainly exists to perserve the existing function division,
-        replacing _get_measure_outcome which is called for the other simulators
-
-        Args:
-            qubit (int): the qubit to measure
-            wanted_state (int): the outcome state to return
-
-        Return:
-            tuple: pair (outcome, probability) where outcome is '0' or '1' and
-            probability is the probability of the returned outcome.
-        """
-        # Axis for numpy.sum to compute probabilities
-        axis = list(range(self._number_of_qubits))
-        axis.remove(self._number_of_qubits - 1 - qubit)
-        probabilities = np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis))
-        # Compute einsum index string for 1-qubit matrix multiplication
-
-        return str(wanted_state), probabilities[wanted_state]
-
-    def _split_statevector(self, qubit, probabilities, cmembit, cregbit=None):
-        """Split the statevector into two substates corresponding to the two measurement options.
-
-        Args:
-            qubit (int): the measured qubit
-            probabilities (list[float]): the probabilities of measuring 0 or 1
-            cmembit (int): the classical memory bit to store outcome in.
-            cregbit (int, optional): is the classical register bit to store outcome in.
-
-        Raises:
-            BasicAerError: if an error occurred.
-        """
-        # Getting the data for each split possibility
-        outcome0, probability0 = self._get_single_outcome(qubit, 0)
-        outcome1, probability1 = self._get_single_outcome(qubit, 1)
-
-        # Copying the statevector into its two substates
-        temp = copy.deepcopy(self)
-        self._substates.append(copy.deepcopy(temp))
-        self._substate_probabilities.append(probabilities[0])
-        self._substates.append(copy.deepcopy(temp))
-        self._substate_probabilities.append(probabilities[1])
-
-        # Updating the states after the split
-        self._substates[0]._update_state_after_measure(qubit, cmembit,
-                                                       outcome0, probability0, cregbit)
-        self._substates[1]._update_state_after_measure(qubit, cmembit,
-                                                       outcome1, probability1, cregbit)
-
-    def _generate_data(self):
-        """Run an experiment (circuit) and return a single experiment result.
-
-        Args:
-            experiment (QobjExperiment): experiment from qobj experiments list
-
-        Returns:
-             data: A result dictionary in the form of a binary tree which looks something like:
-
-                {
-                "value": The statevector of the state at the first measurement
-                "prob_0": The probability to get a measurement of 0 at the first measurement
-                "prob_1": The probability to get a measurement of 1 at the first measurement
-                "path_0":
-                    {
-                        "value": The statevector evolved from result 0 in the first measurement,
-                                 at the second measurement or at the end of the circuit
-                        "prob_0": The probability for a measurement of 0 at the second measurement
-                        "prob_1": The probability for a measurement of 1 at the second measurement
-                        "path_0":
-                            {
-                                ...
-                            }
-                        "path_1":
-                            {
-                                ...
-                            }
-                    }
-                "path_1":
-                    {
-                        ...
-                    }
-                }
-        Raises:
-            BasicAerError: if an error occurred.
-        """
-        if self._substates != []:
-            data = {'value': self._get_statevector(),
-                    'path_0': self._substates[0]._generate_data(),
-                    'path_0_probability': self._substate_probabilities[0],
-                    'path_1': self._substates[1]._generate_data(),
-                    'path_1_probability': self._substate_probabilities[1]}
-        else:
-            data = {'value': self._get_statevector()}
-
-        return data
 
     # TODO: Add a _validate method

--- a/qiskit/providers/basicaer/split_statevector_simulator.py
+++ b/qiskit/providers/basicaer/split_statevector_simulator.py
@@ -1,0 +1,187 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Contains a (slow) python statevector simulator which splits for every non-zero probability measurement
+
+It simulates the statevector through a quantum circuit. It is exponential in
+the number of qubits, and in the number of non-zero probability measurements within the circuit.
+
+We advise using the c++ simulator or online simulator for larger size systems.
+
+The input is a qobj dictionary and the output is a Result object.
+
+The input qobj to this simulator has no shots, no measures, no reset, no noise.
+
+The data object of the result is a dictionary containing a binary tree data structure for the different splits
+"""
+
+import logging
+import copy
+from math import log2
+import numpy as np
+from qiskit.util import local_hardware_info
+from qiskit.providers.basicaer.exceptions import BasicAerError
+from qiskit.providers.models import QasmBackendConfiguration
+from .qasm_simulator import QasmSimulatorPy
+from .statevector_simulator import StatevectorSimulatorPy
+
+logger = logging.getLogger(__name__)
+
+
+class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
+    """Python statevector simulator."""
+
+    # TODO: Set a memory bound which depends on the amount of measurements as well
+    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()['memory'] * (1024 ** 3) / 16))
+
+    DEFAULT_CONFIGURATION = {
+        'backend_name': 'split_statevector_simulator',
+        'backend_version': '1.0.0',
+        'n_qubits': min(24, MAX_QUBITS_MEMORY),
+        'url': 'https://github.com/Qiskit/qiskit-terra',
+        'simulator': True,
+        'local': True,
+        'conditional': True,
+        'open_pulse': False,
+        'memory': True,
+        'max_shots': 65536,
+        'coupling_map': None,
+        'description': 'A Python statevector simulator for qobj files',
+        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'snapshot'],
+        'gates': [
+            {
+                'name': 'u1',
+                'parameters': ['lambda'],
+                'qasm_def': 'gate u1(lambda) q { U(0,0,lambda) q; }'
+            },
+            {
+                'name': 'u2',
+                'parameters': ['phi', 'lambda'],
+                'qasm_def': 'gate u2(phi,lambda) q { U(pi/2,phi,lambda) q; }'
+            },
+            {
+                'name': 'u3',
+                'parameters': ['theta', 'phi', 'lambda'],
+                'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }'
+            },
+            {
+                'name': 'cx',
+                'parameters': ['c', 't'],
+                'qasm_def': 'gate cx c,t { CX c,t; }'
+            },
+            {
+                'name': 'id',
+                'parameters': ['a'],
+                'qasm_def': 'gate id a { U(0,0,0) a; }'
+            },
+            {
+                'name': 'snapshot',
+                'parameters': ['slot'],
+                'qasm_def': 'gate snapshot(slot) q { TODO }'
+            }
+        ]
+    }
+
+    # SSS: This should be set to True to use multiverse reperesentation for measurments
+    SPLIT_STATES = True
+
+    
+    def __init__(self, configuration=None, provider=None):
+        super().__init__(configuration=(
+            configuration or QasmBackendConfiguration.from_dict(self.DEFAULT_CONFIGURATION)),
+                         provider=provider)
+        # SSS: Substates field will contain 2 sons to split the statevector into two (parallel universe) statevectors.
+        self._substates = []
+        self._substate_probabilities = []
+
+    def run(self, qobj, backend_options=None):
+        """Run qobj asynchronously.
+
+        Args:
+            qobj (Qobj): payload of the experiment
+            backend_options (dict): backend options
+
+        Returns:
+            BasicAerJob: derived from BaseJob
+
+        Additional Information::
+
+            backend_options: Is a dict of options for the backend. It may contain
+                * "initial_statevector": vector_like
+                * "chop_threshold": double
+
+            The "initial_statevector" option specifies a custom initial
+            initial statevector for the simulator to be used instead of the all
+            zero state. This size of this vector must be correct for the number
+            of qubits in all experiments in the qobj.
+
+            The "chop_threshold" option specifies a truncation value for
+            setting small values to zero in the output statevector. The default
+            value is 1e-15.
+
+            Example::
+
+                backend_options = {
+                    "initial_statevector": np.array([1, 0, 0, 1j]) / np.sqrt(2),
+                    "chop_threshold": 1e-15
+                }
+        """
+        return super().run(qobj, backend_options=backend_options)
+
+    # SSS: Getting only the desired result (0 or 1)
+    def _get_single_outcome(self, qubit, wantedState):
+        """Simulate the outcome of measurement of a qubit.
+
+        Args:
+            qubit (int): the qubit to measure
+
+        Return:
+            tuple: pair (outcome, probability) where outcome is '0' or '1' and
+            probability is the probability of the returned outcome.
+        """
+        # Axis for numpy.sum to compute probabilities
+        axis = list(range(self._number_of_qubits))
+        axis.remove(self._number_of_qubits - 1 - qubit)
+        probabilities = np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis))
+        # Compute einsum index string for 1-qubit matrix multiplication
+
+        return str(wantedState), probabilities[wantedState]
+
+    def _split_statevector(self, qubit, probabilities, cmembit, cregbit=None):
+        # Getting the data for each split possibility
+        outcome0, probability0 = self._get_single_outcome(qubit, 0)
+        outcome1, probability1 = self._get_single_outcome(qubit, 1)
+
+        # Copying the statevector into its two substates
+        temp = copy.deepcopy(self)
+        self._substates.append(copy.deepcopy(temp))
+        self._substate_probabilities.append(probabilities[0]) 
+        self._substates.append(copy.deepcopy(temp))
+        self._substate_probabilities.append(probabilities[1])
+
+        # Updating the states after the split
+        self._substates[0]._update_state_after_measure(qubit, cmembit, outcome0, probability0, cregbit)
+        self._substates[1]._update_state_after_measure(qubit, cmembit, outcome1, probability1, cregbit)
+
+    def _generate_data(self):
+        if len(self._substates) != 0:
+            data = {'value': self._get_statevector(),
+                    'path_0': self._substates[0]._generate_data(), 'path_0_probability': self._substate_probabilities[0],
+                    'path_1': self._substates[1]._generate_data(), 'path_1_probability': self._substate_probabilities[1]}
+        else:
+            data = {'value': self._get_statevector()}
+        
+        return data
+    # TODO: Add a _validate method

--- a/qiskit/providers/basicaer/split_statevector_simulator.py
+++ b/qiskit/providers/basicaer/split_statevector_simulator.py
@@ -181,7 +181,7 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         # Copying the statevector into its two substates
         temp = copy.deepcopy(self)
         self._substates.append(copy.deepcopy(temp))
-        self._substate_probabilities.append(probabilities[0]) 
+        self._substate_probabilities.append(probabilities[0])
         self._substates.append(copy.deepcopy(temp))
         self._substate_probabilities.append(probabilities[1])
 
@@ -227,7 +227,7 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
         Raises:
             BasicAerError: if an error occurred.
         """
-        if len(self._substates) != 0:
+        if self._substates != []:
             data = {'value': self._get_statevector(),
                     'path_0': self._substates[0]._generate_data(),
                     'path_0_probability': self._substate_probabilities[0],
@@ -235,7 +235,7 @@ class SplitStatevectorSimulatorPy(StatevectorSimulatorPy):
                     'path_1_probability': self._substate_probabilities[1]}
         else:
             data = {'value': self._get_statevector()}
-        
+
         return data
 
     # TODO: Add a _validate method

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -212,18 +212,19 @@ class Result(BaseModel):
                 If None, does not round.
 
         Returns:
-            dictionary[list[complex]]: The value elements will be of type list of 2^n_qubits complex amplitudes.
+            dictionary[list[complex]]:
+            The value elements will be of type list of 2^n_qubits complex amplitudes.
             The dictionary's structure is:
                 {
                 "value": The statevector of the state at the first measurement
                 "prob_0": The probability to get a measurement of 0 at the first measurement
                 "prob_1": The probability to get a measurement of 1 at the first measurement
-                "path_0": 
+                "path_0":
                     {
                         "value": The statevector evolved from result 0 in the first measurement,
                                  at the second measurement or at the end of the circuit
-                        "prob_0": The probability to get a measurement of 0 at the second measurement
-                        "prob_1": The probability to get a measurement of 1 at the second measurement
+                        "prob_0": The probability for a measurement of 0 at the second measurement
+                        "prob_1": The probability for a measurement of 1 at the second measurement
                         "path_0":
                             {
                                 ...
@@ -237,7 +238,7 @@ class Result(BaseModel):
                     {
                         ...
                     }
-                }            
+                }
 
         Raises:
             QiskitError: if there is no statevector for the experiment.
@@ -251,7 +252,7 @@ class Result(BaseModel):
 
     def _format_tree(self, current_node, decimals=None):
         current_node['value'] = postprocess.format_statevector(current_node['value'],
-                                                  decimals=decimals)
+                                                               decimals=decimals)
         if 'path_0' in current_node:
             self._format_tree(current_node['path_0'])
             self._format_tree(current_node['path_1'])

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -245,17 +245,17 @@ class Result(BaseModel):
         """
         try:
             tree = self.data(experiment)['statevector_tree']
-            self._format_tree(tree)
+            self._format_tree(tree, decimals)
             return tree
         except KeyError:
             raise QiskitError('No statevector for experiment "{0}"'.format(experiment))
 
-    def _format_tree(self, current_node, decimals=None):
+    def _format_tree(self, current_node, decimals):
         current_node['value'] = postprocess.format_statevector(current_node['value'],
                                                                decimals=decimals)
         if 'path_0' in current_node:
-            self._format_tree(current_node['path_0'])
-            self._format_tree(current_node['path_1'])
+            self._format_tree(current_node['path_0'], decimals)
+            self._format_tree(current_node['path_1'], decimals)
 
     def get_unitary(self, experiment=None, decimals=None):
         """Get the final unitary of an experiment.

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -14,8 +14,10 @@
 
 """Reference circuits used by the tests."""
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 import math
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
 
 class ReferenceCircuits:
     """Container for reference circuits used by the tests."""
@@ -62,7 +64,7 @@ class ReferenceCircuits:
         cr = ClassicalRegister(2, name='cr')
         qc = QuantumCircuit(qr, cr, name='h_measure_h_double')
         qc.h(qr[0])
-        qc.measure(qr[0], cr[0])        
+        qc.measure(qr[0], cr[0])
         qc.h(qr[0])
         qc.measure(qr[0], cr[0])
 
@@ -75,7 +77,7 @@ class ReferenceCircuits:
         cr = ClassicalRegister(2, name='cr')
         qc = QuantumCircuit(qr, cr, name='rx_measure_rx')
         qc.rx(math.pi/3, qr[0])
-        qc.measure(qr[0], cr[0])        
+        qc.measure(qr[0], cr[0])
         qc.rx(math.pi/3, qr[0])
         qc.measure(qr[0], cr[0])
 

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -15,7 +15,7 @@
 """Reference circuits used by the tests."""
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
-
+import math
 
 class ReferenceCircuits:
     """Container for reference circuits used by the tests."""
@@ -36,8 +36,47 @@ class ReferenceCircuits:
     def bell_no_measure():
         """Return a Bell circuit."""
         qr = QuantumRegister(2, name='qr')
-        qc = QuantumCircuit(qr, name='bell_no_measure')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='bell_no_measure')
         qc.h(qr[0])
         qc.cx(qr[0], qr[1])
+
+        return qc
+
+    @staticmethod
+    def h_measure_h():
+        """Return circuit with two Hadamard gates and a measurement in between."""
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='h_measure_h')
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])
+        qc.h(qr[0])
+
+        return qc
+
+    @staticmethod
+    def h_measure_h_double():
+        """Return circuit with two Hadamard gates and a measurement after each one."""
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='h_measure_h_double')
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])        
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])
+
+        return qc
+
+    @staticmethod
+    def rx_measure_rx():
+        """Return circuit with two R_x(pi/3) gates and a measurement after each one."""
+        qr = QuantumRegister(2, name='qr')
+        cr = ClassicalRegister(2, name='cr')
+        qc = QuantumCircuit(qr, cr, name='rx_measure_rx')
+        qc.rx(math.pi/3, qr[0])
+        qc.measure(qr[0], cr[0])        
+        qc.rx(math.pi/3, qr[0])
+        qc.measure(qr[0], cr[0])
 
         return qc

--- a/test/python/basicaer/test_split_statevector_simulator.py
+++ b/test/python/basicaer/test_split_statevector_simulator.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""Test SplitStateVectorSimulatorPy."""
+
+import unittest
+
+import numpy as np
+import math
+
+from qiskit.providers.basicaer.split_statevector_simulator import SplitStatevectorSimulatorPy
+from qiskit.test import ReferenceCircuits
+from qiskit.test import providers
+
+
+class StatevectorSimulatorTest(providers.BackendTestCase):
+    """Test BasicAer split_statevector simulator."""
+
+    backend_cls = SplitStatevectorSimulatorPy
+    circuit = None
+
+    def test_run_circuit(self):
+        """Test that the simulator works for a circuit without measurements in the middle."""
+        # Set test circuit
+        self.circuit = ReferenceCircuits.bell_no_measure()
+        # Execute
+        result = super().test_run_circuit()
+        actual = result.get_statevector_tree()['value']
+
+
+        # state is 1/sqrt(2)|00> + 1/sqrt(2)|11>, up to a global phase
+        self.assertAlmostEqual((abs(actual[0]))**2, 1 / 2)
+        self.assertEqual(actual[1], 0)
+        self.assertEqual(actual[2], 0)
+        self.assertAlmostEqual((abs(actual[3]))**2, 1 / 2)
+
+    def test_measure_split(self):
+        """Test the result of a single qubit split by one measurement"""
+        # Set test circuit
+        self.circuit = ReferenceCircuits.h_measure_h()
+        # Execute
+        result = super().test_run_circuit()
+        actual = result.get_statevector_tree()
+        initial = actual['value']
+        path_0 = actual['path_0']['value']
+        path_1 = actual['path_1']['value']
+
+        # initial (before measurement) state is 1/sqrt(2)|00> + 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((initial[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((initial[1]), 1 / math.sqrt(2))
+        self.assertEqual(initial[2], 0)
+        self.assertEqual(initial[3], 0)
+        # path 0 state is 1/sqrt(2)|00> + 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_0[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((path_0[1]), 1 / math.sqrt(2))
+        self.assertEqual(path_0[2], 0)
+        self.assertEqual(path_0[3], 0)
+        # path 1 state is 1/sqrt(2)|00> - 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_1[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((path_1[1]), -1 / math.sqrt(2))
+        self.assertEqual(path_1[2], 0)
+        self.assertEqual(path_1[3], 0)
+
+    def test_double_measure_split(self):
+        """Test the result of a single qubit split by two measurements"""
+        # Set test circuit
+        self.circuit = ReferenceCircuits.h_measure_h_double()
+        # Execute
+        result = super().test_run_circuit()
+        actual = result.get_statevector_tree()
+        initial = actual['value']
+        path_0 = actual['path_0']['value']
+        path_1 = actual['path_1']['value']
+        path_00 = actual['path_0']['path_0']['value']
+        path_01 = actual['path_0']['path_1']['value']
+        path_10 = actual['path_1']['path_0']['value']
+        path_11 = actual['path_1']['path_1']['value']
+        
+        prob_0 = actual['path_0_probability']
+        prob_1 = actual['path_1_probability']
+        prob_00 = actual['path_0']['path_0_probability']
+        prob_01 = actual['path_0']['path_1_probability']
+        prob_10 = actual['path_1']['path_0_probability']
+        prob_11 = actual['path_1']['path_1_probability']
+
+        # initial (before measurement) state is 1/sqrt(2)|00> + 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((initial[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((initial[1]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((prob_0), 1 / 2)
+        self.assertAlmostEqual((prob_1), 1 / 2)
+        self.assertEqual(initial[2], 0)
+        self.assertEqual(initial[3], 0)
+        # path 0 state is 1/sqrt(2)|00> + 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_0[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((path_0[1]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((prob_00), 1 / 2)
+        self.assertAlmostEqual((prob_01), 1 / 2)
+        self.assertEqual(path_0[2], 0)
+        self.assertEqual(path_0[3], 0)
+        # path 1 state is 1/sqrt(2)|00> - 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_1[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((path_1[1]), -1 / math.sqrt(2))
+        self.assertAlmostEqual((prob_10), 1 / 2)
+        self.assertAlmostEqual((prob_11), 1 / 2)        
+        self.assertEqual(path_1[2], 0)
+        self.assertEqual(path_1[3], 0)
+        # path 00 state |00> up to a global phase
+        self.assertAlmostEqual((path_00[0]), 1)
+        self.assertEqual(path_00[1], 0)
+        self.assertEqual(path_00[2], 0)
+        self.assertEqual(path_00[3], 0)
+        # path 01 state |01> up to a global phase
+        self.assertAlmostEqual((path_01[1]), 1)
+        self.assertEqual(path_01[0], 0)
+        self.assertEqual(path_01[2], 0)
+        self.assertEqual(path_01[3], 0)
+        # path 10 state |00> up to a global phase
+        self.assertAlmostEqual((path_10[0]), 1)
+        self.assertEqual(path_10[1], 0)
+        self.assertEqual(path_10[2], 0)
+        self.assertEqual(path_10[3], 0)
+        # path 01 state -|01> up to a global phase
+        self.assertAlmostEqual((path_11[1]), -1)
+        self.assertEqual(path_11[0], 0)
+        self.assertEqual(path_11[2], 0)
+        self.assertEqual(path_11[3], 0)
+
+    def test_double_measure_split_unequal_probability(self):
+        """Test the result of a single qubit split by two measurements, when each measurement has unequal probabilities for the possible outcomes"""
+        # Set test circuit
+        self.circuit = ReferenceCircuits.rx_measure_rx()
+        # Execute
+        result = super().test_run_circuit()
+        actual = result.get_statevector_tree()
+        initial = actual['value']
+        path_0 = actual['path_0']['value']
+        path_1 = actual['path_1']['value']
+        path_00 = actual['path_0']['path_0']['value']
+        path_01 = actual['path_0']['path_1']['value']
+        path_10 = actual['path_1']['path_0']['value']
+        path_11 = actual['path_1']['path_1']['value']
+        
+        prob_0 = actual['path_0_probability']
+        prob_1 = actual['path_1_probability']
+        prob_00 = actual['path_0']['path_0_probability']
+        prob_01 = actual['path_0']['path_1_probability']
+        prob_10 = actual['path_1']['path_0_probability']
+        prob_11 = actual['path_1']['path_1_probability']
+
+        # initial (before measurement) state is sqrt(3)/2|00> (- 1/2)j|01>, up to a global phase
+        self.assertAlmostEqual((initial[0]), math.sqrt(3) / 2)
+        self.assertAlmostEqual((initial[1]), -0.5j)
+        self.assertAlmostEqual((prob_0), 3 / 4)
+        self.assertAlmostEqual((prob_1), 1 / 4)
+        self.assertEqual(initial[2], 0)
+        self.assertEqual(initial[3], 0)
+        # path 0 state is 1/sqrt(2)|00> + 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_0[0]), math.sqrt(3) / 2)
+        self.assertAlmostEqual((path_0[1]), -0.5j)
+        self.assertAlmostEqual((prob_00), 3 / 4)
+        self.assertAlmostEqual((prob_01), 1 / 4)
+        self.assertEqual(path_0[2], 0)
+        self.assertEqual(path_0[3], 0)
+        # path 1 state is 1/sqrt(2)|00> - 1/sqrt(2)|01>, up to a global phase
+        self.assertAlmostEqual((path_1[0]), -0.5)
+        self.assertAlmostEqual((path_1[1]), -1j* (math.sqrt(3) / 2))
+        self.assertAlmostEqual((prob_10), 1 / 4)
+        self.assertAlmostEqual((prob_11), 3 / 4)        
+        self.assertEqual(path_1[2], 0)
+        self.assertEqual(path_1[3], 0)
+        # path 00 state is |00> up to a global phase
+        self.assertAlmostEqual(abs((path_00[0]**2)), 1)
+        self.assertEqual(path_00[1], 0)
+        self.assertEqual(path_00[2], 0)
+        self.assertEqual(path_00[3], 0)
+        # path 01 state is |01> up to a global phase
+        self.assertAlmostEqual(abs((path_01[1]**2)), 1)
+        self.assertEqual(path_01[0], 0)
+        self.assertEqual(path_01[2], 0)
+        self.assertEqual(path_01[3], 0)
+        # path 10 state is |00> up to a global phase
+        self.assertAlmostEqual(abs((path_10[0]**2)), 1)
+        self.assertEqual(path_10[1], 0)
+        self.assertEqual(path_10[2], 0)
+        self.assertEqual(path_10[3], 0)
+        # path 01 state is -|01> up to a global phase
+        self.assertAlmostEqual(abs((path_11[1]**2)), 1)
+        self.assertEqual(path_11[0], 0)
+        self.assertEqual(path_11[2], 0)
+        self.assertEqual(path_11[3], 0)
+
+    def test_bell_split(self):
+        """Test the result of a two qubit bell state split by one measurement"""
+        # Set test circuit
+        self.circuit = ReferenceCircuits.bell()
+        # Execute
+        result = super().test_run_circuit()
+        actual = result.get_statevector_tree()
+        initial = actual['value']
+        path_0 = actual['path_0']['value']
+        path_1 = actual['path_1']['value']
+
+        prob_0 = actual['path_0_probability']
+        prob_1 = actual['path_1_probability']
+
+        # initial (before measurement) state is 1/sqrt(2)|00> + 1/sqrt(2)|11>, up to a global phase
+        self.assertAlmostEqual((initial[0]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((initial[3]), 1 / math.sqrt(2))
+        self.assertAlmostEqual((prob_0), 1 / 2)
+        self.assertAlmostEqual((prob_1), 1 / 2)
+        self.assertEqual(initial[1], 0)
+        self.assertEqual(initial[2], 0)
+        # path 0 state is |00>, up to a global phase
+        self.assertAlmostEqual((path_0[0]), 1)
+        self.assertEqual(path_0[1], 0)
+        self.assertEqual(path_0[2], 0)
+        self.assertEqual(path_0[3], 0)
+        # path 1 state is |11>, up to a global phase
+        self.assertAlmostEqual((path_1[3]), 1)
+        self.assertEqual(path_1[0], 0)
+        self.assertEqual(path_1[1], 0)
+        self.assertEqual(path_1[2], 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/basicaer/test_split_statevector_simulator.py
+++ b/test/python/basicaer/test_split_statevector_simulator.py
@@ -37,7 +37,6 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         result = super().test_run_circuit()
         actual = result.get_statevector_tree()['value']
 
-
         # state is 1/sqrt(2)|00> + 1/sqrt(2)|11>, up to a global phase
         self.assertAlmostEqual((abs(actual[0]))**2, 1 / 2)
         self.assertEqual(actual[1], 0)
@@ -85,7 +84,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         path_01 = actual['path_0']['path_1']['value']
         path_10 = actual['path_1']['path_0']['value']
         path_11 = actual['path_1']['path_1']['value']
-        
+
         prob_0 = actual['path_0_probability']
         prob_1 = actual['path_1_probability']
         prob_00 = actual['path_0']['path_0_probability']
@@ -111,7 +110,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.assertAlmostEqual((path_1[0]), 1 / math.sqrt(2))
         self.assertAlmostEqual((path_1[1]), -1 / math.sqrt(2))
         self.assertAlmostEqual((prob_10), 1 / 2)
-        self.assertAlmostEqual((prob_11), 1 / 2)        
+        self.assertAlmostEqual((prob_11), 1 / 2)
         self.assertEqual(path_1[2], 0)
         self.assertEqual(path_1[3], 0)
         # path 00 state |00> up to a global phase
@@ -136,7 +135,8 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.assertEqual(path_11[3], 0)
 
     def test_double_measure_split_unequal_probability(self):
-        """Test the result of a single qubit split by two measurements, when each measurement has unequal probabilities for the possible outcomes"""
+        """Test the result of a single qubit split by two measurements,
+        when each measurement has unequal probabilities for the possible outcomes"""
         # Set test circuit
         self.circuit = ReferenceCircuits.rx_measure_rx()
         # Execute
@@ -149,7 +149,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         path_01 = actual['path_0']['path_1']['value']
         path_10 = actual['path_1']['path_0']['value']
         path_11 = actual['path_1']['path_1']['value']
-        
+
         prob_0 = actual['path_0_probability']
         prob_1 = actual['path_1_probability']
         prob_00 = actual['path_0']['path_0_probability']
@@ -173,9 +173,9 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.assertEqual(path_0[3], 0)
         # path 1 state is 1/sqrt(2)|00> - 1/sqrt(2)|01>, up to a global phase
         self.assertAlmostEqual((path_1[0]), -0.5)
-        self.assertAlmostEqual((path_1[1]), -1j* (math.sqrt(3) / 2))
+        self.assertAlmostEqual((path_1[1]), -1j * (math.sqrt(3) / 2))
         self.assertAlmostEqual((prob_10), 1 / 4)
-        self.assertAlmostEqual((prob_11), 3 / 4)        
+        self.assertAlmostEqual((prob_11), 3 / 4)
         self.assertEqual(path_1[2], 0)
         self.assertEqual(path_1[3], 0)
         # path 00 state is |00> up to a global phase
@@ -230,6 +230,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.assertEqual(path_1[0], 0)
         self.assertEqual(path_1[1], 0)
         self.assertEqual(path_1[2], 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/basicaer/test_split_statevector_simulator.py
+++ b/test/python/basicaer/test_split_statevector_simulator.py
@@ -15,7 +15,6 @@
 
 import unittest
 
-import numpy as np
 import math
 
 from qiskit.providers.basicaer.split_statevector_simulator import SplitStatevectorSimulatorPy


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Adds a new backend, inheriting from the statevector_simulator allowing to run a circuit and get the binary tree containing the statevectors at each measurement point, as described in issue #2550.

The basic logic of the split_statevector_simulator algorithm is as follows:
The class SplitStatevectorSimulatorPy has attributes _substates and _substate_probabilities, both of which are lists
On measurement operations, Two copies of the current statevector are inserted into _substates. These states are then collapsed into measurement results 0 and 1, and the probabilities for these outcomes are inserted into _substate_probabilities.
At this point the for loop going over the operations is stopped for the initial statevector and is called to continue from the next measurement operation for both substates.

### Details and comments
The changes include 2 new files: qiskit\providers\basicaer\split_statevector_simulator.py, and qiskit\test\python\basicaer\test_split_statevector_simulator.py
In the qasm_simulator most changes are superficial involving a refactoring of existing functions. One notable change is the handling of the "memory" and "measure_sample_ops" variables in the qasm_simulator method "run_experiment", which were slightly moved around to accommodate the python value semantics.

This pull request solves #2550 

