### PR TITLE
avoid hard set QISKIT_IN_PARALLEL, sometime can improve hundreds of times

### DIFF
--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -58,7 +58,7 @@ from qiskit.util import local_hardware_info
 from qiskit.tools.events.pubsub import Publisher
 
 # Set parallel flag
-if os.environ.get('QISKIT_IN_PARALLEL', None) == None:
+if os.environ.get('QISKIT_IN_PARALLEL', None) is None:
     os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
 
 # Number of local physical cpus

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -58,7 +58,7 @@ from qiskit.util import local_hardware_info
 from qiskit.tools.events.pubsub import Publisher
 
 # Set parallel flag
-os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
+# os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
 
 # Number of local physical cpus
 CPU_COUNT = local_hardware_info()['cpus']

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -61,7 +61,6 @@ from qiskit.tools.events.pubsub import Publisher
 if os.environ.get('QISKIT_IN_PARALLEL', None) == None:
     os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
 
-
 # Number of local physical cpus
 CPU_COUNT = local_hardware_info()['cpus']
 

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -58,7 +58,9 @@ from qiskit.util import local_hardware_info
 from qiskit.tools.events.pubsub import Publisher
 
 # Set parallel flag
-# os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
+if os.environ.get('QISKIT_IN_PARALLEL', None) == None:
+    os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
+
 
 # Number of local physical cpus
 CPU_COUNT = local_hardware_info()['cpus']

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -113,19 +113,19 @@ def parallel_map(  # pylint: disable=dangerous-default-value
             except queue.Empty:
                 pass
 
-    parallel_counts = os.environ.get('QISKIT_PARALLEL_COUNTS', 1)
     input_queue = queue.Queue(maxsize=0)
     output_queue = queue.Queue(maxsize=0)
     for value in values:
         input_queue.put((task, (value,) + task_args, task_kwargs, _callback))
 
     # start executors
-    _executors = futures.ThreadPoolExecutor(max_workers=parallel_counts)
+    _executors = futures.ThreadPoolExecutor(max_workers=num_processes)
     _futures = [_executors.submit(task_executor, input_queue, output_queue)
-                for _ in range(parallel_counts)]
+                for _ in range(num_processes)]
 
     # wait executors to finish
-    [_future.result(timeout=None) for _future in _futures]
+    for _future in _futures:
+        _future.result(timeout=None)
 
     results = []
     while not output_queue.empty():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the CONTRIBUTING document.
-->

### Summary
avoid hard set QISKIT_IN_PARALLEL. Then users can set this environment for different cases.


### Details and comments
Currently qiskit-terra hardly set QISKIT_IN_PARALLEL=False to start parallel_map. However parallel_map frequently is not efficient for small calculations, sometimes is very inefficient. The reason is that parallel_map is using multprocessing pool and the communication between linux processes is very slow.

Below is one example. we call the same function in qsvm method. With multiple processes, it will take about 48 hours to calculate overlaps with 1.2M circuit results. When disabling multiple processes, it can finish in 5 minutes.

https://github.com/Qiskit/qiskit-aqua/blob/0.6.1/qiskit/aqua/algorithms/many_sample/qsvm/qsvm.py#L252-L259

1) enable parallel_map with multiple process
DEBUG:qiskit.aqua.algorithms.many_sample.qsvm.qsvm:Calculating overlap:
|--------------------------------------------------| 0/1279200 []DEBUG:root:QISKIT_IN_PARALLEL: FALSE
DEBUG:root:Using process pool with 6 processes
|--------------------------------------------------| 855/1279200 [01:23:39:17]

2) with parallel_map without multiple process
DEBUG:qiskit.aqua.algorithms.many_sample.qsvm.qsvm:Calculating overlap:
|--------------------------------------------------| 0/1279200 []DEBUG:root:QISKIT_IN_PARALLEL: TRUE
|¨¨------------------------------------------------| 56569/12^C200 [00:00:05:03]

