### PR TITLE
[Stable] Pin nbformat to 4.4.0 (#3691)

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 astroid==2.2.5
 cryptography==2.5.0
 pylint==2.3.1
+nbformat==4.4.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent nbformat release 5.0.0 that was just pushed to pypi is
missing jsonschema files from the uploaded artifacts,
(see jupyter/nbformat#155). This is causing CI failures, until the issue
is resolved this commit pins the version installed via pip using the
constraints file (since it's not a direct dependency).

### Details and comments

Backported from #3691 
(cherry picked from commit 7718e3576d0c9d77991c8c4b813ac05b7b1aa940)
