### PR TITLE
fix ``state_fidelity`` to work with ``Statevector`` and ``DensityMatrix`` classes

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -109,9 +109,8 @@ from .operators.measures import process_fidelity
 from .operators import average_gate_fidelity
 from .operators import gate_error
 from .states import Statevector, DensityMatrix
-from .states.utils import partial_trace
+from .states import state_fidelity, partial_trace
 from .states.states import basis_state, projector, purity
-from .states.measures import state_fidelity
 from .random import random_unitary, random_state, random_density_matrix
 from .synthesis import (TwoQubitBasisDecomposer, euler_angles_1q,
                         two_qubit_cnot_decompose)

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -19,3 +19,4 @@ from .densitymatrix import DensityMatrix
 from .utils import partial_trace
 from .states import basis_state, projector, purity
 from .counts import state_to_counts
+from .measures import state_fidelity

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -11,71 +11,61 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
-A collection of useful quantum information functions for states.
-
-
+Quantum information measures, metrics, and related functions for states.
 """
 
 import numpy as np
-import scipy.linalg as la
+from qiskit.quantum_info.states.statevector import Statevector
+from qiskit.quantum_info.states.utils import _format_state, _funm_svd
 
 
-def state_fidelity(state1, state2):
-    """Return the state fidelity between two quantum states.
+def state_fidelity(state1, state2, validate=True):
+    r"""Return the state fidelity between two quantum states.
 
-    Either input may be a state vector, or a density matrix. The state
-    fidelity (F) for two density matrices is defined as::
+    The state fidelity :math:`F` for density matrix input states
+    :math:`\rho_1, \rho_2` is given by
 
-        F(rho1, rho2) = Tr[sqrt(sqrt(rho1).rho2.sqrt(rho1))] ^ 2
+    .. math::
+        F(\rho_1, \rho_2) = Tr[\sqrt{\sqrt{\rho_1}\rho_2\sqrt{\rho_1}}]^2.
 
-    For a pure state and mixed state the fidelity is given by::
-
-        F(|psi1>, rho2) = <psi1|rho2|psi1>
-
-    For two pure states the fidelity is given by::
-
-        F(|psi1>, |psi2>) = |<psi1|psi2>|^2
+    If one of the states is a pure state this simplies to
+    :math:`F(\rho_1, \rho_2) = \langle\psi_1|\rho_2|\psi_1\rangle`, where
+    :math:`\rho_1 = |\psi_1\rangle\!\langle\psi_1|`.
 
     Args:
-        state1 (array_like): a quantum state vector or density matrix.
-        state2 (array_like): a quantum state vector or density matrix.
+        state1 (Statevector or DensityMatrix): the first quantum state.
+        state2 (Statevector or DensityMatrix): the second quantum state.
+        validate (bool): check if the inputs are valid quantum states
+                         [Default: True]
 
     Returns:
-        array_like: The state fidelity F(state1, state2).
+        float: The state fidelity :math:`F(\rho_1, \rho_2)`.
+
+    Raises:
+        QiskitError: if ``validate=True`` and the inputs are invalid quantum states.
     """
     # convert input to numpy arrays
-    state1 = np.array(state1)
-    state2 = np.array(state2)
+    state1 = _format_state(state1, validate=validate)
+    state2 = _format_state(state2, validate=validate)
 
