### PR TITLE
Revert #3421 "Set the scale parameter of QuantumCircuit.draw to a default 1"

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -642,7 +642,7 @@ class QuantumCircuit:
             gate._qasm_def_written = False
         return string_temp
 
-    def draw(self, scale=1, filename=None, style=None, output=None,
+    def draw(self, scale=0.7, filename=None, style=None, output=None,
              interactive=False, line_length=None, plot_barriers=True,
              reverse_bits=False, justify=None, vertical_compression='medium', idle_wires=True,
              with_layout=True, fold=None, ax=None):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This reverts commit e276505ffd78dee937d8879fceff9e71d72d5a4a. The scale
parameter default value of 0.7 was chosen intentionally to keep the
image sizes more reasonable, especially inside of jupyter notebooks. This
value of 0.7 is used in several other places as well for this reason. The
issue with the images being cutoff that this was trying to address isn't
because we're scaling the image and it's a more general problem.
Especially when you can consider the images can still be scaled down they
will still experience the same issue. Just increasing the size of the
image isn't a general solution and only fixed it for specific cases. There
is a tight_layout method in matplotlib that should be used to address
images getting truncated which we can look into in adding back in a future
PR.

### Details and comments


