### PR TITLE
Fixed block collection with classical conditions in Collect2QBlocks

### DIFF
--- a/qiskit/transpiler/passes/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/collect_2q_blocks.py
@@ -59,7 +59,7 @@ class Collect2qBlocks(AnalysisPass):
             if nd.name == "cx" and nd.condition is None and not nodes_seen[nd]:
                 these_qubits = set(nd.qargs)
                 # Explore predecessors of the "cx" node
-                pred = list(dag.predecessors(nd))
+                pred = list(dag.quantum_predecessors(nd))
                 explore = True
                 while explore:
                     pred_next = []
@@ -71,7 +71,7 @@ class Collect2qBlocks(AnalysisPass):
                                     pnd.name != "cx":
                                 group.append(pnd)
                                 nodes_seen[pnd] = True
-                                pred_next.extend(dag.predecessors(pnd))
+                                pred_next.extend(dag.quantum_predecessors(pnd))
                     # If there are two, then we consider cases
                     elif len(pred) == 2:
                         # First, check if there is a relationship
@@ -105,7 +105,7 @@ class Collect2qBlocks(AnalysisPass):
                                 if not nodes_seen[pnd]:
                                     group.append(pnd)
                                     nodes_seen[pnd] = True
-                                    pred_next.extend(dag.predecessors(pnd))
+                                    pred_next.extend(dag.quantum_predecessors(pnd))
                             # If cx, check qubits
                             else:
                                 pred_qubits = set(pnd.qargs)
@@ -114,7 +114,7 @@ class Collect2qBlocks(AnalysisPass):
                                     if not nodes_seen[pnd]:
                                         group.append(pnd)
                                         nodes_seen[pnd] = True
-                                        pred_next.extend(dag.predecessors(pnd))
+                                        pred_next.extend(dag.quantum_predecessors(pnd))
                                 else:
                                     # remove qubit from consideration if not
                                     these_qubits = list(set(these_qubits) -
@@ -131,7 +131,7 @@ class Collect2qBlocks(AnalysisPass):
                 # Reset these_qubits
                 these_qubits = set(nd.qargs)
                 # Explore successors of the "cx" node
-                succ = list(dag.successors(nd))
+                succ = list(dag.quantum_successors(nd))
                 explore = True
                 while explore:
                     succ_next = []
@@ -143,7 +143,7 @@ class Collect2qBlocks(AnalysisPass):
                                     snd.name != "cx":
                                 group.append(snd)
                                 nodes_seen[snd] = True
-                                succ_next.extend(dag.successors(snd))
+                                succ_next.extend(dag.quantum_successors(snd))
                     # If there are two, then we consider cases
                     elif len(succ) == 2:
                         # First, check if there is a relationship
@@ -181,7 +181,7 @@ class Collect2qBlocks(AnalysisPass):
                                 if not nodes_seen[snd]:
                                     group.append(snd)
                                     nodes_seen[snd] = True
-                                    succ_next.extend(dag.successors(snd))
+                                    succ_next.extend(dag.quantum_successors(snd))
                             else:
                                 # If cx, check qubits
                                 succ_qubits = set(snd.qargs)
@@ -190,7 +190,7 @@ class Collect2qBlocks(AnalysisPass):
                                     if not nodes_seen[snd]:
                                         group.append(snd)
                                         nodes_seen[snd] = True
-                                        succ_next.extend(dag.successors(snd))
+                                        succ_next.extend(dag.quantum_successors(snd))
                                 else:
                                     # remove qubit from consideration if not
                                     these_qubits = list(set(these_qubits) -

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -20,8 +20,11 @@ import unittest
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.converters import circuit_to_dag
+from qiskit.compiler import transpile
+from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.test import QiskitTestCase
+from qiskit.test.mock import FakeMelbourne
 
 
 class TestCollect2qBlocks(QiskitTestCase):
@@ -96,6 +99,46 @@ class TestCollect2qBlocks(QiskitTestCase):
         pass_nodes = [set(bl) for bl in pass_.property_set['block_list']]
 
         self.assertEqual(dag_nodes, pass_nodes)
+
+    def test_block_with_classical_register(self):
+        """Test that only blocks that share quantum wires are added to the block.
+        It was the case that gates which shared a classical wire could be added to
+        the same block, despite not sharing the same qubits. This was fixed in #2956.
+
+                                    ┌─────────────────────┐
+        q_0: |0>────────────────────┤ U2(0.25*pi,0.25*pi) ├
+                     ┌─────────────┐└──────────┬──────────┘
+        q_1: |0>──■──┤ U1(0.25*pi) ├───────────┼───────────
+                ┌─┴─┐└──────┬──────┘           │
+        q_2: |0>┤ X ├───────┼──────────────────┼───────────
+                └───┘    ┌──┴──┐            ┌──┴──┐
+        c0_0: 0 ═════════╡ = 0 ╞════════════╡ = 0 ╞════════
+                         └─────┘            └─────┘
+
+        Previously the blocks collected were : [['cx', 'u1', 'u2']]
+        This is now corrected to : [['cx', 'u1']]
+        """
+
+        qasmstr = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c0[1];
+
+        cx q[1],q[2];
+        if(c0==0) u1(0.25*pi) q[1];
+        if(c0==0) u2(0.25*pi, 0.25*pi) q[0];
+        """
+        qc = QuantumCircuit.from_qasm_str(qasmstr)
+        backend = FakeMelbourne()
+
+        pass_manager = PassManager()
+        pass_manager.append(Collect2qBlocks())
+
+        transpile(qc, backend, pass_manager=pass_manager)
+
+        self.assertEqual([['cx', 'u1']],
+                         [[n.name for n in block] for block in pass_manager.property_set['block_list']])
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -138,7 +138,8 @@ class TestCollect2qBlocks(QiskitTestCase):
         transpile(qc, backend, pass_manager=pass_manager)
 
         self.assertEqual([['cx', 'u1']],
-                         [[n.name for n in block] for block in pass_manager.property_set['block_list']])
+                         [[n.name for n in block]
+                          for block in pass_manager.property_set['block_list']])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
As revealed in the [random testing](https://travis-ci.com/Qiskit/qiskit-terra/jobs/223620181#L4545) there was a niche bug in Collect2QBlocks that lead to blocks of 3 qubits being collected. This occured because the predeccessors/successors of the nodes were added using the calls `predecessors()` and `successors()` rather than `quantum_predecessors()` and `quantum_successors()`. This meant that if there was a pred/succ node that shared the same classical register, but was not a `cx` node it could [be added](https://github.com/Qiskit/qiskit-terra/blob/3c1ad77cfecc1485179a42117d219249106bbaca/qiskit/transpiler/passes/collect_2q_blocks.py#L70) despite potentially not sharing the same qubits as the node currently being looked at.

As it is blocks of quantum gates we are looking for, it makes sense to only look at the quantum successors/predecessors.


### Details and comments
Solved by replacing all the relevant calls. 

NB there are still some calls to `predecessors()` and `successors()` as these calls are looking at the ordering of the nodes, so they need to take into account any classical aspects as well as quantum.
