### PR TITLE
fix ``purity`` function to work with ``Statevector`` and ``DensityMatrix`` classes

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -59,6 +59,7 @@ Measures
    :toctree: ../stubs/
 
    state_fidelity
+   purity
    average_gate_fidelity
    process_fidelity
    gate_error
@@ -109,8 +110,8 @@ from .operators.measures import process_fidelity
 from .operators import average_gate_fidelity
 from .operators import gate_error
 from .states import Statevector, DensityMatrix
-from .states import state_fidelity, partial_trace
-from .states.states import basis_state, projector, purity
+from .states import state_fidelity, partial_trace, purity
+from .states.states import basis_state, projector
 from .random import random_unitary, random_state, random_density_matrix
 from .synthesis import (TwoQubitBasisDecomposer, euler_angles_1q,
                         two_qubit_cnot_decompose)

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -17,6 +17,6 @@
 from .statevector import Statevector
 from .densitymatrix import DensityMatrix
 from .utils import partial_trace
-from .states import basis_state, projector, purity
+from .measures import state_fidelity, purity
+from .states import basis_state, projector
 from .counts import state_to_counts
-from .measures import state_fidelity

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -69,3 +69,26 @@ def state_fidelity(state1, state2, validate=True):
         fid = np.linalg.norm(s1sq.dot(s2sq), ord='nuc')**2
     # Convert to py float rather than return np.float
     return float(np.real(fid))
+
+
+def purity(state, validate=True):
+    r"""Calculate the purity of a quantum state.
+
+    The purity of a density matrix :math:`\rho` is
+
+    ..code:
+
+        \text{Purity}(\rho) = \Tr[\rho^2]
+
+    Args:
+        state (Statevector or DensityMatrix): a quantum state.
+        validate (bool): check if input state is valid [Default: True]
+
+    Returns:
+        float: the purity :math:`\Tr[\rho^2]`.
+
+    Raises:
+        QiskitError: if the input isn't a valid quantum state.
+    """
+    state = _format_state(state, validate=validate)
+    return state.purity()

--- a/qiskit/quantum_info/states/states.py
+++ b/qiskit/quantum_info/states/states.py
@@ -57,17 +57,3 @@ def projector(state, flatten=False):
     if flatten:
         return density_matrix.flatten(order='F')
     return density_matrix
