### PR TITLE
Fix bug where too many framechanges in table would cause plotting to fail

### DIFF
--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -393,7 +393,12 @@ class ScheduleDrawer:
             # table area size
             ncols = self.style.table_columns
             nrows = int(np.ceil(len(table_data)/ncols))
-
+            full_size = nrows * self.style.fig_unit_h_table
+            max_size = self.style.max_table_ratio * self.style.figsize[1]
+            max_rows = np.floor(max_size/self.style.fig_unit_h_table/ncols)
+            nrows = int(min(nrows, max_rows))
+            # don't overflow plot with table data
+            table_data = table_data[:int(nrows*ncols)]
             # fig size
             h_table = nrows * self.style.fig_unit_h_table
             h_waves = (self.style.figsize[1] - h_table)

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -393,7 +393,6 @@ class ScheduleDrawer:
             # table area size
             ncols = self.style.table_columns
             nrows = int(np.ceil(len(table_data)/ncols))
-            full_size = nrows * self.style.fig_unit_h_table
             max_size = self.style.max_table_ratio * self.style.figsize[1]
             max_rows = np.floor(max_size/self.style.fig_unit_h_table/ncols)
             nrows = int(min(nrows, max_rows))

--- a/qiskit/visualization/pulse/qcstyle.py
+++ b/qiskit/visualization/pulse/qcstyle.py
@@ -21,7 +21,8 @@ class SchedStyle:
                  label_font_size=10, icon_font_size=18, label_ch_linestyle='--',
                  label_ch_color=None, label_ch_alpha=0.3, d_ch_color=None, u_ch_color=None,
                  m_ch_color=None, s_ch_color=None, s_ch_linestyle='-', table_color=None,
-                 bg_color=None, num_points=1000, dpi=150, remove_spacing=True):
+                 bg_color=None, num_points=1000, dpi=150, remove_spacing=True,
+                 max_table_ratio=0.5):
         """Set style sheet for OpenPulse schedule drawer.
 
         Args:
@@ -46,6 +47,8 @@ class SchedStyle:
             num_points (int): number of points for interpolation
             dpi (int): dpi to save image
             remove_spacing(bool): Remove redundant spacing when the waveform has no negative values
+            max_table_ratio (float): Maximum portion of the plot the table can take up. Limited to
+                range between 0 and 1.
         """
         self.figsize = figsize
         self.fig_unit_h_table = fig_unit_h_table
@@ -69,6 +72,7 @@ class SchedStyle:
         self.num_points = num_points
         self.dpi = dpi
         self.remove_spacing = remove_spacing
+        self.max_table_ratio = max(min(max_table_ratio, 0.0), 1.0)
 
 
 class PulseStyle:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes a bug where too many framechanges in a plot would cause the table to become too large and the waveform section would have a negative height.


### Details and comments


