### PR TITLE
if passmanager.draw(raw=true), do not create the png

### DIFF
--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -28,6 +28,7 @@ except ImportError:
 
 from qiskit.visualization import utils
 from qiskit.transpiler.basepasses import AnalysisPass, TransformationPass
+from qiskit.exceptions import QiskitError
 
 DEFAULT_STYLE = {AnalysisPass: 'red',
                  TransformationPass: 'blue'}
@@ -151,9 +152,12 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
 
         graph.add_subgraph(subgraph)
 
-    if raw and filename:
-        graph.write(filename, format='raw')
-        return
+    if raw:
+        if filename:
+            graph.write(filename, format='raw')
+            return
+        else:
+            raise QiskitError("if format=raw, then a filename is required.")
 
     if not HAS_PIL and filename:
         # linter says this isn't a method - it is

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -153,6 +153,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
 
     if raw and filename:
         graph.write(filename, format='raw')
+        return
 
     if not HAS_PIL and filename:
         # linter says this isn't a method - it is

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -27,8 +27,8 @@ except ImportError:
     HAS_PIL = False
 
 from qiskit.visualization import utils
+from qiskit.visualization.exceptions import VisualizationError
 from qiskit.transpiler.basepasses import AnalysisPass, TransformationPass
-from qiskit.exceptions import QiskitError
 
 DEFAULT_STYLE = {AnalysisPass: 'red',
                  TransformationPass: 'blue'}
@@ -71,7 +71,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
                            no image was generated or PIL is not installed.
     Raises:
         ImportError: when nxpd or pydot not installed.
-        QiskitError: If raw=True and filename=None.
+        VisualizationError: If raw=True and filename=None.
     """
 
     try:
@@ -158,7 +158,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
             graph.write(filename, format='raw')
             return None
         else:
-            raise QiskitError("if format=raw, then a filename is required.")
+            raise VisualizationError("if format=raw, then a filename is required.")
 
     if not HAS_PIL and filename:
         # linter says this isn't a method - it is

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -71,6 +71,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
                            no image was generated or PIL is not installed.
     Raises:
         ImportError: when nxpd or pydot not installed.
+        QiskitError: If raw=True and filename=None.
     """
 
     try:
@@ -155,7 +156,7 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
     if raw:
         if filename:
             graph.write(filename, format='raw')
-            return
+            return None
         else:
             raise QiskitError("if format=raw, then a filename is required.")
 

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -66,8 +66,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
         self.assertFilesAreEqual(filename, path_to_diagram_reference('pass_manager_standard.dot'))
         os.remove(filename)
 
-    @unittest.skipIf(not HAS_GRAPHVIZ,
-                     'Graphviz not installed.')
+    @unittest.skipIf(not HAS_GRAPHVIZ, 'Graphviz not installed.')
     def test_pass_manager_drawer_style(self):
         """Test to see if the colours are updated when provided by the user"""
         # set colours for some passes, but leave others to take the default values
@@ -79,8 +78,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
         filename = self._get_resource_path('current_style.dot')
         self.pass_manager.draw(filename=filename, style=style, raw=True)
 
-        self.assertFilesAreEqual(filename,
-                                 path_to_diagram_reference('pass_manager_style.dot'))
+        self.assertFilesAreEqual(filename, path_to_diagram_reference('pass_manager_style.dot'))
         os.remove(filename)
 
 


### PR DESCRIPTION
I accidentally introduced this bug in PR #3005. When `passmanager.draw(raw=true)`, a filename needs to be provided and the method returns `None`. This PR handles that situation which was not capture by the CI (see #3023)