-
-
-def purity(state):
-    """Calculate the purity of a quantum state.
-
-    Args:
-        state (ndarray): a quantum state
-    Returns:
-        float: purity.
-    """
-    rho = np.array(state)
-    if rho.ndim == 1:
-        return 1.0
-    return np.real(np.trace(rho.dot(rho)))

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=missing-docstring
+
+"""Quick program to test the quantum information states modules."""
+
+import unittest
+import numpy as np
+
+from qiskit import QiskitError
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info.states import DensityMatrix, Statevector
+from qiskit.quantum_info import state_fidelity
+from qiskit.quantum_info import purity
+
+
+class TestStateMeasures(QiskitTestCase):
+    """Tests state measure functions"""
+
+    def test_state_fidelity_statevector(self):
+        """Test state_fidelity function for statevector inputs"""
+
+        psi1 = [0.70710678118654746, 0, 0, 0.70710678118654746]
+        psi2 = [0., 0.70710678118654746, 0.70710678118654746, 0.]
+        self.assertAlmostEqual(state_fidelity(psi1, psi1), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi2, psi2), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi1, psi2), 0.0, places=7,
+                               msg='vector-vector input')
+
+        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
+        psi2 = Statevector([0., 0.70710678118654746, 0.70710678118654746, 0.])
+        self.assertAlmostEqual(state_fidelity(psi1, psi1), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi2, psi2), 1.0, places=7,
+                               msg='vector-vector input')
+        self.assertAlmostEqual(state_fidelity(psi1, psi2), 0.0, places=7,
+                               msg='vector-vector input')
+
+        psi1 = Statevector([1, 0, 0, 1])  # invalid state
+        psi2 = Statevector([1, 0, 0, 0])
+        self.assertRaises(QiskitError, state_fidelity, psi1, psi2)
+        self.assertRaises(QiskitError, state_fidelity, psi1, psi2, validate=True)
+        self.assertEqual(state_fidelity(psi1, psi2, validate=False), 1)
+
+    def test_state_fidelity_density_matrix(self):
+        """Test state_fidelity function for density matrix inputs"""
+        rho1 = [[0.5, 0, 0, 0.5],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0],
+                [0.5, 0, 0, 0.5]]
+        mix = [[0.25, 0, 0, 0],
+               [0, 0.25, 0, 0],
+               [0, 0, 0.25, 0],
+               [0, 0, 0, 0.25]]
+        self.assertAlmostEqual(state_fidelity(rho1, rho1), 1.0, places=7,
+                               msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(mix, mix), 1.0, places=7,
+                               msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, mix), 0.25, places=7,
+                               msg='matrix-matrix input')
+
+        rho1 = DensityMatrix(rho1)
+        mix = DensityMatrix(mix)
+        self.assertAlmostEqual(state_fidelity(rho1, rho1), 1.0, places=7,
+                               msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(mix, mix), 1.0, places=7,
+                               msg='matrix-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, mix), 0.25, places=7,
+                               msg='matrix-matrix input')
+
+        rho1 = DensityMatrix([1, 0, 0, 0])
+        mix = DensityMatrix(np.diag([1, 0, 0, 1]))
+        self.assertRaises(QiskitError, state_fidelity, rho1, mix)
+        self.assertRaises(QiskitError, state_fidelity, rho1, mix, validate=True)
+        self.assertEqual(state_fidelity(rho1, mix, validate=False), 1)
+
+    def test_state_fidelity_mixed(self):
+        """Test state_fidelity function for statevector and density matrix inputs"""
+        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
+        rho1 = DensityMatrix([[0.5, 0, 0, 0.5],
+                              [0, 0, 0, 0],
+                              [0, 0, 0, 0],
+                              [0.5, 0, 0, 0.5]])
+        mix = DensityMatrix([[0.25, 0, 0, 0],
+                             [0, 0.25, 0, 0],
+                             [0, 0, 0.25, 0],
+                             [0, 0, 0, 0.25]])
+        self.assertAlmostEqual(state_fidelity(psi1, rho1), 1.0, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(psi1, mix), 0.25, places=7,
+                               msg='vector-matrix input')
+        self.assertAlmostEqual(state_fidelity(rho1, psi1), 1.0, places=7,
+                               msg='matrix-vector input')
+
+    def test_purity_statevector(self):
+        """Test purity function on statevector inputs"""
+        psi = Statevector([1, 0, 0, 0])
+        self.assertEqual(purity(psi), 1)
+        self.assertEqual(purity(psi, validate=True), 1)
+        self.assertEqual(purity(psi, validate=False), 1)
+
+        psi = [0.70710678118654746, 0.70710678118654746]
+        self.assertAlmostEqual(purity(psi), 1)
+        self.assertAlmostEqual(purity(psi, validate=True), 1)
+        self.assertAlmostEqual(purity(psi, validate=False), 1)
+
+        psi = np.array([0.5, 0.5j, -0.5j, -0.5])
+        self.assertAlmostEqual(purity(psi), 1)
+        self.assertAlmostEqual(purity(psi, validate=True), 1)
+        self.assertAlmostEqual(purity(psi, validate=False), 1)
+
+        psi = Statevector([1, 0, 0, 1])
+        self.assertRaises(QiskitError, purity, psi)
+        self.assertRaises(QiskitError, purity, psi, validate=True)
+        self.assertEqual(purity(psi, validate=False), 4)
+
+    def test_purity_density_matrix(self):
+        """Test purity function on density matrix inputs"""
+        rho = DensityMatrix(np.diag([1, 0, 0, 0]))
+        self.assertEqual(purity(rho), 1)
+        self.assertEqual(purity(rho, validate=True), 1)
+        self.assertEqual(purity(rho, validate=False), 1)
+
+        rho = np.diag([0.25, 0.25, 0.25, 0.25])
+        self.assertEqual(purity(rho), 0.25)
+        self.assertEqual(purity(rho, validate=True), 0.25)
+        self.assertEqual(purity(rho, validate=False), 0.25)
+
+        rho = [[0.5, 0, 0, 0.5],
+               [0, 0, 0, 0],
+               [0, 0, 0, 0],
+               [0.5, 0, 0, 0.5]]
+        self.assertEqual(purity(rho), 1)
+        self.assertEqual(purity(rho, validate=True), 1)
+        self.assertEqual(purity(rho, validate=False), 1)
+
+        rho = np.diag([1, 0, 0, 1])
+        self.assertRaises(QiskitError, purity, rho)
+        self.assertRaises(QiskitError, purity, rho, validate=True)
+        self.assertEqual(purity(rho, validate=False), 2)
+
+    def test_purity_statevector_density_matrix(self):
+        """Test purity is same for equivalent statevector and density matrix inputs"""
+        psi = Statevector([0.5, -0.5, 0.5j, -0.5j])
+        rho = DensityMatrix(psi)
+        self.assertAlmostEqual(purity(psi), purity(rho))
+
+        psi = Statevector([0.5, 0, 0, -0.5j])
+        rho = DensityMatrix(psi)
+        self.assertAlmostEqual(purity(psi, validate=False), purity(rho, validate=False))
+
+        psi = Statevector([1, 1])
+        rho = DensityMatrix(psi)
+        self.assertAlmostEqual(purity(psi, validate=False), purity(rho, validate=False))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/quantum_info/test_states.py
+++ b/test/python/quantum_info/test_states.py
@@ -23,59 +23,8 @@ from qiskit import execute, QuantumRegister, QuantumCircuit, BasicAer
 from qiskit.quantum_info import basis_state, random_state
 from qiskit.quantum_info import state_fidelity
 from qiskit.quantum_info import projector
