### PR TITLE
Add ``dot`` method to operator classes

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -182,14 +182,31 @@ class BaseOperator(ABC):
 
     @abstractmethod
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied operator other * self.
 
         Args:
             other (BaseOperator): an operator object.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
+            qargs (list or None): a list of subsystem positions to apply other on.
+            front (bool): DEPRECATED If False compose in standard order other(self(input))
                           otherwise compose in reverse order self(other(input))
                           [default: False]
+
+        Returns:
+            BaseOperator: The composed operator.
+
+        Raises:
+            QiskitError: if other cannot be converted to an operator, or has
+            incompatible dimensions for specified subsystems.
+        """
+        pass
+
+    @abstractmethod
+    def dot(self, other, qargs=None):
+        """Return the right multiplied operator self * other.
+
+        Args:
+            other (BaseOperator): an operator object.
+            qargs (list or None): a list of subsystem positions to apply other on.
 
         Returns:
             BaseOperator: The composed operator.
@@ -355,20 +372,20 @@ class BaseOperator(ABC):
     def __matmul__(self, other):
         return self.compose(other)
 
+    def __mul__(self, other):
+        return self.dot(other)
+
+    def __rmul__(self, other):
+        return self.multiply(other)
+
     def __pow__(self, n):
         return self.power(n)
 
     def __xor__(self, other):
         return self.tensor(other)
 
-    def __mul__(self, other):
-        return self.multiply(other)
-
     def __truediv__(self, other):
         return self.multiply(1 / other)
-
-    def __rmul__(self, other):
-        return self.__mul__(other)
 
     def __add__(self, other):
         return self.add(other)

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -33,7 +33,6 @@ References:
 """
 
 from numbers import Number
-
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -47,7 +46,6 @@ from qiskit.quantum_info.operators.channel.transformations import _bipartite_ten
 
 class Choi(QuantumChannel):
     """Choi-matrix representation of a quantum channel"""
-
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Choi matrix operator.
 
@@ -138,61 +136,43 @@ class Choi(QuantumChannel):
         data = np.transpose(data, (1, 0, 3, 2))
         # Transpose channel has input and output dimensions swapped
         data = np.reshape(data, (d_in * d_out, d_in * d_out))
-        return Choi(
-            data, input_dims=self.output_dims(), output_dims=self.input_dims())
+        return Choi(data,
+                    input_dims=self.output_dims(),
+                    output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied channel other * self.
 
         Args:
             other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
-            Choi: The composition channel as a Choi object.
+            Choi: The left multiplied quantum channel.
 
         Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
+            QiskitError: if other cannot be converted to a Choi or has
+            incompatible dimensions.
         """
-        if qargs is not None:
-            return Choi(
-                SuperOp(self).compose(other, qargs=qargs, front=front))
+        return super().compose(other, qargs=qargs, front=front)
 
-        # Convert to Choi matrix
-        if not isinstance(other, Choi):
-            other = Choi(other)
-        # Check dimensions match up
-        if front and self._input_dim != other._output_dim:
-            raise QiskitError(
-                'input_dim of self must match output_dim of other')
-        if not front and self._output_dim != other._input_dim:
-            raise QiskitError(
-                'input_dim of other must match output_dim of self')
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
 
-        if front:
-            first = np.reshape(other._data, other._bipartite_shape)
-            second = np.reshape(self._data, self._bipartite_shape)
-            input_dim = other._input_dim
-            input_dims = other.input_dims()
-            output_dim = self._output_dim
-            output_dims = self.output_dims()
-        else:
-            first = np.reshape(self._data, self._bipartite_shape)
-            second = np.reshape(other._data, other._bipartite_shape)
-            input_dim = self._input_dim
-            input_dims = self.input_dims()
-            output_dim = other._output_dim
-            output_dims = other.output_dims()
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
 
-        # Contract Choi matrices for composition
-        data = np.reshape(
-            np.einsum('iAjB,AkBl->ikjl', first, second),
-            (input_dim * output_dim, input_dim * output_dim))
-        return Choi(data, input_dims, output_dims)
+        Returns:
+            Choi: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other cannot be converted to a Choi or has
+            incompatible dimensions.
+        """
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """The matrix power of the channel.
@@ -229,11 +209,10 @@ class Choi(QuantumChannel):
 
         input_dims = other.input_dims() + self.input_dims()
         output_dims = other.output_dims() + self.output_dims()
-        data = _bipartite_tensor(
-            self._data,
-            other.data,
-            shape1=self._bipartite_shape,
-            shape2=other._bipartite_shape)
+        data = _bipartite_tensor(self._data,
+                                 other.data,
+                                 shape1=self._bipartite_shape,
+                                 shape2=other._bipartite_shape)
         return Choi(data, input_dims, output_dims)
 
     def expand(self, other):
@@ -254,11 +233,10 @@ class Choi(QuantumChannel):
 
         input_dims = self.input_dims() + other.input_dims()
         output_dims = self.output_dims() + other.output_dims()
-        data = _bipartite_tensor(
-            other.data,
-            self._data,
-            shape1=other._bipartite_shape,
-            shape2=self._bipartite_shape)
+        data = _bipartite_tensor(other.data,
+                                 self._data,
+                                 shape1=other._bipartite_shape,
+                                 shape2=self._bipartite_shape)
         return Choi(data, input_dims, output_dims)
 
     def add(self, other):
@@ -333,3 +311,56 @@ class Choi(QuantumChannel):
             specified quantum state subsystem dimensions.
         """
         return SuperOp(self)._evolve(state, qargs)
+
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            Choi: The composition channel as a Choi object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
+        if qargs is not None:
+            return Choi(
+                SuperOp(self)._chanmul(other,
+                                       qargs=qargs,
+                                       left_multiply=left_multiply))
+
+        # Convert to Choi matrix
+        if not isinstance(other, Choi):
+            other = Choi(other)
+        # Check dimensions match up
+        if not left_multiply and self._input_dim != other._output_dim:
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
+        if left_multiply and self._output_dim != other._input_dim:
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
+
+        if left_multiply:
+            first = np.reshape(self._data, self._bipartite_shape)
+            second = np.reshape(other._data, other._bipartite_shape)
+            input_dim = self._input_dim
+            input_dims = self.input_dims()
+            output_dim = other._output_dim
+            output_dims = other.output_dims()
+        else:
+            first = np.reshape(other._data, other._bipartite_shape)
+            second = np.reshape(self._data, self._bipartite_shape)
+            input_dim = other._input_dim
+            input_dims = other.input_dims()
+            output_dim = self._output_dim
+            output_dims = self.output_dims()
+
+        # Contract Choi matrices for composition
+        data = np.reshape(np.einsum('iAjB,AkBl->ikjl', first, second),
+                          (input_dim * output_dim, input_dim * output_dim))
+        return Choi(data, input_dims, output_dims)

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -13,7 +13,6 @@
 # that they have been altered from the originals.
 
 # pylint: disable=len-as-condition
-
 """
 Kraus representation of a Quantum Channel.
 
