### PR TITLE
Reset python env for CI benchmarks to 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -180,6 +180,7 @@ jobs:
     - stage: test
       name: Benchmarks
       <<: *stage_linux
+      python: 3.5
       script:
       - python setup.py build_ext --inplace
       - pip install "qiskit-aer"


### PR DESCRIPTION
#3143 restored travis jobs for environments other than 3.6, but the benchmarks are currently set to run on 3.5, which needed to be overridden explicitly.