### PR TITLE
Deprecate circuit_instruction_map, rename it to instruction_schedule_…

### DIFF
--- a/qiskit/compiler/schedule.py
+++ b/qiskit/compiler/schedule.py
@@ -40,7 +40,7 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         circuits: The quantum circuit or circuits to translate
         backend: A backend instance, which contains hardware-specific data required for scheduling
         inst_map: Mapping of circuit operations to pulse schedules. If None, defaults to the
-                  `backend` `circuit_instruction_map`
+                  `backend` `instruction_schedule_map`
         cmd_def: Deprecated
         meas_map: List of sets of qubits that must be measured together. If `None`, defaults to
                   the `backend` `meas_map`
@@ -56,7 +56,7 @@ def schedule(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         if backend is None:
             raise QiskitError("Must supply either a backend or InstructionScheduleMap for "
                               "scheduling passes.")
-        inst_map = backend.defaults().circuit_instruction_map
+        inst_map = backend.defaults().instruction_schedule_map
     if meas_map is None:
         if backend is None:
             raise QiskitError("Must supply either a backend or a meas_map for scheduling passes.")

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -139,13 +139,13 @@ class PulseDefaults(BaseModel):
         self._meas_freq_est = [freq * 1e9 for freq in meas_freq_est]
         self.pulse_library = pulse_library
         self.cmd_def = cmd_def
-        self.circuit_instruction_map = InstructionScheduleMap()
+        self.instruction_schedule_map = InstructionScheduleMap()
 
         self.converter = QobjToInstructionConverter(pulse_library)
         for inst in cmd_def:
             pulse_insts = [self.converter(inst) for inst in inst.sequence]
             schedule = ParameterizedSchedule(*pulse_insts, name=inst.name)
-            self.circuit_instruction_map.add(inst.name, inst.qubits, schedule)
+            self.instruction_schedule_map.add(inst.name, inst.qubits, schedule)
 
     @property
     def qubit_freq_est(self) -> float:  # pylint: disable=invalid-name
@@ -169,13 +169,20 @@ class PulseDefaults(BaseModel):
 
         return self._meas_freq_est
 
+    @property
+    def circuit_instruction_map(self):
+        """Deprecated property, use ``instruction_schedule_map`` instead."""
+        warnings.warn("The `circuit_instruction_map` attribute has been renamed to "
+                      "`instruction_schedule_map`.", DeprecationWarning)
+        return self.instruction_schedule_map
+
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]
         meas_freqs = [freq / 1e9 for freq in self.meas_freq_est]
         qfreq = "Qubit Frequencies [GHz]\n{freqs}".format(freqs=qubit_freqs)
         mfreq = "Measurement Frequencies [GHz]\n{freqs} ".format(freqs=meas_freqs)
         return ("<{name}({insts}{qfreq}\n{mfreq})>"
-                "".format(name=self.__class__.__name__, insts=str(self.circuit_instruction_map),
+                "".format(name=self.__class__.__name__, insts=str(self.instruction_schedule_map),
                           qfreq=qfreq, mfreq=mfreq))
 
     def build_cmd_def(self) -> InstructionScheduleMap:
@@ -186,6 +193,6 @@ class PulseDefaults(BaseModel):
             InstructionScheduleMap: Generated from defaults.
         """
         warnings.warn("This method is deprecated. Returning a InstructionScheduleMap instead. "
-                      "This can be accessed simply through the `circuit_instruction_map` attribute "
-                      "of this PulseDefaults instance.", DeprecationWarning)
-        return self.circuit_instruction_map
+                      "This can be accessed simply through the `instruction_schedule_map` "
+                      "attribute of this PulseDefaults instance.", DeprecationWarning)
+        return self.instruction_schedule_map

--- a/qiskit/pulse/cmd_def.py
+++ b/qiskit/pulse/cmd_def.py
@@ -62,7 +62,7 @@ class CmdDef:
         """
         warnings.warn("The CmdDef is being deprecated. All CmdDef methods are now supported by "
                       "`InstructionScheduleMap` accessible as "
-                      "`backend.defaults().circuit_instruction_map` for any Pulse enabled system.",
+                      "`backend.defaults().instruction_schedule_map` for any Pulse enabled system.",
                       DeprecationWarning)
         self._cmd_dict = {}
 

--- a/releasenotes/notes/circuit_instruction_map-rename-d011d5cc34d16b7b.yaml
+++ b/releasenotes/notes/circuit_instruction_map-rename-d011d5cc34d16b7b.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    The attribute of PulseDefaults, `circuit_instruction_map`, has been renamed
+    to `instruction_schedule_map`, to match the type of the attribute, which is
+    an InstructionScheduleMap.

--- a/test/python/providers/test_pulse_defaults.py
+++ b/test/python/providers/test_pulse_defaults.py
@@ -28,7 +28,7 @@ class TestPulseDefaults(QiskitTestCase):
 
     def setUp(self):
         self.defs = FakeOpenPulse2Q().defaults()
-        self.inst_map = self.defs.circuit_instruction_map
+        self.inst_map = self.defs.instruction_schedule_map
 
     def test_buffer(self):
         """Test getting the buffer value."""

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -77,7 +77,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
 
     def test_has_from_mock(self):
         """Test `has` and `assert_has` from mock data."""
-        inst_map = FakeOpenPulse2Q().defaults().circuit_instruction_map
+        inst_map = FakeOpenPulse2Q().defaults().instruction_schedule_map
         self.assertTrue(inst_map.has('u1', [0]))
         self.assertTrue(inst_map.has('cx', (0, 1)))
         self.assertTrue(inst_map.has('u3', 0))

--- a/test/python/pulse/test_reschedule.py
+++ b/test/python/pulse/test_reschedule.py
@@ -33,7 +33,7 @@ class TestAutoMerge(QiskitTestCase):
     def setUp(self):
         self.backend = FakeOpenPulse2Q()
         self.config = self.backend.configuration()
-        self.cmd_def = self.backend.defaults().circuit_instruction_map
+        self.cmd_def = self.backend.defaults().instruction_schedule_map
         self.short_pulse = pulse.SamplePulse(samples=np.array([0.02739068], dtype=np.complex128),
                                              name='p0')
 
@@ -136,7 +136,7 @@ class TestAddImplicitAcquires(QiskitTestCase):
     def setUp(self):
         self.backend = FakeOpenPulse2Q()
         self.config = self.backend.configuration()
-        self.cmd_def = self.backend.defaults().circuit_instruction_map
+        self.cmd_def = self.backend.defaults().instruction_schedule_map
         self.short_pulse = pulse.SamplePulse(samples=np.array([0.02739068], dtype=np.complex128),
                                              name='p0')
         acquire = pulse.Acquire(5)

--- a/test/python/scheduler/test_basic_scheduler.py
+++ b/test/python/scheduler/test_basic_scheduler.py
@@ -27,7 +27,7 @@ class TestBasicSchedule(QiskitTestCase):
 
     def setUp(self):
         self.backend = FakeOpenPulse2Q()
-        self.inst_map = self.backend.defaults().circuit_instruction_map
+        self.inst_map = self.backend.defaults().instruction_schedule_map
 
     def test_alap_pass(self):
         """Test ALAP scheduling."""
@@ -181,7 +181,7 @@ class TestBasicSchedule(QiskitTestCase):
     def test_3q_schedule(self):
         """Test a schedule that was recommended by David McKay :D """
         backend = FakeOpenPulse3Q()
-        inst_map = backend.defaults().circuit_instruction_map
+        inst_map = backend.defaults().instruction_schedule_map
         q = QuantumRegister(3)
         c = ClassicalRegister(3)
         qc = QuantumCircuit(q, c)


### PR DESCRIPTION
…map bc the class name is InstructionScheduleMap

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Match attribute name to type



