### PR TITLE
Disable QasmQobjInstruction validation during circuit assembly.

### DIFF
--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -116,7 +116,8 @@ def assemble_circuits(circuits, run_config, qobj_id, qobj_header):
                                                        mask="0x%X" % mask,
                                                        relation='==',
                                                        val="0x%X" % val,
-                                                       register=conditional_reg_idx)
+                                                       register=conditional_reg_idx,
+                                                       validate=False)
                 instructions.append(conversion_bfunc)
                 instruction.conditional = conditional_reg_idx
                 max_conditional_idx += 1

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -222,7 +222,7 @@ class Instruction:
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""
-        instruction = QasmQobjInstruction(name=self.name)
+        instruction = QasmQobjInstruction(name=self.name, validate=False)
         # Evaluate parameters
         if self.params:
             params = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Following #3368 , disables on-init validation of `QasmQobjInstruction` during `assemble_circuits`.

```
$ asv continuous --bench assembl master assemble_circuits-disable-instruction-validation
...
       before           after         ratio
     [2ad7a666]       [45740444]
     <master>         <assemble_circuits-disable-instruction-validation>
-     1.26±0.06ms         584±10μs     0.46  assembler.AssemblerBenchmarks.time_assemble_circuit(1, 8)
-     4.50±0.07ms       1.55±0.2ms     0.34  assembler.AssemblerBenchmarks.time_assemble_circuit(8, 8)
-      2.11±0.5ms         701±20μs     0.33  assembler.AssemblerBenchmarks.time_assemble_circuit(2, 8)
-     2.95±0.03ms         966±80μs     0.33  assembler.AssemblerBenchmarks.time_assemble_circuit(5, 8)
-        383±10ms        96.2±10ms     0.25  assembler.AssemblerBenchmarks.time_assemble_circuit(8, 1024)
-        969±10ms         204±20ms     0.21  assembler.AssemblerBenchmarks.time_assemble_circuit(5, 4096)
-      32.9±0.6ms       6.86±0.2ms     0.21  assembler.AssemblerBenchmarks.time_assemble_circuit(5, 128)
-        48.4±1ms       9.94±0.5ms     0.21  assembler.AssemblerBenchmarks.time_assemble_circuit(8, 128)
-        777±40ms         156±10ms     0.20  assembler.AssemblerBenchmarks.time_assemble_circuit(8, 2048)
-      1.55±0.04s          309±5ms     0.20  assembler.AssemblerBenchmarks.time_assemble_circuit(8, 4096)
-        499±20ms         98.9±4ms     0.20  assembler.AssemblerBenchmarks.time_assemble_circuit(5, 2048)
-        17.9±1ms      3.53±0.07ms     0.20  assembler.AssemblerBenchmarks.time_assemble_circuit(2, 128)
-         256±3ms         49.2±2ms     0.19  assembler.AssemblerBenchmarks.time_assemble_circuit(5, 1024)
-         129±4ms         24.5±1ms     0.19  assembler.AssemblerBenchmarks.time_assemble_circuit(2, 1024)
-        13.6±2ms       2.57±0.3ms     0.19  assembler.AssemblerBenchmarks.time_assemble_circuit(1, 128)
-        341±20ms         63.2±4ms     0.19  assembler.AssemblerBenchmarks.time_assemble_circuit(1, 4096)
-         168±7ms       30.6±0.2ms     0.18  assembler.AssemblerBenchmarks.time_assemble_circuit(1, 2048)
-       92.0±20ms         16.4±3ms     0.18  assembler.AssemblerBenchmarks.time_assemble_circuit(1, 1024)
-         537±6ms         95.0±3ms     0.18  assembler.AssemblerBenchmarks.time_assemble_circuit(2, 4096)
-        281±20ms         48.2±1ms     0.17  assembler.AssemblerBenchmarks.time_assemble_circuit(2, 2048)
```

### Details and comments


