### PR TITLE
Add equiv method to Operator and Statevector classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog].
 -   Added n-qubit unitaries to BasicAer simulator basis gates (\#2342)
 -   Added a ``random_circuit`` function under ``qiskit.circuit.random``
     (#2553)
+-   Added `equiv` method to `Operator` and `Statevector` classes for
+    testing if two objects are equivalent up to global phase (\#2910)
 
 ### Changed
 

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -18,6 +18,7 @@ from .operators.operator import Operator
 from .operators.pauli import Pauli, pauli_group
 from .operators.channel import Choi, SuperOp, Kraus, Stinespring, Chi, PTM
 from .operators.measures import process_fidelity
+from .states import Statevector, DensityMatrix
 from .states.states import basis_state, projector, purity
 from .states.measures import state_fidelity
 from .random import random_unitary, random_state, random_density_matrix

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -23,7 +23,7 @@ import numpy as np
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.instruction import Instruction
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info.operators.predicates import is_unitary_matrix
+from qiskit.quantum_info.operators.predicates import is_unitary_matrix, matrix_equal
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 
@@ -281,6 +281,32 @@ class Operator(BaseOperator):
             raise QiskitError("other is not a number")
         return Operator(other * self.data, self.input_dims(),
                         self.output_dims())
+
+    def equiv(self, other, rtol=None, atol=None):
+        """Return True if operators are equivalent up to global phase.
+
+        Args:
+            other (Operator): an operator object.
+            rtol (float): relative tolerance value for comparison.
+            atol (float): absolute tolerance value for comparison.
+
+        Returns:
+            bool: True if operators are equivalent up to global phase.
+
+        Raises:
+            QiskitError: if other is not an operator, or has incompatible
+            dimensions.
+        """
+        if not isinstance(other, Operator):
+            other = Operator(other)
+        if self.dim != other.dim:
+            raise QiskitError("other operator has different dimensions.")
+        if atol is None:
+            atol = self._atol
+        if rtol is None:
+            rtol = self._rtol
+        return matrix_equal(self.data, other.data, ignore_phase=True,
+                            rtol=rtol, atol=atol)
 
     @property
     def _shape(self):

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -292,15 +292,14 @@ class Operator(BaseOperator):
 
         Returns:
             bool: True if operators are equivalent up to global phase.
-
-        Raises:
-            QiskitError: if other is not an operator, or has incompatible
-            dimensions.
         """
         if not isinstance(other, Operator):
-            other = Operator(other)
+            try:
+                other = Operator(other)
+            except QiskitError:
+                return False
         if self.dim != other.dim:
-            raise QiskitError("other operator has different dimensions.")
+            return False
         if atol is None:
             atol = self._atol
         if rtol is None:

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -26,6 +26,7 @@ from qiskit.circuit.instruction import Instruction
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.states.quantum_state import QuantumState
 from qiskit.quantum_info.operators.operator import Operator
+from qiskit.quantum_info.operators.predicates import matrix_equal
 
 
 class Statevector(QuantumState):
@@ -226,6 +227,31 @@ class Statevector(QuantumState):
             new_dims[qubit] = other._output_dims[i]
         # Replace evolved dimensions
         return Statevector(np.reshape(tensor, np.product(new_dims)), dims=new_dims)
+
+    def equiv(self, other, rtol=None, atol=None):
+        """Return True if statevectors are equivalent up to global phase.
+
+        Args:
+            other (Statevector): a statevector object.
+            rtol (float): relative tolerance value for comparison.
+            atol (float): absolute tolerance value for comparison.
+
+        Returns:
+            bool: True if statevectors are equivalent up to global phase.
+        """
+        if not isinstance(other, Statevector):
+            try:
+                other = Statevector(other)
+            except QiskitError:
+                return False
+        if self.dim != other.dim:
+            return False
+        if atol is None:
+            atol = self._atol
+        if rtol is None:
+            rtol = self._rtol
+        return matrix_equal(self.data, other.data, ignore_phase=True,
+                            rtol=rtol, atol=atol)
 
     @classmethod
     def from_label(cls, label):

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -526,5 +526,6 @@ class TestOperator(OperatorTestCase):
         self.assertTrue(op.equiv(Operator(phase * mat)))
         self.assertFalse(op.equiv(2 * mat))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -517,6 +517,14 @@ class TestOperator(OperatorTestCase):
         op = Operator(mat)
         self.assertEqual(-op, Operator(-1 * mat))
 
+    def test_equiv(self):
+        """Test negate method"""
+        mat = np.diag([1, np.exp(1j * np.pi / 2)])
+        phase = np.exp(-1j * np.pi / 4)
+        op = Operator(mat)
+        self.assertTrue(op.equiv(phase * mat))
+        self.assertTrue(op.equiv(Operator(phase * mat)))
+        self.assertFalse(op.equiv(2 * mat))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -354,5 +354,6 @@ class TestStatevector(QiskitTestCase):
         self.assertTrue(statevec.equiv(Statevector(phase * vec)))
         self.assertFalse(statevec.equiv(2 * vec))
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -345,6 +345,14 @@ class TestStatevector(QiskitTestCase):
             state = Statevector(vec)
             self.assertEqual(-state, Statevector(-1 * vec))
 
+    def test_equiv(self):
+        """Test negate method"""
+        vec = np.array([1, 0, 0, -1j]) / np.sqrt(2)
+        phase = np.exp(-1j * np.pi / 4)
+        statevec = Statevector(vec)
+        self.assertTrue(statevec.equiv(phase * vec))
+        self.assertTrue(statevec.equiv(Statevector(phase * vec)))
+        self.assertFalse(statevec.equiv(2 * vec))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Adds `equiv` method to `Operator` class that returns `True` if two operators are equivalent up to global phase.
* Adds `equiv` method to `Statevector` class that returns `True` if two statevectors are equivalent up to global phase.
* Adds equiv tests
* Adds `Statevector` and `DensityMatrix` classes to `quantum_info.__init__.py` 

### Details and comments


