### PR TITLE
Introducing PassContext

### DIFF
--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -22,4 +22,4 @@ from .basepasses import AnalysisPass, TransformationPass
 from .coupling import CouplingMap
 from .layout import Layout
 from .transpile_circuit import transpile_circuit
-from .passcontext import PassContext
+from .passcontext import TimeLoggerPassContext

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -22,3 +22,4 @@ from .basepasses import AnalysisPass, TransformationPass
 from .coupling import CouplingMap
 from .layout import Layout
 from .transpile_circuit import transpile_circuit
+from .passcontext import PassManagerContext

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -22,4 +22,4 @@ from .basepasses import AnalysisPass, TransformationPass
 from .coupling import CouplingMap
 from .layout import Layout
 from .transpile_circuit import transpile_circuit
-from .passcontext import PassManagerContext
+from .passcontext import PassContext

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""PassContext class."""
+
+from time import time
+
+
+class PassManagerContext:
+    """ A wrap around the execution of a pass."""
+
+    def __init__(self, pm_instance, pass_instance):
+        self.pm_instance = pm_instance
+        self.pass_instance = pass_instance
+        self.start_time = None
+
+    def __enter__(self):
+        if self.pm_instance.log_passes:
+            self.start_time = time()
+
+    def __exit__(self, *exc_info):
+        if self.pm_instance.log_passes:
+            end_time = time()
+            raw_log_dict = {
+                'name': self.pass_instance.name(),
+                'start_time': self.start_time,
+                'end_time': end_time,
+                'running_time': end_time - self.start_time
+            }
+            log_dict = "%s: %.5f (ms)" % (self.pass_instance.name(),
+                                          (end_time - self.start_time) * 1000)
+            if self.pm_instance.property_set['pass_raw_log'] is None:
+                self.pm_instance.property_set['pass_raw_log'] = []
+            if self.pm_instance.property_set['pass_log'] is None:
+                self.pm_instance.property_set['pass_log'] = []
+            self.pm_instance.property_set['pass_raw_log'].append(raw_log_dict)
+            self.pm_instance.property_set['pass_log'].append(log_dict)
+

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -25,24 +25,22 @@ class PassContext:
         self.start_time = None
 
     def __enter__(self):
-        if self.pm_instance.log_passes:
-            self.start_time = time()
+        self.start_time = time()
 
     def __exit__(self, *exc_info):
-        if self.pm_instance.log_passes:
-            end_time = time()
-            raw_log_dict = {
-                'name': self.pass_instance.name(),
-                'start_time': self.start_time,
-                'end_time': end_time,
-                'running_time': end_time - self.start_time
-            }
-            log_dict = "%s: %.5f (ms)" % (self.pass_instance.name(),
-                                          (end_time - self.start_time) * 1000)
-            if self.pm_instance.property_set['pass_raw_log'] is None:
-                self.pm_instance.property_set['pass_raw_log'] = []
-            if self.pm_instance.property_set['pass_log'] is None:
-                self.pm_instance.property_set['pass_log'] = []
-            self.pm_instance.property_set['pass_raw_log'].append(raw_log_dict)
-            self.pm_instance.property_set['pass_log'].append(log_dict)
+        end_time = time()
+        raw_log_dict = {
+            'name': self.pass_instance.name(),
+            'start_time': self.start_time,
+            'end_time': end_time,
+            'running_time': end_time - self.start_time
+        }
+        log_dict = "%s: %.5f (ms)" % (self.pass_instance.name(),
+                                      (end_time - self.start_time) * 1000)
+        if self.pm_instance.property_set['pass_raw_log'] is None:
+            self.pm_instance.property_set['pass_raw_log'] = []
+        if self.pm_instance.property_set['pass_log'] is None:
+            self.pm_instance.property_set['pass_log'] = []
+        self.pm_instance.property_set['pass_raw_log'].append(raw_log_dict)
+        self.pm_instance.property_set['pass_log'].append(log_dict)
 

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -28,6 +28,16 @@ class PassContext:
     def __exit__(self, *exc_info):
         self.exit(*exc_info)
 
+    def init(self):
+        pass
+
+    def enter(self):
+        pass
+
+    def exit(self):
+        pass
+
+
 class TimeLoggerPassContext(PassContext):
     def enter(self):
         self.start_time = time()

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -15,21 +15,27 @@
 
 from time import time
 
+from .basepasses import TransformationPass, AnalysisPass
+
 class PassContext:
     """ A wrap around the execution of a pass."""
     def __init__(self, pm_instance, pass_instance):
         self.pm_instance = pm_instance
         self.pass_instance = pass_instance
-        self.init()
 
     def __enter__(self):
         self.enter()
+        if isinstance(self.pass_instance, TransformationPass):
+            self.enterTransformationPass()
+        if isinstance(self.pass_instance, AnalysisPass):
+            self.enterAnalysisPass()
 
     def __exit__(self, *exc_info):
         self.exit(*exc_info)
-
-    def init(self):
-        pass
+        if isinstance(self.pass_instance, TransformationPass):
+            self.exitTransformationPass()
+        if isinstance(self.pass_instance, AnalysisPass):
+            self.exitAnalysisPass()
 
     def enter(self):
         pass
@@ -37,6 +43,17 @@ class PassContext:
     def exit(self):
         pass
 
+    def enterTransformationPass(self):
+        pass
+
+    def enterAnalysisPass(self):
+        pass
+
+    def exitTransformationPass(self):
+        pass
+
+    def exitAnalysisPass(self):
+        pass
 
 class TimeLoggerPassContext(PassContext):
     def enter(self):

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -73,7 +73,7 @@ class TimeLoggerPassContext(PassContext):
             'end_time': end_time,
             'running_time': end_time - self.start_time
         }
-        log_dict = "%s: %.5f (ms)" % (self.passmanager.name(),
+        log_dict = "%s: %.5f (ms)" % (self.current_pass.name(),
                                       (end_time - self.start_time) * 1000)
         if self.passmanager.property_set['pass_raw_log'] is None:
             self.passmanager.property_set['pass_raw_log'] = []

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -16,7 +16,7 @@
 from time import time
 
 
-class PassContext:
+class TimeLoggerPassContext:
     """ A wrap around the execution of a pass."""
 
     def __init__(self, pm_instance, pass_instance):

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -68,6 +68,8 @@ class PassContext:
 
 
 class TimeLoggerPassContext(PassContext):
+    """A PassContext for timing pass execution"""
+
     def enter(self):
         """Starts the stopwatch for timing pass execution"""
         self.start_time = time()

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -16,7 +16,7 @@
 from time import time
 
 
-class PassManagerContext:
+class PassContext:
     """ A wrap around the execution of a pass."""
 
     def __init__(self, pm_instance, pass_instance):

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -11,14 +11,18 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=attribute-defined-outside-init
+
 """PassContext class."""
 
 from time import time
 
 from .basepasses import TransformationPass, AnalysisPass
 
+
 class PassContext:
     """ A wrap around the execution of a pass."""
+
     def __init__(self, pm_instance, pass_instance):
         self.pm_instance = pm_instance
         self.pass_instance = pass_instance
@@ -26,34 +30,35 @@ class PassContext:
     def __enter__(self):
         self.enter()
         if isinstance(self.pass_instance, TransformationPass):
-            self.enterTransformationPass()
+            self.enter_transformation()
         if isinstance(self.pass_instance, AnalysisPass):
-            self.enterAnalysisPass()
+            self.enter_analysis()
 
     def __exit__(self, *exc_info):
         self.exit(*exc_info)
         if isinstance(self.pass_instance, TransformationPass):
-            self.exitTransformationPass()
+            self.exit_transformation()
         if isinstance(self.pass_instance, AnalysisPass):
-            self.exitAnalysisPass()
+            self.exit_analysis()
 
     def enter(self):
         pass
 
-    def exit(self):
+    def exit(self, *exc_info):
         pass
 
-    def enterTransformationPass(self):
+    def enter_transformation(self):
         pass
 
-    def enterAnalysisPass(self):
+    def enter_analysis(self):
         pass
 
-    def exitTransformationPass(self):
+    def exit_transformation(self):
         pass
 
-    def exitAnalysisPass(self):
+    def exit_analysis(self):
         pass
+
 
 class TimeLoggerPassContext(PassContext):
     def enter(self):
@@ -75,4 +80,3 @@ class TimeLoggerPassContext(PassContext):
             self.pm_instance.property_set['pass_log'] = []
         self.pm_instance.property_set['pass_raw_log'].append(raw_log_dict)
         self.pm_instance.property_set['pass_log'].append(log_dict)
-

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -15,19 +15,24 @@
 
 from time import time
 
-
-class TimeLoggerPassContext:
+class PassContext:
     """ A wrap around the execution of a pass."""
-
     def __init__(self, pm_instance, pass_instance):
         self.pm_instance = pm_instance
         self.pass_instance = pass_instance
-        self.start_time = None
+        self.init()
 
     def __enter__(self):
-        self.start_time = time()
+        self.enter()
 
     def __exit__(self, *exc_info):
+        self.exit(*exc_info)
+
+class TimeLoggerPassContext(PassContext):
+    def enter(self):
+        self.start_time = time()
+
+    def exit(self, *exc_info):
         end_time = time()
         raw_log_dict = {
             'name': self.pass_instance.name(),

--- a/qiskit/transpiler/passcontext.py
+++ b/qiskit/transpiler/passcontext.py
@@ -43,29 +43,38 @@ class PassContext:
             self.exit_analysis()
 
     def enter(self):
+        """The method runs before executing a pass"""
         pass
 
     def exit(self, *exc_info):
+        """The method runs after executing a pass"""
         pass
 
     def enter_transformation(self):
+        """The method runs before executing a transformation pass"""
         pass
 
     def enter_analysis(self):
+        """The method runs before executing a analysis pass"""
         pass
 
     def exit_transformation(self):
+        """The method runs after executing a transformation pass"""
         pass
 
     def exit_analysis(self):
+        """The method runs after executing an analysis pass"""
         pass
 
 
 class TimeLoggerPassContext(PassContext):
     def enter(self):
+        """Starts the stopwatch for timing pass execution"""
         self.start_time = time()
 
     def exit(self, *exc_info):
+        """Stops the stopwatch for timing pass execution and save the result in
+        property_set['pass_log'] and property_set['pass_raw_log']"""
         end_time = time()
         raw_log_dict = {
             'name': self.current_pass.name(),

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -23,7 +23,7 @@ from .propertyset import PropertySet
 from .basepasses import BasePass
 from .fencedobjs import FencedPropertySet, FencedDAGCircuit
 from .exceptions import TranspilerError
-from .passcontext import PassManagerContext
+from .passcontext import PassContext
 
 
 class PassManager():
@@ -175,7 +175,7 @@ class PassManager():
     def _run_this_pass(self, pass_, dag):
         if pass_.is_transformation_pass:
             pass_.property_set = self.fenced_property_set
-            with PassManagerContext(self, pass_):
+            with PassContext(self, pass_):
                 new_dag = pass_.run(dag)
             if not isinstance(new_dag, DAGCircuit):
                 raise TranspilerError("Transformation passes should return a transformed dag."
@@ -184,7 +184,7 @@ class PassManager():
             dag = new_dag
         elif pass_.is_analysis_pass:
             pass_.property_set = self.property_set
-            with PassManagerContext(self, pass_):
+            with PassContext(self, pass_):
                 pass_.run(FencedDAGCircuit(dag))
         else:
             raise TranspilerError("I dont know how to handle this type of pass")

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -23,7 +23,6 @@ from .propertyset import PropertySet
 from .basepasses import BasePass
 from .fencedobjs import FencedPropertySet, FencedDAGCircuit
 from .exceptions import TranspilerError
-from .passcontext import PassContext
 
 
 class PassManager():
@@ -175,7 +174,7 @@ class PassManager():
         if pass_.is_transformation_pass:
             pass_.property_set = self.fenced_property_set
             if self.pass_context:
-                with PassContext(self, pass_):
+                with self.pass_context(self, pass_):
                     new_dag = pass_.run(dag)
             else:
                 new_dag = pass_.run(dag)
@@ -187,7 +186,7 @@ class PassManager():
         elif pass_.is_analysis_pass:
             pass_.property_set = self.property_set
             if self.pass_context:
-                with PassContext(self, pass_):
+                with self.pass_context(self, pass_):
                     pass_.run(FencedDAGCircuit(dag))
             else:
                 pass_.run(FencedDAGCircuit(dag))

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -37,6 +37,8 @@ class PassManager():
                 None.
             max_iteration (int): The schedule looping iterates until the condition is met or until
                 max_iteration is reached.
+            context (PassContext): A PassContext to hook pre and post pass processing.
+                See qiskit.transpiler.PassContext for details.
         """
         # the pass manager's schedule of passes, including any control-flow.
         # Populated via PassManager.append().

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -174,7 +174,7 @@ class PassManager():
         if pass_.is_transformation_pass:
             pass_.property_set = self.fenced_property_set
             if self.pass_context:
