### PR TITLE
Decompose substitute_node only when gate width matches definition.

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -886,7 +886,7 @@ class DAGCircuit:
         ):
             raise DAGCircuitError(
                 'Cannot replace node of width ({} qubits, {} clbits) with '
-                'instruction of mismatched with ({} qubits, {} clbits).'.format(
+                'instruction of mismatched width ({} qubits, {} clbits).'.format(
                     node.op.num_qubits, node.op.num_clbits,
                     op.num_qubits, op.num_clbits))
 

--- a/qiskit/transpiler/passes/decompose.py
+++ b/qiskit/transpiler/passes/decompose.py
@@ -47,7 +47,7 @@ class Decompose(TransformationPass):
             # TODO: allow choosing among multiple decomposition rules
             rule = node.op.definition
 
-            if len(rule) == 1:
+            if len(rule) == 1 and len(node.qargs) == len(rule[0][1]):
                 dag.substitute_node(node, rule[0][0], inplace=True)
             else:
                 # hacky way to build a dag on the same register as the rule is defined

--- a/test/python/circuit/test_isometry.py
+++ b/test/python/circuit/test_isometry.py
@@ -49,8 +49,13 @@ class TestIsometry(QiskitTestCase):
                 q = QuantumRegister(n)
                 qc = QuantumCircuit(q)
                 qc.iso(iso, q[:num_q_input], q[num_q_input:])
+
+                # Verify the circuit can be decomposed
+                self.assertIsInstance(qc.decompose(), QuantumCircuit)
+
                 # Decompose the gate
                 qc = transpile(qc, basis_gates=['u1', 'u3', 'u2', 'cx', 'id'])
+
                 # Simulate the decomposed gate
                 simulator = BasicAer.get_backend('unitary_simulator')
                 result = execute(qc, simulator).result()

--- a/test/python/transpiler/test_decompose.py
+++ b/test/python/transpiler/test_decompose.py
@@ -88,3 +88,17 @@ class TestDecompose(QiskitTestCase):
         ref_dag = circuit_to_dag(ref_circuit)
 
         self.assertEqual(after_dag, ref_dag)
+
+    def test_decompose_oversized_instruction(self):
+        """Test decompose on a single-op gate that doesn't use all qubits."""
+        # ref: https://github.com/Qiskit/qiskit-terra/issues/3440
+        qc1 = QuantumCircuit(2)
+        qc1.x(0)
+        gate = qc1.to_gate()
+
+        qc2 = QuantumCircuit(2)
+        qc2.append(gate, [0, 1])
+
+        output = qc2.decompose()
+
+        self.assertEqual(qc1, output)


### PR DESCRIPTION
Fixes #3440 

When #3233 was implemented, a check was added to the unroller to ensure that, before using `DAGCircuit.substitute_node`,  the definition width matched that of the instruction being replaced, but this fix was not included in the `Decompose` pass. This PR add that check.

### Summary



### Details and comments


