### PR TITLE
Replaced relative imports with absolute imports in visualization tests.

### DIFF
--- a/test/python/visualization/test_circuit_matplotlib_drawer.py
+++ b/test/python/visualization/test_circuit_matplotlib_drawer.py
@@ -20,7 +20,7 @@ import os
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit import visualization
 
-from .visualization import QiskitVisualizationTestCase
+from test.python.visualization.visualization import QiskitVisualizationTestCase
 
 if visualization.HAS_MATPLOTLIB:
     from matplotlib import pyplot as plt

--- a/test/python/visualization/test_circuit_visualization_output.py
+++ b/test/python/visualization/test_circuit_visualization_output.py
@@ -24,7 +24,7 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 from qiskit.tools.visualization import HAS_MATPLOTLIB, circuit_drawer
 
-from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
+from test.python.visualization.visualization import QiskitVisualizationTestCase, path_to_diagram_reference
 
 
 class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -23,7 +23,7 @@ from qiskit.visualization.gate_map import _GraphDist, plot_gate_map, plot_circui
 from qiskit.tools.visualization import HAS_MATPLOTLIB
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import Layout
-from .visualization import path_to_diagram_reference, QiskitVisualizationTestCase
+from test.python.visualization.visualization import path_to_diagram_reference, QiskitVisualizationTestCase
 
 if HAS_MATPLOTLIB:
     import matplotlib.pyplot as plt

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -30,7 +30,7 @@ from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
 from qiskit.transpiler.passes import RemoveResetInZeroState
 
-from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
+from test.python.visualization.visualization import QiskitVisualizationTestCase, path_to_diagram_reference
 
 try:
     import subprocess

--- a/test/python/visualization/test_pulse_visualization_output.py
+++ b/test/python/visualization/test_pulse_visualization_output.py
@@ -26,7 +26,7 @@ from qiskit.pulse.commands import FrameChange, Acquire, PersistentValue, Snapsho
 from qiskit.pulse.schedule import Schedule
 from qiskit.pulse import pulse_lib
 
-from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
+from test.python.visualization.visualization import QiskitVisualizationTestCase, path_to_diagram_reference
 
 
 class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Relative imports were causing some visualization tests to fail with errors.


### Details and comments
Example of the import error:
```
======================================================================
ERROR: test_circuit_visualization_output (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_circuit_visualization_output
Traceback (most recent call last):
  File "/Users/scottwn/miniconda3/envs/QiskitDevenv/lib/python3.7/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Users/scottwn/miniconda3/envs/QiskitDevenv/lib/python3.7/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/Users/scottwn/qiskit-terra/test/python/visualization/test_circuit_visualization_output.py", line 27, in <module>
    from .visualization import QiskitVisualizationTestCase, path_to_diagram_reference
ImportError: attempted relative import with no known parent package
```

