### PR TITLE
fix backend monitor multi-qubits

### DIFF
--- a/qiskit/tools/monitor/backend_overview.py
+++ b/qiskit/tools/monitor/backend_overview.py
@@ -115,7 +115,7 @@ def backend_monitor(backend):
         print(offset+qstr)
 
     print()
-    multi_qubit_gates = props['gates'][3*config['n_qubits']:]
+    multi_qubit_gates = [g for g in props['gates'] if len(g['qubits']) > 1]
     multi_header = 'Multi-Qubit Gates [Name / Type / Gate Error]'
     print(multi_header)
     print('-'*len(multi_header))


### PR DESCRIPTION
### Summary
Fixes #2604, fixes #2602 

The backend monitor code had a bug in finding multi-qubit gates. It assumed that the gate set only has u1,u2,u3,cx. The addition of `id` to the Tokyo device breaks the assumption and caused failures on the master branch. This fixes that.