### PR TITLE
remove optimization_level=None from randomized tests

### DIFF
--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -198,7 +198,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         backend=st.one_of(
             st.none(),
             st.sampled_from(mock_backends)),
-        opt_level=st.integers(min_value=0, max_value=3)
+        opt_level=st.integers(min_value=0, max_value=3))
     def equivalent_transpile(self, backend, opt_level):
         """Simulate, transpile and simulate the present circuit. Verify that the
         counts are not significantly different before and after transpilation.

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -199,7 +199,6 @@ class QCircuitMachine(RuleBasedStateMachine):
             st.none(),
             st.sampled_from(mock_backends)),
         opt_level=st.one_of(
-            st.none(),
             st.integers(min_value=0, max_value=3)))
     def equivalent_transpile(self, backend, opt_level):
         """Simulate, transpile and simulate the present circuit. Verify that the

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -198,8 +198,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         backend=st.one_of(
             st.none(),
             st.sampled_from(mock_backends)),
-        opt_level=st.one_of(
-            st.integers(min_value=0, max_value=3)))
+        opt_level=st.integers(min_value=0, max_value=3)
     def equivalent_transpile(self, backend, opt_level):
         """Simulate, transpile and simulate the present circuit. Verify that the
         counts are not significantly different before and after transpilation.


### PR DESCRIPTION
since #2672, the default optimization level is just level 1, so there is no need to test `optimization_level=None` anymore.