### PR TITLE
Add isometry benchmarks to travis ci benchmark job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -222,7 +222,7 @@ jobs:
       - echo $TRAVIS_BRANCH
       - echo $TRAVIS_PULL_REQUEST_BRANCH
       - asv --config meta-qiskit/asv.conf.json machine --machine travis-ci
-      - travis_wait 45 asv --config meta-qiskit/asv.conf.json continuous --interleave-processes --machine travis-ci --no-only-changed --python 3.5 --bench '^(qft|transpiler_benchmarks|state_tomography)\.' $TRAVIS_BRANCH HEAD
+      - travis_wait 45 asv --config meta-qiskit/asv.conf.json continuous --interleave-processes --machine travis-ci --no-only-changed --python 3.5 --bench '^(qft|transpiler_benchmarks|state_tomography|isometry)\.' $TRAVIS_BRANCH HEAD
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the isometry benchmarks to the set of benchmarks we run
in CI. This shouldn't significant additional time to the job run, but
will add a useful benchmarks for tracking the performance of a patch.
Most interestingly it will add a benchmark that doesn't measure time but
instead compares the CNOT count output from the transpiler. Which makes
a lot of sense in this CI job because it won't be bound to the
variable performance of the cloud guests that travis runs it's jobs on.

### Details and comments


