### PR TITLE
Fix passing of kwargs to the compiler assembler

### DIFF
--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -121,9 +121,10 @@ def assemble(experiments,
             length-n list, and there are m experiments, a total of m x n
             experiments will be run (one for each experiment/bind pair).
 
-        run_config (dict):
-            extra arguments used to configure the run (e.g. for Aer configurable backends)
-            Refer to the backend documentation for details on these arguments
+        **run_config (dict):
+            extra arguments used to configure the run (e.g. for Aer configurable
+            backends). Refer to the backend documentation for details on these
+            arguments.
 
     Returns:
         Qobj: a qobj which can be run on a backend. Depending on the type of input,

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -215,7 +215,7 @@ def execute(experiments, backend,
                     rep_time=rep_time,
                     parameter_binds=parameter_binds,
                     backend=backend,
-                    run_config=run_config
+                    **run_config
                     )
 
     # executing the circuits on the backend and returning the job


### PR DESCRIPTION
### Summary

The use of assemble() from the execute function in
https://github.com/Qiskit/qiskit-terra/blame/master/qiskit/execute.py#L218
passes run_config as a named parameter when assemble expects it as
kwargs. This causes it to be packed into a dict with a single run_config
key that is never unpacked.

### Details and comments

The fix was to pass run_config, instead of as a named param, as an unpacked dict to assemble as it expects.