-                with self.pass_context(self, pass_):
+                with self.pass_context(self, pass_, dag):
                     new_dag = pass_.run(dag)
             else:
                 new_dag = pass_.run(dag)
@@ -186,7 +186,7 @@ class PassManager():
         elif pass_.is_analysis_pass:
             pass_.property_set = self.property_set
             if self.pass_context:
-                with self.pass_context(self, pass_):
+                with self.pass_context(self, pass_, dag):
                     pass_.run(FencedDAGCircuit(dag))
             else:
                 pass_.run(FencedDAGCircuit(dag))

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -15,7 +15,6 @@
 
 from functools import partial
 from collections import OrderedDict
-from time import time
 
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
@@ -24,6 +23,7 @@ from .propertyset import PropertySet
 from .basepasses import BasePass
 from .fencedobjs import FencedPropertySet, FencedDAGCircuit
 from .exceptions import TranspilerError
+from .passcontext import PassManagerContext
 
 
 class PassManager():
@@ -205,37 +205,6 @@ class PassManager():
         for pass_ in self.working_list:
             ret.append(pass_.dump_passes())
         return ret
-
-
-class PassManagerContext:
-    """ A wrap around the execution of a pass."""
-
-    def __init__(self, pm_instance, pass_instance):
-        self.pm_instance = pm_instance
-        self.pass_instance = pass_instance
-        self.start_time = None
-
-    def __enter__(self):
-        if self.pm_instance.log_passes:
-            self.start_time = time()
-
-    def __exit__(self, *exc_info):
-        if self.pm_instance.log_passes:
-            end_time = time()
-            raw_log_dict = {
-                'name': self.pass_instance.name(),
-                'start_time': self.start_time,
-                'end_time': end_time,
-                'running_time': end_time - self.start_time
-            }
-            log_dict = "%s: %.5f (ms)" % (self.pass_instance.name(),
-                                          (end_time - self.start_time) * 1000)
-            if self.pm_instance.property_set['pass_raw_log'] is None:
-                self.pm_instance.property_set['pass_raw_log'] = []
-            if self.pm_instance.property_set['pass_log'] is None:
-                self.pm_instance.property_set['pass_log'] = []
-            self.pm_instance.property_set['pass_raw_log'].append(raw_log_dict)
-            self.pm_instance.property_set['pass_log'].append(log_dict)
 
 
 class FlowController():

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -22,8 +22,9 @@ from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
 from qiskit.compiler import transpile
 from qiskit.transpiler import TranspilerAccessError, TranspilerError
