### PR TITLE
deprecate qobj.as_dict

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Deprecated
 
 - The gates ``U`` and ``CX`` are being deprecated in favor of ``u3`` and ``cx``.
 - The decorator ``requires_qe_access`` is being deprecated in favor of ``online_test``.
+- The ``as_dict`` method of Qobj is deprecated in favor of ``to_dict``.
 
 Added
 -----

--- a/qiskit/qobj/utils.py
+++ b/qiskit/qobj/utils.py
@@ -38,6 +38,6 @@ def validate_qobj_against_schema(qobj):
         qobj (Qobj): Qobj to be validated.
     """
     validate_json_against_schema(
-        qobj.as_dict(), 'qobj',
+        qobj.to_dict(), 'qobj',
         err_msg='Qobj failed validation. Set Qiskit log level to DEBUG '
                 'for further information.')

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -29,6 +29,7 @@ together by using ``bind_schema``::
     class Person(BaseModel):
         pass
 """
+import warnings
 
 from functools import wraps
 from types import SimpleNamespace, MethodType
@@ -355,6 +356,8 @@ class BaseModel(SimpleNamespace):
 
     def as_dict(self):
         """Serialize the model into a Python dict of simple types."""
+        warnings.warn('The as_dict() method is deprecated, use to_dict().',
+                      DeprecationWarning)
         return self.to_dict()
 
 

--- a/qiskit/validation/fields/custom.py
+++ b/qiskit/validation/fields/custom.py
@@ -103,8 +103,8 @@ class InstructionParameter(ModelTypeValidator):
                 return float(value.evalf())
 
         # Fallback for attempting serialization.
-        if hasattr(value, 'as_dict'):
-            return value.as_dict()
+        if hasattr(value, 'to_dict'):
+            return value.to_dict()
 
         return self.fail('format', input=value)
 

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -169,7 +169,7 @@ class TestUnitaryCircuit(QiskitTestCase):
             numpy.array(instr.params).astype(numpy.complex64),
             matrix))
         # check conversion to dict
-        qobj_dict = qobj.as_dict()
+        qobj_dict = qobj.to_dict()
         # check json serialization
         self.assertTrue(isinstance(json.dumps(qobj_dict), str))
 

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -69,7 +69,7 @@ class TestQASMQobj(QiskitTestCase):
         self.bad_qobj = copy.deepcopy(self.valid_qobj)
         self.bad_qobj.experiments = None  # set experiments to None to cause the qobj to be invalid
 
-    def test_as_dict_against_schema(self):
+    def test_to_dict_against_schema(self):
         """Test dictionary representation of Qobj against its schema."""
         try:
             validate_qobj_against_schema(self.valid_qobj)
@@ -208,7 +208,7 @@ class TestPulseQobj(QiskitTestCase):
             ]
         }
 
-    def test_as_dict_against_schema(self):
+    def test_to_dict_against_schema(self):
         """Test dictionary representation of Qobj against its schema."""
         try:
             validate_qobj_against_schema(self.valid_qobj)
@@ -258,7 +258,7 @@ class TestPulseQobj(QiskitTestCase):
             with self.subTest(msg=str(qobj_class)):
                 self.assertEqual(qobj_item, qobj_class.from_dict(expected_dict))
 
-    def test_as_dict_per_class(self):
+    def test_to_dict_per_class(self):
         """Test converting from Qobj and its subclass representations given a dictionary."""
         test_parameters = {
             PulseQobj: (
@@ -299,7 +299,7 @@ class TestPulseQobj(QiskitTestCase):
 
         for qobj_class, (qobj_item, expected_dict) in test_parameters.items():
             with self.subTest(msg=str(qobj_class)):
-                self.assertEqual(qobj_item.as_dict(), expected_dict)
+                self.assertEqual(qobj_item.to_dict(), expected_dict)
 
 
 def _nop():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Fixes #2487 

deprecate qobj.as_dict and use qobj.to_dict
