### PR TITLE
Add entropy and entanglement state measures to quantum_info

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -11,7 +11,6 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-
 """
 ================================================
 Quantum Information (:mod:`qiskit.quantum_info`)
@@ -63,6 +62,11 @@ Measures
    average_gate_fidelity
    process_fidelity
    gate_error
+   purity
+   concurrence
+   entropy
+   entanglement_of_formation
+   mutual_information
 
 Utility Functions
 =================
@@ -71,6 +75,7 @@ Utility Functions
    :toctree: ../stubs/
 
    partial_trace
+   shannon_entropy
 
 Random
 ======
@@ -110,7 +115,9 @@ from .operators.measures import process_fidelity
 from .operators import average_gate_fidelity
 from .operators import gate_error
 from .states import Statevector, DensityMatrix
-from .states import state_fidelity, partial_trace, purity
+from .states import (partial_trace, state_fidelity, purity, entropy,
+                     concurrence, entanglement_of_formation,
+                     mutual_information, shannon_entropy)
 from .states.states import basis_state, projector
 from .random import random_unitary, random_state, random_density_matrix
 from .synthesis import (TwoQubitBasisDecomposer, euler_angles_1q,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -16,7 +16,8 @@
 
 from .statevector import Statevector
 from .densitymatrix import DensityMatrix
-from .utils import partial_trace
-from .measures import state_fidelity, purity
+from .utils import partial_trace, shannon_entropy
+from .measures import (state_fidelity, purity, entropy, concurrence,
+                       mutual_information, entanglement_of_formation)
 from .states import basis_state, projector
 from .counts import state_to_counts

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -16,8 +16,11 @@ Quantum information measures, metrics, and related functions for states.
 """
 
 import numpy as np
-from qiskit.quantum_info.states.statevector import Statevector
-from qiskit.quantum_info.states.utils import _format_state, _funm_svd
+import scipy.linalg as la
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.states.densitymatrix import DensityMatrix, Statevector
+from qiskit.quantum_info.states.utils import (partial_trace, shannon_entropy,
+                                              _format_state, _funm_svd)
 
 
 def state_fidelity(state1, state2, validate=True):
