### PR TITLE
[Stable] Remove jsonschema cap (#3037)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonschema>=2.6,<2.7
+jsonschema>=2.6
 marshmallow>=2.17.0,<3
 marshmallow_polyfield>=3.2,<4
 networkx>=2.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ except ImportError:
     from Cython.Build import cythonize
 
 REQUIREMENTS = [
-    "jsonschema>=2.6,<2.7",
+    "jsonschema>=2.6",
     "marshmallow>=2.17.0,<3",
     "marshmallow_polyfield>=3.2,<4",
     "networkx>=2.2",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We have had the jsonschema version capped since it was introduced as a
requirement into terra. There is no clear reason for this and it limits
interoperability with other python packages. Especially because
jsonschema is commonly used library across the python ecosystem. The
version we were capping to was also quite old being release 2.5 years
ago. This commit removes the cap so that people can run terra in
environments where newer jsonschema is required.

(cherry picked from commit e1fc918751462af4a1f9f22a3e084083f4779cf9)

### Details and comments

Backported from #3037
