### PR TITLE
Explicitly set postscript mpl backend for gate map tests

### DIFF
--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -15,6 +15,7 @@
 """A test for visualizing device coupling maps"""
 import unittest
 import os
+import matplotlib
 import matplotlib.pyplot as plt
 from ddt import ddt, data
 from qiskit.test.mock import FakeProvider
@@ -28,6 +29,11 @@ from .visualization import path_to_diagram_reference, QiskitVisualizationTestCas
 @ddt
 class TestGateMap(QiskitVisualizationTestCase):
     """ visual tests for plot_gate_map """
+
+    def setUp(self):
+        super(TestGateMap, self).setUpClass()
+        matplotlib.use('ps')
+
     backends = list(filter(lambda x:
                            not (x.configuration().simulator or x.configuration().n_qubits == 2),
                            FakeProvider().backends()))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The gate map tests with layout added in #2928 built the reference images
assuming the postscript backend. This causes these tests to fail in any
environment where 'ps' isn't set as the backend. This happens fairly
regularly on local environments where normally an interactive backend is
used depending on your OS. This is just another example of how image
comparison tests are unreliable. This commit works around this issue by
having the test be opinionated about it's backend an explicitly setting
the backend to be 'ps' prior to running the tests where that's required
to make the images match.

### Details and comments

Fixes #2982 