### PR TITLE
fix no IBMQ.backends()

### DIFF
--- a/examples/python/ibmq/using_qiskit_terra_level_0.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_0.py
@@ -60,7 +60,7 @@ print(sim_result.get_counts(qc2))
 
 # see a list of available remote backends
 print("\n(IBMQ Backends)")
-print(IBMQ.backends())
+print(IBMQ.providers()[0].backends())
 
 # Compile and run on a real device backend
 try:

--- a/test/python/tools/monitor/test_backend_monitor.py
+++ b/test/python/tools/monitor/test_backend_monitor.py
@@ -46,10 +46,11 @@ class TestBackendOverview(QiskitTestCase):
         IBMQ.enable_account(qe_token, qe_url)
         self.addCleanup(IBMQ.disable_account)
 
-        for back in IBMQ.backends():
-            if not back.configuration().simulator:
-                backend = back
-                break
+        for provider in IBMQ.providers():
+            for back in provider.backends():
+                if not back.configuration().simulator:
+                    backend = back
+                    break
         with patch('sys.stdout', new=StringIO()) as fake_stdout:
             backend_monitor(backend)
 


### PR DESCRIPTION
in the new release of IBMQ, the .backends() method no longer exists and this is on individual providers. Tweak terra to match.