### PR TITLE
Fixed issue 3099 by removing try and except blocks in dag_visualtion

### DIFF
--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -28,7 +28,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
 
     Note this function leverages
     `pydot <https://github.com/erocarrera/pydot>`_ (via
-    `nxpd <https://github.com/chebee7i/nxpd`_) to generate the graph, which
+    `nxpd <https://github.com/chebee7i/nxpd>`_) to generate the graph, which
     means that having `Graphviz <https://www.graphviz.org/>`_ installed on your
     system is required for this to work.
 
@@ -45,14 +45,9 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
 
     Raises:
         VisualizationError: when style is not recognized.
-        ImportError: when nxpd or pydot not installed.
     """
-    try:
-        import nxpd
-        import pydot  # pylint: disable=unused-import
-    except ImportError:
-        raise ImportError("dag_drawer requires nxpd and pydot. "
-                          "Run 'pip install nxpd pydot'.")
+    import nxpd
+    import pydot  # pylint: disable=unused-import
 
     G = dag.to_networkx()
     G.graph['dpi'] = 100 * scale
@@ -87,9 +82,4 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
     else:
         show = True
 
-    try:
-        return nxpd.draw(G, filename=filename, show=show)
-    except nxpd.pydot.InvocationException:
-        raise VisualizationError("dag_drawer requires GraphViz installed in the system. "
-                                 "Check https://www.graphviz.org/download/ for details on "
-                                 "how to install GraphViz in your system.")
+    return nxpd.draw(G, filename=filename, show=show)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3099

### Details and comments

I removed the try and except block surrounding the import nxpd and pydot (50, 53-55) because the ModuleNotFoundError gives sufficient information to install the packages. I also removed the try and except block surrounding the return nxpd.draw() function (90, 92-95) because in the case of issue #3099, the Qiskit VisualizationError was being thrown for an nxpd InvocationException. Import and extension errors will now be correctly shown as suggested by @kdk and @we-taper:

**Raised import error**:
```
ModuleNotFoundError: No module named 'nxpd'
ModuleNotFoundError: No module named 'pydot'
```

![image](https://user-images.githubusercontent.com/25377399/65370248-765bf600-dc0b-11e9-8328-f400b5930d95.png)


**Raised extension error**:
`InvocationException: Program terminated with status: 1. stderr follows: Format: "/var/folders/kh/wvhq4p916pgdhhcxjr2btq_00000gn/T/tmpp34a77_0" not recognized. Use one of: bmp canon cgimage cmap cmapx cmapx_np dot dot_json eps exr fig gif gv icns ico imap imap_np ismap jp2 jpe jpeg jpg json json0 mp pct pdf pic pict plain plain-ext png pov ps ps2 psd sgi svg svgz tga tif tiff tk vml vmlz xdot xdot1.2 xdot1.4 xdot_json`

![image](https://user-images.githubusercontent.com/25377399/65370137-790a1b80-dc0a-11e9-8027-7afcee846200.png)

I also fixed a small stylistic error where an open angle bracket was left unclosed (31).