### PR TITLE
skip test_crosstalk_adaptive_scheduler when z3-solver not available

### DIFF
--- a/qiskit/transpiler/passes/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/crosstalk_adaptive_schedule.py
@@ -35,14 +35,15 @@ import operator
 from itertools import chain, combinations
 try:
     from z3 import Real, Bool, Sum, Implies, And, Or, Not, Optimize
-    Z3_AVAIL = True
+    HAS_Z3 = True
 except ImportError:
-    Z3_AVAIL = False
+    HAS_Z3 = False
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.extensions.standard import U1Gate, U2Gate, U3Gate, CnotGate
 from qiskit.circuit import Measure
 from qiskit.extensions.standard.barrier import Barrier
+from qiskit.transpiler.exceptions import TranspilerError
 
 NUM_PREC = 10
 TWOQ_XTALK_THRESH = 3
@@ -92,8 +93,6 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
 
         """
         super().__init__()
-        if not Z3_AVAIL:
-            raise ImportError('z3-solver is required to use CrosstalkAdaptiveSchedule')
         self.backend_prop = backend_prop
         self.crosstalk_prop = crosstalk_prop
         self.weight_factor = weight_factor
@@ -700,6 +699,9 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
         """
         Main scheduling function
         """
+        if not HAS_Z3:
+            raise TranspilerError('z3-solver is required to use CrosstalkAdaptiveSchedule')
+
         self.dag = dag
 
         # process input program

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -21,4 +21,3 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints
 jupyter-sphinx
-z3-solver>=4.7

--- a/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
+++ b/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
@@ -99,6 +99,7 @@ class TestCrosstalk(QiskitTestCase):
     """
     Tests for crosstalk adaptivity
     """
+
     def test_schedule_length1(self):
         """Testing with high crosstalk between CNOT 0,1 and CNOT 2,3"""
         bprop = create_fake_machine()
@@ -118,7 +119,7 @@ class TestCrosstalk(QiskitTestCase):
         dag = circuit_to_dag(new_circ)
         pass_ = CrosstalkAdaptiveSchedule(bprop, crosstalk_prop)
         scheduled_dag = pass_.run(dag)
-        assert scheduled_dag.depth() == 3
+        self.assertEqual(scheduled_dag.depth(), 3)
 
     def test_schedule_length2(self):
         """Testing with no crosstalk between CNOT 0,1 and CNOT 2,3"""
@@ -139,7 +140,7 @@ class TestCrosstalk(QiskitTestCase):
         dag = circuit_to_dag(new_circ)
         pass_ = CrosstalkAdaptiveSchedule(bprop, crosstalk_prop)
         scheduled_dag = pass_.run(dag)
-        assert scheduled_dag.depth() == 1
+        self.assertEqual(scheduled_dag.depth(), 1)
 
     def test_schedule_length3(self):
         """Testing with repeated calls to run"""
@@ -161,8 +162,8 @@ class TestCrosstalk(QiskitTestCase):
         pass_ = CrosstalkAdaptiveSchedule(bprop, crosstalk_prop)
         scheduled_dag1 = pass_.run(dag)
         scheduled_dag2 = pass_.run(dag)
-        assert scheduled_dag1.depth() == 3
-        assert scheduled_dag2.depth() == 3
+        self.assertEqual(scheduled_dag1.depth(), 3)
+        self.assertEqual(scheduled_dag2.depth(), 3)
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
+++ b/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
@@ -20,7 +20,7 @@ import unittest
 from datetime import datetime
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import Layout
-from qiskit.transpiler.passes import CrosstalkAdaptiveSchedule
+from qiskit.transpiler.passes.crosstalk_adaptive_schedule import CrosstalkAdaptiveSchedule, HAS_Z3
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
 from qiskit.compiler import transpile
@@ -94,6 +94,7 @@ def create_fake_machine():
     return bprop
 
 
+@unittest.skipIf(not HAS_Z3, 'z3-solver not installed.')
 class TestCrosstalk(QiskitTestCase):
     """
     Tests for crosstalk adaptivity


### PR DESCRIPTION
PR #3532 introduced an optional dependency on `z3-solver`. This PR skips the tests using that module when not available.