### PR TITLE
Update schemas for parametric pulses

### DIFF
--- a/qiskit/schemas/backend_configuration_schema.json
+++ b/qiskit/schemas/backend_configuration_schema.json
@@ -250,7 +250,12 @@
                                 "type": "array",
                                 "minItems": 1,
                                 "description": "Array of dimension n_channels [d->u->m] x n_registers. Latency (in units of dt) to do a conditional operation on channel n from register slot m",
-                                "items": {"type": "array", "minItems": 1, "items": {"type": "number"}}}
+                                "items": {"type": "array", "minItems": 1, "items": {"type": "number"}}},
+                            "parametric_pulses": {
+                                "type": "array",
+                                "minItems": 0,
+                                "description": "A list of available parametric pulse shapes",
+                                "items": {"type": "string"}}
                             }},
         "gateconfig": {
             "type": "object",

--- a/qiskit/schemas/examples/backend_configuration_openpulse_example.json
+++ b/qiskit/schemas/examples/backend_configuration_openpulse_example.json
@@ -55,5 +55,6 @@
     "meas_kernels": ["kern1","kern2"],
     "discriminators": ["disc1","dis2"],
     "acquisition_latency": [[100,120],[90,150],[500,100]],
-    "conditional_latency": [[200,200],[190,160],[500,100],[200,200],[190,160],[200,200],[190,160],[500,100]]
+    "conditional_latency": [[200,200],[190,160],[500,100],[200,200],[190,160],[200,200],[190,160],[500,100]],
+    "parametric_pulses": ["constant", "gaussian_square", "gaussian"]
 }

--- a/qiskit/schemas/examples/qobj_openpulse_example.json
+++ b/qiskit/schemas/examples/qobj_openpulse_example.json
@@ -34,10 +34,9 @@
             {"name": "copy", "register_orig": 1, "register_copy": [3,4]},
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
             {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
-            {"name": "parametric_pulse", "t0": 0, "params": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"},
+            {"name": "parametric_pulse", "t0": 0, "params": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"}
             ]
         }
         ]    
 }
-
 

--- a/qiskit/schemas/examples/qobj_openpulse_example.json
+++ b/qiskit/schemas/examples/qobj_openpulse_example.json
@@ -34,7 +34,7 @@
             {"name": "copy", "register_orig": 1, "register_copy": [3,4]},
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
             {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
-            {"name": "parametric_pulse", "t0": 0, "params": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"}
+            {"name": "parametric_pulse", "t0": 0, "parameters": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"}
             ]
         }
         ]    

--- a/qiskit/schemas/examples/qobj_openpulse_example.json
+++ b/qiskit/schemas/examples/qobj_openpulse_example.json
@@ -33,7 +33,8 @@
             {"name": "acquire", "t0": 10, "duration": 90, "qubits": [0,1,2], "register_slot": [0,1,2], "memory_slot": [0,1,2]},
             {"name": "copy", "register_orig": 1, "register_copy": [3,4]},
             {"name": "bfunc", "mask": "0xE", "relation": "==", "val": "0xA", "register": 3, "memory": 3},
-            {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3}
+            {"name": "pulse1", "ch": "d0", "t0": 120, "conditional": 3},
+            {"name": "parametric_pulse", "t0": 0, "params": {"amp": [0.0, 0.5], "sigma": 4, "duration": 25}, "ch": "d0", "pulse_shape": "gaussian"},
             ]
         }
         ]    

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -161,7 +161,7 @@
                             ]
                         },
                         "pulse_shape": {"type": "string"},
-                        "params": {"type": "array"}
+                        "params": {"type": "object"}
                     },
                     "required": [
                         "pulse_shape",

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -96,7 +96,8 @@
                                 "enum": [
                                     "pv",
                                     "fc",
-                                    "acquire"
+                                    "acquire",
+                                    "parametric_pulse"
                                 ]
                             }
                         }
@@ -147,6 +148,24 @@
                     },
                     "required": [
                         "phase",
+                        "t0",
+                        "ch"
+                    ],
+                    "title": "Frame change pulse"
+                },
+                {
+                    "properties": {
+                        "name": {
+                            "enum": [
+                                "parametric_pulse"
+                            ]
+                        },
+                        "pulse_shape": {"type": "string"},
+                        "params": {"type": "array"}
+                    },
+                    "required": [
+                        "pulse_shape",
+                        "params",
                         "t0",
                         "ch"
                     ],

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -169,7 +169,7 @@
                         "t0",
                         "ch"
                     ],
-                    "title": "Frame change pulse"
+                    "title": "Parametric pulse"
                 },
                 {
                     "properties": {

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -161,11 +161,11 @@
                             ]
                         },
                         "pulse_shape": {"type": "string"},
-                        "params": {"type": "object"}
+                        "parameters": {"type": "object"}
                     },
                     "required": [
                         "pulse_shape",
-                        "params",
+                        "parameters",
                         "t0",
                         "ch"
                     ],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Update schemas as necessary for #3463 

 - expects BackendConfiguration `parametric_pulses` field to be allowed
 - expects Qobj instruction with `name="parametric_pulse"` and `params` field
