### PR TITLE
Add partial transpiler support for targeting ion trap backends.

### DIFF
--- a/qiskit/transpiler/passes/ms_basis_decomposer.py
+++ b/qiskit/transpiler/passes/ms_basis_decomposer.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Pass for converting a circuit targeting U3,CX basis to Rx,Ry,Rxx."""
+
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.exceptions import QiskitError
+
+from qiskit.converters import circuit_to_dag
+from qiskit.extensions.standard import U3Gate, CnotGate
+
+from qiskit.transpiler.passes import Unroller
+from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
+from qiskit.quantum_info.synthesis.ion_decompose import cnot_rxx_decompose
+
+
+class MSBasisDecomposer(TransformationPass):
+    """
+    Convert a circuit in U3,CX to Rx,Ry,Rxx without unrolling or simplification.
+    """
+
+    supported_input_gates = (U3Gate, CnotGate)
+    supported_basis_names = ('rx', 'ry', 'rxx')
+
+    def __init__(self, basis):
+        """
+        Args:
+            basis (list[str]): Target basis names, e.g. `['rx', 'ry', 'rxx']` .
+
+        Raises:
+            QiskitError: if target basis is not [ 'rx', 'ry', 'rxx' ]
+
+        """
+        super().__init__()
+
+        self.basis = basis
+        self.requires = [Unroller(['u3', 'cx'])]
+
+        if set(basis) != {gate_name for gate_name in self.supported_basis_names}:
+            raise QiskitError("Cannot unroll the circuit to the given basis, %s. "
+                              % str(self.basis))
+
+    def run(self, dag):
+        """Replace U3,CX nodes in input dag with equivalent Rx,Ry,Rxx gates.
+
+        Args:
+            dag(DAGCircuit): input dag
+
+        Raises:
+            QiskitError: if input dag includes gates outside U3,CX.
+
+        Returns:
+            DAGCircuit: output dag
+        """
+
+        one_q_decomposer = OneQubitEulerDecomposer(basis='XYX')
+        cnot_decomposition = cnot_rxx_decompose()
+
+        for node in dag.op_nodes():
+
+            if not isinstance(node.op, self.supported_input_gates):
+                raise QiskitError("Cannot convert the circuit to the given basis, %s. "
+                                  "No rule to expand instruction %s." %
+                                  (str(self.basis), node.op.name))
+
+            if isinstance(node.op, U3Gate):
+                replacement_circuit = one_q_decomposer(node.op)
+            elif isinstance(node.op, CnotGate):
+                # N.B. We can't circuit_to_dag once outside the loop because
+                # substitute_node_with_dag will modify the input DAG if the
+                # node to be replaced is conditional.
+
+                replacement_circuit = cnot_decomposition
+            else:
+                raise QiskitError("Unable to handle instruction (%s, %s)."
+                                  % (node.op.name, type(node.op)))
+
+            replacement_dag = circuit_to_dag(replacement_circuit)
+
+            # N.B. wires kwarg can be omitted for both 1Q and 2Q substitutions.
+            # For 1Q, one-to-one mapping is always correct. For 2Q,
+            # cnot_rxx_decompose follows convention of control as q[0], target
+            # as q[1], which matches qarg order in CX node.
+
+            dag.substitute_node_with_dag(node, replacement_dag)
+
+        return dag

--- a/qiskit/transpiler/transpile_circuit.py
+++ b/qiskit/transpiler/transpile_circuit.py
@@ -18,6 +18,7 @@ from qiskit.transpiler.preset_passmanagers import (level_0_pass_manager,
                                                    level_1_pass_manager,
                                                    level_2_pass_manager,
                                                    level_3_pass_manager)
+from qiskit.transpiler.passes.ms_basis_decomposer import MSBasisDecomposer
 from qiskit.transpiler.exceptions import TranspilerError
 
 
@@ -40,6 +41,17 @@ def transpile_circuit(circuit, transpile_config):
 
     # or we choose an appropriate one based on desired optimization level (default: level 1)
     else:
+        # Workaround for ion trap support: If basis gates includes
+        # Mølmer-Sørensen (rxx) and the circuit includes gates outside the basis,
+        # first unroll to u3, cx, then run MSBasisDecomposer to target basis.
+        ms_basis_swap = None
+        if (
+                'rxx' in transpile_config.basis_gates
+                and not set(transpile_config.basis_gates) >= circuit.count_ops().keys()
+        ):
+            ms_basis_swap = transpile_config.basis_gates
+            transpile_config.basis_gates = ['u3', 'cx']
+
         level = transpile_config.optimization_level
         if level is None:
             level = 1
@@ -54,6 +66,9 @@ def transpile_circuit(circuit, transpile_config):
             pass_manager = level_3_pass_manager(transpile_config)
         else:
             raise TranspilerError("optimization_level can range from 0 to 3.")
+
+        if ms_basis_swap is not None:
+            pass_manager.append(MSBasisDecomposer(ms_basis_swap))
 
     # Set a callback on the pass manager there is one
     if getattr(transpile_config, 'callback', None):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Mølmer-Sørensen basis decomposer

### Details and comments

Adds a simple pass to convert a circuit unrolled to U3,CX to Rx, Ry, Rxx.
Modifies default pass_manager selection if user is targeting an ion-trap backend. If the circuit needs to be unrolled (contains gates outside the backend's basis gates), first unroll to U3,CX, then decompose to backend's basis gates.
