### PR TITLE
De-deprecated front compose for operators, update operator API docs

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -182,40 +182,48 @@ class BaseOperator(ABC):
 
     @abstractmethod
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied operator other * self.
+        """Return the composed operator.
 
         Args:
             other (BaseOperator): an operator object.
-            qargs (list or None): a list of subsystem positions to apply other on.
-            front (bool): DEPRECATED If False compose in standard order other(self(input))
-                          otherwise compose in reverse order self(other(input))
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            BaseOperator: The composed operator.
+            BaseOperator: The operator self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to an operator, or has
             incompatible dimensions for specified subsystems.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            matrix operators. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         pass
 
-    @abstractmethod
     def dot(self, other, qargs=None):
         """Return the right multiplied operator self * other.
 
         Args:
             other (BaseOperator): an operator object.
-            qargs (list or None): a list of subsystem positions to apply other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            BaseOperator: The composed operator.
+            BaseOperator: The operator self * other.
 
         Raises:
             QiskitError: if other cannot be converted to an operator, or has
             incompatible dimensions for specified subsystems.
         """
-        pass
+        return self.compose(other, qargs=qargs, front=True)
 
     def power(self, n):
         """Return the compose of a operator with itself n times.

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -16,19 +16,6 @@
 
 """
 Chi-matrix representation of a Quantum Channel.
-
-
-This is the matrix χ such that:
-
-    E(ρ) = sum_{i, j} χ_{i,j} P_i.ρ.P_j^dagger
-
-where [P_i, i=0,...4^{n-1}] is the n-qubit Pauli basis in lexicographic order.
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
 """
 
 from numbers import Number
@@ -44,10 +31,28 @@ from qiskit.quantum_info.operators.channel.transformations import _to_chi
 
 
 class Chi(QuantumChannel):
-    """Pauli basis Chi-matrix representation of a quantum channel
+    r"""Pauli basis Chi-matrix representation of a quantum channel.
 
-    The Chi-matrix is the Pauli-basis representation of the Chi-Matrix.
+    The Chi-matrix representation of an :math:`n`-qubit quantum channel
+    :math:`\mathcal{E}` is a matrix :math:`\chi` such that the evolution of a
+    :class:`~qiskit.quantum_info.DensityMatrix` :math:`\rho` is given by
+
+    .. math::
+
+        \mathcal{E}(ρ) = \sum_{i, j} \chi_{i,j} P_i ρ P_j
+
+    where :math:`[P_0, P_1, ..., P_{4^{n}-1}]` is the :math:`n`-qubit Pauli basis in
+    lexicographic order. It is related to the :class:`Choi` representation by a change
+    of basis of the Choi-matrix into the Pauli basis.
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
     """
+
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Chi-matrix operator.
 

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -142,32 +142,40 @@ class Chi(QuantumChannel):
         return Chi(Choi(self).transpose())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            Chi: The left multiplied quantum channel.
+            Chi: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a Chi or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
             qargs (list): a list of subsystem positions to compose other on.
 
         Returns:
-            Chi: The right multiplied quantum channel.
+            Chi: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a Chi or has

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -141,32 +141,42 @@ class Choi(QuantumChannel):
                     output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            Choi: The left multiplied quantum channel.
+            Choi: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a Choi or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            Choi: The right multiplied quantum channel.
+            Choi: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a Choi or has

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -16,20 +16,6 @@
 
 """
 Choi-matrix representation of a Quantum Channel.
-
-
-For a quantum channel E, the Choi matrix Λ is defined by:
-Λ = sum_{i,j} |i⟩⟨j|⊗E(|i⟩⟨j|)
-
-Evolution of a density matrix with respect to the Choi-matrix is given by:
-
-    E(ρ) = Tr_{1}[Λ.(ρ^T⊗I)]
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
 """
 
 from numbers import Number
@@ -45,7 +31,34 @@ from qiskit.quantum_info.operators.channel.transformations import _bipartite_ten
 
 
 class Choi(QuantumChannel):
-    """Choi-matrix representation of a quantum channel"""
+    r"""Choi-matrix representation of a Quantum Channel.
+
+    The Choi-matrix representation of a quantum channel :math:`\mathcal{E}`
+    is a matrix
+
+    .. math::
+
+        \Lambda = \sum_{i,j} |i\rangle\!\langle j|\otimes
+                    \mathcal{E}\left(|i\rangle\!\langle j|\right)
+
+    Evolution of a :class:`~qiskit.quantum_info.DensityMatrix`
+    :math:`\rho` with respect to the Choi-matrix is given by
+
+    .. math::
+
+        \mathcal{E}(\rho) = \mbox{Tr}_{1}\left[\Lambda
+                            (\rho^T \otimes \mathbb{I})\right]
+
+    where :math:`\mbox{Tr}_1` is the :func:`partial_trace` over subsystem 1.
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
+    """
+
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Choi matrix operator.
 

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -15,22 +15,6 @@
 # pylint: disable=len-as-condition
 """
 Kraus representation of a Quantum Channel.
