### PR TITLE
Add IBMQ cleanup to backend monitor test

### DIFF
--- a/test/python/tools/monitor/test_backend_monitor.py
+++ b/test/python/tools/monitor/test_backend_monitor.py
@@ -30,10 +30,11 @@ class TestBackendOverview(QiskitTestCase):
         """Test backend_overview"""
         from qiskit import IBMQ  # pylint: disable: import-error
         IBMQ.enable_account(qe_token, qe_url)
+        self.addCleanup(IBMQ.disable_account)
 
-        with patch('sys.stdout', new=StringIO()) as fake_stout:
+        with patch('sys.stdout', new=StringIO()) as fake_stdout:
             backend_overview()
-        stdout = fake_stout.getvalue()
+        stdout = fake_stdout.getvalue()
         self.assertIn('Operational:', stdout)
         self.assertIn('Avg. T1:', stdout)
         self.assertIn('Num. Qubits:', stdout)
@@ -43,14 +44,16 @@ class TestBackendOverview(QiskitTestCase):
         """Test backend_monitor"""
         from qiskit import IBMQ  # pylint: disable: import-error
         IBMQ.enable_account(qe_token, qe_url)
+        self.addCleanup(IBMQ.disable_account)
+
         for back in IBMQ.backends():
             if not back.configuration().simulator:
                 backend = back
                 break
-        with patch('sys.stdout', new=StringIO()) as fake_stout:
+        with patch('sys.stdout', new=StringIO()) as fake_stdout:
             backend_monitor(backend)
 
-        stdout = fake_stout.getvalue()
+        stdout = fake_stdout.getvalue()
         self.assertIn('Configuration', stdout)
         self.assertIn('Qubits [Name / Freq / T1 / T2 / U1 err / U2 err / U3 err / Readout err]',
                       stdout)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Sort of follow-up from the changes at #2828 - explicitly disable the provider account on the backend monitor tests in order to advance in getting `master` passing, as being a global variable the state is shared between tests.


### Details and comments


