### PR TITLE
Reduce randomize testing timeouts in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -196,7 +196,7 @@ jobs:
       script:
       - python setup.py build_ext --inplace
       - pip install "qiskit-aer"
-      - travis_wait make test_randomized
+      - travis_wait 45 make test_randomized
 
 matrix:
   fast_finish: true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage>=4.4.0
-hypothesis>=4.7.3
+hypothesis>=4.24.3
 ipywidgets>=7.3.0
 jupyter
 matplotlib>=2.1

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -17,7 +17,7 @@
 
 import os
 
-from hypothesis import assume
+from hypothesis import assume, settings
 from hypothesis.stateful import multiple, rule, precondition, invariant
 from hypothesis.stateful import Bundle, RuleBasedStateMachine
 
@@ -52,6 +52,7 @@ mock_backends = [FakeTenerife(), FakeMelbourne(), FakeRueschlikon(),
                  FakeTokyo(), FakePoughkeepsie()]
 
 
+@settings(report_multiple_bugs=False, max_examples=50)
 class QCircuitMachine(RuleBasedStateMachine):
     """Build a Hypothesis rule based state machine for constructing, transpiling
     and simulating a series of random QuantumCircuits.

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -52,7 +52,9 @@ mock_backends = [FakeTenerife(), FakeMelbourne(), FakeRueschlikon(),
                  FakeTokyo(), FakePoughkeepsie()]
 
 
-@settings(report_multiple_bugs=False, max_examples=50)
+@settings(report_multiple_bugs=False,
+          max_examples=50,
+          deadline=None)
 class QCircuitMachine(RuleBasedStateMachine):
     """Build a Hypothesis rule based state machine for constructing, transpiling
     and simulating a series of random QuantumCircuits.


### PR DESCRIPTION
The randomized tests have been consistently timing out when run on merges to master (even though they consistently complete on PR branches). To better understand why:
- Increase the `travis_wait` time to 45 minutes
- Tell hypothesis to stop at the first found error, and not try to search further
- Cut the random circuit count from 100 to 50.

These can be revised when we better understand why the master jobs are running so long. 