### PR TITLE
Add automation for sdist pypi upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,14 @@ jobs:
         - sudo pip install -U twine
         - cibuildwheel --output-dir wheelhouse
         - twine upload wheelhouse/*
+    - if: tag IS present
+      env:
+        - TWINE_USERNAME=qiskit
+      python: 3.6
+      install: pip install -U twine
+      script:
+        - python3 setup.py sdist
+        - twine upload dist/qiskit-terra*tar.gz
     - os: osx
       language: generic
       if: tag IS present


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As part of streamlining the release process, this commit adds automation
for publishing an sdist to pypi. This was one of the last manual steps
that was part of the release process. Now there are no manual steps left
after pushing a git tag. There are still some optimizations that need to
be done prior to pushing a tag, but that is more of a process problem
rather than something that can directly be fixed by automation.

### Details and comments
