### PR TITLE
add negation support for Parameter. closes #3098.

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -66,8 +66,7 @@ class ParameterExpression():
         """
 
         self._raise_if_passed_unknown_parameters(parameter_values.keys())
-        #self._raise_if_passed_non_real_value(parameter_values)
-        self._raise_if_passed_non_complex_value(parameter_values)
+        self._raise_if_passed_non_real_value(parameter_values)
 
         symbol_values = {self._parameter_symbols[parameter]: value
                          for parameter, value in parameter_values.items()}
@@ -143,13 +142,6 @@ class ParameterExpression():
             raise QiskitError('Expression cannot bind non-real or non-numeric '
                               'values ({}).'.format(nonreal_parameter_values))
 
-    def _raise_if_passed_non_complex_value(self, parameter_values):
-        noncomplex_parameter_values = {p: v for p, v in parameter_values.items()
-                                    if not isinstance(v, numbers.Complex)}
-        if noncomplex_parameter_values:
-            raise QiskitError('Expression cannot bind non-complex or non-numeric '
-                              'values ({}).'.format(noncomplex_parameter_values))
-
     def _raise_if_parameter_names_conflict(self, other_parameters):
         self_names = {p.name: p for p in self.parameters}
         other_names = {p.name: p for p in other_parameters}
@@ -167,7 +159,7 @@ class ParameterExpression():
 
         Args:
             operation (function): One of operator.{add,sub,mul,truediv}.
-            other (Parameter or number.Complex): The second argument to be used
+            other (Parameter or numbers.Real): The second argument to be used
                with self in operation.
             reflected (bool): Optional - The default ordering is
                 "self operator other". If reflected is True, this is switched
@@ -191,7 +183,7 @@ class ParameterExpression():
 
             parameter_symbols = {**self._parameter_symbols, **other._parameter_symbols}
             other_expr = other._symbol_expr
-        elif isinstance(other, numbers.Complex) and numpy.isfinite(other):
+        elif isinstance(other, numbers.Real) and numpy.isfinite(other):
             parameter_symbols = self._parameter_symbols.copy()
             other_expr = other
         else:
@@ -244,12 +236,6 @@ class ParameterExpression():
             raise TypeError('ParameterExpression with unbound parameters ({}) '
                             'cannot be cast to a float.'.format(self.parameters))
         return float(self._symbol_expr)
-
-    def __complex__(self):
-        if self.parameters:
-            raise TypeError('ParameterExpression with unbound parameters ({}) '
-                            'cannot be cast to a complex.'.format(self.parameters))
-        return complex(self._symbol_expr)
 
     def __copy__(self):
         return self

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -421,8 +421,8 @@ class TestParameterExpressions(QiskitTestCase):
                 self.assertEqual(float(bound_expr),
                                  op(2.3, const))
 
-    def test_operating_on_a_parameter_with_a_non_complex_will_raise(self):
-        """Verify operations between a Parameter and a non-complex will raise."""
+    def test_operating_on_a_parameter_with_a_non_float_will_raise(self):
+        """Verify operations between a Parameter and a non-float will raise."""
 
         bad_constants = ['1', numpy.Inf, numpy.NaN, None, {}, []]
 
@@ -535,30 +535,6 @@ class TestParameterExpressions(QiskitTestCase):
 
         self.assertEqual(float(bound_expr2), 3)
 
-    def test_complex_expression(self):
-        """Verify ParameterExpressions can be negated."""
-
-        x = Parameter('x')
-        y = Parameter('y')
-        z = Parameter('z')
-
-        expr1 = (x + 1j * y) * z
-        bound_expr = expr1.bind({x: 1, y: 2, z: 3j})
-
-        self.assertEqual(complex(bound_expr), 3j-6)
-
-    def test_complex_gate_binding(self):
-        """Verify ParameterExpressions can be negated."""
-        from qiskit import transpile
-        from qiskit import QuantumRegister, QuantumCircuit
-        from qiskit.circuit import Parameter
-
-        qc = QuantumCircuit(2)
-        qc.cu3(Parameter('a'), Parameter('b'), Parameter('c'), 0, 1)
-        qc = transpile(qc, basis_gates=['u1', 'u2', 'u3', 'cx'])
-        qobj = assemble(qc, parameter_binds=[
-            {x:1j*ix for ix, x in enumerate(qc.parameters)}])
-        
     def test_name_collision(self):
         """Verify Expressions of distinct Parameters of shared name raises."""
 

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -19,6 +19,7 @@ from operator import add, sub, mul, truediv
 
 import numpy
 
+import qiskit
 from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Gate, Parameter, ParameterVector, ParameterExpression
@@ -424,7 +425,7 @@ class TestParameterExpressions(QiskitTestCase):
     def test_operating_on_a_parameter_with_a_non_float_will_raise(self):
         """Verify operations between a Parameter and a non-float will raise."""
 
-        bad_constants = ['1', numpy.Inf, numpy.NaN, None, {}, []]
+        bad_constants = [1j, '1', numpy.Inf, numpy.NaN, None, {}, []]
 
         x = Parameter('x')
 
@@ -534,6 +535,19 @@ class TestParameterExpressions(QiskitTestCase):
         bound_expr2 = expr2.bind({x: 1, y: 2, z: 3})
 
         self.assertEqual(float(bound_expr2), 3)
+
+    def test_standard_cu3(self):
+        """This tests parameter negation in standard extension gate cu3."""
+        x = Parameter('x')
+        y = Parameter('y')
+        z = Parameter('z')
+        qc = qiskit.QuantumCircuit(2)
+        qc.cu3(x, y, z, 0, 1)
+        try:
+            qc.decompose()
+        except TypeError:
+            self.fail('failed to decompose cu3 gate with negated parameter '
+                      'expression')
 
     def test_name_collision(self):
         """Verify Expressions of distinct Parameters of shared name raises."""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -421,10 +421,10 @@ class TestParameterExpressions(QiskitTestCase):
                 self.assertEqual(float(bound_expr),
                                  op(2.3, const))
 
-    def test_operating_on_a_parameter_with_a_non_float_will_raise(self):
-        """Verify operations between a Parameter and a non-float will raise."""
+    def test_operating_on_a_parameter_with_a_non_complex_will_raise(self):
+        """Verify operations between a Parameter and a non-complex will raise."""
 
-        bad_constants = [1j, '1', numpy.Inf, numpy.NaN, None, {}, []]
+        bad_constants = ['1', numpy.Inf, numpy.NaN, None, {}, []]
 
         x = Parameter('x')
 
@@ -522,6 +522,43 @@ class TestParameterExpressions(QiskitTestCase):
 
         self.assertEqual(float(bound_expr2), 5)
 
+    def test_negated_expression(self):
+        """Verify ParameterExpressions can be negated."""
+
+        x = Parameter('x')
+        y = Parameter('y')
+        z = Parameter('z')
+
+        expr1 = -x + y
+        expr2 = -expr1 * (-z)
+        bound_expr2 = expr2.bind({x: 1, y: 2, z: 3})
+
+        self.assertEqual(float(bound_expr2), 3)
+
+    def test_complex_expression(self):
+        """Verify ParameterExpressions can be negated."""
+
+        x = Parameter('x')
+        y = Parameter('y')
+        z = Parameter('z')
+
+        expr1 = (x + 1j * y) * z
+        bound_expr = expr1.bind({x: 1, y: 2, z: 3j})
+
+        self.assertEqual(complex(bound_expr), 3j-6)
+
+    def test_complex_gate_binding(self):
+        """Verify ParameterExpressions can be negated."""
+        from qiskit import transpile
+        from qiskit import QuantumRegister, QuantumCircuit
+        from qiskit.circuit import Parameter
+
+        qc = QuantumCircuit(2)
+        qc.cu3(Parameter('a'), Parameter('b'), Parameter('c'), 0, 1)
+        qc = transpile(qc, basis_gates=['u1', 'u2', 'u3', 'cx'])
+        qobj = assemble(qc, parameter_binds=[
+            {x:1j*ix for ix, x in enumerate(qc.parameters)}])
+        
     def test_name_collision(self):
         """Verify Expressions of distinct Parameters of shared name raises."""
 


### PR DESCRIPTION
also start to support complex Parameters

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR supports negated expressions. This resolves an exception which would be raised when using gates which negate their parameters, such as `extensions.standard.cu3`. For example,

```
x = Parameter('x')
y = Parameter('y')
expr = -x + y
```


### Details and comments


