### PR TITLE
Pin pylint and astroid in requirements-dev.txt

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,2 @@
-astroid==2.3.3
-pylint==2.4.4
 matplotlib==3.2.0rc1;python_version=='3.8'
 nbformat==4.4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,8 @@ matplotlib>=2.1
 pillow>=4.2.1
 pycodestyle
 pydot
-pylint>=2.3,<2.4
+astroid==2.3.3
+pylint==2.4.4
 pylintfileheader>=0.0.2
 stestr>=2.0.0
 PyGithub


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently we're pinning pylint and astroid via a constraints file. This
was done primarily because astroid is not a direct dependency for
development since we only actually directly use pylint. The constraints
file mechanism is designed for this purpose to let us set explict
versions for repeatability for any package installed via pip, even if
it's not a direct requirement. However, the constraints file mechanism
isn't obvious to developers who are manually installing development
requirements into their environment. Additionally, the
requirements-dev.txt had a pylint version cap which conflicts with the
version set via the constraints file which made it extra confusing.
This commit moves away from using the constraints for pylint and moves
to using requirements-dev.txt directly. To facilitate this astroid
pinned at a specific version is also added to the requirements-dev.txt
file to ensure we have a consistent output from pylint. While this isn't
a direct dependency for development it does make it simpler to find and
install a consistent pylint env locally.

### Details and comments