### PR TITLE
Fix matplotlib with wide parameters

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -250,7 +250,8 @@ class MatplotlibDrawer:
 
         if wide:
             if subtext:
-                wid = WID * 2.2
+                boxes_wide = round(max(len(subtext), len(text)) / 10, 1) or 1
+                wid = WID * 1.5 * boxes_wide
             else:
                 boxes_wide = round(len(text) / 10) or 1
                 wid = WID * 2.2 * boxes_wide
@@ -663,8 +664,26 @@ class MatplotlibDrawer:
             for op in layer:
 
                 if op.name in _wide_gate:
+                    if op.type == 'op' and hasattr(op.op, 'params'):
+                        param = self.param_parse(op.op.params)
+                        if '$\\pi$' in param:
+                            pi_count = param.count('pi')
+                            len_param = len(param) - (5 * pi_count)
+                        else:
+                            len_param = len(param)
+                        if len_param > len(op.name):
+                            box_width = round(len(param) / 10)
+                            # If more than 4 characters min width is 2
+                            if box_width <= 1:
+                                box_width = 2
+                            if layer_width < box_width:
+                                if box_width > 2:
+                                    layer_width = box_width * 2
+                                else:
+                                    layer_width = 2
                     if layer_width < 2:
                         layer_width = 2
+
                 # if custom gate with a longer than standard name determine
                 # width
                 elif op.name not in ['barrier', 'snapshot', 'load', 'save',
@@ -675,7 +694,12 @@ class MatplotlibDrawer:
                     # handle params/subtext longer than op names
                     if op.type == 'op' and hasattr(op.op, 'params'):
                         param = self.param_parse(op.op.params)
-                        if len(param) > len(op.name):
+                        if '$\\pi$' in param:
+                            pi_count = param.count('pi')
+                            len_param = len(param) - (5 * pi_count)
+                        else:
+                            len_param = len(param)
+                        if len_param > len(op.name):
                             box_width = round(len(param) / 8)
                             # If more than 4 characters min width is 2
                             if box_width <= 1:
@@ -811,12 +835,8 @@ class MatplotlibDrawer:
                 elif len(q_xy) == 1:
                     disp = op.name
                     if param:
-                        prm = '({})'.format(param)
-                        if len(prm) < 20:
-                            self._gate(q_xy[0], wide=_iswide, text=disp,
-                                       subtext=prm)
-                        else:
-                            self._gate(q_xy[0], wide=_iswide, text=disp)
+                        self._gate(q_xy[0], wide=_iswide, text=disp,
+                                   subtext=str(param))
                     else:
                         self._gate(q_xy[0], wide=_iswide, text=disp)
                 #
@@ -989,7 +1009,7 @@ class MatplotlibDrawer:
         param_parts = [None] * len(v)
         for i, e in enumerate(v):
             try:
-                param_parts[i] = pi_check(e, output='mpl')
+                param_parts[i] = pi_check(e, output='mpl', ndigits=3)
             except TypeError:
                 param_parts[i] = str(e)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes issues reported with long parameter lists in the mpl
drawer. The issue is that when the length of the parameters list exceeds
20 characters the mpl drawer removes the parameters. Multiple attempts
have attempted to address this issue (#2994 #3353) by just increasing
that limit. But this doesn't actually solve the problem because the
boxes are fixed width so the parameters just exceed the width of the
boxes. The proper way to fix this is to dynamically

In addition this whole problem is primarily caused because we don't
round any parameter values. This commit rounds the parameters so that we
rarely have to scale to have super wide parameter lists.

### Details and comments

Fixes #2822