### PR TITLE
Remove duplicated field in json example

### DIFF
--- a/qiskit/schemas/examples/qobj_openpulse_example.json
+++ b/qiskit/schemas/examples/qobj_openpulse_example.json
@@ -4,8 +4,7 @@
     "type": "PULSE",
     "header": {
         "description": "Set of Experiments 1",
-        "backend_name": "pulse_simulator2",
-        "description": "Sample pulse experiment"
+        "backend_name": "pulse_simulator2"
         },
     "config": {
         "shots": 1024,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

While reviewing #3702, noticed that one of the examples had a duplicate `description` field in the `header` - this PR fixes it by picking the most recent description.


### Details and comments


