### PR TITLE
deprecate u0 gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog].
 
 -   The gates `U` and `CX` are being deprecated in favor of `u3` and
     `cx`.
+-   The gate `u0` is being deprecated in favor of using multiple `id` gates
+    to insert delays (\#2664)
 -   The decorator `requires_qe_access` is being deprecated in favor of
     `online_test`.
 -   The `as_dict` method of Qobj is deprecated in favor of `to_dict`.

--- a/qiskit/extensions/standard/u0.py
+++ b/qiskit/extensions/standard/u0.py
@@ -17,6 +17,7 @@
 """
 Single qubit gate cycle idle.
 """
+import warnings
 import numpy
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
@@ -29,6 +30,8 @@ class U0Gate(Gate):
 
     def __init__(self, m):
         """Create new u0 gate."""
+        warnings.warn("The u0 gate is deprecated in Qiskit Terra 0.9+. "
+                      "Use the iden gate to insert delays.", DeprecationWarning)
         super().__init__("u0", 1, [m])
 
     def _define(self):

--- a/qiskit/extensions/standard/u0.py
+++ b/qiskit/extensions/standard/u0.py
@@ -30,7 +30,7 @@ class U0Gate(Gate):
 
     def __init__(self, m):
         """Create new u0 gate."""
-        warnings.warn("The u0 gate is deprecated in Qiskit Terra 0.9+. "
+        warnings.warn("The u0 gate is deprecated and will be removed after Qiskit Terra 0.10. "
                       "Use the iden gate to insert delays.", DeprecationWarning)
         super().__init__("u0", 1, [m])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The `u0` gate was used to insert variable amounts of noise. From now on, the `id` gate is the only gate used for this purpose that allows inserting variable amounts of delay (as integer multiples of a single-qubit-gate delay). So insert an `id` raised to the power of 5 to force 5 units of delay. For more fine-grained control over delays, use open pulse.

