### PR TITLE
never remove id gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ The format is based on [Keep a Changelog].
 
 -   Possible to decompose SU(4) gate into non-CNOT basis with
     `TwoQubitDecomposer`
+-   Fixes a bug that removed `id` gates from circuit. id gates are
+    like a `wait` command and will never be removed (\#2663)
 
 
 ## [0.8.2] - 2019-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
--   Fixes a bug that removed `id` gates from circuit. id gates are
-    like a `wait` command and will never be removed (\#2663)
+-   Possible to decompose SU(4) gate into non-CNOT basis with
+    `TwoQubitDecomposer`
 
 
 ## [0.8.2] - 2019-06-14
@@ -225,8 +225,6 @@ The format is based on [Keep a Changelog].
 -   Added support for parameterized circuits. (\#2103)
 -   Added preset PassManagers that offer predetermined pipelines of
     transpiler passes. (\#2163)
--   Possible to decompose SU(4) gate into non-CNOT basis with
-    `TwoQubitDecomposer`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,8 @@ The format is based on [Keep a Changelog].
 
 ### Fixed
 
--   Possible to decompose SU(4) gate into non-CNOT basis with
-    `TwoQubitDecomposer`
+-   Fixes a bug that removed `id` gates from circuit. id gates are
+    like a `wait` command and will never be removed (\#2663)
 
 
 ## [0.8.2] - 2019-06-14
@@ -225,6 +225,8 @@ The format is based on [Keep a Changelog].
 -   Added support for parameterized circuits. (\#2103)
 -   Added preset PassManagers that offer predetermined pipelines of
     transpiler passes. (\#2163)
+-   Possible to decompose SU(4) gate into non-CNOT basis with
+    `TwoQubitDecomposer`
 
 ### Changed
 

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -18,8 +18,6 @@ Identity gate.
 import numpy
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit import QuantumRegister
-from qiskit.extensions.standard.u3 import U3Gate
 
 
 class IdGate(Gate):

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -26,22 +26,12 @@ class IdGate(Gate):
     """Identity gate.
 
     Identity gate corresponds to a single-qubit gate wait cycle,
-    and should not be optimized.
+    and should not be optimized or unrolled (it is an opaque gate).
     """
 
     def __init__(self, label=None):
         """Create new Identity gate."""
         super().__init__("id", 1, [], label=label)
-
-    def _define(self):
-        definition = []
-        q = QuantumRegister(1, "q")
-        rule = [
-            (U3Gate(0, 0, 0), [q[0]], [])
-        ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def inverse(self):
         """Invert this gate."""
@@ -57,7 +47,7 @@ def iden(self, q):
     """Apply Identity to q.
 
     Identity gate corresponds to a single-qubit gate wait cycle,
-    and should not be optimized.
+    and should not be optimized or unrolled (it is an opaque gate).
     """
     return self.append(IdGate(), [q], [])
 

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -23,7 +23,11 @@ from qiskit.extensions.standard.u3 import U3Gate
 
 
 class IdGate(Gate):
-    """Identity gate."""
+    """Identity gate.
+
+    Identity gate corresponds to a single-qubit gate wait cycle,
+    and should not be optimized.
+    """
 
     def __init__(self, label=None):
         """Create new Identity gate."""
@@ -50,7 +54,11 @@ class IdGate(Gate):
 
 
 def iden(self, q):
-    """Apply Identity to q."""
+    """Apply Identity to q.
+
+    Identity gate corresponds to a single-qubit gate wait cycle,
+    and should not be optimized.
+    """
     return self.append(IdGate(), [q], [])
 
 

--- a/qiskit/transpiler/passes/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimize_1q_gates.py
@@ -39,7 +39,7 @@ class Optimize1qGates(TransformationPass):
     """Simplify runs of single qubit gates in the ["u1", "u2", "u3", "cx", "id"] basis."""
     def run(self, dag):
         """Return a new circuit that has been optimized."""
-        runs = dag.collect_runs(["u1", "u2", "u3", "id"])
+        runs = dag.collect_runs(["u1", "u2", "u3"])
         runs = _split_runs_on_parameters(runs)
         for run in runs:
             right_name = "u1"

--- a/test/python/circuit/test_diag.py
+++ b/test/python/circuit/test_diag.py
@@ -42,7 +42,7 @@ class TestDiagGate(QiskitTestCase):
                 qc = QuantumCircuit(q)
                 qc.diagGate(diag, q[0:num_qubits])
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx'])
+                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/circuit/test_isometry.py
+++ b/test/python/circuit/test_isometry.py
@@ -50,7 +50,7 @@ class TestIsometry(QiskitTestCase):
                 qc = QuantumCircuit(q)
                 qc.iso(iso, q[:num_q_input], q[num_q_input:])
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx'])
+                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/circuit/test_squ.py
+++ b/test/python/circuit/test_squ.py
@@ -47,7 +47,7 @@ class TestSingleQubitUnitary(QiskitTestCase):
                 qc = QuantumCircuit(qr)
                 qc.squ(u, qr[0], up_to_diagonal=up_to_diagonal)
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx'])
+                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/circuit/test_ucg.py
+++ b/test/python/circuit/test_ucg.py
@@ -57,7 +57,7 @@ class TestUCG(QiskitTestCase):
                 qc = QuantumCircuit(q)
                 qc.ucg(squs, q[1:], q[0], up_to_diagonal=up_to_diagonal)
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx'])
+                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/circuit/test_ucx_y_z.py
+++ b/test/python/circuit/test_ucx_y_z.py
@@ -53,7 +53,7 @@ class TestUCXYZ(QiskitTestCase):
                 else:
                     qc.ucz(angles, q[1:num_contr + 1], q[0])
                 # Decompose the gate
-                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx'])
+                qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -31,19 +31,22 @@ from qiskit.circuit import Parameter
 class TestOptimize1qGates(QiskitTestCase):
     """Test for 1q gate optimizations. """
 
-    def test_optimize_id(self):
-        """ qr0:--[id]-- == qr0:------ """
+    def test_dont_optimize_id(self):
+        """Identity gates are like 'wait' commands.
+        They should never be optimized (even without barriers).
+
+        See: https://github.com/Qiskit/qiskit-terra/issues/2373
+        """
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr)
         circuit.iden(qr)
         circuit.iden(qr)
         dag = circuit_to_dag(circuit)
-        expected = QuantumCircuit(qr)
 
         pass_ = Optimize1qGates()
         after = pass_.run(dag)
 
-        self.assertEqual(circuit_to_dag(expected), after)
+        self.assertEqual(dag, after)
 
     def test_optimize_h_gates_pass_manager(self):
         """Transpile: qr:--[H]-[H]-[H]-- == qr:--[u2]-- """

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -66,7 +66,7 @@ class TestOptimize1qGates(QiskitTestCase):
 
         self.assertEqual(expected, result)
 
-    def test_optimize_1q_gates_collapse_identity(self):
+    def test_optimize_1q_gates_collapse_identity_equivalent(self):
         """test optimize_1q_gates removes u1(2*pi) rotations.
 
         See: https://github.com/Qiskit/qiskit-terra/issues/159

--- a/test/python/transpiler/test_unroller.py
+++ b/test/python/transpiler/test_unroller.py
@@ -143,7 +143,7 @@ class TestUnroller(QiskitTestCase):
         circuit.snapshot('0')
         circuit.measure(qr, cr)
         dag = circuit_to_dag(circuit)
-        pass_ = Unroller(basis=['u3', 'cx'])
+        pass_ = Unroller(basis=['u3', 'cx', 'id'])
         unrolled_dag = pass_.run(dag)
 
         ref_circuit = QuantumCircuit(qr, cr)
@@ -213,7 +213,7 @@ class TestUnroller(QiskitTestCase):
         ref_circuit.u3(0, 0, pi/2, qr[2])
         ref_circuit.cx(qr[2], qr[0])
         ref_circuit.u3(pi/2, 0, pi, qr[0])
-        ref_circuit.u3(0, 0, 0, qr[0])
+        ref_circuit.iden(qr[0])
         ref_circuit.u3(0.1, -pi/2, pi/2, qr[0])
         ref_circuit.cx(qr[1], qr[0])
         ref_circuit.u3(0, 0, 0.6, qr[0])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2373 

Identity gates are now like explicit 'wait' commands. They will never be removed. Even in the absence of barriers:

i.e. this circuit will stay like this even at high optimization levels, and will mean "excite qubit, then wait for 11 single-qubit-gate cycles.
![image](https://user-images.githubusercontent.com/8622381/59860561-18d6b580-934d-11e9-9f2d-a89edb2ad924.png)