@@ -35,7 +34,6 @@ References:
 """
 
 from numbers import Number
-
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -50,7 +48,6 @@ from qiskit.quantum_info.operators.channel.transformations import _to_kraus
 
 class Kraus(QuantumChannel):
     """Kraus representation of a quantum channel."""
-
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Kraus operator.
 
@@ -203,57 +200,38 @@ class Kraus(QuantumChannel):
                      output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied channel other * self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass.
+            other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
-            Kraus: The composition channel as a Kraus object.
+            Kraus: The left multiplied quantum channel.
 
         Raises:
-            QiskitError: if other cannot be converted to a channel, or
-            has incompatible dimensions.
+            QiskitError: if other cannot be converted to a Kraus or has
+            incompatible dimensions.
         """
-        if qargs is not None:
-            return Kraus(
-                SuperOp(self).compose(other, qargs=qargs, front=front))
+        return super().compose(other, qargs=qargs, front=front)
 
-        if not isinstance(other, Kraus):
-            other = Kraus(other)
-        # Check dimensions match up
-        if front and self._input_dim != other._output_dim:
-            raise QiskitError(
-                'input_dim of self must match output_dim of other')
-        if not front and self._output_dim != other._input_dim:
-            raise QiskitError(
-                'input_dim of other must match output_dim of self')
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
 
-        if front:
-            ka_l, ka_r = self._data
-            kb_l, kb_r = other._data
-            input_dim = other._input_dim
-            output_dim = self._output_dim
-        else:
-            ka_l, ka_r = other._data
-            kb_l, kb_r = self._data
-            input_dim = self._input_dim
-            output_dim = other._output_dim
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
 
-        kab_l = [np.dot(a, b) for a in ka_l for b in kb_l]
-        if ka_r is None and kb_r is None:
-            kab_r = None
-        elif ka_r is None:
-            kab_r = [np.dot(a, b) for a in ka_l for b in kb_r]
-        elif kb_r is None:
-            kab_r = [np.dot(a, b) for a in ka_r for b in kb_l]
-        else:
-            kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
-        return Kraus((kab_l, kab_r), input_dim, output_dim)
+        Returns:
+            Kraus: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other cannot be converted to a Kraus or has
+            incompatible dimensions.
+        """
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """The matrix power of the channel.
@@ -424,3 +402,57 @@ class Kraus(QuantumChannel):
                 kab_r = [np.kron(a, b) for a in ka_r for b in kb_r]
         data = (kab_l, kab_r)
         return Kraus(data, input_dims, output_dims)
