### PR TITLE
Fixed issue 2822 by updating matplotlib drawer

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -785,8 +785,8 @@ class MatplotlibDrawer:
                 elif len(q_xy) == 1:
                     disp = op.name
                     if param:
-                        prm = '({})'.format(param)
-                        if len(prm) < 20:
+                        prm = '{}'.format(param)
+                        if len(prm) < 28:
                             self._gate(q_xy[0], wide=_iswide, text=disp,
                                        subtext=prm)
                         else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2822 


### Details and comments
Matplotlib drawing was limiting subtexts to 20 characters, which is not sufficient to show things like pi, pi, pi. Changed the limit to 28 characters.

Another issue was the presence of parentheses in the single-qubit gates but not multi-qubit gates. This has also been fixed.