@@ -92,3 +95,156 @@ def purity(state, validate=True):
     """
     state = _format_state(state, validate=validate)
     return state.purity()
+
+
+def entropy(state, base=2):
+    r"""Calculate the von-Neumann entropy of a quantum state.
+
+    The entropy :math:`S` is given by
+
+    .. math:
+
+        S(\rho) = - Tr[\rho \log(\rho)]
+
+    Args:
+        state (Statevector or DensityMatrix): a quantum state.
+        base (int): the base of the logarithm [Default: 2].
+
+    Returns:
+        float: The von-Neumann entropy S(rho).
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+    """
+    # pylint: disable=assignment-from-no-return
+    state = _format_state(state, validate=True)
+    if isinstance(state, Statevector):
+        return 0
+    # Density matrix case
+    evals = np.maximum(np.real(la.eigvals(state.data)), 0.)
+    return shannon_entropy(evals, base=base)
+
+
+def mutual_information(state, base=2):
+    r"""Calculate the mutual information of a bipartite state.
+
+    The mutual information :math:`I` is given by:
+
+    .. math:
+
+        I(\rho_{AB}) = S(\rho_A) + S(\rho_B) - S(\rho_{AB})
+
+    where :math:`\rho_A=Tr_B[\rho_{AB}], \rho_B=Tr_A[\rho_{AB}]`, are the
+    reduced density matrices of the bipartite state :math:`\rho_{AB}`.
+
+    Args:
+        state (Statevector or DensityMatrix): a bipartite state.
+        base (int): the base of the logarithm [Default: 2].
+
+    Returns:
+        float: The mutual information :math:`I(\rho_{AB})`.
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+        QiskitError: if input is not a bipartite QuantumState.
+    """
+    state = _format_state(state, validate=True)
+    if len(state.dims()) != 2:
+        raise QiskitError('Input must be a bipartite quantum state.')
+    rho_a = partial_trace(state, [1])
+    rho_b = partial_trace(state, [0])
+    return entropy(rho_a, base=base) + entropy(
+        rho_b, base=base) - entropy(state, base=base)
+
+
+def concurrence(state):
+    r"""Calculate the concurrence of a quantum state.
+
+    The concurrence of a bipartite
+    :class:`~qiskit.quantum_info.Statevector` :math:`|\psi\rangle` is
+    given by
+
+    .. math:
+
+        C(|\psi\rangle) = \sqrt{2(1 - Tr[\rho_0^2])}
+
+    where :math:`\rho_0 = Tr_1[|\psi\rangle\!\langle\psi|]` is the
+    reduced state from by taking the
+    :math:`~qiskit.quantum_info.partial_trace` of the input state.
+
+    For density matrices the concurrence is only defined for
+    2-qubit states, it is given by:
+
+    .. math:
+
+        C(\rho) = \max(0, \lambda_1 - \lambda_2 - \lamda_3 - \lambda_4)
+
+    where  :math:`\lambda _1 \ge \lambda _2 \ge \lambda _3 \ge \lambda _4`
+    are the ordered eigenvalues of the matrix
+    :math:`R=\sqrt{\sqrt{\rho }(Y\otimes Y)\overline{\rho}(Y\otimes Y)\sqrt{\rho}}}`.
+
+    Args:
+        state (Statevector or DensityMatrix): a 2-qubit quantum state.
+
+    Returns:
+        float: The concurrence.
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+        QiskitError: if input is not a bipartite QuantumState.
+        QiskitError: if density matrix input is not a 2-qubit state.
+    """
+    # Concurrence computation requires the state to be valid
+    state = _format_state(state, validate=True)
+    if isinstance(state, Statevector):
+        # Pure state concurrence
+        dims = state.dims()
+        if len(dims) != 2:
+            raise QiskitError('Input is not a bipartite quantum state.')
+        qargs = [0] if dims[0] > dims[1] else [1]
+        rho = partial_trace(state, qargs)
+        return float(np.sqrt(2 * (1 - np.real(purity(rho)))))
+    # If input is a density matrix it must be a 2-qubit state
+    if state.dim != 4:
+        raise QiskitError('Input density matrix must be a 2-qubit state.')
+    rho = DensityMatrix(state).data
+    yy_mat = np.fliplr(np.diag([-1, 1, 1, -1]))
+    sigma = rho.dot(yy_mat).dot(rho.conj()).dot(yy_mat)
+    w = np.sort(np.real(la.eigvals(sigma)))
+    w = np.sqrt(np.maximum(w, 0.))
+    return max(0.0, w[-1] - np.sum(w[0:-1]))
+
+
+def entanglement_of_formation(state):
+    """Calculate the entanglement of formation of quantum state.
+
+    The input quantum state must be either a bipartite state vector, or a
+    2-qubit density matrix.
+
+    Args:
+        state (Statevector or DensityMatrix): a 2-qubit quantum state.
+
+    Returns:
+        float: The entanglement of formation.
+
+    Raises:
+        QiskitError: if the input state is not a valid QuantumState.
+        QiskitError: if input is not a bipartite QuantumState.
+        QiskitError: if density matrix input is not a 2-qubit state.
+    """
+    state = _format_state(state, validate=True)
+    if isinstance(state, Statevector):
+        # The entanglement of formation is given by the reduced state
+        # entropy
+        dims = state.dims()
+        if len(dims) != 2:
+            raise QiskitError('Input is not a bipartite quantum state.')
+        qargs = [0] if dims[0] > dims[1] else [1]
+        return entropy(partial_trace(state, qargs), base=2)
+
+    # If input is a density matrix it must be a 2-qubit state
+    if state.dim != 4:
+        raise QiskitError('Input density matrix must be a 2-qubit state.')
+    conc = concurrence(state)
+    val = (1 + np.sqrt(1 - (conc ** 2))) / 2
+    return shannon_entropy([val, 1 - val])

--- a/qiskit/quantum_info/states/states.py
+++ b/qiskit/quantum_info/states/states.py
@@ -13,10 +13,9 @@
 # that they have been altered from the originals.
 
 """
