### PR TITLE
Added one time warnings for dt and qubit_freq_est turning into properties

### DIFF
--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -332,12 +332,6 @@ class PulseBackendConfiguration(BackendConfiguration):
         self.discriminators = discriminators
         self.hamiltonian = hamiltonian
 
-        # only raise dt/dtm warning once
-        if not PulseBackendConfiguration._dt_warning_done:
-            warnings.warn('`dt` and `dtm` now have units of seconds(s) rather '
-                          'than nanoseconds(ns).')
-            PulseBackendConfiguration._dt_warning_done = True
-
         super().__init__(backend_name=backend_name, backend_version=backend_version,
                          n_qubits=n_qubits, basis_gates=basis_gates, gates=gates,
                          local=local, simulator=simulator, conditional=conditional,
@@ -345,9 +339,20 @@ class PulseBackendConfiguration(BackendConfiguration):
                          n_uchannels=n_uchannels, u_channel_lo=u_channel_lo,
                          meas_levels=meas_levels, qubit_lo_range=qubit_lo_range,
                          meas_lo_range=meas_lo_range,
-                         dt=dt * 1e-9, dtm=dtm * 1e-9,
+                         _dt=dt * 1e-9, dtm=dtm * 1e-9,
                          rep_times=rep_times, meas_kernels=meas_kernels,
                          discriminators=discriminators, **kwargs)
+
+    @property
+    def dt(self) -> float:  # pylint: disable=invalid-name
+        """Drive channel sampling time in seconds(s)."""
+        # only raise dt warning once
+        if not PulseBackendConfiguration._dt_warning_done:
+            warnings.warn('`dt` and `dtm` now have units of seconds(s) rather '
+                          'than nanoseconds(ns).')
+            PulseBackendConfiguration._dt_warning_done = True
+
+        return self._dt
 
     @property
     def sample_rate(self) -> float:

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -331,6 +331,8 @@ class PulseBackendConfiguration(BackendConfiguration):
         self.meas_kernels = meas_kernels
         self.discriminators = discriminators
         self.hamiltonian = hamiltonian
+        self._dt = dt*1e-9
+        self._dtm = dtm*1e-9
 
         super().__init__(backend_name=backend_name, backend_version=backend_version,
                          n_qubits=n_qubits, basis_gates=basis_gates, gates=gates,
@@ -353,6 +355,17 @@ class PulseBackendConfiguration(BackendConfiguration):
             PulseBackendConfiguration._dt_warning_done = True
 
         return self._dt
+
+    @property
+    def dtm(self) -> float:  # pylint: disable=invalid-name
+        """Measure channel sampling time in seconds(s)."""
+        # only raise dt warning once
+        if not PulseBackendConfiguration._dt_warning_done:
+            warnings.warn('`dt` and `dtm` now have units of seconds(s) rather '
+                          'than nanoseconds(ns).')
+            PulseBackendConfiguration._dt_warning_done = True
+
+        return self._dtm
 
     @property
     def sample_rate(self) -> float:

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -341,7 +341,6 @@ class PulseBackendConfiguration(BackendConfiguration):
                          n_uchannels=n_uchannels, u_channel_lo=u_channel_lo,
                          meas_levels=meas_levels, qubit_lo_range=qubit_lo_range,
                          meas_lo_range=meas_lo_range,
-                         _dt=dt * 1e-9, dtm=dtm * 1e-9,
                          rep_times=rep_times, meas_kernels=meas_kernels,
                          discriminators=discriminators, **kwargs)
 

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -136,7 +136,7 @@ class PulseDefaults(BaseModel):
 
         self.buffer = buffer
         self._qubit_freq_est = [freq * 1e9 for freq in qubit_freq_est]
-        self.meas_freq_est = [freq * 1e9 for freq in meas_freq_est]
+        self._meas_freq_est = [freq * 1e9 for freq in meas_freq_est]
         self.pulse_library = pulse_library
         self.cmd_def = cmd_def
         self.circuit_instruction_map = InstructionScheduleMap()
@@ -157,6 +157,17 @@ class PulseDefaults(BaseModel):
             PulseDefaults._freq_warning_done = True
 
         return self._qubit_freq_est
+
+    @property
+    def meas_freq_est(self) -> float:  # pylint: disable=invalid-name
+        """Measurement frequencies in Hertz(Hz)."""
+        # only raise qubit_freq_est warning once
+        if not PulseDefaults._freq_warning_done:
+            warnings.warn('`qubit_freq_est` and `meas_freq_est` now have units of '
+                          'Hertz(Hz) rather than gigahertz(GHz).')
+            PulseDefaults._freq_warning_done = True
+
+        return self._meas_freq_est
 
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -148,7 +148,7 @@ class PulseDefaults(BaseModel):
             self.circuit_instruction_map.add(inst.name, inst.qubits, schedule)
 
     @property
-    def qubit_freq_est(self) -> float: # pylint: disable=invalid-name
+    def qubit_freq_est(self) -> float:  # pylint: disable=invalid-name
         """Qubit frequencies in Hertz(Hz)."""
         # only raise qubit_freq_est warning once
         if not PulseDefaults._freq_warning_done:

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -112,6 +112,8 @@ class PulseDefaults(BaseModel):
     scheduling.
     """
 
+    _freq_warning_done = False
+
     def __init__(self,
                  qubit_freq_est: List[float],
                  meas_freq_est: List[float],
@@ -133,7 +135,7 @@ class PulseDefaults(BaseModel):
         super().__init__(**kwargs)
 
         self.buffer = buffer
-        self.qubit_freq_est = [freq * 1e9 for freq in qubit_freq_est]
+        self._qubit_freq_est = [freq * 1e9 for freq in qubit_freq_est]
         self.meas_freq_est = [freq * 1e9 for freq in meas_freq_est]
         self.pulse_library = pulse_library
         self.cmd_def = cmd_def
@@ -144,6 +146,17 @@ class PulseDefaults(BaseModel):
             pulse_insts = [self.converter(inst) for inst in inst.sequence]
             schedule = ParameterizedSchedule(*pulse_insts, name=inst.name)
             self.circuit_instruction_map.add(inst.name, inst.qubits, schedule)
+
+    @property
+    def qubit_freq_est(self) -> float: # pylint: disable=invalid-name
+        """Qubit frequencies in Hertz(Hz)."""
+        # only raise qubit_freq_est warning once
+        if not PulseDefaults._freq_warning_done:
+            warnings.warn('`qubit_freq_est` and `meas_freq_est` now have units of '
+                          'Hertz(Hz) rather than gigahertz(GHz).')
+            PulseDefaults._freq_warning_done = True
+
+        return self._qubit_freq_est
 
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is a patch fix to make warnings for dt and qubit_freq_est only be raised when called. This is achieved by turning these attributes into properties.

### Details and comments