-
-
-The Kraus representation for a quantum channel E is given by a set of matrices [A_i] such that
-
-    E(ρ) = sum_i A_i.ρ.A_i^dagger
-
-A general operator map G can also be written using the generalized Kraus representation which
-is given by two sets of matrices [A_i], [B_i] such that
-
-    G(ρ) = sum_i A_i.ρ.B_i^dagger
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
 """
 
 from numbers import Number
@@ -47,7 +31,36 @@ from qiskit.quantum_info.operators.channel.transformations import _to_kraus
 
 
 class Kraus(QuantumChannel):
-    """Kraus representation of a quantum channel."""
+    r"""Kraus representation of a quantum channel.
+
+    The Kraus representation for a quantum channel :math:`\mathcal{E}` is a
+    set of matrices :math:`[A_0,...,A_{K-1}]` such that
+
+    For a quantum channel :math:`\mathcal{E}`, the Kraus representation is
+    given by a set of matrices :math:`[A_0,...,A_{K-1}]` such that the
+    evolution of a :class:`~qiskit.quantum_info.DensityMatrix`
+    :math:`\rho` is given by
+
+    .. math::
+
+        \mathcal{E}(\rho) = \sum_{i=0}^{K-1} A_i \rho A_i^\dagger
+
+    A general operator map :math:`\mathcal{G}` can also be written using the
+    generalized Kraus representation which is given by two sets of matrices
+    :math:`[A_0,...,A_{K-1}]`, :math:`[B_0,...,A_{B-1}]` such that
+
+    .. math::
+
+        \mathcal{G}(\rho) = \sum_{i=0}^{K-1} A_i \rho B_i^\dagger
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
+    """
+
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Kraus operator.
 

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -200,32 +200,42 @@ class Kraus(QuantumChannel):
                      output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            Kraus: The left multiplied quantum channel.
+            Kraus: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a Kraus or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            Kraus: The right multiplied quantum channel.
+            Kraus: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a Kraus or has

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -16,25 +16,6 @@
 
 """
 Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
-
-The PTM is the n-qubit superoperator defined with respect to vectorization in
-the Pauli basis. For a quantum channel E, the PTM is defined by
-
-    PTM_{i,j} = Tr[P_i.E(P_j)]
-
-where [P_i, i=0,...4^{n-1}] is the n-qubit Pauli basis in lexicographic order.
-
-Evolution is given by
-
-    |E(ρ)⟩⟩_p = PTM|ρ⟩⟩_p
-
-where |A⟩⟩_p denotes vectorization in the Pauli basis: ⟨i|A⟩⟩_p = Tr[P_i.A]
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
 """
 
 from numbers import Number
@@ -49,7 +30,41 @@ from qiskit.quantum_info.operators.channel.transformations import _to_ptm
 
 
 class PTM(QuantumChannel):
-    """Initialize a quantum channel Pauli-Transfer Matrix operator.
+    r"""Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
+
+    The PTM representation of an :math:`n`-qubit quantum channel
+    :math:`\mathcal{E}` is an :math:`n`-qubit :class:`SuperOp` :math:`R`
+    defined with respect to vectorization in the Pauli basis instead of
+    column-vectorization. The elements of the PTM :math:`R` are
+    given by
+
+    .. math::
+
+        R_{i,j} = \mbox{Tr}\left[P_i \mathcal{E}(P_j) \right]
+
+    where :math:`[P_0, P_1, ..., P_{4^{n}-1}]` is the :math:`n`-qubit Pauli basis in
+    lexicographic order.
+
+    Evolution of a :class:`~qiskit.quantum_info.DensityMatrix`
+    :math:`\rho` with respect to the PTM is given by
+
+    .. math::
+
+        |\mathcal{E}(\rho)\rangle\!\rangle_P = S_P |\rho\rangle\!\rangle_P
+
+    where :math:`|A\rangle\!\rangle_P` denotes vectorization in the Pauli basis
+    :math:`\langle i | A\rangle\!\rangle_P = \mbox{Tr}[P_i A]`.
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
+    """
+
+    def __init__(self, data, input_dims=None, output_dims=None):
+        """Initialize a PTM quantum channel operator.
 
         Args:
             data (QuantumCircuit or
@@ -71,8 +86,6 @@ class PTM(QuantumChannel):
         automatically determined from the input data. The PTM
         representation is only valid for N-qubit channels.
         """
