### PR TITLE
Handle unitary width issue in matplotlib drawer

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -555,7 +555,7 @@ class MatplotlibDrawer:
                                  - n_fold * (self._cond['n_lines'] + 1)))
 
     def _draw_ops(self, verbose=False):
-        _wide_gate = ['u2', 'u3', 'cu2', 'cu3']
+        _wide_gate = ['u2', 'u3', 'cu2', 'cu3', 'unitary']
         _barriers = {'coord': [], 'group': []}
 
         #


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit handles fixes a spacing issue when drawing a unitary gate
with the matplotlib circuit drawer backend. Previously it was assuming
the gate was as wide as the operation name which was "unitary" and was
spacing based on that. However the gate is drawn with the name "u" and
is using a standard wide gate box (which has a layer width of 2). This
commit fixes the issue by treating the unitary gate as a standard wide
gate.

### Details and comments

Fixes #2686
