### PR TITLE
remove ignore_preserves and ignore_requires from PassManager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,7 @@ Removed
   ``qiskit.exceptions`` instead. (#2399)
 - Removed previously deprecated DAGCircuit methods (#2542)
 - Removed ``CompositeGate`` class, in favor of adding Instruction objects directly (#2543)
+- Removed ``ignore_requires`` and ``ignore_preserves`` options from ``PassManager`` (#2565).
 
 Fixed
 -----

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -30,8 +30,6 @@ class PassManager():
     """A PassManager schedules the passes"""
 
     def __init__(self, passes=None,
-                 ignore_requires=None,
-                 ignore_preserves=None,
                  max_iteration=None):
         """
         Initialize an empty PassManager object (with no passes scheduled).
@@ -39,10 +37,6 @@ class PassManager():
         Args:
             passes (list[BasePass] or BasePass): pass(es) to be added to schedule. The default is
                 None.
-            ignore_requires (bool): The schedule ignores the requires field in the passes. The
-                default setting in the pass is False.
-            ignore_preserves (bool): The schedule ignores the preserves field in the passes. The
-                default setting in the pass is False.
             max_iteration (int): The schedule looping iterates until the condition is met or until
                 max_iteration is reached.
         """
@@ -60,9 +54,7 @@ class PassManager():
         self.valid_passes = set()
 
         # pass manager's overriding options for the passes it runs (for debugging)
-        self.passmanager_options = {'ignore_requires': ignore_requires,
-                                    'ignore_preserves': ignore_preserves,
-                                    'max_iteration': max_iteration}
+        self.passmanager_options = {'max_iteration': max_iteration}
 
         # The property log_passes allows to log and time the passes as they run in the pass manager
         self.log_passes = False
@@ -76,21 +68,16 @@ class PassManager():
         passmanager options (set via ``PassManager.__init__()``), which override Default.
         .
         """
-        default = {'ignore_preserves': False,  # Ignore preserves for this pass
-                   'ignore_requires': False,  # Ignore requires for this pass
-                   'max_iteration': 1000}  # Maximum allowed iteration on this pass
+        default = {'max_iteration': 1000}  # Maximum allowed iteration on this pass
 
         passmanager_level = {k: v for k, v in self.passmanager_options.items() if v is not None}
         passset_level = {k: v for k, v in passset_options.items() if v is not None}
         return {**default, **passmanager_level, **passset_level}
 
-    def append(self, passes, ignore_requires=None, ignore_preserves=None, max_iteration=None,
-               **flow_controller_conditions):
+    def append(self, passes, max_iteration=None, **flow_controller_conditions):
         """
         Args:
             passes (list[BasePass] or BasePass): pass(es) to be added to schedule
-            ignore_preserves (bool): ignore the preserves claim of passes. Default: False
-            ignore_requires (bool): ignore the requires need of passes. Default: False
             max_iteration (int): max number of iterations of passes. Default: 1000
             flow_controller_conditions (kwargs): See add_flow_controller(): Dictionary of
             control flow plugins. Default:
@@ -107,9 +94,7 @@ class PassManager():
             TranspilerError: if a pass in passes is not a proper pass.
         """
 
-        passset_options = {'ignore_requires': ignore_requires,
-                           'ignore_preserves': ignore_preserves,
-                           'max_iteration': max_iteration}
+        passset_options = {'max_iteration': max_iteration}
 
         options = self._join_options(passset_options)
 
@@ -175,16 +160,15 @@ class PassManager():
         """
 
         # First, do the requires of pass_
-        if not options["ignore_requires"]:
-            for required_pass in pass_.requires:
-                dag = self._do_pass(required_pass, dag, options)
+        for required_pass in pass_.requires:
+            dag = self._do_pass(required_pass, dag, options)
 
         # Run the pass itself, if not already run
         if pass_ not in self.valid_passes:
             dag = self._run_this_pass(pass_, dag)
 
             # update the valid_passes property
-            self._update_valid_passes(pass_, options['ignore_preserves'])
+            self._update_valid_passes(pass_)
 
         return dag
 
@@ -206,13 +190,10 @@ class PassManager():
             raise TranspilerError("I dont know how to handle this type of pass")
         return dag
 
-    def _update_valid_passes(self, pass_, ignore_preserves):
+    def _update_valid_passes(self, pass_):
         self.valid_passes.add(pass_)
         if not pass_.is_analysis_pass:  # Analysis passes preserve all
-            if ignore_preserves:
-                self.valid_passes.clear()
-            else:
-                self.valid_passes.intersection_update(set(pass_.preserves))
+            self.valid_passes.intersection_update(set(pass_.preserves))
 
     def passes(self):
         """

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -34,11 +34,13 @@ logger = "LocalLogger"
 
 
 class SchedulerTestCase(QiskitTestCase):
-    """ Asserts for the scheduler. """
+    """Asserts for the scheduler."""
 
     def assertScheduler(self, circuit, passmanager, expected):
         """
-        Runs transpiler(circuit, passmanager) and checks if the passes run as expected.
+        Run `transpile(circuit, passmanager)` and check
+        if the passes run as expected.
+
         Args:
             circuit (QuantumCircuit): Circuit to transform via transpilation.
             passmanager (PassManager): pass manager instance for the transpilation process
@@ -51,8 +53,9 @@ class SchedulerTestCase(QiskitTestCase):
 
     def assertSchedulerRaises(self, circuit, passmanager, expected, exception_type):
         """
-        Runs transpiler(circuit, passmanager) and checks if the passes run as expected until
-        exception_type is raised.
+        Run `transpile(circuit, passmanager)` and check
+        if the passes run as expected until exception_type is raised.
+
         Args:
             circuit (QuantumCircuit): Circuit to transform via transpilation
             passmanager (PassManager): pass manager instance for the transpilation process
@@ -85,17 +88,17 @@ class TestPassManagerInit(SchedulerTestCase):
 
 
 class TestUseCases(SchedulerTestCase):
-    """ The pass manager schedules passes in, sometimes, tricky ways. These tests combine passes in
-     many ways, and checks that passes are ran in the right order. """
+    """Combine passes in different ways and checks that passes are run
+    in the right order."""
 
     def setUp(self):
         self.circuit = QuantumCircuit(QuantumRegister(1))
         self.passmanager = PassManager()
 
     def test_chain(self):
-        """ A single chain of passes, with Requests and Preserves."""
-        self.passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
-        self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
+        """A single chain of passes, with Requires and Preserves."""
+        self.passmanager.append(PassC_TP_RA_PA())  # Requires: PassA / Preserves: PassA
+        self.passmanager.append(PassB_TP_RA_PA())  # Requires: PassA / Preserves: PassA
         self.passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {}/ Preserves: {}
         self.passmanager.append(PassB_TP_RA_PA())
         self.assertScheduler(self.circuit, self.passmanager,
@@ -108,7 +111,7 @@ class TestUseCases(SchedulerTestCase):
                               'run transformation pass PassB_TP_RA_PA'])
 
     def test_conditional_passes_true(self):
-        """ A pass set with a conditional parameter. The callable is True. """
+        """A pass set with a conditional parameter. The callable is True."""
         self.passmanager.append(PassE_AP_NR_NP(True))
         self.passmanager.append(PassA_TP_NR_NP(),
                                 condition=lambda property_set: property_set['property'])
@@ -118,15 +121,16 @@ class TestUseCases(SchedulerTestCase):
                               'run transformation pass PassA_TP_NR_NP'])
 
     def test_conditional_passes_false(self):
-        """ A pass set with a conditional parameter. The callable is False. """
+        """A pass set with a conditional parameter. The callable is False."""
         self.passmanager.append(PassE_AP_NR_NP(False))
         self.passmanager.append(PassA_TP_NR_NP(),
                                 condition=lambda property_set: property_set['property'])
-        self.assertScheduler(self.circuit, self.passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                              'set property as False'])
+        self.assertScheduler(self.circuit, self.passmanager,
+                             ['run analysis pass PassE_AP_NR_NP',
+                              'set property as False'])
 
     def test_conditional_and_loop(self):
-        """ Run a conditional first, then a loop"""
+        """Run a conditional first, then a loop."""
         self.passmanager.append(PassE_AP_NR_NP(True))
         self.passmanager.append(
             [PassK_check_fixed_point_property(),
@@ -181,7 +185,7 @@ class TestUseCases(SchedulerTestCase):
                               'dag property = 2'])
 
     def test_loop_and_conditional(self):
-        """ Run a loop first, then a conditional"""
+        """Run a loop first, then a conditional."""
         FlowController.remove_flow_controller('condition')
         FlowController.add_flow_controller('condition', ConditionalController)
 
@@ -237,15 +241,18 @@ class TestUseCases(SchedulerTestCase):
                               'dag property = 2'])
 
     def test_do_not_repeat_based_on_preservation(self):
-        """ When a pass is still a valid pass (because following passes preserved it), it should not
-        run again"""
-        self.passmanager.append([PassB_TP_RA_PA(), PassA_TP_NR_NP(), PassB_TP_RA_PA()])
+        """When a pass is still a valid pass (because the following passes
+        preserved it), it should not run again."""
+        self.passmanager.append([PassB_TP_RA_PA(),
+                                 PassA_TP_NR_NP(),
+                                 PassB_TP_RA_PA()])
         self.assertScheduler(self.circuit, self.passmanager,
                              ['run transformation pass PassA_TP_NR_NP',
                               'run transformation pass PassB_TP_RA_PA'])
 
     def test_do_not_repeat_based_on_idempotence(self):
-        """ Repetition can be optimized to a single execution when the pass is idempotent"""
+        """Repetition can be optimized to a single execution when
+        the pass is idempotent."""
         self.passmanager.append(PassA_TP_NR_NP())
         self.passmanager.append([PassA_TP_NR_NP(), PassA_TP_NR_NP()])
         self.passmanager.append(PassA_TP_NR_NP())
@@ -253,9 +260,10 @@ class TestUseCases(SchedulerTestCase):
                              ['run transformation pass PassA_TP_NR_NP'])
 
     def test_non_idempotent_pass(self):
-        """ Two or more runs of a non-idempotent pass cannot be optimized. """
+        """Two or more runs of a non-idempotent pass cannot be optimized."""
         self.passmanager.append(PassF_reduce_dag_property())
-        self.passmanager.append([PassF_reduce_dag_property(), PassF_reduce_dag_property()])
+        self.passmanager.append([PassF_reduce_dag_property(),
+                                 PassF_reduce_dag_property()])
         self.passmanager.append(PassF_reduce_dag_property())
         self.assertScheduler(self.circuit, self.passmanager,
                              ['run transformation pass PassF_reduce_dag_property',
@@ -268,14 +276,14 @@ class TestUseCases(SchedulerTestCase):
                               'dag property = 3'])
 
     def test_fenced_property_set(self):
-        """ Transformation passes are not allowed to modified the property set. """
+        """Transformation passes are not allowed to modify the property set."""
         self.passmanager.append(PassH_Bad_TP())
         self.assertSchedulerRaises(self.circuit, self.passmanager,
                                    ['run transformation pass PassH_Bad_TP'],
                                    TranspilerAccessError)
 
     def test_fenced_dag(self):
-        """ Analysis passes are not allowed to modified the DAG. """
+        """Analysis passes are not allowed to modified the DAG."""
         qr = QuantumRegister(2)
         circ = QuantumCircuit(qr)
         circ.cx(qr[0], qr[1])
@@ -289,100 +297,50 @@ class TestUseCases(SchedulerTestCase):
                                     'cx_runs: {(5, 6, 7, 8)}'],
                                    TranspilerAccessError)
 
-    def test_ignore_request_pm(self):
-        """ A pass manager that ignores requires does not run the passes declared in the 'requires'
-        field of the passes."""
-        passmanager = PassManager(ignore_requires=True)
-        passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
-        passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
-        passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {} / Preserves: {}
-        passmanager.append(PassB_TP_RA_PA())
-        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassC_TP_RA_PA',
-                                                         'run transformation pass PassB_TP_RA_PA',
-                                                         'run transformation pass PassD_TP_NR_NP',
-                                                         'argument [1, 2]',
-                                                         'run transformation pass PassB_TP_RA_PA'])
-
-    def test_ignore_preserves_pm(self):
-        """ A pass manager that ignores preserves does not record the passes declared in the
-        'preserves' field of the passes as valid passes."""
-        passmanager = PassManager(ignore_preserves=True)
-        passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
-        passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
-        passmanager.append(PassD_TP_NR_NP(argument1=[1, 2]))  # Requires: {} / Preserves: {}
-        passmanager.append(PassB_TP_RA_PA())
-        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassC_TP_RA_PA',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassB_TP_RA_PA',
-                                                         'run transformation pass PassD_TP_NR_NP',
-                                                         'argument [1, 2]',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassB_TP_RA_PA'])
-
-    def test_pass_non_idempotence_pm(self):
-        """ A pass manager that considers every pass as not idempotent, allows the immediate
-        repetition of a pass"""
-        passmanager = PassManager(ignore_preserves=True)
-        passmanager.append(PassA_TP_NR_NP())
-        passmanager.append(PassA_TP_NR_NP())  # Normally removed for optimization, not here.
-        passmanager.append(PassB_TP_RA_PA())  # Normally required is ignored for optimization,
-        # not here
-        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassB_TP_RA_PA'])
-
-    def test_pass_non_idempotence_passset(self):
-        """ A pass set that is not idempotent. """
-        passmanager = PassManager()
-        passmanager.append([PassA_TP_NR_NP(), PassB_TP_RA_PA()], ignore_preserves=True)
-        self.assertScheduler(self.circuit, passmanager, ['run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run transformation pass PassB_TP_RA_PA'])
-
     def test_analysis_pass_is_idempotent(self):
-        """ Analysis passes are idempotent. """
+        """Analysis passes are idempotent."""
         passmanager = PassManager()
         passmanager.append(PassE_AP_NR_NP(argument1=1))
         passmanager.append(PassE_AP_NR_NP(argument1=1))
-        self.assertScheduler(self.circuit, passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                         'set property as 1'])
+        self.assertScheduler(self.circuit, passmanager,
+                             ['run analysis pass PassE_AP_NR_NP',
+                              'set property as 1'])
 
     def test_ap_before_and_after_a_tp(self):
-        """ A default transformation does not preserves anything and analysis passes
-        need to be re-run"""
+        """A default transformation does not preserves anything
+        and analysis passes need to be re-run"""
         passmanager = PassManager()
         passmanager.append(PassE_AP_NR_NP(argument1=1))
         passmanager.append(PassA_TP_NR_NP())
         passmanager.append(PassE_AP_NR_NP(argument1=1))
-        self.assertScheduler(self.circuit, passmanager, ['run analysis pass PassE_AP_NR_NP',
-                                                         'set property as 1',
-                                                         'run transformation pass PassA_TP_NR_NP',
-                                                         'run analysis pass PassE_AP_NR_NP',
-                                                         'set property as 1'])
+        self.assertScheduler(self.circuit, passmanager,
+                             ['run analysis pass PassE_AP_NR_NP',
+                              'set property as 1',
+                              'run transformation pass PassA_TP_NR_NP',
+                              'run analysis pass PassE_AP_NR_NP',
+                              'set property as 1'])
 
     def test_pass_option_precedence(self):
-        """ The precedence of options is, in order of priority:
+        """The precedence of options is, in order of priority:
          - The passset option
          - The Pass Manager option
          - Default
         """
-        passmanager = PassManager(ignore_preserves=False, ignore_requires=True)
+        passmanager = PassManager(max_iteration=10)
         tp_pass = PassA_TP_NR_NP()
-        passmanager.append(tp_pass, ignore_preserves=True)
-        the_pass_in_the_workinglist = next(iter(passmanager.working_list))
-        self.assertTrue(the_pass_in_the_workinglist.options['ignore_preserves'])
-        self.assertTrue(the_pass_in_the_workinglist.options['ignore_requires'])
+        passmanager.append(tp_pass, max_iteration=5)
+        pass_in_workinglist = next(iter(passmanager.working_list))
+        self.assertEqual(pass_in_workinglist.options['max_iteration'], 5)
 
-    def test_pass_no_return_a_dag(self):
-        """ Passes instances with same arguments (independently of the order) are the same. """
+    def test_pass_no_return(self):
+        """Transformation passes that don't return a DAG raise error."""
         self.passmanager.append(PassJ_Bad_NoReturn())
         self.assertSchedulerRaises(self.circuit, self.passmanager,
-                                   ['run transformation pass PassJ_Bad_NoReturn'], TranspilerError)
+                                   ['run transformation pass PassJ_Bad_NoReturn'],
+                                   TranspilerError)
 
     def test_fixed_point_pass(self):
-        """ A pass set with a do_while parameter that checks for a fixed point. """
+        """A pass set with a do_while parameter that checks for a fixed point."""
         self.passmanager.append(
             [PassK_check_fixed_point_property(),
              PassA_TP_NR_NP(),
@@ -433,7 +391,8 @@ class TestUseCases(SchedulerTestCase):
                               'dag property = 2'])
 
     def test_fixed_point_pass_max_iteration(self):
-        """ A pass set with a do_while parameter that checks that the max_iteration is raised. """
+        """A pass set with a do_while parameter that checks that
+        the max_iteration is raised."""
         self.passmanager.append(
             [PassK_check_fixed_point_property(),
              PassA_TP_NR_NP(),
@@ -455,7 +414,7 @@ class TestUseCases(SchedulerTestCase):
                                     'dag property = 5'], TranspilerError)
 
     def test_fresh_initial_state(self):
-        """ New construction gives fresh instance """
+        """New construction gives fresh instance."""
         self.passmanager.append(PassM_AP_NR_NP(argument1=1))
         self.passmanager.append(PassA_TP_NR_NP())
         self.passmanager.append(PassM_AP_NR_NP(argument1=1))
@@ -468,7 +427,7 @@ class TestUseCases(SchedulerTestCase):
 
 
 class DoXTimesController(FlowController):
-    """ A control-flow plugin for running a set of passes an X amount of times."""
+    """A control-flow plugin for running a set of passes an X amount of times."""
 
     def __init__(self, passes, options, do_x_times=0, **_):
         self.do_x_times = do_x_times()
@@ -481,16 +440,17 @@ class DoXTimesController(FlowController):
 
 
 class TestControlFlowPlugin(SchedulerTestCase):
-    """ Testing the control flow plugin system. """
+    """Testing the control flow plugin system."""
 
     def setUp(self):
         self.passmanager = PassManager()
         self.circuit = QuantumCircuit(QuantumRegister(1))
 
     def test_control_flow_plugin(self):
-        """ Adds a control flow plugin with a single parameter and runs it. """
+        """Adds a control flow plugin with a single parameter and runs it."""
         FlowController.add_flow_controller('do_x_times', DoXTimesController)
-        self.passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()], do_x_times=lambda x: 3)
+        self.passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()],
+                                do_x_times=lambda x: 3)
         self.assertScheduler(self.circuit, self.passmanager,
                              ['run transformation pass PassA_TP_NR_NP',
                               'run transformation pass PassB_TP_RA_PA',
@@ -501,10 +461,11 @@ class TestControlFlowPlugin(SchedulerTestCase):
                               'run transformation pass PassC_TP_RA_PA'])
 
     def test_callable_control_flow_plugin(self):
