### PR TITLE
added y axis ticks to schedule.draw()

### DIFF
--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -536,9 +536,9 @@ class ScheduleDrawer:
                 continue
 
             # plot label
-            ax.text(x=0, y=y0, s=channel.name,
+            ax.text(x=0.5, y=y0, s=channel.name,
                     fontsize=self.style.axis_font_size,
-                    ha='right', va='center')
+                    ha='left', va='bottom')
 
             # change the y0 offset for removing spacing when a channel has negative values
             if self.style.remove_spacing:
@@ -572,6 +572,7 @@ class ScheduleDrawer:
         Raises:
             VisualizationError: when schedule cannot be drawn
         """
+
         figure = plt.figure()
 
         if channels_to_plot is not None:
@@ -624,6 +625,6 @@ class ScheduleDrawer:
 
         ax.set_xlim(t0 * dt, tf * dt)
         ax.set_ylim(y0, 1)
-        ax.set_yticklabels([])
+        ax.set_yticks(ax.get_yticks())
 
         return figure

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -572,7 +572,6 @@ class ScheduleDrawer:
         Raises:
             VisualizationError: when schedule cannot be drawn
         """
-
         figure = plt.figure()
 
         if channels_to_plot is not None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3485 

### Details and comments

Y ticks are now displayed (before the change, no ticks will be displayed with the empty array in the parameter). As a result of this I had to shift the channel labels over. 

<img width="658" alt="Screen Shot 2019-11-20 at 2 10 05 PM" src="https://user-images.githubusercontent.com/54714046/69211058-1f898300-0ba0-11ea-9f4d-eb88cea0a88d.png">
