### PR TITLE
Correct warning check for proper BasicAer name

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -45,11 +45,9 @@ import qiskit.circuit.reset
 __path__ = pkgutil.extend_path(__path__, __name__)
 
 # Please note these are global instances, not modules.
-from qiskit.providers.basicaer import BasicAer
-
 # Try to import the Aer provider if installed.
 try:
-    from qiskit.providers.aer import Aer
+    from qiskit.providers.basicaer import BasicAer
 except ImportError:
     warnings.warn('Could not import the Aer provider from the qiskit-aer '
                   'package. Install qiskit-aer or check your installation.',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Resolves #3183


### Details and comments
This fix may be incorrect if Aer is now a hard requirement for the package, since failure to load it simply prints a warning message. 

Apologies for not adding this to "the CHANGELOG file under Unreleased section" as it's not clear what exactly is needed. 