-A collection of useful quantum information functions for states.
-
-
+A collection of DEPRECATED quantum information functions for states.
 """
+import warnings
 import numpy as np
 from qiskit.exceptions import QiskitError
 
@@ -33,6 +32,10 @@ def basis_state(str_state, num):
      Raises:
         QiskitError: if the dimensions is wrong
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' Please use `quantum_info.Statevector.from_label(label) for '
+        ' equivalent functionality.', DeprecationWarning)
     n = int(str_state, 2)
     if num >= len(str_state):
         state = np.zeros(1 << num, dtype=complex)
@@ -53,6 +56,10 @@ def projector(state, flatten=False):
         ndarray:  state_mat(2**num, 2**num) if flatten is false
         ndarray:  state_mat(4**num) if flatten is true stacked on by the column
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' Please use `quantum_info.DensityMatrix(state) for '
+        ' equivalent functionality.', DeprecationWarning)
     density_matrix = np.outer(state.conjugate(), state)
     if flatten:
         return density_matrix.flatten(order='F')

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -77,6 +77,43 @@ def partial_trace(state, qargs):
     return ret
 
 
+def shannon_entropy(pvec, base=2):
+    r"""Compute the Shannon entropy of a probability vector.
+
+    The shannon entropy of a probability vector
+    :math:`\vec{p} = [p_0, ..., p_{n-1}]` is defined as
+
+    .. math:
+
+        H(\vec{p}) = \sum_{i=0}^{n-1} p_i \log_b(p_i)
+
+    where :math:`b` is the log base and (default 2), and
+    :math:`0 \log_b(0) \equiv 0`.
+
+    Args:
+        pvec (array_like): a probability vector.
+        base (int): the base of the logarithm [Default: 2].
+
+    Returns:
+        float: The Shannon entropy H(pvec).
+    """
+    if base == 2:
+        def logfn(x):
+            return - x * np.log2(x)
+    elif base == np.e:
+        def logfn(x):
+            return - x * np.log(x)
+    else:
+        def logfn(x):
+            return -x * np.log(x) / np.log(base)
+
+    h_val = 0.
+    for x in pvec:
+        if 0 < x < 1:
+            h_val += logfn(x)
+    return h_val
+
+
 def _format_state(state, validate=True):
     """Format input state into class object"""
     if isinstance(state, list):

--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -73,7 +73,7 @@ def partial_trace(state, trace_systems, dimensions=None, reverse=True):
     # DEPRECATED
     warnings.warn(
         'This function is deprecated and will be removed in the future.'
-        ' It is superseded by the `quantum_info.partial_trace` method',
+        ' It is superseded by the `quantum_info.partial_trace` function',
         DeprecationWarning)
 
     if dimensions is None:  # compute dims if not specified
@@ -304,6 +304,7 @@ def chop(array, epsilon=1e-10):
     Returns:
         np.array: A new operator with small values set to zero.
     """
+    
     ret = np.array(array)
 
     if np.isrealobj(ret):
@@ -351,6 +352,10 @@ def concurrence(state):
     Raises:
         Exception: if attempted on more than two qubits.
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the `quantum_info.concurrence` function',
+        DeprecationWarning)
     rho = np.array(state)
     if rho.ndim == 1:
         rho = outer(state)
@@ -378,6 +383,10 @@ def shannon_entropy(pvec, base=2):
     Returns:
         float: The Shannon entropy H(pvec).
     """
+    # DEPRECATED
+    warnings.warn(
+        'This function has been moved to `quantum_info.utils.shannon_entropy`',
+        DeprecationWarning)
     if base == 2:
         def logfn(x):
             return - x * np.log2(x)
@@ -405,8 +414,12 @@ def entropy(state):
     Returns:
         float: The von-Neumann entropy S(rho).
     """
+    # DEPRECATED
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the `quantum_info.entropy` method',
+        DeprecationWarning)
     # pylint: disable=assignment-from-no-return
-
     rho = np.array(state)
     if rho.ndim == 1:
         return 0
