### PR TITLE
Fix rst formatting for QuantumCircuit docstrings

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -59,11 +59,11 @@ class QuantumCircuit:
         A circuit is a list of instructions bound to some registers.
 
         Args:
-            regs (`list(Register)` or `list(int)`): The registers to be
+            regs: list(:class:`Register`) or list(``int``) The registers to be
                 included in the circuit.
 
                  * If a list of :class:`Register` objects, represents the :class:`QuantumRegister`
-                   and/or :class:`ClassicalRegister` to include in the circuit.
+                   and/or :class:`ClassicalRegister` objects to include in the circuit.
 
                    For example:
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -57,19 +57,32 @@ class QuantumCircuit:
     def __init__(self, *regs, name=None):
         """Create a new circuit.
         A circuit is a list of instructions bound to some registers.
+
         Args:
-            *regs (list(Register) or list(Int)): To be included in the circuit.
-                  - If [Register], the QuantumRegister and/or ClassicalRegister
-                    to include in the circuit.
-                    E.g.: QuantumCircuit(QuantumRegister(4))
-                          QuantumCircuit(QuantumRegister(4), ClassicalRegister(3))
-                          QuantumCircuit(QuantumRegister(4, 'qr0'), QuantumRegister(2, 'qr1'))
-                  - If [Int], the amount of qubits and/or classical bits to include
-                  in the circuit. It can be (Int, ) or (Int, Int).
-                    E.g.: QuantumCircuit(4) # A QuantumCircuit with 4 qubits
-                          QuantumCircuit(4, 3) # A QuantumCircuit with 4 qubits and 3 classical bits
-            name (str or None): the name of the quantum circuit. If
-                None, an automatically generated string will be assigned.
+            regs (`list(Register)` or `list(int)`): The registers to be
+                included in the circuit.
+
+                 * If a list of :class:`Register` objects, represents the :class:`QuantumRegister`
+                   and/or :class:`ClassicalRegister` to include in the circuit.
+
+                   For example:
+
+                    * ``QuantumCircuit(QuantumRegister(4))``
+                    * ``QuantumCircuit(QuantumRegister(4), ClassicalRegister(3))``
+                    * ``QuantumCircuit(QuantumRegister(4, 'qr0'), QuantumRegister(2, 'qr1'))``
+
+                 * If a list of ``int``, the amount of qubits and/or classical
+                   bits to include in the circuit. It can either be a single
+                   int for just the number of quantum bits, or 2 ints for the number of
+                   quantum bits and classical bits respectively.
+
+                   For example:
+
+                    * ``QuantumCircuit(4) # A QuantumCircuit with 4 qubits``
+                    * ``QuantumCircuit(4, 3) # A QuantumCircuit with 4 qubits and 3 classical bits``
+
+            name (str): the name of the quantum circuit. If not set, an
+                automatically generated string will be assigned.
 
         Raises:
             QiskitError: if the circuit name, if given, is not valid.
@@ -104,14 +117,15 @@ class QuantumCircuit:
 
     @property
     def data(self):
-        """Return the circuit data (instructions and context)
+        """Return the circuit data (instructions and context).
 
         Returns:
-            QuantumCircuitData: a list-like object containing the tuples for the
-               circuit's data. Each tuple is in the format (instruction, qargs,
-               cargs). Where instruction is an Instruction (or subclass) object,
-               qargs is a list of Qubit objects, and cargs is a list of Clbit
-               objects.
+            QuantumCircuitData: a list-like object containing the tuples for the circuit's data.
+
+            Each tuple is in the format ``(instruction, qargs, cargs)``.
+            Where instruction is an Instruction (or subclass) object,
+            qargs is a list of Qubit objects, and cargs is a list of Clbit
+            objects.
         """
         return QuantumCircuitData(self)
 
@@ -209,8 +223,7 @@ class QuantumCircuit:
         return inverse_circ
 
     def combine(self, rhs):
-        """
-        Append rhs to self if self contains compatible registers.
+        """Append rhs to self if self contains compatible registers.
 
         Two circuits are compatible if they contain the same registers
         or if they contain different registers with unique names. The
@@ -218,6 +231,15 @@ class QuantumCircuit:
         circuits.
 
         Return self + rhs as a new object.
