### PR TITLE
Add warning on jupyter imports if matplotlib isn't found

### DIFF
--- a/qiskit/tools/jupyter/__init__.py
+++ b/qiskit/tools/jupyter/__init__.py
@@ -15,6 +15,8 @@
 """Initialize the Jupyter routines.
 """
 
+import warnings
+
 from IPython import get_ipython          # pylint: disable=import-error
 from qiskit.tools.visualization import HAS_MATPLOTLIB
 from .jupyter_magics import (ProgressBarMagic, StatusMagic)
@@ -46,3 +48,9 @@ if _IP is not None:
             HTML_FORMATTER = _IP.display_formatter.formatters['text/html']
             # Make _backend_monitor the html repr for IBM Q backends
             HTML_FORMATTER.for_type(IBMQBackend, _backend_monitor)
+    else:
+        warnings.warn(
+            "matplotlib can't be found, ensure you have matplotlib and other "
+            "visualization dependencies installed. You can run "
+            "'!pip install qiskit-terra[visualization]' to install it from "
+            "jupyter", RuntimeWarning)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Normally if you're importing the qiskit jupyter magics from inside a
jupyter environment you'll want to use the widgets with matplotlib. If
you're running this and you forgot to install matplotlib it's not
exactly clear what happened. Especially if you're following a tutorial
or guide that uses `%qiskit_backend_overview` and it just raises a
UsageError because it was never initialized when you don't have
matplotlib installed. This commit attempts to mitigate this by raising a
runtime warning if the backend overview magic registration was skipped
because matplotlib wasn't found explaining that you need to have
matplotlib for that magic.

### Details and comments