### PR TITLE
remove try/except in examples

### DIFF
--- a/examples/python/ghz.py
+++ b/examples/python/ghz.py
@@ -43,8 +43,8 @@ for i in range(num_qubits):
 try:
     IBMQ.load_accounts()
 except:
-    print("""WARNING: There's no connection with the API for remote backends.
-             Have you initialized a file with your personal token?
+    print("""WARNING: No valid IBMQ credentials found on disk. 
+             You must store your credentials using IBMQ.save_account(token, url). 
              For now, there's only access to local simulator backends...""")
 
 # First version: simulator

--- a/examples/python/hello_quantum.py
+++ b/examples/python/hello_quantum.py
@@ -23,51 +23,47 @@ from qiskit.providers.ibmq import least_busy
 try:
     IBMQ.load_accounts()
 except:
-    print("""WARNING: There's no connection with the API for remote backends.
-             Have you initialized a file with your personal token?
+    print("""WARNING: No valid IBMQ credentials found on disk. 
+             You must store your credentials using IBMQ.save_account(token, url). 
              For now, there's only access to local simulator backends...""")
 
+# Create a Quantum Circuit
+qc = QuantumCircuit(2, 2)
+
+# Add a H gate on qubit 0, putting this qubit in superposition.
+qc.h(0)
+# Add a CX (CNOT) gate on control qubit 0 and target qubit 1, putting
+# the qubits in a Bell state.
+qc.cx(0, 1)
+# Add a Measure gate to see the state.
+qc.measure([0, 1], [0, 1])
+
+# See a list of available local simulators
+print("BasicAer backends: ", BasicAer.backends())
+backend_sim = BasicAer.get_backend('qasm_simulator')
+
+# Compile and run the Quantum circuit on a simulator backend
+job_sim = execute(qc, backend_sim)
+result_sim = job_sim.result()
+
+# Show the results
+print(result_sim.get_counts(qc))
+
+# see a list of available remote backends
+ibmq_backends = IBMQ.backends()
+
+print("Remote backends: ", ibmq_backends)
+# Compile and run the Quantum Program on a real device backend
 try:
-    # Create a Quantum Circuit
-    qc = QuantumCircuit(2, 2)
+    least_busy_device = least_busy(IBMQ.backends(simulator=False))
+except:
+    print("All devices are currently unavailable.")
 
-    # Add a H gate on qubit 0, putting this qubit in superposition.
-    qc.h(0)
-    # Add a CX (CNOT) gate on control qubit 0 and target qubit 1, putting
-    # the qubits in a Bell state.
-    qc.cx(0, 1)
-    # Add a Measure gate to see the state.
-    qc.measure([0, 1], [0, 1])
+print("Running on current least busy device: ", least_busy_device)
 
-    # See a list of available local simulators
-    print("BasicAer backends: ", BasicAer.backends())
-    backend_sim = BasicAer.get_backend('qasm_simulator')
+#running the job
+job_exp = execute(qc, least_busy_device, shots=1024, max_credits=10)
+result_exp = job_exp.result()
 
-    # Compile and run the Quantum circuit on a simulator backend
-    job_sim = execute(qc, backend_sim)
-    result_sim = job_sim.result()
-
-    # Show the results
-    print(result_sim.get_counts(qc))
-
-    # see a list of available remote backends
-    ibmq_backends = IBMQ.backends()
-
-    print("Remote backends: ", ibmq_backends)
-    # Compile and run the Quantum Program on a real device backend
-    try:
-        least_busy_device = least_busy(IBMQ.backends(simulator=False))
-    except:
-        print("All devices are currently unavailable.")
-
-    print("Running on current least busy device: ", least_busy_device)
-
-    #running the job
-    job_exp = execute(qc, least_busy_device, shots=1024, max_credits=10)
-    result_exp = job_exp.result()
-
-    # Show the results
-    print('Counts: ', result_exp.get_counts(qc))
-
-except QiskitError as ex:
-    print('There was an error in the circuit!. Error = {}'.format(ex))
+# Show the results
+print('Counts: ', result_exp.get_counts(qc))

--- a/examples/python/load_qasm.py
+++ b/examples/python/load_qasm.py
@@ -17,22 +17,17 @@
 from qiskit import QuantumCircuit
 from qiskit import QiskitError, execute, BasicAer
 
-try:
-    circ = QuantumCircuit.from_qasm_file("examples/qasm/entangled_registers.qasm")
-    print(circ)
+circ = QuantumCircuit.from_qasm_file("examples/qasm/entangled_registers.qasm")
+print(circ)
 
-    # See the backend
-    sim_backend = BasicAer.get_backend('qasm_simulator')
+# See the backend
+sim_backend = BasicAer.get_backend('qasm_simulator')
 
 
-    # Compile and run the Quantum circuit on a local simulator backend
-    job_sim = execute(circ, sim_backend)
-    sim_result = job_sim.result()
+# Compile and run the Quantum circuit on a local simulator backend
+job_sim = execute(circ, sim_backend)
+sim_result = job_sim.result()
 
-    # Show the results
-    print("simulation: ", sim_result)
-    print(sim_result.get_counts(circ))
-
-except QiskitError as ex:
-    print('There was an internal Qiskit error. Error = {}'.format(ex))
-
+# Show the results
+print("simulation: ", sim_result)
+print(sim_result.get_counts(circ))

--- a/examples/python/qft.py
+++ b/examples/python/qft.py
@@ -74,8 +74,8 @@ print(qft5)
 try:
     IBMQ.load_accounts()
 except:
-    print("""WARNING: There's no connection with the API for remote backends.
-             Have you initialized a file with your personal token?
+    print("""WARNING: No valid IBMQ credentials found on disk. 
+             You must store your credentials using IBMQ.save_account(token, url). 
              For now, there's only access to local simulator backends...""")
 
 print('Qasm simulator')

--- a/examples/python/using_qiskit_terra_level_1.py
+++ b/examples/python/using_qiskit_terra_level_1.py
@@ -42,78 +42,73 @@ from qiskit.tools.monitor import job_monitor
 try:
     IBMQ.load_accounts()
 except:
-    print("""WARNING: There's no connection with the API for remote backends.
-             Have you initialized a file with your personal token?
+    print("""WARNING: No valid IBMQ credentials found on disk. 
+             You must store your credentials using IBMQ.save_account(token, url). 
              For now, there's only access to local simulator backends...""")
 
+# Making first circuit: bell state
+qc1 = QuantumCircuit(2, 2, name="bell")
+qc1.h(0)
+qc1.cx(0, 1)
+qc1.measure([0,1], [0,1])
+
+# Making another circuit: superpositions
+qc2 = QuantumCircuit(2, 2, name="superposition")
+qc2.h([0,1])
+qc2.measure([0,1], [0,1])
+
+# Setting up the backend
+print("(Aer Backends)")
+for backend in BasicAer.backends():
+    print(backend.status())
+qasm_simulator = BasicAer.get_backend('qasm_simulator')
+
+
+# Compile and run the circuit on a real device backend
+# See a list of available remote backends
+print("\n(IBMQ Backends)")
+for backend in IBMQ.backends():
+    print(backend.status())
+
 try:
+    # select least busy available device and execute.
+    least_busy_device = least_busy(IBMQ.backends(simulator=False))
+except:
+    print("All devices are currently unavailable.")
 
-    # Making first circuit: bell state
-    qc1 = QuantumCircuit(2, 2, name="bell")
-    qc1.h(0)
-    qc1.cx(0, 1)
-    qc1.measure([0,1], [0,1])
+print("Running on current least busy device: ", least_busy_device)
 
-    # Making another circuit: superpositions
-    qc2 = QuantumCircuit(2, 2, name="superposition")
-    qc2.h([0,1])
-    qc2.measure([0,1], [0,1])
+# Transpile the circuits to make them compatible with the experimental backend
+[qc1_new, qc2_new] = transpile(circuits=[qc1, qc2], backend=least_busy_device)
 
-    # Setting up the backend
-    print("(Aer Backends)")
-    for backend in BasicAer.backends():
-        print(backend.status())
-    qasm_simulator = BasicAer.get_backend('qasm_simulator')
+print("Bell circuit before transpile:")
+print(qc1)
+print("Bell circuit after transpile:")
+print(qc1_new)
+print("Superposition circuit before transpile:")
+print(qc2)
+print("Superposition circuit after transpile:")
+print(qc2_new)
 
+# Assemble the two circuits into a runnable qobj
+qobj = assemble([qc1_new, qc2_new], shots=1000)
 
-    # Compile and run the circuit on a real device backend
-    # See a list of available remote backends
-    print("\n(IBMQ Backends)")
-    for backend in IBMQ.backends():
-        print(backend.status())
+# Running qobj on the simulator
+sim_job = qasm_simulator.run(qobj)
 
-    try:
-        # select least busy available device and execute.
-        least_busy_device = least_busy(IBMQ.backends(simulator=False))
-    except:
-        print("All devices are currently unavailable.")
+# Getting the result
+sim_result=sim_job.result()
 
-    print("Running on current least busy device: ", least_busy_device)
+# Show the results
+print(sim_result.get_counts(qc1))
+print(sim_result.get_counts(qc2))
 
-    # Transpile the circuits to make them compatible with the experimental backend
-    [qc1_new, qc2_new] = transpile(circuits=[qc1, qc2], backend=least_busy_device)
+# Running the job.
+exp_job = least_busy_device.run(qobj)
 
-    print("Bell circuit before transpile:")
-    print(qc1)
-    print("Bell circuit after transpile:")
-    print(qc1_new)
-    print("Superposition circuit before transpile:")
-    print(qc2)
-    print("Superposition circuit after transpile:")
-    print(qc2_new)
+job_monitor(exp_job)
+exp_result = exp_job.result()
 
-    # Assemble the two circuits into a runnable qobj
-    qobj = assemble([qc1_new, qc2_new], shots=1000)
-
-    # Running qobj on the simulator
-    sim_job = qasm_simulator.run(qobj)
-
-    # Getting the result
-    sim_result=sim_job.result()
-
-    # Show the results
-    print(sim_result.get_counts(qc1))
-    print(sim_result.get_counts(qc2))
-
-    # Running the job.
-    exp_job = least_busy_device.run(qobj)
-
-    job_monitor(exp_job)
-    exp_result = exp_job.result()
-
-    # Show the results
-    print(exp_result.get_counts(qc1))
-    print(exp_result.get_counts(qc2))
-
-except QiskitError as ex:
-    print('There was an error in the circuit!. Error = {}'.format(ex))
+# Show the results
+print(exp_result.get_counts(qc1))
+print(exp_result.get_counts(qc2))

--- a/examples/python/using_qiskit_terra_level_2.py
+++ b/examples/python/using_qiskit_terra_level_2.py
@@ -44,108 +44,103 @@ from qiskit.transpiler.passes import LookaheadSwap
 try:
     IBMQ.load_accounts()
 except:
-    print("""WARNING: There's no connection with the API for remote backends.
-             Have you initialized a file with your personal token?
+    print("""WARNING: No valid IBMQ credentials found on disk. 
+             You must store your credentials using IBMQ.save_account(token, url). 
              For now, there's only access to local simulator backends...""")
 
+# Making first circuit: superpositions
+qc1 = QuantumCircuit(4, 4)
+qc1.h(0)
+qc1.cx(0, 1)
+qc1.measure([0,1], [0,1])
+
+# Making another circuit: GHZ State
+qc2 = QuantumCircuit(4, 4)
+qc2.h([0,1,2,3])
+qc2.cx(0, 1)
+qc2.cx(0, 2)
+qc2.cx(0, 3)
+qc2.measure([0,1,2,3], [0,1,2,3])
+
+# Setting up the backend
+print("(Aer Backends)")
+for backend in BasicAer.backends():
+    print(backend.status())
+qasm_simulator = BasicAer.get_backend('qasm_simulator')
+
+
+# Compile and run the circuit on a real device backend
+# See a list of available remote backends
+print("\n(IBMQ Backends)")
+for backend in IBMQ.backends():
+    print(backend.status())
+
 try:
+    # select least busy available device and execute.
+    least_busy_device = least_busy(IBMQ.backends(simulator=False))
+except:
+    print("All devices are currently unavailable.")
 
-    # Making first circuit: superpositions
-    qc1 = QuantumCircuit(4, 4)
-    qc1.h(0)
-    qc1.cx(0, 1)
-    qc1.measure([0,1], [0,1])
-
-    # Making another circuit: GHZ State
-    qc2 = QuantumCircuit(4, 4)
-    qc2.h([0,1,2,3])
-    qc2.cx(0, 1)
-    qc2.cx(0, 2)
-    qc2.cx(0, 3)
-    qc2.measure([0,1,2,3], [0,1,2,3])
-
-    # Setting up the backend
-    print("(Aer Backends)")
-    for backend in BasicAer.backends():
-        print(backend.status())
-    qasm_simulator = BasicAer.get_backend('qasm_simulator')
+print("Running on current least busy device: ", least_busy_device)
 
 
-    # Compile and run the circuit on a real device backend
-    # See a list of available remote backends
-    print("\n(IBMQ Backends)")
-    for backend in IBMQ.backends():
-        print(backend.status())
+# making a pass manager to compile the circuits
+coupling_map = CouplingMap(least_busy_device.configuration().coupling_map)
+print("coupling map: ", coupling_map)
 
-    try:
-        # select least busy available device and execute.
-        least_busy_device = least_busy(IBMQ.backends(simulator=False))
-    except:
-        print("All devices are currently unavailable.")
+pm = PassManager()
 
-    print("Running on current least busy device: ", least_busy_device)
+# Use the trivial layout
+pm.append(TrivialLayout(coupling_map))
 
+# Extend the the dag/layout with ancillas using the full coupling map
+pm.append(FullAncillaAllocation(coupling_map))
+pm.append(EnlargeWithAncilla())
 
-    # making a pass manager to compile the circuits
-    coupling_map = CouplingMap(least_busy_device.configuration().coupling_map)
-    print("coupling map: ", coupling_map)
+# Swap mapper
+pm.append(LookaheadSwap(coupling_map))
 
-    pm = PassManager()
+# Expand swaps
+pm.append(Decompose(SwapGate))
 
-    # Use the trivial layout
-    pm.append(TrivialLayout(coupling_map))
+# Simplify CXs
+pm.append(CXDirection(coupling_map))
 
-    # Extend the the dag/layout with ancillas using the full coupling map
-    pm.append(FullAncillaAllocation(coupling_map))
-    pm.append(EnlargeWithAncilla())
+# unroll to single qubit gates
+pm.append(Unroller(['u1', 'u2', 'u3', 'id', 'cx']))
+qc1_new = pm.run(qc1)
+qc2_new = pm.run(qc2)
 
-    # Swap mapper
-    pm.append(LookaheadSwap(coupling_map))
+print("Bell circuit before passes:")
+print(qc1)
+print("Bell circuit after passes:")
+print(qc1_new)
+print("Superposition circuit before passes:")
+print(qc2)
+print("Superposition circuit after passes:")
+print(qc2_new)
 
-    # Expand swaps
-    pm.append(Decompose(SwapGate))
-    
-    # Simplify CXs
-    pm.append(CXDirection(coupling_map))
+# Assemble the two circuits into a runnable qobj
+qobj = assemble([qc1_new, qc2_new], shots=1000)
 
-    # unroll to single qubit gates
-    pm.append(Unroller(['u1', 'u2', 'u3', 'id', 'cx']))
-    qc1_new = pm.run(qc1)
-    qc2_new = pm.run(qc2)
+# Running qobj on the simulator
+print("Running on simulator:")
+sim_job = qasm_simulator.run(qobj)
 
-    print("Bell circuit before passes:")
-    print(qc1)
-    print("Bell circuit after passes:")
-    print(qc1_new)
-    print("Superposition circuit before passes:")
-    print(qc2)
-    print("Superposition circuit after passes:")
-    print(qc2_new)
+# Getting the result
+sim_result=sim_job.result()
 
-    # Assemble the two circuits into a runnable qobj
-    qobj = assemble([qc1_new, qc2_new], shots=1000)
+# Show the results
+print(sim_result.get_counts(qc1))
+print(sim_result.get_counts(qc2))
 
-    # Running qobj on the simulator
-    print("Running on simulator:")
-    sim_job = qasm_simulator.run(qobj)
+# Running the job.
+print("Running on device:")
+exp_job = least_busy_device.run(qobj)
 
-    # Getting the result
-    sim_result=sim_job.result()
+job_monitor(exp_job)
+exp_result = exp_job.result()
 
-    # Show the results
-    print(sim_result.get_counts(qc1))
-    print(sim_result.get_counts(qc2))
-
-    # Running the job.
-    print("Running on device:")
-    exp_job = least_busy_device.run(qobj)
-
-    job_monitor(exp_job)
-    exp_result = exp_job.result()
-
-    # Show the results
-    print(exp_result.get_counts(qc1))
-    print(exp_result.get_counts(qc2))
-
-except QiskitError as ex:
-    print('There was an error in the circuit!. Error = {}'.format(ex))
+# Show the results
+print(exp_result.get_counts(qc1))
+print(exp_result.get_counts(qc2))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
For some examples, the whole logic is encapsulated in a try/except block. I don't think this is useful. Those try/excepts that are targeting user error are useful in examples (for example try loading IBMQ credentials, and if unsuccessful provide a helpful error message).

But putting the whole example in try/except just makes it hard to debug when things go wrong, as it suppresses the traceback (for example the error in https://github.com/Qiskit/qiskit-terra/issues/2498#issuecomment-497979061). Those errors are usually our errors, and not the user.

