### PR TITLE
The timeslots argument in Command isn't used

### DIFF
--- a/qiskit/pulse/commands/command.py
+++ b/qiskit/pulse/commands/command.py
@@ -23,7 +23,6 @@ import numpy as np
 
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.channels import Channel
-from qiskit.pulse.timeslots import TimeslotCollection
 
 from .instruction import Instruction
 
@@ -92,7 +91,6 @@ class Command(metaclass=MetaCount):
 
     @abstractmethod
     def to_instruction(self, command, *channels: List[Channel],
-                       timeslots: Optional[TimeslotCollection] = None,
                        name: Optional[str] = None) -> Instruction:
         """Create an instruction from command."""
         pass


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This argument is specified by `Command`, but no implementations of `Command` allow `timeslots` as an input argument. Commands can be made into instructions and then shifted in time.

### Details and comments

This follows along with not letting Instructions take timeslots as input; the timeslots are only used for internal time tracking, rather than a user interface.

