### PR TITLE
Dagwidth part2 2564

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@ The format is based on [Keep a Changelog].
 -   Replaces LegacySwap by faster, more stable StochasticSwap pass (\#2672)
 -   Uses level 1 by default as transpiler optimization level (\#2672)
 -   Change Snapshot signature to match simulator.snapshot (\#2592)
+-   DAGCircuit.width() formerly returned number of qubits, now returns total number of qubits + classical bits (\#2564)
+-   Functions assuming the former semantics of DAGCircuit.width() now call DAGCircuit.num_qubits() (\#2564)
+-   DAGCircuit.num_cbits() renamed to DAGCircuit.num_clbits() (\#2564)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,9 +71,9 @@ The format is based on [Keep a Changelog].
 -   Replaces LegacySwap by faster, more stable StochasticSwap pass (\#2672)
 -   Uses level 1 by default as transpiler optimization level (\#2672)
 -   Change Snapshot signature to match simulator.snapshot (\#2592)
--   DAGCircuit.width() formerly returned number of qubits, now returns total number of qubits + classical bits (\#2564)
--   Functions assuming the former semantics of DAGCircuit.width() now call DAGCircuit.num_qubits() (\#2564)
--   DAGCircuit.num_cbits() renamed to DAGCircuit.num_clbits() (\#2564)
+-   `DAGCircuit.width()` formerly returned number of qubits, now returns total number of qubits + classical bits (\#2564)
+-   Functions assuming the former semantics of `DAGCircuit.width()` now call `DAGCircuit.num_qubits()` (\#2564)
+-   `DAGCircuit.num_cbits()` renamed to `DAGCircuit.num_clbits()` (\#2564)
 
 ### Removed
 

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -588,17 +588,20 @@ class DAGCircuit:
         return depth if depth != -1 else 0
 
     def width(self):
-        """Return the total number of qubits used by the circuit."""
-        return len(self.wires) - self.num_clbits()
+        """Return the total number of qubits + clbits used by the circuit.
+           This function formerly returned the number of qubits by the calculation
+           return len(self.wires) - self.num_clbits()
+           but was changed by issue #2564 to return number of qubits + clbits
+           with the new function DAGCircuit.num_qubits replacing the former
+           semantic of DAGCircuit.width().
+        """
+        return len(self.wires)
 
     def num_qubits(self):
         """Return the total number of qubits used by the circuit.
-           num_qubits() intends to replace current use of width().
-           DAGCircuit.width() should return qubits + cbits for
+           num_qubits() replaces former use of width().
+           DAGCircuit.width() now returns qubits + clbits for
            consistency with Circuit.width() [qiskit-terra #2564].
-           After all calling code has been edited to replace DAGCircuit.width()
-           with DAGCircuit.num_qubits(), then DAGCircuit.width() can be modified
-           to express the desired semantic.
         """
         return len(self.wires) - self.num_clbits()
 
@@ -1248,7 +1251,7 @@ class DAGCircuit:
         """Return a dictionary of circuit properties."""
         summary = {"size": self.size(),
                    "depth": self.depth(),
-                   "width": self.width(),
+                   "width": self.num_qubits(),
                    "bits": self.num_clbits(),
                    "factors": self.num_tensor_factors(),
                    "operations": self.count_ops()}

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -605,15 +605,8 @@ class DAGCircuit:
         """
         return len(self.wires) - self.num_clbits()
 
-    def num_cbits(self):
-        """Return the total number of bits used by the circuit."""
-        return sum(creg.size for creg in self.cregs.values())
-
     def num_clbits(self):
-        """Return the total number of bits used by the circuit.
-           Replacement for num_cbits() for consistent naming [qiskit-terra #2564].
-           Both defs will stay until num_cbits() changed to num_clbits() in
-           calls from qiskit_tutorials and qiskit-aqua."""
+        """Return the total number of classical bits used by the circuit."""
         return sum(creg.size for creg in self.cregs.values())
 
     def num_tensor_factors(self):

--- a/qiskit/transpiler/passes/width.py
+++ b/qiskit/transpiler/passes/width.py
@@ -22,4 +22,4 @@ class Width(AnalysisPass):
     """
 
     def run(self, dag):
-        self.property_set['width'] = dag.width()
+        self.property_set['width'] = dag.num_qubits()

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -498,7 +498,7 @@ class TestCircuitProperties(QiskitTestCase):
 
     def test_circuit_width(self):
         """Test number of qubits in circuit."""
-        self.assertEqual(self.dag.width(), 6)
+        self.assertEqual(self.dag.num_qubits(), 6)
 
     def test_circuit_operations(self):
         """Test circuit operations breakdown by kind of op."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Along with the just-submitted pull request to qiskit-aqua (number 613) this should complete #2564 


### Details and comments
- Changed invocations of `DAGCircuit.width()` to `DAGCircuit.num_qubits()`
- Changed  `DAGCircuit.width()` to intended semantic of "all bits, qu + cl"



