### PR TITLE
Fix bug in circuit to Operator/SuperOp conversion

### DIFF
--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -474,9 +474,10 @@ class SuperOp(QuantumChannel):
                             'Cannot apply instruction with classical registers: {}'
                             .format(instr.name))
                     # Get the integer position of the flat register
-                    new_qargs = qargs
-                    if new_qargs is None:
+                    if qargs is None:
                         new_qargs = [tup.index for tup in qregs]
+                    else:
+                        new_qargs = [qargs[tup.index] for tup in qregs]
                     self._append_instruction(instr, qargs=new_qargs)
         else:
             raise QiskitError('Input is not an instruction.')

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -462,9 +462,10 @@ class Operator(BaseOperator):
                             'Cannot apply instruction with classical registers: {}'.format(
                                 instr.name))
                     # Get the integer position of the flat register
-                    new_qargs = qargs
-                    if new_qargs is None:
+                    if qargs is None:
                         new_qargs = [tup.index for tup in qregs]
+                    else:
+                        new_qargs = [qargs[tup.index] for tup in qregs]
                     self._append_instruction(instr, qargs=new_qargs)
         else:
             raise QiskitError('Input is not an instruction.')

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -69,8 +69,10 @@ class TestSuperOp(ChannelTestCase):
         circuit = QuantumCircuit(2)
         circuit.ch(0, 1)
         op = SuperOp(circuit)
-        target = SuperOp(Operator(np.kron(self.UI, np.diag([1, 0])) +
-                 np.kron(self.UH, np.diag([0, 1]))))
+        target = SuperOp(
+            Operator(
+                np.kron(self.UI, np.diag([1, 0])) +
+                np.kron(self.UH, np.diag([0, 1]))))
         self.assertEqual(target, op)
 
     def test_circuit_init_except(self):

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -17,7 +17,8 @@
 import unittest
 import numpy as np
 
-from qiskit import QiskitError
+from qiskit import QiskitError, QuantumCircuit
+from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.channel import SuperOp
 from .channel_test_case import ChannelTestCase
 
@@ -46,10 +47,31 @@ class TestSuperOp(ChannelTestCase):
 
     def test_circuit_init(self):
         """Test initialization from a circuit."""
-        circuit, target = self.simple_circuit_no_measure()
+        # Test tensor product of 1-qubit gates
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.x(1)
+        circuit.ry(np.pi / 2, 2)
         op = SuperOp(circuit)
-        target = SuperOp(target)
-        self.assertEqual(op, target)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = SuperOp(Operator(np.kron(y90, np.kron(self.UX, self.UH))))
+        self.assertEqual(target, op)
+
+        # Test decomposition of Controlled-u1 gate
+        lam = np.pi / 4
+        circuit = QuantumCircuit(2)
+        circuit.cu1(lam, 0, 1)
+        op = SuperOp(circuit)
+        target = SuperOp(Operator(np.diag([1, 1, 1, np.exp(1j * lam)])))
+        self.assertEqual(target, op)
+
+        # Test decomposition of controlled-H gate
+        circuit = QuantumCircuit(2)
+        circuit.ch(0, 1)
+        op = SuperOp(circuit)
+        target = SuperOp(Operator(np.kron(self.UI, np.diag([1, 0])) +
+                 np.kron(self.UH, np.diag([0, 1]))))
+        self.assertEqual(target, op)
 
     def test_circuit_init_except(self):
         """Test initialization from circuit with measure raises exception."""

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -150,7 +150,8 @@ class TestOperator(OperatorTestCase):
         op = Operator(circuit)
         y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
         target = np.kron(y90, np.kron(self.UX, self.UH))
-        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        global_phase_equivalent = matrix_equal(
+            op.data, target, ignore_phase=True)
         self.assertTrue(global_phase_equivalent)
 
         # Test decomposition of Controlled-u1 gate
@@ -159,18 +160,20 @@ class TestOperator(OperatorTestCase):
         circuit.cu1(lam, 0, 1)
         op = Operator(circuit)
         target = np.diag([1, 1, 1, np.exp(1j * lam)])
-        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        global_phase_equivalent = matrix_equal(
+            op.data, target, ignore_phase=True)
         self.assertTrue(global_phase_equivalent)
 
         # Test decomposition of controlled-H gate
         circuit = QuantumCircuit(2)
         circuit.ch(0, 1)
         op = Operator(circuit)
-        target = np.kron(self.UI, np.diag([1, 0])) + \
-                 np.kron(self.UH, np.diag([0, 1]))
-        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        target = np.kron(self.UI, np.diag([1, 0])) + np.kron(
+            self.UH, np.diag([0, 1]))
+        global_phase_equivalent = matrix_equal(
+            op.data, target, ignore_phase=True)
         self.assertTrue(global_phase_equivalent)
-    
+
     def test_instruction_init(self):
         """Test initialization from a circuit."""
         gate = CnotGate()

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -142,11 +142,35 @@ class TestOperator(OperatorTestCase):
 
     def test_circuit_init(self):
         """Test initialization from a circuit."""
-        circuit, target = self.simple_circuit_no_measure()
+        # Test tensor product of 1-qubit gates
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.x(1)
+        circuit.ry(np.pi / 2, 2)
         op = Operator(circuit)
-        target = Operator(target)
-        self.assertEqual(op, target)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = np.kron(y90, np.kron(self.UX, self.UH))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
 
+        # Test decomposition of Controlled-u1 gate
+        lam = np.pi / 4
+        circuit = QuantumCircuit(2)
+        circuit.cu1(lam, 0, 1)
+        op = Operator(circuit)
+        target = np.diag([1, 1, 1, np.exp(1j * lam)])
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of controlled-H gate
+        circuit = QuantumCircuit(2)
+        circuit.ch(0, 1)
+        op = Operator(circuit)
+        target = np.kron(self.UI, np.diag([1, 0])) + \
+                 np.kron(self.UH, np.diag([0, 1]))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+    
     def test_instruction_init(self):
         """Test initialization from a circuit."""
         gate = CnotGate()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug in converting circuits/instructions to operator objects that wasn't fixed by #2723. 

This bug is where 2-qubit gates without an explicit matrix def (like cu1, cu3) are decomposed into gates was raising an error that they were being applied to incorrect sized qargs.

### Details and comments


