### PR TITLE
Fix qasm_simulator measure sampling bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ The format is based on [Keep a Changelog].
 -   Fixes a bug that removed `id` gates from circuit. id gates are
     like a `wait` command and will never be removed (\#2663)
 -   Fixed bug in CommutationAnalysis pass affecting conditional gates (\#2669)
+-   Fixed bug in measure sampling for BasicAer Qasm simulator if a qubit
+    was measured into more than one memory cbit (\#2735)
 
 
 ## [0.8.2] - 2019-06-14

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -202,8 +202,8 @@ class QasmSimulatorPy(BaseBackend):
         memory = []
         for sample in samples:
             classical_memory = self._classical_memory
-            for count, (qubit, cmembit) in enumerate(sorted(measure_params)):
-                qubit_outcome = int((sample & (1 << count)) >> count)
+            for qubit, cmembit in measure_params:
+                qubit_outcome = int((sample & (1 << qubit)) >> qubit)
                 membit = 1 << cmembit
                 classical_memory = (classical_memory & (~membit)) | (qubit_outcome << cmembit)
             value = bin(classical_memory)[2:]

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -48,6 +48,27 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         result = self.backend.run(self.qobj).result()
         self.assertEqual(result.success, True)
 
+    def test_qasm_simulator_measure_sampler(self):
+        """Test measure sampler if qubits measured more than once."""
+        shots = 100
+        qr = QuantumRegister(2, 'qr')
+        cr = ClassicalRegister(4, 'cr')
+        circuit = QuantumCircuit(qr, cr)
+        circuit.x(qr[1])
+        circuit.measure(qr[0], cr[0])
+        circuit.measure(qr[1], cr[1])
+        circuit.measure(qr[1], cr[2])
+        circuit.measure(qr[0], cr[3])
+        target = {'0110': shots}
+        job = execute(
+            circuit,
+            backend=self.backend,
+            shots=shots,
+            seed_simulator=self.seed)
+        result = job.result()
+        counts = result.get_counts(0)
+        self.assertEqual(counts, target)
+
     def test_qasm_simulator(self):
         """Test data counts output for single circuit run against reference."""
         result = self.backend.run(self.qobj).result()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug where measure sampling was incorrectly done if the same qubit was measured more than once.

Fixes #2664 

### Details and comments


