### PR TITLE
Add diff-cover output when coverage is collected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,6 +145,9 @@ jobs:
       after_success:
         - coverage combine || true
         - coveralls || true
+        - coverage xml || true
+        - pip install diff-cover || true
+        - diff-cover --compare-branch master coverage_xml || true
 
     # GNU/Linux, Python 3.7
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,7 @@ jobs:
         - coveralls || true
         - coverage xml || true
         - pip install diff-cover || true
-        - diff-cover --compare-branch master coverage_xml || true
+        - diff-cover --compare-branch master coverage.xml || true
 
     # GNU/Linux, Python 3.7
     - stage: test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds an additional output stage to the python 3.6 job, which
is used for collecting coverage, that runs the diff-cover tool to show
which parts of the diff have test coverage. This is useful for both
reviewers and the commit author to see if the changes being made in a PR
are actually being exercised by the testing we run.

### Details and comments
