### PR TITLE
Make python 3.7 default in CI and remove duplicate job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,6 @@ jobs:
         - pip install diff-cover || true
         - diff-cover --compare-branch master coverage.xml || true
 
-    - name: Python 3.8 Tests
-      <<: *stage_linux
-      python: 3.8
-
     # Randomized testing
     - name: Randomized tests
       <<: *stage_linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,8 +122,8 @@ stages:
       condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
       strategy:
         matrix:
-          Python35:
-            python.version: '3.5'
+          Python37:
+            python.version: '3.7'
       steps:
         - task: UsePythonVersion@0
           inputs:
@@ -227,8 +227,8 @@ stages:
       condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))
       strategy:
         matrix:
-          Python35:
-            python.version: '3.5'
+          Python37:
+            python.version: '3.7'
       steps:
         - task: UsePythonVersion@0
           inputs:
@@ -338,8 +338,8 @@ stages:
         matrix:
           Python36:
             python.version: '3.6'
-          Python37:
-            python.version: '3.7'
+          Python35:
+            python.version: '3.5'
           Python38:
             python.version: '3.8'
       steps:
@@ -393,8 +393,8 @@ stages:
         matrix:
           Python36:
             python.version: '3.6'
-          Python37:
-            python.version: '3.7'
+          Python35:
+            python.version: '3.5'
           Python38:
             python.version: '3.8'
       steps:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since we've deprecated python 3.5 having 3.5 be the first round of
testing performed in CI feels out of place. This commit makes the
default jobs run in the first stage of the CI pipeline in azure all use
python 3.7. We still need to verify that 3.5 works and still gate on the
3.5 job passing. But, it doesn't get as much attention now that it's
deprecated. At the same time this commit takes the opportunity to remove
the duplicated python 3.8 job in the travis config. This was added
originally because travis had 3.8 support well before azure pipelines
but was never removed after azure added their 3.8 support.

### Details and comments