@@ -426,6 +439,11 @@ def mutual_information(state, d0, d1=None):
     Returns:
         float: The mutual information S(rho_A) + S(rho_B) - S(rho_AB).
     """
+    # DEPRECATED
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the `quantum_info.mutual_information` function',
+        DeprecationWarning)
     if d1 is None:
         d1 = int(len(state) / d0)
     mi = entropy(partial_trace(state, [0], dimensions=[d0, d1]))
@@ -450,6 +468,11 @@ def entanglement_of_formation(state, d0, d1=None):
     Returns:
         float: The entanglement of formation.
     """
+    # DEPRECATED
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the `quantum_info.entanglement_of_formation` function',
+        DeprecationWarning)
     state = np.array(state)
 
     if d1 is None:

--- a/qiskit/tools/qi/qi.py
+++ b/qiskit/tools/qi/qi.py
@@ -14,10 +14,9 @@
 
 # pylint: disable=invalid-name,unsupported-assignment-operation
 """
-A collection of useful quantum information functions.
+A collection of DEPRECATED quantum information functions.
 
-Currently this file is very sparse. More functions will be added
-over time.
+Please see the `qiskit.quantum_info` module for replacements.
 """
 
 import warnings
@@ -27,7 +26,6 @@ import scipy.linalg as la
 
 from qiskit.quantum_info import pauli_group
 
-
 ###############################################################
 # circuit manipulation.
 ###############################################################
@@ -36,6 +34,9 @@ from qiskit.quantum_info import pauli_group
 # Define methods for making QFT circuits
 def qft(circ, q, n):
     """n-qubit QFT on q in circ."""
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.',
+        DeprecationWarning)
     for j in range(n):
         for k in range(j):
             circ.cu1(math.pi / float(2**(j - k)), q[j], q[k])
@@ -79,7 +80,7 @@ def partial_trace(state, trace_systems, dimensions=None, reverse=True):
     if dimensions is None:  # compute dims if not specified
         num_qubits = int(np.log2(len(state)))
         dimensions = [2 for _ in range(num_qubits)]
-        if len(state) != 2 ** num_qubits:
+        if len(state) != 2**num_qubits:
             raise Exception("Input is not a multi-qubit state, "
                             "specify input state dims")
     else:
@@ -168,12 +169,14 @@ def __partial_trace_mat(mat, trace_systems, dimensions, reverse=True):
 
         # Reshape input array into tri-partite system with system to be
         # traced as the middle index
-        mat = mat.reshape([dimension_left, dimension_trace, dimension_right,
-                           dimension_left, dimension_trace, dimension_right])
+        mat = mat.reshape([
+            dimension_left, dimension_trace, dimension_right, dimension_left,
+            dimension_trace, dimension_right
+        ])
         # trace out the middle system and reshape back to a matrix
-        mat = mat.trace(axis1=1, axis2=4).reshape(
-            dimension_left * dimension_right,
-            dimension_left * dimension_right)
+        mat = mat.trace(axis1=1,
+                        axis2=4).reshape(dimension_left * dimension_right,
+                                         dimension_left * dimension_right)
     return mat
 
 
@@ -194,6 +197,9 @@ def vectorize(density_matrix, method='col'):
     Raises:
         Exception: if input state is not a n-qubit state
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.',
+        DeprecationWarning)
     density_matrix = np.array(density_matrix)
     if method == 'col':
         return density_matrix.flatten(order='F')
@@ -207,8 +213,9 @@ def vectorize(density_matrix, method='col'):
             pgroup = pauli_group(num, case='weight')
         else:
             pgroup = pauli_group(num, case='tensor')
-        vals = [np.trace(np.dot(p.to_matrix(), density_matrix))
-                for p in pgroup]
+        vals = [
+            np.trace(np.dot(p.to_matrix(), density_matrix)) for p in pgroup
+        ]
         return np.array(vals)
     return None
 
@@ -230,6 +237,9 @@ def devectorize(vectorized_mat, method='col'):
     Raises:
         Exception: if input state is not a n-qubit state
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.',
+        DeprecationWarning)
     vectorized_mat = np.array(vectorized_mat)
     dimension = int(np.sqrt(vectorized_mat.size))
     if len(vectorized_mat) != dimension * dimension:
