### PR TITLE
Adjust deprecated bit access in latex drawer

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -330,7 +330,7 @@ class QCircuitImage:
     def _get_mask(self, creg_name):
         mask = 0
         for index, cbit in enumerate(self.clbit_list):
-            if creg_name == cbit[0]:
+            if creg_name == cbit.register:
                 mask |= (1 << index)
         return mask
 
@@ -361,7 +361,7 @@ class QCircuitImage:
                 if op.condition:
                     mask = self._get_mask(op.condition[0])
                     cl_reg = self.clbit_list[self._ffs(mask)]
-                    if_reg = cl_reg[0]
+                    if_reg = cl_reg.register
                     pos_2 = self.img_regs[cl_reg]
                     if_value = format(op.condition[1],
                                       'b').zfill(self.cregs[if_reg])[::-1]
@@ -378,7 +378,7 @@ class QCircuitImage:
                         if op.condition:
                             mask = self._get_mask(op.condition[0])
                             cl_reg = self.clbit_list[self._ffs(mask)]
-                            if_reg = cl_reg[0]
+                            if_reg = cl_reg.register
                             pos_2 = self.img_regs[cl_reg]
 
                             if nm == "x":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Right now the latex drawer has a few instances of deprecated bit access
assuming a tuple right now. This results in a deprecation warning when
calling the latex drawer. To avoid emitting a deprecation warning
internally from qiskit this commit fixes this and updates the access
to use the bit class attributes.

### Details and comments