-        """ Removes do_while, then adds it back. Checks max_iteration still working. """
+        """Removes do_while, then adds it back. Checks max_iteration still working."""
         controllers_length = len(FlowController.registered_controllers)
         FlowController.remove_flow_controller('do_while')
-        self.assertEqual(controllers_length - 1, len(FlowController.registered_controllers))
+        self.assertEqual(controllers_length - 1,
+                         len(FlowController.registered_controllers))
         FlowController.add_flow_controller('do_while', DoWhileController)
         self.assertEqual(controllers_length, len(FlowController.registered_controllers))
         self.passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()],
@@ -514,15 +475,16 @@ class TestControlFlowPlugin(SchedulerTestCase):
                                     'run transformation pass PassB_TP_RA_PA',
                                     'run transformation pass PassC_TP_RA_PA',
                                     'run transformation pass PassB_TP_RA_PA',
-                                    'run transformation pass PassC_TP_RA_PA'], TranspilerError)
+                                    'run transformation pass PassC_TP_RA_PA'],
+                                   TranspilerError)
 
     def test_remove_nonexistent_plugin(self):
-        """ Tries to remove a plugin that does not exist. """
+        """Tries to remove a plugin that does not exist."""
         self.assertRaises(KeyError, FlowController.remove_flow_controller, "foo")
 
 
 class TestDumpPasses(SchedulerTestCase):
