### PR TITLE
Make pip error for version discovery non-fatal

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -108,7 +108,10 @@ def _get_qiskit_versions():
         pass
 
     cmd = [sys.executable, '-m', 'pip', 'freeze']
-    reqs = _minimal_ext_cmd(cmd)
+    try:
+        reqs = _minimal_ext_cmd(cmd)
+    except Exception:
+        return out_dict
     reqs_dict = {}
     for req in reqs.split():
         req_parts = req.decode().split('==')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of the `qiskit.__qiskit_version__` attribute we have to call pip
to check for the meta-package version (since it doesn't contain any
python code). However, when doing this there was no error handling in
case pip failed for any reason. This is an issue because the version
discovery code runs on import, so if pip fails for any reason, this
becomes fatal and makes all of qiskit unusable. Since versions queried
via pip aren't critical to the operation this commit adds the necessary
error handling to the pip call. If pip fails for any reason we catch it
and just move on.

### Details and comments

Fixes #2660