### PR TITLE
Remove implicit string cast of the snapshot label

### DIFF
--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -115,12 +115,6 @@ def snapshot(self,
     Raises:
         ExtensionError: malformed command
     """
-    # Convert label to string for backwards compatibility
-    if not isinstance(label, str):
-        warnings.warn(
-            "Snapshot label should be a string, "
-            "implicit conversion is depreciated.", DeprecationWarning)
-        label = str(label)
     # If no qubits are specified we add all qubits so it acts as a barrier
     # This is needed for full register snapshots like statevector
     if isinstance(qubits, QuantumRegister):

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -15,8 +15,6 @@
 Simulator command to snapshot internal simulator representation.
 """
 
-import warnings
-
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.instruction import Instruction

--- a/releasenotes/notes/remove_implicit_conversion_snapshot_label-f3082561ede0bed5.yaml
+++ b/releasenotes/notes/remove_implicit_conversion_snapshot_label-f3082561ede0bed5.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The instruction ``snapshot`` used to implicitly convert the ``label`` parameter to string. That convertion has been removed and an error is raised if a string is not provided.


### PR DESCRIPTION
The label has to be a string. The warning with the cast is being removed after 7 months of being there.