### PR TITLE
Remove log_level kwarg from transpile()

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -14,7 +14,6 @@
 
 """Circuit transpile function"""
 
-import logging
 import warnings
 
 from qiskit.transpiler import Layout, CouplingMap

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -32,8 +32,7 @@ def transpile(circuits,
               basis_gates=None, coupling_map=None, backend_properties=None,
               initial_layout=None, seed_transpiler=None,
               optimization_level=None,
-              pass_manager=None, callback=None, output_name=None,
-              log_level=logging.INFO):
+              pass_manager=None, callback=None, output_name=None):
     """Transpile one or more circuits, according to some desired transpilation targets.
 
     All arguments may be given as either singleton or list. In case of list,
@@ -165,19 +164,12 @@ def transpile(circuits,
             A list with strings to identify the output circuits. The length of
             `list[str]` should be exactly the length of `circuits` parameter.
 
-        log_level (int): The python logging level to use for the transpiler
-            passes. You should use the logging level attributes from the stdlib
-            module, for example something like: 'logging.DEBUG'.
-
     Returns:
         QuantumCircuit or list[QuantumCircuit]: transpiled circuit(s).
 
     Raises:
         TranspilerError: in case of bad inputs to transpiler or errors in passes
     """
-    logger = logging.getLogger(name='qiskit.transpiler')
-    logger.setLevel(log_level)
-
     # transpiling schedules is not supported yet.
     if isinstance(circuits, Schedule) or \
             (isinstance(circuits, list) and all(isinstance(c, Schedule) for c in circuits)):

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -175,7 +175,7 @@ def transpile(circuits,
     Raises:
         TranspilerError: in case of bad inputs to transpiler or errors in passes
     """
-    logger = logging.getLogger(name='qiskit.transpiler.passmanager')
+    logger = logging.getLogger(name='qiskit.transpiler')
     logger.setLevel(log_level)
 
     # transpiling schedules is not supported yet.

--- a/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
+++ b/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
@@ -93,19 +93,6 @@ features:
             print(kwargs['pass'])
 
         transpile(circ, callback=my_callback)
-
-  - |
-    A new kwarg ``log_level`` was added to ``qiskit.compiler.transpile()``.
-    This can be used to change the default logging level for the Pass Manager
-    used to perform the transpile. For example::
-
-        import logging
-        from qiskit.compiler import transpile
-
-        transpile(circ, log_level=logging.DEBUG)
-
-    will set the log level for the pass manager to DEBUG when transpiling the
-    circuit circ.
   - |
     A new method ``filter()`` was added to the ``qiskit.pulse.Schedule`` class.
     This enables filtering the instructions in a schedule. For example,
@@ -202,4 +189,17 @@ other:
   - |
     Calls to ``PassManager.run()`` now will emit python logging messages at the
     INFO level for each pass execution. These messages will include the Pass
-    name and the total execution time of the pass.
+    name and the total execution time of the pass. Python's standard logging
+    was used because it allows Qiskit-Terra's logging to integrate in a standard
+    way with other applications and libraries. All logging for the transpiler
+    occurs under the ``qiskit.transpiler`` namespace, as used by
+    ``logging.getLogger('qiskit.transpiler``). For example, to turn on DEBUG
+    level logging for the transpiler you can run::
+
+        import logging
+
+        logging.basicConfig()
+        logging.getLogger('qiskit.transpiler').setLevel(logging.DEBUG)
+
+    which will set the log level for the transpiler to DEBUG and configure
+    those messages to be printed to stderr.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When the log_level parameter is set on the `transpile()` call we use that
to set the level for all the transpiler functions called. To do this we
get an instance of the pass manager logger and set the level of logs
we want. However, this functionality is redundant because python stdlib
logging already exposes, users just need to call
`logging.getLoggger('qiskit.transpiler').setLevel()`. Since the `transpile()`
function is widely used and has a stable interface the cost for removing
a potentially unnecessary argument is high, so to err on the side of caution
this removes the kwarg for the 0.9 release. If we decide that it's needed in
a future release we can always add it back when we find the need.

### Details and comments

Fixes #3010
