### PR TITLE
Fix memory_slots number bug in pulse assembler

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -71,7 +71,7 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
                 user_pulselib[name] = instruction.command
             if isinstance(instruction, AcquireInstruction):
                 max_memory_slot = max(max_memory_slot,
-                                      *[slot.index + 1 for slot in instruction.mem_slots])
+                                      *[slot.index for slot in instruction.mem_slots])
                 if meas_map:
                     # verify all acquires satisfy meas_map
                     _validate_meas_map(instruction, meas_map)
@@ -89,7 +89,7 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
         })
 
     # set number of memoryslots
-    qobj_config['memory_slots'] = max_memory_slot
+    qobj_config['memory_slots'] = max_memory_slot + 1
 
     # setup pulse_library
     qobj_config['pulse_library'] = [PulseLibraryItem(name=pulse.name, samples=pulse.samples)

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -71,7 +71,7 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
                 user_pulselib[name] = instruction.command
             if isinstance(instruction, AcquireInstruction):
                 max_memory_slot = max(max_memory_slot,
-                                      *[slot.index for slot in instruction.mem_slots])
+                                      *[slot.index + 1 for slot in instruction.mem_slots])
                 if meas_map:
                     # verify all acquires satisfy meas_map
                     _validate_meas_map(instruction, meas_map)

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -390,6 +390,30 @@ class TestPulseAssembler(QiskitTestCase):
                      schedule_los=[self.user_lo_config, self.user_lo_config],
                      **self.config)
 
+    def test_assemble_acq_command(self):
+        """Test extracting correct number of memory slot."""
+        acquire_channels = [pulse.AcquireChannel(idx) for idx in range(10)]
+        mem_slots = [pulse.MemorySlot(idx) for idx in range(10)]
+
+        acquire = pulse.Acquire(5)
+
+        schedule = pulse.Schedule(name='all_acquire')
+        schedule = schedule.insert(0, acquire(acquire_channels, mem_slots))
+
+        qobj = assemble(schedule)
+        test_dict = qobj.to_dict()
+
+        self.assertEqual(test_dict['config']['memory_slots'], 10)
+
+        schedule = pulse.Schedule(name='partial_acquire')
+        schedule = schedule.insert(0, acquire([acquire_channels[3], acquire_channels[5]],
+                                              [mem_slots[3], mem_slots[5]]))
+
+        qobj = assemble(schedule)
+        test_dict = qobj.to_dict()
+
+        self.assertEqual(test_dict['config']['memory_slots'], 6)
+
     def test_assemble_meas_map(self):
         """Test assembling a single schedule, no lo config."""
         acquire = pulse.Acquire(5)
@@ -559,6 +583,30 @@ class TestPulseAssemblerWithDeviceSpecification(QiskitTestCase):
                      meas_lo_freq=self.default_meas_lo_freq,
                      schedule_los=[self.user_lo_config, self.user_lo_config],
                      **self.config)
+
+    def test_assemble_acq_command(self):
+        """Test extracting correct number of memory slot."""
+        acquire_channels = [pulse.AcquireChannel(idx) for idx in range(10)]
+        mem_slots = [pulse.MemorySlot(idx) for idx in range(10)]
+
+        acquire = pulse.Acquire(5)
+
+        schedule = pulse.Schedule(name='all_acquire')
+        schedule = schedule.insert(0, acquire(acquire_channels, mem_slots))
+
+        qobj = assemble(schedule)
+        test_dict = qobj.to_dict()
+
+        self.assertEqual(test_dict['config']['memory_slots'], 10)
+
+        schedule = pulse.Schedule(name='partial_acquire')
+        schedule = schedule.insert(0, acquire([acquire_channels[3], acquire_channels[5]],
+                                              [mem_slots[3], mem_slots[5]]))
+
+        qobj = assemble(schedule)
+        test_dict = qobj.to_dict()
+
+        self.assertEqual(test_dict['config']['memory_slots'], 6)
 
     def test_assemble_meas_map(self):
         """Test assembling a single schedule, no lo config."""

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -390,8 +390,17 @@ class TestPulseAssembler(QiskitTestCase):
                      schedule_los=[self.user_lo_config, self.user_lo_config],
                      **self.config)
 
