### PR TITLE
Fix for #3106 gatefacecolor key on circuit diagrams

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -244,7 +244,7 @@ class MatplotlibDrawer:
             _fc = fc
         elif self._style.gc != DefaultStyle().gc:
             _fc = self._style.gc
-        elif text and text in self._style.dispcol :
+        elif text and text in self._style.dispcol:
             _fc = self._style.dispcol[text]
         else:
             _fc = self._style.gc

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -186,7 +186,10 @@ class MatplotlibDrawer:
             _fc = fc
         else:
             if self._style.name != 'bw':
-                _fc = self._style.dispcol['multi']
+                if self._style.gc != DefaultStyle().gc:
+                    _fc = self._style.gc
+                else:
+                    _fc = self._style.dispcol['multi']
                 _ec = self._style.dispcol['multi']
             else:
                 _fc = self._style.gc
@@ -239,7 +242,9 @@ class MatplotlibDrawer:
             wid = WID
         if fc:
             _fc = fc
-        elif text and text in self._style.dispcol:
+        elif self._style.gc != DefaultStyle().gc:
+            _fc = self._style.gc
+        elif text and text in self._style.dispcol :
             _fc = self._style.dispcol[text]
         else:
             _fc = self._style.gc
@@ -383,6 +388,9 @@ class MatplotlibDrawer:
         self.ax.add_patch(box)
 
     def _ctrl_qubit(self, xy, fc=None, ec=None):
+        if self._style.gc != DefaultStyle().gc:
+            fc = self._style.gc
+            ec = self._style.gc
         if fc is None:
             fc = self._style.lc
         if ec is None:
@@ -395,6 +403,9 @@ class MatplotlibDrawer:
 
     def _tgt_qubit(self, xy, fc=None, ec=None, ac=None,
                    add_width=None):
+        if self._style.gc != DefaultStyle().gc:
+            fc = self._style.gc
+            ec = self._style.gc
         if fc is None:
             fc = self._style.dispcol['target']
         if ec is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
If the style property "gatefacecolor" is set to a different value than the default, this color is applied.

### Details and comments
Code for testing:

```
%matplotlib inline
from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister


qr = QuantumRegister(3)
cr = ClassicalRegister(1)
qc1 = QuantumCircuit(qr)

qc1.x(qr[1])
qc1.h(range(3))
qc1.cx(qr[1], qr[2])
qc1.cx(qr[0], qr[1])

style = {'gatefacecolor': '#FF0000'}

f = qc1.draw(output='mpl', style=style)

f

```

![image](https://user-images.githubusercontent.com/11366772/65526975-3be7a700-def2-11e9-9ae3-a3dbba345830.png)

Fixes #3106
