### PR TITLE
Travis CI: The sudo: tag is deprecated on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ notifications:
   email: false
 
 cache: pip
-sudo: false
 
 ###############################################################################
 # Anchored and aliased definitions.


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Travis CI: The sudo: tag is deprecated on Travis


### Details and comments
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

