### PR TITLE
Cleanup inst control usage from source tree

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -245,7 +245,7 @@ class Instruction:
         return inverse_gate
 
     def c_if(self, classical, val):
-        """Add classical control on register classical and value val."""
+        """Add classical condition on register classical and value val."""
         if not isinstance(classical, ClassicalRegister):
             raise QiskitError("c_if must be used with a classical register")
         if val < 0:

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -344,7 +344,6 @@ class Instruction:
     @property
     def control(self):
         """temporary classical control. Will be deprecated."""
-        raise AttributeError
         import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '
@@ -353,7 +352,6 @@ class Instruction:
 
     @control.setter
     def control(self, value):
-        raise AttributeError        
         import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -344,6 +344,7 @@ class Instruction:
     @property
     def control(self):
         """temporary classical control. Will be deprecated."""
+        raise AttributeError
         import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '
@@ -352,6 +353,7 @@ class Instruction:
 
     @control.setter
     def control(self, value):
+        raise AttributeError        
         import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '

--- a/qiskit/circuit/instructionset.py
+++ b/qiskit/circuit/instructionset.py
@@ -62,7 +62,7 @@ class InstructionSet:
         return self
 
     def c_if(self, classical, val):
-        """Add classical control register to all instructions."""
+        """Add condition on classical register to all instructions."""
         for gate in self.instructions:
             gate.c_if(classical, val)
         return self

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -698,13 +698,13 @@ class QuantumCircuit:
                     levels.append(op_stack[reg_ints[ind]] + 1)
                 else:
                     levels.append(op_stack[reg_ints[ind]])
-            # Assuming here that there is no controlled
+            # Assuming here that there is no conditional
             # snapshots or barriers ever.
-            if instr.control:
+            if instr.condition:
                 # Controls operate over all bits in the
                 # classical register they use.
-                cint = reg_map[instr.control[0].name]
-                for off in range(instr.control[0].size):
+                cint = reg_map[instr.condition[0].name]
+                for off in range(instr.condition[0].size):
                     if cint + off not in reg_ints:
                         reg_ints.append(cint + off)
                         levels.append(op_stack[cint + off] + 1)
@@ -782,15 +782,15 @@ class QuantumCircuit:
                 num_qargs = len(args)
             else:
                 args = qargs + cargs
-                num_qargs = len(args) + (1 if instr.control else 0)
+                num_qargs = len(args) + (1 if instr.condition else 0)
 
             if num_qargs >= 2 and instr.name not in ['barrier', 'snapshot']:
                 graphs_touched = []
                 num_touched = 0
                 # Controls necessarily join all the cbits in the
                 # register that they use.
-                if instr.control and not unitary_only:
-                    creg = instr.control[0]
+                if instr.condition and not unitary_only:
+                    creg = instr.condition[0]
                     creg_int = reg_map[creg.name]
                     for coff in range(creg.size):
                         temp_int = creg_int + coff

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -98,7 +98,7 @@ def random_circuit(n_qubits, depth, max_operands=3, measure=False,
             if conditional and rng.choice(range(10)) == 0:
                 possible_values = range(pow(2, n_qubits))
                 value = rng.choice(list(possible_values))
-                op.control = (cr, value)
+                op.condition = (cr, value)
 
             qc.append(op, register_operands)
 

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -50,8 +50,8 @@ def dag_to_circuit(dag):
         for clbit in node.cargs:
             clbits.append(cregs[clbit.register.name][clbit.index])
 
-        # Get arguments for classical control (if any)
+        # Get arguments for classical condition (if any)
         inst = node.op.copy()
-        inst.control = node.condition
+        inst.condition = node.condition
         circuit.append(inst, qubits, clbits)
     return circuit

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -751,7 +751,7 @@ class DAGCircuit:
             to_replay = []
             for sorted_node in input_dag.topological_nodes():
                 if sorted_node.type == "op":
-                    sorted_node.op.control = condition
+                    sorted_node.op.condition = condition
                     to_replay.append(sorted_node)
             for input_node in input_dag.op_nodes():
                 input_dag.remove_op_node(input_node)
@@ -784,7 +784,7 @@ class DAGCircuit:
         # Replace the node by iterating through the input_circuit.
         # Constructing and checking the validity of the wire_map.
         # If a gate is conditioned, we expect the replacement subcircuit
-        # to depend on those control bits as well.
+        # to depend on those condition bits as well.
         if node.type != "op":
             raise DAGCircuitError("expected node type \"op\", got %s"
                                   % node.type)

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -211,13 +211,13 @@ class TestDagOperations(QiskitTestCase):
         # Single qubit gate conditional: qc.h(qr[2]).c_if(cr, 3)
 
         h_gate = HGate()
-        h_gate.control = self.condition
+        h_gate.condition = self.condition
         h_node = self.dag.apply_operation_back(
-            h_gate, [self.qubit2], [], h_gate.control)
+            h_gate, [self.qubit2], [], h_gate.condition)
 
         self.assertEqual(h_node.qargs, [self.qubit2])
         self.assertEqual(h_node.cargs, [])
-        self.assertEqual(h_node.condition, h_gate.control)
+        self.assertEqual(h_node.condition, h_gate.condition)
 
         self.assertEqual(
             sorted(self.dag._multi_graph.in_edges(h_node, data=True)),
@@ -253,13 +253,13 @@ class TestDagOperations(QiskitTestCase):
         self.dag.add_creg(new_creg)
 
         meas_gate = Measure()
-        meas_gate.control = (new_creg, 0)
+        meas_gate.condition = (new_creg, 0)
         meas_node = self.dag.apply_operation_back(
-            meas_gate, [self.qubit0], [self.clbit0], meas_gate.control)
+            meas_gate, [self.qubit0], [self.clbit0], meas_gate.condition)
 
         self.assertEqual(meas_node.qargs, [self.qubit0])
         self.assertEqual(meas_node.cargs, [self.clbit0])
-        self.assertEqual(meas_node.condition, meas_gate.control)
+        self.assertEqual(meas_node.condition, meas_gate.condition)
 
         self.assertEqual(
             sorted(self.dag._multi_graph.in_edges(meas_node, data=True)),
@@ -292,13 +292,13 @@ class TestDagOperations(QiskitTestCase):
         # register. qc.measure(qr[0], cr[0]).c_if(cr, 3)
 
         meas_gate = Measure()
-        meas_gate.control = self.condition
+        meas_gate.condition = self.condition
         meas_node = self.dag.apply_operation_back(
             meas_gate, [self.qubit1], [self.clbit1], self.condition)
 
         self.assertEqual(meas_node.qargs, [self.qubit1])
         self.assertEqual(meas_node.cargs, [self.clbit1])
-        self.assertEqual(meas_node.condition, meas_gate.control)
+        self.assertEqual(meas_node.condition, meas_gate.condition)
 
         self.assertEqual(
             sorted(self.dag._multi_graph.in_edges(meas_node, data=True)),
@@ -873,9 +873,9 @@ class TestDagSubstitute(QiskitTestCase):
         # case.
 
         instr = Instruction('opaque', 1, 1, [])
-        instr.control = self.condition
+        instr.condition = self.condition
         instr_node = self.dag.apply_operation_back(
-            instr, [self.qubit0], [self.clbit1], instr.control)
+            instr, [self.qubit0], [self.clbit1], instr.condition)
 
         sub_dag = DAGCircuit()
         sub_qr = QuantumRegister(1, 'sqr')


### PR DESCRIPTION
Cleaning up some more references to `inst.control` to not get warnings.