-    def __init__(self, data, input_dims=None, output_dims=None):
-        """Initialize a PTM quantum channel operator."""
         # If the input is a raw list or matrix we assume that it is
         # already a Chi matrix.
         if isinstance(data, (list, np.ndarray)):

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -138,32 +138,42 @@ class PTM(QuantumChannel):
         return PTM(SuperOp(self).transpose())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            PTM: The left multiplied quantum channel.
+            PTM: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a PTM or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            PTM: The right multiplied quantum channel.
+            PTM: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a PTM or has

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -16,7 +16,6 @@
 Abstract base class for Quantum Channels.
 """
 
-import warnings
 from abc import abstractmethod
 import numpy as np
 
@@ -34,44 +33,50 @@ class QuantumChannel(BaseOperator):
     """Quantum channel representation base class."""
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            QuantumChannel: The left multiplied quantum channel.
+            QuantumChannel: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other is not a QuantumChannel subclass, or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         if front:
-            # DEPRECATED
-            warnings.warn(
-                '`compose(other, front=True)` is deprecated, use `dot(other)` instead.',
-                DeprecationWarning)
             return self._chanmul(other, qargs, left_multiply=False)
         return self._chanmul(other, qargs, left_multiply=True)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            QuantumChannel: The right multiplied quantum channel.
+            QuantumChannel: The quantum channel self * other.
 
         Raises:
             QiskitError: if other is not a QuantumChannel subclass, or has
             incompatible dimensions.
         """
-        return self._chanmul(other, qargs, left_multiply=False)
+        super().dot(other, qargs=qargs)
 
     def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving (CPTP)."""

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -76,7 +76,7 @@ class QuantumChannel(BaseOperator):
             QiskitError: if other is not a QuantumChannel subclass, or has
             incompatible dimensions.
         """
-        super().dot(other, qargs=qargs)
+        return super().dot(other, qargs=qargs)
 
     def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving (CPTP)."""

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -13,22 +13,6 @@
 # that they have been altered from the originals.
 """
 Stinespring representation of a Quantum Channel.
-
-
-The Stinespring representation for a quantum channel E is given by a rectangular matrix A such that
-
-    E(ρ) = Tr_2[A.ρ.A^dagger]
-
-A general operator map G can also be written using the generalized Kraus representation which
-is given by two matrices A, B such that
-
-    G(ρ) = Tr_2[A.ρ.B^dagger]
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
 """
 
 from numbers import Number
@@ -46,7 +30,34 @@ from qiskit.quantum_info.operators.channel.transformations import _to_stinesprin
 
 
 class Stinespring(QuantumChannel):
-    """Stinespring representation of a quantum channel"""
+    r"""Stinespring representation of a quantum channel.
+
+    The Stinespring representation of a quantum channel :math:`\mathcal{E}`
+    is a rectangular matrix :math:`A` such that the evolution of a
+    :class:`~qiskit.quantum_info.DensityMatrix` :math:`\rho` is given by
+
+    .. math::
+
+        \mathcal{E}(ρ) = \mbox{Tr}_2\left[A ρ A^\dagger\right]
+
+    where :math:`\mbox{Tr}_2` is the :func:`partial_trace` over subsystem 2.
+
+    A general operator map :math:`\mathcal{G}` can also be written using the
+    generalized Stinespring representation which is given by two matrices
+    :math:`A`, :math:`B` such that
+
+    .. math::
+
+        \mathcal{G}(ρ) = \mbox{Tr}_2\left[A ρ B^\dagger\right]
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
+    """
+
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Stinespring operator.
 

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -179,32 +179,42 @@ class Stinespring(QuantumChannel):
                            output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            Stinespring: The left multiplied quantum channel.
+            Stinespring: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a Stinespring or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            Stinespring: The right multiplied quantum channel.
+            Stinespring: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a Stinespring or has

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -15,21 +15,7 @@
 # pylint: disable=unpacking-non-sequence
 
 """
