### PR TITLE
Supress config warnings in visualization and jupyter tools

### DIFF
--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -14,6 +14,7 @@
 # pylint: disable=invalid-name
 
 """A module for monitoring backends."""
+import warnings
 
 import types
 import math
@@ -136,7 +137,10 @@ def config_tab(backend):
         grid: A GridBox widget.
     """
     status = backend.status().to_dict()
+    # TODO: remove filters when dt warnings are removed
+    warnings.filterwarnings("ignore")
     config = backend.configuration().to_dict()
+    warnings.resetwarnings()
 
     config_dict = {**status, **config}
 
@@ -158,6 +162,13 @@ def config_tab(backend):
     if 'hamiltonian' in lower_list:
         htex = config_dict['hamiltonian']['h_latex']
         config_dict['hamiltonian'] = "$$%s$$" % htex
+
+    # Can also be removed when dt warnings are removed
+    lower_list.remove('_dt')
+    lower_list.remove('_dtm')
+
+    config_dict['dt'] = "{} s".format(config_dict['dt'])
+    config_dict['dtm'] = "{} s".format(config_dict['dtm'])
 
     upper_str = "<table>"
     upper_str += """<style>

--- a/qiskit/tools/jupyter/backend_overview.py
+++ b/qiskit/tools/jupyter/backend_overview.py
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 """A module for monitoring backends."""
+import warnings
 
 import time
 import threading
@@ -125,7 +126,10 @@ class GridBox_with_thread(widgets.GridBox):  # pylint: disable=invalid-name
 def backend_widget(backend):
     """Creates a backend widget.
     """
+    # TODO: remove filters when dt warnings are removed
+    warnings.filterwarnings("ignore")
     config = backend.configuration().to_dict()
+    warnings.resetwarnings()
     props = backend.properties().to_dict()
 
     name = widgets.HTML(value="<h4>{name}</h4>".format(name=backend.name()),

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 """A module for visualizing device coupling maps"""
+import warnings
 
 import math
 import numpy as np
@@ -374,7 +375,11 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True):
     color_map = cm.viridis
 
     props = backend.properties().to_dict()
+
+    # TODO: remove filters when dt warnings are removed
+    warnings.filterwarnings("ignore")
     config = backend.configuration().to_dict()
+    warnings.resetwarnings()
 
     n_qubits = config['n_qubits']
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #3369 

### Details and comments

Not beautiful. This was simpler than modifying `config.to_dict`. Luckily, it's temporary. The warnings, the private vars, and these `filterwarnings` can all be removed after 2 release cycles.

