### PR TITLE
Remove broken docs link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,7 @@ intimate familiarity with qiskit-terra to develop a fix for the issue.
 ### Documentation
 
 If you make a change, make sure you update the associated
-*docstrings* and parts of the
-[documentation](https://github.com/Qiskit/qiskit/tree/master/docs/terra)
-that corresponds to it. You can also make a [documentation issue](
+*docstrings*. You can also make a [documentation issue](
 https://github.com/Qiskit/qiskit/issues/new/choose) if you see doc bugs, have a
 new feature that needs to be documented, or think that material could be added
 to the existing docs.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

We don't have those docs anymore, right? Anyway, the link is broken now.


