### PR TITLE
Remove git stestr usage from macOS jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,6 @@ jobs:
         pip install -e .
         pip install "qiskit-ibmq-provider" -c constraints.txt
         python setup.py build_ext --inplace
-        pip install git+https://github.com/mtreinish/stestr
       displayName: 'Install dependencies'
 
     - bash: |


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2905 we switched the stestr version used for the macOS jobs to use
master from git instead of the release at the time. This was to mostly
pull in some result analysis fixes that were added to be able to debug
segfaults in the macOS jobs. While these fixes weren't 100% necessary it
was useful to avoid secondary stack traces in stestr when the test
runner segfaulted. However, now stestr 2.5.0 has been released which
includes all of these fixes. This commit removes this so we switch macOS
back to following released stestr.


### Details and comments
