### PR TITLE
Make azure pipeline steps fail on intermediate commands

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,3 +160,8 @@ jobs:
         stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'
+
+    - bash: |
+        set -e
+        dmesg
+      displayName: 'Debug info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,6 +157,6 @@ jobs:
 
     - bash: |
         set -e
-        stestr run --concurrency 2
+        stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -165,4 +165,6 @@ jobs:
     - bash: |
         set -e
         sudo dmesg
+        sudo cat /var/log/system.log
+        sudo log show --debug
       displayName: 'Debug info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,7 @@ jobs:
       displayName: 'Run tests'
 
 - job: 'MacOS_Mojave_Tests'
-  pool: {vmImage: 'macOS-10.14'}
+  pool: {vmImage: 'macOS-10.13'}
   condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
   variables:
     MPLBACKEND: ps
@@ -157,14 +157,6 @@ jobs:
 
     - bash: |
         set -e
-        stestr run
+        stestr run --concurrency 2
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'
-      continueOnError: true
-
-    - bash: |
-        set -e
-        sudo dmesg
-        sudo cat /var/log/system.log
-        sudo log show --debug
-      displayName: 'Debug info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,6 +160,7 @@ jobs:
         stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'
+      continueOnError: true
 
     - bash: |
         set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,8 @@ jobs:
         versionSpec: '$(python.version)'
       displayName: 'Use Python $(python.version)'
 
-    - script: |
+    - bash: |
+        set -e
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
         pip install -e .
@@ -44,7 +45,8 @@ jobs:
     #     pylint -rn qiskit test
     #   displayName: 'Style and lint'
 
-    - script: |
+    - bash: |
+        set -e
         stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'
@@ -94,7 +96,8 @@ jobs:
         versionSpec: '$(python.version)'
       displayName: 'Use Python $(python.version)'
 
-    - script: |
+    - bash: |
+        set -e
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
         pip install -e .
@@ -102,13 +105,15 @@ jobs:
         python setup.py build_ext --inplace
       displayName: 'Install dependencies'
 
-    - script: |
+    - bash: |
+        set -e
         pycodestyle --max-line-length=100 qiskit test
         pylint -rn qiskit test
       displayName: 'Style and lint'
       condition: eq(variables['python.version'], '3.5')
 
-    - script: |
+    - bash: |
+        set -e
         stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'
@@ -133,7 +138,8 @@ jobs:
         versionSpec: '$(python.version)'
       displayName: 'Use Python $(python.version)'
 
-    - script: |
+    - bash: |
+        set -e
         python -m pip install --upgrade pip
         pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
         pip install -e .
@@ -141,13 +147,15 @@ jobs:
         python setup.py build_ext --inplace
       displayName: 'Install dependencies'
 
-    - script: |
+    - bash: |
+        set -e
         pycodestyle --max-line-length=100 qiskit test
         pylint -rn qiskit test
       displayName: 'Style and lint'
       condition: eq(variables['python.version'], '3.5')
 
-    - script: |
+    - bash: |
+        set -e
         stestr run
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,6 @@ jobs:
 
     - bash: |
         set -e
-        stestr run --no-subunit-trace
-        stestr failing --list
+        stestr run --concurrency 2
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,6 +157,6 @@ jobs:
 
     - bash: |
         set -e
-        stestr run
+        stestr run --no-subunit-trace
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,5 +164,5 @@ jobs:
 
     - bash: |
         set -e
-        dmesg
+        sudo dmesg
       displayName: 'Debug info'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -158,5 +158,6 @@ jobs:
     - bash: |
         set -e
         stestr run --no-subunit-trace
+        stestr failing --list
         stestr last --subunit > test_results.subunit
       displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,6 +145,7 @@ jobs:
         pip install -e .
         pip install "qiskit-ibmq-provider" -c constraints.txt
         python setup.py build_ext --inplace
+        pip install git+https://github.com/mtreinish/stestr
       displayName: 'Install dependencies'
 
     - bash: |

--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -116,6 +116,7 @@ class TestMatplotlibDrawer(QiskitVisualizationTestCase):
 
     @unittest.skipIf(not visualization.HAS_MATPLOTLIB,
                      'matplotlib not available.')
+    @unittest.skipIf(os.name == 'nt', 'Rendered image differs on windows')
     def test_long_name(self):
         """Test to see that long register names can be seen completely
         As reported in #2605


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The azure pipelines commands were previously using the script directive
which on windows uses cmd.exe to run commands. The return code for the
step process only returns non-zero and exits if the last command in the
script returns non-zero, it will continue running if an intermediate
command fails. This can lead to hard to parse errors because something
failed earlier in the pipeline and we don't catch it until later. For
example pip install stestr failing because of a network issues and then
we get a command not found error when we go to run tests. This commit
fixes this issue by switching all the scripts to explicitly use bash
and then using 'set -e' to set errexit to make sure any failing
command causes the job to fail there.

### Details and comments

Related to #2879