### PR TITLE
[Stable] Fix latex columns count

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -276,8 +276,14 @@ class QCircuitImage:
         # wires in the beginning and end
         columns = 2
 
-        # all gates take up 1 column except from those with labels (cu1) which take 2
-        columns += sum([2 if nd.name == 'cu1' else 1 for layer in self.ops for nd in layer])
+        # all gates take up 1 column except from those with labels (ie cu1)
+        # which take 2 columns
+        for layer in self.ops:
+            column_width = 1
+            for nd in layer:
+                if nd.name in ['cu1', 'rzz']:
+                    column_width = 2
+            columns += column_width
 
         # every 3 characters is roughly one extra 'unit' of width in the cell
         # the gate name is 1 extra 'unit'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The latex drawer uses a class attribute img_depth to keep track of the
number of columns to put in the output img_depth (along with some other
things related to that). This value was attempted to be figured out by
looking at the number of layers except if there is a cu1 gate in a
layer then that layer has 2 columns (because the label takes up one).
However this count was done incorrectly and instead the number of
columns was equivalent to the number of gates in each layer plus 2
columns for each cu1. This resulted in a huge empty space for circuits
with lots of qubits, especially if they had lots of gates per layer.
This commit corrects the layer count loop to instead properly only
count a layer once and twice if it has a cu1 gate in the layer.

(cherry picked from commit 52b4dc12f2fce2643c71e45046c30dfbba589a24)

### Details and comments

Fixes #3232 

Backported from #3243
