### PR TITLE
Add __init__ to test/randomized directory and fix missing import

### DIFF
--- a/test/randomized/__init__.py
+++ b/test/randomized/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Qiskit randomized tests."""

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -25,7 +25,7 @@ import hypothesis.strategies as st
 
 from qiskit import execute, transpile, Aer
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit.circuit import Measure, Reset
+from qiskit.circuit import Measure, Reset, Gate
 from qiskit.test.mock import \
     FakeTenerife, FakeMelbourne, FakeRueschlikon, FakeTokyo, FakePoughkeepsie
 from qiskit.test.base import dicts_almost_equal


### PR DESCRIPTION
### Summary

#2892 removed an import that was needed by #2783 . This wasn't caught by pylint because `test/randomized` had no `__init__.py`. This PR adds the missing import, and the init file.