-from qiskit.quantum_info import purity
 from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.test import QiskitTestCase
-
-
-class TestStateFidelity(QiskitTestCase):
-    """Tests state_fidelity function"""
-
-    def test_both_statevector(self):
-        """Test state_fidelity function for statevector inputs"""
-        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
-        psi2 = Statevector([0., 0.70710678118654746, 0.70710678118654746, 0.])
-        self.assertAlmostEqual(state_fidelity(psi1, psi1), 1.0, places=7,
-                               msg='vector-vector input')
-        self.assertAlmostEqual(state_fidelity(psi2, psi2), 1.0, places=7,
-                               msg='vector-vector input')
-        self.assertAlmostEqual(state_fidelity(psi1, psi2), 0.0, places=7,
-                               msg='vector-vector input')
-
-    def test_statevector_density_matrix(self):
-        """Test state_fidelity function for statevector and density matrix inputs"""
-        rho1 = DensityMatrix([[0.5, 0, 0, 0.5],
-                              [0, 0, 0, 0],
-                              [0, 0, 0, 0],
-                              [0.5, 0, 0, 0.5]])
-        mix = DensityMatrix([[0.25, 0, 0, 0],
-                             [0, 0.25, 0, 0],
-                             [0, 0, 0.25, 0],
-                             [0, 0, 0, 0.25]])
-        self.assertAlmostEqual(state_fidelity(rho1, rho1), 1.0, places=7,
-                               msg='matrix-matrix input')
-        self.assertAlmostEqual(state_fidelity(mix, mix), 1.0, places=7,
-                               msg='matrix-matrix input')
-        self.assertAlmostEqual(state_fidelity(rho1, mix), 0.25, places=7,
-                               msg='matrix-matrix input')
-
-    def test_both_density_matrix(self):
-        """Test state_fidelity function for density matrix inputs"""
-        psi1 = Statevector([0.70710678118654746, 0, 0, 0.70710678118654746])
-        rho1 = DensityMatrix([[0.5, 0, 0, 0.5],
-                              [0, 0, 0, 0],
-                              [0, 0, 0, 0],
-                              [0.5, 0, 0, 0.5]])
-        mix = DensityMatrix([[0.25, 0, 0, 0],
-                             [0, 0.25, 0, 0],
-                             [0, 0, 0.25, 0],
-                             [0, 0, 0, 0.25]])
-        self.assertAlmostEqual(state_fidelity(psi1, rho1), 1.0, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(psi1, mix), 0.25, places=7,
-                               msg='vector-matrix input')
-        self.assertAlmostEqual(state_fidelity(rho1, psi1), 1.0, places=7,
-                               msg='matrix-vector input')
 
 
 class TestStates(QiskitTestCase):
@@ -122,60 +71,6 @@ class TestStates(QiskitTestCase):
         backend = BasicAer.get_backend('statevector_simulator')
         qc_state = execute(qc, backend).result().get_statevector(qc)
         self.assertAlmostEqual(state_fidelity(qc_state, state), 1.0, places=7)
