### PR TITLE
do not commute conditional gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog].
     `TwoQubitDecomposer`
 -   Fixes a bug that removed `id` gates from circuit. id gates are
     like a `wait` command and will never be removed (\#2663)
+-   Fixed bug in CommutationAnalysis pass affecting conditional gates (\#2669)
 
 
 ## [0.8.2] - 2019-06-14

--- a/qiskit/transpiler/passes/commutation_analysis.py
+++ b/qiskit/transpiler/passes/commutation_analysis.py
@@ -101,6 +101,9 @@ def _commute(node1, node2):
             for nd in [node1, node2]]):
         return False
 
+    if node1.condition or node2.condition:
+        return False
+
     qarg = list(set(node1.qargs + node2.qargs))
     qbit_num = len(qarg)
 

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -522,7 +522,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.measure(0, 0)
         circuit.cx(1, 2)
         circuit.cx(1, 2).c_if(circuit.cregs[0], 0)
-        circuit.measure([1, 2],[0, 1])
+        circuit.measure([1, 2], [0, 1])
 
         new_pm = PassManager(CommutativeCancellation())
         new_circuit = transpile(circuit, pass_manager=new_pm)

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -515,6 +515,20 @@ class TestCommutativeCancellation(QiskitTestCase):
 
         self.assertEqual(expected, new_circuit)
 
+    def test_conditional_gates_dont_commute(self):
+        """Conditional gates do not commute and do not cancel"""
+        circuit = QuantumCircuit(3, 2)
+        circuit.h(0)
+        circuit.measure(0, 0)
+        circuit.cx(1, 2)
+        circuit.cx(1, 2).c_if(circuit.cregs[0], 0)
+        circuit.measure([1, 2],[0, 1])
+
+        new_pm = PassManager(CommutativeCancellation())
+        new_circuit = transpile(circuit, pass_manager=new_pm)
+
+        self.assertEqual(circuit, new_circuit)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2667, Fixes #2668 

Conditional gates must be excluded when computing commutation relations.
