### PR TITLE
Fix labeling of 2Q gate qubits on FakeBackends.

### DIFF
--- a/qiskit/test/mock.py
+++ b/qiskit/test/mock.py
@@ -135,8 +135,8 @@ class FakeBackend(BaseBackend):
                     }
                 ],
                 "qubits": [
-                    1,
-                    0
+                    pair[0],
+                    pair[1]
                 ]
             } for pair in coupling_map],
             'general': []


### PR DESCRIPTION
Fixes generation of 2Q gates definitions on FakeBackends to reference correct qubits.

Fixes the following bug:
```
>>> qc = qk.QuantumCircuit(3)
>>> qc.cx(0,1)
<qiskit.circuit.instructionset.InstructionSet object at 0x1334ca048>
>>> qc.cx(1,2)
<qiskit.circuit.instructionset.InstructionSet object at 0x1334ca128>
>>> qk.transpile(qc, backend=FakeTenerife())
<qiskit.circuit.quantumcircuit.QuantumCircuit object at 0x13358fbe0>
>>> qk.transpile(qc, backend=FakeTenerife(), optimization_level=2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/compiler/transpile.py", line 147, in transpile
    circuits = parallel_map(_transpile_circuit, list(zip(circuits, transpile_configs)))
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/tools/parallel.py", line 100, in parallel_map
    return [task(values[0], *task_args, **task_kwargs)]
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/compiler/transpile.py", line 168, in _transpile_circuit
    return transpile_circuit(circuit, transpile_config)
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/transpiler/transpile_circuit.py", line 62, in transpile_circuit
    return pass_manager.run(circuit)
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/transpiler/passmanager.py", line 147, in run
    dag = self._do_pass(pass_, dag, passset.options)
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/transpiler/passmanager.py", line 188, in _do_pass
    pass_.run(FencedDAGCircuit(dag))
  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py", line 218, in run
    raise TranspilerError('Number of qubits greater than device.')
qiskit.transpiler.exceptions.TranspilerError: 'Number of qubits greater than device.'
```