### PR TITLE
Enhancement #3169 - Increase swap mapper trials

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -95,7 +95,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _swap = [BarrierBeforeFinalMeasurements(),
              Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler),
+             StochasticSwap(coupling_map, trials=40, seed=seed_transpiler),
              Decompose(SwapGate)]
 
     # 6. Fix any bad CX directions

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -94,7 +94,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _swap = [BarrierBeforeFinalMeasurements(),
              Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler),
+             StochasticSwap(coupling_map, trials=80, seed=seed_transpiler),
              Decompose(SwapGate)]
 
     # 5. Fix any bad CX directions

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -101,7 +101,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _swap = [BarrierBeforeFinalMeasurements(),
              Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler),
+             StochasticSwap(coupling_map, trials=160, seed=seed_transpiler),
              Decompose(SwapGate)]
 
     _direction_check = [CheckCXDirection(coupling_map)]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Increase de default value for swap mapper trials. This should reduce the variability of swap mapper, and lead to shorter depth circuits.


### Details and comments
Set different values in the different preset_passmanager levels:

level0 -> 20
level1 -> 40
level2 -> 80
level3 -> 160

