### PR TITLE
Use README as package long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,13 +70,18 @@ for ext in CYTHON_EXTS:
                     language='c++')
     EXT_MODULES.append(mod)
 
+# Read long description from README.
+README_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                           'README.md')
+with open(README_PATH) as readme_file:
+    README = readme_file.read()
 
 setup(
     name="qiskit-terra",
     version="0.12.0",
     description="Software for developing quantum computing programs",
-    long_description="""Terra provides the foundations for Qiskit. It allows the user to write
-        quantum circuits easily, and takes care of the constraints of real hardware.""",
+    long_description=README,
+    long_description_content_type='text/markdown',
     url="https://github.com/Qiskit/qiskit-terra",
     author="Qiskit Development Team",
     author_email="qiskit@qiskit.org",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The project description on pypi (https://pypi.org/project/qiskit-terra/) is currently a bit lacking (and with a formatting artifact):

![pypi](https://user-images.githubusercontent.com/418311/72725587-6b4baf00-3b86-11ea-80dd-921fe512b831.png)

As pypi supports markdown since a while ago, this PR replaces the current long_description with the contents of `README.md`, in order to use it as the project description in the pypi web interface (similar to the current https://pypi.org/project/qiskit-ibmq-provider/).

### Details and comments


