### PR TITLE
Add coverage collection to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,15 +34,18 @@ stage_generic: &stage_generic
   install:
     # Install step for jobs that require compilation and qa.
     - pip install -U -r requirements.txt
-    - pip install -U -r requirements-dev.txt -c constraints.txt
+    - pip install -U -r requirements-dev.txt coveralls -c constraints.txt
     - pip install -e .
     - pip install "qiskit-ibmq-provider" -c constraints.txt
   script:
-    # Compile the executables and run the tests.
+    # Compile the executables and run th tests.
     - python setup.py build_ext --inplace
     - make test_ci
   after_failure:
     - python tools/report_ci_failure.py
+  after_success:
+    - coverage combine || true
+    - coveralls || true
 
 stage_linux: &stage_linux
   <<: *stage_generic
@@ -140,6 +143,8 @@ jobs:
       name: Python 3.6 Tests Linux
       <<: *stage_linux
       python: 3.6
+      env:
+        - PYTHON=coverage run --source qiskit --parallel-mode
 
     # GNU/Linux, Python 3.7
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stage_generic: &stage_generic
     - pip install -e .
     - pip install "qiskit-ibmq-provider" -c constraints.txt
   script:
-    # Compile the executables and run th tests.
+    # Compile the executables and run the tests.
     - python setup.py build_ext --inplace
     - make test_ci
   after_failure:
@@ -144,7 +144,7 @@ jobs:
       <<: *stage_linux
       python: 3.6
       env:
-        - PYTHON=coverage run --source qiskit --parallel-mode
+        - PYTHON="coverage run --source qiskit --parallel-mode"
 
     # GNU/Linux, Python 3.7
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ stage_generic: &stage_generic
     - make test_ci
   after_failure:
     - python tools/report_ci_failure.py
-  after_success:
-    - coverage combine || true
-    - coveralls || true
 
 stage_linux: &stage_linux
   <<: *stage_generic
@@ -145,6 +142,9 @@ jobs:
       python: 3.6
       env:
         - PYTHON="coverage run --source qiskit --parallel-mode"
+      after_success:
+        - coverage combine || true
+        - coveralls || true
 
     # GNU/Linux, Python 3.7
     - stage: test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds coverage collection to the CI environment. It adds
reporting back to coveralls for the python 3.6 job. So when that job
finishes executing it will send the collected coverage data to coveralls
so we can track out unit test coverage.

### Details and comments

Fixes #771