+
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            Kraus: The composition channel as a Kraus object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
+        if qargs is not None:
+            return Kraus(
+                SuperOp(self)._chanmul(other,
+                                       qargs=qargs,
+                                       left_multiply=left_multiply))
+
+        if not isinstance(other, Kraus):
+            other = Kraus(other)
+        # Check dimensions match up
+        if not left_multiply and self._input_dim != other._output_dim:
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
+        if left_multiply and self._output_dim != other._input_dim:
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
+
+        if left_multiply:
+            ka_l, ka_r = other._data
+            kb_l, kb_r = self._data
+            input_dim = self._input_dim
+            output_dim = other._output_dim
+        else:
+            ka_l, ka_r = self._data
+            kb_l, kb_r = other._data
+            input_dim = other._input_dim
+            output_dim = self._output_dim
+
+        kab_l = [np.dot(a, b) for a in ka_l for b in kb_l]
+        if ka_r is None and kb_r is None:
+            kab_r = None
+        elif ka_r is None:
+            kab_r = [np.dot(a, b) for a in ka_l for b in kb_r]
+        elif kb_r is None:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_l]
+        else:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
+        return Kraus((kab_l, kab_r), input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -38,7 +38,6 @@ References:
 """
 
 from numbers import Number
-
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -139,45 +138,38 @@ class PTM(QuantumChannel):
         return PTM(SuperOp(self).transpose())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied channel other * self.
 
         Args:
             other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
-            PTM: The composition channel as a PTM object.
+            PTM: The left multiplied quantum channel.
 
         Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
+            QiskitError: if other cannot be converted to a PTM or has
+            incompatible dimensions.
         """
-        if qargs is not None:
-            return PTM(
-                SuperOp(self).compose(other, qargs=qargs, front=front))
+        return super().compose(other, qargs=qargs, front=front)
 
-        # Convert other to PTM
-        if not isinstance(other, PTM):
-            other = PTM(other)
-        # Check dimensions match up
-        if front and self._input_dim != other._output_dim:
-            raise QiskitError(
-                'input_dim of self must match output_dim of other')
-        if not front and self._output_dim != other._input_dim:
-            raise QiskitError(
-                'input_dim of other must match output_dim of self')
-        if front:
-            # Composition A(B(input))
-            input_dim = other._input_dim
-            output_dim = self._output_dim
-            return PTM(np.dot(self._data, other.data), input_dim, output_dim)
-        # Composition B(A(input))
-        input_dim = self._input_dim
-        output_dim = other._output_dim
-        return PTM(np.dot(other.data, self._data), input_dim, output_dim)
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+
+        Returns:
+            PTM: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other cannot be converted to a PTM or has
+            incompatible dimensions.
+        """
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """The matrix power of the channel.
@@ -306,3 +298,46 @@ class PTM(QuantumChannel):
             specified quantum state subsystem dimensions.
         """
         return SuperOp(self)._evolve(state, qargs)
+
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            PTM: The composition channel as a PTM object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
+        if qargs is not None:
+            return PTM(
+                SuperOp(self)._chanmul(other,
+                                       qargs=qargs,
+                                       left_multiply=left_multiply))
+
+        # Convert other to PTM
+        if not isinstance(other, PTM):
+            other = PTM(other)
+        # Check dimensions match up
+        if not left_multiply and self._input_dim != other._output_dim:
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
+        if left_multiply and self._output_dim != other._input_dim:
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
+        if left_multiply:
+            # other * self
+            input_dim = self._input_dim
+            output_dim = other._output_dim
+            return PTM(np.dot(other.data, self._data), input_dim, output_dim)
+
+        # self * other
+        input_dim = other._input_dim
+        output_dim = self._output_dim
+        return PTM(np.dot(self._data, other.data), input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -16,8 +16,8 @@
 Abstract base class for Quantum Channels.
 """
 
+import warnings
 from abc import abstractmethod
-
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -32,6 +32,46 @@ from qiskit.quantum_info.operators.channel.transformations import _to_operator
 
 class QuantumChannel(BaseOperator):
     """Quantum channel representation base class."""
+
+    def compose(self, other, qargs=None, front=False):
+        """Return the left multiplied channel other * self.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            front (bool): DEPRECATED If True return self * other instead.
+                          [default: False]
+
+        Returns:
+            QuantumChannel: The left multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or has
+            incompatible dimensions.
+        """
+        if front:
+            # DEPRECATED
+            warnings.warn(
+                '`compose(other, front=True)` is deprecated, use `dot(other)` instead.',
+                DeprecationWarning)
+            return self._chanmul(other, qargs, left_multiply=False)
+        return self._chanmul(other, qargs, left_multiply=True)
+
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+
+        Returns:
+            QuantumChannel: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or has
+            incompatible dimensions.
+        """
+        return self._chanmul(other, qargs, left_multiply=False)
 
     def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving (CPTP)."""
@@ -149,6 +189,25 @@ class QuantumChannel(BaseOperator):
         Raises:
             QiskitError: if the quantum channel dimension does not match the
             specified quantum state subsystem dimensions.
+        """
+        pass
+
+    @abstractmethod
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            QuantumChannel: The composition channel.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
         """
         pass
 

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -11,7 +11,6 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 Stinespring representation of a Quantum Channel.
 
@@ -33,7 +32,6 @@ References:
 """
 
 from numbers import Number
-
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -49,7 +47,6 @@ from qiskit.quantum_info.operators.channel.transformations import _to_stinesprin
 
 class Stinespring(QuantumChannel):
     """Stinespring representation of a quantum channel"""
-
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Stinespring operator.
 
@@ -128,17 +125,15 @@ class Stinespring(QuantumChannel):
         # Initialize either single or general Stinespring
         if stine[1] is None or (stine[1] == stine[0]).all():
             # Standard Stinespring map
-            super().__init__(
-                'Stinespring', (stine[0], None),
-                input_dims=input_dims,
-                output_dims=output_dims)
+            super().__init__('Stinespring', (stine[0], None),
+                             input_dims=input_dims,
+                             output_dims=output_dims)
         else:
             # General (non-CPTP) Stinespring map
-            super().__init__(
-                'Stinespring',
-                stine,
-                input_dims=input_dims,
-                output_dims=output_dims)
+            super().__init__('Stinespring',
+                             stine,
+                             input_dims=input_dims,
+                             output_dims=output_dims)
 
     @property
     def data(self):
@@ -179,45 +174,43 @@ class Stinespring(QuantumChannel):
                 stine[i] = np.reshape(
                     np.transpose(np.reshape(mat, (dout, dtr, din)), (2, 1, 0)),
                     (din * dtr, dout))
-        return Stinespring(
-            tuple(stine),
-            input_dims=self.output_dims(),
-            output_dims=self.input_dims())
+        return Stinespring(tuple(stine),
+                           input_dims=self.output_dims(),
+                           output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied channel other * self.
 
         Args:
-            other (QuantumChannel): a quantum channel subclass.
+            other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
-            Stinespring: The composition channel as a Stinespring object.
+            Stinespring: The left multiplied quantum channel.
 
         Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
+            QiskitError: if other cannot be converted to a Stinespring or has
+            incompatible dimensions.
         """
-        if qargs is not None:
-            return Stinespring(
-                SuperOp(self).compose(other, qargs=qargs, front=front))
+        return super().compose(other, qargs=qargs, front=front)
 
-        # Convert other to Kraus
-        if not isinstance(other, Kraus):
-            other = Kraus(other)
-        # Check dimensions match up
-        if front and self._input_dim != other._output_dim:
-            raise QiskitError(
-                'input_dim of self must match output_dim of other')
-        if not front and self._output_dim != other._input_dim:
-            raise QiskitError(
-                'input_dim of other must match output_dim of self')
-        # Since we cannot directly compose two channels in Stinespring
-        # representation we convert to the Kraus representation
-        return Stinespring(Kraus(self).compose(other, front=front))
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+
+        Returns:
+            Stinespring: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other cannot be converted to a Stinespring or has
+            incompatible dimensions.
+        """
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """The matrix power of the channel.
@@ -416,3 +409,40 @@ class Stinespring(QuantumChannel):
                 np.transpose(np.reshape(sab_r, shape_in), (0, 2, 1, 3, 4)),
                 shape_out)
         return Stinespring((sab_l, sab_r), input_dims, output_dims)
+
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            Stinespring: The composition channel as a Stinespring object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
+        if qargs is not None:
+            return Stinespring(
+                SuperOp(self)._chanmul(other,
+                                       qargs=qargs,
+                                       left_multiply=left_multiply))
+
+        # Convert other to Kraus
+        if not isinstance(other, Kraus):
+            other = Kraus(other)
+        # Check dimensions match up
+        if not left_multiply and self._input_dim != other._output_dim:
+            raise QiskitError(
+                'input_dim of self must match output_dim of other')
+        if left_multiply and self._output_dim != other._input_dim:
+            raise QiskitError(
+                'input_dim of other must match output_dim of self')
+        # Since we cannot directly compose two channels in Stinespring
+        # representation we convert to the Kraus representation
+        return Stinespring(
+            Kraus(self)._chanmul(other, left_multiply=left_multiply))

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -44,7 +44,6 @@ from qiskit.quantum_info.operators.channel.transformations import _bipartite_ten
 
 class SuperOp(QuantumChannel):
     """Superoperator representation of a quantum channel"""
