### PR TITLE
[WIP] Drop python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ stage_linux: &stage_linux
   os: linux
   dist: trusty
   language: python
-  python: 3.5
+  python: 3.6
 
 stage_osx: &stage_osx
   <<: *stage_generic
@@ -96,7 +96,7 @@ jobs:
         - docker
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython"
-        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_SKIP="cp27-* cp34-* cp35-*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       if: tag IS present
@@ -110,7 +110,7 @@ jobs:
       if: tag IS present
       env:
         - CIBW_BEFORE_BUILD="pip install -U Cython"
-        - CIBW_SKIP="cp27-* cp34-*"
+        - CIBW_SKIP="cp27-* cp34-* cp35-*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python3 {project}/examples/python/stochastic_swap.py"
       script:
@@ -121,25 +121,19 @@ jobs:
 
     # "lint and and pure python test" stage
     ###########################################################################
-    # Linter and style check (GNU/Linux, Python 3.5)
+    # Linter and style check (GNU/Linux, Python 3.6)
     - stage: lint and pure python test
       name: Python Style and Linter
       <<: *stage_linux
       script: make style && make lint
 
-    # Run the tests against without compilation (GNU/Linux, Python 3.5)
+    # Run the tests against without compilation (GNU/Linux, Python 3.6)
     - stage: lint and pure python test
-      name: Python 3.5 Tests Linux
+      name: Python 3.6 Tests Linux
       <<: *stage_linux
 
     # "test" stage
     ###########################################################################
-
-    # GNU/Linux, Python 3.6
-    - stage: test
-      name: Python 3.6 Tests Linux
-      <<: *stage_linux
-      python: 3.6
 
     # GNU/Linux, Python 3.7
     - stage: test
@@ -152,14 +146,6 @@ jobs:
       dist: xenial
       python: 3.7
       sudo: true
-
-    # OSX, Python 3.5.6 (via pyenv)
-    - stage: test
-      <<: *stage_osx
-      name: Python 3.5 Tests OSX
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.5.6
 
     # OSX, Python 3.6.5 (via pyenv)
     - stage: test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,16 +14,14 @@ version: 1.0.{build}
 
 environment:
     matrix:
-        - PYTHON: C:\Python35
-          TAG_SCENARIO: false
         - PYTHON: C:\Python36
           TAG_SCENARIO: false
         - PYTHON: C:\Python37
           TAG_SCENARIO: false
         - WHEEL: 1
-          PYTHON: C:\Python35
+          PYTHON: C:\Python36
           CIBW_BEFORE_BUILD: pip install -U Cython
-          CIBW_SKIP: cp27-* cp34-*
+          CIBW_SKIP: cp27-* cp34-* cp35-*
           TWINE_USERNAME: qiskit
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
           TAG_SCENARIO: true

--- a/qiskit/util.py
+++ b/qiskit/util.py
@@ -24,9 +24,9 @@ from marshmallow.warnings import ChangedInMarshmallow3Warning
 
 
 def _check_python_version():
-    """Check for Python version 3.5+."""
-    if sys.version_info < (3, 5):
-        raise Exception('Qiskit requires Python version 3.5 or greater.')
+    """Check for Python version 3.6+."""
+    if sys.version_info < (3, 6):
+        raise Exception('Qiskit requires Python version 3.6 or greater.')
 
 
 def _filter_deprecation_warnings():

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Scientific/Engineering",
@@ -96,7 +95,7 @@ setup(
     install_requires=REQUIREMENTS,
     setup_requires=['Cython>=0.27.1'],
     include_package_data=True,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require={
         'visualization': ['matplotlib>=2.1', 'nxpd>=0.2', 'ipywidgets>=7.3.0',
                           'pydot', "pillow>=4.2.1", "pylatexenc>=1.4"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py35, py36, py37, lint
+envlist = py36, py37, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
For discussion: I propose dropping support for python 3.5.

## Reasons to do this:

1. [f-Strings are awesome](https://docs.python.org/3/reference/lexical_analysis.html#f-strings)
    ```python
    msg = f"The circle has r={r} and A={np.pi*r*r}"
    ```
1. Python 3.5 was released September 2015 and superceded by python 3.6, released on December 23, 2016
1. [A bunch of other new features](https://docs.python.org/3/whatsnew/3.6.html)
1. [Better type hinting syntax for variables](https://www.python.org/dev/peps/pep-0484):
    ```python
    primes: List[int] = []
    ```
1. Much cleaner ways to do asynchronous things
1. f-strings!
1. 33% faster CI testing (smaller testing matrix)

Over the last 60 days, only about 10% of pip installs have been with python 3.5:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.6            |  48.28% |          6,102 |
| 3.7            |  40.54% |          5,124 |
| 3.5            |  10.22% |          1,292 |
| 2.7            |   0.80% |            101 |
| 3.4            |   0.14% |             18 |
| 3.8            |   0.02% |              2 |
| 2.6            |   0.01% |              1 |
| Total          |         |         12,640 |

## WIP
I think the attached patch does everything needed for dropping py 3.5 from the metadata and CI setup, but this PR is more of a placeholder for discussion

