### PR TITLE
Fix transpile to only check for max qubits if backend is not a simulator

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -192,7 +192,7 @@ def transpile(circuits,
             max_qubits = parsed_coupling_map.size()
 
         # If coupling_map is None, the limit might be in the backend (like in 1Q devices)
-        elif backend is not None:
+        elif backend is not None and not backend.configuration().simulator:
             max_qubits = backend.configuration().n_qubits
 
         if max_qubits is not None and (n_qubits > max_qubits):

--- a/test/python/basicaer/test_basicaer_integration.py
+++ b/test/python/basicaer/test_basicaer_integration.py
@@ -77,7 +77,7 @@ class TestBasicAerIntegration(QiskitTestCase):
         qc.x(0)
         qc.measure(0, 0)
         job = execute(qc, self.backend)
-        self.assertRaises(BasicAerError, lambda: job.result())
+        self.assertRaises(BasicAerError, job.result)
 
 
 if __name__ == '__main__':

--- a/test/python/basicaer/test_basicaer_integration.py
+++ b/test/python/basicaer/test_basicaer_integration.py
@@ -20,6 +20,7 @@ from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import execute
 from qiskit.result import Result
+from qiskit.providers.basicaer import BasicAerError
 from qiskit.test import QiskitTestCase
 
 
@@ -69,6 +70,14 @@ class TestBasicAerIntegration(QiskitTestCase):
         job = execute([qc, qc_extra], self.backend)
         result = job.result()
         self.assertIsInstance(result, Result)
+
+    def test_basicaer_nqubits(self):
+        """Test BasicAerError is raised if n_qubits too large to simulate."""
+        qc = QuantumCircuit(50, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        job = execute(qc, self.backend)
+        self.assertRaises(BasicAerError, lambda: job.result())
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_1q.py
+++ b/test/python/transpiler/test_1q.py
@@ -59,8 +59,23 @@ class Test1QWorking(QiskitTestCase):
              level=[0, 1, 2, 3],
              dsc='Transpiling {circuit.__name__} at level {level} should work',
              name='{circuit.__name__}_level{level}_valid')
-    def test(self, circuit, level):
+    def test_device(self, circuit, level):
         """All the levels with all the 1Q backend"""
         result = transpile(circuit(), backend=Fake1Q(), optimization_level=level,
+                           seed_transpiler=42)
+        self.assertIsInstance(result, QuantumCircuit)
+
+    @combine(circuit=[circuit_3516],
+             level=[0, 1, 2, 3],
+             dsc='Transpiling {circuit.__name__} at level {level} should work for simulator',
+             name='{circuit.__name__}_level{level}_valid')
+    def test_simulator(self, circuit, level):
+        """All the levels with all the 1Q simulator backend"""
+        # Set fake backend config to simulator
+        backend = Fake1Q()
+        config = backend.configuration()
+        config.simulator = True
+        backend._configuration = config
+        result = transpile(circuit(), backend=backend, optimization_level=level,
                            seed_transpiler=42)
         self.assertIsInstance(result, QuantumCircuit)

--- a/test/python/transpiler/test_1q.py
+++ b/test/python/transpiler/test_1q.py
@@ -73,9 +73,7 @@ class Test1QWorking(QiskitTestCase):
         """All the levels with all the 1Q simulator backend"""
         # Set fake backend config to simulator
         backend = Fake1Q()
-        config = backend.configuration()
-        config.simulator = True
-        backend._configuration = config
+        backend._configuration.simulator = True
         result = transpile(circuit(), backend=backend, optimization_level=level,
                            seed_transpiler=42)
         self.assertIsInstance(result, QuantumCircuit)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

If transpile is called with `coupling_map=None` this checks the number of qubits in the circuit doesnt exceed the backends `n_qubits` only if it is a real device with a physical qubit limit, not a simulator

Fixes failing build in Qiskit Aer

### Details and comments

#3557 introduced an unintended bug where transpile would fail for simulations that should be possible due to truncation of qubits. The Aer simulators check the size of the circuit during execution after any qubit trunction/remapping is performed.