### PR TITLE
Allow for functions defining pass_managers in transpile

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -114,11 +114,13 @@ def transpile(circuits,
                 2: heavy optimization
                 3: even heavier optimization
 
-        pass_manager (PassManager):
+        pass_manager (PassManager or FunctionType):
             The pass manager to use for a custom pipeline of transpiler passes.
             If this arg is present, all other args will be ignored and the
             pass manager will be used directly (Qiskit will not attempt to
-            auto-select a pass manager based on transpile options).
+            auto-select a pass manager based on transpile options). If
+            FunctionType, the function takes a TranspileConfig as its
+            sole argument.
 
 
     Returns:

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -108,10 +108,11 @@ def execute(experiments, backend,
                 1: light optimization
                 2: heavy optimization
 
-        pass_manager (PassManager):
+        pass_manager (PassManager or FunctionType):
             The pass manager to use during transpilation. If this arg is present,
             auto-selection of pass manager based on the transpile options will be
-            turned off and this pass manager will be used directly.
+            turned off and this pass manager will be used directly.If FunctionType,
+            the function takes a TranspileConfig as its sole argument.
 
         qobj_id (str):
             String identifier to annotate the Qobj

--- a/qiskit/transpiler/transpile_circuit.py
+++ b/qiskit/transpiler/transpile_circuit.py
@@ -14,6 +14,8 @@
 
 """Circuit transpile function"""
 
+import types
+from functools import partial
 from qiskit.transpiler.preset_passmanagers import (default_pass_manager_simulator,
                                                    default_pass_manager,
                                                    level_0_pass_manager,
@@ -38,7 +40,12 @@ def transpile_circuit(circuit, transpile_config):
     """
     # if the pass manager is not already selected, choose an appropriate one.
     if transpile_config.pass_manager:
-        pass_manager = transpile_config.pass_manager
+        if isinstance(transpile_config.pass_manager, (types.FunctionType,
+                                                      types.BuiltinFunctionType,
+                                                      partial)):
+            pass_manager = transpile_config.pass_manager(transpile_config)
+        else:
+            pass_manager = transpile_config.pass_manager
 
     elif transpile_config.optimization_level is not None:
         level = transpile_config.optimization_level


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR allows for passing functions defining pass managers, taking a `TranspileConfig` as their sole input argument, to be passed to `transpile`.  These functions work in the exact same way as the builtin pass managers, and allow one to define a pass manager using a single function, without the need for a separate init step.


### Details and comments


