### PR TITLE
Fix ``Operator.transpose`` for rectangular operators

### DIFF
--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -171,13 +171,15 @@ class Operator(BaseOperator):
 
     def conjugate(self):
         """Return the conjugate of the operator."""
-        return Operator(
-            np.conj(self.data), self.input_dims(), self.output_dims())
+        return Operator(np.conj(self.data),
+                        input_dims=self.input_dims(),
+                        output_dims=self.output_dims())
 
     def transpose(self):
         """Return the transpose of the operator."""
-        return Operator(
-            np.transpose(self.data), self.input_dims(), self.output_dims())
+        return Operator(np.transpose(self.data),
+                        input_dims=self.output_dims(),
+                        output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
         """Return the composition channel self∘other.

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -279,24 +279,24 @@ class TestOperator(OperatorTestCase):
 
     def test_conjugate(self):
         """Test conjugate method."""
-        matr = self.rand_matrix(2, 2, real=True)
-        mati = self.rand_matrix(2, 2, real=True)
+        matr = self.rand_matrix(2, 4, real=True)
+        mati = self.rand_matrix(2, 4, real=True)
         op = Operator(matr + 1j * mati)
         uni_conj = op.conjugate()
         self.assertEqual(uni_conj, Operator(matr - 1j * mati))
 
     def test_transpose(self):
         """Test transpose method."""
-        matr = self.rand_matrix(2, 2, real=True)
-        mati = self.rand_matrix(2, 2, real=True)
+        matr = self.rand_matrix(2, 4, real=True)
+        mati = self.rand_matrix(2, 4, real=True)
         op = Operator(matr + 1j * mati)
         uni_t = op.transpose()
         self.assertEqual(uni_t, Operator(matr.T + 1j * mati.T))
 
     def test_adjoint(self):
         """Test adjoint method."""
-        matr = self.rand_matrix(2, 2, real=True)
-        mati = self.rand_matrix(2, 2, real=True)
+        matr = self.rand_matrix(2, 4, real=True)
+        mati = self.rand_matrix(2, 4, real=True)
         op = Operator(matr + 1j * mati)
         uni_adj = op.adjoint()
         self.assertEqual(uni_adj, Operator(matr.T - 1j * mati.T))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3671 

Fixes bug with `Operator.transpose` not swapping input and output dimensions. This would case transpose to fail for rectangular operators.

### Details and comments


