### PR TITLE
Change Parameter equality from python id() to internal uuid().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ The format is based on [Keep a Changelog].
 -   Correctly serialize complex numbers with a nonzero real part
 -   Fixed bug in measure sampling for `BasicAer` Qasm simulator if only a
     subset of qubits are measured (\#2790)
+-   Parameter objects can be serialized and communicated between
+    sub-processes (\#2429)
+-   Parameterized circuits no longer need to be transpiled individually (\#2864)
 
 
 ## [0.8.2] - 2019-06-14

--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -15,6 +15,8 @@
 Parameter Class for variable parameters.
 """
 
+from uuid import uuid4
+
 import sympy
 
 from .parameterexpression import ParameterExpression
@@ -22,6 +24,27 @@ from .parameterexpression import ParameterExpression
 
 class Parameter(ParameterExpression):
     """Parameter Class for variable parameters"""
+
+    def __new__(cls, _, uuid=None):
+        # Parameter relies on self._uuid being set prior to other attributes
+        # (e.g. symbol_map) which may depend on self._uuid for Parameter's hash
+        # or __eq__ functions.
+
+        obj = object.__new__(cls)
+
+        if uuid is None:
+            obj._uuid = uuid4()
+        else:
+            obj._uuid = uuid
+
+        return obj
+
+    def __getnewargs__(self):
+        # Unpickling won't in general call __init__ but will always call
+        # __new__. Specify arguments to be passed to __new__ when unpickling.
+
+        return (self.name, self._uuid)
+
     def __init__(self, name):
         self._name = name
 
@@ -48,3 +71,9 @@ class Parameter(ParameterExpression):
 
     def __repr__(self):
         return '{}({})'.format(self.__class__.__name__, self.name)
+
+    def __eq__(self, other):
+        return isinstance(other, Parameter) and self._uuid == other._uuid
+
+    def __hash__(self):
+        return hash(self._uuid)


### PR DESCRIPTION

### Summary
Fixes #2429
Fixes #2864

### Details and comments

`Parameter`s were defined such that they would only ever `__eq__ self`. That way, if a user defined a `Parameter('theta')` and wanted to compose in a subcircuit defined elsewhere which contained a different `Parameter('theta')`, we would be able to detect that the parameter names overlapped and raise an error.

However, if a user sent a `Parameter` to a different python instance though (say through `multiprocessing.Pool` or `qiskit.tools.parallel_map`), it would be instantiated as a different python object and so no longer be considered equal to the original parameter.

This PR changes `Parameter` to instead generate a random UUID on instantiation and use that for equality testing. Unlike `id(self)`, `self._uuid` will be preserved across pickling and de-pickling, but should otherwise preserve `Parameter`'s equality behavior.