@@ -241,13 +251,13 @@ def devectorize(vectorized_mat, method='col'):
         return vectorized_mat.reshape(dimension, dimension, order='C')
     elif method in ['pauli', 'pauli_weights']:
         num_qubits = int(np.log2(dimension))  # number of qubits
-        if dimension != 2 ** num_qubits:
+        if dimension != 2**num_qubits:
             raise Exception('Input state must be n-qubit state')
         if method == 'pauli_weights':
             pgroup = pauli_group(num_qubits, case='weight')
         else:
             pgroup = pauli_group(num_qubits, case='tensor')
-        pbasis = np.array([p.to_matrix() for p in pgroup]) / 2 ** num_qubits
+        pbasis = np.array([p.to_matrix() for p in pgroup]) / 2**num_qubits
         return np.tensordot(vectorized_mat, pbasis, axes=1)
     return None
 
@@ -277,6 +287,10 @@ def choi_to_pauli(choi, order=1):
     Returns:
         np.array: A superoperator in the Pauli basis.
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.'
+        ' Use the `quantum_info.Choi` and `quantum_info.PTM` quantum channel'
+        ' classes for similar functionality', DeprecationWarning)
     if order == 0:
         order = 'weight'
     elif order == 1:
@@ -290,7 +304,7 @@ def choi_to_pauli(choi, order=1):
         for j in pgp:
             pauliop = np.kron(j.to_matrix().T, i.to_matrix())
             rauli += [np.trace(np.dot(choi, pauliop))]
-    return np.array(rauli).reshape(4 ** num_qubits, 4 ** num_qubits)
+    return np.array(rauli).reshape(4**num_qubits, 4**num_qubits)
 
 
 def chop(array, epsilon=1e-10):
@@ -304,7 +318,9 @@ def chop(array, epsilon=1e-10):
     Returns:
         np.array: A new operator with small values set to zero.
     """
-    
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.'
+        ' Use `numpy.round` for similar functionality.', DeprecationWarning)
     ret = np.array(array)
 
     if np.isrealobj(ret):
@@ -330,11 +346,16 @@ def outer(vector1, vector2=None):
         np.array: The matrix |v1><v2|.
 
     """
+    warnings.warn(
+        'This function is deprecated and will be removed in a future release.'
+        ' Please use `numpy.outer` function for similar functionality.',
+        DeprecationWarning)
     if vector2 is None:
         vector2 = np.array(vector1).conj()
     else:
         vector2 = np.array(vector2).conj()
     return np.outer(vector1, vector2)
+
 
 ###############################################################
 # Measures.
@@ -353,8 +374,8 @@ def concurrence(state):
         Exception: if attempted on more than two qubits.
     """
     warnings.warn(
-        'This function is deprecated and will be removed in the future.'
-        ' It is superseded by the `quantum_info.concurrence` function',
+        'This function is deprecated and will be removed in a future release.'
+        ' It is superseded by the `quantum_info.concurrence` function.',
         DeprecationWarning)
     rho = np.array(state)
     if rho.ndim == 1:
@@ -385,15 +406,19 @@ def shannon_entropy(pvec, base=2):
     """
     # DEPRECATED
     warnings.warn(
-        'This function has been moved to `quantum_info.utils.shannon_entropy`',
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the `quantum_info.shannon_entropy` function',
         DeprecationWarning)
     if base == 2:
+
         def logfn(x):
-            return - x * np.log2(x)
+            return -x * np.log2(x)
     elif base == np.e:
+
         def logfn(x):
-            return - x * np.log(x)
+            return -x * np.log(x)
     else:
+
         def logfn(x):
             return -x * np.log(x) / np.log(base)
 
@@ -417,7 +442,7 @@ def entropy(state):
     # DEPRECATED
     warnings.warn(
         'This function is deprecated and will be removed in the future.'
-        ' It is superseded by the `quantum_info.entropy` method',
+        ' It is superseded by the `quantum_info.entropy` function.',
         DeprecationWarning)
     # pylint: disable=assignment-from-no-return
     rho = np.array(state)
