### PR TITLE
Remove deprecated path to align_measures, add_implicit_acquires and p…

### DIFF
--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -15,29 +15,3 @@
 """
 Pulse utilities.
 """
-import warnings
-# pylint: disable=unused-argument
-
-
-def align_measures(schedules, cmd_def, cal_gate, max_calibration_duration=None, align_time=None):
-    """
-    This function has been moved!
-    """
-    warnings.warn("The function `align_measures` has been moved to qiskit.pulse.reschedule. "
-                  "It cannot be invoked from `utils` anymore (this call returns None).")
-
-
-def add_implicit_acquires(schedule, meas_map):
-    """
-    This function has been moved!
-    """
-    warnings.warn("The function `add_implicit_acquires` has been moved to qiskit.pulse.reschedule."
-                  " It cannot be invoked from `utils` anymore (this call returns None).")
-
-
-def pad(schedule, channels=None, until=None):
-    """
-    This function has been moved!
-    """
-    warnings.warn("The function `pad` has been moved to qiskit.pulse.reschedule. It cannot be "
-                  "invoked from `utils` anymore (this call returns None).")


### PR DESCRIPTION
…ad. These functions are found in qiskit.pulse.reschedule rather than qiskit.pulse.utils

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

It's been deprecated for the required period

### Details and comments


