### PR TITLE
Update dagcircuit docstrings for bit class arguments

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -287,8 +287,8 @@ class DAGCircuit:
 
         Args:
             op (Instruction): the operation associated with the DAG node
-            qargs (list[tuple]): qubits that op will be applied to
-            cargs (list[tuple]): cbits that op will be applied to
+            qargs (list[Qubit]): Qubits that op will be applied to
+            cargs (list[Clbit]): Clbits that op will be applied to
             condition (tuple or None): optional condition (ClassicalRegister, value)
 
         Returns:
@@ -442,9 +442,10 @@ class DAGCircuit:
 
         Args:
             input_circuit (DAGCircuit): circuit to append
-            edge_map (dict): map {(Register, int): (Register, int)}
-                from the output wires of input_circuit to input wires
-                of self.
+            edge_map (dict): map {Bit: Bit} from the output wires of
+                input_circuit to input wires of self. The key and value
+                can either be of type Qubit or Clbit depending on the
+                type of the node.
 
         Raises:
             DAGCircuitError: if missing, duplicate or inconsistent wire

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -190,7 +190,7 @@ class DAGCircuit:
 
         Args:
             args (list): (register,idx) tuples
-            amap (dict): a dictionary keyed on (register,idx) tuples
+            amap (dict): a dictionary keyed on bit objects
 
         Raises:
             DAGCircuitError: if a qubit is not contained in amap
@@ -199,7 +199,7 @@ class DAGCircuit:
         for wire in args:
             if wire not in amap:
                 raise DAGCircuitError("(qu)bit %s[%d] not found" %
-                                      (wire[0].name, wire[1]))
+                                      (wire.register.name, wire.index))
 
     def _bits_in_condition(self, cond):
         """Return a list of bits in the given condition.
@@ -478,11 +478,12 @@ class DAGCircuit:
                 m_wire = edge_map.get(nd.wire, nd.wire)
                 # the mapped wire should already exist
                 if m_wire not in self.output_map:
-                    raise DAGCircuitError("wire %s[%d] not in self" % (m_wire[0].name, m_wire[1]))
+                    raise DAGCircuitError("wire %s[%d] not in self" % (
+                        m_wire.register.name, m_wire.index))
 
                 if nd.wire not in input_circuit.wires:
                     raise DAGCircuitError("inconsistent wire type for %s[%d] in input_circuit"
-                                          % (nd.wire[0].name, nd.wire[1]))
+                                          % (nd.register.name, nd.wire.index))
 
             elif nd.type == "out":
                 # ignore output nodes
@@ -541,12 +542,13 @@ class DAGCircuit:
                 m_name = edge_map.get(nd.wire, nd.wire)
                 # the mapped wire should already exist
                 if m_name not in self.input_map:
-                    raise DAGCircuitError("wire %s[%d] not in self" % (m_name[0].name, m_name[1]))
+                    raise DAGCircuitError("wire %s[%d] not in self" % (
+                        m_name.register.name, m_name.index))
 
                 if nd.wire not in input_circuit.wires:
                     raise DAGCircuitError(
                         "inconsistent wire for %s[%d] in input_circuit"
-                        % (nd.wire[0].name, nd.wire[1]))
+                        % (nd.wire.register.name, nd.wire.index))
 
             elif nd.type == "in":
                 # ignore input nodes
@@ -693,7 +695,7 @@ class DAGCircuit:
                     self.output_map[w])[0]
                 if len(list(self._multi_graph.predecessors(self.output_map[w]))) != 1:
                     raise DAGCircuitError("too many predecessors for %s[%d] "
-                                          "output node" % (w[0], w[1]))
+                                          "output node" % (w.register, w.index))
 
         return full_pred_map, full_succ_map
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the introduction of the Bit classes in #2414 the arguments for
many of the methods in the DAGCircuit class, which often deal with
individual bits, were changed to deal with these new classes instead of
tuples. However, in that process a couple of docstrings were missed and
not updated to reflect the expected types. This commit corrects the
oversight and updates the docstrings for those cases. This also updates
several cases of using the deprecated tuple based bit access in exception
messages, which would generate a warning in addition to the expected
exception.

### Details and comments

Fixes #2820
