### PR TITLE
Set an explicit random hashseed for tests in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -143,7 +143,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -200,7 +200,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))"
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -252,7 +252,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -304,7 +304,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run --concurrency 2
           displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,7 +67,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -143,7 +143,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -200,7 +200,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(shuf -i 1-1024 -n 1)
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))"
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -252,7 +252,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
@@ -304,7 +304,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))"
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run --concurrency 2
           displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,8 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
         - task: CopyFiles@2
@@ -141,6 +143,8 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
         - task: CopyFiles@2
@@ -196,6 +200,8 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            export PYTHONHASHSEED=$(shuf -i 1-1024 -n 1)
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
         - task: CopyFiles@2
@@ -246,6 +252,8 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
         - task: CopyFiles@2
@@ -296,6 +304,8 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            export PYTHONHASHSEED=$(shuf -i 1-4294967295 -n 1)
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run --concurrency 2
           displayName: 'Run tests'
         - task: CopyFiles@2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The python hash seed is used to control the seed for the hash() function
for types covered by hash randomization. If we encounter errors around
ordering for things like iterating over dictionaries to reproduce
failures locally it is useful to know what the hash seed was. However,
to ensure the code is robust we still want to have a random value for
the hash seed to make sure things aren't dependent on a single order.
This commit accomplishes this by explicitly selecting a random number
and setting that to the value of PYTHONHASHSEED. This value is then
printed right before we run the tests. This way if we encounter an issue
around ordering we can try and reproduce it locally.

### Details and comments
