### PR TITLE
Decompose cx into cz and two hadamards

### DIFF
--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -24,7 +24,6 @@ from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.extensions.standard.h import HGate
-from qiskit.extensions.standard.cz import CzGate
 
 
 class CnotGate(Gate):
@@ -36,8 +35,10 @@ class CnotGate(Gate):
 
     def _define(self):
         """
-        gate cx a,b { h b; cx a,b; h b; }
+        gate cx a,b { h b; cz a,b; h b; }
         """
+        from qiskit.extensions.standard.cz import CzGate
+        
         definition = []
         q = QuantumRegister(2, "q")
         rule = [

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -22,6 +22,9 @@ import numpy
 
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumRegister
+from qiskit.extensions.standard.h import HGate
+from qiskit.extensions.standard.cz import CzGate
 
 
 class CnotGate(Gate):
@@ -30,6 +33,21 @@ class CnotGate(Gate):
     def __init__(self):
         """Create new CNOT gate."""
         super().__init__("cx", 2, [])
+
+    def _define(self):
+        """
+        gate cx a,b { h b; cx a,b; h b; }
+        """
+        definition = []
+        q = QuantumRegister(2, "q")
+        rule = [
+            (HGate(), [q[1]], []),
+            (CzGate(), [q[0], q[1]], []),
+            (HGate(), [q[1]], [])
+        ]
+        for inst in rule:
+            definition.append(inst)
+        self.definition = definition
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -23,8 +23,6 @@ from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.extensions.standard.h import HGate
-# from qiskit.extensions.standard.cx import CnotGate
-
 
 class CzGate(Gate):
     """controlled-Z gate."""

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -23,6 +23,8 @@ from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.extensions.standard.h import HGate
+from qiskit.extensions.standard.cx import CnotGate
+
 
 class CzGate(Gate):
     """controlled-Z gate."""

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -23,7 +23,7 @@ from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.extensions.standard.h import HGate
-from qiskit.extensions.standard.cx import CnotGate
+# from qiskit.extensions.standard.cx import CnotGate
 
 
 class CzGate(Gate):

--- a/test/python/transpiler/test_unroll_cx.py
+++ b/test/python/transpiler/test_unroll_cx.py
@@ -37,7 +37,7 @@ class TestUnrollCX(QiskitTestCase):
         circuit = QuantumCircuit(qr)
         circuit.cx(qr[0], qr[1])
         dag = circuit_to_dag(circuit)
-        pass_ = Unroller(['cz','h'])
+        pass_ = Unroller(['cz', 'h'])
         unrolled_dag = pass_.run(dag)
         op_nodes = unrolled_dag.op_nodes()
         self.assertEqual(len(op_nodes), 3)

--- a/test/python/transpiler/test_unroll_cx.py
+++ b/test/python/transpiler/test_unroll_cx.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=unused-import
+
+"""Test the unrolling of cx into cz"""
+
+
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.transpiler.passes import Unroller
+from qiskit.converters import circuit_to_dag
+from qiskit.test import QiskitTestCase
+from qiskit.exceptions import QiskitError
+
+
+class TestUnrollCX(QiskitTestCase):
+    """Tests the unrolling of CX into CZ."""
+
+    def test_cx_unroll(self):
+        """Test decompose a CX into CZ and Hadamards.
+        """
+        qr = QuantumRegister(2, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        dag = circuit_to_dag(circuit)
+        pass_ = Unroller(['cz','h'])
+        unrolled_dag = pass_.run(dag)
+        op_nodes = unrolled_dag.op_nodes()
+        self.assertEqual(len(op_nodes), 3)
+        self.assertEqual(op_nodes[0].name, 'h')
+        self.assertEqual(op_nodes[1].name, 'cz')
+        self.assertEqual(op_nodes[2].name, 'h')

--- a/test/python/transpiler/test_unroll_cx.py
+++ b/test/python/transpiler/test_unroll_cx.py
@@ -29,6 +29,9 @@ class TestUnrollCX(QiskitTestCase):
 
     def test_cx_unroll(self):
         """Test decompose a CX into CZ and Hadamards.
+        q0:-----.-----      q0:---------.---------
+                |                       |
+        q1:----(+)----   =  q1:---[H]--[z]--[H]---
         """
         qr = QuantumRegister(2, 'qr')
         circuit = QuantumCircuit(qr)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
It is now possible to unroll a cx gate into a cz and two hadamards. This can for e.g. be used when transpiling a circuit containing 'cx' gates into 'cz' and 'h' gates.

### Details and comments
To avoid circular import the CzGate is imported inside the _define function.

Added a test file that verify if the unrolling works