### PR TITLE
Deprecate the PersistentValue instruction. 

### DIFF
--- a/qiskit/pulse/commands/persistent_value.py
+++ b/qiskit/pulse/commands/persistent_value.py
@@ -15,6 +15,8 @@
 """
 Persistent value.
 """
+import warnings
+
 from typing import Optional
 
 from qiskit.pulse.channels import PulseChannel
@@ -42,6 +44,9 @@ class PersistentValue(Command):
 
         if abs(value) > 1:
             raise PulseError("Absolute value of PV amplitude exceeds 1.")
+
+        warnings.warn("The PersistentValue command is deprecated. Use qiskit.pulse.ConstantPulse "
+                      "instead.", DeprecationWarning)
 
         self._value = complex(value)
         self._name = PersistentValue.create_name(name)

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -192,6 +192,8 @@ class InstructionToQobjConverter:
         Returns:
             dict: Dictionary of required parameters.
         """
+        warnings.warn("The PersistentValue command is deprecated. Use qiskit.pulse.ConstantPulse "
+                      "instead.", DeprecationWarning)
         command_dict = {
             'name': 'pv',
             't0': shift + instruction.start_time,

--- a/releasenotes/notes/deprecate-persistent-value-command-4ec516a314197887.yaml
+++ b/releasenotes/notes/deprecate-persistent-value-command-4ec516a314197887.yaml
@@ -1,0 +1,18 @@
+---
+deprecations:
+  - |
+    The PersistentValue command is deprecated from Qiskit Pulse. Similar
+    functionality can be achieved with the ConstantPulse command (one of
+    the new parametric pulses). Compare the following:
+
+        from qiskit.pulse import Schedule, PersistentValue, ConstantPulse, \
+                                 DriveChannel
+
+        # deprecated implementation
+        sched_w_pv = Schedule()
+        sched_w_pv += PersistentValue(value=0.5)(DriveChannel(0))
+        sched_w_pv += PersistentValue(value=0)(DriveChannel(0)) << 10
+
+        # preferred implementation
+        sched_w_const = Schedule()
+        sched_w_const += ConstantPulse(duration=10, amp=0.5)(DriveChannel(0))


### PR DESCRIPTION
### Summary


The ConstantPulse parametric pulse should be used in its place. This requires the user to know the duration for which the signal amplitude should be changed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->




### Details and comments