+
+        Args:
+            rhs (QuantumCircuit): The quantum circuit to append to the right hand side.
+
+        Returns:
+            QuantumCircuit: Returns a new QuantumCircuit object
+
+        Raises:
+            QiskitError: if the rhs circuit is not compatible
         """
         # Check registers in LHS are compatible with RHS
         self._check_compatible_regs(rhs)
@@ -238,8 +260,7 @@ class QuantumCircuit:
         return circuit
 
     def extend(self, rhs):
-        """
-        Append rhs to self if self contains compatible registers.
+        """Append QuantumCircuit to the right hand side if it contains compatible registers.
 
         Two circuits are compatible if they contain the same registers
         or if they contain different registers with unique names. The
@@ -247,6 +268,15 @@ class QuantumCircuit:
         circuits.
 
         Modify and return self.
+
+        Args:
+            rhs (QuantumCircuit): The quantum circuit to append to the right hand side.
+
+        Returns:
+            QuantumCircuit: Returns this QuantumCircuit object (which has been modified)
+
+        Raises:
+            QiskitError: if the rhs circuit is not compatible
         """
         # Check registers in LHS are compatible with RHS
         self._check_compatible_regs(rhs)
@@ -508,7 +538,7 @@ class QuantumCircuit:
 
         Returns:
             Instruction: a composite instruction encapsulating this circuit
-                (can be decomposed back)
+            (can be decomposed back)
         """
         from qiskit.converters.circuit_to_instruction import circuit_to_instruction
         return circuit_to_instruction(self, parameter_map)
@@ -975,12 +1005,13 @@ class QuantumCircuit:
         return self.num_unitary_factors()
 
     def copy(self, name=None):
-        """
+        """Copy the circuit.
+
         Args:
           name (str): name to be given to the copied circuit, if None then the name stays the same
+
         Returns:
-          QuantumCircuit: a deepcopy of the current circuit, with the name updated if
-                          it was provided
+          QuantumCircuit: a deepcopy of the current circuit, with the specified name
         """
         cpy = deepcopy(self)
         if name:

--- a/qiskit/extensions/quantum_initializer/diag.py
+++ b/qiskit/extensions/quantum_initializer/diag.py
@@ -101,27 +101,27 @@ def _extract_rz(phi1, phi2):
 
 
 def diag_gate(self, diag, qubit):
-    """
-    Attach a diagonal gate to a circuit. The decomposition is based on Theorem 7 given in
-    "Synthesis of Quantum Logic Circuits" by Shende et al.
-    (https://arxiv.org/pdf/quant-ph/0406176.pdf).
+    """Attach a diagonal gate to a circuit.
 
