### PR TITLE
Params in controlled gates

### DIFF
--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -188,7 +188,7 @@ def q_if(operation, num_ctrl_qubits=1, label=None):
     new_name = '{0}{1}'.format(ctrl_substr, base_name)
     cgate = controlledgate.ControlledGate(new_name,
                                           instr.num_qubits,
-                                          instr.params,
+                                          operation.params,
                                           label=label,
                                           num_ctrl_qubits=new_num_ctrl_qubits,
                                           definition=instr.definition)

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -671,9 +671,9 @@ class TextDrawing():
         return "= %s" % instruction.condition[1]
 
     @staticmethod
-    def params_for_label(instruction, controlled=False):
+    def params_for_label(instruction):
         """Get the params and format them to add them to a label. None if there
-         are no params of if the params are numpy.ndarrays."""
+         are no params or if the params are numpy.ndarrays."""
         op = instruction.op
         if not hasattr(op, 'params'):
             return None

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -697,7 +697,7 @@ class TextDrawing():
             label = instruction.op.base_gate_name
         else:
             label = instruction.name
-        params = TextDrawing.params_for_label(instruction, controlled=controlled)
+        params = TextDrawing.params_for_label(instruction)
         label = label.capitalize()
         if params:
             label += "(%s)" % ','.join(params)

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -674,11 +674,7 @@ class TextDrawing():
     def params_for_label(instruction, controlled=False):
         """Get the params and format them to add them to a label. None if there
          are no params of if the params are numpy.ndarrays."""
-        if controlled:
-            # TODO Find a way to print parameters for controlled gates
-            return None
-        else:
-            op = instruction.op
+        op = instruction.op
         if not hasattr(op, 'params'):
             return None
         if all([isinstance(param, ndarray) for param in op.params]):

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1615,15 +1615,16 @@ class TestTextControlledGate(QiskitTestCase):
 
     def test_c3u2(self):
         """Controlled Controlled U2"""
-        expected = '\n'.join(["              ",
-                              "q_0: |0>──■───",
-                              "        ┌─┴──┐",
-                              "q_1: |0>┤ U2 ├",
-                              "        └─┬──┘",
-                              "q_2: |0>──■───",
-                              "          │   ",
-                              "q_3: |0>──■───",
-                              "              "])
+        expected = '\n'.join([
+            "                         ",
+            "q_0: |0>────────■────────",
+            "        ┌───────┴───────┐",
+            "q_1: |0>┤ U2(pi,-5pi/8) ├",
+            "        └───────┬───────┘",
+            "q_2: |0>────────■────────",
+            "                │        ",
+            "q_3: |0>────────■────────",
+            "                         "])
         qr = QuantumRegister(4, 'q')
         circuit = QuantumCircuit(qr)
         circuit.append(U2Gate(pi, -5 * pi / 8).q_if(3), [qr[0], qr[3], qr[2], qr[1]])


### PR DESCRIPTION
With the help of @ewinston, we solved a small issue in which the params the `ControlledGate.base_gate` were getting lost. This is the fix. 