-Superoperator representation of a Quantum Channel.
-
-
-For a quantum channel E, the superoperator is defined as the matrix S such that
-
-    |E(ρ)⟩⟩ = S|ρ⟩⟩
-
-where |A⟩⟩ denotes the column stacking vectorization of a matrix A.
-
-See [1] for further details.
-
-References:
-    [1] C.J. Wood, J.D. Biamonte, D.G. Cory, Quant. Inf. Comp. 15, 0579-0811 (2015)
-        Open access: arXiv:1111.6950 [quant-ph]
-"""
+Superoperator representation of a Quantum Channel."""
 
 from numbers import Number
 import numpy as np
@@ -43,7 +29,28 @@ from qiskit.quantum_info.operators.channel.transformations import _bipartite_ten
 
 
 class SuperOp(QuantumChannel):
-    """Superoperator representation of a quantum channel"""
+    r"""Superoperator representation of a quantum channel.
+
+    The Superoperator representation of a quantum channel :math:`\mathcal{E}`
+    is a matrix :math:`S` such that the evolution of a
+    :class:`~qiskit.quantum_info.DensityMatrix` :math:`\rho` is given by
+
+    .. math::
+
+        |\mathcal{E}(\rho)\rangle\!\rangle = S |\rho\rangle\!\rangle
+
+    where the double-ket notation :math:`|A\rangle\!\rangle` denotes a vector
+    formed by stacking the columns of the matrix :math:`A`
+    *(column-vectorization)*.
+
+    See reference [1] for further details.
+
+    References:
+        1. C.J. Wood, J.D. Biamonte, D.G. Cory, *Tensor networks and graphical calculus
+           for open quantum systems*, Quant. Inf. Comp. 15, 0579-0811 (2015).
+           `arXiv:1111.6950 [quant-ph] <https://arxiv.org/abs/1111.6950>`_
+    """
+
     def __init__(self, data, input_dims=None, output_dims=None):
         """Initialize a quantum channel Superoperator operator.
 

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -135,32 +135,42 @@ class SuperOp(QuantumChannel):
                        output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left multiplied channel other * self.
+        """Return the composed quantum channel self @ other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            SuperOp: The left multiplied quantum channel.
+            SuperOp: The quantum channel self @ other.
 
         Raises:
             QiskitError: if other cannot be converted to a SuperOp or has
             incompatible dimensions.
+
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         return super().compose(other, qargs=qargs, front=front)
 
     def dot(self, other, qargs=None):
-        """Return the right multiplied channel self * other.
+        """Return the right multiplied quantum channel self * other.
 
         Args:
             other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            SuperOp: The right multiplied quantum channel.
+            SuperOp: The quantum channel self * other.
 
         Raises:
             QiskitError: if other cannot be converted to a SuperOp or has

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -233,7 +233,7 @@ class Operator(BaseOperator):
             QiskitError: if other cannot be converted to an Operator or has
             incompatible dimensions.
         """
-        super().dot(other, qargs=qargs)
+        return super().dot(other, qargs=qargs)
 
     def power(self, n):
         """Return the matrix power of the operator.

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -17,7 +17,6 @@ Matrix Operator class.
 """
 
 import re
-import warnings
 from numbers import Number
 
 import numpy as np
@@ -183,43 +182,46 @@ class Operator(BaseOperator):
                         output_dims=self.input_dims())
 
     def compose(self, other, qargs=None, front=False):
-        """Return the left matrix multipled operator other * self.
+        """Return the composed operator.
 
         Args:
             other (Operator): an operator object.
-            qargs (list): a list of subsystem positions to compose other on.
-            front (bool): DEPRECATED If True return self * other instead.
-                          [default: False]
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
+            front (bool): If True compose using right operator multiplication,
+                          instead of left multiplication [default: False].
 
         Returns:
-            Operator: The composed operator.
+            Operator: The operator self @ other.
 
-        Raises:
-            QiskitError: if other cannot be converted to an Operator or has
-            incompatible dimensions.
+        Additional Information:
+            Composition (``@``) is defined as `left` matrix multiplication for
+            matrix operators. That is that ``A @ B`` is equal to ``B * A``.
+            Setting ``front=True`` returns `right` matrix multiplication
+            ``A * B`` and is equivalent to the :meth:`dot` method.
         """
         if front:
