### PR TITLE
Fixed issue 2788 by updating qiskit/visualization/matplotlib.py

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -580,7 +580,7 @@ class MatplotlibDrawer:
                          color=self._style.tc,
                          clip_on=True,
                          zorder=PORDER_TEXT)
-            self._line([self.x_offset + 0.5, y], [self._cond['xmax'], y],
+            self._line([self.x_offset + 0.05, y], [self._cond['xmax'], y],
                        zorder=PORDER_REGLINE)
         # classical register
         this_creg_dict = {}
@@ -611,7 +611,7 @@ class MatplotlibDrawer:
                          color=self._style.tc,
                          clip_on=True,
                          zorder=PORDER_TEXT)
-            self._line([self.x_offset + 0.5, y], [self._cond['xmax'], y], lc=self._style.cc,
+            self._line([self.x_offset + 0.05, y], [self._cond['xmax'], y], lc=self._style.cc,
                        ls=self._style.cline, zorder=PORDER_REGLINE)
 
         # lf line


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes #2788 

### Details and comments
Simple fix: just reduced the extra x_offset from 0.5 to 0.05 in both the quantum register and classical register parts of "_draw_regs_sub"
defined in :   qiskit/visualization/matplotlib.py

This changes the x_offset of the parallel lines drawn for both the quantum and classical registers

After the fix, the result looks like this:
![changed_fix_issue_2788](https://user-images.githubusercontent.com/54737489/65815049-be7ca900-e207-11e9-86ea-46c0134f7479.png)



Earlier, before the fix, the result was like this

![before_fix_issue_2788](https://user-images.githubusercontent.com/54737489/65815116-9d688800-e208-11e9-8186-1e0ab6092d82.png)


In my opinion reducing the x_offset any less than 0.05 makes the figure look unpleasant to eyes so I kept it to 0.05 only