### PR TITLE
Passmanager.draw() in Jupyter notebooks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ The format is based on [Keep a Changelog].
     using the option ``with_layout=False`` in the method
     ``QuantumCircuit.draw``. (\#2739)
 -   Q-sphere visualization is enhanced and corrected (\#2932)
+-   Now PassManager.draw() (without any argument) will return an in-memory PIL image.
 
 
 ### Removed

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -176,9 +176,9 @@ class PassManager():
         circuit._layout = self.property_set['layout']
         return circuit
 
-    def draw(self, filename, style=None, raw=False):
+    def draw(self, filename=None, style=None, raw=False):
         """Draw the pass manager"""
-        pass_manager_drawer(self, filename=filename, style=style, raw=raw)
+        return pass_manager_drawer(self, filename=filename, style=style, raw=raw)
 
     def _do_pass(self, pass_, dag, options):
         """Do a pass and its "requires".

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -177,7 +177,27 @@ class PassManager():
         return circuit
 
     def draw(self, filename=None, style=None, raw=False):
-        """Draw the pass manager"""
+        """
+        Draws the pass manager.
+
+        This function needs `pydot <https://github.com/erocarrera/pydot>`, which in turn needs
+        Graphviz <https://www.graphviz.org/>` to be installed.
+
+        Args:
+            filename (str or None): file path to save image to
+            style (dict or OrderedDict): keys are the pass classes and the values are
+                the colors to make them. An example can be seen in the DEFAULT_STYLE. An ordered
+                dict can be used to ensure a priority coloring when pass falls into multiple
+                categories. Any values not included in the provided dict will be filled in from
+                the default dict
+            raw (Bool) : True if you want to save the raw Dot output not an image. The
+                default is False.
+        Returns:
+            PIL.Image or None: an in-memory representation of the pass manager. Or None if
+                               no image was generated or PIL is not installed.
+        Raises:
+            ImportError: when nxpd or pydot not installed.
+        """
         return pass_manager_drawer(self, filename=filename, style=style, raw=raw)
 
     def _do_pass(self, pass_, dag, options):

--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -433,7 +433,6 @@ def _latex_circuit_drawer(circuit,
                                plot_barriers=plot_barriers,
                                reverse_bits=reverse_bits, justify=justify,
                                idle_wires=idle_wires, with_layout=with_layout)
-        image = None
         try:
 
             subprocess.run(["pdflatex", "-halt-on-error",

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -21,6 +21,7 @@ import tempfile
 
 try:
     from PIL import Image
+
     HAS_PIL = True
 except ImportError:
     HAS_PIL = False
@@ -31,9 +32,9 @@ from qiskit.transpiler.basepasses import AnalysisPass, TransformationPass
 DEFAULT_STYLE = {AnalysisPass: 'red',
                  TransformationPass: 'blue'}
 
-
 try:
     import subprocess
+
     _PROC = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
     _PROC.communicate()
@@ -151,7 +152,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
         graph.add_subgraph(subgraph)
 
     if raw and filename:
-            graph.write(filename, format='raw')
+        graph.write(filename, format='raw')
 
     if not HAS_PIL and filename:
         # linter says this isn't a method - it is
@@ -173,7 +174,6 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
 
 
 def _get_node_color(pss, style):
-
     # look in the user provided dict first
     for typ, color in style.items():
         if isinstance(pss, typ):


### PR DESCRIPTION
`PassManager.draw()` requires `filename` parameter and it was kind of inconvenient in the context of jupyter notebooks.
```
pass_manager.draw("temp.png")
from IPython.display import Image
Image("temp.png")
```
This PR allows `PassManager.draw()` to dump the picture directly as an image in the notebook, making the `filename` parameter optional, inline with the circuit drawers.

<img width="693" alt="Screen Shot 2019-08-19 at 5 59 50 PM" src="https://user-images.githubusercontent.com/766693/63280504-353e9200-c2ab-11e9-93f7-b3d0b8385a11.png">
