### PR TITLE
Use raw literals in strings

### DIFF
--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -48,14 +48,14 @@ def generate_latex_label(label):
     regex = re.compile(r"(?<!\\)\$(.*)(?<!\\)\$")
     match = regex.search(label)
     if not match:
-        label = label.replace('\$', '$')  # noqa
+        label = label.replace(r'\$', '$')
         return utf8tolatex(label)
     else:
-        mathmode_string = match.group(1).replace('\$', '$')  # noqa
+        mathmode_string = match.group(1).replace(r'\$', '$')
         before_match = label[:match.start()]
-        before_match = before_match.replace('\$', '$')  # noqa
+        before_match = before_match.replace(r'\$', '$')
         after_match = label[match.end():]
-        after_match = after_match.replace('\$', '$')  # noqa
+        after_match = after_match.replace(r'\$', '$')
         return utf8tolatex(before_match) + mathmode_string + utf8tolatex(
             after_match)
 

--- a/test/python/visualization/test_visualization.py
+++ b/test/python/visualization/test_visualization.py
@@ -418,13 +418,13 @@ c1_0: 0 ════════════════════════
         """Test generate latex label with escaped dollarsign."""
         self.assertEqual(
             '{\\$}{\\ensuremath{\\forall}}{\\$}',
-            utils.generate_latex_label('\$∀\$'))  # noqa
+            utils.generate_latex_label(r'\$∀\$'))
 
     def test_generate_latex_label_escaped_dollar_sign_in_mathmode(self):
         """Test generate latex label with escaped dollar sign in mathmode."""
         self.assertEqual(
             'a$bc{\\_}{\\ensuremath{\\iiint}}X{\\ensuremath{\\forall}}Y',
-            utils.generate_latex_label('$a$bc$_∭X∀Y'))  # noqa
+            utils.generate_latex_label(r'$a$bc$_∭X∀Y'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix some instances of strings that contain invalid escape sequences (that were actually emitting [`DeprecationWarnings`](https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals) under some configurations) by using raw strings instead.


### Details and comments


