### PR TITLE
Use nprocs concurrency for test running on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -133,7 +133,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            stestr run --concurrency 2
+            stestr run
           displayName: 'Run tests'
         - bash: |
             set -e


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2905 we switched the macOS jobs only use a concurrency of 2 instead
of nprocs for running tests. This was done in an attempt to debug a
segfault (which wasn't easy to diagnose from CI). But as #2793 has shown
the issue isn't the concurrency but instead running on macOS 10.14.
Since we also downgraded the macOS version used for these jobs we
shouldn't need to limit the concurrency anymore and increase it back to
4 workers. This should hopefully improve the test runtime on macOS jobs
slightly since they report having 4 CPUs available.

### Details and comments