### PR TITLE
Fix latex drawer bit subscript for indexes >=10

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -221,7 +221,7 @@ class QCircuitImage:
                                     ": 0}"
             else:
                 if self.layout is None:
-                    self._latex[i][0] = "\\lstick{{ {}_{} : \\ket{{0}} }}".format(
+                    self._latex[i][0] = "\\lstick{{ {}_{{{}}} : \\ket{{0}} }}".format(
                         self.ordered_regs[i].register.name, self.ordered_regs[i].index)
                 else:
                     self._latex[i][0] = "\\lstick{{({}_{{{}}})~q_{{{}}} : \\ket{{0}} }}".format(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The latex drawer was writing out latex for the bit labels as:

\lstick{$REG_$INDEX: \ket{0}}

where $REG and $INDEX are a quantum register name and index
respectively. However, if the index exceeds 1 character in length the
latex subscript doesn't work anymore because it will only apply to the
first character. This commit fixes that issue by wrapping the index in
{} to make the subscript apply to the whole thing.

### Details and comments

Fixes #3244
