### PR TITLE
Add release note for plot_error_map

### DIFF
--- a/releasenotes/notes/0.9/error_map-plot-5d995d0fd67fbe35.yaml
+++ b/releasenotes/notes/0.9/error_map-plot-5d995d0fd67fbe35.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added a new visualization function
+    ``qiskit.visualization.plot_error_map()`` to plot the error map for a given
+    backend. It takes in a backend object from the qiskit-ibmq-provider and
+    will plot the current error map for that device.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In #2965 we added a new visualization function, plot_error_map(), but
that PR was original proposed prior to our adoption of reno to handle
release notes. Therefore it was missing the corresponding release
documentation for the new feature. This commit address that oversignt
and adds a release note for this new feature.

### Details and comments