### PR TITLE
Update release note styling and wording

### DIFF
--- a/releasenotes/notes/Instruction-layering-for-circuit-drawing-has-changed-f62ce5aaeb8ce221.yaml
+++ b/releasenotes/notes/Instruction-layering-for-circuit-drawing-has-changed-f62ce5aaeb8ce221.yaml
@@ -4,5 +4,5 @@ fixes:
     Instructions layering which underlies all types of circuit drawing has
     changed to address right/left justification. This sometimes results in
     output which is topologically equivalent to the rendering in prior versions
-    but visually different than previously rendered. The change in layering
-    fixes qiskit-terra issue \#2802
+    but visually different than previously rendered. Fixes
+    `issue #2802 <https://github.com/Qiskit/qiskit-terra/issues/2802>`_

--- a/releasenotes/notes/add-memory-slots-to-pulse-qobj-exp-header-c21c795d761ab5a3.yaml
+++ b/releasenotes/notes/add-memory-slots-to-pulse-qobj-exp-header-c21c795d761ab5a3.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Add `memory_slots` to `QobjExperimentHeader` of pulse Qobj. This fixes a
-    bug in the data format of `meas_level=2` result of pulse experiment.
+    Add ``memory_slots`` to ``QobjExperimentHeader`` of pulse Qobj. This fixes
+    a bug in the data format of ``meas_level=2`` results of pulse experiments.
     Measured quantum states are returned as a bit string with zero padding
-    based on `memory_slots` number.
+    based on the number set for ``memory_slots``.

--- a/releasenotes/notes/circuit-data-modification-validation-52f02f955ecf90a1.yaml
+++ b/releasenotes/notes/circuit-data-modification-validation-52f02f955ecf90a1.yaml
@@ -2,7 +2,7 @@
 upgrade:
   - |
     Assignments and modifications to the ``data`` attribute of
-    ``qiskit.QuantumCircuit`` objects are no validated following the same
+    ``qiskit.QuantumCircuit`` objects are now validated following the same
     rules used throughout the ``QuantumCircuit`` API. This was done to
     improve the performance of the circuits API since we can now assume the
     ``data`` attribute is in a known format. If you were manually modifying

--- a/releasenotes/notes/dense_noise_aware-46489df2439aab05.yaml
+++ b/releasenotes/notes/dense_noise_aware-46489df2439aab05.yaml
@@ -1,5 +1,7 @@
 ---
 upgrade:
   - |
-    The `DenseLayout` is now noise-aware. The optimization level 2 uses this layout selection
-    mechanisms.
+    The transpiler default passmanager for optimization level 2 now uses the
+    ``DenseLayout`` layout selection mechanism by default instead of
+    ``NoiseAdaptiveLayout``. The ``Denselayout`` pass has also been modified
+    to be made noise-aware.

--- a/releasenotes/notes/deprecate-instruction-control-a363a15b3f0f0d72.yaml
+++ b/releasenotes/notes/deprecate-instruction-control-a363a15b3f0f0d72.yaml
@@ -1,7 +1,7 @@
 ---
 deprecations:
   - |
-    Instruction.control is used for classical control. This usage is
-    being deprecated this can be used for quantum control in the
-    future. Classically conditioned operations will instead be handled
-    by Instruction.condition.
+    Using the ``control`` property of ``qiskit.circuit.Instruction`` for
+    classical control is now deprecated. In the future this property will be
+    used for quantum control. Classically conditioned operations will instead
+    be handled by the ``condition`` property of ``qiskit.circuit.Instruction``.

--- a/releasenotes/notes/deprecate_bit_eq_tuple-e751168412b09702.yaml
+++ b/releasenotes/notes/deprecate_bit_eq_tuple-e751168412b09702.yaml
@@ -1,7 +1,11 @@
 ---
 deprecations:
   - |
-    Until Qiskit-terra 8.0, bits (qubits and classical bits) used to be represented as a tuple.
-    In 0.8, qubits and classical bits are instances of `Qubit` and `Clbit` classes respectably.
-    Therefore, all the tuples had been converted to instances. Additionally, comparing tuples and
-    `Qubits`/`Clbits` is also being deprecated now.
+    In the qiskit 0.9.0 release the representation of bits (both qubits and
+    classical bits) changed from tuples of the form ``(register, index)`` to be
+    instances of the classes ``qiskit.circuit.Qubit`` and
+    ``qiskit.circuit.Clbit``. For backwards compatibility comparing
+    the equality between a legacy tuple and the bit classes was supported as
+    everything transitioned from tuples to being objects. This support is now
+    deprecated and will be removed in the future. Everything should use the bit
+    classes instead of tuples moving forward.

--- a/releasenotes/notes/deprecate_unknown_styles-93f84aedd1887c44.yaml
+++ b/releasenotes/notes/deprecate_unknown_styles-93f84aedd1887c44.yaml
@@ -1,6 +1,8 @@
 ---
 deprecations:
   - |
