### PR TITLE
Allow bypassing validation during model instantiation

### DIFF
--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -57,17 +57,17 @@ class ModelTypeValidator(_fields.Field):
 
         Subclasses can do one of the following:
 
-            1. They can override the ``valid_types`` property with a tuple with
-            the expected types for this field.
+        1. Override the ``valid_types`` property with a tuple with the expected
+           types for this field.
 
-            2. They can override the ``_expected_types`` method to return a
-            tuple of expected types for the field.
+        2. Override the ``_expected_types`` method to return a tuple of
+           expected types for the field.
 
-            3. They can change ``check_type`` completely to customize
-            validation.
+        3. Change ``check_type`` completely to customize validation.
 
-        This method or the overrides must return the ``value`` parameter
-        untouched.
+        Note:
+            This method or the overrides must return the ``value`` parameter
+            untouched.
         """
         expected_types = self._expected_types()
         if not isinstance(value, expected_types):
@@ -179,9 +179,8 @@ class _SchemaBinder:
         """Create a patched Schema for validating models.
 
         Model validation is not part of Marshmallow. Schemas have a ``validate``
-        method but this delegates execution on ``load`` and discards the result.
-        Similarly, ``load`` will call ``_deserialize`` on every field in the
-        schema.
+        method but this delegates execution on ``load``. Similarly, ``load``
+        will call ``_deserialize`` on every field in the schema.
 
         This function patches the ``_deserialize`` instance method of each
         field to make it call a custom defined method ``check_type``
@@ -220,10 +219,6 @@ class _SchemaBinder:
 
 def bind_schema(schema):
     """Class decorator for adding schema validation to its instances.
-
-    Instances of the decorated class are automatically validated after
-    instantiation and they are augmented to allow further validations with the
-    private method ``_validate()``.
 
     The decorator also adds the class attribute ``schema`` with the schema used
     for validation, along with a class attribute ``shallow_schema`` used for

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -205,12 +205,14 @@ class _SchemaBinder:
 
         @wraps(init_method)
         def _decorated(self, **kwargs):
-            try:
-                _ = self.shallow_schema._do_load(kwargs,
-                                                 postprocess=False)
-            except ValidationError as ex:
-                raise ModelValidationError(
-                    ex.messages, ex.field_name, ex.data, ex.valid_data, **ex.kwargs) from None
+            do_validation = kwargs.pop('validate', True)
+            if do_validation:
+                try:
+                    _ = self.shallow_schema._do_load(kwargs,
+                                                     postprocess=False)
+                except ValidationError as ex:
+                    raise ModelValidationError(
+                        ex.messages, ex.field_name, ex.data, ex.valid_data, **ex.kwargs) from None
 
             init_method(self, **kwargs)
 

--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -204,8 +204,8 @@ class _SchemaBinder:
     def _validate_after_init(init_method):
         """Add validation during instantiation.
 
-        The validation is performed depending on the `validate` parameter
-        passed to the `init_method`. If `False`, the validation will not be
+        The validation is performed depending on the ``validate`` parameter
+        passed to the ``init_method``. If ``False``, the validation will not be
         performed.
         """
         @wraps(init_method)
@@ -220,7 +220,7 @@ class _SchemaBinder:
                     raise ModelValidationError(
                         ex.messages, ex.field_name, ex.data, ex.valid_data, **ex.kwargs) from None
 
-            # Set the 'validate' parameter to `False`, assuming that if a
+            # Set the 'validate' parameter to False, assuming that if a
             # subclass has been validated, it superclasses will also be valid.
             return init_method(self, **kwargs, validate=False)
 
@@ -255,7 +255,7 @@ def bind_schema(schema):
 
     Note:
         By default, models decorated with this decorator are validated during
-        instantiation. If `validate=False` is passed to the constructor, this
+        instantiation. If ``validate=False`` is passed to the constructor, this
         validation will not be performed.
 
     Raises:

--- a/test/python/validation/test_models.py
+++ b/test/python/validation/test_models.py
@@ -164,3 +164,9 @@ class TestModels(QiskitTestCase):
         self.assertEqual(book.to_dict(),
                          {'title': 'A Book',
                           'author': {'name': 'Foo', 'other': 'bar'}})
+
+    def test_instantiate_no_validation(self):
+        """Test model instantiation without validation."""
+        person = Person(name='Foo', birth_date='INVALID', validate=False)
+        self.assertEqual(person.name, 'Foo')
+        self.assertEqual(person.birth_date, 'INVALID')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As explored with @ajavadia , this PR introduces a way of opting-in for not performing validation when creating an instance of a `BaseModel`, intended for cases where the creator of the object has strong assurances about its validity. It does so by using a `validate=False` argument to the instantiation, which is treated as a special flag swallowed by the binder - a side effect is that it becomes sort of a reserved word.

Additionally, it revises some of the docstrings that were not accurate enough as a result of #3084 and others.

### Details and comments


