### PR TITLE
[Stable] Fix for #3106 gatefacecolor key on circuit diagrams (#3137)

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -185,7 +185,10 @@ class MatplotlibDrawer:
             _fc = fc
         else:
             if self._style.name != 'bw':
-                _fc = self._style.dispcol['multi']
+                if self._style.gc != DefaultStyle().gc:
+                    _fc = self._style.gc
+                else:
+                    _fc = self._style.dispcol['multi']
                 _ec = self._style.dispcol['multi']
             else:
                 _fc = self._style.gc
@@ -238,6 +241,8 @@ class MatplotlibDrawer:
             wid = WID
         if fc:
             _fc = fc
+        elif self._style.gc != DefaultStyle().gc:
+            _fc = self._style.gc
         elif text and text in self._style.dispcol:
             _fc = self._style.dispcol[text]
         else:
@@ -382,6 +387,9 @@ class MatplotlibDrawer:
         self.ax.add_patch(box)
 
     def _ctrl_qubit(self, xy, fc=None, ec=None):
+        if self._style.gc != DefaultStyle().gc:
+            fc = self._style.gc
+            ec = self._style.gc
         if fc is None:
             fc = self._style.lc
         if ec is None:
@@ -394,6 +402,9 @@ class MatplotlibDrawer:
 
     def _tgt_qubit(self, xy, fc=None, ec=None, ac=None,
                    add_width=None):
+        if self._style.gc != DefaultStyle().gc:
+            fc = self._style.gc
+            ec = self._style.gc
         if fc is None:
             fc = self._style.dispcol['target']
         if ec is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

* Issue #3106 gatefacecolor key has no effect on circuit diagrams

If the style property "gatefacecolor" is set to a different value than the default, this color is applied.

Fixes #3106

* Solved style problem

space before : eliminated

### Details and comments

Backported from #3137 
(cherry picked from commit 531666618f798007fdded883afc6aadbcb5661c9)
