### PR TITLE
Fix error message for shots exceeding max_shots

### DIFF
--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -225,7 +225,7 @@ def _parse_common_args(backend, qobj_id, qobj_header, shots,
     elif max_shots and max_shots < shots:
         raise QiskitError(
             'Number of shots specified: %s exceeds max_shots property of the '
-            'backend: %s. Reducing shots to max_shots' % (shots, max_shots))
+            'backend: %s.' % (shots, max_shots))
 
     # create run configuration and populate
     run_config_dict = dict(shots=shots,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3606 an error condition was added to the qiskit.compiler.assemble()
function when the shots parameter exceeds max_shots set in the backend.
However, the first revision of #3606 was originally raising a warning
and changing the shots value used. When the PR was repurposed to instead
raise an error, the old warning message was used as the new error
message. However, this also mentions changing the value of shots which
was no longer relevant. This commit corrects the oversight so that the
error message no longer says "Reducing shots to max_shots".

### Details and comments