### PR TITLE
[Stable] Upload wheels to pypi.org instead of test.pypi.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,6 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython"
         - CIBW_SKIP="cp27-* cp34-*"
-        - TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       if: tag IS present
@@ -112,7 +111,6 @@ jobs:
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython"
         - CIBW_SKIP="cp27-* cp34-*"
-        - TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,6 @@ environment:
           CIBW_BEFORE_BUILD: pip install -U Cython
           CIBW_SKIP: cp27-* cp34-*
           TWINE_USERNAME: qiskit
-          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
           TAG_SCENARIO: true
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The current wheel build automation uploads the wheel files to
test.pypi.org. The idea behind this was to enable manual verification of
the built wheels prior to pushing the releases for real. However, this
just adds another manual process to the release process and increases
the chance of something going wrong. There also isn't any manual
validation that happens for most of the wheels. When it is done, it
provides no more than what the build automation does already
(running an example script). To simplify the release process and reduce
the chances for errors involved with downloading and re-uploading
this commit switches the build automation to directly upload to
pypi.org. The release workflow with this is now just push a tag for the
release, then build and upload a sdist to pypi. Everything else is
automated.

(cherry picked from commit 5524f56629074e4bebd6d28954fcb53b210f0209)

### Details and comments

Backported from #2561