+from qiskit.transpiler.passcontext import TimeLoggerPassContext
 from qiskit.transpiler.passmanager import DoWhileController, ConditionalController, \
-    FlowController, FlowControllerLinear, PassContext
+    FlowController, FlowControllerLinear
 from qiskit.test import QiskitTestCase
 from ._dummy_passes import (PassA_TP_NR_NP, PassB_TP_RA_PA, PassC_TP_RA_PA,
                             PassD_TP_NR_NP, PassE_AP_NR_NP, PassF_reduce_dag_property,
@@ -551,8 +552,8 @@ class TestDumpPasses(SchedulerTestCase):
         self.assertEqual(expected, passmanager.passes())
 
 
-class TestPassContext(QiskitTestCase):
-    """Testing the PassContext."""
+class TestTimeLoggerPassContext(QiskitTestCase):
+    """Testing the TimeLoggerPassContext."""
 
     def setUp(self):
         self.circuit = QuantumCircuit(QuantumRegister(1))
@@ -578,7 +579,7 @@ class TestPassContext(QiskitTestCase):
 
     def test_passes(self):
         """Dump passes in different FlowControllerLinear"""
-        passmanager = PassManager(context=PassContext)
+        passmanager = PassManager(context=TimeLoggerPassContext)
         passmanager.append(PassC_TP_RA_PA())
         passmanager.append(PassB_TP_RA_PA())
 
@@ -592,7 +593,7 @@ class TestPassContext(QiskitTestCase):
             PassC_TP_RA_PA(),
             PassB_TP_RA_PA(),
             PassD_TP_NR_NP(argument1=[1, 2]),
-            PassB_TP_RA_PA()], context=PassContext)
+            PassB_TP_RA_PA()], context=TimeLoggerPassContext)
 
         self.assertPassLog(passmanager, ['PassA_TP_NR_NP',
                                          'PassC_TP_RA_PA',
@@ -603,7 +604,7 @@ class TestPassContext(QiskitTestCase):
 
     def test_control_flow_plugin(self):
         """ Dump passes in a custom flow controller. """
-        passmanager = PassManager(context=PassContext)
+        passmanager = PassManager(context=TimeLoggerPassContext)
         FlowController.add_flow_controller('do_x_times', DoXTimesController)
         passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()], do_x_times=lambda x: 3)
         self.assertPassLog(passmanager, ['PassA_TP_NR_NP',
@@ -616,7 +617,7 @@ class TestPassContext(QiskitTestCase):
 
     def test_conditional_and_loop(self):
         """ Dump passes with a conditional and a loop"""
-        passmanager = PassManager(context=PassContext)
+        passmanager = PassManager(context=TimeLoggerPassContext)
         passmanager.append(PassE_AP_NR_NP(True))
         passmanager.append(
             [PassK_check_fixed_point_property(),

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -23,7 +23,7 @@ from qiskit.transpiler import PassManager
 from qiskit.compiler import transpile
 from qiskit.transpiler import TranspilerAccessError, TranspilerError
 from qiskit.transpiler.passmanager import DoWhileController, ConditionalController, \
-    FlowController, FlowControllerLinear
+    FlowController, FlowControllerLinear, PassContext
 from qiskit.test import QiskitTestCase
 from ._dummy_passes import (PassA_TP_NR_NP, PassB_TP_RA_PA, PassC_TP_RA_PA,
                             PassD_TP_NR_NP, PassE_AP_NR_NP, PassF_reduce_dag_property,
@@ -551,8 +551,8 @@ class TestDumpPasses(SchedulerTestCase):
         self.assertEqual(expected, passmanager.passes())
 
 
-class TestLogPasses(QiskitTestCase):
-    """Testing the log_passes option."""
+class TestPassContext(QiskitTestCase):
+    """Testing the PassContext."""
 
     def setUp(self):
         self.circuit = QuantumCircuit(QuantumRegister(1))
@@ -578,8 +578,7 @@ class TestLogPasses(QiskitTestCase):
 
     def test_passes(self):
         """Dump passes in different FlowControllerLinear"""
-        passmanager = PassManager()
-        passmanager.log_passes = True
+        passmanager = PassManager(context=PassContext)
         passmanager.append(PassC_TP_RA_PA())
         passmanager.append(PassB_TP_RA_PA())
 
@@ -593,8 +592,7 @@ class TestLogPasses(QiskitTestCase):
             PassC_TP_RA_PA(),
             PassB_TP_RA_PA(),
             PassD_TP_NR_NP(argument1=[1, 2]),
-            PassB_TP_RA_PA()])
-        passmanager.log_passes = True
+            PassB_TP_RA_PA()], context=PassContext)
 
         self.assertPassLog(passmanager, ['PassA_TP_NR_NP',
                                          'PassC_TP_RA_PA',
@@ -605,10 +603,9 @@ class TestLogPasses(QiskitTestCase):
 
     def test_control_flow_plugin(self):
         """ Dump passes in a custom flow controller. """
-        passmanager = PassManager()
+        passmanager = PassManager(context=PassContext)
         FlowController.add_flow_controller('do_x_times', DoXTimesController)
         passmanager.append([PassB_TP_RA_PA(), PassC_TP_RA_PA()], do_x_times=lambda x: 3)
-        passmanager.log_passes = True
         self.assertPassLog(passmanager, ['PassA_TP_NR_NP',
                                          'PassB_TP_RA_PA',
                                          'PassC_TP_RA_PA',
@@ -619,7 +616,7 @@ class TestLogPasses(QiskitTestCase):
 
     def test_conditional_and_loop(self):
         """ Dump passes with a conditional and a loop"""
-        passmanager = PassManager()
+        passmanager = PassManager(context=PassContext)
         passmanager.append(PassE_AP_NR_NP(True))
         passmanager.append(
             [PassK_check_fixed_point_property(),
@@ -627,7 +624,6 @@ class TestLogPasses(QiskitTestCase):
              PassF_reduce_dag_property()],
             do_while=lambda property_set: not property_set['property_fixed_point'],
             condition=lambda property_set: property_set['property_fixed_point'])
-        passmanager.log_passes = True
         self.assertPassLog(passmanager, ['PassE_AP_NR_NP'])
 
 


### PR DESCRIPTION
In #2579, a debugging callback for the passmanager was discussed. This PR introduces `PassContext` as an alternative solution.

For time logging, very similarly as currently in master
```python
from qiskit.transpiler.passcontext import TimeLoggerPassContext 

...

passmanager = PassManager(context=TimeLoggerPassContext) 
passmanager.append(Unroller(['u2'])) 
passmanager.append(Optimize1qGates()) 
transpile(circuit, pass_manager=passmanager)

passmanager.property_set['pass_log']
```
```
['Unroller: 1.17302 (ms)', 'Optimize1qGates: 0.93293 (ms)']
```

If you want to print the circuit after a transformation, you need to subclass `PassContext` (or `TimeLoggerPassContext` if you want to also do time logging) and extend `exit_transformation`:
```python
class PrintTransformation(PassContext): 
     def exit_transformation(self): 
         print(dag_to_circuit(self.dag))
         super().exit_transformation()
...
passmanager = PassManager(context=PrintTransformation) 
passmanager.append(Unroller(['u2'])) 
passmanager.append(Optimize1qGates()) 
transpile(circuit, pass_manager=passmanager)
```
```
         ┌──────────┐┌──────────┐┌──────────┐
qr_0: |0>┤ U2(0,pi) ├┤ U2(0,pi) ├┤ U2(0,pi) ├
         └──────────┘└──────────┘└──────────┘
         ┌──────────────┐
qr_0: |0>┤ U2(0,3.1416) ├
         └──────────────┘
```