### PR TITLE
Revert "Schedule: deprecate channels_to_plot parameter and use channels instead"

### DIFF
--- a/qiskit/pulse/commands/instruction.py
+++ b/qiskit/pulse/commands/instruction.py
@@ -194,8 +194,7 @@ class Instruction(ScheduleComponent):
              scaling: float = 1, channels_to_plot: Optional[List[Channel]] = None,
              plot_all: bool = False, plot_range: Optional[Tuple[float]] = None,
              interactive: bool = False, table: bool = True,
-             label: bool = False, framechange: bool = True,
-             channels: Optional[List[Channel]] = None):
+             label: bool = False, framechange: bool = True):
         """Plot the instruction.
 
         Args:
@@ -204,7 +203,7 @@ class Instruction(ScheduleComponent):
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scaling: Relative visual scaling of waveform amplitudes
-            channels_to_plot: Deprecated, see `channels`
+            channels_to_plot: A list of channel names to plot
             plot_all: Plot empty channels
             plot_range: A tuple of time range to plot
             interactive: When set true show the circuit in a new window
@@ -212,7 +211,6 @@ class Instruction(ScheduleComponent):
             table: Draw event table for supported commands
             label: Label individual instructions
             framechange: Add framechange indicators
-            channels: A list of channel names to plot
 
 
         Returns:
@@ -222,17 +220,12 @@ class Instruction(ScheduleComponent):
 
         from qiskit import visualization
 
-        if channels_to_plot:
-            warnings.warn('The parameter "channels_to_plot" is being replaced by "channels"',
-                          DeprecationWarning, 3)
-            channels = channels_to_plot
-
         return visualization.pulse_drawer(self, dt=dt, style=style,
                                           filename=filename, interp_method=interp_method,
-                                          scaling=scaling, plot_all=plot_all,
-                                          plot_range=plot_range, interactive=interactive,
-                                          table=table, label=label,
-                                          framechange=framechange, channels=channels)
+                                          scaling=scaling, channels_to_plot=channels_to_plot,
+                                          plot_all=plot_all, plot_range=plot_range,
+                                          interactive=interactive, table=table,
+                                          label=label, framechange=framechange)
 
     def __eq__(self, other: 'Instruction'):
         """Check if this Instruction is equal to the `other` instruction.

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -355,7 +355,7 @@ class Schedule(ScheduleComponent):
              scaling: float = None, channels_to_plot: Optional[List[Channel]] = None,
              plot_all: bool = False, plot_range: Optional[Tuple[float]] = None,
              interactive: bool = False, table: bool = True, label: bool = False,
-             framechange: bool = True, channels: Optional[List[Channel]] = None):
+             framechange: bool = True):
         """Plot the schedule.
 
         Args:
@@ -364,7 +364,7 @@ class Schedule(ScheduleComponent):
             filename: Name required to save pulse image
             interp_method: A function for interpolation
             scaling: Relative visual scaling of waveform amplitudes
-            channels_to_plot: Deprecated, see `channels`
+            channels_to_plot: A list of channel names to plot
             plot_all: Plot empty channels
             plot_range: A tuple of time range to plot
             interactive: When set true show the circuit in a new window
@@ -372,7 +372,6 @@ class Schedule(ScheduleComponent):
             table: Draw event table for supported commands
             label: Label individual instructions
             framechange: Add framechange indicators
-            channels: A list of channel names to plot
 
         Returns:
             matplotlib.figure: A matplotlib figure object of the pulse schedule.
@@ -381,17 +380,12 @@ class Schedule(ScheduleComponent):
 
         from qiskit import visualization
 
-        if channels_to_plot:
-            warnings.warn('The parameter "channels_to_plot" is being replaced by "channels"',
-                          DeprecationWarning, 3)
-            channels = channels_to_plot
-
         return visualization.pulse_drawer(self, dt=dt, style=style,
                                           filename=filename, interp_method=interp_method,
-                                          scaling=scaling, plot_all=plot_all,
-                                          plot_range=plot_range, interactive=interactive,
-                                          table=table, label=label,
-                                          framechange=framechange, channels=channels)
+                                          scaling=scaling, channels_to_plot=channels_to_plot,
+                                          plot_all=plot_all, plot_range=plot_range,
+                                          interactive=interactive, table=table,
+                                          label=label, framechange=framechange)
 
     def __eq__(self, other: ScheduleComponent) -> bool:
         """Test if two ScheduleComponents are equal.

--- a/qiskit/visualization/pulse_visualization.py
+++ b/qiskit/visualization/pulse_visualization.py
@@ -17,7 +17,6 @@
 """
 matplotlib pulse visualization.
 """
-import warnings
 
 from qiskit.pulse import Schedule, Instruction, SamplePulse
 from qiskit.visualization.exceptions import VisualizationError
@@ -30,8 +29,7 @@ if _matplotlib.HAS_MATPLOTLIB:
 def pulse_drawer(data, dt=1, style=None, filename=None,
                  interp_method=None, scaling=None, channels_to_plot=None,
                  plot_all=False, plot_range=None, interactive=False,
-                 table=True, label=False, framechange=True,
-                 channels=None):
+                 table=True, label=False, framechange=True):
     """Plot the interpolated envelope of pulse
 
     Args:
@@ -43,7 +41,7 @@ def pulse_drawer(data, dt=1, style=None, filename=None,
         interp_method (Callable): interpolation function
             See `qiskit.visualization.interpolation` for more information
         scaling (float): scaling of waveform amplitude
-        channels_to_plot (list): Deprecated, see `channels`
+        channels_to_plot (list): A list of channel names to plot
         plot_all (bool): Plot empty channels
         plot_range (tuple): A tuple of time range to plot
         interactive (bool): When set true show the circuit in a new window
@@ -51,7 +49,6 @@ def pulse_drawer(data, dt=1, style=None, filename=None,
         table (bool): Draw event table for supported commands
         label (bool): Label individual instructions
         framechange (bool): Add framechange indicators
-        channels (list): A list of channel names to plot
 
     Returns:
         matplotlib.figure: A matplotlib figure object for the pulse envelope
@@ -60,11 +57,6 @@ def pulse_drawer(data, dt=1, style=None, filename=None,
         VisualizationError: when invalid data is given or lack of information
         ImportError: when matplotlib is not installed
     """
-    if channels_to_plot:
-        warnings.warn('The parameter "channels_to_plot" is being replaced by "channels"',
-                      DeprecationWarning, 3)
-        channels = channels_to_plot
-
     if not _matplotlib.HAS_MATPLOTLIB:
         raise ImportError('Must have Matplotlib installed.')
     if isinstance(data, SamplePulse):
@@ -73,8 +65,9 @@ def pulse_drawer(data, dt=1, style=None, filename=None,
     elif isinstance(data, (Schedule, Instruction)):
         drawer = _matplotlib.ScheduleDrawer(style=style)
         image = drawer.draw(data, dt=dt, interp_method=interp_method, scaling=scaling,
-                            plot_range=plot_range, plot_all=plot_all, table=table,
-                            label=label, framechange=framechange, channels=channels)
+                            plot_range=plot_range, channels_to_plot=channels_to_plot,
+                            plot_all=plot_all, table=table, label=label,
+                            framechange=framechange)
     else:
         raise VisualizationError('This data cannot be visualized.')
 


### PR DESCRIPTION
Reverts Qiskit/qiskit-terra#3394

Closes #3471 

This PR broke the schedule drawer. I am reverting and please redo the PR making sure that the `schedule.draw()` works. 

All the pulse visualization tests are skipped by default, which is why this was not caught.