### PR TITLE
Add support for partial results to Result class

### DIFF
--- a/releasenotes/notes/partialresults-44d0ce37b1c09413.yaml
+++ b/releasenotes/notes/partialresults-44d0ce37b1c09413.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Allows the Result class to return partial results. If a valid result schema
+    is loaded that contains some experiments which succeeded and some which
+    failed, this allows accessing the data from experiments that succeeded,
+    while raising an exception for experiments that failed and displaying the
+    appropriate error message for the failed results.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR allows the `Result` class to return partial results. If a valid result schema is loaded that contains some experiments which succeeded and some which failed, this allows accessing the data from experiments that succeeded, while raising an exception for experiments that failed and displaying the appropriate error message for the failed results.

This is related to Qiskit-Aer [Issue #346](https://github.com/Qiskit/qiskit-aer/issues/346).

Should be synced with Qiskit Aer [PR #365](https://github.com/Qiskit/qiskit-aer/pull/365)

### Details and comments

Currently when `Result` is loaded from a valid JSON, if the top level `success` is false it will raise an exception when any experiment data is accessed, and only return the top level `status` message.

If a provider returned a valid JSON schema result for a partial success then the top level `success` should still be false. However, each individual experiment also has its own `success` flag in the JSON schema. This change checks the experiment level `success == True` whem `Result.data/get_counts/get_memory` etc is called rather than the top level. It will also return the error message for the experiment level as well.

#### Example
Run several circuits on the stabilizer simulator, where one has an unsupported instruction (t gate).

```python
from qiskit import *
from qiskit.providers.aer import QasmSimulator
sim = QasmSimulator()

circ1 = QuantumCircuit(2, 2)
circ1.h(0)
circ1.cx(0, 1)
circ1.measure([0, 1], [0, 1])

circ2 = QuantumCircuit(2, 2)
circ2.h(0)
circ2.t(0)
circ2.cx(0, 1)
circ2.measure([0, 1], [0, 1])

job = execute([circ1, circ2], sim, backend_options={"method": "stabilizer"})
result = job.result()
```

Then `result.get_counts(0)` will return the counts for `circ1` while `result.get_counts(1)` raises
```python
QiskitError: 'RESULT STATUS: PARTIAL COMPLETED | EXPERIMENT STATUS: ERROR: Circuit contains invalid instructions ( invalid gate instructions: {t} for stabilizer method)'
```
Where the status comse from the result schema ` 'RESULT STATUS: <result.status> | EXPERIMENT STATUS: <experiment.status>`







