### PR TITLE
Issue #2194: Implement Operator + 0 and Operator + None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,9 @@ Added
 - The attribute ``PassManager.log_passes`` was added to log and time the passes when they are
   executed. The results is stored in the attribute ``pass_log`` of the property set as a
   dictionary.
+- Adding ``0`` or ``None`` to an ``Operator`` instance now returns the instance
+  unchanged. This allows the use of Python's ``sum`` function on ``Operator``
+  lists without specifying an initial value. (#2582)
 
 Changed
 -------

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -391,6 +391,9 @@ class BaseOperator(ABC):
     def __add__(self, other):
         return self.add(other)
 
+    def __radd__(self, other):
+        return self.__add__(other)
+
     def __sub__(self, other):
         return self.subtract(other)
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -219,15 +219,18 @@ class Operator(BaseOperator):
         """Return the operator self + other.
 
         Args:
-            other (Operator): an operator object.
+            other (Operator, 0 or None): an operator object, 0 or None.
 
         Returns:
-            Operator: the operator self + other.
+            Operator: the operator self + other. If other == 0 or other is
+            None, returns self.
 
         Raises:
-            QiskitError: if other is not an operator, or has incompatible
-            dimensions.
+            QiskitError: if other is not an operator (except 0 or None), or has
+            incompatible dimensions.
         """
+        if other == 0 or other is None:
+            return self
         if not isinstance(other, Operator):
             other = Operator(other)
         if self.dim != other.dim:

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -531,6 +531,10 @@ class TestOperator(OperatorTestCase):
         op2 = Operator(mat2)
         self.assertEqual(op1.add(op2), Operator(mat1 + mat2))
         self.assertEqual(op1 + op2, Operator(mat1 + mat2))
+        self.assertEqual(op1 + 0, op1)
+        self.assertEqual(0 + op1, op1)
+        self.assertEqual(op1 + None, op1)
+        self.assertEqual(None + op1, op1)
 
     def test_add_except(self):
         """Test add method raises exceptions."""


### PR DESCRIPTION
### Summary

Adding 0 or None to an Operator instance now returns the instance unchanged.

### Details and comments

This allows the use of Python's sum function on Operator lists without specifying an initial value.

Fixes Issue [#2194](https://github.com/Qiskit/qiskit-terra/issues/2194).