-    """ Testing the passes method. """
+    """Testing the passes method."""
 
     def test_passes(self):
         """Dump passes in different FlowControllerLinear"""
@@ -530,14 +492,10 @@ class TestDumpPasses(SchedulerTestCase):
         passmanager.append(PassC_TP_RA_PA())
         passmanager.append(PassB_TP_RA_PA())
 
-        expected = [{'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+        expected = [{'options': {'max_iteration': 1000},
                      'passes': [PassC_TP_RA_PA()],
                      'type': FlowControllerLinear},
-                    {'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+                    {'options': {'max_iteration': 1000},
                      'passes': [PassB_TP_RA_PA()],
                      'type': FlowControllerLinear}]
         self.assertEqual(expected, passmanager.passes())
@@ -550,9 +508,7 @@ class TestDumpPasses(SchedulerTestCase):
             PassD_TP_NR_NP(argument1=[1, 2]),
             PassB_TP_RA_PA()])
 
-        expected = [{'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+        expected = [{'options': {'max_iteration': 1000},
                      'passes': [PassC_TP_RA_PA(),
                                 PassB_TP_RA_PA(),
                                 PassD_TP_NR_NP(argument1=[1, 2]),
@@ -561,21 +517,20 @@ class TestDumpPasses(SchedulerTestCase):
         self.assertEqual(expected, passmanager.passes())
 
     def test_control_flow_plugin(self):
-        """ Dump passes in a custom flow controller. """
+        """Dump passes in a custom flow controller."""
         passmanager = PassManager()
         FlowController.add_flow_controller('do_x_times', DoXTimesController)
-        passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()], do_x_times=lambda x: 3)
+        passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()],
+                           do_x_times=lambda x: 3)
 
