### PR TITLE
Fix parallel flags

### DIFF
--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -127,10 +127,10 @@ def parallel_map(  # pylint: disable=dangerous-default-value
         except (KeyboardInterrupt, Exception) as error:
             if isinstance(error, KeyboardInterrupt):
                 Publisher().publish("terra.parallel.finish")
-                os.environ['QISKIT_IN_PARALLEL'] = 'False'
+                os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
                 raise QiskitError('Keyboard interrupt in parallel_map.')
             # Otherwise just reset parallel flag and error
-            os.environ['QISKIT_IN_PARALLEL'] = 'False'
+            os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
             raise error
 
         Publisher().publish("terra.parallel.finish")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Some of the reset flags for parallel were `False` rather than `FALSE` as they should be.


### Details and comments


