### PR TITLE
Pin networkx in constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ cache: pip
 stage_generic: &stage_generic
   install:
     # Install step for jobs that require compilation and qa.
-    - pip install -U -r requirements.txt
+    - pip install -U -r requirements.txt -c constraints.txt
     - pip install -U -r requirements-dev.txt coveralls -c constraints.txt
-    - pip install -e .
+    - pip install -c constraints.txt -e .
     - pip install "qiskit-ibmq-provider" -c constraints.txt
   script:
     # Compile the executables and run the tests.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
@@ -180,7 +180,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
@@ -233,7 +233,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
@@ -290,7 +290,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
@@ -342,7 +342,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
@@ -394,7 +394,7 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -e .
+            pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 astroid==2.2.5
 cryptography==2.5.0
 pylint==2.3.1
+networkx==2.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of networkx 2.4 several deprecated APIs were
removed. This broke the visualization dependency nxpd. A fix is in
progress [1] to address this. But in the meantime to get tests working
again we need to make sure we do not install networkx 2.4 for testing.
This commit does this by pinning the version we use in our testing in
the constraints file to 2.3. This will unblock our development while we
wait for a new nxpd release.

### Details and comments

[1] https://github.com/chebee7i/nxpd/pull/15