### PR TITLE
Fix enum meas_return to_dict bug

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -55,7 +55,6 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
     meas_lo_range = qobj_config.pop('meas_lo_range', None)
     meas_map = qobj_config.pop('meas_map', None)
 
-
     # convert enums to serialized values
     meas_return = qobj_config.get('meas_return', 'avg')
     if isinstance(meas_return, MeasReturnType):

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -20,6 +20,7 @@ from qiskit.qobj import (PulseQobj, QobjExperimentHeader,
                          PulseQobjInstruction, PulseQobjExperimentConfig,
                          PulseQobjExperiment, PulseQobjConfig, PulseLibraryItem)
 from qiskit.qobj.converters import InstructionToQobjConverter, LoConfigConverter
+from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 
 def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
@@ -53,6 +54,16 @@ def assemble_schedules(schedules, qobj_id, qobj_header, run_config):
     qubit_lo_range = qobj_config.pop('qubit_lo_range', None)
     meas_lo_range = qobj_config.pop('meas_lo_range', None)
     meas_map = qobj_config.pop('meas_map', None)
+
+
+    # convert enums to serialized values
+    meas_return = qobj_config.get('meas_return', 'avg')
+    if isinstance(meas_return, MeasReturnType):
+        qobj_config['meas_return'] = meas_return.value
+
+    meas_level = qobj_config.get('meas_return', 2)
+    if isinstance(meas_level, MeasLevel):
+        qobj_config['meas_level'] = meas_level.value
 
     instruction_converter = instruction_converter(PulseQobjInstruction, **qobj_config)
 

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -570,7 +570,7 @@ class TestPulseAssembler(QiskitTestCase):
 
         test_dict = qobj.to_dict()
         self.assertEqual(test_dict['config']['meas_return'], 'avg')
-        self.assertEqual(test_dict['config']['meas_level'], '2')
+        self.assertEqual(test_dict['config']['meas_level'], 2)
 
 
 class TestPulseAssemblerMissingKwargs(QiskitTestCase):

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -52,7 +52,6 @@ class TestCircuitAssembler(QiskitTestCase):
         self.assertEqual(len(qobj.experiments), 1)
         self.assertEqual(qobj.experiments[0].instructions[1].name, 'cx')
 
-
     def test_assemble_multiple_circuits(self):
         """Test assembling multiple circuits, all should have the same config.
         """

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -24,7 +24,8 @@ from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.compiler.assemble import assemble
 from qiskit.exceptions import QiskitError
 from qiskit.pulse.channels import MemorySlot, AcquireChannel
-from qiskit.qobj import QasmQobj
+from qiskit.qobj import QasmQobj, validate_qobj_against_schema
+from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeOpenPulse2Q
 
@@ -43,11 +44,14 @@ class TestCircuitAssembler(QiskitTestCase):
         circ.measure(qr, cr)
 
         qobj = assemble(circ, shots=2000, memory=True)
+        validate_qobj_against_schema(qobj)
+
         self.assertIsInstance(qobj, QasmQobj)
         self.assertEqual(qobj.config.shots, 2000)
         self.assertEqual(qobj.config.memory, True)
         self.assertEqual(len(qobj.experiments), 1)
         self.assertEqual(qobj.experiments[0].instructions[1].name, 'cx')