-    # fidelity of two state vectors
-    if state1.ndim == 1 and state2.ndim == 1:
-        return np.abs(state2.conj().dot(state1)) ** 2
-    # fidelity of vector and density matrix
-    elif state1.ndim == 1:
-        # psi = s1, rho = s2
-        return np.abs(state1.conj().dot(state2).dot(state1))
-    elif state2.ndim == 1:
-        # psi = s2, rho = s1
-        return np.abs(state2.conj().dot(state1).dot(state2))
-    # fidelity of two density matrices
-    s1sq = _funm_svd(state1, np.sqrt)
-    s2sq = _funm_svd(state2, np.sqrt)
-    return np.linalg.norm(s1sq.dot(s2sq), ord='nuc') ** 2
-
-
-def _funm_svd(matrix, func):
-    """Apply real scalar function to singular values of a matrix.
-
-    Args:
-        matrix (array_like): (N, N) Matrix at which to evaluate the function.
-        func (callable): Callable object that evaluates a scalar function f.
-
-    Returns:
-        ndarray: funm (N, N) Value of the matrix function specified by func
-        evaluated at `A`.
-    """
-    unitary1, singular_values, unitary2 = la.svd(matrix, lapack_driver='gesvd')
-    diag_func_singular = np.diag(func(singular_values))
-    return unitary1.dot(diag_func_singular).dot(unitary2)
+    # Get underlying numpy arrays
+    arr1 = state1.data
+    arr2 = state2.data
+    if isinstance(state1, Statevector):
+        if isinstance(state2, Statevector):
+            # Fidelity of two Statevectors
+            fid = np.abs(arr2.conj().dot(arr1))**2
+        else:
+            # Fidelity of Statevector(1) and DensityMatrix(2)
+            fid = arr1.conj().dot(arr2).dot(arr1)
+    elif isinstance(state2, Statevector):
+        # Fidelity of Statevector(2) and DensityMatrix(1)
+        fid = arr2.conj().dot(arr1).dot(arr2)
+    else:
+        # Fidelity of two DensityMatrices
+        s1sq = _funm_svd(arr1, np.sqrt)
+        s2sq = _funm_svd(arr2, np.sqrt)
+        fid = np.linalg.norm(s1sq.dot(s2sq), ord='nuc')**2
+    # Convert to py float rather than return np.float
+    return float(np.real(fid))

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -17,6 +17,7 @@ Quantum information utility functions for states.
 """
 
 import numpy as np
+import scipy.linalg as la
 
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.states.statevector import Statevector
@@ -95,3 +96,19 @@ def _format_state(state, validate=True):
     if validate and not state.is_valid():
         raise QiskitError("Input quantum state is not a valid")
     return state
+
+
+def _funm_svd(matrix, func):
+    """Apply real scalar function to singular values of a matrix.
+
+    Args:
+        matrix (array_like): (N, N) Matrix at which to evaluate the function.
+        func (callable): Callable object that evaluates a scalar function f.
+
+    Returns:
+        ndarray: funm (N, N) Value of the matrix function specified by func
+        evaluated at `A`.
+    """
+    unitary1, singular_values, unitary2 = la.svd(matrix, lapack_driver='gesvd')
+    diag_func_singular = np.diag(func(singular_values))
+    return unitary1.dot(diag_func_singular).dot(unitary2)

--- a/test/python/quantum_info/test_states.py
+++ b/test/python/quantum_info/test_states.py
@@ -28,40 +28,58 @@ from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.test import QiskitTestCase
 
 
-class TestStates(QiskitTestCase):
-    """Tests for qi.py"""
+class TestStateFidelity(QiskitTestCase):
+    """Tests state_fidelity function"""
 
-    def test_state_fidelity(self):
-        psi1 = [0.70710678118654746, 0, 0, 0.70710678118654746]
-        psi2 = [0., 0.70710678118654746, 0.70710678118654746, 0.]
-        rho1 = [[0.5, 0, 0, 0.5], [0, 0, 0, 0], [0, 0, 0, 0], [0.5, 0, 0, 0.5]]
-        mix = [[0.25, 0, 0, 0], [0, 0.25, 0, 0],
-               [0, 0, 0.25, 0], [0, 0, 0, 0.25]]
+    def test_both_statevector(self):
+        """Test state_fidelity function for statevector inputs"""
+        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
+        psi2 = Statevector([0., 0.70710678118654746, 0.70710678118654746, 0.])
         self.assertAlmostEqual(state_fidelity(psi1, psi1), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi2, psi2), 1.0, places=7,
                                msg='vector-vector input')
         self.assertAlmostEqual(state_fidelity(psi1, psi2), 0.0, places=7,
                                msg='vector-vector input')
-        self.assertAlmostEqual(state_fidelity(psi1, rho1), 1.0, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(psi1, mix), 0.25, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(psi2, rho1), 0.0, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(psi2, mix), 0.25, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(rho1, psi1), 1.0, places=7,
-                               msg='matrix-vector input')
+
+    def test_statevector_density_matrix(self):
+        """Test state_fidelity function for statevector and density matrix inputs"""
+        rho1 = DensityMatrix([[0.5, 0, 0, 0.5],
+                              [0, 0, 0, 0],
+                              [0, 0, 0, 0],
+                              [0.5, 0, 0, 0.5]])
+        mix = DensityMatrix([[0.25, 0, 0, 0],
+                             [0, 0.25, 0, 0],
+                             [0, 0, 0.25, 0],
+                             [0, 0, 0, 0.25]])
         self.assertAlmostEqual(state_fidelity(rho1, rho1), 1.0, places=7,
                                msg='matrix-matrix input')
         self.assertAlmostEqual(state_fidelity(mix, mix), 1.0, places=7,
                                msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, mix), 0.25, places=7,
+                               msg='matrix-matrix input')
 
-    def test_state_fidelity_qubit(self):
-        state0 = np.array([1.+0.j, 0.+0.j])
-        state1 = np.array([0.+0.j, 1.+0.j])
-        self.assertEqual(state_fidelity(state0, state0), 1.0)
-        self.assertEqual(state_fidelity(state1, state1), 1.0)
-        self.assertEqual(state_fidelity(state0, state1), 0.0)
+    def test_both_density_matrix(self):
+        """Test state_fidelity function for density matrix inputs"""
+        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
+        rho1 = DensityMatrix([[0.5, 0, 0, 0.5],
+                              [0, 0, 0, 0],
+                              [0, 0, 0, 0],
+                              [0.5, 0, 0, 0.5]])
+        mix = DensityMatrix([[0.25, 0, 0, 0],
+                             [0, 0.25, 0, 0],
+                             [0, 0, 0.25, 0],
+                             [0, 0, 0, 0.25]])
+        self.assertAlmostEqual(state_fidelity(psi1, rho1), 1.0, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(psi1, mix), 0.25, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, psi1), 1.0, places=7,
+                               msg='matrix-vector input')
+
+
+class TestStates(QiskitTestCase):
+    """Tests for qi.py"""
 
     def test_projector(self):
         state0 = np.array([1.+0.j, 0.+0.j])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Updates the `quantum_info.state_fidelity` function to work with `Statevector` and `DensityMatrix` objects, along with raw numpy statevector and density matrix arrays.

Updates state_fidelity documentation

### Details and comments


