### PR TITLE
Make seaborn import work if it's not installed

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -38,7 +38,6 @@ if HAS_MATPLOTLIB:
     from qiskit.visualization.exceptions import VisualizationError
     from qiskit.visualization.bloch import Bloch
     from qiskit.visualization.utils import _validate_input_state
-    import seaborn as sns
 
 
 if HAS_MATPLOTLIB:
@@ -479,6 +478,11 @@ def plot_state_qsphere(rho, figsize=None):
     """
     if not HAS_MATPLOTLIB:
         raise ImportError('Must have Matplotlib installed.')
+    try:
+        import seaborn as sns
+    except ImportError:
+        raise ImportError('Must have seaborn installed to use '
+                          'plot_state_qsphere')
     rho = _validate_input_state(rho)
     if figsize is None:
         figsize = (7, 7)

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -22,7 +22,6 @@ from functools import reduce
 import colorsys
 import numpy as np
 from scipy import linalg
-import seaborn as sns
 from qiskit.quantum_info.operators.pauli import pauli_group, Pauli
 from .matplotlib import HAS_MATPLOTLIB
 
@@ -39,6 +38,8 @@ if HAS_MATPLOTLIB:
     from qiskit.visualization.exceptions import VisualizationError
     from qiskit.visualization.bloch import Bloch
     from qiskit.visualization.utils import _validate_input_state
+    import seaborn as sns
+
 
 if HAS_MATPLOTLIB:
     class Arrow3D(FancyArrowPatch):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Seaborn is an optional visualization dependency only ever used if we
have matplotlib installed and support using visualizations. However, we
were previously unconditionally importing it when we load the
qiskit.visualization.state_visualization module. This leads to an error
if you have not installed seaborn even though this is a supported state.
This commit corrects it by moving the seaborn import into the
conditional section of imports after we've verified that matplotlib is
installed and the installation supports running visualization.

### Details and comments