### PR TITLE
Fixup bug where name isnt maintained by align_measures

### DIFF
--- a/qiskit/pulse/reschedule.py
+++ b/qiskit/pulse/reschedule.py
@@ -94,7 +94,7 @@ def align_measures(schedules: Iterable[ScheduleComponent],
     # Shift acquires according to the new scheduled time
     new_schedules = []
     for schedule in schedules:
-        new_schedule = Schedule()
+        new_schedule = Schedule(name=schedule.name)
         acquired_channels = set()
         measured_channels = set()
 

--- a/test/python/pulse/test_reschedule.py
+++ b/test/python/pulse/test_reschedule.py
@@ -47,6 +47,7 @@ class TestAutoMerge(QiskitTestCase):
         sched = sched.insert(10, self.short_pulse(self.config.measure(0)))
         sched = sched.insert(10, self.short_pulse(self.config.measure(1)))
         sched = align_measures([sched], self.cmd_def)[0]
+        self.assertEqual(sched.name, 'fake_experiment')
         for time, inst in sched.instructions:
             if isinstance(inst, AcquireInstruction):
                 self.assertEqual(time, 10)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

```
input_sched = Schedule(name="X")
sched = align_measures([input_sched], self.cmd_def)[0]
```
Before, `sched.name` would be `None`, now it is `"X"`


Thank you @nkanazawa1989 for reporting