### PR TITLE
Collect element version info only on first use and cache.

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -12,16 +12,18 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=wrong-import-order
+# pylint: disable=wrong-import-order, wrong-import-position
 
 
 """Main Qiskit public functionality."""
-
+import sys
 import pkgutil
 import warnings
 
 # First, check for required Python and API version
 from . import util
+
+import qiskit.version
 
 # qiskit errors operator
 from .exceptions import QiskitError
@@ -44,12 +46,52 @@ import qiskit.circuit.reset
 # importing the package you want to allow extensions for (in this case `backends`).
 __path__ = pkgutil.extend_path(__path__, __name__)
 
+
+class QiskitBaseModule():
+    """Emulate qiskit base package as a class so that __version__ can be a
+    @property. Can be converted to a module-level __getattr__ once support is
+    available on all supported python versions (See PEP 562)."""
+
+    __path__ = __path__
+    QiskitError = QiskitError
+    ClassicalRegister = ClassicalRegister
+    QuantumRegister = QuantumRegister
+    QuantumCircuit = QuantumCircuit
+    execute = execute
+    transpile = transpile
+    assemble = assemble
+
+    __version__cache = None
+
+    @property
+    def __version__(self):
+        if self.__version__cache is None:
+            # pylint: disable=no-member
+            self.__version__cache = qiskit.version.__version__
+
+        return self.__version__cache
+
+    __qiskit_version__cache = None
+
+    @property
+    def __qiskit_version__(self):
+        if self.__qiskit_version__cache is None:
+            # pylint: disable=no-member
+            self.__qiskit_version__cache = qiskit.version.__qiskit_version__
+
+        return self.__qiskit_version__cache
+
+
+sys.modules[__name__] = QiskitBaseModule()
+
 # Please note these are global instances, not modules.
-from qiskit.providers.basicaer import BasicAer
+from qiskit.providers.basicaer import BasicAer  # noqa
+sys.modules[__name__].BasicAer = BasicAer
 
 # Try to import the Aer provider if installed.
 try:
     from qiskit.providers.aer import Aer
+    sys.modules[__name__].Aer = Aer
 except ImportError:
     warnings.warn('Could not import the Aer provider from the qiskit-aer '
                   'package. Install qiskit-aer or check your installation.',
@@ -57,11 +99,9 @@ except ImportError:
 # Try to import the IBMQ provider if installed.
 try:
     from qiskit.providers.ibmq import IBMQ
+    sys.modules[__name__].IBMQ = IBMQ
 except ImportError:
     warnings.warn('Could not import the IBMQ provider from the '
                   'qiskit-ibmq-provider package. Install qiskit-ibmq-provider '
                   'or check your installation.',
                   RuntimeWarning)
-
-from .version import __version__
-from .version import __qiskit_version__

--- a/qiskit/tools/jupyter/version_table.py
+++ b/qiskit/tools/jupyter/version_table.py
@@ -40,7 +40,7 @@ class VersionTable(Magics):
         html += "<tr><th>Qiskit Software</th><th>Version</th></tr>"
 
         packages = []
-        qver = qiskit.__qiskit_version__
+        qver = qiskit.__qiskit_version__  # pylint: disable=no-member
 
         packages.append(('Qiskit', qver['qiskit']))
         packages.append(('Terra', qver['qiskit-terra']))

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -82,12 +82,9 @@ def get_version_info():
     return full_version
 
 
-__version__ = get_version_info()
-
-
-def _get_qiskit_versions():
+def _get_qiskit_versions(terra_version):
     out_dict = {}
-    out_dict['qiskit-terra'] = __version__
+    out_dict['qiskit-terra'] = terra_version
     try:
         from qiskit.providers import aer
         out_dict['qiskit-aer'] = aer.__version__
@@ -146,4 +143,34 @@ def _get_qiskit_versions():
     return out_dict
 
 
-__qiskit_version__ = _get_qiskit_versions()
+class QiskitVersionModule():
+    """Emulate qiskit version package as a class so that __version__ can be a
+    @property. Can be converted to a module-level __getattr__ once support is
+    available on all supported python versions (See PEP 562)."""
+
+    VERSION = VERSION
+    ROOT_DIR = ROOT_DIR
+
+    git_version = git_version
+    get_version_info = get_version_info
+
+    __version__cache = None
+
+    @property
+    def __version__(self):
+        if self.__version__cache is None:
+            self.__version__cache = get_version_info()
+
+        return self.__version__cache
+
+    __qiskit_version__cache = None
+
+    @property
+    def __qiskit_version__(self):
+        if self.__qiskit_version__cache is None:
+            self.__qiskit_version__cache = _get_qiskit_versions(self.__version__)
+
+        return self.__qiskit_version__cache
+
+
+sys.modules[__name__] = QiskitVersionModule()


### PR DESCRIPTION
Moves `qiskit.__version__` and `qiskit.__qiskit_version__` to be lazily generated and cached. This substantially decreases import time, but may no longer be necessary after #3158 .

There are some unresolved test failures, likely due to the way we handle package name spacing.

Data (without #3158 or #3156) before:
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/2241698/65773388-39f83080-e10a-11e9-94fe-87e88d5c687f.png">

[qiskit_eagerversion.log](https://github.com/Qiskit/qiskit-terra/files/3662960/qiskit_eagerversion.log)

After:
<img width="1393" alt="image" src="https://user-images.githubusercontent.com/2241698/65773417-4bd9d380-e10a-11e9-83ab-c82d7a3f3aa7.png">

[qiskit_lazyversion.log](https://github.com/Qiskit/qiskit-terra/files/3662961/qiskit_lazyversion.log)

