### PR TITLE
Replace tabs with spaces in .json schemas

### DIFF
--- a/qiskit/schemas/deprecated/qobj/qobj_generic_schema.json
+++ b/qiskit/schemas/deprecated/qobj/qobj_generic_schema.json
@@ -12,7 +12,7 @@
     },
     "definitions": {
         "generic_instructions": {
-            "anyOf": [{		
+            "anyOf": [{
                 "title": "3-param 1Q op",
                 "required": ["qubits", "params"],
                 "properties": {
@@ -41,17 +41,17 @@
                 "clbits": {"maxItems": 0},
                 "params": {"minItems": 1, "maxItems": 1},
                 "texparams": {"minItems": 1, "maxItems": 1}
-            }			
+            }
             }, {
             "title": "2-param 1Q op",
-            "required": ["qubits", "params"],				
+            "required": ["qubits", "params"],
             "properties": {
                 "name": {"enum": ["u2"]},
                 "qubits": {"maxItems": 1},
                 "clbits": {"maxItems": 0},
                 "params": {"minItems": 2, "maxItems": 2},
                 "texparams": {"minItems": 2, "maxItems": 2}
-            }			
+            }
             }, {
             "title": "fixed 2Q gate",
             "required": ["qubits"],

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -270,7 +270,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -287,7 +287,7 @@
                             "maxItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -304,7 +304,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -329,7 +329,7 @@
                             "minItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -344,7 +344,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -365,7 +365,7 @@
                             "minItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -382,7 +382,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -399,7 +399,7 @@
                             "minItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -416,7 +416,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -438,7 +438,7 @@
                             "minItems": 2
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -453,7 +453,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -473,7 +473,7 @@
                             "minItems": 2
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -490,7 +490,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -508,7 +508,7 @@
                             "minItems": 2
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -525,7 +525,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -543,7 +543,7 @@
                             "minItems": 3
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -558,7 +558,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "minItems": 1
                         },
                         "name": {
@@ -573,7 +573,7 @@
                             "minItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "minItems": 1
                         },
                         "texparams": {
@@ -589,7 +589,7 @@
                 {
                     "properties": {
                         "memory": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "name": {
@@ -604,7 +604,7 @@
                             "minItems": 1
                         },
                         "register": {
-			    "type": "array",
+                            "type": "array",
                             "maxItems": 0
                         },
                         "texparams": {
@@ -622,7 +622,7 @@
                             "type": "string"
                         },
                         "memory": {
-			                "type": "array"
+                            "type": "array"
                         },
                         "name": {
                             "enum": [
@@ -636,7 +636,7 @@
                             "type": "array"
                         },
                         "register": {
-			                "type": "array"
+                            "type": "array"
                         },
                         "snapshot_type": {
                             "type": "string"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Small fix noticed during #3553, with some of the .json files having tabs instead of spaces during recent (and not so recent) additions. This PR replaces the tabs with spaces to avoid formatting issues.

### Details and comments


