### PR TITLE
Fix text drawer DeprecationWarning

### DIFF
--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -959,7 +959,7 @@ class Layer:
             label (string): The label for the multi clbit box.
             top_connect (char): The char to connect the box on the top.
         """
-        clbit = [bit for bit in self.cregs if bit[0] == creg]
+        clbit = [bit for bit in self.cregs if bit.register == creg]
         self._set_multibox("cl", clbit, label, top_connect=top_connect)
 
     def set_qu_multibox(self, bits, label, conditional=False):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Small tweak to avoid a bunch of:

```
qiskit-sdk-py/qiskit/visualization/text.py:962: DeprecationWarning: Accessing a bit register by bit[0] or its index by bit[1] is deprecated. Go for bit.register and bit.index.
    clbit = [bit for bit in self.cregs if bit[0] == creg]
```

when running the tests.

### Details and comments


