### PR TITLE
remove cx_direction from O3 if symmetric

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -120,7 +120,7 @@ def level_3_pass_manager(transpile_config):
             Optimize1qGates(), CommutativeCancellation(),
             OptimizeSwapBeforeMeasure(), RemoveDiagonalGatesBeforeMeasure()]
 
-    if coupling_map:
+    if coupling_map and not coupling_map.is_symmetric:
         _opt.append(CXDirection(coupling_map))
         # if a coupling map has been provided, match coupling
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This removes the calls to `CXDirection` pass in O3 passmanager if the coupling map is symmetric.  This reduces the compile time of QV circuits by a factor of two in this mode.


### Details and comments


