### PR TITLE
Rename InstructionScheduleMap to CircuitInstructionMap

### DIFF
--- a/qiskit/compiler/schedule.py
+++ b/qiskit/compiler/schedule.py
@@ -20,14 +20,14 @@ from typing import List, Optional, Union
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
-from qiskit.pulse import CmdDef, InstructionScheduleMap, Schedule
+from qiskit.pulse import CmdDef, CircuitInstructionMap, Schedule
 
 from qiskit.scheduler import schedule_circuit, ScheduleConfig
 
 
 def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
              backend: Optional['BaseBackend'] = None,
-             inst_map: Optional[InstructionScheduleMap] = None,
+             inst_map: Optional[CircuitInstructionMap] = None,
              cmd_def: Optional[CmdDef] = None,
              meas_map: Optional[List[List[int]]] = None,
              method: Optional[Union[str, List[str]]] = None) -> Union[Schedule, List[Schedule]]:
@@ -54,7 +54,7 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         if cmd_def is not None:
             inst_map = cmd_def
         if backend is None:
-            raise QiskitError("Must supply either a backend or InstructionScheduleMap for "
+            raise QiskitError("Must supply either a backend or CircuitInstructionMap for "
                               "scheduling passes.")
         inst_map = backend.defaults().circuit_instruction_map
     if meas_map is None:

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -22,7 +22,7 @@ from qiskit.validation import BaseModel, BaseSchema, bind_schema, fields
 from qiskit.validation.base import ObjSchema
 from qiskit.qobj import PulseLibraryItemSchema, PulseQobjInstructionSchema, PulseLibraryItem
 from qiskit.qobj.converters import QobjToInstructionConverter
-from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
+from qiskit.pulse.circuit_instruction_map import CircuitInstructionMap
 from qiskit.pulse.schedule import ParameterizedSchedule
 
 
@@ -137,7 +137,7 @@ class PulseDefaults(BaseModel):
         self.meas_freq_est = [freq * 1e9 for freq in meas_freq_est]
         self.pulse_library = pulse_library
         self.cmd_def = cmd_def
-        self.circuit_instruction_map = InstructionScheduleMap()
+        self.circuit_instruction_map = CircuitInstructionMap()
 
         self.converter = QobjToInstructionConverter(pulse_library)
         for inst in cmd_def:
@@ -154,14 +154,14 @@ class PulseDefaults(BaseModel):
                 "".format(name=self.__class__.__name__, insts=str(self.circuit_instruction_map),
                           qfreq=qfreq, mfreq=mfreq))
 
-    def build_cmd_def(self) -> InstructionScheduleMap:
+    def build_cmd_def(self) -> CircuitInstructionMap:
         """
-        Return the InstructionScheduleMap built for this PulseDefaults instance.
+        Return the CircuitInstructionMap built for this PulseDefaults instance.
 
         Returns:
-            InstructionScheduleMap: Generated from defaults.
+            CircuitInstructionMap: Generated from defaults.
         """
-        warnings.warn("This method is deprecated. Returning a InstructionScheduleMap instead. "
+        warnings.warn("This method is deprecated. Returning a CircuitInstructionMap instead. "
                       "This can be accessed simply through the `circuit_instruction_map` attribute "
                       "of this PulseDefaults instance.", DeprecationWarning)
         return self.circuit_instruction_map

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -87,6 +87,6 @@ from .commands import (Instruction, Acquire, FrameChange, PersistentValue,
                        functional_pulse)
 from .configuration import LoConfig, LoRange
 from .exceptions import PulseError
-from .instruction_schedule_map import InstructionScheduleMap
+from .circuit_instruction_map import CircuitInstructionMap, InstructionScheduleMap
 from .interfaces import ScheduleComponent
 from .schedule import Schedule

--- a/qiskit/pulse/circuit_instruction_map.py
+++ b/qiskit/pulse/circuit_instruction_map.py
@@ -278,10 +278,10 @@ class CircuitInstructionMap():
                 "".format(name=self.__class__.__name__, insts=instructions))
 
 
-class CircuitInstructionMap(CircuitInstructionMap):
-    """Deprecated name for CircuitInstructionMap."""
+class InstructionScheduleMap(CircuitInstructionMap):
+    """Deprecated for CircuitInstructionMap."""
     def __init__(self):
