### PR TITLE
fix typo under python/test

### DIFF
--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -41,7 +41,7 @@ class TestGateDefinitions(QiskitTestCase):
         self.assertTrue(Operator(circ).equiv(Operator(decomposed_circ)))
 
     def test_crz_definition(self):
-        """Test crz gate matrix and defintion.
+        """Test crz gate matrix and definition.
         """
         circ = QuantumCircuit(2)
         circ.crz(1, 0, 1)
@@ -49,7 +49,7 @@ class TestGateDefinitions(QiskitTestCase):
         self.assertTrue(Operator(circ).equiv(Operator(decomposed_circ)))
 
     def test_cry_definition(self):
-        """Test cry gate matrix and defintion.
+        """Test cry gate matrix and definition.
         """
         circ = QuantumCircuit(2)
         circ.cry(1, 0, 1)
@@ -57,7 +57,7 @@ class TestGateDefinitions(QiskitTestCase):
         self.assertTrue(Operator(circ).equiv(Operator(decomposed_circ)))
 
     def test_crx_definition(self):
-        """Test crx gate matrix and defintion.
+        """Test crx gate matrix and definition.
         """
         circ = QuantumCircuit(2)
         circ.crx(1, 0, 1)
@@ -72,7 +72,7 @@ class TestGateDefinitions(QiskitTestCase):
         decomposed_circ = circ.decompose()
         self.assertTrue(Operator(circ).equiv(Operator(decomposed_circ)))
 
-    def test_cu1_defintion(self):
+    def test_cu1_definition(self):
         """Test cu1 gate matrix and definition.
         """
         circ = QuantumCircuit(2)

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -257,7 +257,7 @@ class TestParameters(QiskitTestCase):
         self.assertRaises(CircuitError, qc.u1, theta2, 0)
 
     def test_bind_ryrz_vector(self):
-        """Test binding a list of floats to a ParamterVector"""
+        """Test binding a list of floats to a ParameterVector"""
         qc = QuantumCircuit(4)
         depth = 4
         theta = ParameterVector('θ', length=len(qc.qubits) * depth * 2)
@@ -277,7 +277,7 @@ class TestParameters(QiskitTestCase):
                 self.assertIn(float(gate_tuple[0].params[0]), theta_vals)
 
     def test_compile_vector(self):
-        """Test compiling a circuit with an unbound ParamterVector"""
+        """Test compiling a circuit with an unbound ParameterVector"""
         qc = QuantumCircuit(4)
         depth = 4
         theta = ParameterVector('θ', length=len(qc.qubits)*depth*2)
@@ -295,7 +295,7 @@ class TestParameters(QiskitTestCase):
             self.assertIn(param, qc_aer.parameters)
 
     def test_instruction_ryrz_vector(self):
-        """Test constructing a circuit from instructions with remapped ParamterVectors"""
+        """Test constructing a circuit from instructions with remapped ParameterVectors"""
         qubits = 5
         depth = 4
         ryrz = QuantumCircuit(qubits, name='ryrz')
@@ -488,7 +488,7 @@ class TestParameterExpressions(QiskitTestCase):
                     _ = op(x, const)
 
     def test_expressions_division_by_zero(self):
-        """Verify divding a Parameter by 0, or binding 0 as a denominator raises."""
+        """Verify dividing a Parameter by 0, or binding 0 as a denominator raises."""
 
         x = Parameter('x')
 
@@ -620,7 +620,7 @@ class TestParameterExpressions(QiskitTestCase):
         with self.assertRaises(CircuitError):
             _ = x / y
 
-    def test_to_instruction_with_expresion(self):
+    def test_to_instruction_with_expression(self):
         """Test preservation of expressions via parameterized instructions."""
 
         theta = Parameter('θ')

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -36,7 +36,7 @@ class TestCircuitDrawer(QiskitTestCase):
             self.assertIsInstance(out, text.TextDrawing)
 
     @unittest.skipUnless(visualization.HAS_MATPLOTLIB,
-                         'Skipped because matplotib is not available')
+                         'Skipped because matplotlib is not available')
     def test_user_config_default_output(self):
         with patch('qiskit.user_config.get_config',
                    return_value={'circuit_drawer': 'mpl'}):
@@ -52,7 +52,7 @@ class TestCircuitDrawer(QiskitTestCase):
             self.assertIsInstance(out, text.TextDrawing)
 
     @unittest.skipUnless(visualization.HAS_MATPLOTLIB,
-                         'Skipped because matplotib is not available')
+                         'Skipped because matplotlib is not available')
     def test_kwarg_priority_over_user_config_default_output(self):
         with patch('qiskit.user_config.get_config',
                    return_value={'circuit_drawer': 'latex'}):
@@ -61,7 +61,7 @@ class TestCircuitDrawer(QiskitTestCase):
             self.assertIsInstance(out, figure.Figure)
 
     @unittest.skipUnless(visualization.HAS_MATPLOTLIB,
-                         'Skipped because matplotib is not available')
+                         'Skipped because matplotlib is not available')
     def test_default_backend_auto_output_with_mpl(self):
         with patch('qiskit.user_config.get_config',
                    return_value={'circuit_drawer': 'auto'}):

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -787,7 +787,7 @@ class TestTextDrawerGatesInCircuit(QiskitTestCase):
 
 
 class TestTextDrawerMultiQGates(QiskitTestCase):
-    """ Gates impling multiple qubits."""
+    """ Gates implying multiple qubits."""
 
     def test_2Qgate(self):
         """ 2Q no params. """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fix typos in python files under `test/python/circuit` and `test/python/visualization`.   
Most of them in comment or message. Two lines change test method name.

### Details and comments


