### PR TITLE
Update pip prior to installing aer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,7 @@ jobs:
         directories:
         - .hypothesis
       script:
+      - pip install -U pip
       - python setup.py build_ext --inplace
       - pip install "qiskit-aer"
       - make test_randomized


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The new aer packages use manylinux2010, and the randomized testing job
is using the sdist instead of the wheel. This commit updates the pip
version prior to installing aer to try and get it to install the binary
version instead of the source package.

### Details and comments