-
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Superoperator operator.
 
@@ -136,46 +135,38 @@ class SuperOp(QuantumChannel):
                        output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left multiplied channel other * self.
 
         Args:
             other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
-            SuperOp: The composition channel as a SuperOp object.
+            SuperOp: The left multiplied quantum channel.
 
         Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or
-            has incompatible dimensions.
+            QiskitError: if other cannot be converted to a SuperOp or has
+            incompatible dimensions.
         """
-        # Convert other to SuperOp
-        if not isinstance(other, SuperOp):
-            other = SuperOp(other)
-        # Check dimensions are compatible
-        if front and self.input_dims(qargs=qargs) != other.output_dims():
-            raise QiskitError(
-                'output_dims of other must match subsystem input_dims')
-        if not front and self.output_dims(qargs=qargs) != other.input_dims():
-            raise QiskitError(
-                'input_dims of other must match subsystem output_dims')
+        return super().compose(other, qargs=qargs, front=front)
 
-        # Full composition of superoperators
-        if qargs is None:
-            if front:
-                # Composition A(B(input))
-                return SuperOp(np.dot(self._data, other.data),
-                               input_dims=other.input_dims(),
-                               output_dims=self.output_dims())
-            # Composition B(A(input))
-            return SuperOp(np.dot(other.data, self._data),
-                           input_dims=self.input_dims(),
-                           output_dims=other.output_dims())
-        # Composition on subsystem
-        return self._compose_subsystem(other, qargs, front)
+    def dot(self, other, qargs=None):
+        """Return the right multiplied channel self * other.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+
+        Returns:
+            SuperOp: The right multiplied quantum channel.
+
+        Raises:
+            QiskitError: if other cannot be converted to a SuperOp or has
+            incompatible dimensions.
+        """
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """Return the compose of a QuantumChannel with itself n times.
@@ -365,6 +356,81 @@ class SuperOp(QuantumChannel):
         # reshape tensor to density matrix
         tensor = np.reshape(tensor, (new_dim, new_dim))
         return DensityMatrix(tensor, dims=new_dims)
+
+    def _chanmul(self, other, qargs=None, left_multiply=False):
+        """Multiply two quantum channels.
+
+        Args:
+            other (QuantumChannel): a quantum channel.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+
+        Returns:
+            SuperOp: The composition channel as a SuperOp object.
+
+        Raises:
+            QiskitError: if other is not a QuantumChannel subclass, or
+            has incompatible dimensions.
+        """
+        # Convert other to SuperOp
+        if not isinstance(other, SuperOp):
+            other = SuperOp(other)
+        # Check dimensions are compatible
+        if left_multiply and self.output_dims(
+                qargs=qargs) != other.input_dims():
+            raise QiskitError(
+                'input_dims of other must match subsystem output_dims')
+        if not left_multiply and self.input_dims(
+                qargs=qargs) != other.output_dims():
+            raise QiskitError(
+                'output_dims of other must match subsystem input_dims')
+
+        # Full composition of superoperators
+        if qargs is None:
+            if left_multiply:
+                # other * self
+                return SuperOp(np.dot(other.data, self._data),
+                               input_dims=self.input_dims(),
+                               output_dims=other.output_dims())
+            # self * other
+            return SuperOp(np.dot(self._data, other.data),
+                           input_dims=other.input_dims(),
+                           output_dims=self.output_dims())
+        # Composition on subsystem
+        return self._chanmul_subsystem(other, qargs, left_multiply)
+
+    def _chanmul_subsystem(self, other, qargs, left_multiply=False):
+        """Matrix multiply on subsystem."""
+        # Compute tensor contraction indices from qargs
+        input_dims = list(self.input_dims())
+        output_dims = list(self.output_dims())
+        if left_multiply:
+            num_indices = len(self.output_dims())
+            shift = 0
+            right_mul = False
+            for pos, qubit in enumerate(qargs):
+                output_dims[qubit] = other._output_dims[pos]
+        else:
+            num_indices = len(self.input_dims())
+            shift = 2 * len(self.output_dims())
+            right_mul = True
+            for pos, qubit in enumerate(qargs):
+                input_dims[qubit] = other._input_dims[pos]
+        # Reshape current matrix
+        # Note that we must reverse the subsystem dimension order as
+        # qubit 0 corresponds to the right-most position in the tensor
+        # product, which is the last tensor wire index.
+        tensor = np.reshape(self.data, self._shape)
+        mat = np.reshape(other.data, other._shape)
+        # Add first set of indices
+        indices = [2 * num_indices - 1 - qubit for qubit in qargs
+                   ] + [num_indices - 1 - qubit for qubit in qargs]
+        final_shape = [np.product(output_dims)**2, np.product(input_dims)**2]
+        data = np.reshape(
+            self._einsum_matmul(tensor, mat, indices, shift, right_mul),
+            final_shape)
+        return SuperOp(data, input_dims, output_dims)
 
     def _compose_subsystem(self, other, qargs, front=False):
         """Return the composition channel."""

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -17,6 +17,7 @@ Matrix Operator class.
 """
 
 import re
+import warnings
 from numbers import Number
 
 import numpy as np
@@ -182,13 +183,12 @@ class Operator(BaseOperator):
                         output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the composition channel self∘other.
+        """Return the left matrix multipled operator other * self.
 
         Args:
             other (Operator): an operator object.
             qargs (list): a list of subsystem positions to compose other on.
-            front (bool): If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
+            front (bool): DEPRECATED If True return self * other instead.
                           [default: False]
 
         Returns:
