### PR TITLE
Speed up qiskit import by not using pip in version.py

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -109,7 +109,7 @@ def _get_qiskit_versions():
     try:
         out_dict['qiskit'] = pkg_resources.get_distribution('qiskit').version
     except Exception:
-        pass
+        out_dict['qiskit'] = None
 
     return out_dict
 

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -17,10 +17,10 @@
 """Contains the terra version."""
 
 import os
+import pkg_resources
 import subprocess
 import sys
 import warnings
-
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -92,57 +92,27 @@ def _get_qiskit_versions():
         from qiskit.providers import aer
         out_dict['qiskit-aer'] = aer.__version__
     except Exception:
-        pass
+        out_dict['qiskit-aer'] = None
     try:
         from qiskit import ignis
         out_dict['qiskit-ignis'] = ignis.__version__
     except Exception:
-        pass
+        out_dict['qiskit-ignis'] = None
     try:
         from qiskit.providers import ibmq
         out_dict['qiskit-ibmq-provider'] = ibmq.__version__
     except Exception:
-        pass
+        out_dict['qiskit-ibmq-provider'] = None
     try:
         from qiskit import aqua
         out_dict['qiskit-aqua'] = aqua.__version__
     except Exception:
+        out_dict['qiskit-aqua'] = None
+    try:
+        out_dict['qiskit'] = pkg_resources.get_distribution('qiskit').version
+    except Exception:
         pass
 
-    cmd = [sys.executable, '-m', 'pip', 'freeze']
-    try:
-        reqs = _minimal_ext_cmd(cmd)
-    except Exception as exc:
-        warnings.warn(str(exc))
-        return out_dict
-    reqs_dict = {}
-    for req in reqs.split():
-        req_parts = req.decode().split('==')
-        if len(req_parts) == 1 and req_parts[0].startswith('git'):
-            if 'qiskit' in req_parts[0]:
-                package = req_parts[0].split('#egg=')[1]
-                sha = req_parts[0].split('@')[-1].split('#')[0]
-                reqs_dict[package] = 'dev-' + sha
-            continue
-        elif len(req_parts) == 1:
-            continue
-        reqs_dict[req_parts[0]] = req_parts[1]
-    # Dev/Egg _ to - conversion
-    for package in ['qiskit_terra', 'qiskit_ignis', 'qiskit_aer',
-                    'qiskit_ibmq_provider', 'qiskit_aqua']:
-        if package in reqs_dict:
-            if package.replace('_', '-') in out_dict:
-                continue
-            out_dict[package.replace('_', '-')] = reqs_dict[package]
-
-    for package in ['qiskit', 'qiskit-terra', 'qiskit-ignis', 'qiskit-aer',
-                    'qiskit-ibmq-provider', 'qiskit-aqua']:
-        if package in out_dict:
-            continue
-        if package in reqs_dict:
-            out_dict[package] = reqs_dict[package]
-        else:
-            out_dict[package] = None
     return out_dict
 
 

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -17,10 +17,8 @@
 """Contains the terra version."""
 
 import os
-import pkg_resources
 import subprocess
-import sys
-import warnings
+import pkg_resources
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit speeds up the import time of qiskit by removing the pip call
at run time. This call was overkill and slow, since all we really needed
it for was to get the installed versions of the qiskit meta package. We
were also using as a fallback if element.`__version__` failed, but that
was potentially misleading. This commit replaces the pip subprocess call
with the pkg_resources setuptools module to query if the metapackage is
installed and if so to grab that version. This is always faster than
subprocess to call pip freeze. That being said the performance at import
will vary based on the number of installed python packages because it
still has to check all the installed packages.

### Details and comments


