### PR TITLE
Default to __version__ attribute for __qiskit_version__

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -82,6 +82,29 @@ __version__ = get_version_info()
 
 
 def _get_qiskit_versions():
+    out_dict = {}
+    out_dict['qiskit-terra'] = __version__
+    try:
+        from qiskit.providers import aer
+        out_dict['qiskit-aer'] = aer_version = aer.__version__
+    except Exception:
+        pass
+    try:
+        from qiskit import ignis
+        out_dict['qiskit-ignis'] = ignis.__version__
+    except Exception:
+        pass
+    try:
+        from qiskit.providers import ibmq
+        out_dict['qiskit-ibmq-provider'] = ibmq.__version__
+    except Exception:
+        pass
+    try:
+        from qiskit import aqua
+        out_dict['qiskit-aqua'] = aqua.__version__
+    except Exception:
+        pass
+
     cmd = [sys.executable, '-m', 'pip', 'freeze']
     reqs = _minimal_ext_cmd(cmd)
     reqs_dict = {}
@@ -96,11 +119,12 @@ def _get_qiskit_versions():
         elif len(req_parts) == 1:
             continue
         reqs_dict[req_parts[0]] = req_parts[1]
-    out_dict = {}
     # Dev/Egg _ to - conversion
     for package in ['qiskit_terra', 'qiskit_ignis', 'qiskit_aer',
                     'qiskit_ibmq_provider', 'qiskit_aqua']:
         if package in reqs_dict:
+            if package.replace('_', '-') in out_dict:
+                continue
             out_dict[package.replace('_', '-')] = reqs_dict[package]
 
     for package in ['qiskit', 'qiskit-terra', 'qiskit-ignis', 'qiskit-aer',

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=no-name-in-module,broad-except,cyclic-import
+
 """Contains the terra version."""
 
 import os
@@ -86,7 +88,7 @@ def _get_qiskit_versions():
     out_dict['qiskit-terra'] = __version__
     try:
         from qiskit.providers import aer
-        out_dict['qiskit-aer'] = aer_version = aer.__version__
+        out_dict['qiskit-aer'] = aer.__version__
     except Exception:
         pass
     try:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the behavior slightly for the
qiskit.__qiskit_version__ attribute. Previously we relied solely on pip
to extract the version information for installed packages. However, in
some situtations this can get out of sync with the actual version of the
package. To address this potential issue this commit adds a first round
check to use the attributes from the installed packages. If it doesn't
work then we look at the pip data as a fallback (because we have to use
pip anyway for the meta-package which doesn't contain any python code).

### Details and comments

Fixes #2494