@@ -198,31 +198,28 @@ class Operator(BaseOperator):
             QiskitError: if other cannot be converted to an Operator or has
             incompatible dimensions.
         """
-        # Convert to Operator
-        if not isinstance(other, Operator):
-            other = Operator(other)
-        # Check dimensions are compatible
-        if front and self.input_dims(qargs=qargs) != other.output_dims():
-            raise QiskitError(
-                'output_dims of other must match subsystem input_dims')
-        if not front and self.output_dims(qargs=qargs) != other.input_dims():
-            raise QiskitError(
-                'input_dims of other must match subsystem output_dims')
-        # Full composition of operators
-        if qargs is None:
-            if front:
-                # Composition A(B(input))
-                input_dims = other.input_dims()
-                output_dims = self.output_dims()
-                data = np.dot(self._data, other.data)
-            else:
-                # Composition B(A(input))
-                input_dims = self.input_dims()
-                output_dims = other.output_dims()
-                data = np.dot(other.data, self._data)
-            return Operator(data, input_dims, output_dims)
-        # Compose with other on subsystem
-        return self._compose_subsystem(other, qargs, front)
+        if front:
+            # DEPRECATED
+            warnings.warn('`compose(other, front=True)` is deprecated, use `dot(other)` instead.',
+                          DeprecationWarning)
+            return self._matmul(other, qargs, left_multiply=False)
+        return self._matmul(other, qargs, left_multiply=True)
+
+    def dot(self, other, qargs=None):
+        """Return the right matrix multiplied operator self * other.
+
+        Args:
+            other (Operator): an operator object.
+            qargs (list): a list of subsystem positions to compose other on.
+
+        Returns:
+            Operator: The composed operator.
+
+        Raises:
+            QiskitError: if other cannot be converted to an Operator or has
+            incompatible dimensions.
+        """
+        return self._matmul(other, qargs, left_multiply=False)
 
     def power(self, n):
         """Return the matrix power of the operator.
@@ -372,6 +369,77 @@ class Operator(BaseOperator):
         """Return the tensor shape of the matrix operator"""
         return tuple(reversed(self.output_dims())) + tuple(
             reversed(self.input_dims()))
+
+    def _matmul(self, other, qargs=None, left_multiply=False):
+        """Matrix multiply two operators
+
+        Args:
+            other (Operator): an operator object.
+            qargs (list): a list of subsystem positions to compose other on.
+            left_multiply (bool): If True return other * self
+                                  If False return self * other [Default:False]
+        Returns:
+            Operator: The output operator.
+
+        Raises:
+            QiskitError: if other cannot be converted to an Operator or has
+            incompatible dimensions.
+        """
+        # Convert to Operator
+        if not isinstance(other, Operator):
+            other = Operator(other)
+        # Check dimensions are compatible
+        if not left_multiply and self.input_dims(qargs=qargs) != other.output_dims():
+            raise QiskitError(
+                'output_dims of other must match subsystem input_dims')
+        if left_multiply and self.output_dims(qargs=qargs) != other.input_dims():
+            raise QiskitError(
+                'input_dims of other must match subsystem output_dims')
+        # Full composition of operators
+        if qargs is None:
+            if left_multiply:
+                # Composition other * self
+                input_dims = self.input_dims()
+                output_dims = other.output_dims()
+                data = np.dot(other.data, self._data)
+            else:
+                # Composition self * other
+                input_dims = other.input_dims()
+                output_dims = self.output_dims()
+                data = np.dot(self._data, other.data)
+            return Operator(data, input_dims, output_dims)
+        # Compose with other on subsystem
+        return self._matmul_subsystem(other, qargs, left_multiply)
+
+    def _matmul_subsystem(self, other, qargs, left_multiply=False):
+        """Matrix multiply on subsystem."""
+        # Compute tensor contraction indices from qargs
+        input_dims = list(self.input_dims())
+        output_dims = list(self.output_dims())
+        if left_multiply:
+            num_indices = len(self.output_dims())
+            shift = 0
+            right_mul = False
+            for pos, qubit in enumerate(qargs):
+                output_dims[qubit] = other._output_dims[pos]
+        else:
+            num_indices = len(self.input_dims())
+            shift = len(self.output_dims())
+            right_mul = True
+            for pos, qubit in enumerate(qargs):
+                input_dims[qubit] = other._input_dims[pos]
+        # Reshape current matrix
+        # Note that we must reverse the subsystem dimension order as
+        # qubit 0 corresponds to the right-most position in the tensor
+        # product, which is the last tensor wire index.
+        tensor = np.reshape(self.data, self._shape)
+        mat = np.reshape(other.data, other._shape)
+        indices = [num_indices - 1 - qubit for qubit in qargs]
+        final_shape = [np.product(output_dims), np.product(input_dims)]
+        data = np.reshape(
+            self._einsum_matmul(tensor, mat, indices, shift, right_mul),
+            final_shape)
+        return Operator(data, input_dims, output_dims)
 
     def _compose_subsystem(self, other, qargs, front=False):
         """Return the composition channel."""

--- a/releasenotes/notes/operator-dot-fd90e7e5ad99ff9b.yaml
+++ b/releasenotes/notes/operator-dot-fd90e7e5ad99ff9b.yaml
@@ -1,0 +1,18 @@
+---
+features:
+  - |
+    Added ``dot`` as an abstract method to the ``BaseOperator`` class and hence
+    to ``Operator`` and ``QuantumChannel`` classes. This method returns the
+    right operator multiplication ``a.dot(b) = a * b``.
+upgrade:
+  - |
+    Changed operator magic methods so that ``__mul__`` implements right matrix
+    multiplication ``dot``, and ``__rmul__`` implements scalar multiplication
+    ``multiply``. Previously both implemented scalar multiplciation.
+deprecations:
+  - |
+    Deprecated the ``front`` kwarg of operator method ``compose``. This
+    functionality is replaced by the ``dot`` operator method:
+    ``a.compose(b, front=True) == a.dot(b)``. Compose is intended to be
+    used for left operator multiplication only, while right operator
+    multiplication should be implemented with the new ``dot`` method.

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -118,6 +118,31 @@ class TestChi(ChannelTestCase):
         self.assertEqual(chan.dim, (2, 2))
         self.assertEqual(output, target)
 
