### PR TITLE
Allow for visualizing empty waveform

### DIFF
--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -356,6 +356,9 @@ class ScheduleDrawer:
                                 max(np.abs(np.imag(waveform))))
                     n_valid_waveform += 1
                     events.enable = True
+
+        v_max = v_max or 1
+
         if scaling:
             v_max = 0.5 * scaling
         else:
@@ -489,7 +492,10 @@ class ScheduleDrawer:
                 # plot waveform
                 waveform = events.waveform
                 time = np.arange(t0, tf + 1, dtype=float) * dt
-                time, re, im = interp_method(time, waveform, self.style.num_points)
+                if waveform.any():
+                    time, re, im = interp_method(time, waveform, self.style.num_points)
+                else:
+                    re, im = np.zeros_like(time), np.zeros_like(time)
                 color = self._get_channel_color(channel)
                 # scaling and offset
                 re = v_max * re + y0
@@ -560,7 +566,7 @@ class ScheduleDrawer:
             tf = int(np.floor(plot_range[1]/dt))
         else:
             t0 = 0
-            tf = schedule.stop_time
+            tf = schedule.stop_time or 1
         # prepare waveform channels
         (channels, output_channels,
          snapshot_channels) = self._build_channels(schedule, channels_to_plot, t0, tf)

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -357,6 +357,9 @@ class ScheduleDrawer:
                     n_valid_waveform += 1
                     events.enable = True
 
+        # when input schedule is empty or comprises only frame changes,
+        # we need to overwrite maximum amplitude by a value greater than zero,
+        # otherwise auto axis scaling will fail with zero division.
         v_max = v_max or 1
 
         if scaling:
@@ -495,6 +498,9 @@ class ScheduleDrawer:
                 if waveform.any():
                     time, re, im = interp_method(time, waveform, self.style.num_points)
                 else:
+                    # when input schedule is empty or comprises only frame changes,
+                    # we should avoid interpolation due to lack of data points.
+                    # instead, it just returns vector of zero.
                     re, im = np.zeros_like(time), np.zeros_like(time)
                 color = self._get_channel_color(channel)
                 # scaling and offset
@@ -566,6 +572,9 @@ class ScheduleDrawer:
             tf = int(np.floor(plot_range[1]/dt))
         else:
             t0 = 0
+            # when input schedule is empty or comprises only frame changes,
+            # we need to overwrite pulse duration by an integer greater than zero,
+            # otherwise waveform returns empty array and matplotlib will be crashed.
             tf = schedule.stop_time or 1
         # prepare waveform channels
         (channels, output_channels,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
fix #2984 


### Details and comments
Maximum time duration (`.tf`) and waveform amplitude (`v_max`) are overwritten by 1 when schedule's waveform is empty. Just in case a schedule contains only FCs.