### PR TITLE
Result marginal counts

### DIFF
--- a/qiskit/result/__init__.py
+++ b/qiskit/result/__init__.py
@@ -28,3 +28,4 @@ Experiment Results (:mod:`qiskit.result`)
 
 from .result import Result
 from .exceptions import ResultError
+from .utils import marginal_counts

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -23,9 +23,11 @@ def _hex_to_bin(hexstring):
     """Convert hexadecimal readouts (memory) to binary readouts."""
     return str(bin(int(hexstring, 16)))[2:]
 
+
 def _bin_to_hex(bitstring):
     """Convert bitstring readouts (memory) to hexadecimal readouts."""
     return hex(int(bitstring, 2))
+
 
 def _pad_zeros(bitstring, memory_slots):
     """If the bitstring is truncated, pad extra zeros to make its

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -23,6 +23,9 @@ def _hex_to_bin(hexstring):
     """Convert hexadecimal readouts (memory) to binary readouts."""
     return str(bin(int(hexstring, 16)))[2:]
 
+def _bin_to_hex(bitstring):
+    """Convert bitstring readouts (memory) to hexadecimal readouts."""
+    return hex(int(bitstring, 2))
 
 def _pad_zeros(bitstring, memory_slots):
     """If the bitstring is truncated, pad extra zeros to make its

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -37,7 +37,7 @@ class Result(BaseModel):
         job_id (str): unique execution id from the backend.
         success (bool): True if complete input qobj executed correctly. (Implies
             each experiment success)
-        results (ExperimentResult): corresponding results for array of
+        results (list[ExperimentResult]): corresponding results for array of
             experiments of the input qobj
     """
 

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -14,6 +14,9 @@
 
 """Model for schema-conformant Results."""
 
+from functools import reduce
+from re import match
+
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.pulse.schedule import Schedule
 from qiskit.exceptions import QiskitError
@@ -183,13 +186,13 @@ class Result(BaseModel):
         except KeyError:
             raise QiskitError('No counts for experiment "{0}"'.format(experiment))
 
-    def get_marginal_counts(self, experiment=None, clbits=None, pad_zeros=False):
-        """Get histogram data of an experiment, marginalized over classical bits of interest.
+    def get_marginal_counts(self, experiment=None, indices=None, pad_zeros=False):
+        """Get histogram data of an experiment, marginalized over indices of interest.
 
         Args:
             experiment (str or QuantumCircuit or Schedule or int or None): the index of the
                 experiment, as specified by ``get_data()``.
-            clbits (list(int) or None): the bit positions of interest to NOT marinalize over.
+            indices (list(int) or None): the bit positions of interest to NOT marinalize over.
                 If None, do not marginalize at all.
             pad_zeros (Bool): Include zero count outcomes in return dict.
 
@@ -198,38 +201,43 @@ class Result(BaseModel):
                 only account for frequency of observations of bits of interest.
         """
         counts = self.get_counts(experiment)
-        if clbits is None:  # all measured
-            return counts
 
-        # Extract total number of qubits from first count key
+        # Extract total number of clbits from first count key
         # We trim the whitespace seperating classical registers
         # and count the number of digits
-        num_qubits = len(next(iter(counts)).replace(' ', ''))
+        num_clbits = len(next(iter(counts)).replace(' ', ''))
 
         # Check if we do not need to marginalize. In this case we just trim
         # whitespace from count keys
-        if num_qubits == len(clbits) or (clbits is True):
+        if (indices is None) or set(range(num_clbits)) == set(indices):
             ret = {}
             for key, val in counts.items():
                 key = key.replace(' ', '')
                 ret[key] = val
             return ret
 
-        # Sort the measured qubits into decending order
-        # Since bitstrings have qubit-0 as least significant bit
-        qs = sorted(clbits, reverse=True)
+        if not set(indices).issubset(set(range(num_clbits))):
+            raise QiskitError('indices must be in range [0, {0}].'.format(num_clbits-1))
 