+    def test_dot(self):
+        """Test dot method."""
+        # Random input test state
+        rho = DensityMatrix(self.rand_rho(2))
+
+        # UnitaryChannel evolution
+        chan1 = Chi(self.chiX)
+        chan2 = Chi(self.chiY)
+        target = rho.evolve(Chi(self.chiZ))
+        output = rho.evolve(chan2.dot(chan1))
+        self.assertEqual(output, target)
+        output = rho.evolve(chan2 * chan1)
+        self.assertEqual(output, target)
+
+        # Compose random
+        chi1 = self.rand_matrix(4, 4, real=True)
+        chi2 = self.rand_matrix(4, 4, real=True)
+        chan1 = Chi(chi1, input_dims=2, output_dims=2)
+        chan2 = Chi(chi2, input_dims=2, output_dims=2)
+        target = rho.evolve(chan1).evolve(chan2)
+        output = rho.evolve(chan2.dot(chan1))
+        self.assertEqual(output, target)
+        output = rho.evolve(chan2 * chan1)
+        self.assertEqual(output, target)
+
     def test_compose_front(self):
         """Test front compose method."""
         # Random input test state
@@ -260,13 +285,14 @@ class TestChi(ChannelTestCase):
         targ = Chi(val * self.chiI)
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
-        self.assertEqual(chan * val, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Chi(self.chiI)
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/channel/test_choi.py
+++ b/test/python/quantum_info/operators/channel/test_choi.py
@@ -169,6 +169,44 @@ class TestChoi(ChannelTestCase):
         chan = chan2.compose(chan1)
         self.assertEqual(chan.dim, (4, 4))
 
+    def test_dot(self):
+        """Test dot method."""
+        # UnitaryChannel evolution
+        chan1 = Choi(self.choiX)
+        chan2 = Choi(self.choiY)
+        targ = Choi(self.choiZ)
+        self.assertEqual(chan1.dot(chan2), targ)
+        self.assertEqual(chan1 * chan2, targ)
+
+        # 50% depolarizing channel
+        chan1 = Choi(self.depol_choi(0.5))
+        targ = Choi(self.depol_choi(0.75))
+        self.assertEqual(chan1.dot(chan1), targ)
+        self.assertEqual(chan1 * chan1, targ)
+
+        # Measure and rotation
+        Zp, Zm = np.diag([1, 0]), np.diag([0, 1])
+        Xp, Xm = np.array([[1, 1], [1, 1]]) / 2, np.array([[1, -1], [-1, 1]
+                                                           ]) / 2
+        chan1 = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        chan2 = Choi(self.choiX)
+        # X-gate second does nothing
+        targ = Choi(np.kron(Zp, Xp) + np.kron(Zm, Xm))
+        self.assertEqual(chan2.dot(chan1), targ)
+        self.assertEqual(chan2 * chan1, targ)
+        # X-gate first swaps Z states
+        targ = Choi(np.kron(Zm, Xp) + np.kron(Zp, Xm))
+        self.assertEqual(chan1.dot(chan2), targ)
+        self.assertEqual(chan1 * chan2, targ)
+
+        # Compose different dimensions
+        chan1 = Choi(np.eye(8) / 4, input_dims=2, output_dims=4)
+        chan2 = Choi(np.eye(8) / 2, input_dims=4, output_dims=2)
+        chan = chan1.dot(chan2)
+        self.assertEqual(chan.dim, (4, 4))
+        chan = chan2.dot(chan1)
+        self.assertEqual(chan.dim, (2, 2))
+
     def test_compose_front(self):
         """Test front compose method."""
         # UnitaryChannel evolution
@@ -329,13 +367,14 @@ class TestChoi(ChannelTestCase):
         targ = Choi(val * self.choiI)
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
-        self.assertEqual(chan * val, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Choi(self.choiI)
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/channel/test_kraus.py
+++ b/test/python/quantum_info/operators/channel/test_kraus.py
@@ -180,8 +180,34 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(chan.dim, (2, 2))
         self.assertEqual(rho @ chan, targ)
 
+    def test_dot(self):
+        """Test dot method."""
+        # Random input test state
+        rho = DensityMatrix(self.rand_rho(2))
+
+        # UnitaryChannel evolution
+        chan1 = Kraus(self.UX)
+        chan2 = Kraus(self.UY)
+        targ = rho.evolve(Kraus(self.UZ))
+        self.assertEqual(rho.evolve(chan1.dot(chan2)), targ)
+        self.assertEqual(rho.evolve(chan1 * chan2), targ)
+
+        # 50% depolarizing channel
+        chan1 = Kraus(self.depol_kraus(0.5))
+        targ = rho @ Kraus(self.depol_kraus(0.75))
+        self.assertEqual(rho.evolve(chan1.dot(chan1)), targ)
+        self.assertEqual(rho.evolve(chan1 * chan1), targ)
+
+        # Compose different dimensions
+        kraus1, kraus2 = self.rand_kraus(2, 4, 4), self.rand_kraus(4, 2, 4)
+        chan1 = Kraus(kraus1)
+        chan2 = Kraus(kraus2)
+        targ = rho @ chan1 @ chan2
+        self.assertEqual(rho.evolve(chan2.dot(chan1)), targ)
+        self.assertEqual(rho.evolve(chan2 * chan1), targ)
+
     def test_compose_front(self):
-        """Test front compose method."""
+        """Test deprecated front compose method."""
         # Random input test state
         rho = DensityMatrix(self.rand_rho(2))
 
@@ -336,8 +362,6 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(rho @ chan, targ)
         chan = val * chan1
         self.assertEqual(rho @ chan, targ)
-        chan = chan1 * val
-        self.assertEqual(rho @ chan, targ)
 
         # Double Kraus set
         chan2 = Kraus((kraus1, kraus2))
@@ -346,14 +370,14 @@ class TestKraus(ChannelTestCase):
         self.assertEqual(rho @ chan, targ)
         chan = val * chan2
         self.assertEqual(rho @ chan, targ)
-        chan = chan2 * val
-        self.assertEqual(rho @ chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Kraus(self.depol_kraus(1))
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/channel/test_ptm.py
+++ b/test/python/quantum_info/operators/channel/test_ptm.py
@@ -114,8 +114,29 @@ class TestPTM(ChannelTestCase):
         self.assertEqual(chan.dim, (2, 2))
         self.assertEqual(rho.evolve(chan), rho_targ)
 
+    def test_dot(self):
+        """Test dot method."""
+        # Random input test state
+        rho = DensityMatrix(self.rand_rho(2))
+
+        # UnitaryChannel evolution
+        chan1 = PTM(self.ptmX)
+        chan2 = PTM(self.ptmY)
+        rho_targ = rho.evolve(PTM(self.ptmZ))
+        self.assertEqual(rho.evolve(chan2.dot(chan1)), rho_targ)
+        self.assertEqual(rho.evolve(chan2 * chan1), rho_targ)
+
+        # Compose random
+        ptm1 = self.rand_matrix(4, 4, real=True)
+        ptm2 = self.rand_matrix(4, 4, real=True)
+        chan1 = PTM(ptm1, input_dims=2, output_dims=2)
+        chan2 = PTM(ptm2, input_dims=2, output_dims=2)
+        rho_targ = rho.evolve(chan1).evolve(chan2)
+        self.assertEqual(rho.evolve(chan2.dot(chan1)), rho_targ)
+        self.assertEqual(rho.evolve(chan2 * chan1), rho_targ)
+
     def test_compose_front(self):
-        """Test front compose method."""
+        """Test deprecated front compose method."""
         # Random input test state
         rho = DensityMatrix(self.rand_rho(2))
 
@@ -249,13 +270,14 @@ class TestPTM(ChannelTestCase):
         targ = PTM(val * self.ptmI)
         self.assertEqual(chan.multiply(val), targ)
         self.assertEqual(val * chan, targ)
-        self.assertEqual(chan * val, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = PTM(self.ptmI)
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/channel/test_stinespring.py
+++ b/test/python/quantum_info/operators/channel/test_stinespring.py
@@ -173,8 +173,34 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(chan.dim, (2, 2))
         self.assertEqual(rho_init.evolve(chan), rho_targ)
 
+    def test_dot(self):
+        """Test deprecated front compose method."""
+        # Random input test state
+        rho_init = DensityMatrix(self.rand_rho(2))
+
+        # UnitaryChannel evolution
+        chan1 = Stinespring(self.UX)
+        chan2 = Stinespring(self.UY)
+        rho_targ = rho_init.evolve(Stinespring(self.UZ))
+        self.assertEqual(rho_init.evolve(chan1.dot(chan2)), rho_targ)
+        self.assertEqual(rho_init.evolve(chan1 * chan2), rho_targ)
+
+        # 50% depolarizing channel
+        chan1 = Stinespring(self.depol_stine(0.5))
+        rho_targ = rho_init @ Stinespring(self.depol_stine(0.75))
+        self.assertEqual(rho_init.evolve(chan1.dot(chan1)), rho_targ)
+        self.assertEqual(rho_init.evolve(chan1 * chan1), rho_targ)
+
+        # Compose different dimensions
+        stine1, stine2 = self.rand_matrix(16, 2), self.rand_matrix(8, 4)
+        chan1 = Stinespring(stine1, input_dims=2, output_dims=4)
+        chan2 = Stinespring(stine2, input_dims=4, output_dims=2)
+        rho_targ = rho_init @ chan1 @ chan2
+        self.assertEqual(rho_init.evolve(chan2.dot(chan1)), rho_targ)
+        self.assertEqual(rho_init.evolve(chan2 * chan1), rho_targ)
+
     def test_compose_front(self):
-        """Test front compose method."""
+        """Test deprecated front compose method."""
         # Random input test state
         rho_init = DensityMatrix(self.rand_rho(2))
 
@@ -329,8 +355,6 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = val * chan1
         self.assertEqual(rho_init.evolve(chan), rho_targ)
-        chan = chan1 * val
-        self.assertEqual(rho_init.evolve(chan), rho_targ)
 
         # Double Stinespring set
         chan2 = Stinespring((stine1, stine2), input_dims=2, output_dims=4)
@@ -339,14 +363,14 @@ class TestStinespring(ChannelTestCase):
         self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = val * chan2
         self.assertEqual(rho_init.evolve(chan), rho_targ)
-        chan = chan2 * val
-        self.assertEqual(rho_init.evolve(chan), rho_targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Stinespring(self.depol_stine(1))
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -244,8 +244,43 @@ class TestSuperOp(ChannelTestCase):
         chan = chan2.compose(chan1)
         self.assertEqual(chan.dim, (4, 4))
 
+    def test_dot(self):
+        """Test dot method."""
+        # UnitaryChannel evolution
+        chan1 = SuperOp(self.sopX)
+        chan2 = SuperOp(self.sopY)
+        targ = SuperOp(self.sopZ)
+        self.assertEqual(chan1.dot(chan2), targ)
+        self.assertEqual(chan1 * chan2, targ)
+
+        # 50% depolarizing channel
+        chan1 = SuperOp(self.depol_sop(0.5))
+        targ = SuperOp(self.depol_sop(0.75))
+        self.assertEqual(chan1.dot(chan1), targ)
+        self.assertEqual(chan1 * chan1, targ)
+
+        # Random superoperator
+        mat1 = self.rand_matrix(4, 4)
+        mat2 = self.rand_matrix(4, 4)
+        chan1 = SuperOp(mat1)
+        chan2 = SuperOp(mat2)
+        targ = SuperOp(np.dot(mat2, mat1))
+        self.assertEqual(chan2.dot(chan1), targ)
+        self.assertEqual(chan2 * chan1, targ)
+        targ = SuperOp(np.dot(mat1, mat2))
+        self.assertEqual(chan1 * chan2, targ)
+
+        # Compose different dimensions
+        chan1 = SuperOp(self.rand_matrix(16, 4))
+        chan2 = SuperOp(self.rand_matrix(4, 16))
+        chan = chan1.dot(chan2)
+        self.assertEqual(chan.dim, (4, 4))
+        chan = chan2.dot(chan1)
+        self.assertEqual(chan.dim, (2, 2))
+
     def test_compose_front(self):
         """Test front compose method."""
+        # DEPRECATED
         # UnitaryChannel evolution
         chan1 = SuperOp(self.sopX)
         chan2 = SuperOp(self.sopY)
@@ -322,6 +357,52 @@ class TestSuperOp(ChannelTestCase):
         full_op = SuperOp(mat_a).tensor(iden).tensor(iden)
         targ = np.dot(full_op.data, mat)
         self.assertEqual(op.compose(op1, qargs=[2]), SuperOp(targ))
+
+    def test_dot_subsystem(self):
+        """Test subsystem dot method."""
+        # 3-qubit operator
+        mat = self.rand_matrix(64, 64)
+        mat_a = self.rand_matrix(4, 4)
+        mat_b = self.rand_matrix(4, 4)
+        mat_c = self.rand_matrix(4, 4)
+        iden = SuperOp(np.eye(4))
+        op = SuperOp(mat)
+        op1 = SuperOp(mat_a)
+        op2 = SuperOp(mat_b).tensor(SuperOp(mat_a))
+        op3 = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
+
+        # op3 qargs=[0, 1, 2]
+        full_op = SuperOp(mat_c).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op3, qargs=[0, 1, 2]), SuperOp(targ))
+        # op3 qargs=[2, 1, 0]
+        full_op = SuperOp(mat_a).tensor(SuperOp(mat_b)).tensor(SuperOp(mat_c))
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op3, qargs=[2, 1, 0]), SuperOp(targ))
+
+        # op2 qargs=[0, 1]
+        full_op = iden.tensor(SuperOp(mat_b)).tensor(SuperOp(mat_a))
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op2, qargs=[0, 1]), SuperOp(targ))
+        # op2 qargs=[2, 0]
+        full_op = SuperOp(mat_a).tensor(iden).tensor(SuperOp(mat_b))
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op2, qargs=[2, 0]), SuperOp(targ))
+
+        # op1 qargs=[0]
+        full_op = iden.tensor(iden).tensor(SuperOp(mat_a))
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op1, qargs=[0]), SuperOp(targ))
+
+        # op1 qargs=[1]
+        full_op = iden.tensor(SuperOp(mat_a)).tensor(iden)
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op1, qargs=[1]), SuperOp(targ))
+
+        # op1 qargs=[2]
+        full_op = SuperOp(mat_a).tensor(iden).tensor(iden)
+        targ = np.dot(mat, full_op.data)
+        self.assertEqual(op.dot(op1, qargs=[2]), SuperOp(targ))
 
     def test_compose_front_subsystem(self):
         """Test subsystem front compose method."""
