### PR TITLE
Backend monitor as backend HTML repr in Jupyter 

### DIFF
--- a/qiskit/tools/jupyter/__init__.py
+++ b/qiskit/tools/jupyter/__init__.py
@@ -22,7 +22,14 @@ from .progressbar import HTMLProgressBar
 
 if HAS_MATPLOTLIB:
     from .backend_overview import BackendOverview
-    from .backend_monitor import BackendMonitor
+    from .backend_monitor import BackendMonitor, _backend_monitor
+
+try:
+    from qiskit.providers.ibmq.ibmqbackend import IBMQBackend
+    HAS_IBMQ = True
+except ImportError:
+    HAS_IBMQ = False
+
 
 _IP = get_ipython()
 if _IP is not None:
@@ -31,3 +38,7 @@ if _IP is not None:
     if HAS_MATPLOTLIB:
         _IP.register_magics(BackendOverview)
         _IP.register_magics(BackendMonitor)
+        if HAS_IBMQ:
+            HTML_FORMATTER = _IP.display_formatter.formatters['text/html']
+            # Make _backend_monitor the html repr for IBM Q backends
+            HTML_FORMATTER.for_type(IBMQBackend, _backend_monitor)

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -50,6 +50,7 @@ MONTH_NAMES = {1: 'Jan.',
                12: 'Dec.'
                }
 
+
 @magics_class
 class BackendMonitor(Magics):
     """A class of status magic functions.
@@ -134,6 +135,7 @@ def _backend_monitor(backend):
                                                   max_height='650px', min_height='650px',
                                                   overflow_y='hidden'))
     display(bmonitor)
+
 
 def config_tab(backend):
     """The backend configuration widget.

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -17,6 +17,7 @@
 
 import math
 import datetime
+from warnings import warn
 from IPython.display import display                     # pylint: disable=import-error
 from IPython.core.magic import (line_magic,             # pylint: disable=import-error
                                 Magics, magics_class)
@@ -44,6 +45,7 @@ class BackendMonitor(Magics):
     def qiskit_backend_monitor(self, line='', cell=None):
         """A Jupyter magic function to monitor backends.
         """
+        warn('The backend monitor widget is now the backend repr.', DeprecationWarning)
         del cell  # Unused
         backend = self.shell.user_ns[line]
         if not isinstance(backend, IBMQBackend):
@@ -78,6 +80,47 @@ class BackendMonitor(Magics):
 
         display(bmonitor)
 
+
+def _backend_monitor(backend):
+    """ A private function to generate a monitor widget
+    for a IBMQ bakend repr.
+
+    Args:
+        backend (IBMQbackend): The backend.
+
+    Raises:
+        QiskitError: Input is not an IBMQBackend
+    """
+    if not isinstance(backend, IBMQBackend):
+        raise QiskitError('Input variable is not of type IBMQBackend.')
+    title_style = "style='color:#ffffff;background-color:#000000;padding-top: 1%;"
+    title_style += "padding-bottom: 1%;padding-left: 1%; margin-top: 0px'"
+    title_html = "<h1 {style}>{name}</h1>".format(
+        style=title_style, name=backend.name())
+
+    details = [config_tab(backend)]
+
+    tab_contents = ['Configuration']
+
+    if not backend.configuration().simulator:
+        tab_contents.extend(['Qubit Properties', 'Multi-Qubit Gates',
+                             'Error Map', 'Job History'])
+        details.extend([qubits_tab(backend), gates_tab(backend),
+                        detailed_map(backend), job_history(backend)])
+
+    tabs = widgets.Tab(layout=widgets.Layout(overflow_y='scroll'))
+    tabs.children = details
+    for i in range(len(details)):
+        tabs.set_title(i, tab_contents[i])
+
+    title_widget = widgets.HTML(value=title_html,
+                                layout=widgets.Layout(margin='0px 0px 0px 0px'))
+
+    bmonitor = widgets.VBox([title_widget, tabs],
+                            layout=widgets.Layout(border='4px solid #000000',
+                                                  max_height='650px', min_height='650px',
+                                                  overflow_y='hidden'))
+    display(bmonitor)
 
 def config_tab(backend):
     """The backend configuration widget.

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -116,7 +116,7 @@ def _load_jobs_data(self, change):
         self.children[4].children = [year, month, week]
         self.children[4].set_title(0, 'Year')
         self.children[4].set_title(1, 'Month')
-        self.children[4]    .set_title(2, 'Week')
+        self.children[4].set_title(2, 'Week')
         self.children[4].selected_index = 1
         _build_job_history(self.children[4], self._backend)
 

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -152,7 +152,7 @@ def config_tab(backend):
     upper_list = ['n_qubits', 'operational',
                   'status_msg', 'pending_jobs',
                   'backend_version', 'basis_gates',
-                  'local', 'simulator']
+                  'max_shots', 'max_experiments']
 
     lower_list = list(set(config_dict.keys()).difference(upper_list))
     # Remove gates because they are in a different tab

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -36,6 +36,19 @@ try:
 except ImportError:
     pass
 
+MONTH_NAMES = {1: 'Jan.',
+               2: 'Feb.',
+               3: 'Mar.',
+               4: 'Apr.',
+               5: 'May',
+               6: 'June',
+               7: 'July',
+               8: 'Aug.',
+               9: 'Sept.',
+               10: 'Oct.',
+               11: 'Nov.',
+               12: 'Dec.'
+               }
 
 @magics_class
 class BackendMonitor(Magics):
@@ -628,12 +641,12 @@ def plot_job_history(jobs, interval='year'):
               '#7a5195', '#ef5675', '#bc5090']
 
     if interval == 'year':
-        labels = ['{}-{}'.format(str(bins[b].year)[2:], bins[b].month) for b in nz_idx]
+        labels = ['{}-{}'.format(str(bins[b].year)[2:], MONTH_NAMES[bins[b].month]) for b in nz_idx]
     else:
-        labels = ['{}-{}'.format(bins[b].month, bins[b].day) for b in nz_idx]
-    fig, ax = plt.subplots(1, 1, figsize=(5, 5))  # pylint: disable=invalid-name
+        labels = ['{}-{}'.format(MONTH_NAMES[bins[b].month], bins[b].day) for b in nz_idx]
+    fig, ax = plt.subplots(1, 1, figsize=(5.5, 5.5))  # pylint: disable=invalid-name
     ax.pie(nz_bins[::-1], labels=labels, colors=colors, textprops={'fontsize': 14},
-           rotatelabels=True, counterclock=False)
+           rotatelabels=True, counterclock=False, radius=1)
     ax.add_artist(Circle((0, 0), 0.7, color='white', zorder=1))
     ax.text(0, 0, total_jobs, horizontalalignment='center',
             verticalalignment='center', fontsize=26)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR deprecates the `qiskit_backend_monitor` Jupyter magic in favor of an HTML repr callback that is added in the Jupyter kernel for `IBMQbackend` class objects.

Additionally, jobs data is now loaded only when the jobs tab is selected to decrease initial load time.

<img width="1020" alt="Screen Shot 2019-06-13 at 12 33 24 PM" src="https://user-images.githubusercontent.com/1249193/59450584-8330a880-8dd7-11e9-8777-eb99061ade9d.png">

### Details and comments


