### PR TITLE
Deprecate passing in an ast node as a instruction parameter

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -34,6 +34,8 @@ The circuit itself keeps this context.
 """
 import copy
 from itertools import zip_longest
+import warnings
+
 import sympy
 import numpy
 
@@ -52,11 +54,14 @@ class Instruction:
 
     def __init__(self, name, num_qubits, num_clbits, params):
         """Create a new instruction.
+
         Args:
             name (str): instruction name
             num_qubits (int): instruction's qubit width
             num_clbits (int): instruction's clbit width
-            params (list[sympy.Basic|qasm.Node|int|float|complex|str|ndarray]): list of parameters
+            params (list[sympy.Basic||int|float|complex|str|ParameterExpressionndarray]): list of
+                parameters
+
         Raises:
             QiskitError: when the register is not in the correct format.
         """
@@ -140,6 +145,15 @@ class Instruction:
                 self._params.append(single_param)
             # example: OpenQASM parsed instruction
             elif isinstance(single_param, node.Node):
+                warnings.warn('Using qasm ast node as a circuit.Instruction '
+                              'parameter is deprecated as of the 0.10.0, and '
+                              'will be removed no earlier than 3 months after '
+                              'that release date. You should convert the qasm '
+                              'node to a supported type int, float, complex, '
+                              'str, circuit.ParameterExpression, or ndarray '
+                              'before setting Instruction.parameters',
+                              DeprecationWarning, stacklevel=3)
+
                 self._params.append(single_param.sym())
             # example: u3(0.1, 0.2, 0.3)
             elif isinstance(single_param, (int, float)):
@@ -344,7 +358,6 @@ class Instruction:
     @property
     def control(self):
         """temporary classical control. Will be deprecated."""
-        import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '
                       'to create quantum controlled gates')
@@ -352,7 +365,6 @@ class Instruction:
 
     @control.setter
     def control(self, value):
-        import warnings
         warnings.warn('The instruction attribute, "control", will be renamed '
                       'to "condition". The "control" method will later be used '
                       'to create quantum controlled gates')

--- a/releasenotes/notes/deprecate-qasm-ast-node-params-3cc930ea2c677a96.yaml
+++ b/releasenotes/notes/deprecate-qasm-ast-node-params-3cc930ea2c677a96.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    Support for setting ``qiskit.circuit.Instruction`` parameters with an object
+    of type ``qiskit.qasm.node.Node`` has been deprecated. ``Node`` objects that
+    were previously used as parameters should be converted to a supported type
+    prior to initializing a new ``Instruction`` object or calling the
+    ``Instruction.params`` setter. Supported types are ``int``, ``float``,
+    ``complex``, ``str``, ``qiskit.circuit.ParameterExpression``, or
+    ``numpy.ndarray``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit deprecates the option of passing in a circuit parameter of
a qasm.node.Node type. Passing in qasm ast nodes as a parameter is
rarely used and is not actually done anywhere in the qiskit-terra code
or tests. Additionally there is the qiskit ast_to_circuit converter
which will take a program node object (the root node of a qasm ast) and
convert that directly to a circuit object.

### Details and comments