### PR TITLE
[stable] deprecate Bit-tuple equality check 

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -62,5 +62,7 @@ class Bit:
         if isinstance(other, Bit):
             return other.index == self.index and other.register == self.register
         if isinstance(other, tuple):
+            warn('Equality check between a tuple and a Bit instances is deprecated. '
+                 'Convert your tuples to a Bit object.', DeprecationWarning, stacklevel=2)
             return other[1] == self.index and other[0] == self.register
         return False

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -364,11 +364,11 @@ class DAGCircuit:
                     # If mapping to a register not in valregs, add it.
                     # (k,0) exists in edge_map because edge_map doesn't
                     # fragment k
-                    if not edge_map[(k, 0)].register.name in valregs:
+                    if not edge_map[k[0]].register.name in valregs:
                         size = max(map(lambda x: x.index,
-                                       filter(lambda x: x.register == edge_map[(k, 0)].register,
+                                       filter(lambda x: x.register == edge_map[k[0]].register,
                                               edge_map.values())))
-                        qreg = QuantumRegister(size + 1, edge_map[(k, 0)].register.name)
+                        qreg = QuantumRegister(size + 1, edge_map[k[0]].register.name)
                         add_regs.add(qreg)
         return add_regs
 
@@ -718,8 +718,7 @@ class DAGCircuit:
         Returns:
             generator(DAGNode): node in topological order
         """
-        return nx.lexicographical_topological_sort(self._multi_graph,
-                                                   key=lambda x: str(x.qargs))
+        return nx.lexicographical_topological_sort(self._multi_graph, key=lambda x: str(x.qargs))
 
     def topological_op_nodes(self):
         """

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -372,8 +372,7 @@ class QCircuitImage:
                     if aliases is not None:
                         qarglist = map(lambda x: aliases[x], qarglist)
                     if len(qarglist) == 1:
-                        pos_1 = self.img_regs[(qarglist[0].register,
-                                               qarglist[0].index)]
+                        pos_1 = self.img_regs[qarglist[0]]
 
                         if op.condition:
                             mask = self._get_mask(op.condition[0])
@@ -486,8 +485,8 @@ class QCircuitImage:
                                 self._latex[pos_1][column] = ("\\gate{%s}" % nm)
 
                     elif len(qarglist) == 2:
-                        pos_1 = self.img_regs[(qarglist[0].register, qarglist[0].index)]
-                        pos_2 = self.img_regs[(qarglist[1].register, qarglist[1].index)]
+                        pos_1 = self.img_regs[qarglist[0]]
+                        pos_2 = self.img_regs[qarglist[1]]
 
                         if op.condition:
                             pos_3 = self.img_regs[(if_reg, 0)]
@@ -611,9 +610,9 @@ class QCircuitImage:
                                                                      nm)
 
                     elif len(qarglist) == 3:
-                        pos_1 = self.img_regs[(qarglist[0].register, qarglist[0].index)]
-                        pos_2 = self.img_regs[(qarglist[1].register, qarglist[1].index)]
-                        pos_3 = self.img_regs[(qarglist[2].register, qarglist[2].index)]
+                        pos_1 = self.img_regs[qarglist[0]]
+                        pos_2 = self.img_regs[qarglist[1]]
+                        pos_3 = self.img_regs[qarglist[2]]
 
                         if op.condition:
                             pos_4 = self.img_regs[(if_reg, 0)]
@@ -727,17 +726,13 @@ class QCircuitImage:
                         raise exceptions.VisualizationError(
                             "If controlled measures currently not supported.")
 
-                    qname = op.qargs[0].register
-                    qindex = op.qargs[0].index
-                    cname = op.cargs[0].register
-                    cindex = op.cargs[0].index
                     if aliases:
                         newq = aliases[(qname, qindex)]
                         qname = newq[0]
                         qindex = newq[1]
 
-                    pos_1 = self.img_regs[(qname, qindex)]
-                    pos_2 = self.img_regs[(cname, cindex)]
+                    pos_1 = self.img_regs[op.qargs[0]]
+                    pos_2 = self.img_regs[op.cargs[0]]
 
                     try:
                         self._latex[pos_1][column] = "\\meter"

--- a/test/python/visualization/test_visualization.py
+++ b/test/python/visualization/test_visualization.py
@@ -140,18 +140,18 @@ class TestVisualizationUtils(QiskitTestCase):
         """ _get_layered_instructions without reverse_bits """
         (qregs, cregs, layered_ops) = utils._get_layered_instructions(self.circuit)
 