-
-    def test_purity_list_input(self):
-        rho1 = [[1, 0], [0, 0]]
-        rho2 = [[0.5, 0], [0, 0.5]]
-        rho3 = 0.7 * np.array(rho1) + 0.3 * np.array(rho2)
-        test_pass = (purity(rho1) == 1.0 and
-                     purity(rho2) == 0.5 and
-                     round(purity(rho3), 10) == 0.745)
-        self.assertTrue(test_pass)
-
-    def test_purity_1d_list_input(self):
-        input_state = [1, 0]
-        res = purity(input_state)
-        self.assertEqual(1, res)
-
-    def test_purity_basis_state_input(self):
-        state_1 = basis_state('0', 1)
-        state_2 = basis_state('11', 2)
-        state_3 = basis_state('010', 3)
-        self.assertAlmostEqual(purity(state_1), 1.0)
-        self.assertAlmostEqual(purity(state_2), 1.0)
-        self.assertAlmostEqual(purity(state_3), 1.0)
-
-    def test_purity_pure_state(self):
-        state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
-        state_2 = (1/np.sqrt(3))*(basis_state('00', 2)
-                                  + basis_state('01', 2) + basis_state('11', 2))
-        state_3 = 0.5*(basis_state('000', 3) + basis_state('001', 3)
-                       + basis_state('010', 3) + basis_state('100', 3))
-        self.assertAlmostEqual(purity(state_1), 1.0)
-        self.assertAlmostEqual(purity(state_2), 1.0)
-        self.assertAlmostEqual(purity(state_3), 1.0)
-
-    def test_purity_pure_matrix_state(self):
-        state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
-        state_1 = projector(state_1)
-        state_2 = (1/np.sqrt(3))*(basis_state('00', 2)
-                                  + basis_state('01', 2) + basis_state('11', 2))
-        state_2 = projector(state_2)
-        state_3 = 0.5*(basis_state('000', 3) + basis_state('001', 3)
-                       + basis_state('010', 3) + basis_state('100', 3))
-        state_3 = projector(state_3)
-        self.assertAlmostEqual(purity(state_1), 1.0, places=10)
-        self.assertAlmostEqual(purity(state_2), 1.0, places=10)
-        self.assertAlmostEqual(purity(state_3), 1.0)
-
-    def test_purity_mixed_state(self):
-        state_1 = 0.5*(projector(basis_state('0', 1))
-                       + projector(basis_state('1', 1)))
-        state_2 = (1/3.0)*(projector(basis_state('00', 2))
-                           + projector(basis_state('01', 2))
-                           + projector(basis_state('10', 2)))
-        self.assertEqual(purity(state_1), 0.5)
-        self.assertEqual(purity(state_2), 1.0/3)
 
     def statevector_to_counts(self):
         """Statevector to counts dict"""

--- a/test/python/quantum_info/test_states.py
+++ b/test/python/quantum_info/test_states.py
@@ -106,7 +106,7 @@ class TestStates(QiskitTestCase):
 
     def test_random_state(self):
         # this test that a random state converges to 1/d
-        number = 100000
+        number = 1000
         E_P0_last = 0
         for ii in range(number):
             state = basis_state(bin(3)[2:].zfill(3), 3)
@@ -141,9 +141,9 @@ class TestStates(QiskitTestCase):
         state_1 = basis_state('0', 1)
         state_2 = basis_state('11', 2)
         state_3 = basis_state('010', 3)
-        self.assertEqual(purity(state_1), 1.0)
-        self.assertEqual(purity(state_2), 1.0)
-        self.assertEqual(purity(state_3), 1.0)
+        self.assertAlmostEqual(purity(state_1), 1.0)
+        self.assertAlmostEqual(purity(state_2), 1.0)
+        self.assertAlmostEqual(purity(state_3), 1.0)
 
     def test_purity_pure_state(self):
         state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
@@ -151,9 +151,9 @@ class TestStates(QiskitTestCase):
                                   + basis_state('01', 2) + basis_state('11', 2))
         state_3 = 0.5*(basis_state('000', 3) + basis_state('001', 3)
                        + basis_state('010', 3) + basis_state('100', 3))
-        self.assertEqual(purity(state_1), 1.0)
-        self.assertEqual(purity(state_2), 1.0)
-        self.assertEqual(purity(state_3), 1.0)
+        self.assertAlmostEqual(purity(state_1), 1.0)
+        self.assertAlmostEqual(purity(state_2), 1.0)
+        self.assertAlmostEqual(purity(state_3), 1.0)
 
     def test_purity_pure_matrix_state(self):
         state_1 = (1/np.sqrt(2))*(basis_state('0', 1) + basis_state('1', 1))
@@ -166,7 +166,7 @@ class TestStates(QiskitTestCase):
         state_3 = projector(state_3)
         self.assertAlmostEqual(purity(state_1), 1.0, places=10)
         self.assertAlmostEqual(purity(state_2), 1.0, places=10)
-        self.assertEqual(purity(state_3), 1.0)
+        self.assertAlmostEqual(purity(state_3), 1.0)
 
     def test_purity_mixed_state(self):
         state_1 = 0.5*(projector(basis_state('0', 1))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This removes function `quantum_info.states.states.purity` and replaces it with a function `quantum_info.states.measures.purity` which works with Statevector and DensityMatrix classes (along with raw nparrays).

### Details and comments

The function is a wrapper for converting the input to a Statevector or DensityMatrix and calling the `.purity` method of that class with additional.