-    def test_assemble_acq_command(self):
-        """Test extracting correct number of memory slot."""
+    def test_assemble_meas_map(self):
+        """Test assembling a single schedule, no lo config."""
+        acquire = pulse.Acquire(5)
+        schedule = acquire(self.device.acquires, mem_slots=self.device.memoryslots)
+        assemble(schedule, meas_map=[[0], [1]])
+
+        with self.assertRaises(QiskitError):
+            assemble(schedule, meas_map=[[0, 1, 2]])
+
+    def test_assemble_memory_slots(self):
+        """Test assembling a schedule and inferring number of memoryslots."""
         acquire_channels = [pulse.AcquireChannel(idx) for idx in range(10)]
         mem_slots = [pulse.MemorySlot(idx) for idx in range(10)]
 
@@ -408,29 +417,13 @@ class TestPulseAssembler(QiskitTestCase):
         schedule = pulse.Schedule(name='partial_acquire')
         schedule = schedule.insert(0, acquire([acquire_channels[3], acquire_channels[5]],
                                               [mem_slots[3], mem_slots[5]]))
+        schedule = schedule.insert(0, acquire([acquire_channels[7]],
+                                              [mem_slots[7]]))
 
         qobj = assemble(schedule)
         test_dict = qobj.to_dict()
 
-        self.assertEqual(test_dict['config']['memory_slots'], 6)
-
-    def test_assemble_meas_map(self):
-        """Test assembling a single schedule, no lo config."""
-        acquire = pulse.Acquire(5)
-        schedule = acquire(self.device.acquires, mem_slots=self.device.memoryslots)
-        assemble(schedule, meas_map=[[0], [1]])
-
-        with self.assertRaises(QiskitError):
-            assemble(schedule, meas_map=[[0, 1, 2]])
-
-    def test_assemble_memory_slots(self):
-        """Test assembling a schedule and inferring number of memoryslots."""
-        acquire = pulse.Acquire(5)
-        n_memoryslots = 10
-        schedule = acquire(self.device.acquires[0], mem_slots=pulse.MemorySlot(n_memoryslots))
-
-        qobj = assemble(schedule, meas_map=[[0], [1]])
-        self.assertEqual(qobj.config.memory_slots, n_memoryslots)
+        self.assertEqual(test_dict['config']['memory_slots'], 8)
 
     def test_pulse_name_conflicts(self):
         """Test that pulse name conflicts can be resolved."""
@@ -584,8 +577,17 @@ class TestPulseAssemblerWithDeviceSpecification(QiskitTestCase):
                      schedule_los=[self.user_lo_config, self.user_lo_config],
                      **self.config)
 
-    def test_assemble_acq_command(self):
-        """Test extracting correct number of memory slot."""
+    def test_assemble_meas_map(self):
+        """Test assembling a single schedule, no lo config."""
+        acquire = pulse.Acquire(5)
+        schedule = acquire(self.device.q, mem_slots=self.device.mem)
+        assemble(schedule, meas_map=[[0], [1]])
+
+        with self.assertRaises(QiskitError):
+            assemble(schedule, meas_map=[[0, 1, 2]])
+
+    def test_assemble_memory_slots(self):
+        """Test assembling a schedule and inferring number of memoryslots."""
         acquire_channels = [pulse.AcquireChannel(idx) for idx in range(10)]
         mem_slots = [pulse.MemorySlot(idx) for idx in range(10)]
 
@@ -602,20 +604,13 @@ class TestPulseAssemblerWithDeviceSpecification(QiskitTestCase):
         schedule = pulse.Schedule(name='partial_acquire')
         schedule = schedule.insert(0, acquire([acquire_channels[3], acquire_channels[5]],
                                               [mem_slots[3], mem_slots[5]]))
+        schedule = schedule.insert(0, acquire([acquire_channels[7]],
+                                              [mem_slots[7]]))
 
         qobj = assemble(schedule)
         test_dict = qobj.to_dict()
 
-        self.assertEqual(test_dict['config']['memory_slots'], 6)
-
-    def test_assemble_meas_map(self):
-        """Test assembling a single schedule, no lo config."""
-        acquire = pulse.Acquire(5)
-        schedule = acquire(self.device.q, mem_slots=self.device.mem)
-        assemble(schedule, meas_map=[[0], [1]])
-
-        with self.assertRaises(QiskitError):
-            assemble(schedule, meas_map=[[0, 1, 2]])
+        self.assertEqual(test_dict['config']['memory_slots'], 8)
 
     def test_pulse_name_conflicts(self):
         """Test that pulse name conflicts can be resolved."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a bug creating qobj with wrong `memory_slots`. Also tests are added.

fix #2913 

### Details and comments


