### PR TITLE
Add appveyor config back for building windows wheels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
           CIBW_SKIP: cp27-* cp34-*
           TWINE_USERNAME: qiskit
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
-          TAG_SCENARIO: false
+          TAG_SCENARIO: true
 
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
@@ -41,7 +41,7 @@ for:
     only:
       - TAG_SCENARIO: true
 
-#  skip_non_tags: true
+  skip_non_tags: true
 
 
 build: false
@@ -55,7 +55,7 @@ build_script:
   - if defined WHEEL (pip install cibuildwheel==0.10.1)
   - if defined WHEEL (pip install -U twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
-#  - if defined WHEEL (twine upload wheelhouse\*)
+  - if defined WHEEL (twine upload wheelhouse\*)
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
     matrix:
         - PYTHON: C:\Python37
           TAG_SCENARIO: false
+          MPLBACKEND: ps
         - WHEEL: 1
           PYTHON: C:\Python35
           CIBW_BEFORE_BUILD: pip install -U Cython

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,61 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+version: 1.0.{build}
+
+environment:
+    matrix:
+        - WHEEL: 1
+          PYTHON: C:\Python35
+          CIBW_BEFORE_BUILD: pip install -U Cython
+          CIBW_SKIP: cp27-* cp34-*
+          TWINE_USERNAME: qiskit
+          CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
+          TAG_SCENARIO: true
+
+    # Set Travis CI variables for skipping the CI-unavailable tests.
+    TRAVIS_PULL_REQUEST_SLUG: invalid
+    TRAVIS_REPO_SLUG: invalid-but-different
+
+for:
+-
+  # non-tagged scenario
+  matrix:
+    only:
+      - TAG_SCENARIO: false
+
+  skip_tags: true
+
+-
+  # tagged scenario
+  matrix:
+    only:
+      - TAG_SCENARIO: true
+
+  skip_non_tags: true
+
+
+build: false
+deploy: false
+#      on:
+#        APPVEYOR_REPO_TAG: true
+
+skip_branch_with_pr: true
+
+build_script:
+  - if defined WHEEL (pip install cibuildwheel==0.10.1)
+  - if defined WHEEL (pip install -U twine)
+  - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
+  - if defined WHEEL (twine upload wheelhouse\*)
+artifacts:
+  - path: "wheelhouse\\*.whl"
+    name: Wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ version: 1.0.{build}
 
 environment:
     matrix:
+        - PYTHON: C:\Python37
+          TAG_SCENARIO: false
         - WHEEL: 1
           PYTHON: C:\Python35
           CIBW_BEFORE_BUILD: pip install -U Cython
@@ -46,8 +48,6 @@ for:
 
 build: false
 deploy: false
-#      on:
-#        APPVEYOR_REPO_TAG: true
 
 skip_branch_with_pr: true
 
@@ -59,5 +59,26 @@ build_script:
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels
+install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    # The AppVeyor 'rollout builds' option is supposed to serve the same
+    # purpose but it is problematic because it tends to cancel builds pushed
+    # directly to master instead of just PR builds (or the converse).
+    # credits: JuliaLang developers.
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+          https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+          Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+            throw "There are newer queued builds for this pull request, failing early." }
+    - "%PYTHON%\\python.exe -m venv venv"
+    - venv\Scripts\activate.bat
+    - pip.exe install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
+    - pip.exe install -e .
+    - pip.exe install "qiskit-ibmq-provider" -c constraints.txt
+    - python setup.py build_ext --inplace
+
+test_script:
+    - stestr run
+    - stestr last --subunit > test_results.subunit
+
 on_failure:
   - appveyor PushArtifact wheelhouse\*whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
           CIBW_SKIP: cp27-* cp34-*
           TWINE_USERNAME: qiskit
           CIBW_TEST_COMMAND: python {project}\examples\python\stochastic_swap.py
-          TAG_SCENARIO: true
+          TAG_SCENARIO: false
 
     # Set Travis CI variables for skipping the CI-unavailable tests.
     TRAVIS_PULL_REQUEST_SLUG: invalid
@@ -41,7 +41,7 @@ for:
     only:
       - TAG_SCENARIO: true
 
-  skip_non_tags: true
+#  skip_non_tags: true
 
 
 build: false
@@ -55,7 +55,7 @@ build_script:
   - if defined WHEEL (pip install cibuildwheel==0.10.1)
   - if defined WHEEL (pip install -U twine)
   - if defined WHEEL (cibuildwheel --output-dir wheelhouse)
-  - if defined WHEEL (twine upload wheelhouse\*)
+#  - if defined WHEEL (twine upload wheelhouse\*)
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,3 +59,5 @@ build_script:
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels
+on_failure:
+  - appveyor PushArtifact wheelhouse\*whl


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent instability and unreliability with azure-pipelines
relying on it to build our windows wheels for the upcoming 0.9 release
doesn't seem to be prudent. Especially when considering our ability to
create reliable portable wheels for a windows environment manually
outside of CI is limited (we've had issues trying to do it manually in
the past). This commit adds back our appveyor config for building wheels
which has worked well for past releases. This way even if azure fails
for us we have a fallback available when we push our release tag.

### Details and comments