### PR TITLE
a less noisy test_deprecated

### DIFF
--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -42,14 +42,14 @@ class TestBasicAerBackends(providers.ProviderTestCase):
 
         deprecated_names = BasicAer._deprecated_backend_names()
         for oldname, newname in deprecated_names.items():
+            expected = "WARNING:qiskit.providers.providerutils:Backend '%s' is deprecated. " \
+                       "Use '%s'." % (oldname, newname)
             with self.subTest(oldname=oldname, newname=newname):
-                with self.assertLogs('qiskit.providers.providerutils', level='WARNING') as cm:
+                with self.assertLogs('qiskit.providers.providerutils', level='WARNING') as context:
                     resolved_newname = _get_first_available_backend(BasicAer, newname)
                     real_backend = BasicAer.get_backend(resolved_newname)
                     self.assertEqual(BasicAer.backends(oldname)[0], real_backend)
-                expected = "WARNING:qiskit.providers.providerutils:Backend '%s' is deprecated. " \
-                           "Use '%s'." % (oldname, newname)
-                self.assertEqual(cm.output, [expected])
+                self.assertEqual(context.output, [expected])
 
     def test_aliases_fail(self):
         """Test a failing backend lookup."""

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -43,14 +43,13 @@ class TestBasicAerBackends(providers.ProviderTestCase):
         deprecated_names = BasicAer._deprecated_backend_names()
         for oldname, newname in deprecated_names.items():
             with self.subTest(oldname=oldname, newname=newname):
-                try:
+                with self.assertLogs('qiskit.providers.providerutils', level='WARNING') as cm:
                     resolved_newname = _get_first_available_backend(BasicAer, newname)
                     real_backend = BasicAer.get_backend(resolved_newname)
-                except QiskitBackendNotFoundError:
-                    # The real name of the backend might not exist
-                    pass
-                else:
                     self.assertEqual(BasicAer.backends(oldname)[0], real_backend)
+                expected = "WARNING:qiskit.providers.providerutils:Backend '%s' is deprecated. " \
+                           "Use '%s'." % (oldname, newname)
+                self.assertEqual(cm.output, [expected])
 
     def test_aliases_fail(self):
         """Test a failing backend lookup."""


### PR DESCRIPTION
I noticed that `test.python.basicaer.test_basicaer_backends.TestBasicAerBackends.test_deprecated` was printing log when tested: 
```
test_deprecated (test.python.basicaer.test_basicaer_backends.TestBasicAerBackends)
Test that deprecated names map the same backends as the new names. ... Backend 'qasm_simulator_py' is deprecated. Use 'qasm_simulator'.
Backend 'statevector_simulator_py' is deprecated. Use 'statevector_simulator'.
Backend 'unitary_simulator_py' is deprecated. Use 'unitary_simulator'.
Backend 'local_qasm_simulator_py' is deprecated. Use 'qasm_simulator'.
Backend 'local_statevector_simulator_py' is deprecated. Use 'statevector_simulator'.
Backend 'local_unitary_simulator_py' is deprecated. Use 'unitary_simulator'.
Backend 'local_unitary_simulator' is deprecated. Use 'unitary_simulator'.
ok
```

This PR silents that and makes sure that the logger does the right thing.