-        exp = [[('cx', [(QuantumRegister(2, 'qr2'), 0), (QuantumRegister(2, 'qr2'), 1)], []),
-                ('cx', [(QuantumRegister(2, 'qr1'), 0), (QuantumRegister(2, 'qr1'), 1)], [])],
-               [('measure', [(QuantumRegister(2, 'qr2'), 0)], [(ClassicalRegister(2, 'cr2'), 0)])],
-               [('measure', [(QuantumRegister(2, 'qr1'), 0)], [(ClassicalRegister(2, 'cr1'), 0)])],
-               [('cx', [(QuantumRegister(2, 'qr2'), 1), (QuantumRegister(2, 'qr2'), 0)], []),
-                ('cx', [(QuantumRegister(2, 'qr1'), 1), (QuantumRegister(2, 'qr1'), 0)], [])],
-               [('measure', [(QuantumRegister(2, 'qr2'), 1)], [(ClassicalRegister(2, 'cr2'), 1)])],
-               [('measure', [(QuantumRegister(2, 'qr1'), 1)], [(ClassicalRegister(2, 'cr1'), 1)])]
+        exp = [[('cx', [self.qr2[0], self.qr2[1]], []),
+                ('cx', [self.qr1[0], self.qr1[1]], [])],
+               [('measure', [self.qr2[0]], [self.cr2[0]])],
+               [('measure', [self.qr1[0]], [self.cr1[0]])],
+               [('cx', [self.qr2[1], self.qr2[0]], []),
+                ('cx', [self.qr1[1], self.qr1[0]], [])],
+               [('measure', [self.qr2[1]], [self.cr2[1]])],
+               [('measure', [self.qr1[1]], [self.cr1[1]])]
                ]
 
-        self.assertEqual([(self.qr1, 0), (self.qr1, 1), (self.qr2, 0), (self.qr2, 1)], qregs)
-        self.assertEqual([(self.cr1, 0), (self.cr1, 1), (self.cr2, 0), (self.cr2, 1)], cregs)
+        self.assertEqual([self.qr1[0], self.qr1[1], self.qr2[0], self.qr2[1]], qregs)
+        self.assertEqual([self.cr1[0], self.cr1[1], self.cr2[0], self.cr2[1]], cregs)
         self.assertEqual(exp,
                          [[(op.name, op.qargs, op.cargs) for op in ops] for ops in layered_ops])
 
@@ -160,18 +160,18 @@ class TestVisualizationUtils(QiskitTestCase):
         (qregs, cregs, layered_ops) = utils._get_layered_instructions(self.circuit,
                                                                       reverse_bits=True)
 
-        exp = [[('cx', [(QuantumRegister(2, 'qr2'), 0), (QuantumRegister(2, 'qr2'), 1)], []),
-                ('cx', [(QuantumRegister(2, 'qr1'), 0), (QuantumRegister(2, 'qr1'), 1)], [])],
-               [('measure', [(QuantumRegister(2, 'qr2'), 0)], [(ClassicalRegister(2, 'cr2'), 0)])],
-               [('measure', [(QuantumRegister(2, 'qr1'), 0)], [(ClassicalRegister(2, 'cr1'), 0)])],
-               [('cx', [(QuantumRegister(2, 'qr2'), 1), (QuantumRegister(2, 'qr2'), 0)], []),
-                ('cx', [(QuantumRegister(2, 'qr1'), 1), (QuantumRegister(2, 'qr1'), 0)], [])],
-               [('measure', [(QuantumRegister(2, 'qr2'), 1)], [(ClassicalRegister(2, 'cr2'), 1)])],
-               [('measure', [(QuantumRegister(2, 'qr1'), 1)], [(ClassicalRegister(2, 'cr1'), 1)])]
+        exp = [[('cx', [self.qr2[0], self.qr2[1]], []),
+                ('cx', [self.qr1[0], self.qr1[1]], [])],
+               [('measure', [self.qr2[0]], [self.cr2[0]])],
+               [('measure', [self.qr1[0]], [self.cr1[0]])],
+               [('cx', [self.qr2[1], self.qr2[0]], []),
+                ('cx', [self.qr1[1], self.qr1[0]], [])],
+               [('measure', [self.qr2[1]], [self.cr2[1]])],
+               [('measure', [self.qr1[1]], [self.cr1[1]])]
                ]
 
-        self.assertEqual([(self.qr2, 1), (self.qr2, 0), (self.qr1, 1), (self.qr1, 0)], qregs)
-        self.assertEqual([(self.cr2, 1), (self.cr2, 0), (self.cr1, 1), (self.cr1, 0)], cregs)
+        self.assertEqual([self.qr2[1], self.qr2[0], self.qr1[1], self.qr1[0]], qregs)
+        self.assertEqual([self.cr2[1], self.cr2[0], self.cr1[1], self.cr1[0]], cregs)
         self.assertEqual(exp,
                          [[(op.name, op.qargs, op.cargs) for op in ops] for ops in layered_ops])
 


### PR DESCRIPTION
porting #3040 to 0.9 stable.