-        Args:
-            diag (list): list of the 2^k diagonal entries (for a diagonal gate on k qubits).
-                Must contain at least two entries
-            qubit (QuantumRegister|list): list of k qubits the diagonal is
-                acting on (the order of the qubits specifies the computational basis in which the
-                diagonal gate is provided: the first element in diag acts on the state where all
-                the qubits in q are in the state 0, the second entry acts on the state where all
-                the qubits q[1],...,q[k-1] are in the state zero and q[0] is in the state 1,
-                and so on
+    The decomposition is based on Theorem 7 given in "Synthesis of Quantum Logic Circuits" by
+    Shende et al. (https://arxiv.org/pdf/quant-ph/0406176.pdf).
 
-        Returns:
-            QuantumCircuit: the diagonal gate is attached to the circuit.
+    Args:
+        diag (list): list of the 2^k diagonal entries (for a diagonal gate on k qubits).
+            Must contain at least two entries
+        qubit (QuantumRegister|list): list of k qubits the diagonal is
+            acting on (the order of the qubits specifies the computational basis in which the
+            diagonal gate is provided: the first element in diag acts on the state where all
+            the qubits in q are in the state 0, the second entry acts on the state where all
+            the qubits q[1],...,q[k-1] are in the state zero and q[0] is in the state 1,
+            and so on
 
-        Raises:
-            QiskitError: if the list of the diagonal entries or the qubit list is in bad format;
-                if the number of diagonal entries is not 2^k, where k denotes the number of qubits
+    Returns:
+        QuantumCircuit: the diagonal gate which was attached to the circuit.
+
+    Raises:
+        QiskitError: if the list of the diagonal entries or the qubit list is in bad format;
+            if the number of diagonal entries is not 2^k, where k denotes the number of qubits
     """
 
     if isinstance(qubit, QuantumRegister):

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -144,26 +144,27 @@ def _ct(m):
 
 
 def squ(self, u, qubit, mode="ZYZ", up_to_diagonal=False):
-    """
-    Decompose an arbitrary 2*2 unitary into three rotation gates: U=R_zR_yR_z.
+    """ Decompose an arbitrary 2*2 unitary into three rotation gates :math:`U=R_zR_yR_z`.
+
     Note that the decomposition is up to a global phase shift.
+
     (This is a well known decomposition, which can be found for example in Nielsen and Chuang's book
     "Quantum computation and quantum information".)
 
-        Args:
-            u (ndarray): 2*2 unitary (given as a (complex) ndarray)
-            qubit (QuantumRegister|Qubit): the qubit, on which the gate is acting on
-            mode (string): determines the used decomposition by providing the rotation axes.
-                The allowed modes are: "ZYZ" (default)
-            up_to_diagonal (bool):  if set to True, the single-qubit unitary is decomposed up to
-                a diagonal matrix, i.e. a unitary u' is implemented such that there exists a 2*2
-                diagonal gate d with u = d.dot(u')
-        Returns:
-            QuantumCircuit: the single-qubit unitary (up to a diagonal gate if
-            up_to_diagonal = True) is attached to the circuit.
+    Args:
+        u (ndarray): 2*2 unitary (given as a (complex) ndarray)
+        qubit (QuantumRegister|Qubit): the qubit, on which the gate is acting on
+        mode (string): determines the used decomposition by providing the rotation axes.
+            The allowed modes are: "ZYZ" (default)
+        up_to_diagonal (bool):  if set to True, the single-qubit unitary is decomposed up to
+            a diagonal matrix, i.e. a unitary u' is implemented such that there exists a 2*2
+            diagonal gate d with u = d.dot(u')
+    Returns:
+        QuantumCircuit: the single-qubit unitary (up to a diagonal gate if
+        up_to_diagonal = True) is attached to the circuit.
 
-        Raises:
-            QiskitError: if the format is wrong; if the array u is not unitary
+    Raises:
+        QiskitError: if the format is wrong; if the array u is not unitary
     """
 
     if isinstance(qubit, QuantumRegister):

--- a/qiskit/extensions/quantum_initializer/ucg.py
+++ b/qiskit/extensions/quantum_initializer/ucg.py
@@ -261,32 +261,32 @@ def _rz(alpha):
 
 
 def ucg(self, gate_list, q_controls, q_target, up_to_diagonal=False):
-    """
-    Attach a uniformly controlled gates (also called multiplexed gates) to a circuit.
+    """Attach a uniformly controlled gates (also called multiplexed gates) to a circuit.
+
     The decomposition was introduced by Bergholm et al. in
     https://arxiv.org/pdf/quant-ph/0410066.pdf.
 
-        Args:
-            gate_list (list[ndarray]): list of two qubit unitaries [U_0,...,U_{2^k-1}],
-                where each single-qubit unitary U_i is a given as a 2*2 array
-            q_controls (QuantumRegister|list[(QuantumRegister,int)]): list of k control qubits.
-                The qubits are ordered according to their significance in the computational basis.
-                For example if q_controls=[q[1],q[2]] (with q = QuantumRegister(2)),
-                the unitary U_0 is performed if q[1] and q[2] are in the state zero, U_1 is
-                performed if q[2] is in the state zero and q[1] is in the state one, and so on
-            q_target (QuantumRegister|(QuantumRegister,int)):  target qubit, where we act on with
-                the single-qubit gates.
-            up_to_diagonal (bool): If set to True, the uniformly controlled gate is decomposed up
-                to a diagonal gate, i.e. a unitary u' is implemented such that there exists a
-                diagonal gate d with u = d.dot(u'), where the unitary u describes the uniformly
-                controlled gate
+    Args:
+        gate_list (list[ndarray]): list of two qubit unitaries [U_0,...,U_{2^k-1}],
+            where each single-qubit unitary U_i is a given as a 2*2 array
+        q_controls (QuantumRegister|list[(QuantumRegister,int)]): list of k control qubits.
+            The qubits are ordered according to their significance in the computational basis.
+            For example if q_controls=[q[1],q[2]] (with q = QuantumRegister(2)),
+            the unitary U_0 is performed if q[1] and q[2] are in the state zero, U_1 is
+            performed if q[2] is in the state zero and q[1] is in the state one, and so on
+        q_target (QuantumRegister|(QuantumRegister,int)):  target qubit, where we act on with
+            the single-qubit gates.
+        up_to_diagonal (bool): If set to True, the uniformly controlled gate is decomposed up
+            to a diagonal gate, i.e. a unitary u' is implemented such that there exists a
+            diagonal gate d with u = d.dot(u'), where the unitary u describes the uniformly
+            controlled gate
 
-        Returns:
-            QuantumCircuit: the uniformly controlled gate is attached to the circuit.
+    Returns:
+        QuantumCircuit: the uniformly controlled gate is attached to the circuit.
 
-        Raises:
-            QiskitError: if the list number of control qubits does not correspond to the provided
-                number of single-qubit unitaries; if an input is of the wrong type
+    Raises:
+        QiskitError: if the list number of control qubits does not correspond to the provided
+            number of single-qubit unitaries; if an input is of the wrong type
     """
 
     if isinstance(q_controls, QuantumRegister):

--- a/qiskit/extensions/quantum_initializer/ucx.py
+++ b/qiskit/extensions/quantum_initializer/ucx.py
@@ -46,27 +46,27 @@ class UCX(UCRot):
 
 
 def ucx(self, angle_list, q_controls, q_target):
-    """
-    Attach a uniformly controlled (also called multiplexed) Rx rotation gate to a circuit.
+    """Attach a uniformly controlled (also called multiplexed) Rx rotation gate to a circuit.
+
     The decomposition is base on https://arxiv.org/pdf/quant-ph/0406176.pdf by Shende et al.
 
-        Args:
-            angle_list (list): list of (real) rotation angles [a_0,...,a_{2^k-1}]
-            q_controls (QuantumRegister|list): list of k control qubits
-                (or empty list if no controls). The control qubits are ordered according to their
-                significance in increasing order: For example if q_controls=[q[1],q[2]]
-                (with q = QuantumRegister(2)), the rotation Rx(a_0)is performed if q[1] and q[2]
-                are in the state zero, the rotation  Rx(a_1) is performed if q[1] is in the state
-                 one and q[2] is in the state zero, and so on
-            q_target (QuantumRegister|Qubit): target qubit, where we act on with
-                the single-qubit rotation gates
+    Args:
+        angle_list (list): list of (real) rotation angles [a_0,...,a_{2^k-1}]
+        q_controls (QuantumRegister|list): list of k control qubits
+            (or empty list if no controls). The control qubits are ordered according to their
+            significance in increasing order: For example if q_controls=[q[1],q[2]]
+            (with q = QuantumRegister(2)), the rotation Rx(a_0)is performed if q[1] and q[2]
+            are in the state zero, the rotation  Rx(a_1) is performed if q[1] is in the state
+             one and q[2] is in the state zero, and so on
+        q_target (QuantumRegister|Qubit): target qubit, where we act on with
+            the single-qubit rotation gates
 
-        Returns:
-            QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
+    Returns:
+        QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
 
-        Raises:
-            QiskitError: if the list number of control qubits does not correspond to the provided
-                number of single-qubit unitaries; if an input is of the wrong type
+    Raises:
+        QiskitError: if the list number of control qubits does not correspond to the provided
+            number of single-qubit unitaries; if an input is of the wrong type
     """
 
     if isinstance(q_controls, QuantumRegister):

--- a/qiskit/extensions/quantum_initializer/ucy.py
+++ b/qiskit/extensions/quantum_initializer/ucy.py
@@ -43,27 +43,27 @@ class UCY(UCRot):
 
 
 def ucy(self, angle_list, q_controls, q_target):
-    """
-    Attach a uniformly controlled (also called multiplexed) Ry rotation gate to a circuit.
+    """Attach a uniformly controlled (also called multiplexed) Ry rotation gate to a circuit.
+
     The decomposition is base on https://arxiv.org/pdf/quant-ph/0406176.pdf by Shende et al.
 
-        Args:
-            angle_list (list[numbers): list of (real) rotation angles [a_0,...,a_{2^k-1}]
-            q_controls (QuantumRegister|list[Qubit]): list of k control qubits
-                (or empty list if no controls). The control qubits are ordered according to their
-                significance in increasing order: For example if q_controls=[q[1],q[2]]
-                (with q = QuantumRegister(2)), the rotation Ry(a_0)is performed if q[1] and q[2]
-                are in the state zero, the rotation  Ry(a_1) is performed if q[1] is in the state
-                 one and q[2] is in the state zero, and so on
-            q_target (QuantumRegister|Qubit): target qubit, where we act on with
-                the single-qubit rotation gates
+    Args:
+        angle_list (list[numbers): list of (real) rotation angles [a_0,...,a_{2^k-1}]
+        q_controls (QuantumRegister|list[Qubit]): list of k control qubits
+            (or empty list if no controls). The control qubits are ordered according to their
+            significance in increasing order: For example if q_controls=[q[1],q[2]]
+            (with q = QuantumRegister(2)), the rotation Ry(a_0)is performed if q[1] and q[2]
+            are in the state zero, the rotation  Ry(a_1) is performed if q[1] is in the state
+             one and q[2] is in the state zero, and so on
+        q_target (QuantumRegister|Qubit): target qubit, where we act on with
+            the single-qubit rotation gates
 
-        Returns:
-            QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
+    Returns:
+        QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
 
-        Raises:
-            QiskitError: if the list number of control qubits does not correspond to the provided
-                number of single-qubit unitaries; if an input is of the wrong type
+    Raises:
+        QiskitError: if the list number of control qubits does not correspond to the provided
+            number of single-qubit unitaries; if an input is of the wrong type
     """
 
     if isinstance(q_controls, QuantumRegister):

--- a/qiskit/extensions/quantum_initializer/ucz.py
+++ b/qiskit/extensions/quantum_initializer/ucz.py
@@ -43,27 +43,28 @@ class UCZ(UCRot):
 
 
 def ucz(self, angle_list, q_controls, q_target):
-    """
-    Attach a uniformly controlled (also called multiplexed gates) Rz rotation gate to a circuit.
+    """Attach a uniformly controlled (also called multiplexed gates) Rz rotation gate to a circuit.
+
     The decomposition is base on https://arxiv.org/pdf/quant-ph/0406176.pdf by Shende et al.
 
-        Args:
-            angle_list (list[numbers): list of (real) rotation angles [a_0,...,a_{2^k-1}]
-            q_controls (QuantumRegister|list[Qubit]): list of k control qubits
-                (or empty list if no controls). The control qubits are ordered according to their
-                significance in increasing order: For example if q_controls=[q[1],q[2]]
-                (with q = QuantumRegister(2)), the rotation Rz(a_0)is performed if q[1] and q[2]
-                are in the state zero, the rotation  Rz(a_1) is performed if q[1] is in
-                the state one and q[2] is in the state zero, and so on
-            q_target (QuantumRegister|Qubit): target qubit, where we act on with
-                the single-qubit rotation gates
+    Args:
+        angle_list (list[numbers): list of (real) rotation angles [a_0,...,a_{2^k-1}]
+        q_controls (QuantumRegister|list[Qubit]): list of k control qubits
+            (or empty list if no controls). The control qubits are ordered according to their
+            significance in increasing order: For example if q_controls=[q[1],q[2]]
+            (with q = QuantumRegister(2)), the rotation Rz(a_0)is performed if q[1] and q[2]
+            are in the state zero, the rotation  Rz(a_1) is performed if q[1] is in
+            the state one and q[2] is in the state zero, and so on
+        q_target (QuantumRegister|Qubit): target qubit, where we act on with
+            the single-qubit rotation gates
 
-        Returns:
-            QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
+    Returns:
+        QuantumCircuit: the uniformly controlled rotation gate is attached to the circuit.
 
-        Raises:
-            QiskitError: if the list number of control qubits does not correspond to the provided
-                number of single-qubit unitaries; if an input is of the wrong type
+    Raises:
+        QiskitError: if the list number of control qubits does not correspond to
+            the provided number of single-qubit unitaries; if an input is of
+            the wrong type
     """
 
     if isinstance(q_controls, QuantumRegister):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The QuantumCircuit had several instances of invalid rst formatting that
prevented the docs from rendering clearly. This commit fixes several of
them.

Two follow ups to this should be fixing all the warnings issued
during the docs builds (since most of them are highlighting valid
issues with formatting). Additionally all the docstrings for the
standard gate and circuit instruction methods should be updated to
flush out the docs here. Most of the docstrings for these methods are
one line and don't explain clearly what the inputs or outputs are.

### Details and comments