### PR TITLE
fix measure sampling bug in BasicAer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ The format is based on [Keep a Changelog].
 -   Fixed bug in CommutationAnalysis pass affecting conditional gates (\#2669)
 -   Fixed bug in measure sampling for BasicAer Qasm simulator if a qubit
     was measured into more than one memory cbit (\#2735)
+-   Fixed bug in measure sampling for BasicAer Qasm simulator if only a
+    subset of qubits are measured (\#2790)
 
 
 ## [0.8.2] - 2019-06-14

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -183,10 +183,13 @@ class QasmSimulatorPy(BaseBackend):
         Returns:
             list: A list of memory values in hex format.
         """
-        # Get unique qubits that are actually measured
+        # Get unique qubits that are actually measured and sort in
+        # ascending order
         measured_qubits = sorted(list({qubit for qubit, cmembit in measure_params}))
         num_measured = len(measured_qubits)
-        # Axis for numpy.sum to compute probabilities
+        # We use the axis kwarg for numpy.sum to compute probabilities
+        # this sums over all non-measured qubits to return a vector
+        # of measure probabilities for the measured qubits
         axis = list(range(self._number_of_qubits))
         for qubit in reversed(measured_qubits):
             # Remove from largest qubit to smallest so list position is correct
@@ -195,10 +198,12 @@ class QasmSimulatorPy(BaseBackend):
         probabilities = np.reshape(np.sum(np.abs(self._statevector) ** 2,
                                           axis=tuple(axis)),
                                    2 ** num_measured)
-        # Generate samples on measured qubits
+        # Generate samples on measured qubits as ints with qubit
+        # position in the bit-string for each int given by the qubit
+        # position in the sorted measured_qubits list
         samples = self._local_random.choice(range(2 ** num_measured),
                                             num_samples, p=probabilities)
-        # Convert to bit-strings
+        # Convert the ints to bitstrings
         memory = []
         for sample in samples:
             classical_memory = self._classical_memory

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -184,7 +184,7 @@ class QasmSimulatorPy(BaseBackend):
             list: A list of memory values in hex format.
         """
         # Get unique qubits that are actually measured
-        measured_qubits = list({qubit for qubit, cmembit in measure_params})
+        measured_qubits = sorted(list({qubit for qubit, cmembit in measure_params}))
         num_measured = len(measured_qubits)
         # Axis for numpy.sum to compute probabilities
         axis = list(range(self._number_of_qubits))
@@ -203,7 +203,8 @@ class QasmSimulatorPy(BaseBackend):
         for sample in samples:
             classical_memory = self._classical_memory
             for qubit, cmembit in measure_params:
-                qubit_outcome = int((sample & (1 << qubit)) >> qubit)
+                pos = measured_qubits.index(qubit)
+                qubit_outcome = int((sample & (1 << pos)) >> pos)
                 membit = 1 << cmembit
                 classical_memory = (classical_memory & (~membit)) | (qubit_outcome << cmembit)
             value = bin(classical_memory)[2:]

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -75,7 +75,7 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         num_qubits = 5
         qr = QuantumRegister(num_qubits, 'qr')
         cr = ClassicalRegister(1, 'cr')
-        
+
         for qubit in range(num_qubits):
             circuit = QuantumCircuit(qr, cr)
             circuit.x(qr[qubit])
@@ -89,14 +89,14 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
             result = job.result()
             counts = result.get_counts(0)
             self.assertEqual(counts, target)
-    
+
     def test_measure_sampler_partial_qubit(self):
         """Test measure sampler if single-qubit is measured."""
         shots = 100
         num_qubits = 5
         qr = QuantumRegister(num_qubits, 'qr')
         cr = ClassicalRegister(4, 'cr')
-        
+
         circuit = QuantumCircuit(qr, cr)
         circuit.x(qr[3])
         circuit.x(qr[1])

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -175,7 +175,7 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         circuit = QuantumCircuit(qr, cr0, cr1, cr2, name='teleport')
         circuit.h(qr[1])
         circuit.cx(qr[1], qr[2])
-        circuit.ry(pi/4, qr[0])
+        circuit.ry(pi / 4, qr[0])
         circuit.cx(qr[0], qr[1])
         circuit.h(qr[0])
         circuit.barrier(qr)
@@ -202,8 +202,8 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         self.log.info('test_teleport: data %s', data)
         self.log.info('test_teleport: alice %s', alice)
         self.log.info('test_teleport: bob %s', bob)
-        alice_ratio = 1/np.tan(pi/8)**2
-        bob_ratio = bob['0']/float(bob['1'])
+        alice_ratio = 1 / np.tan(pi / 8) ** 2
+        bob_ratio = bob['0'] / float(bob['1'])
         error = abs(alice_ratio - bob_ratio) / alice_ratio
         self.log.info('test_teleport: relative error = %s', error)
         self.assertLess(error, 0.05)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #2744. Adds some additional tests for BasicAer qasm simulator

### Details and comments

Measure sampling was behaving incorrectly if a subset of qubits were measured since it was assuming the position in the measured qubit list was the qubit number.

