### PR TITLE
Fix dynamic spacing for gate params in mpl circuit.draw()

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -253,13 +253,15 @@ class MatplotlibDrawer:
                 subtext_len = len(subtext)
                 if '$\\pi$' in subtext:
                     pi_count = subtext.count('pi')
-                    subtext_len = subtext_len - (5 * pi_count)
+                    subtext_len = subtext_len - (4 * pi_count)
 
                 boxes_wide = round(max(subtext_len, len(text)) / 10, 1) or 1
                 wid = WID * 1.5 * boxes_wide
             else:
                 boxes_wide = round(len(text) / 10) or 1
                 wid = WID * 2.2 * boxes_wide
+            if wid < WID:
+                wid = WID
         else:
             wid = WID
         if fc:
@@ -675,7 +677,7 @@ class MatplotlibDrawer:
                         param = self.param_parse(op.op.params)
                         if '$\\pi$' in param:
                             pi_count = param.count('pi')
-                            len_param = len(param) - (5 * pi_count)
+                            len_param = len(param) - (4 * pi_count)
                         else:
                             len_param = len(param)
                         if len_param > len(op.name):
@@ -702,7 +704,7 @@ class MatplotlibDrawer:
                         param = self.param_parse(op.op.params)
                         if '$\\pi$' in param:
                             pi_count = param.count('pi')
-                            len_param = len(param) - (5 * pi_count)
+                            len_param = len(param) - (4 * pi_count)
                         else:
                             len_param = len(param)
                         if len_param > len(op.name):

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -250,7 +250,12 @@ class MatplotlibDrawer:
 
         if wide:
             if subtext:
-                boxes_wide = round(max(len(subtext), len(text)) / 10, 1) or 1
+                subtext_len = len(subtext)
+                if '$\\pi$' in subtext:
+                    pi_count = subtext.count('pi')
+                    subtext_len = subtext_len - (5 * pi_count)
+
+                boxes_wide = round(max(subtext_len, len(text)) / 10, 1) or 1
                 wid = WID * 1.5 * boxes_wide
             else:
                 boxes_wide = round(len(text) / 10) or 1
@@ -664,6 +669,8 @@ class MatplotlibDrawer:
             for op in layer:
 
                 if op.name in _wide_gate:
+                    if layer_width < 2:
+                        layer_width = 2
                     if op.type == 'op' and hasattr(op.op, 'params'):
                         param = self.param_parse(op.op.params)
                         if '$\\pi$' in param:
@@ -672,17 +679,16 @@ class MatplotlibDrawer:
                         else:
                             len_param = len(param)
                         if len_param > len(op.name):
-                            box_width = round(len(param) / 10)
+                            box_width = math.floor(len(param) / 10)
                             # If more than 4 characters min width is 2
                             if box_width <= 1:
                                 box_width = 2
                             if layer_width < box_width:
                                 if box_width > 2:
-                                    layer_width = box_width * 2
+                                    layer_width = box_width
                                 else:
                                     layer_width = 2
-                    if layer_width < 2:
-                        layer_width = 2
+                            continue
 
                 # if custom gate with a longer than standard name determine
                 # width
@@ -700,7 +706,7 @@ class MatplotlibDrawer:
                         else:
                             len_param = len(param)
                         if len_param > len(op.name):
-                            box_width = round(len(param) / 8)
+                            box_width = math.floor(len(param) / 8)
                             # If more than 4 characters min width is 2
                             if box_width <= 1:
                                 box_width = 2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes 2 issues related to the dynamic spacing regarding
both the dynamic width of gates with parameters and the corresponding
spacing between the gates. The first issue regarding gate width, we were
incorrectly using the raw string length for the parameters of a wide
gate when dynamically spacing it. This was incorrect because there is
often $\pi$ included in a gate's parameters which will increase the
number of characters from len() calls on the string, but because of
mathtext markup in mpl results in a single character on the output. This
meant we were incorrectly assuming the gates were significantly longer
than the actual length causing unnecessarily long boxes.

The second issue regarding spacing is a bit more subtle, when dynamic
width boxes for parameters were introduced the spacing code from custom
multi-qubit gates was copied and used for cases where the length of the
parameters in a gate were longer than the gates name. This both had a
bug in it and also was not a perfect fit for the second use case. First
the existing bug was around rounding the output layer width, we
previously used the round() function which would result in unnecessarily
large gaps between gates because a width < 1 is still sufficient for
spacing because it's > 0. To account for this math.floor() is used
instead resulting in much tighter spacing (this is updated for both
custom multi-qubit gates and single qubit gates with parameters). Then,
the custom multiqubit case path needed to make the spacing between the
gates wider given the nature of how they're drawn, but for the single
qubit gate with params this is needlessly long. This commit reduces it
to just be wide enough since the gate drawings are smaller especially
after fixing the issue with the box width.

### Details and comments

Fixes #3571
Fixes #3489
