### PR TITLE
[Stable] Add python 3.5 pin for networkx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 jsonschema>=2.6
 marshmallow>=3,<4
 marshmallow_polyfield>=5.7,<6
-networkx>=2.2
+networkx>=2.2;python_version>'3.5'
+# Networkx 2.4 is the final version with python 3.5 support.
+networkx>=2.2,<2.4;python_version=='3.5'
 numpy>=1.13
 ply>=3.10
 psutil>=5

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ REQUIREMENTS = [
     "jsonschema>=2.6",
     "marshmallow>=3,<4",
     "marshmallow_polyfield>=5.7,<6",
-    "networkx>=2.2",
+    "networkx>=2.2;python_version>'3.5'",
+    # Networkx 2.4 is the final version with python 3.5 support.
+    "networkx>=2.2,<2.4;python_version=='3.5'",
     "numpy>=1.13",
     "ply>=3.10",
     "psutil>=5",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the networkx release notes for 2.4 [1] it states clearly that the 2.4
release is the last release with python 3.5 support. Since the release
timeline is not fixed and we may end up support python 3.5 in terra
longer than networkx this adds a capped version of networkx on 2.4 for
python 3.5. However, since networkx 2.4 is seemingly relying on the
guaranteed insertion ordering for dicts introduced in 3.6 for how we're
using topological sort this adjusts the cap previously introduced to be
< 2.4 instead of <= 2.4. This should avoid the failures related to this
on python 3.5 and networx 2.4.

As part of #3280 the networkx version for python 3.5 was pinned to be
< 2.4 as part of a larger refactor of the dag drawer. That refactor is
not eligble for backport to a stable branch because of the likelihood
that it changes behavior in the dag drawer. This commit adds a pin
from that PR without the dag drawer refactor.

### Details and comments

Backported from #3280

[1] https://networkx.github.io/documentation/stable/release/release_2.4.html
