### PR TITLE
Disable warnings output for LayoutDeprecatedTest

### DIFF
--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -16,6 +16,7 @@
 
 import copy
 import unittest
+import warnings
 
 from qiskit.circuit import QuantumRegister, Qubit
 from qiskit.transpiler.layout import Layout
@@ -409,6 +410,10 @@ class LayoutDeprecatedTest(QiskitTestCase):
 
     def setUp(self):
         self.qr = QuantumRegister(3, 'qr')
+
+        # Disable specific DeprecationWarning from this TestCase.
+        warnings.filterwarnings('ignore', category=DeprecationWarning,
+                                module='qiskit.transpiler.layout')
 
     def test_default_layout(self):
         """Static method generate_trivial_layout creates a Layout"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Related to #2576.

In an effort to reduce the number of warnings when running tests, this PR silences some specific `DeprecationWarnings` during `LayoutDeprecatedTest` (with the assumption that they are fully in control, due to the class' purpose). The end goal is being able to detect _unintended_ warnings (deprecated and otherwise) in the tests a bit more easily, cleaning up a bit the test output in the process.


### Details and comments


