### PR TITLE
Fixed is complex function

### DIFF
--- a/qiskit/validation/fields/custom.py
+++ b/qiskit/validation/fields/custom.py
@@ -95,7 +95,7 @@ class InstructionParameter(ModelTypeValidator):
         if isinstance(value, sympy.Symbol):
             return str(value)
         if isinstance(value, sympy.Basic):
-            if sympy.im(value) != 0:
+            if sympy.is_complex:
                 return [float(sympy.re(value)), float(sympy.im(value))]
             if value.is_Integer:
                 return int(value.evalf())

--- a/qiskit/validation/fields/custom.py
+++ b/qiskit/validation/fields/custom.py
@@ -95,7 +95,7 @@ class InstructionParameter(ModelTypeValidator):
         if isinstance(value, sympy.Symbol):
             return str(value)
         if isinstance(value, sympy.Basic):
-            if sympy.is_complex:
+            if value.is_complex:
                 return [float(sympy.re(value)), float(sympy.im(value))]
             if value.is_Integer:
                 return int(value.evalf())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Changed the method of checking if number is complex when serialized. 

### Details and comments

Function sometimes fails when value.imag ==0, but the number is complex, since float(complex(1,)) fails, and similar thing happens for a sympy number.  Example of failing code:


import math
from qiskit import QuantumCircuit, execute, BasicAer
n = 3
circuit = QuantumCircuit(n, n, name="initializer_circ")
desired_vector = [(1+1j)/math.sqrt(2)/(2**(n/2))]*2**n
circuit.initialize(desired_vector, range(n))
circuit.measure(range(n), range(n))
sim_backend = Aer.get_backend('qasm_simulator')
job = execute(circuit, sim_backend)
result = job.result()