-        # Generate bitstring keys for measured qubits
-        meas_keys = count_keys(len(qs))
+        # Sort the indices to keep in decending order
+        # Since bitstrings have qubit-0 as least significant bit
+        qs = sorted(indices, reverse=True)
+
+        # Generate bitstring keys for indices to keep
+        def _count_keys(num_clbits):
+            """Return ordered count keys."""
+            return [bin(j)[2:].zfill(num_clbits)
+                    for j in range(2 ** num_clbits)]
+        meas_keys = _count_keys(len(qs))
 
         # Get regex match strings for suming outcomes of other qubits
         rgx = []
         for key in meas_keys:
-            def helper(x, y):
+            def _helper(x, y):
                 if y in qs:
                     return key[qs.index(y)] + x
                 return '\\d' + x
-            rgx.append(reduce(helper, range(num_qubits), ''))
+            rgx.append(reduce(_helper, range(num_clbits), ''))
 
         # Build the return list
         meas_counts = []
@@ -240,7 +248,7 @@ class Result(BaseModel):
                     c += val
             meas_counts.append(c)
 
-        # Return as counts dict on measured qubits only
+        # Return as counts dict on desired indices only
         if pad_zeros is True:
             return dict(zip(meas_keys, meas_counts))
         ret = {}

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -16,8 +16,6 @@
 
 from functools import reduce
 from re import match
-from qiskit.result import Result
-from qiskit.result.postprocess import _bin_to_hex
 from qiskit.validation.base import Obj
 from qiskit.exceptions import QiskitError
 
@@ -39,6 +37,8 @@ def marginal_counts(result, indices=None):
     Raises:
         QiskitError: in case of invalid indices to marginalize over.
     """
+    from qiskit.result.result import Result
+    from qiskit.result.postprocess import _bin_to_hex
     if isinstance(result, Result):
         for i, experiment_result in enumerate(result.results):
             counts = result.get_counts(i)

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -16,6 +16,7 @@
 
 from functools import reduce
 from re import match
+from qiskit import QiskitError
 
 
 def marginal_counts(counts, indices=None, pad_zeros=False):
@@ -50,17 +51,17 @@ def marginal_counts(counts, indices=None, pad_zeros=False):
 
     # Sort the indices to keep in decending order
     # Since bitstrings have qubit-0 as least significant bit
-    qs = sorted(indices, reverse=True)
+    indices = sorted(indices, reverse=True)
 
     # Generate bitstring keys for indices to keep
-    meas_keys = count_keys(len(qs))
+    meas_keys = count_keys(len(indices))
 
     # Get regex match strings for suming outcomes of other qubits
     rgx = []
     for key in meas_keys:
         def _helper(x, y):
-            if y in qs:
-                return key[qs.index(y)] + x
+            if y in indices:
+                return key[indices.index(y)] + x
             return '\\d' + x
         rgx.append(reduce(_helper, range(num_clbits), ''))
 

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2018.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility functions for working with Results."""
+
+from functools import reduce
+from re import match
+
+
+def marginal_counts(counts, indices=None, pad_zeros=False):
+    """Marginalize counts from an experiment over some indices of interest.
+
+    Args:
+        counts (dict): Counts of some measurement results, to be marginalized.
+        indices (list(int) or None): The bit positions of interest to NOT marinalize over.
+            If None, do not marginalize at all.
+        pad_zeros (Bool): Include zero count outcomes in return dict.
+
+    Returns:
+        dict[str:int]: a dictionary with the observed counts, marginalized to
+            only account for frequency of observations of bits of interest.
+    """
+    # Extract total number of clbits from first count key
+    # We trim the whitespace seperating classical registers
+    # and count the number of digits
+    num_clbits = len(next(iter(counts)).replace(' ', ''))
+
+    # Check if we do not need to marginalize. In this case we just trim
+    # whitespace from count keys
+    if (indices is None) or set(range(num_clbits)) == set(indices):
+        ret = {}
+        for key, val in counts.items():
+            key = key.replace(' ', '')
+            ret[key] = val
+        return ret
+
+    if not set(indices).issubset(set(range(num_clbits))):
+        raise QiskitError('indices must be in range [0, {0}].'.format(num_clbits-1))
+
+    # Sort the indices to keep in decending order
+    # Since bitstrings have qubit-0 as least significant bit
+    qs = sorted(indices, reverse=True)
+
+    # Generate bitstring keys for indices to keep
+    meas_keys = count_keys(len(qs))
+
+    # Get regex match strings for suming outcomes of other qubits
+    rgx = []
+    for key in meas_keys:
+        def _helper(x, y):
+            if y in qs:
+                return key[qs.index(y)] + x
+            return '\\d' + x
+        rgx.append(reduce(_helper, range(num_clbits), ''))
+
+    # Build the return list
+    meas_counts = []
+    for m in rgx:
+        c = 0
+        for key, val in counts.items():
+            if match(m, key.replace(' ', '')):
+                c += val
+        meas_counts.append(c)
+
+    # Return as counts dict on desired indices only
+    if pad_zeros is True:
+        return dict(zip(meas_keys, meas_counts))
+    ret = {}
+    for key, val in zip(meas_keys, meas_counts):
+        if val != 0:
+            ret[key] = val
+    return ret
+
+
+def count_keys(num_clbits):
+    """Return ordered count keys."""
+    return [bin(j)[2:].zfill(num_clbits) for j in range(2 ** num_clbits)]

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -16,7 +16,7 @@
 
 from functools import reduce
 from re import match
