### PR TITLE
Fix aer name in transpiler_equivalence test

### DIFF
--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -23,7 +23,7 @@ from hypothesis.stateful import Bundle, RuleBasedStateMachine
 
 import hypothesis.strategies as st
 
-from qiskit import execute, transpile, Aer
+from qiskit import execute, transpile, BasicAer
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit import Measure, Reset, Gate
 from qiskit.test.mock import \


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Rename Aer to BasicAer


### Details and comments
No new tests needed