@@ -479,14 +560,14 @@ class TestSuperOp(ChannelTestCase):
         val = 0.5
         targ = SuperOp(val * self.sopI)
         self.assertEqual(chan.multiply(val), targ)
-        self.assertEqual(val * chan, targ)
-        self.assertEqual(chan * val, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = SuperOp(self.sopI)
         self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan.__rmul__, 's')
         self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):
         """Test negate method"""

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -322,6 +322,19 @@ class TestOperator(OperatorTestCase):
         self.assertEqual(op2.compose(op1), targ)
         self.assertEqual(op2 @ op1, targ)
 
+    def test_dot(self):
+        """Test dot method."""
+        op1 = Operator(self.UY)
+        op2 = Operator(self.UX)
+
+        targ = Operator(np.dot(self.UY, self.UX))
+        self.assertEqual(op1.dot(op2), targ)
+        self.assertEqual(op1 * op2, targ)
+
+        targ = Operator(np.dot(self.UX, self.UY))
+        self.assertEqual(op2.dot(op1), targ)
+        self.assertEqual(op2 * op1, targ)
+
     def test_compose_front(self):
         """Test front compose method."""
 
@@ -370,6 +383,44 @@ class TestOperator(OperatorTestCase):
         # op1 qargs=[2]
         targ = np.dot(np.kron(mat_a, np.eye(4)), mat)
         self.assertEqual(op.compose(op1, qargs=[2]), Operator(targ))
