### PR TITLE
Change warning class for Aer and IBMQ warning

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -53,7 +53,7 @@ try:
 except ImportError:
     warnings.warn('Could not import the Aer provider from the qiskit-aer '
                   'package. Install qiskit-aer or check your installation.',
-                  ImportWarning)
+                  RuntimeWarning)
 # Try to import the IBMQ provider if installed.
 try:
     from qiskit.providers.ibmq import IBMQ
@@ -61,7 +61,7 @@ except ImportError:
     warnings.warn('Could not import the IBMQ provider from the '
                   'qiskit-ibmq-provider package. Install qiskit-ibmq-provider '
                   'or check your installation.',
-                  ImportWarning)
+                  RuntimeWarning)
 
 from .version import __version__
 from .version import __qiskit_version__


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Recently we started emitting on failed imports for IBMQ and Aer in #2842
to tell users if they have a misconfigured or missing qiskit-aer or
qiskit-ibmq-provider package. However, in that PR we set the warning
class to ImportWarning which is ignored by default in python. This
defeats the whole purpose of emitting the warning because no one will
see it unless they explicit enable printing ImportWarnings to stderr.
ImportWarning was chosen because it seems to map the best to what we're
warning about and provides a unique enough class that is easy to filter
for those users who do not wish to install either Aer or IBMQ. This
commit changes the warning class to RuntimeWarning so that it will show
by default but still meet the criteria that we original chose
ImportWarning based on.

### Details and comments