### PR TITLE
Fixed noise adaptive layout choosing 0 reliability cx

### DIFF
--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -91,7 +91,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
                     else:
                         g_reliab = 1.0
                 swap_reliab = pow(g_reliab, 3)
-                swap_reliab = -math.log(swap_reliab) if swap_reliab != 0 else -math.inf
+                swap_reliab = -math.log(swap_reliab) if swap_reliab != 0 else math.inf
                 self.swap_graph.add_edge(ginfo.qubits[0], ginfo.qubits[1], weight=swap_reliab)
                 self.swap_graph.add_edge(ginfo.qubits[1], ginfo.qubits[0], weight=swap_reliab)
                 self.cx_reliability[(ginfo.qubits[0], ginfo.qubits[1])] = g_reliab

--- a/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/mapping/noise_adaptive_layout.py
@@ -91,7 +91,8 @@ class NoiseAdaptiveLayout(AnalysisPass):
                     else:
                         g_reliab = 1.0
                 swap_reliab = pow(g_reliab, 3)
-                # convert swap reliability to edge weight for Floyd-Warshall shortest weighted paths algorithm
+                # convert swap reliability to edge weight
+                # for the Floyd-Warshall shortest weighted paths algorithm
                 swap_cost = -math.log(swap_reliab) if swap_reliab != 0 else math.inf
                 self.swap_graph.add_edge(ginfo.qubits[0], ginfo.qubits[1], weight=swap_cost)
                 self.swap_graph.add_edge(ginfo.qubits[1], ginfo.qubits[0], weight=swap_cost)


### PR DESCRIPTION
Changed swap_reliab of swap graph edges with 0 reliability from -math.inf to math.inf

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixed issue   #3517 

### Details and comments

Fixed the issue where a cx with 0 reliability would be always choosed by the `NoiseAdaptiveLayout` trasnpiler pass.
