### PR TITLE
Add ddt as a setup.py optional dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,8 @@ setup(
     extras_require={
         'visualization': ['matplotlib>=2.1', 'nxpd>=0.2', 'ipywidgets>=7.3.0',
                           'pydot', "pillow>=4.2.1", "pylatexenc>=1.4"],
-        'full-featured-simulators': ['qiskit-aer>=0.1']
+        'full-featured-simulators': ['qiskit-aer>=0.1'],
+        'tests': ['ddt>=1.2.0']
     },
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-terra/issues",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As a side effect of #2563, currently the `qiskit.test` module fails to import if `ddt` is not installed. This PR adds `ddt` as an optional dependency to `setup.py` in a similar spirit to other optional dependencies (visualization, full-featured-simulators), aiming for the minimal-effort approach for reintroducing the ability of installing "everything terra needs in a single pip instruction".


### Details and comments