-        expected = [{'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+        expected = [{'options': {'max_iteration': 1000},
                      'passes': [PassB_TP_RA_PA(),
                                 PassC_TP_RA_PA()],
                      'type': DoXTimesController}]
         self.assertEqual(expected, passmanager.passes())
 
     def test_conditional_and_loop(self):
-        """ Dump passes with a conditional and a loop"""
+        """Dump passes with a conditional and a loop."""
         passmanager = PassManager()
         passmanager.append(PassE_AP_NR_NP(True))
         passmanager.append(
@@ -585,14 +540,10 @@ class TestDumpPasses(SchedulerTestCase):
             do_while=lambda property_set: not property_set['property_fixed_point'],
             condition=lambda property_set: property_set['property_fixed_point'])
 
-        expected = [{'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+        expected = [{'options': {'max_iteration': 1000},
                      'passes': [PassE_AP_NR_NP(True)],
                      'type': FlowControllerLinear},
-                    {'options': {'ignore_preserves': False,
-                                 'ignore_requires': False,
-                                 'max_iteration': 1000},
+                    {'options': {'max_iteration': 1000},
                      'passes': [PassK_check_fixed_point_property(),
                                 PassA_TP_NR_NP(),
                                 PassF_reduce_dag_property()],
@@ -681,7 +632,7 @@ class TestLogPasses(QiskitTestCase):
 
 
 class TestPassManagerReuse(SchedulerTestCase):
-    """ The PassManager instance should be resusable"""
+    """The PassManager instance should be resusable."""
 
     def setUp(self):
         self.passmanager = PassManager()
@@ -713,7 +664,7 @@ class TestPassManagerReuse(SchedulerTestCase):
         self.assertScheduler(self.circuit, self.passmanager, expected)
 
     def test_fixed_point_twice(self):
-        """ A fixed point scheduler, twice """
+        """A fixed point scheduler, twice."""
         self.passmanager.append(
             [PassK_check_fixed_point_property(),
              PassA_TP_NR_NP(),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Simplify pass manager by removing 2 unused options. Also a bit of docstring cleanup.