-            # DEPRECATED
-            warnings.warn('`compose(other, front=True)` is deprecated, use `dot(other)` instead.',
-                          DeprecationWarning)
             return self._matmul(other, qargs, left_multiply=False)
         return self._matmul(other, qargs, left_multiply=True)
 
     def dot(self, other, qargs=None):
-        """Return the right matrix multiplied operator self * other.
+        """Return the right multiplied operator self * other.
 
         Args:
             other (Operator): an operator object.
-            qargs (list): a list of subsystem positions to compose other on.
+            qargs (list or None): a list of subsystem positions to apply
+                                  other on. If None apply on all
+                                  subsystems [default: None].
 
         Returns:
-            Operator: The composed operator.
+            Operator: The operator self * other.
 
         Raises:
             QiskitError: if other cannot be converted to an Operator or has
             incompatible dimensions.
         """
-        return self._matmul(other, qargs, left_multiply=False)
+        super().dot(other, qargs=qargs)
 
     def power(self, n):
         """Return the matrix power of the operator.

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -30,10 +30,22 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 
 class Operator(BaseOperator):
-    """Matrix operator class
+    r"""Matrix operator class
 
-    This represents a matrix operator `M` that acts on a statevector as: `M|v⟩`
-    or on a density matrix as M.ρ.M^dagger.
+    This represents a matrix operator :math:`M` that will
+    :meth:`~Statevector.evolve` a :class:`Statevector` :math:`|\psi\rangle`
+    by matrix-vector multiplication
+
+    .. math::
+
+        |\psi\rangle \mapsto M|\psi\rangle,
+
+    and will :meth:`~DensityMatrix.evolve` a :class:`DensityMatrix` :math:`\rho`
+    by left and right multiplication
+
+    .. math::
+
+        \rho \mapsto M \rho M^\dagger.
     """
 
     def __init__(self, data, input_dims=None, output_dims=None):

--- a/releasenotes/notes/operator-dot-fd90e7e5ad99ff9b.yaml
+++ b/releasenotes/notes/operator-dot-fd90e7e5ad99ff9b.yaml
@@ -3,16 +3,10 @@ features:
   - |
     Added ``dot`` as an abstract method to the ``BaseOperator`` class and hence
     to ``Operator`` and ``QuantumChannel`` classes. This method returns the
-    right operator multiplication ``a.dot(b) = a * b``.
+    right operator multiplication ``a.dot(b) = a * b``. It is equivalent to
+    calling the operator ``compose`` method with kwarg ``front=True``.
 upgrade:
   - |
     Changed operator magic methods so that ``__mul__`` implements right matrix
     multiplication ``dot``, and ``__rmul__`` implements scalar multiplication
     ``multiply``. Previously both implemented scalar multiplciation.
-deprecations:
-  - |
-    Deprecated the ``front`` kwarg of operator method ``compose``. This
-    functionality is replaced by the ``dot`` operator method:
-    ``a.compose(b, front=True) == a.dot(b)``. Compose is intended to be
-    used for left operator multiplication only, while right operator
-    multiplication should be implemented with the new ``dot`` method.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

* Removes the deprecation of the `front=True` kwarg for the BaseOperator class from when the `dot` method for front composition was added in PR #3740.

* Adds class level API documentation for Operator and quantum channel classes.

### Details and comments

Now `front=True` is a allowed, but still equivalent to the `dot` method. The motivation for not deprecating it if a compose method is added to circuits, dot likely will not be added as `compose(other, qargs, front=True)` makes more sense than `dot` which is specifically referring to matrix multiplication of operators, not contraction of a DAG.