+
+    def test_dot_subsystem(self):
+        """Test subsystem dot method."""
+        # 3-qubit operator
+        mat = self.rand_matrix(8, 8)
+        mat_a = self.rand_matrix(2, 2)
+        mat_b = self.rand_matrix(2, 2)
+        mat_c = self.rand_matrix(2, 2)
+        op = Operator(mat)
+        op1 = Operator(mat_a)
+        op2 = Operator(np.kron(mat_b, mat_a))
+        op3 = Operator(np.kron(mat_c, np.kron(mat_b, mat_a)))
+
+        # op3 qargs=[0, 1, 2]
+        targ = np.dot(mat, np.kron(mat_c, np.kron(mat_b, mat_a)))
+        self.assertEqual(op.dot(op3, qargs=[0, 1, 2]), Operator(targ))
+        # op3 qargs=[2, 1, 0]
+        targ = np.dot(mat, np.kron(mat_a, np.kron(mat_b, mat_c)))
+        self.assertEqual(op.dot(op3, qargs=[2, 1, 0]), Operator(targ))
+
+        # op2 qargs=[0, 1]
+        targ = np.dot(mat, np.kron(np.eye(2), np.kron(mat_b, mat_a)))
+        self.assertEqual(op.dot(op2, qargs=[0, 1]), Operator(targ))
+        # op2 qargs=[2, 0]
+        targ = np.dot(mat, np.kron(mat_a, np.kron(np.eye(2), mat_b)))
+        self.assertEqual(op.dot(op2, qargs=[2, 0]), Operator(targ))
+
+        # op1 qargs=[0]
+        targ = np.dot(mat, np.kron(np.eye(4), mat_a))
+        self.assertEqual(op.dot(op1, qargs=[0]), Operator(targ))
+
+        # op1 qargs=[1]
+        targ = np.dot(mat, np.kron(np.eye(2), np.kron(mat_a, np.eye(2))))
+        self.assertEqual(op.dot(op1, qargs=[1]), Operator(targ))
+
+        # op1 qargs=[2]
+        targ = np.dot(mat, np.kron(mat_a, np.eye(4)))
+        self.assertEqual(op.dot(op1, qargs=[2]), Operator(targ))
 
     def test_compose_front_subsystem(self):
         """Test subsystem front compose method."""
@@ -495,7 +546,9 @@ class TestOperator(OperatorTestCase):
         """Test multiply method raises exceptions."""
         op = Operator(self.rand_matrix(2, 2))
         self.assertRaises(QiskitError, op.multiply, 's')
+        self.assertRaises(QiskitError, op.__rmul__, 's')
         self.assertRaises(QiskitError, op.multiply, op)
+        self.assertRaises(QiskitError, op.__rmul__, op)
 
     def test_negate(self):
         """Test negate method"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

* Adds `dot` method to operator API in BaseOperator class
* Changes operator `__mul__` method to implement `dot`
* Leaves operator `__rmul__` method as implementing `multiply` (scalar multiplication)
* Deprecates `front=True` kwarg of operator `compose` method which is now implemented with `dot`.

### Details and comments