+
 
     def test_assemble_multiple_circuits(self):
         """Test assembling multiple circuits, all should have the same config.
@@ -68,6 +72,8 @@ class TestCircuitAssembler(QiskitTestCase):
         circ1.measure(qr1, qc1)
 
         qobj = assemble([circ0, circ1], shots=100, memory=False, seed_simulator=6)
+        validate_qobj_against_schema(qobj)
+
         self.assertIsInstance(qobj, QasmQobj)
         self.assertEqual(qobj.config.seed_simulator, 6)
         self.assertEqual(len(qobj.experiments), 2)
@@ -86,6 +92,8 @@ class TestCircuitAssembler(QiskitTestCase):
         circ.measure(qr, qc)
 
         qobj = assemble(circ)
+        validate_qobj_against_schema(qobj)
+
         self.assertIsInstance(qobj, QasmQobj)
         self.assertEqual(qobj.config.shots, 1024)
 
@@ -97,6 +105,8 @@ class TestCircuitAssembler(QiskitTestCase):
         circ.initialize([1/np.sqrt(2), 0, 0, 1/np.sqrt(2)], q[:])
 
         qobj = assemble(circ)
+        validate_qobj_against_schema(qobj)
+
         self.assertIsInstance(qobj, QasmQobj)
         self.assertEqual(qobj.experiments[0].instructions[0].name, 'initialize')
         np.testing.assert_almost_equal(qobj.experiments[0].instructions[0].params,
@@ -110,7 +120,10 @@ class TestCircuitAssembler(QiskitTestCase):
         c = ClassicalRegister(4, name='c')
         circ = QuantumCircuit(q, c, name='circ')
         circ.append(opaque_inst, [q[0], q[2], q[5], q[3]], [c[3], c[0]])
+
         qobj = assemble(circ)
+        validate_qobj_against_schema(qobj)
+
         self.assertIsInstance(qobj, QasmQobj)
         self.assertEqual(len(qobj.experiments[0].instructions), 1)
         self.assertEqual(qobj.experiments[0].instructions[0].name, 'my_inst')
@@ -131,6 +144,7 @@ class TestCircuitAssembler(QiskitTestCase):
         qc.h(qr[1]).c_if(cr2, 3)
 
         qobj = assemble(qc)
+        validate_qobj_against_schema(qobj)
 
         first_measure, second_measure = [op for op in qobj.experiments[0].instructions
                                          if op.name == 'measure']
@@ -149,6 +163,7 @@ class TestCircuitAssembler(QiskitTestCase):
         qc.h(qr[0]).c_if(cr, 1)
 
         qobj = assemble(qc)
+        validate_qobj_against_schema(qobj)
 
         bfunc_op, h_op = qobj.experiments[0].instructions
 
@@ -172,6 +187,7 @@ class TestCircuitAssembler(QiskitTestCase):
         qc.h(qr[0]).c_if(cr2, 2)
 
         qobj = assemble(qc)
+        validate_qobj_against_schema(qobj)
 
         bfunc_op, h_op = qobj.experiments[0].instructions
 
@@ -268,6 +284,7 @@ class TestCircuitAssembler(QiskitTestCase):
                                          {x: 1, y: 1}]}
 
         qobj = assemble([qc1, qc2, qc3], **bind_args)
+        validate_qobj_against_schema(qobj)
 
         self.assertEqual(len(qobj.experiments), 9)
         self.assertEqual([len(expt.instructions) for expt in qobj.experiments],
@@ -338,8 +355,9 @@ class TestPulseAssembler(QiskitTestCase):
                         meas_lo_freq=self.default_meas_lo_freq,
                         schedule_los=[],
                         **self.config)
-        test_dict = qobj.to_dict()
+        validate_qobj_against_schema(qobj)
 
+        test_dict = qobj.to_dict()
         self.assertListEqual(test_dict['config']['qubit_lo_freq'], [4.9, 5.0])
         self.assertEqual(len(test_dict['experiments']), 1)
         self.assertEqual(len(test_dict['experiments'][0]['instructions']), 2)
@@ -351,8 +369,9 @@ class TestPulseAssembler(QiskitTestCase):
                         qubit_lo_freq=self.default_qubit_lo_freq,
                         meas_lo_freq=self.default_meas_lo_freq,
                         **self.config)
-        test_dict = qobj.to_dict()
+        validate_qobj_against_schema(qobj)
 
+        test_dict = qobj.to_dict()
         self.assertListEqual(test_dict['config']['qubit_lo_freq'], [4.9, 5.0])
         self.assertEqual(len(test_dict['experiments']), 2)
         self.assertEqual(len(test_dict['experiments'][0]['instructions']), 2)
@@ -365,8 +384,9 @@ class TestPulseAssembler(QiskitTestCase):
                         meas_lo_freq=self.default_meas_lo_freq,
                         schedule_los=self.user_lo_config,
                         **self.config)
-        test_dict = qobj.to_dict()
+        validate_qobj_against_schema(qobj)
 
+        test_dict = qobj.to_dict()
         self.assertListEqual(test_dict['config']['qubit_lo_freq'], [4.91, 5.0])
         self.assertEqual(len(test_dict['experiments']), 1)
         self.assertEqual(len(test_dict['experiments'][0]['instructions']), 2)
@@ -379,8 +399,9 @@ class TestPulseAssembler(QiskitTestCase):
                         meas_lo_freq=self.default_meas_lo_freq,
                         schedule_los=self.user_lo_config_dict,
                         **self.config)
-        test_dict = qobj.to_dict()
+        validate_qobj_against_schema(qobj)
 
+        test_dict = qobj.to_dict()
         self.assertListEqual(test_dict['config']['qubit_lo_freq'], [4.91, 5.0])
         self.assertEqual(len(test_dict['experiments']), 1)
         self.assertEqual(len(test_dict['experiments'][0]['instructions']), 2)
@@ -409,8 +430,9 @@ class TestPulseAssembler(QiskitTestCase):
                         meas_lo_freq=self.default_meas_lo_freq,
                         schedule_los=[self.user_lo_config, self.user_lo_config],
                         **self.config)
-        test_dict = qobj.to_dict()
+        validate_qobj_against_schema(qobj)
 
+        test_dict = qobj.to_dict()
         self.assertListEqual(test_dict['config']['qubit_lo_freq'], [4.9, 5.0])
         self.assertEqual(len(test_dict['experiments']), 2)
         self.assertEqual(len(test_dict['experiments'][0]['instructions']), 2)
@@ -432,10 +454,11 @@ class TestPulseAssembler(QiskitTestCase):
         acquire = pulse.Acquire(5)
         schedule = acquire([AcquireChannel(0), AcquireChannel(1)],
                            [MemorySlot(0), MemorySlot(1)])
-        assemble(schedule,
-                 qubit_lo_freq=self.default_qubit_lo_freq,
-                 meas_lo_freq=self.default_meas_lo_freq,
-                 meas_map=[[0], [1]])
+        qobj = assemble(schedule,
+                        qubit_lo_freq=self.default_qubit_lo_freq,
+                        meas_lo_freq=self.default_meas_lo_freq,
+                        meas_map=[[0], [1]])
+        validate_qobj_against_schema(qobj)
 
         with self.assertRaises(QiskitError):
             assemble(schedule,
@@ -456,6 +479,7 @@ class TestPulseAssembler(QiskitTestCase):
                         qubit_lo_freq=self.default_qubit_lo_freq,
                         meas_lo_freq=self.default_meas_lo_freq,
                         meas_map=[[0], [1]])
+        validate_qobj_against_schema(qobj)
 
         self.assertEqual(qobj.config.memory_slots, n_memoryslots)
         # this should be in experimental header as well
@@ -471,6 +495,7 @@ class TestPulseAssembler(QiskitTestCase):
                         qubit_lo_freq=self.default_qubit_lo_freq,
                         meas_lo_freq=self.default_meas_lo_freq,
                         meas_map=[[0], [1]])
+        validate_qobj_against_schema(qobj)
 
         self.assertEqual(qobj.config.memory_slots, n_memoryslots)
         # this should be in experimental header as well
@@ -491,6 +516,7 @@ class TestPulseAssembler(QiskitTestCase):
                         qubit_lo_freq=self.default_qubit_lo_freq,
                         meas_lo_freq=self.default_meas_lo_freq,
                         meas_map=[[0], [1]])
+        validate_qobj_against_schema(qobj)
 
         self.assertEqual(qobj.config.memory_slots, max(n_memoryslots))
         self.assertEqual(qobj.experiments[0].header.memory_slots, n_memoryslots[0])
@@ -510,6 +536,7 @@ class TestPulseAssembler(QiskitTestCase):
                         meas_lo_freq=self.default_meas_lo_freq,
                         schedule_los=[],
                         **self.config)
+        validate_qobj_against_schema(qobj)
 
         self.assertNotEqual(qobj.config.pulse_library[1], 'pulse0')
         self.assertEqual(qobj.experiments[0].instructions[0].name, 'pulse0')
@@ -523,10 +550,27 @@ class TestPulseAssembler(QiskitTestCase):
         delay_schedule = orig_schedule + pulse.Delay(10)(self.backend_config.drive(0))
 
         orig_qobj = assemble(orig_schedule, backend)
+        validate_qobj_against_schema(orig_qobj)
         delay_qobj = assemble(delay_schedule, backend)
+        validate_qobj_against_schema(delay_qobj)
 
         self.assertEqual(orig_qobj.experiments[0].to_dict(),
                          delay_qobj.experiments[0].to_dict())
+
+    def test_assemble_schedule_enum(self):
+        """Test assembling a schedule with enum input values to assemble."""
+        qobj = assemble(self.schedule,
+                        qobj_header=self.header,
+                        qubit_lo_freq=self.default_qubit_lo_freq,
+                        meas_lo_freq=self.default_meas_lo_freq,
+                        schedule_los=[],
+                        meas_level=MeasLevel.CLASSIFIED,
+                        meas_return=MeasReturnType.AVERAGE)
+        validate_qobj_against_schema(qobj)
+
+        test_dict = qobj.to_dict()
+        self.assertEqual(test_dict['config']['meas_return'], 'avg')
+        self.assertEqual(test_dict['config']['meas_level'], '2')
 
 
 class TestPulseAssemblerMissingKwargs(QiskitTestCase):
@@ -553,15 +597,16 @@ class TestPulseAssemblerMissingKwargs(QiskitTestCase):
 
     def test_defaults(self):
         """Test defaults work."""
-        assemble(self.schedule,
-                 qubit_lo_freq=self.qubit_lo_freq,
-                 meas_lo_freq=self.meas_lo_freq,
-                 qubit_lo_range=self.qubit_lo_range,
-                 meas_lo_range=self.meas_lo_range,
-                 schedule_los=self.schedule_los,
-                 meas_map=self.meas_map,
-                 memory_slots=self.memory_slots,
-                 rep_time=self.rep_time)
+        qobj = assemble(self.schedule,
+                        qubit_lo_freq=self.qubit_lo_freq,
+                        meas_lo_freq=self.meas_lo_freq,
+                        qubit_lo_range=self.qubit_lo_range,
+                        meas_lo_range=self.meas_lo_range,
+                        schedule_los=self.schedule_los,
+                        meas_map=self.meas_map,
+                        memory_slots=self.memory_slots,
+                        rep_time=self.rep_time)
+        validate_qobj_against_schema(qobj)
 
     def test_missing_qubit_lo_freq(self):
         """Test error raised if qubit_lo_freq missing."""
@@ -591,54 +636,58 @@ class TestPulseAssemblerMissingKwargs(QiskitTestCase):
 
     def test_missing_memory_slots(self):
         """Test error is not raised if memory_slots are missing."""
-        assemble(self.schedule,
-                 qubit_lo_freq=self.qubit_lo_freq,
-                 meas_lo_freq=self.meas_lo_freq,
-                 qubit_lo_range=self.qubit_lo_range,
-                 meas_lo_range=self.meas_lo_range,
-                 schedule_los=self.schedule_los,
-                 meas_map=self.meas_map,
-                 memory_slots=None,
-                 rep_time=self.rep_time)
+        qobj = assemble(self.schedule,
+                        qubit_lo_freq=self.qubit_lo_freq,
+                        meas_lo_freq=self.meas_lo_freq,
+                        qubit_lo_range=self.qubit_lo_range,
+                        meas_lo_range=self.meas_lo_range,
+                        schedule_los=self.schedule_los,
+                        meas_map=self.meas_map,
+                        memory_slots=None,
+                        rep_time=self.rep_time)
+        validate_qobj_against_schema(qobj)
 
     def test_missing_rep_time(self):
         """Test that assembly still works if rep_time is missing.
 
         The case of no rep_time will exist for a simulator.
         """
-        assemble(self.schedule,
-                 qubit_lo_freq=self.qubit_lo_freq,
-                 meas_lo_freq=self.meas_lo_freq,
-                 qubit_lo_range=self.qubit_lo_range,
-                 meas_lo_range=self.meas_lo_range,
-                 schedule_los=self.schedule_los,
-                 meas_map=self.meas_map,
-                 memory_slots=self.memory_slots,
-                 rep_time=None)
+        qobj = assemble(self.schedule,
+                        qubit_lo_freq=self.qubit_lo_freq,
+                        meas_lo_freq=self.meas_lo_freq,
+                        qubit_lo_range=self.qubit_lo_range,
+                        meas_lo_range=self.meas_lo_range,
+                        schedule_los=self.schedule_los,
+                        meas_map=self.meas_map,
+                        memory_slots=self.memory_slots,
+                        rep_time=None)
+        validate_qobj_against_schema(qobj)
 
     def test_missing_meas_map(self):
         """Test that assembly still works if meas_map is missing."""
-        assemble(self.schedule,
-                 qubit_lo_freq=self.qubit_lo_freq,
-                 meas_lo_freq=self.meas_lo_freq,
-                 qubit_lo_range=self.qubit_lo_range,
-                 meas_lo_range=self.meas_lo_range,
-                 schedule_los=self.schedule_los,
-                 meas_map=None,
-                 memory_slots=self.memory_slots,
-                 rep_time=self.rep_time)
+        qobj = assemble(self.schedule,
+                        qubit_lo_freq=self.qubit_lo_freq,
+                        meas_lo_freq=self.meas_lo_freq,
+                        qubit_lo_range=self.qubit_lo_range,
+                        meas_lo_range=self.meas_lo_range,
+                        schedule_los=self.schedule_los,
+                        meas_map=None,
+                        memory_slots=self.memory_slots,
+                        rep_time=self.rep_time)
+        validate_qobj_against_schema(qobj)
 
     def test_missing_lo_ranges(self):
         """Test that assembly still works if lo_ranges are missing."""
-        assemble(self.schedule,
-                 qubit_lo_freq=self.qubit_lo_freq,
-                 meas_lo_freq=self.meas_lo_freq,
-                 qubit_lo_range=None,
-                 meas_lo_range=None,
-                 schedule_los=self.schedule_los,
-                 meas_map=self.meas_map,
-                 memory_slots=self.memory_slots,
-                 rep_time=self.rep_time)
+        qobj = assemble(self.schedule,
+                        qubit_lo_freq=self.qubit_lo_freq,
+                        meas_lo_freq=self.meas_lo_freq,
+                        qubit_lo_range=None,
+                        meas_lo_range=None,
+                        schedule_los=self.schedule_los,
+                        meas_map=self.meas_map,
+                        memory_slots=self.memory_slots,
+                        rep_time=self.rep_time)
+        validate_qobj_against_schema(qobj)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Closes #3580. Adds conversion of enums to canonical serialized values in `assemble_schedules`. Also, all assembly tests now test against the json schema.


### Details and comments


