### PR TITLE
Barriers plot correctly over multiple registers in mpl

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -764,9 +764,6 @@ class MatplotlibDrawer:
                         _barriers['coord'].append(q_xy[index])
                     if self.plot_barriers:
                         self._barrier(_barriers, this_anc)
-                    else:
-                        # this stop there being blank lines plotted in place of barriers
-                        this_anc -= 1
                 elif op.name == 'initialize':
                     vec = '[%s]' % param
                     self._custom_multiqubit_gate(q_xy, wide=_iswide,
@@ -912,7 +909,14 @@ class MatplotlibDrawer:
                     logger.critical('Invalid gate %s', op)
                     raise exceptions.VisualizationError('invalid gate {}'.format(op))
 
-            prev_anc = this_anc + layer_width - 1
+            # adjust the column if there have been barriers encountered, but not plotted
+            barrier_offset = 0
+            if not self.plot_barriers:
+                # only adjust if everything in the layer wasn't plotted
+                barrier_offset = -1 if all([op.name in
+                                            ['barrier', 'snapshot', 'load', 'save', 'noise']
+                                            for op in layer]) else 0
+            prev_anc = this_anc + layer_width + barrier_offset - 1
         #
         # adjust window size and draw horizontal lines
         #


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2953 

This was occurring when there were multiple barriers in a layer, which can happen when there are multiple registers in a circuit. Previously, if a barrier was encountered and not plotted, the count of where to put the next gate would be decremented. However this would happen for every barrier hit, so if there were 2 barriers in the layer it would be decremented twice and cause the overlap seen in #2953.

Fixed by calculating when to move the barrier better. Only decrementing by 1 when everything in the layer hasn't been plotted.

Part of the updated circuit :
![image](https://user-images.githubusercontent.com/40489777/62782880-0bb78680-bab3-11e9-9441-ad4fca778bb1.png)

