### PR TITLE
Fix CHANGELOG display errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a
-Changelog](http://keepachangelog.com/en/1.0.0/).
+The format is based on [Keep a Changelog].
 
 > **Types of changes:**
 >
@@ -14,7 +13,7 @@ Changelog](http://keepachangelog.com/en/1.0.0/).
 > -   **Fixed**: for any bug fixes.
 > -   **Security**: in case of vulnerabilities.
 
-[UNRELEASED](https://github.com/Qiskit/qiskit-terra/compare/0.8.0...HEAD)
+[UNRELEASED]
 =========================================================================
 
 Deprecated
@@ -79,7 +78,7 @@ Fixed
 -   Possible to decompose SU(4) gate into non-CNOT basis with
     `TwoQubitDecomposer`
 
-[0.8.0](https://github.com/Qiskit/qiskit-terra/compare/0.7.2...0.8.0) - 2019-05-02
+[0.8.0] - 2019-05-02
 ==================================================================================
 
 Added
@@ -375,7 +374,7 @@ Removed
     (\#1860).
 -   Removed `Instruction.reapply()` method (\#1816).
 
-[0.7.2](https://github.com/Qiskit/qiskit-terra/compare/0.7.1...0.7.2) - 2019-05-01
+[0.7.2] - 2019-05-01
 ==================================================================================
 
 Fixed
@@ -384,7 +383,7 @@ Fixed
 -   A potential issue where the backend configuration schema validation
     would improperly reject valid responses from the API (\#2258)
 
-[0.7.1](https://github.com/Qiskit/qiskit-terra/compare/0.7.0...0.7.1) - 2019-03-04
+[0.7.1] - 2019-03-04
 ==================================================================================
 
 Fixed
@@ -393,7 +392,7 @@ Fixed
 -   Fixed a bug with measurement sampling optimization in BasicAer
     qasm\_simulator (\#1624).
 
-[0.7.0](https://github.com/Qiskit/qiskit-terra/compare/0.6.0...0.7.0) - 2018-12-19
+[0.7.0] - 2018-12-19
 ==================================================================================
 
 Added
@@ -624,7 +623,7 @@ Removed
     convert the output with the functions provided in
     `qiskit.converters`.
 
-[0.6.0](https://github.com/Qiskit/qiskit-terra/compare/0.5.7...0.6.0) - 2018-10-04
+[0.6.0] - 2018-10-04
 ==================================================================================
 
 Added
@@ -720,7 +719,7 @@ Fixed
 -   Fixed bug in checking that a circuit already matches a coupling map
     (\#1024).
 
-[0.5.7](https://github.com/Qiskit/qiskit-terra/compare/0.5.6...0.5.7) - 2018-07-19
+[0.5.7] - 2018-07-19
 ==================================================================================
 
 Changed
@@ -728,7 +727,7 @@ Changed
 
 -   Add new backend names support, with aliasing for the old ones.
 
-[0.5.6](https://github.com/Qiskit/qiskit-terra/compare/0.5.5...0.5.6) - 2018-07-06
+[0.5.6] - 2018-07-06
 ==================================================================================
 
 Changed
@@ -751,7 +750,7 @@ Fixed
 -   Fixed yzy\_to\_zyz bugs (\#520, \#607) by moving to quaternions
     (\#626).
 
-[0.5.5](https://github.com/Qiskit/qiskit-terra/compare/0.5.4...0.5.5) - 2018-07-02
+[0.5.5] - 2018-07-02
 ==================================================================================
 
 Added
@@ -796,7 +795,7 @@ Fixed
 -   Fix issue with skip\_transpiler causing some gates to be ignored
     silently (\#562).
 
-[0.5.4](https://github.com/Qiskit/qiskit-terra/compare/0.5.3...0.5.4) - 2018-06-11
+[0.5.4] - 2018-06-11
 ==================================================================================
 
 Added
@@ -838,7 +837,7 @@ Fixed
 -   Fix issue with simulator extension commands not reapplying correctly
     (\#556)
 
-[0.5.3](https://github.com/Qiskit/qiskit-terra/compare/0.5.2...0.5.3) - 2018-05-29
+[0.5.3] - 2018-05-29
 ==================================================================================
 
 Added
@@ -857,7 +856,7 @@ Fixed
 -   Crash in the cpp simulator for some linux platforms
 -   Fixed some minor bugs
 
-[0.5.2](https://github.com/Qiskit/qiskit-terra/compare/0.5.1...0.5.2) - 2018-05-21
+[0.5.2] - 2018-05-21
 ==================================================================================
 
 Changed
@@ -877,7 +876,7 @@ Fixed
 -   Fixing a Mapper issue.
 -   Fixing Windows 7 builds.
 
-[0.5.1](https://github.com/Qiskit/qiskit-terra/compare/0.5.0...0.5.1) - 2018-05-15
+[0.5.1] - 2018-05-15
 ==================================================================================
 
 -   There are no code changes.
@@ -889,7 +888,7 @@ Fixed
     Pypi forces us to bump up the version number if we want to upload a
     new package, so this is basically what have changed.
 
-[0.5.0](https://github.com/Qiskit/qiskit-terra/compare/0.4.15...0.5.0) - 2018-05-11
+[0.5.0] - 2018-05-11
 ===================================================================================
 
 Improvements
@@ -1001,7 +1000,7 @@ Deprecated
 -   Move simulator extensions to `qiskit/extensions/simulator`
 -   Move Rzz and CSwap to standard extension library
 
-[0.4.15](https://github.com/Qiskit/qiskit-terra/compare/0.4.14...0.4.15) - 2018-05-07
+[0.4.15] - 2018-05-07
 =====================================================================================
 
 Fixed
@@ -1010,7 +1009,7 @@ Fixed
 -   Fixed an issue with legacy code that was affecting Developers
     Challenge.
 
-[0.4.14](https://github.com/Qiskit/qiskit-terra/compare/0.4.13...0.4.14) - 2018-04-18
+[0.4.14] - 2018-04-18
 =====================================================================================
 
 Fixed
@@ -1019,7 +1018,7 @@ Fixed
 -   Fixed an issue about handling Basis Gates parameters on backend
     configurations.
 
-[0.4.13](https://github.com/Qiskit/qiskit-terra/compare/0.4.12...0.4.13) - 2018-04-16
+[0.4.13] - 2018-04-16
 =====================================================================================
 
 Changed
@@ -1032,7 +1031,7 @@ Fixed
 
 -   Fixes an issue regarding barrier gate misuse in some circumstances.
 
-[0.4.12](https://github.com/Qiskit/qiskit-terra/compare/0.4.11...0.4.12) - 2018-03-11
+[0.4.12] - 2018-03-11
 =====================================================================================
 
 Changed
@@ -1047,7 +1046,7 @@ Fixed
 
 -   A bunch of minor bugs have been fixed.
 
-[0.4.11](https://github.com/Qiskit/qiskit-terra/compare/0.4.10...0.4.11) - 2018-03-13
+[0.4.11] - 2018-03-13
 =====================================================================================
 
 Added
@@ -1066,7 +1065,7 @@ Fixed
 -   Fixed bug in circuit drawing where some gates in the standard
     library were not plotting correctly.
 
-[0.4.10](https://github.com/Qiskit/qiskit-terra/compare/0.4.9...0.4.10) - 2018-03-06
+[0.4.10] - 2018-03-06
 ====================================================================================
 
 Added
@@ -1088,7 +1087,7 @@ Fixed
     simulator.
 -   Fix a bug in the async code.
 
-[0.4.9](https://github.com/Qiskit/qiskit-terra/compare/0.4.8...0.4.9) - 2018-02-12
+[0.4.9] - 2018-02-12
 ==================================================================================
 
 Changed
@@ -1103,7 +1102,7 @@ Fixed
 
 -   Some minor C++ Simulator bug-fixes.
 
-[0.4.8](https://github.com/Qiskit/qiskit-terra/compare/0.4.7...0.4.8) - 2018-01-29
+[0.4.8] - 2018-01-29
 ==================================================================================
 
 Fixed
@@ -1112,7 +1111,7 @@ Fixed
 -   Fix parsing U\_error matrix in C++ Simulator python helper class.
 -   Fix display of code-blocks on `.rst` pages.
 
-[0.4.7](https://github.com/Qiskit/qiskit-terra/compare/0.4.6...0.4.7) - 2018-01-26
+[0.4.7] - 2018-01-26
 ==================================================================================
 
 Changed
@@ -1127,7 +1126,7 @@ Fixed
 -   Fixes several bugs with noise implementations in the simulator.
 -   Fixes many spelling mistakes in simulator README.
 
-[0.4.6](https://github.com/Qiskit/qiskit-terra/compare/0.4.5...0.4.6) - 2018-01-22
+[0.4.6] - 2018-01-22
 ==================================================================================
 
 Changed
@@ -1143,7 +1142,7 @@ Changed
     > -   Sphinx\>=1.6,\<1.7
     > -   sympy\>=1.0
 
-[0.4.4](https://github.com/Qiskit/qiskit-terra/compare/0.4.3...0.4.4) - 2018-01-09
+[0.4.4] - 2018-01-09
 ==================================================================================
 
 Changed
@@ -1156,7 +1155,7 @@ Fixed
 
 -   Fix bug with process tomography reversing qubit preparation order.
 
-[0.4.3](https://github.com/Qiskit/qiskit-terra/compare/0.4.2...0.4.3) - 2018-01-08
+[0.4.3] - 2018-01-08
 ==================================================================================
 
 Removed
@@ -1165,7 +1164,7 @@ Removed
 -   Static compilation has been removed because it seems to be failing
     while installing Qiskit via pip on Mac.
 
-[0.4.2](https://github.com/Qiskit/qiskit-terra/compare/0.4.1...0.4.2) - 2018-01-08
+[0.4.2] - 2018-01-08
 ==================================================================================
 
 Fixed
@@ -1173,7 +1172,7 @@ Fixed
 
 -   Minor bug fixing related to pip installation process.
 
-[0.4.0](https://github.com/Qiskit/qiskit-terra/compare/0.3.16...0.4.0) - 2018-01-08
+[0.4.0] - 2018-01-08
 ===================================================================================
 
 Added
@@ -1304,3 +1303,34 @@ Fixed
 -   Enable QASM parser to work in multiuser environments.
 -   Correct operator precedence when parsing expressions (\#190).
 -   Fix \"math domain error\" in mapping (\#111, \#151).
+
+[UNRELEASED]: https://github.com/Qiskit/qiskit-terra/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/Qiskit/qiskit-terra/compare/0.7.2...0.8.0
+[0.7.2]: https://github.com/Qiskit/qiskit-terra/compare/0.7.1...0.7.2
+[0.7.1]: https://github.com/Qiskit/qiskit-terra/compare/0.7.0...0.7.1
+[0.7.0]: https://github.com/Qiskit/qiskit-terra/compare/0.6.0...0.7.0
+[0.6.0]: https://github.com/Qiskit/qiskit-terra/compare/0.5.7...0.6.0
+[0.5.7]: https://github.com/Qiskit/qiskit-terra/compare/0.5.6...0.5.7
+[0.5.6]: https://github.com/Qiskit/qiskit-terra/compare/0.5.5...0.5.6
+[0.5.5]: https://github.com/Qiskit/qiskit-terra/compare/0.5.4...0.5.5
+[0.5.4]: https://github.com/Qiskit/qiskit-terra/compare/0.5.3...0.5.4
+[0.5.3]: https://github.com/Qiskit/qiskit-terra/compare/0.5.2...0.5.3
+[0.5.2]: https://github.com/Qiskit/qiskit-terra/compare/0.5.1...0.5.2
+[0.5.1]: https://github.com/Qiskit/qiskit-terra/compare/0.5.0...0.5.1
+[0.5.0]: https://github.com/Qiskit/qiskit-terra/compare/0.4.15...0.5.0
+[0.4.15]: https://github.com/Qiskit/qiskit-terra/compare/0.4.14...0.4.15
+[0.4.14]: https://github.com/Qiskit/qiskit-terra/compare/0.4.13...0.4.14
+[0.4.13]: https://github.com/Qiskit/qiskit-terra/compare/0.4.12...0.4.13
+[0.4.12]: https://github.com/Qiskit/qiskit-terra/compare/0.4.11...0.4.12
+[0.4.11]: https://github.com/Qiskit/qiskit-terra/compare/0.4.10...0.4.11
+[0.4.10]: https://github.com/Qiskit/qiskit-terra/compare/0.4.9...0.4.10
+[0.4.9]: https://github.com/Qiskit/qiskit-terra/compare/0.4.8...0.4.9
+[0.4.8]: https://github.com/Qiskit/qiskit-terra/compare/0.4.7...0.4.8
+[0.4.7]: https://github.com/Qiskit/qiskit-terra/compare/0.4.6...0.4.7
+[0.4.6]: https://github.com/Qiskit/qiskit-terra/compare/0.4.5...0.4.6
+[0.4.4]: https://github.com/Qiskit/qiskit-terra/compare/0.4.3...0.4.4
+[0.4.3]: https://github.com/Qiskit/qiskit-terra/compare/0.4.2...0.4.3
+[0.4.2]: https://github.com/Qiskit/qiskit-terra/compare/0.4.1...0.4.2
+[0.4.0]: https://github.com/Qiskit/qiskit-terra/compare/0.3.16...0.4.0
+
+[Keep a Changelog]: http://keepachangelog.com/en/1.0.0/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ The format is based on [Keep a Changelog].
 > -   **Fixed**: for any bug fixes.
 > -   **Security**: in case of vulnerabilities.
 
-[UNRELEASED]
-=========================================================================
+## [UNRELEASED]
 
 Deprecated
 ----------
@@ -78,8 +77,7 @@ Fixed
 -   Possible to decompose SU(4) gate into non-CNOT basis with
     `TwoQubitDecomposer`
 
-[0.8.0] - 2019-05-02
-==================================================================================
+## [0.8.0] - 2019-05-02
 
 Added
 -----
@@ -374,8 +372,7 @@ Removed
     (\#1860).
 -   Removed `Instruction.reapply()` method (\#1816).
 
-[0.7.2] - 2019-05-01
-==================================================================================
+## [0.7.2] - 2019-05-01
 
 Fixed
 -----
@@ -383,8 +380,7 @@ Fixed
 -   A potential issue where the backend configuration schema validation
     would improperly reject valid responses from the API (\#2258)
 
-[0.7.1] - 2019-03-04
-==================================================================================
+## [0.7.1] - 2019-03-04
 
 Fixed
 -----
@@ -392,8 +388,7 @@ Fixed
 -   Fixed a bug with measurement sampling optimization in BasicAer
     qasm\_simulator (\#1624).
 
-[0.7.0] - 2018-12-19
-==================================================================================
+## [0.7.0] - 2018-12-19
 
 Added
 -----
@@ -623,8 +618,7 @@ Removed
     convert the output with the functions provided in
     `qiskit.converters`.
 
-[0.6.0] - 2018-10-04
-==================================================================================
+## [0.6.0] - 2018-10-04
 
 Added
 -----
@@ -719,16 +713,14 @@ Fixed
 -   Fixed bug in checking that a circuit already matches a coupling map
     (\#1024).
 
-[0.5.7] - 2018-07-19
-==================================================================================
+## [0.5.7] - 2018-07-19
 
 Changed
 -------
 
 -   Add new backend names support, with aliasing for the old ones.
 
-[0.5.6] - 2018-07-06
-==================================================================================
+## [0.5.6] - 2018-07-06
 
 Changed
 -------
@@ -750,8 +742,7 @@ Fixed
 -   Fixed yzy\_to\_zyz bugs (\#520, \#607) by moving to quaternions
     (\#626).
 
-[0.5.5] - 2018-07-02
-==================================================================================
+## [0.5.5] - 2018-07-02
 
 Added
 -----
@@ -795,8 +786,7 @@ Fixed
 -   Fix issue with skip\_transpiler causing some gates to be ignored
     silently (\#562).
 
-[0.5.4] - 2018-06-11
-==================================================================================
+## [0.5.4] - 2018-06-11
 
 Added
 -----
@@ -837,8 +827,7 @@ Fixed
 -   Fix issue with simulator extension commands not reapplying correctly
     (\#556)
 
-[0.5.3] - 2018-05-29
-==================================================================================
+## [0.5.3] - 2018-05-29
 
 Added
 -----
@@ -856,8 +845,7 @@ Fixed
 -   Crash in the cpp simulator for some linux platforms
 -   Fixed some minor bugs
 
-[0.5.2] - 2018-05-21
-==================================================================================
+## [0.5.2] - 2018-05-21
 
 Changed
 -------
@@ -876,8 +864,7 @@ Fixed
 -   Fixing a Mapper issue.
 -   Fixing Windows 7 builds.
 
-[0.5.1] - 2018-05-15
-==================================================================================
+## [0.5.1] - 2018-05-15
 
 -   There are no code changes.
 
@@ -888,8 +875,7 @@ Fixed
     Pypi forces us to bump up the version number if we want to upload a
     new package, so this is basically what have changed.
 
-[0.5.0] - 2018-05-11
-===================================================================================
+## [0.5.0] - 2018-05-11
 
 Improvements
 ------------
@@ -1000,8 +986,7 @@ Deprecated
 -   Move simulator extensions to `qiskit/extensions/simulator`
 -   Move Rzz and CSwap to standard extension library
 
-[0.4.15] - 2018-05-07
-=====================================================================================
+## [0.4.15] - 2018-05-07
 
 Fixed
 -----
@@ -1009,8 +994,7 @@ Fixed
 -   Fixed an issue with legacy code that was affecting Developers
     Challenge.
 
-[0.4.14] - 2018-04-18
-=====================================================================================
+## [0.4.14] - 2018-04-18
 
 Fixed
 -----
@@ -1018,8 +1002,7 @@ Fixed
 -   Fixed an issue about handling Basis Gates parameters on backend
     configurations.
 
-[0.4.13] - 2018-04-16
-=====================================================================================
+## [0.4.13] - 2018-04-16
 
 Changed
 -------
@@ -1031,8 +1014,7 @@ Fixed
 
 -   Fixes an issue regarding barrier gate misuse in some circumstances.
 
-[0.4.12] - 2018-03-11
-=====================================================================================
+## [0.4.12] - 2018-03-11
 
 Changed
 -------
@@ -1046,8 +1028,7 @@ Fixed
 
 -   A bunch of minor bugs have been fixed.
 
-[0.4.11] - 2018-03-13
-=====================================================================================
+## [0.4.11] - 2018-03-13
 
 Added
 -----
@@ -1065,8 +1046,7 @@ Fixed
 -   Fixed bug in circuit drawing where some gates in the standard
     library were not plotting correctly.
 
-[0.4.10] - 2018-03-06
-====================================================================================
+## [0.4.10] - 2018-03-06
 
 Added
 -----
@@ -1087,8 +1067,7 @@ Fixed
     simulator.
 -   Fix a bug in the async code.
 
-[0.4.9] - 2018-02-12
-==================================================================================
+## [0.4.9] - 2018-02-12
 
 Changed
 -------
@@ -1102,8 +1081,7 @@ Fixed
 
 -   Some minor C++ Simulator bug-fixes.
 
-[0.4.8] - 2018-01-29
-==================================================================================
+## [0.4.8] - 2018-01-29
 
 Fixed
 -----
@@ -1111,8 +1089,7 @@ Fixed
 -   Fix parsing U\_error matrix in C++ Simulator python helper class.
 -   Fix display of code-blocks on `.rst` pages.
 
-[0.4.7] - 2018-01-26
-==================================================================================
+## [0.4.7] - 2018-01-26
 
 Changed
 -------
@@ -1126,8 +1103,7 @@ Fixed
 -   Fixes several bugs with noise implementations in the simulator.
 -   Fixes many spelling mistakes in simulator README.
 
-[0.4.6] - 2018-01-22
-==================================================================================
+## [0.4.6] - 2018-01-22
 
 Changed
 -------
@@ -1142,8 +1118,7 @@ Changed
     > -   Sphinx\>=1.6,\<1.7
     > -   sympy\>=1.0
 
-[0.4.4] - 2018-01-09
-==================================================================================
+## [0.4.4] - 2018-01-09
 
 Changed
 -------
@@ -1155,8 +1130,7 @@ Fixed
 
 -   Fix bug with process tomography reversing qubit preparation order.
 
-[0.4.3] - 2018-01-08
-==================================================================================
+## [0.4.3] - 2018-01-08
 
 Removed
 -------
@@ -1164,16 +1138,14 @@ Removed
 -   Static compilation has been removed because it seems to be failing
     while installing Qiskit via pip on Mac.
 
-[0.4.2] - 2018-01-08
-==================================================================================
+## [0.4.2] - 2018-01-08
 
 Fixed
 -----
 
 -   Minor bug fixing related to pip installation process.
 
-[0.4.0] - 2018-01-08
-===================================================================================
+## [0.4.0] - 2018-01-08
 
 Added
 -----

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,11 +447,8 @@ The format is based on [Keep a Changelog].
     `qiskit.tools.visualizations`. (\#1105, \#1111)
 -   DAG nodes contain pointers to Register and Instruction objects,
     rather than their string names (\#1189).
--   
-
-    Upgraded some external dependencies to:
-
-    :   -   networkx\>=2.2 (\#1267).
+-   Upgraded some external dependencies to:
+    -   networkx\>=2.2 (\#1267).
 
 -   The `qiskit.tools.visualization.circuit_drawer()`
     method now returns a matplotlib.Figure object when the
@@ -500,22 +497,14 @@ The format is based on [Keep a Changelog].
 
 ### Deprecated
 
--   
-
-    `plot_circuit()`, `latex_circuit_drawer()`, `generate_latex_source()`,
-
-    :   and `matplotlib_circuit_drawer()` from
-        qiskit.tools.visualization are deprecated. Instead the
-        `circuit_drawer()` function from the same module should be used.
-        (\#1055)
-
--   
-
-    The current default output of `circuit_drawer()` (using latex and falling
-
-    :   back on python) is deprecated and will be changed in the future.
-        (\#1055)
-
+-   `plot_circuit()`, `latex_circuit_drawer()`, `generate_latex_source()`,
+    and `matplotlib_circuit_drawer()` from
+    qiskit.tools.visualization are deprecated. Instead the
+    `circuit_drawer()` function from the same module should be used.
+    (\#1055)
+-   The current default output of `circuit_drawer()` (using latex and falling
+    back on python) is deprecated and will be changed in the future.
+    (\#1055)
 -   The `qiskit.wrapper.load_qasm_string()` and
     `qiskit.wrapper.load_qasm_file()` functions are
     deprecated and the `QuantumCircuit.from_qasm_str()`
@@ -760,12 +749,9 @@ The format is based on [Keep a Changelog].
 
 ### Added
 
--   
-
-    Performance improvements:
-
-    :   -   remove deepcopies from dagcircuit, and extra check on qasm()
-            (\#523).
+-   Performance improvements:
+    -   remove deepcopies from dagcircuit, and extra check on qasm()
+        (\#523).
 
 ### Changed
 
@@ -839,38 +825,26 @@ The format is based on [Keep a Changelog].
 
 ### Improvements
 
--   
-
-    Introduce providers and rework backends (\#376).
-
-    :   -   Split backends into `local` and `ibmq`.
-        -   Each provider derives from the following classes for its
-            specific requirements (`BaseProvider`, `BaseBackend`,
-            `BaseJob`).
-        -   Allow querying result by both circuit name and
-            QuantumCircuit instance.
-
--   
-
-    Introduce the Qiskit `wrapper` (\#376).
-
-    :   -   Introduce convenience wrapper functions around commonly used
-            Qiskit components (e.g. `compile` and `execute` functions).
-        -   Introduce the DefaultQISKitProvider, which acts as a context
-            manager for the current session (e.g. providing easy access
-            to all `available_backends`).
-        -   Avoid relying on QuantumProgram (eventual deprecation).
-        -   The functions are also available as top-level functions (for
-            example, `qiskit.get_backend()`).
-
--   
-
-    Introduce `BaseJob` class and asynchronous jobs (\#403).
-
-    :   -   Return `BaseJob` after `run()`.
-        -   Mechanisms for querying `status` and `results`, or to
-            `cancel` a job.
-
+-   Introduce providers and rework backends (\#376).
+    -   Split backends into `local` and `ibmq`.
+    -   Each provider derives from the following classes for its
+        specific requirements (`BaseProvider`, `BaseBackend`,
+        `BaseJob`).
+    -   Allow querying result by both circuit name and
+        QuantumCircuit instance.
+-   Introduce the Qiskit `wrapper` (\#376).
+    -   Introduce convenience wrapper functions around commonly used
+        Qiskit components (e.g. `compile` and `execute` functions).
+    -   Introduce the DefaultQISKitProvider, which acts as a context
+        manager for the current session (e.g. providing easy access
+        to all `available_backends`).
+    -   Avoid relying on QuantumProgram (eventual deprecation).
+    -   The functions are also available as top-level functions (for
+        example, `qiskit.get_backend()`).
+-   Introduce `BaseJob` class and asynchronous jobs (\#403).
+    -   Return `BaseJob` after `run()`.
+    -   Mechanisms for querying `status` and `results`, or to
+        `cancel` a job.
 -   Introduce a `skip_transpiler` flag for `compile()` (\#411).
 -   Introduce schemas for validating interfaces between qiskit and
     backends (\#434)
@@ -881,32 +855,24 @@ The format is based on [Keep a Changelog].
     -   backend\_config\_schema
     -   backend\_props\_schema
     -   backend\_status\_schema
--   
-
-    Improve C++ simulator (\#386)
-
-    :   -   Add `tensor_index.hpp` for multi-partite qubit vector
-            indexing.
-        -   Add `qubit_vector.hpp` for multi-partite qubit vector
-            algebra.
-        -   Rework C++ simulator backends to use QubitVector class
-            instead of `std::vector`.
-
--   
-
-    Improve interface to simulator backends (\#435)
-
-    :   -   Introduce `local_statevector_simulator_py` and
-            `local_statevector_simulator_cpp`.
-        -   Introduce aliased and deprecated backend names and
-            mechanisms for resolving them.
-        -   Introduce optional `compact` flag to query backend names
-            only by unique function.
-        -   Introduce result convenience functions `get_statevector`,
-            `get_unitary`
-        -   Add `snapshot` command for caching a copy of the current
-            simulator state.
-
+-   Improve C++ simulator (\#386)
+    -   Add `tensor_index.hpp` for multi-partite qubit vector
+        indexing.
+    -   Add `qubit_vector.hpp` for multi-partite qubit vector
+        algebra.
+    -   Rework C++ simulator backends to use QubitVector class
+        instead of `std::vector`.
+-   Improve interface to simulator backends (\#435)
+    -   Introduce `local_statevector_simulator_py` and
+        `local_statevector_simulator_cpp`.
+    -   Introduce aliased and deprecated backend names and
+        mechanisms for resolving them.
+    -   Introduce optional `compact` flag to query backend names
+        only by unique function.
+    -   Introduce result convenience functions `get_statevector`,
+        `get_unitary`
+    -   Add `snapshot` command for caching a copy of the current
+        simulator state.
 -   Introduce circuit drawing via `circuit_drawer()` and
     `plot_circuit()` (\#295, \#414)
 -   Introduce benchmark suite for performance testing
@@ -1048,14 +1014,13 @@ The format is based on [Keep a Changelog].
 ### Changed
 
 -   We have upgraded some of out external dependencies to:
-
-    > -   matplotlib \>=2.1,\<2.2
-    > -   networkx\>=1.11,\<2.1
-    > -   numpy\>=1.13,\<1.15
-    > -   ply==3.10
-    > -   scipy\>=0.19,\<1.1
-    > -   Sphinx\>=1.6,\<1.7
-    > -   sympy\>=1.0
+    -   matplotlib \>=2.1,\<2.2
+    -   networkx\>=1.11,\<2.1
+    -   numpy\>=1.13,\<1.15
+    -   ply==3.10
+    -   scipy\>=0.19,\<1.1
+    -   Sphinx\>=1.6,\<1.7
+    -   sympy\>=1.0
 
 ## [0.4.4] - 2018-01-09
 
@@ -1084,36 +1049,20 @@ The format is based on [Keep a Changelog].
 
 ### Added
 
--   
-
-    Job handling improvements.
-
-    :   -   Allow asynchronous job submission.
-        -   New JobProcessor class: utilizes concurrent.futures.
-        -   New QuantumJob class: job description.
-
--   
-
-    Modularize circuit \"compilation\".
-
-    :   Takes quantum circuit and information about backend to transform
+-   Job handling improvements.
+    -   Allow asynchronous job submission.
+    -   New JobProcessor class: utilizes concurrent.futures.
+    -   New QuantumJob class: job description.
+-   Modularize circuit \"compilation\".
+    -   Takes quantum circuit and information about backend to transform
         circuit into one which can run on the backend.
-
--   
-
-    Standardize job description.
-
-    :   All backends take QuantumJob objects which wraps `qobj` program
+-   Standardize job description.
+    -   All backends take QuantumJob objects which wraps `qobj` program
         description.
-
--   
-
-    Simplify addition of backends, where circuits are run/simulated.
-
-    :   -   `qiskit.backends` package added.
-        -   Real devices and simulators are considered \"backends\"
-            which inherent from `BaseBackend`.
-
+-   Simplify addition of backends, where circuits are run/simulated.
+    -   `qiskit.backends` package added.
+    -   Real devices and simulators are considered \"backends\"
+        which inherent from `BaseBackend`.
 -   Reorganize and improve Sphinx documentation.
 -   Improve unittest framework.
 -   Add tools for generating random circuits.
@@ -1122,37 +1071,25 @@ The format is based on [Keep a Changelog].
 -   New utilities for classical optimization and chemistry
     (`qiskit/tools/apps/optimization`).
 -   Randomized benchmarking data handling.
--   
-
-    Quantum tomography (`qiskit/tools/qcvv`).
-
-    :   Added functions for generating, running and fitting process
+-   Quantum tomography (`qiskit/tools/qcvv`).
+    -   Added functions for generating, running and fitting process
         tomography experiments.
-
--   
-
-    Quantum information functions (`qiskit/tools/qi`).
-
-    :   -   Partial trace over subsystems of multi-partite vector.
-        -   Partial trace over subsystems of multi-partite matrix.
-        -   Flatten an operator to a vector in a specified basis.
-        -   Generate random unitary matrix.
-        -   Generate random density matrix.
-        -   Generate normally distributed complex matrix.
-        -   Generate random density matrix from Hilbert-Schmidt metric.
-        -   Generate random density matrix from the Bures metric.
-        -   Compute Shannon entropy of probability vector.
-        -   Compute von Neumann entropy of quantum state.
-        -   Compute mutual information of a bipartite state.
-        -   Compute the entanglement of formation of quantum state.
-
--   
-
-    Visualization improvements (`qiskit/tools`).
-
-    :   -   Wigner function representation.
-        -   Latex figure of circuit.
-
+-   Quantum information functions (`qiskit/tools/qi`).
+    -   Partial trace over subsystems of multi-partite vector.
+    -   Partial trace over subsystems of multi-partite matrix.
+    -   Flatten an operator to a vector in a specified basis.
+    -   Generate random unitary matrix.
+    -   Generate random density matrix.
+    -   Generate normally distributed complex matrix.
+    -   Generate random density matrix from Hilbert-Schmidt metric.
+    -   Generate random density matrix from the Bures metric.
+    -   Compute Shannon entropy of probability vector.
+    -   Compute von Neumann entropy of quantum state.
+    -   Compute mutual information of a bipartite state.
+    -   Compute the entanglement of formation of quantum state.
+-   Visualization improvements (`qiskit/tools`).
+    -   Wigner function representation.
+    -   Latex figure of circuit.
 -   Use python logging facility for info, warnings, etc.
 -   Auto-deployment of sphinx docs to github pages.
 -   Check IBMQuantumExperience version at runtime.
@@ -1164,29 +1101,14 @@ The format is based on [Keep a Changelog].
 -   Add QuantumProgram methods for destroying registers and circuits.
 -   Use Sympy for evaluating expressions.
 -   Add support for ibmqx\_hpc\_qasm\_simulator backend.
--   
-
-    Add backend interface to Project Q C++ simulator.
-
-    :   Requires installation of Project Q.
-
--   
-
-    Introduce `Initialize` class.
-
-    :   Generates circuit which initializes qubits in arbitrary state.
-
--   
-
-    Introduce `local_qiskit_simulator` a C++ simulator with realistic noise.
-
-    :   Requires C++ build environment for `make`-based build.
-
--   
-
-    Introduce `local_clifford_simulator` a C++ Clifford simulator.
-
-    :   Requires C++ build environment for `make`-based build.
+-   Add backend interface to Project Q C++ simulator.
+    -   Requires installation of Project Q.
+-   Introduce `Initialize` class.
+    -   Generates circuit which initializes qubits in arbitrary state.
+-   Introduce `local_qiskit_simulator` a C++ simulator with realistic noise.
+    -   Requires C++ build environment for `make`-based build.
+-   Introduce `local_clifford_simulator` a C++ Clifford simulator.
+    -   Requires C++ build environment for `make`-based build.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ The format is based on [Keep a Changelog].
 
 ## [UNRELEASED]
 
-Deprecated
-----------
+### Deprecated
 
 -   The gates `U` and `CX` are being deprecated in favor of `u3` and
     `cx`.
@@ -24,8 +23,7 @@ Deprecated
     `online_test`.
 -   The `as_dict` method of Qobj is deprecated in favor of `to_dict`.
 
-Added
------
+### Added
 
 -   The option `vertical_compression` was added to the text drawer and
     to the `QuantumCircuit.draw` method. The option allows to control
@@ -35,8 +33,7 @@ Added
     passes when they are executed. The results is stored in the
     attribute `pass_log` of the property set as a dictionary.
 
-Changed
--------
+### Changed
 
 -   The `pylatexenc` and `pillow` requirements are now optional. These
     are only used by the `latex` and `latex_source` circuit
@@ -48,8 +45,7 @@ Changed
 -   Qubits and classical bits are not represented as a tuples anymore,
     but as instances of `Qubit` and `Clbit` respectively.
 
-Removed
--------
+### Removed
 
 -   The previously deprecated functions
     `qiksit.visualization.plot_state` and
@@ -71,16 +67,14 @@ Removed
 -   Removed `ignore_requires` and `ignore_preserves` options from
     `PassManager` (\#2565).
 
-Fixed
------
+### Fixed
 
 -   Possible to decompose SU(4) gate into non-CNOT basis with
     `TwoQubitDecomposer`
 
 ## [0.8.0] - 2019-05-02
 
-Added
------
+### Added
 
 -   Added exact and approximate decomposition of SU(4) to arbitrary
     supercontrolled basis
@@ -182,8 +176,7 @@ Added
 -   Added preset PassManagers that offer predetermined pipelines of
     transpiler passes. (\#2163)
 
-Changed
--------
+### Changed
 
 -   require scipy\>=1.0, use
     [scipy.stats.unitary\_group.rvs]{.title-ref} for
@@ -274,8 +267,7 @@ Changed
 -   Layout and CouplingMap classes are now accessible from
     qiskit.transpiler (\#2222).
 
-Deprecated
-----------
+### Deprecated
 
 -   The methods prefixed by [\_get]{.title-ref} in the DAGCircuit object
     are being renamed without that prefix (see \#1346)
@@ -307,8 +299,7 @@ Deprecated
     `qiskit.util`. `qiskit._util` will be removed in the 0.9 release.
     (\#2154)
 
-Fixed
------
+### Fixed
 
 -   Fixed \#1892, whereby inheriting from QuantumRegister or
     ClassicalRegister would cause a QiskitError in instruction.py
@@ -336,8 +327,7 @@ Fixed
 -   Fixed `qobj_to_circuits` for circuits that contain initialize
     instructions (\#2138)
 
-Removed
--------
+### Removed
 
 -   The previously deprecated functions `plot_circuit()`,
     `latex_circuit_drawer()`, `generate_latex_source()`, and
@@ -374,24 +364,21 @@ Removed
 
 ## [0.7.2] - 2019-05-01
 
-Fixed
------
+### Fixed
 
 -   A potential issue where the backend configuration schema validation
     would improperly reject valid responses from the API (\#2258)
 
 ## [0.7.1] - 2019-03-04
 
-Fixed
------
+### Fixed
 
 -   Fixed a bug with measurement sampling optimization in BasicAer
     qasm\_simulator (\#1624).
 
 ## [0.7.0] - 2018-12-19
 
-Added
------
+### Added
 
 -   Added DAG visualizer which requires
     [Graphivz](https://www.graphviz.org/) (\#1059)
@@ -446,8 +433,7 @@ Added
 -   New Optimize1QGate pass for combining chains of 1q rotations
     (\#1442).
 
-Changed
--------
+### Changed
 
 -   Schedules and underlying classes are now immutable. (\#2186)
 -   Evolved pass-based transpiler to support advanced functionality
@@ -512,8 +498,7 @@ Changed
     the Python simulators and `LegacySimulators` which provides the old
     C++ simulators in qiskit-terra. (\#1484)
 
-Deprecated
-----------
+### Deprecated
 
 -   
 
@@ -550,8 +535,7 @@ Deprecated
 -   The `skip_transpiler` arg has been deprecated from `compile()` and
     `execute()` in favor of using the PassManager directly.
 
-Fixed
------
+### Fixed
 
 -   Fixed a variety of typos throughout sources (\#1139)
 -   Fixed horizontal spacing when drawing barriers before CCNOT gates in
@@ -576,8 +560,7 @@ Fixed
     `_wait_for_submission` function in `IBMQJob` from `_wait_for_result`
     (\#1542).
 
-Removed
--------
+### Removed
 
 -   Remove register, available\_backends (\#1131).
 -   Remove tools/apps (\#1184).
@@ -620,8 +603,7 @@ Removed
 
 ## [0.6.0] - 2018-10-04
 
-Added
------
+### Added
 
 -   Added [SchemaValidationError]{.title-ref} to be thrown when schema
     validation fails (\#881)
@@ -648,8 +630,7 @@ Added
 -   Add new [job\_monitor]{.title-ref} function to automaically check
     the status of a job (\#975).
 
-Changed
--------
+### Changed
 
 -   Schema tests in [tests/schemas/test\_schemas.py]{.title-ref}
     replaced with proper unit test (\#834).
@@ -678,8 +659,7 @@ Changed
     drawer. This requires having the LaTeX qcircuit package
     version \>=2.6.0 installed (\#764)
 
-Deprecated
-----------
+### Deprecated
 
 -   The `number_to_keep` kwarg on the `plot_histogram()` function is now
     deprecated. A field of the same name should be used in the `option`
@@ -687,13 +667,11 @@ Deprecated
 -   Breaking change: `backend.properties()` instead of
     `backend.calibration()` and `backend.parameters()` (\#870)
 
-Removed
--------
+### Removed
 
 -   Removed the QuantumProgram class. (\#724)
 
-Fixed
------
+### Fixed
 
 -   Fixed `get_ran_qasm` methods on `Result` instances (\#688).
 -   Fixed `probabilities_ket` computation in C++ simulator (\#580).
@@ -715,27 +693,23 @@ Fixed
 
 ## [0.5.7] - 2018-07-19
 
-Changed
--------
+### Changed
 
 -   Add new backend names support, with aliasing for the old ones.
 
 ## [0.5.6] - 2018-07-06
 
-Changed
--------
+### Changed
 
 -   Rename repository to `qiskit-terra` (\#606).
 -   Update Bloch sphere to QuTiP version (\#618).
 -   Adjust margin of matplotlib\_circuit\_drawer (\#632)
 
-Removed
--------
+### Removed
 
 -   Remove OpenQuantumCompiler (\#610).
 
-Fixed
------
+### Fixed
 
 -   Fixed broken process error and simulator slowdown on Windows
     (\#613).
@@ -744,8 +718,7 @@ Fixed
 
 ## [0.5.5] - 2018-07-02
 
-Added
------
+### Added
 
 -   Retrieve IBM Q jobs from server (\#563, \#585).
 -   Add German introductory documentation (`doc/de`) (\#592).
@@ -758,8 +731,7 @@ Added
 -   Introduce Qiskit Transpiler and refactor compilation flow (\#578)
 -   Add CXCancellation pass (\#578)
 
-Changed
--------
+### Changed
 
 -   Remove backend filtering in individual providers, keep only in
     wrapper (\#575).
@@ -771,16 +743,14 @@ Changed
     [register()]{.title-ref} (\#602).
 -   Order strings in the output of `available_backends()` (\#566)
 
-Removed
--------
+### Removed
 
 -   Remove Clifford simulator from default available\_backends, until
     its stable release (\#555).
 -   Remove ProjectQ simulators for moving to new repository (\#553).
 -   Remove QuantumJob class (\#616)
 
-Fixed
------
+### Fixed
 
 -   Fix issue with unintended inversion of initializer gates (\#573).
 -   Fix issue with skip\_transpiler causing some gates to be ignored
@@ -788,8 +758,7 @@ Fixed
 
 ## [0.5.4] - 2018-06-11
 
-Added
------
+### Added
 
 -   
 
@@ -798,8 +767,7 @@ Added
     :   -   remove deepcopies from dagcircuit, and extra check on qasm()
             (\#523).
 
-Changed
--------
+### Changed
 
 -   Rename repository to `qiskit-core` (\#530).
 -   Repository improvements: new changelog format (\#535), updated issue
@@ -808,13 +776,11 @@ Changed
 -   Convert `LocalJob` tests into unit-tests. (\#526)
 -   Move wrapper `load_qasm_*` methods to a submodule (\#533).
 
-Removed
--------
+### Removed
 
 -   Remove Sympy simulators for moving to new repository (\#514)
 
-Fixed
------
+### Fixed
 
 -   Fix erroneous density matrix and probabilities in C++ simulator
     (\#518)
@@ -829,37 +795,31 @@ Fixed
 
 ## [0.5.3] - 2018-05-29
 
-Added
------
+### Added
 
 -   load\_qasm\_file / load\_qasm\_string methods
 
-Changed
--------
+### Changed
 
 -   Dependencies version bumped
 
-Fixed
------
+### Fixed
 
 -   Crash in the cpp simulator for some linux platforms
 -   Fixed some minor bugs
 
 ## [0.5.2] - 2018-05-21
 
-Changed
--------
+### Changed
 
 -   Adding Result.get\_unitary()
 
-Deprecated
-----------
+### Deprecated
 
 -   Deprecating `ibmqx_hpc_qasm_simulator` and `ibmqx_qasm_simulator` in
     favor of `ibmq_qasm_simulator`.
 
-Fixed
------
+### Fixed
 
 -   Fixing a Mapper issue.
 -   Fixing Windows 7 builds.
@@ -877,8 +837,7 @@ Fixed
 
 ## [0.5.0] - 2018-05-11
 
-Improvements
-------------
+### Improvements
 
 -   
 
@@ -957,8 +916,7 @@ Improvements
 -   Allow combining circuits across both depth and width (\#389)
 -   Enforce string token names (\#395)
 
-Fixed
------
+### Fixed
 
 -   Fix coherent error bug in `local_qasm_simulator_cpp` (\#318)
 -   Fix the order and format of result bits obtained from device
@@ -969,8 +927,7 @@ Fixed
     JobProcessor during \#403)
 -   Fix ability to apply all gates on register (\#369)
 
-Deprecated
-----------
+### Deprecated
 
 -   Some methods of `QuantumProgram` are soon to be deprecated. Please
     use the top-level functions instead.
@@ -988,79 +945,67 @@ Deprecated
 
 ## [0.4.15] - 2018-05-07
 
-Fixed
------
+### Fixed
 
 -   Fixed an issue with legacy code that was affecting Developers
     Challenge.
 
 ## [0.4.14] - 2018-04-18
 
-Fixed
------
+### Fixed
 
 -   Fixed an issue about handling Basis Gates parameters on backend
     configurations.
 
 ## [0.4.13] - 2018-04-16
 
-Changed
--------
+### Changed
 
 -   OpenQuantumCompiler.dag2json() restored for backward compatibility.
 
-Fixed
------
+### Fixed
 
 -   Fixes an issue regarding barrier gate misuse in some circumstances.
 
 ## [0.4.12] - 2018-03-11
 
-Changed
--------
+### Changed
 
 -   Improved circuit visualization.
 -   Improvements in infrastructure code, mostly tests and build system.
 -   Better documentation regarding contributors.
 
-Fixed
------
+### Fixed
 
 -   A bunch of minor bugs have been fixed.
 
 ## [0.4.11] - 2018-03-13
 
-Added
------
+### Added
 
 -   More testing :)
 
-Changed
--------
+### Changed
 
 -   Stabilizing code related to external dependencies.
 
-Fixed
------
+### Fixed
 
 -   Fixed bug in circuit drawing where some gates in the standard
     library were not plotting correctly.
 
 ## [0.4.10] - 2018-03-06
 
-Added
------
+### Added
 
 -   Chinese translation of README.
 
-Changed
--------
+### Changed
 
 -   Changes related with infrastructure (linter, tests, automation)
     enhancement.
 
-Fixed
------
+### Fixed
 
 -   Fix installation issue when simulator cannot be built.
 -   Fix bug with auto-generated CNOT coherent error matrix in C++
@@ -1069,44 +1014,38 @@ Fixed
 
 ## [0.4.9] - 2018-02-12
 
-Changed
--------
+### Changed
 
 -   CMake integration.
 -   QASM improvements.
 -   Mapper optimizer improvements.
 
-Fixed
------
+### Fixed
 
 -   Some minor C++ Simulator bug-fixes.
 
 ## [0.4.8] - 2018-01-29
 
-Fixed
------
+### Fixed
 
 -   Fix parsing U\_error matrix in C++ Simulator python helper class.
 -   Fix display of code-blocks on `.rst` pages.
 
 ## [0.4.7] - 2018-01-26
 
-Changed
--------
+### Changed
 
 -   Changes some naming conventions for `amp_error` noise parameters to
     `calibration_error`.
 
-Fixed
------
+### Fixed
 
 -   Fixes several bugs with noise implementations in the simulator.
 -   Fixes many spelling mistakes in simulator README.
 
 ## [0.4.6] - 2018-01-22
 
-Changed
--------
+### Changed
 
 -   We have upgraded some of out external dependencies to:
 
@@ -1120,35 +1059,30 @@ Changed
 
 ## [0.4.4] - 2018-01-09
 
-Changed
--------
+### Changed
 
 -   Update dependencies to more recent versions.
 
-Fixed
------
+### Fixed
 
 -   Fix bug with process tomography reversing qubit preparation order.
 
 ## [0.4.3] - 2018-01-08
 
-Removed
--------
+### Removed
 
 -   Static compilation has been removed because it seems to be failing
     while installing Qiskit via pip on Mac.
 
 ## [0.4.2] - 2018-01-08
 
-Fixed
------
+### Fixed
 
 -   Minor bug fixing related to pip installation process.
 
 ## [0.4.0] - 2018-01-08
 
-Added
------
+### Added
 
 -   
 
@@ -1254,22 +1188,19 @@ Added
 
     :   Requires C++ build environment for `make`-based build.
 
-Changed
--------
+### Changed
 
 -   The standard extension for creating U base gates has been modified
     to be consistent with the rest of the gate APIs (see \#203).
 
-Removed
--------
+### Removed
 
 -   The `silent` parameter has been removed from a number of
     `QuantumProgram` methods. The same behaviour can be achieved now by
     using the `enable_logs()` and `disable_logs()` methods, which use
     the standard Python logging.
 
-Fixed
------
+### Fixed
 
 -   Fix basis gates (\#76).
 -   Enable QASM parser to work in multiuser environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,7 @@ The format is based on [Keep a Changelog].
     operators.
 -   Introduced the backend defaults model and endpoint for pulse
     backends (\#2101).
--   [meas\_level]{.title-ref} to result schema (\#2085).
+-   `meas_level` to result schema (\#2085).
 -   Core StochasticSwap routine implemented in Cython (\#1789).
 -   New EnlargeWithAncilla pass for adding ancilla qubits after a Layout
     selection pass (\#1603).
@@ -179,8 +179,8 @@ The format is based on [Keep a Changelog].
 ### Changed
 
 -   require scipy\>=1.0, use
-    [scipy.stats.unitary\_group.rvs]{.title-ref} for
-    [random\_unitary()]{.title-ref}.
+    `scipy.stats.unitary_group.rvs` for
+    `random_unitary()`.
 -   two\_qubit\_kak decomposition works with Operator or raw matrix
     input objects.
 -   process\_fidelity works with QuantumChannel and Operator object
@@ -193,8 +193,8 @@ The format is based on [Keep a Changelog].
 -   plot\_histogram now allows sorting by Hamming distance from
     target\_string (\#2064).
 -   FunctionalPulse is no longer a class and instead is a decorator,
-    [functional\_pulse]{.title-ref} that returns a
-    [SamplePulse]{.title-ref} when called. (\#2043)
+    `functional_pulse` that returns a
+    `SamplePulse` when called. (\#2043)
 -   Changed `average_data` to accept observable input in matrix form
     (\#1858)
 -   Change random\_state to take in dim over number of qubits (\#1857)
@@ -224,7 +224,7 @@ The format is based on [Keep a Changelog].
     (\#1591).
 -   Purity function in `qiskit.tools.qi.qi` calls new version in
     `qiskit.quantum_information` and issues deprecation warning (\#1733)
--   Updated [dag.node\_counter]{.title-ref} to return the current number
+-   Updated `dag.node_counter` to return the current number
     of nodes (\#1763)
 -   The argument `basis_gates` used in `compile`, `execute`, and
     `transpile` is not longer a comma-separated string but a list of
@@ -269,7 +269,7 @@ The format is based on [Keep a Changelog].
 
 ### Deprecated
 
--   The methods prefixed by [\_get]{.title-ref} in the DAGCircuit object
+-   The methods prefixed by `\_get` in the DAGCircuit object
     are being renamed without that prefix (see \#1346)
 -   Changed elements in `couplinglist` of `CouplingMap` from tuples to
     lists (\#1666).
@@ -321,9 +321,9 @@ The format is based on [Keep a Changelog].
     conditional gates (\#1943).
 -   Fixed a mapping issue with layouts on non-adjacent qubits, by adding
     ancillas (\#2023).
--   Fixed a bug in which an [initial\_layout]{.title-ref} could be
+-   Fixed a bug in which an `initial_layout` could be
     changed even if it made the circuit compatible with the device
-    [coupling\_map]{.title-ref} (\#2036).
+    `coupling_map` (\#2036).
 -   Fixed `qobj_to_circuits` for circuits that contain initialize
     instructions (\#2138)
 
@@ -385,25 +385,25 @@ The format is based on [Keep a Changelog].
 -   Added an ASCII art circuit visualizer (\#909)
 -   The QuantumCircuit class now returns an ASCII art visualization when
     treated as a string (\#911)
--   The QuantumCircuit class now has a [draw()]{.title-ref} method which
+-   The QuantumCircuit class now has a `draw()` method which
     behaves the same as the
-    [qiskit.tools.visualization.circuit\_drawer()]{.title-ref} function
+    `qiskit.tools.visualization.circuit_drawer()` function
     for visualizing the quantum circuit (\#911)
--   A new method [hinton]{.title-ref} can be used on
-    [qiskit.tools.visualization.plot\_state()]{.title-ref} to draw a
+-   A new method `hinton` can be used on
+    `qiskit.tools.visualization.plot_state()` to draw a
     hinton diagram (\#1246)
--   Two new constructor methods, [from\_qasm\_str()]{.title-ref} and
-    [from\_qasm\_file()]{.title-ref}, to create a QuantumCircuit object
+-   Two new constructor methods, `from_qasm_str()` and
+    `from_qasm_file()`, to create a QuantumCircuit object
     from OpenQASM were added to the QuantumCircuit class. (\#1172)
 -   New methods in QuantumCircuit for common circuit metrics:
-    [size()]{.title-ref}, [depth()]{.title-ref}, [width()]{.title-ref},
-    [count\_ops()]{.title-ref}, [num\_tensor\_factors()]{.title-ref}
+    `size()`, `depth()`, `width()`,
+    `count_ops()`, `num_tensor_factors()`
     (\#1285)
--   Added [backend\_monitor]{.title-ref} and
-    [backend\_overview]{.title-ref} Jupyter magics, as well as
-    [plot\_coupling\_map]{.title-ref} (\#1231)
--   Added a [Layout]{.title-ref} object (\#1313)
--   New [plot\_bloch\_multivector()]{.title-ref} to plot Bloch vectors
+-   Added `backend_monitor` and
+    `backend_overview` Jupyter magics, as well as
+    `plot_coupling_map` (\#1231)
+-   Added a `Layout` object (\#1313)
+-   New `plot_bloch_multivector()` to plot Bloch vectors
     from a tensored state vector or density matrix. (\#1359)
 -   Per-shot measurement results are available in simulators and select
     devices. Request them by setting `memory=True` in
@@ -438,13 +438,13 @@ The format is based on [Keep a Changelog].
 -   Schedules and underlying classes are now immutable. (\#2186)
 -   Evolved pass-based transpiler to support advanced functionality
     (\#1060)
--   [.retrieve\_job()]{.title-ref} and [.jobs()]{.title-ref} no longer
+-   `.retrieve_job()` and `.jobs()` no longer
     returns results by default, instead the result must be accessed by
-    the [result()]{.title-ref} method on the job objects (\#1082).
--   Make [backend.status()]{.title-ref} dictionary conform with schema.
+    the `result()` method on the job objects (\#1082).
+-   Make `backend.status()` dictionary conform with schema.
 -   The different output backends for the circuit\_drawer()
     visualizations have been moved into separate private modules in
-    [qiskit.tools.visualizations]{.title-ref}. (\#1105, \#1111)
+    `qiskit.tools.visualizations`. (\#1105, \#1111)
 -   DAG nodes contain pointers to Register and Instruction objects,
     rather than their string names (\#1189).
 -   
@@ -453,13 +453,13 @@ The format is based on [Keep a Changelog].
 
     :   -   networkx\>=2.2 (\#1267).
 
--   The [qiskit.tools.visualization.circuit\_drawer()]{.title-ref}
+-   The `qiskit.tools.visualization.circuit_drawer()`
     method now returns a matplotlib.Figure object when the
-    [mpl]{.title-ref} output is used and a [TextDrawer]{.title-ref}
-    object when [text]{.title-ref} output is used. (\#1224, \#1181)
+    `mpl` output is used and a `TextDrawer`
+    object when `text` output is used. (\#1224, \#1181)
 -   Speed up the Pauli class and extended its operators (\#1271 \#1166).
--   [IBMQ.save\_account()]{.title-ref} now takes an
-    [overwrite]{.title-ref} option to replace an existing account on
+-   `IBMQ.save_account()` now takes an
+    `overwrite` option to replace an existing account on
     disk. Default is False (\#1295).
 -   Backend and Provider methods defined in the specification use model
     objects rather than dicts, along with validation against schemas
@@ -472,9 +472,9 @@ The format is based on [Keep a Changelog].
 -   `backend.provider()` is now a method instead of a property (\#1312).
 -   Remove local backend (Aer) fallback (\#1303)
 -   The signatures for the plotting functions in
-    [qiskit.tools.visualization.\_counts\_visualization.py]{.title-ref},
-    [qiskit.tools.visualization.\_state\_visualization.py]{.title-ref},
-    and [qiskit.tools.visualization.interactive]{.title-ref} have been
+    `qiskit.tools.visualization._counts_visualization.py`,
+    `qiskit.tools.visualization._state_visualization.py`,
+    and `qiskit.tools.visualization.interactive` have been
     modified to make them in-line with standard Matplotlib calling
     conventions (\#1359).
 -   Remove local backend (Aer) fallback (\#1303).
@@ -516,22 +516,22 @@ The format is based on [Keep a Changelog].
     :   back on python) is deprecated and will be changed in the future.
         (\#1055)
 
--   The [qiskit.wrapper.load\_qasm\_string()]{.title-ref} and
-    [qiskit.wrapper.load\_qasm\_file()]{.title-ref} functions are
-    deprecated and the [QuantumCircuit.from\_qasm\_str()]{.title-ref}
-    and [QuantumCircuit.from\_qasm\_file()]{.title-ref} contstructor
+-   The `qiskit.wrapper.load_qasm_string()` and
+    `qiskit.wrapper.load_qasm_file()` functions are
+    deprecated and the `QuantumCircuit.from_qasm_str()`
+    and `QuantumCircuit.from_qasm_file()` contstructor
     methods should be used instead (\#1172)
 -   The `plot_barriers` and `reverse_bits` keys in the `style` kwarg
     dict are deprecated, instead the
-    [qiskit.tools.visualization.circuit\_drawer()]{.title-ref} kwargs
+    `qiskit.tools.visualization.circuit_drawer()` kwargs
     `plot_barriers` and `reverse_bits` should be used instead. (\#1180)
 -   The `transpile_dag()` function `format` kwarg for emitting different
     output formats is deprecated (\#1319).
 -   Several methods of `qiskit.Result` have been deprecated (\#1360).
--   The functions [plot\_state()]{.title-ref} and
-    [iplot\_state()]{.title-ref} have been depreciated. Instead the
-    functions [plot\_state\_\*()]{.title-ref} and
-    [iplot\_state\_\*()]{.title-ref} should be called. (\#1359)
+-   The functions `plot_state()` and
+    `iplot_state()` have been depreciated. Instead the
+    functions `plot_state_\*()` and
+    `iplot_state_\*()` should be called. (\#1359)
 -   The `skip_transpiler` arg has been deprecated from `compile()` and
     `execute()` in favor of using the PassManager directly.
 
@@ -545,18 +545,18 @@ The format is based on [Keep a Changelog].
 -   Fixed AerJob status when the submitted Job is in a PENDING state.
     (\#1215)
 -   Add fallback for when CPU count can\'t be determined (\#1214)
--   Fix [random\_state]{.title-ref} from returning nan (\#1258)
--   The Clifford simulator [run()]{.title-ref} method now works
+-   Fix `random_state` from returning nan (\#1258)
+-   The Clifford simulator `run()` method now works
     correctly with the updated AerJob usage (\#1125)
 -   Fixed an edge case when connection checks would raise an unhandled
     exception (\#1226)
 -   Fixed a bug where the transpiler moved middle-of-circuit
     measurements to the end (\#1334)
--   The [number\_to\_keep]{.title-ref} kwarg in `plot_histgram()` now
+-   The `number_to_keep` kwarg in `plot_histgram()` now
     functions correctly (\#1359).
 -   parallel\_map no longer creates a progress bar for a single circuit
     (\#1394).
--   The [timeout]{.title-ref} parameter is now passed into the inner
+-   The `timeout` parameter is now passed into the inner
     `_wait_for_submission` function in `IBMQJob` from `_wait_for_result`
     (\#1542).
 
@@ -605,13 +605,13 @@ The format is based on [Keep a Changelog].
 
 ### Added
 
--   Added [SchemaValidationError]{.title-ref} to be thrown when schema
+-   Added `SchemaValidationError` to be thrown when schema
     validation fails (\#881)
 -   Generalized Qobj schema validation functions for all qiskit schemas
     (\#882).
 -   Added decorator to check for C++ simulator availability (\#662)
 -   It is possible to cancel jobs in non comercial backends (\#687)
--   Introduced new [qiskit.IBMQ]{.title-ref} provider, with centralized
+-   Introduced new `qiskit.IBMQ` provider, with centralized
     handling of IBMQ credentials (qiskitrc file, environment variables).
     (\#547, \#948, \#1000)
 -   Add OpenMP parallelization for Apple builds of the cpp simulator
@@ -626,13 +626,13 @@ The format is based on [Keep a Changelog].
 -   Add a new function `qobj_to_circuits` to convert a Qobj object to a
     list of QuantumCircuit objects (\#877)
 -   Allow selective loading of accounts from disk via hub/group/project
-    filters to [IBMQ.load\_accounts()]{.title-ref}.
--   Add new [job\_monitor]{.title-ref} function to automaically check
+    filters to `IBMQ.load_accounts()`.
+-   Add new `job_monitor` function to automaically check
     the status of a job (\#975).
 
 ### Changed
 
--   Schema tests in [tests/schemas/test\_schemas.py]{.title-ref}
+-   Schema tests in `tests/schemas/test_schemas.py`
     replaced with proper unit test (\#834).
 -   Renamed `QISKit` to `Qiskit` in the documentation. (\#634)
 -   Use `Qobj` as the formally defined schema for sending information to
@@ -737,10 +737,10 @@ The format is based on [Keep a Changelog].
     wrapper (\#575).
 -   Single source of version information (\#581)
 -   Bumped IBMQuantumExperience dependency to 1.9.6 (\#600).
--   For backend status, [status\[\'available\'\]]{.title-ref} is now
-    [status\[\'operational\'\]]{.title-ref} (\#609).
+-   For backend status, `status\[\'available\'\]` is now
+    `status\[\'operational\'\]` (\#609).
 -   Added support for registering third-party providers in
-    [register()]{.title-ref} (\#602).
+    `register()` (\#602).
 -   Order strings in the output of `available_backends()` (\#566)
 
 ### Removed


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After #2359, some bits of the changelog and other documents are not displayed properly, most likely due to the automated tool not being able to cope with some of our previous syntax. This PR attempts to get it back to a readable state:
* fixing the:
  > ... [blah]{.title-ref} ...
  
   entries that were present in [a number of places](https://github.com/Qiskit/qiskit-terra/blob/14f9697367e06f4b8397da9142e46e1f97c9e891/CHANGELOG.md#changed-1)
* fixing [blocks with nested indentation](https://github.com/Qiskit/qiskit-terra/blob/14f9697367e06f4b8397da9142e46e1f97c9e891/CHANGELOG.md#deprecated-2)

Additionally:
* updates the links to reference links at the bottom of the document instead of inline
* standardizes the headers, using simple pound-style headers instead of underline

### Details and comments


