### PR TITLE
Update __qiskit_version__ call time

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -64,4 +64,7 @@ except ImportError:
                   RuntimeWarning)
 
 from .version import __version__
-from .version import __qiskit_version__
+from .version import _get_qiskit_versions
+
+
+__qiskit_version__ = _get_qiskit_versions()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There was a race condition for the setting of the `__qiskit_version__`
attribute for the provider packages. Since the provider packages use a
separate pkutil namespace package the qiskit.providers package needs to
be imported for any provider package versions to be initialized for
pkgutil to load the additional packages. However, because of the import
path for python qiskit.version would often be loaded prior to that. This
caused the package versions for aer and ibmq to be missing from
`qiskit.__qiskit_version__`, since it just does an assignment from
qiskit.version's module attribute. To workaround this issue we need to
make sure that `_get_qiskit_versions()` is always called after
qiskit.providers is loaded. This commit does this by changing when we
run the function to be in the `qiskit.__init__` module but after the
Aer and IBMQ aliases are set up. This ensures that we've loaded
everything when we generate the version dict.

### Details and comments