### PR TITLE
Braught pulse command naming in line with circuit Registers (#2593).

### DIFF
--- a/qiskit/pulse/commands/acquire.py
+++ b/qiskit/pulse/commands/acquire.py
@@ -22,6 +22,7 @@ from qiskit.pulse.exceptions import PulseError
 from .instruction import Instruction
 from .meas_opts import Discriminator, Kernel
 from .command import Command
+import itertools
 
 
 class Acquire(Command):
@@ -29,7 +30,10 @@ class Acquire(Command):
 
     ALIAS = 'acquire'
 
-    def __init__(self, duration, discriminator=None, kernel=None):
+    # Counter for the number of instances in this class
+    instances_counter = itertools.count(0)
+
+    def __init__(self, duration, discriminator=None, kernel=None, name=None):
         """Create new acquire command.
 
         Args:
@@ -39,11 +43,14 @@ class Acquire(Command):
             kernel (Kernel): The data structures defining the measurement kernels
                 to be used (from the list of available kernels) and set of parameters
                 (if applicable) if the measurement level is 1 or 2.
+            name (str): Name of this command.
 
         Raises:
             PulseError: when invalid discriminator or kernel object is input.
         """
         super().__init__(duration=duration)
+
+        self._name = self.create_name(name=name, prefix='acq', counter=self.instances_counter)
 
         if discriminator:
             if isinstance(discriminator, Discriminator):

--- a/qiskit/pulse/commands/frame_change.py
+++ b/qiskit/pulse/commands/frame_change.py
@@ -19,20 +19,26 @@ Frame change pulse.
 from qiskit.pulse.channels import PulseChannel
 from .instruction import Instruction
 from .command import Command
+import itertools
 
 
 class FrameChange(Command):
     """Frame change pulse."""
 
-    def __init__(self, phase):
+    # Counter for the number of instances in this class
+    instances_counter = itertools.count(0)
+
+    def __init__(self, phase, name=None):
         """Create new frame change pulse.
 
         Args:
             phase (float): Frame change phase in radians.
                 The allowable precision is device specific.
+            name (str): Name of this command.
         """
         super().__init__(duration=0)
         self._phase = float(phase)
+        self._name = self.create_name(name=name, prefix='fc', counter=self.instances_counter)
 
     @property
     def phase(self):

--- a/qiskit/pulse/commands/persistent_value.py
+++ b/qiskit/pulse/commands/persistent_value.py
@@ -20,17 +20,22 @@ from qiskit.pulse.channels import PulseChannel
 from qiskit.pulse.exceptions import PulseError
 from .instruction import Instruction
 from .command import Command
+import itertools
 
 
 class PersistentValue(Command):
     """Persistent value."""
 
-    def __init__(self, value):
+    # Counter for the number of instances in this class
+    instances_counter = itertools.count(0)
+
+    def __init__(self, value, name=None):
         """create new persistent value command.
 
         Args:
             value (complex): Complex value to apply, bounded by an absolute value of 1.
                 The allowable precision is device specific.
+            name (str): Name of this command.
         Raises:
             PulseError: when input value exceed 1.
         """
@@ -40,6 +45,7 @@ class PersistentValue(Command):
             raise PulseError("Absolute value of PV amplitude exceeds 1.")
 
         self._value = complex(value)
+        self._name = self.create_name(name=name, prefix='pv', counter=self.instances_counter)
 
     @property
     def value(self):

--- a/qiskit/pulse/commands/sample_pulse.py
+++ b/qiskit/pulse/commands/sample_pulse.py
@@ -23,10 +23,14 @@ from qiskit.pulse.channels import PulseChannel
 from qiskit.pulse.exceptions import PulseError
 from .instruction import Instruction
 from .command import Command
+import itertools
 
 
 class SamplePulse(Command):
     """Container for functional pulse."""
+
+    # Counter for the number of instances in this class
+    instances_counter = itertools.count(0)
 
     def __init__(self, samples, name=None):
         """Create new sample pulse command.
@@ -37,12 +41,13 @@ class SamplePulse(Command):
         Raises:
             PulseError: when pulse envelope amplitude exceeds 1.
         """
-        super().__init__(duration=len(samples), name=name)
+        super().__init__(duration=len(samples))
 
         if np.any(np.abs(samples) > 1):
             raise PulseError('Absolute value of pulse envelope amplitude exceeds 1.')
 
         self._samples = np.asarray(samples, dtype=np.complex_)
+        self._name = self.create_name(name=name, prefix='p', counter=self.instances_counter)
 
     @property
     def samples(self):

--- a/qiskit/pulse/commands/snapshot.py
+++ b/qiskit/pulse/commands/snapshot.py
@@ -19,10 +19,14 @@ Snapshot.
 from qiskit.pulse.channels import SnapshotChannel
 from .instruction import Instruction
 from .command import Command
+import itertools
 
 
 class Snapshot(Command, Instruction):
     """Snapshot."""
+
+    # Counter for the number of instances in this class
+    instances_counter = itertools.count(0)
 
     def __init__(self, name: str, snap_type: str):
         """Create new snapshot command.
@@ -35,8 +39,9 @@ class Snapshot(Command, Instruction):
         """
         self._type = snap_type
         self._channel = SnapshotChannel()
-        Command.__init__(self, duration=0, name=name)
-        Instruction.__init__(self, self, self._channel, name=name)
+        Command.__init__(self, duration=0)
+        self._name = self.create_name(name=name, prefix='snap', counter=self.instances_counter)
+        Instruction.__init__(self, self, self._channel, name=self.name)
         self._buffer = 0
 
     @property

--- a/test/python/pulse/test_commands.py
+++ b/test/python/pulse/test_commands.py
@@ -50,15 +50,19 @@ class TestAcquire(QiskitTestCase):
         self.assertEqual(acq_command.discriminator.params, discriminator_opts)
         self.assertEqual(acq_command.kernel.name, 'boxcar')
         self.assertEqual(acq_command.kernel.params, kernel_opts)
+        self.assertTrue(acq_command.name.startswith('acq'))
 
     def test_can_construct_acquire_command_with_default_values(self):
         """Test if an acquire command can be constructed with default discriminator and kernel.
         """
-        acq_command = Acquire(duration=10)
+        acq_command_a = Acquire(duration=10)
+        acq_command_b = Acquire(duration=10)
 
-        self.assertEqual(acq_command.duration, 10)
-        self.assertEqual(acq_command.discriminator, None)
-        self.assertEqual(acq_command.kernel, None)
+        self.assertEqual(acq_command_a.duration, 10)
+        self.assertEqual(acq_command_a.discriminator, None)
+        self.assertEqual(acq_command_a.kernel, None)
+        self.assertTrue(acq_command_a.name.startswith('acq'))
+        self.assertNotEqual(acq_command_a.name, acq_command_b.name)
 
 
 class TestFrameChange(QiskitTestCase):
@@ -71,6 +75,7 @@ class TestFrameChange(QiskitTestCase):
 
         self.assertEqual(fc_command.phase, 1.57)
         self.assertEqual(fc_command.duration, 0)
+        self.assertTrue(fc_command.name.startswith('fc'))
 
 
 class TestFunctionalPulse(QiskitTestCase):
@@ -107,6 +112,7 @@ class TestPersistentValue(QiskitTestCase):
 
         self.assertEqual(pv_command.value, 0.5-0.5j)
         self.assertEqual(pv_command.duration, 0)
+        self.assertTrue(pv_command.name.startswith('pv'))
 
 
 class TestSnapshot(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Braught pulse command naming in line with circuit Registers (#2593).

### Details and comments

* Added `create_name(...)` to command.py that can be used to set pulse command names.

* Added a counter using `itertools` to `class Command` and its children to count the instances of each class.

* Updated the test package to reflect these changes.

* Updated `__init__` of `class Command` and its children to use `create_name(...)`

If a pulse command is not given a name it will have the name `prefix%d` where
`%d` counts the number of class instances. The default prefixes are
* Command: `c`
* SamplePulse: `p`
* FrameChange: `fc`
* PersistentValue: `pv`
* Acquire: `acq`
* Snapshot: `snap`

