### PR TITLE
Remove superfluous reference to timeslots from assemble_schedules

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -83,7 +83,7 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
                     instruction = PulseInstruction(
                         command=SamplePulse(name=name, samples=instruction.command.samples),
                         name=instruction.name,
-                        channel=instruction.timeslots.channels[0])
+                        channel=instruction.channels[0])
                 # add samples to pulse library
                 user_pulselib[name] = instruction.command
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Use `instruction.channels` not `instruction.timeslots.channels`

### Details and comments

In progress of refactoring `Timeslots`, thought this would be an easy separate PR. Fewer files changed in the more interesting PR.

