### PR TITLE
Use numpy randint instead of choice for conditional

### DIFF
--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -96,8 +96,7 @@ def random_circuit(n_qubits, depth, max_operands=3, measure=False,
 
             # with some low probability, condition on classical bit values
             if conditional and rng.choice(range(10)) == 0:
-                possible_values = range(pow(2, n_qubits))
-                value = rng.choice(list(possible_values))
+                value = rng.randint(0, np.power(2, n_qubits))
                 op.condition = (cr, value)
 
             qc.append(op, register_operands)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The conditional code in qiskit.circuit.random.random_circuit() was
creating a list of 2^n_qubits to use np.random.choice() to pick a
single integer from that list. However, when you have a large number of
qubits, like 53, this will result in a memory error because you're
trying to allocate a list larger than is possible. This commit changes
the selection of the conditional value to select a random integer
directly instead of using a list to select a random integer.

### Details and comments