-from qiskit import QiskitError
+from qiskit.exceptions import QiskitError
 
 
 def marginal_counts(counts, indices=None, pad_zeros=False):
@@ -31,6 +31,9 @@ def marginal_counts(counts, indices=None, pad_zeros=False):
     Returns:
         dict[str:int]: a dictionary with the observed counts, marginalized to
             only account for frequency of observations of bits of interest.
+
+    Raises:
+        QiskitError: in case of invalid indices to marginalize over.
     """
     # Extract total number of clbits from first count key
     # We trim the whitespace seperating classical registers

--- a/releasenotes/notes/marginal-counts-51108f216cc684d1.yaml
+++ b/releasenotes/notes/marginal-counts-51108f216cc684d1.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    A new method `get_marginal_counts` is added to the Result class
+    A new utility function `qiskit.result.marginal_counts()` is added
     which allows marginalization of the counts over some indices of interest.
     This is useful when more qubits are measured than needed, and one wishes
     to get the observation counts for some subset of them only.

--- a/releasenotes/notes/result-get-marginal-counts-51108f216cc684d1.yaml
+++ b/releasenotes/notes/result-get-marginal-counts-51108f216cc684d1.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    A new method `get_marginal_counts` is added to the Result class
+    which allows marginalization of the counts over some indices of interest.
+    This is useful when more qubits are measured than needed, and one wishes
+    to get the observation counts for some subset of them only.
+deprecations:
+  - |
+    This function replaces a similar utility function in
+    qiskit.ignis.verification.tomography, which will be deprecated.

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -58,6 +58,19 @@ class TestResultOperations(QiskitTestCase):
 
         self.assertEqual(result.get_counts(0), processed_counts)
 
+    def test_marginal_counts(self):
+        """Test that counts are marginalized correctly."""
+        raw_counts = {'0x0': 4, '0x1': 7, '0x2': 10, '0x6': 5, '0x9': 11, '0xD':9, '0xE':8}
+        data = models.ExperimentResultData(counts=base.Obj(**raw_counts))
+        exp_result_header = base.Obj(creg_sizes=[['c0', 4]], memory_slots=4)
+        exp_result = models.ExperimentResult(shots=54, success=True, data=data,
+                                             header=exp_result_header)
+        result = Result(results=[exp_result], **self.base_result_args)
+        expected_marginal_counts = {'00': 4, '01': 27, '10': 23}
+
+        self.assertEqual(result.get_marginal_counts(0, [0,1]), expected_marginal_counts)
+        self.assertEqual(result.get_marginal_counts(0, [1,0]), expected_marginal_counts)
+
     def test_memory_counts_no_header(self):
         """Test that memory bitstrings are extracted properly without header."""
         raw_memory = ['0x0', '0x0', '0x2', '0x2', '0x2', '0x2', '0x2']

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -17,6 +17,7 @@
 import numpy as np
 
 from qiskit.result import models
+from qiskit.result import marginal_counts
 from qiskit.validation import base
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase
@@ -60,7 +61,7 @@ class TestResultOperations(QiskitTestCase):
 
     def test_marginal_counts(self):
         """Test that counts are marginalized correctly."""
-        raw_counts = {'0x0': 4, '0x1': 7, '0x2': 10, '0x6': 5, '0x9': 11, '0xD':9, '0xE':8}
+        raw_counts = {'0x0': 4, '0x1': 7, '0x2': 10, '0x6': 5, '0x9': 11, '0xD': 9, '0xE': 8}
         data = models.ExperimentResultData(counts=base.Obj(**raw_counts))
         exp_result_header = base.Obj(creg_sizes=[['c0', 4]], memory_slots=4)
         exp_result = models.ExperimentResult(shots=54, success=True, data=data,
@@ -68,8 +69,8 @@ class TestResultOperations(QiskitTestCase):
         result = Result(results=[exp_result], **self.base_result_args)
         expected_marginal_counts = {'00': 4, '01': 27, '10': 23}
 
-        self.assertEqual(result.get_marginal_counts(0, [0,1]), expected_marginal_counts)
-        self.assertEqual(result.get_marginal_counts(0, [1,0]), expected_marginal_counts)
+        self.assertEqual(marginal_counts(result.get_counts(), [0, 1]), expected_marginal_counts)
+        self.assertEqual(marginal_counts(result.get_counts(), [1, 0]), expected_marginal_counts)
 
     def test_memory_counts_no_header(self):
         """Test that memory bitstrings are extracted properly without header."""

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -72,6 +72,30 @@ class TestResultOperations(QiskitTestCase):
         self.assertEqual(marginal_counts(result.get_counts(), [0, 1]), expected_marginal_counts)
         self.assertEqual(marginal_counts(result.get_counts(), [1, 0]), expected_marginal_counts)
 
+    def test_marginal_counts_result(self):
+        """Test that a Result object containing counts marginalizes correctly."""
+        raw_counts_1 = {'0x0': 4, '0x1': 7, '0x2': 10, '0x6': 5, '0x9': 11, '0xD': 9, '0xE': 8}
+        data_1 = models.ExperimentResultData(counts=base.Obj(**raw_counts_1))
+        exp_result_header_1 = base.Obj(creg_sizes=[['c0', 4]], memory_slots=4)
+        exp_result_1 = models.ExperimentResult(shots=54, success=True, data=data_1,
+                                               header=exp_result_header_1)
+
+        raw_counts_2 = {'0x2': 5, '0x3': 8}
+        data_2 = models.ExperimentResultData(counts=base.Obj(**raw_counts_2))
+        exp_result_header_2 = base.Obj(creg_sizes=[['c0', 2]], memory_slots=2)
+        exp_result_2 = models.ExperimentResult(shots=13, success=True, data=data_2,
+                                               header=exp_result_header_2)
+
+        result = Result(results=[exp_result_1, exp_result_2], **self.base_result_args)
+
+        expected_marginal_counts_1 = {'00': 4, '01': 27, '10': 23}
+        expected_marginal_counts_2 = {'0': 5, '1': 8}
+
+        self.assertEqual(marginal_counts(result, [0, 1]).get_counts(0),
+                         expected_marginal_counts_1)
+        self.assertEqual(marginal_counts(result, [0]).get_counts(1),
+                         expected_marginal_counts_2)
+
     def test_memory_counts_no_header(self):
         """Test that memory bitstrings are extracted properly without header."""
         raw_memory = ['0x0', '0x0', '0x2', '0x2', '0x2', '0x2', '0x2']


### PR DESCRIPTION
A utility function `qiskit.result.marginal_counts()` to obtain marginalized counts from an experiment where more measurements were done than desired.
I'll later deprecate the method that exists in ignis tomography module (https://github.com/Qiskit/qiskit-ignis/issues/283)