### PR TITLE
[Stable] Make graphviz availability check at runtime (#3041)

### DIFF
--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -11,6 +11,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+# pylint: disable=invalid-name
+
 """
 Visualization function for a pass manager. Passes are grouped based on their
 flow controller, and coloured based on the type of pass.
@@ -32,21 +35,6 @@ from qiskit.transpiler.basepasses import AnalysisPass, TransformationPass
 
 DEFAULT_STYLE = {AnalysisPass: 'red',
                  TransformationPass: 'blue'}
-
-try:
-    import subprocess
-
-    _PROC = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-    _PROC.communicate()
-    if _PROC.returncode != 0:
-        HAS_GRAPHVIZ = False
-    else:
-        HAS_GRAPHVIZ = True
-except Exception:  # pylint: disable=broad-except
-    # this is raised when the dot command cannot be found, which means GraphViz
-    # isn't installed
-    HAS_GRAPHVIZ = False
 
 
 def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
@@ -73,6 +61,21 @@ def pass_manager_drawer(pass_manager, filename, style=None, raw=False):
         ImportError: when nxpd or pydot not installed.
         VisualizationError: If raw=True and filename=None.
     """
+
+    try:
+        import subprocess
+
+        _PROC = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
+                                 stderr=subprocess.PIPE)
+        _PROC.communicate()
+        if _PROC.returncode != 0:
+            HAS_GRAPHVIZ = False
+        else:
+            HAS_GRAPHVIZ = True
+    except Exception:  # pylint: disable=broad-except
+        # this is raised when the dot command cannot be found, which means GraphViz
+        # isn't installed
+        HAS_GRAPHVIZ = False
 
     try:
         import pydot

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -30,8 +30,22 @@ from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
 from qiskit.transpiler.passes import RemoveResetInZeroState
 
-from qiskit.visualization.pass_manager_visualization import HAS_GRAPHVIZ
 from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
+
+try:
+    import subprocess
+
+    _PROC = subprocess.Popen(['dot', '-V'], stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+    _PROC.communicate()
+    if _PROC.returncode != 0:
+        HAS_GRAPHVIZ = False
+    else:
+        HAS_GRAPHVIZ = True
+except Exception:  # pylint: disable=broad-except
+    # this is raised when the dot command cannot be found, which means GraphViz
+    # isn't installed
+    HAS_GRAPHVIZ = False
 
 
 class TestPassManagerDrawer(QiskitVisualizationTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Previously the graphivz availablity check was performed at import time.
This meant that everytime anyone imported anything from qiskit.* we'd be
shelling out to try and run 'dot -V' to see if python could find
graphviz in order to run the passmanager drawer. This was based on the
model we used for matplotlib which also does it at import time. However,
unlike matplotlib this isn't a simple python import path check shelling
out and running another program takes a non-negligble amount of time to
any import of qiskit. [1] We shouldn't force this check to run all the
time if graphviz is only needed when running the pass manager
visualizer. This commit address this by switching the graphviz check to
be the first operation that occurs in the pass_manager_drawer() function
instead of at the module level. There is no change in behavior except
for when the check is run. However, since this check was used for
testing and is needed to occur at import time for the test module the
check is duplicated in the test code to ensure we can properly skip
tests if graphviz is not present.

### Details and comments

[1] https://qiskit.github.io/qiskit/#import.QiskitImport.time_qiskit_import?commits=2d14c1e3

(cherry picked from commit f54f02d151ed9b671e45da13cf20d22ccbb2d28d)

Backported from #3041 
