### PR TITLE
Ensure is_mergeable_with does not mutate TimeslotCollection

### DIFF
--- a/qiskit/pulse/timeslots.py
+++ b/qiskit/pulse/timeslots.py
@@ -220,9 +220,10 @@ class TimeslotCollection:
             timeslots: TimeslotCollection to be checked
         """
         for slot in timeslots.timeslots:
-            for interval in self._table[slot.channel]:
-                if slot.interval.has_overlap(interval):
-                    return False
+            if slot.channel in self.channels:
+                for interval in self._table[slot.channel]:
+                    if slot.interval.has_overlap(interval):
+                        return False
         return True
 
     def merged(self, timeslots: 'TimeslotCollection') -> 'TimeslotCollection':

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -258,10 +258,9 @@ def gates_tab(backend):
     Returns:
         VBox: A VBox widget.
     """
-    config = backend.configuration().to_dict()
     props = backend.properties().to_dict()
 
-    multi_qubit_gates = props['gates'][3*config['n_qubits']:]
+    multi_qubit_gates = [g for g in props['gates'] if len(g['qubits']) > 1]
 
     header_html = "<div><font style='font-weight:bold'>{key}</font>: {value}</div>"
     header_html = header_html.format(key='last_update_date',

--- a/test/python/pulse/test_timeslots.py
+++ b/test/python/pulse/test_timeslots.py
@@ -120,6 +120,23 @@ class TestTimeslotCollection(QiskitTestCase):
         expected = TimeslotCollection(Timeslot(Interval(11, 13), AcquireChannel(0)))
         self.assertEqual(expected, actual)
 
+    def test_is_mergeable_does_not_mutate_TimeslotCollection(self):
+        """Test that is_mergeable_with does not mutate the given TimeslotCollection"""
+
+        # Different channel but different interval
+        col1 = TimeslotCollection(Timeslot(Interval(1, 2), AcquireChannel(0)))
+        expected_channels = col1.channels
+        col2 = TimeslotCollection(Timeslot(Interval(3, 4), AcquireChannel(1)))
+        col1.is_mergeable_with(col2)
+        self.assertEqual(col1.channels, expected_channels)
+
+        # Different channel but same interval
+        col1 = TimeslotCollection(Timeslot(Interval(1, 2), AcquireChannel(0)))
+        expected_channels = col1.channels
+        col2 = TimeslotCollection(Timeslot(Interval(1, 2), AcquireChannel(1)))
+        col1.is_mergeable_with(col2)
+        self.assertEqual(col1.channels, expected_channels)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2596. 

Within `TimeslotCollections.is_mergeable_with()`, checks if each `slot.channel` already exists in `self._table`. If the `channel` does not exist, it skips the rest of the check and moves on to the next `timeslot` in the `TimeslotCollection`. If the `channel` does exist, it continues to the `Interval.has_overlap()` function.