@@ -471,7 +496,7 @@ def entanglement_of_formation(state, d0, d1=None):
     # DEPRECATED
     warnings.warn(
         'This function is deprecated and will be removed in the future.'
-        ' It is superseded by the `quantum_info.entanglement_of_formation` function',
+        ' It is superseded by the `quantum_info.entanglement_of_formation` function.',
         DeprecationWarning)
     state = np.array(state)
 
@@ -515,4 +540,9 @@ def __eof_qubit(rho):
 
 def is_pos_def(x):
     """Return is_pos_def."""
+    warnings.warn(
+        'This function is deprecated and will be removed in the future.'
+        ' It is superseded by the '
+        '`quantum_info.operators.predicates.is_positive_semidefinite_matrix`'
+        ' function.', DeprecationWarning)
     return np.all(np.linalg.eigvals(x) > 0)

--- a/releasenotes/notes/state-measures-f662a847d0db42b8.yaml
+++ b/releasenotes/notes/state-measures-f662a847d0db42b8.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Add state measure functions to the ``quantum_info`` module for ``entropy``,
+    ``mutual_information``, ``concurrence``, and ``entanglement_of_formation``.
+    These functions work with the ``Statevector`` and ``DensityMatrix`` classes.
+
+deprecations:
+  - |
+    Deprecates everything in the legacy `tools.qi.qi.py` file, and
+    `quantum_info.states.states.py` file. These legacy functions have all been
+    superseded by functions and classes in the ``quantum_info`` module.

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -18,10 +18,11 @@
 
 import unittest
 import logging
+import numpy as np
 
 from qiskit.test import QiskitTestCase
 from qiskit.quantum_info.states import Statevector, DensityMatrix
-from qiskit.quantum_info.states import partial_trace
+from qiskit.quantum_info.states import partial_trace, shannon_entropy
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ class TestStateUtils(QiskitTestCase):
     """Test utility functions for QuantumState classes."""
 
     def test_statevector_partial_trace(self):
-        """Test partial_trace method"""
+        """Test partial_trace function on statevectors"""
         psi = Statevector.from_label('10+')
         self.assertEqual(
             partial_trace(psi, [0, 1]), DensityMatrix.from_label('1'))
@@ -46,7 +47,7 @@ class TestStateUtils(QiskitTestCase):
             partial_trace(psi, [2]), DensityMatrix.from_label('0+'))
 
     def test_density_matrix_partial_trace(self):
-        """Test partial_trace method"""
+        """Test partial_trace function on density matrices"""
         rho = DensityMatrix.from_label('10+')
         self.assertEqual(
             partial_trace(rho, [0, 1]), DensityMatrix.from_label('1'))
@@ -60,6 +61,19 @@ class TestStateUtils(QiskitTestCase):
             partial_trace(rho, [1]), DensityMatrix.from_label('1+'))
         self.assertEqual(
             partial_trace(rho, [2]), DensityMatrix.from_label('0+'))
+
+    def test_shannon_entropy(self):
+        """Test shannon_entropy function"""
+        input_pvec = np.array([0.5, 0.3, 0.07, 0.1, 0.03])
+        # Base 2
+        self.assertAlmostEqual(1.7736043871504037,
+                               shannon_entropy(input_pvec))
+        # Base e
+        self.assertAlmostEqual(1.229368880382052,
+                               shannon_entropy(input_pvec, np.e))
+        # Base 10
+        self.assertAlmostEqual(0.533908120973504,
+                               shannon_entropy(input_pvec, 10))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

* Add functions `entropy`, `mutual_information`, `concurrence`, and
`entanglement_of_formation` to quantum_info.states that work with
`Statevector` and `DensityMatrix` classes.
* Add unittests for new functions
* Deprecate EVERYTHING in `tools.qi.qi.py`
* Deprecate `basis_states` and `projector` in `quantum_info.states.states.py`
* Allow entropy based functions to set custom base with kwarg (default base 2)

### Details and comments