-        raise warnings.warn("CircuitInstructionMap has been renamed to CircuitInstructionMap, "
+        raise warnings.warn("InstructionScheduleMap has been renamed to CircuitInstructionMap, "
                             "please use this instead.", DeprecationWarning)
 
         super().__init__()

--- a/qiskit/pulse/circuit_instruction_map.py
+++ b/qiskit/pulse/circuit_instruction_map.py
@@ -17,7 +17,7 @@ A convenient way to track reusable subschedules by name and qubit.
 
 This can be used for scheduling circuits with custom definitions, for instance:
 
-    inst_map = InstructionScheduleMap()
+    inst_map = CircuitInstructionMap()
     inst_map.add('new_inst', 0, qubit_0_new_inst_schedule)
 
     sched = schedule(quantum_circuit, backend, inst_map)
@@ -31,7 +31,7 @@ from .schedule import Schedule, ParameterizedSchedule
 from .exceptions import PulseError
 
 
-class InstructionScheduleMap():
+class CircuitInstructionMap():
     """Mapping from QuantumCircuit Instruction names to Schedules. In particular:
 
          Dict[str, Dict[Tuple[int], Schedule]]
@@ -277,6 +277,14 @@ class InstructionScheduleMap():
         return ("<{name}({insts})>"
                 "".format(name=self.__class__.__name__, insts=instructions))
 
+
+class CircuitInstructionMap(CircuitInstructionMap):
+    """Deprecated name for CircuitInstructionMap."""
+    def __init__(self):
+        raise warnings.warn("CircuitInstructionMap has been renamed to CircuitInstructionMap, "
+                            "please use this instead.", DeprecationWarning)
+
+        super().__init__()
 
 def _to_tuple(values):
     """

--- a/qiskit/pulse/circuit_instruction_map.py
+++ b/qiskit/pulse/circuit_instruction_map.py
@@ -281,8 +281,8 @@ class CircuitInstructionMap():
 class InstructionScheduleMap(CircuitInstructionMap):
     """Deprecated for CircuitInstructionMap."""
     def __init__(self):
-        raise warnings.warn("InstructionScheduleMap has been renamed to CircuitInstructionMap, "
-                            "please use this instead.", DeprecationWarning)
+        warnings.warn("InstructionScheduleMap has been renamed to CircuitInstructionMap, "
+                      "please use this instead.", DeprecationWarning)
 
         super().__init__()
 

--- a/qiskit/pulse/circuit_instruction_map.py
+++ b/qiskit/pulse/circuit_instruction_map.py
@@ -286,6 +286,7 @@ class InstructionScheduleMap(CircuitInstructionMap):
 
         super().__init__()
 
+
 def _to_tuple(values):
     """
     Return the input as a tuple, even if it is an integer.

--- a/qiskit/pulse/cmd_def.py
+++ b/qiskit/pulse/cmd_def.py
@@ -61,7 +61,7 @@ class CmdDef:
                 `Schedule` or `ParameterizedSchedule`
         """
         warnings.warn("The CmdDef is being deprecated. All CmdDef methods are now supported by "
-                      "`InstructionScheduleMap` accessible as "
+                      "`CircuitInstructionMap` accessible as "
                       "`backend.defaults().circuit_instruction_map` for any Pulse enabled system.",
                       DeprecationWarning)
         self._cmd_dict = {}

--- a/qiskit/pulse/reschedule.py
+++ b/qiskit/pulse/reschedule.py
@@ -26,13 +26,13 @@ from .channels import Channel, AcquireChannel, MeasureChannel, MemorySlot
 from .cmd_def import CmdDef
 from .commands import Acquire, AcquireInstruction, Delay
 from .exceptions import PulseError
-from .instruction_schedule_map import InstructionScheduleMap
+from .circuit_instruction_map import CircuitInstructionMap
 from .interfaces import ScheduleComponent
 from .schedule import Schedule
 
 
 def align_measures(schedules: Iterable[ScheduleComponent],
-                   inst_map: Optional[InstructionScheduleMap] = None,
+                   inst_map: Optional[CircuitInstructionMap] = None,
                    cmd_def: Optional[CmdDef] = None,
                    cal_gate: str = 'u3',
                    max_calibration_duration: Optional[int] = None,

--- a/qiskit/scheduler/config.py
+++ b/qiskit/scheduler/config.py
@@ -16,7 +16,7 @@
 
 from typing import List
 
-from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
+from qiskit.pulse.circuit_instruction_map import CircuitInstructionMap
 
 from qiskit.scheduler.utils import format_meas_map
 
@@ -25,7 +25,7 @@ class ScheduleConfig():
     """Configuration for pulse scheduling."""
 
     def __init__(self,
-                 inst_map: InstructionScheduleMap,
+                 inst_map: CircuitInstructionMap,
                  meas_map: List[List[int]]):
         """
         Container for information needed to schedule a QuantumCircuit into a pulse Schedule.

--- a/releasenotes/notes/0.11/deprecate-cmd-def-097d6a692ade8056.yaml
+++ b/releasenotes/notes/0.11/deprecate-cmd-def-097d6a692ade8056.yaml
@@ -2,7 +2,7 @@
 deprecations:
   - |
     The ``qiskit.pulse.CmdDef`` class has been deprecated. Instead you should
-    use the ``qiskit.pulse.InstructionScheduleMap``. The
-    ``InstructionScheduleMap`` object for a pulse enabled system can be
+    use the ``qiskit.pulse.CircuitInstructionMap``. The
+    ``CircuitInstructionMap`` object for a pulse enabled system can be
     accessed at ``backend.defaults().instruction_schedules``.
 

--- a/releasenotes/notes/0.11/deprecate-cmd-def-097d6a692ade8056.yaml
+++ b/releasenotes/notes/0.11/deprecate-cmd-def-097d6a692ade8056.yaml
@@ -2,7 +2,6 @@
 deprecations:
   - |
     The ``qiskit.pulse.CmdDef`` class has been deprecated. Instead you should
-    use the ``qiskit.pulse.CircuitInstructionMap``. The
-    ``CircuitInstructionMap`` object for a pulse enabled system can be
+    use the ``qiskit.pulse.InstructionScheduleMap``. The
+    ``InstructionScheduleMap`` object for a pulse enabled system can be
     accessed at ``backend.defaults().instruction_schedules``.
-

--- a/releasenotes/notes/0.11/extend-backend-defaults-4370f983d599a26b.yaml
+++ b/releasenotes/notes/0.11/extend-backend-defaults-4370f983d599a26b.yaml
@@ -3,7 +3,7 @@ features:
   - |
     ``PulseDefaults`` (accessed normally as ``backend.defaults()``) has an
     attribute, ``circuit_instruction_map`` which has the methods of CmdDef.
-    The new `circuit_instruction_map` is an ``InstructionScheduleMap`` object
+    The new `circuit_instruction_map` is an ``CircuitInstructionMap`` object
     with three new functions beyond what CmdDef had:
 
      * qubit_instructions(qubits) returns the operations defined for the qubits

--- a/releasenotes/notes/rename-InstructionScheduleMap-to-CircuitInstructionMap-18585c852e2656ce.yaml
+++ b/releasenotes/notes/rename-InstructionScheduleMap-to-CircuitInstructionMap-18585c852e2656ce.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    The ``qiskit.pulse.InstructionScheduleMap`` class has been renamed. Instead you should
+    use the ``qiskit.pulse.CircuitInstructionMap``.

--- a/test/python/providers/test_pulse_defaults.py
+++ b/test/python/providers/test_pulse_defaults.py
@@ -56,7 +56,7 @@ class TestPulseDefaults(QiskitTestCase):
 
     def test_str(self):
         """Test that __str__ method works."""
-        self.assertEqual("<PulseDefaults(<InstructionScheduleMap(1Q instructions:\n  q0:",
+        self.assertEqual("<PulseDefaults(<CircuitInstructionMap(1Q instructions:\n  q0:",
                          str(self.defs)[:61])
         self.assertTrue("Multi qubit instructions:\n  (0, 1): " in str(self.defs)[70:])
         self.assertTrue("Qubit Frequencies [GHz]\n[4.9, 5.0]\nMeasurement Frequencies [GHz]\n[6.5, "

--- a/test/python/providers/test_pulse_defaults.py
+++ b/test/python/providers/test_pulse_defaults.py
@@ -56,7 +56,7 @@ class TestPulseDefaults(QiskitTestCase):
 
     def test_str(self):
         """Test that __str__ method works."""
-        self.assertEqual("<PulseDefaults(<CircuitInstructionMap(1Q instructions:\n  q0:",
+        self.assertEqual("<PulseDefaults(<CircuitInstructionMap(1Q instructions:\n  q0: ",
                          str(self.defs)[:61])
         self.assertTrue("Multi qubit instructions:\n  (0, 1): " in str(self.defs)[70:])
         self.assertTrue("Qubit Frequencies [GHz]\n[4.9, 5.0]\nMeasurement Frequencies [GHz]\n[6.5, "

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=missing-docstring
 
-"""Test the InstructionScheduleMap."""
+"""Test the CircuitInstructionMap."""
 import numpy as np
 
 from qiskit.test import QiskitTestCase
@@ -22,19 +22,19 @@ from qiskit.test.mock import FakeOpenPulse2Q
 from qiskit.qobj.converters import QobjToInstructionConverter
 from qiskit.qobj import PulseQobjInstruction
 
-from qiskit.pulse import InstructionScheduleMap, SamplePulse, Schedule, PulseError
+from qiskit.pulse import CircuitInstructionMap, SamplePulse, Schedule, PulseError
 from qiskit.pulse.channels import DriveChannel
 from qiskit.pulse.schedule import ParameterizedSchedule
 
 
-class TestInstructionScheduleMap(QiskitTestCase):
-    """Test the InstructionScheduleMap."""
+class TestCircuitInstructionMap(QiskitTestCase):
+    """Test the CircuitInstructionMap."""
 
     def test_add(self):
         """Test add, and that errors are raised when expected."""
         sched = Schedule()
         sched.append(SamplePulse(np.ones(5))(DriveChannel(0)))
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', 1, sched)
         inst_map.add('u1', 0, sched)
@@ -51,7 +51,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_instructions(self):
         """Test `instructions`."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', 1, sched)
         inst_map.add('u3', 0, sched)
@@ -63,7 +63,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_has(self):
         """Test `has` and `assert_has`."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', (0,), sched)
         inst_map.add('cx', [0, 1], sched)
@@ -91,7 +91,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_qubits_with_instruction(self):
         """Test `qubits_with_instruction`."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', (0,), sched)
         inst_map.add('u1', (1,), sched)
@@ -104,7 +104,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_qubit_instructions(self):
         """Test `qubit_instructions`."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', (0,), sched)
         inst_map.add('u1', (1,), sched)
@@ -119,7 +119,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
         """Test `get`."""
         sched = Schedule()
         sched.append(SamplePulse(np.ones(5))(DriveChannel(0)))
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('u1', 0, sched)
 
@@ -128,7 +128,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_remove(self):
         """Test removing a defined operation and removing an undefined operation."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('tmp', 0, sched)
         inst_map.remove('tmp', 0)
@@ -140,7 +140,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
     def test_pop(self):
         """Test pop with default."""
         sched = Schedule()
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('tmp', 100, sched)
         self.assertEqual(inst_map.pop('tmp', 100), sched)
@@ -157,7 +157,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
         qobj = PulseQobjInstruction(name='pv', ch='u1', t0=10, val='P2*cos(np.pi*P1)')
         converted_instruction = converter(qobj)
 
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('pv_test', 0, converted_instruction)
         self.assertEqual(inst_map.get_parameters('pv_test', 0), ('P1', 'P2'))
@@ -177,7 +177,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
                  PulseQobjInstruction(name='fc', ch='d0', t0=30, phase='P3')]
         converted_instruction = [converter(qobj) for qobj in qobjs]
 
-        inst_map = InstructionScheduleMap()
+        inst_map = CircuitInstructionMap()
 
         inst_map.add('inst_seq', 0, ParameterizedSchedule(*converted_instruction,
                                                           name='inst_seq'))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Closes #3592. This PR renames `InstructionScheduleMap` to `CircuitInstructionMap` and deprecates `InstructionScheduleMap`.


### Details and comments