-    The matplotlib drawer raises a warning when the `style` argument dictonary includes
-    a key that is not supported by the drawer. In the future, unsupported keys will raise
-    an exception.
+    When the ``mpl`` output is used for either ``qiskit.QuantumCircuit.draw()``
+    or ``qiskit.visualization.circuit_drawer()`` and the ``style`` kwarg is
+    used, passing in unsupported dictionary keys as part of the ``style```
+    dictionary is now deprecated. Where these unknown arguments were previously
+    silently ignored, in the future, unsupported keys will raise an exception.

--- a/releasenotes/notes/mock-backend-properties-a369bb6efdbae602.yaml
+++ b/releasenotes/notes/mock-backend-properties-a369bb6efdbae602.yaml
@@ -1,9 +1,9 @@
 ---
 features:
   - |
-    The backends in `qiskit.test.mock` now contain a snapshot of real
-    device calibration data. This is accessible via `backend.properties()`.
-    This can be used to test any code that depends on backend properties,
-    such as noise-adaptive transpiler passes or device noise models for
-    simulation. This would create a faster testing and development cycle
-    without the need to go to live backends.
+    The backends in ``qiskit.test.mock`` now contain a snapshot of real
+    device calibration data. This is accessible via the ``properties()`` method
+    for each backend. This can be used to test any code that depends on
+    backend properties, such as noise-adaptive transpiler passes or device
+    noise models for simulation. This will create a faster testing and
+    development cycle without the need to go to live backends.

--- a/releasenotes/notes/passmanager_replace-d89e2cc46517d917.yaml
+++ b/releasenotes/notes/passmanager_replace-d89e2cc46517d917.yaml
@@ -7,6 +7,7 @@ features:
     optimization level 0:
 
     .. code-block:: python
+
       from qiskit.transpiler.preset_passmanagers.level0 import level_0_pass_manager
       from qiskit.transpiler.transpile_config import TranspileConfig
 
@@ -15,6 +16,7 @@ features:
       pass_manager.draw()
 
     .. code-block::
+
       [0] FlowLinear: SetLayout
       [1] Conditional: TrivialLayout
       [2] FlowLinear: FullAncillaAllocation, EnlargeWithAncilla, ApplyLayout
@@ -23,12 +25,14 @@ features:
     The layout selection is set in the stage `[1]`. Let's replace it with `DenseLayout`:
 
     .. code-block:: python
+
       from qiskit.transpiler.passes import DenseLayout
 
       pass_manager.replace(1, DenseLayout(coupling_map), condition=lambda property_set: not property_set['layout'])
       pass_manager.draw()
 
     .. code-block::
+
       [0] FlowLinear: SetLayout
       [1] Conditional: DenseLayout
       [2] FlowLinear: FullAncillaAllocation, EnlargeWithAncilla, ApplyLayout
@@ -37,10 +41,12 @@ features:
     If you want to replace it without any condition, you can use set-item shortcut:
 
     .. code-block:: python
+
       pass_manager[1] = DenseLayout(coupling_map)
       pass_manager.draw()
 
     .. code-block::
+
       [0] FlowLinear: SetLayout
       [1] FlowLinear: DenseLayout
       [2] FlowLinear: FullAncillaAllocation, EnlargeWithAncilla, ApplyLayout

--- a/releasenotes/notes/remove-deprecated-device-specs-2d1aeab5f09b5a68.yaml
+++ b/releasenotes/notes/remove-deprecated-device-specs-2d1aeab5f09b5a68.yaml
@@ -3,6 +3,7 @@ upgrade:
   - |
     The deprecated ``DeviceSpecification`` class has been removed. Instead you should
     use the ``PulseChannelSpec``. For example, you can run something like::
+
         device = pulse.PulseChannelSpec.from_backend(backend)
         device.drives[0]    # for DeviceSpecification, this was device.q[0].drive
         device.memoryslots  # this was device.mem

--- a/releasenotes/notes/remove-deprecated-schedule-ops-f57b3c2477312cbb.yaml
+++ b/releasenotes/notes/remove-deprecated-schedule-ops-f57b3c2477312cbb.yaml
@@ -1,14 +1,17 @@
 ---
 upgrade:
   - |
-    Removed deprecated `ops.py` from pulse. Use `Schedule` and `Instruction`
-    methods directly. Rather than::
+    The deprecated module ``qiskit.pulse.ops`` has been removed. Use
+    ``Schedule`` and ``Instruction`` methods directly. For example, rather
+    than::
+
         ops.union(schedule_0, schedule_1)
         ops.union(instruction, schedule)  # etc
 
-    Please use::
+    Instead please use::
+
         schedule_0.union(schedule_1)
         instruction.union(schedule)
 
-    This same pattern applies to other `ops` functions: insert, shift, append,
-    and flatten.
+    This same pattern applies to other ``ops`` functions: ``insert``, ``shift``,
+    ``append``, and ``flatten``.

--- a/releasenotes/notes/rzz-visualization-5ade105ae6cae0eb.yaml
+++ b/releasenotes/notes/rzz-visualization-5ade105ae6cae0eb.yaml
@@ -3,4 +3,5 @@ fixes:
   - |
     Fixed the visualization of the rzz gate in the latex circuit drawer to match
     the cu1 gate to reflect the symmetry in the rzz gate. The fix is based on
-    the cds command of the qcircuit latex package. Fixes issue \#1957
+    the cds command of the qcircuit latex package. Fixes
+    `issue #1957 <https://github.com/Qiskit/qiskit-terra/issues/1957>`_


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates some styling and wording issues in the release notes
for the 0.10.0 release so far. The most common issues is the use of
markdown style formatting instead of rst which is what reno uses.

### Details and comments