### PR TITLE
Remove duplicated test jobs from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,20 +18,6 @@ cache:
   directories:
     - .stestr
 
-###############################################################################
-# Anchored and aliased definitions.
-###############################################################################
-
-# These are used for avoiding repeating code, and due to problems with
-# overriding some keys (in particular, "os" and "language: ptyhon") when using
-# the standard travis matrix with stages.
-#
-# This allows re-using different "sets" of configurations in the stages
-# matrix, mimicking a hierarchy:
-# * stage_generic
-#   * stage_linux
-#   * stage_osx
-
 stage_generic: &stage_generic
   install:
     # Install step for jobs that require compilation and qa.
@@ -47,12 +33,6 @@ stage_generic: &stage_generic
     - stestr run
   after_failure:
     - python tools/report_ci_failure.py
-  before_script:
-    - |
-      if [ ! "$(ls -A .stestr)" ]; then
-          rm -r .stestr
-      fi
-
 
 stage_linux: &stage_linux
   <<: *stage_generic
@@ -61,67 +41,10 @@ stage_linux: &stage_linux
   language: python
   python: 3.7
 
-stage_osx: &stage_osx
-  <<: *stage_generic
-  os: osx
-  osx_image: xcode9.2
-  language: generic
-  cache:
-    pip: true
-    directories:
-      - ~/python-interpreters/
-      - .stestr
-  before_install:
-    # Travis does not provide support for Python 3 under osx - it needs to be
-    # installed manually.
-    |
-    if [ ${TRAVIS_OS_NAME} = "osx" ]; then
-      if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
-        git clone git://github.com/pyenv/pyenv.git
-        cd pyenv/plugins/python-build
-        ./install.sh
-        cd ../../..
-        python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
-      fi
-      virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
-      source venv/bin/activate
-    fi
-
-
-###############################################################################
-# Stage-related definitions
-###############################################################################
-
-# Define the order of the stages.
-stages:
-  - lint and pure python test
-  - test
-
-# Define the job matrix explicitly, as matrix expansion causes issues when
-# using it with stages and some variables/sections cannot be overridden.
 jobs:
   include:
-    # "lint and and pure python test" stage
-    ###########################################################################
-    # Linter and style check (GNU/Linux, Python 3.7)
-    - stage: lint and pure python test
-      name: Python Style and Linter
-      <<: *stage_linux
-      script:
-        - pycodestyle --max-line-length=100 qiskit test
-        - pylint -rn qiskit test
 
-    # Run the tests against without compilation (GNU/Linux, Python 3.7)
-    - stage: lint and pure python test
-      name: Python 3.7 Tests Linux
-      <<: *stage_linux
-
-    # "test" stage
-    ###########################################################################
-
-    # GNU/Linux, Python 3.6
-    - stage: test
-      name: Python 3.6 Tests and Coverage Linux
+    - name: Python 3.6 Tests and Coverage Linux
       <<: *stage_linux
       python: 3.6
       env:
@@ -133,39 +56,8 @@ jobs:
         - pip install diff-cover || true
         - diff-cover --compare-branch master coverage.xml || true
 
-    # GNU/Linux, Python 3.5
-    - stage: test
-      name: Python 3.5 Tests Linux
-      <<: *stage_linux
-      python: 3.5
-
-    # OSX, Python 3.5.6 (via pyenv)
-    - stage: test
-      <<: *stage_osx
-      name: Python 3.5 Tests OSX
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.5.7
-
-    # OSX, Python 3.6.5 (via pyenv)
-    - stage: test
-      name: Python 3.6 Tests OSX
-      <<: *stage_osx
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.6.9
-
-    # OSX, Python 3.7.2 (via pyenv)
-    - stage: test
-      name: Python 3.7 Tests OSX
-      <<: *stage_osx
-      env:
-        - MPLBACKEND=ps
-        - PYTHON_VERSION=3.7.4
-
     # Randomized testing
-    - stage: test
-      name: Randomized tests
+    - name: Randomized tests
       <<: *stage_linux
       cache:
         pip: true
@@ -177,8 +69,7 @@ jobs:
       - pip install "qiskit-aer"
       - make test_randomized
 
-    - stage: test
-      name: Benchmarks
+    - name: Benchmarks
       <<: *stage_linux
       python: 3.5
       script:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3143 we added back most of the jobs which we removed from travis to
see if we preferred running jobs in travis or azure pipelines. After
having this for a full day it's become apparent that even with the extra
capacity from our travis subscription that the wait times on travis with
the full job load are too high. The travis check returned significantly
slower than the equivalent job in azure pipelines. So for now we'll
stick to running the majority of and required testing in azure pipelines
and use travis only for extra jobs where needed. This commit removes all
the duplicated jobs that we run in azure from the travis config.

### Details and comments