### PR TITLE
Stop setting basepython in base tox testenv

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ skipsdist = True
 
 [testenv]
 usedevelop = True
-basepython = python3
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
@@ -18,12 +17,14 @@ commands =
   stestr run {posargs}
 
 [testenv:lint]
+basepython = python3
 commands =
   pycodestyle --max-line-length=100 qiskit test
   pylint -rn qiskit test
   reno lint
 
 [testenv:coverage]
+basepython = python3
 setenv =
   {[testenv]setenv}
   PYTHON=coverage3 run --source qiskit --parallel-mode
@@ -33,6 +34,7 @@ commands =
   coverage3 report
 
 [testenv:docs]
+basepython = python3
 deps =
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We started setting the basepython attribute in the root testenv
configuration in the tox.ini in #1761. This was done to ensure that
users on environments with both python2 and python3 installed that jobs
which weren't explicit about the python version (like 'lint') would not
attempt to use python2 in error. However, this had the unintended side
effect of also making jobs which were opinionated about python version
(basically the standard test jobs 'py37', 'py36', and 'py35') would end
up using the 'python3' binary in the standard path instead of the
version specified in the job name. This mostly came up on systems with
more than one python version installed. The basepython declaration is
only needed for jobs that do not specify a python version. This commit
updates the tox.ini to remove the basepython from the base testenv
definition and only use it for jobs where the python version isn't
explicitly set.

### Details and comments


