### PR TITLE
add plotly based iplot_histogram

### DIFF
--- a/qiskit/visualization/interactive/__init__.py
+++ b/qiskit/visualization/interactive/__init__.py
@@ -13,10 +13,12 @@
 # that they have been altered from the originals.
 
 """Qiskit visualization library."""
+import sys
 
-from .iplot_blochsphere import iplot_bloch_multivector
-from .iplot_cities import iplot_state_city
-from .iplot_qsphere import iplot_state_qsphere
-from .iplot_hinton import iplot_state_hinton
-from .iplot_histogram import iplot_histogram
-from .iplot_paulivec import iplot_state_paulivec
+if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+    from .iplot_blochsphere import iplot_bloch_multivector
+    from .iplot_cities import iplot_state_city
+    from .iplot_qsphere import iplot_state_qsphere
+    from .iplot_hinton import iplot_state_hinton
+    from .iplot_histogram import iplot_histogram
+    from .iplot_paulivec import iplot_state_paulivec

--- a/qiskit/visualization/interactive/iplot_histogram.py
+++ b/qiskit/visualization/interactive/iplot_histogram.py
@@ -12,6 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+
 """Interactive histogram from experiment counts"""
 
 import functools
@@ -60,7 +61,7 @@ def iplot_histogram(data, figsize=(None, None), color=None,
         .. jupyter-execute::
 
            from qiskit import QuantumCircuit, BasicAer, execute
-           from theia.visualization import iplot_histogram
+           from qiskit.visualization.interactive import iplot_histogram
 
            qc = QuantumCircuit(2, 2)
            qc.h(0)

--- a/qiskit/visualization/interactive/iplot_histogram.py
+++ b/qiskit/visualization/interactive/iplot_histogram.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017, 2019.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -12,154 +12,168 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""
-Histogram visualization
-"""
-from string import Template
-from collections import Counter
-import sys
-import time
-import re
+"""Interactive histogram from experiment counts"""
+
+import functools
 import numpy as np
-from ..exceptions import VisualizationError
+from qiskit.exceptions import QiskitError
+from ..counts_visualization import (_plot_histogram_data,
+                                    VALID_SORTS, DIST_MEAS)
 
-if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
+
+def iplot_histogram(data, figsize=(None, None), color=None,
+                    number_to_keep=None,
+                    sort='asc', target_string=None,
+                    legend=None, bar_labels=True,
+                    title=None, background_color='white',
+                    as_widget=False):
+    """Interactive histogram plot of counts data.
+
+    Args:
+        data (list or dict): This is either a list of dictionaries or a single
+            dict containing the values to represent (ex {'001': 130})
+        figsize (tuple): Figure size in pixels.
+        color (list or str): String or list of strings for histogram bar colors.
+        number_to_keep (int): The number of terms to plot and rest
+            is made into a single bar called 'rest'.
+        sort (string): Could be 'asc', 'desc', or 'hamming'.
+        target_string (str): Target string if 'sort' is a distance measure.
+        legend(list): A list of strings to use for labels of the data.
+            The number of entries must match the length of data (if data is a
+            list or 1 if it's a dict)
+        bar_labels (bool): Label each bar in histogram with probability value.
+        title (str): A string to use for the plot title.
+        background_color (str): Set the background color to 'white'
+                                or 'black'.
+        as_widget (bool): Return figure as an ipywidget.
+
+    Returns:
+        PlotlyFigure or PlotlyWidget:
+            A figure for the rendered histogram.
+
+    Raises:
+        ValueError: When legend is provided and the length doesn't
+                    match the input data.
+        QiskitError: When failed to load plotly.
+
+    Example:
+        .. jupyter-execute::
+
+           from qiskit import QuantumCircuit, BasicAer, execute
+           from theia.visualization import iplot_histogram
+
+           qc = QuantumCircuit(2, 2)
+           qc.h(0)
+           qc.cx(0, 1)
+           qc.measure([0, 1], [0, 1])
+
+           backend = BasicAer.get_backend('qasm_simulator')
+           job = execute(qc, backend)
+           iplot_histogram(job.result().get_counts(), as_widget=True)
+    """
     try:
-        from IPython.core.display import display, HTML
+        import plotly.graph_objects as go
+        from .plotly_wrapper import PlotlyWidget, PlotlyFigure
     except ImportError:
-        print("Error importing IPython.core.display")
+        raise QiskitError('iplot_histogram requires plotly to be installed.')
 
+    if sort not in VALID_SORTS:
+        raise ValueError("Value of sort option, %s, isn't a "
+                         "valid choice. Must be 'asc', "
+                         "'desc', or 'hamming'")
+    if sort in DIST_MEAS.keys() and target_string is None:
+        err_msg = 'Must define target_string when using distance measure.'
+        raise ValueError(err_msg)
 
-def process_data(data, number_to_keep):
-    """ Prepare received data for representation.
-
-        Args:
-            data (dict): values to represent (ex. {'001' : 130})
-            number_to_keep (int): number of elements to show individually.
-
-        Returns:
-            dict: processed data to show.
-    """
-
-    result = dict()
-
-    if number_to_keep != 0:
-        data_temp = dict(Counter(data).most_common(number_to_keep))
-        data_temp['rest'] = sum(data.values()) - sum(data_temp.values())
-        data = data_temp
-
-    labels = data
-    values = np.array([data[key] for key in labels], dtype=float)
-    pvalues = values / sum(values)
-    for position, label in enumerate(labels):
-        result[label] = round(pvalues[position], 5)
-
-    return result
-
-
-def iplot_histogram(data, figsize=None, number_to_keep=None,
-                    sort='asc', legend=None):
-    """ Create a histogram representation.
-
-        Graphical representation of the input array using a vertical bars
-        style graph.
-
-        Args:
-            data (list or dict):  This is either a list of dicts or a single
-                dict containing the values to represent (ex. {'001' : 130})
-            figsize (tuple): Figure size in pixels.
-            number_to_keep (int): The number of terms to plot and
-                rest is made into a single bar called other values
-            sort (string): Could be 'asc' or 'desc'
-            legend (list): A list of strings to use for labels of the data.
-                The number of entries must match the length of data.
-
-        Raises:
-            VisualizationError: When legend is provided and the length doesn't
-                match the input data.
-
-        Example:
-            .. code-block::
-
-                from qiskit import QuantumCircuit, BasicAer, execute
-                from qiskit.visualization import iplot_histogram
-                %matplotlib inline
-
-                qc = QuantumCircuit(2, 2)
-                qc.h(0)
-                qc.cx(0, 1)
-                qc.measure([0, 1], [0, 1])
-
-                backend = BasicAer.get_backend('qasm_simulator')
-                job = execute(qc, backend)
-                iplot_histogram(job.result().get_counts())
-    """
-
-    # HTML
-    html_template = Template("""
-    <p>
-        <div id="histogram_$divNumber"></div>
-    </p>
-    """)
-
-    # JavaScript
-    javascript_template = Template("""
-    <script>
-        requirejs.config({
-            paths: {
-                qVisualization: "https://qvisualization.mybluemix.net/q-visualizations"
-            }
-        });
-
-        require(["qVisualization"], function(qVisualizations) {
-            qVisualizations.plotState("histogram_$divNumber",
-                                      "histogram",
-                                      $executions,
-                                      $options);
-        });
-    </script>
-    """)
-
-    # Process data and execute
-    div_number = str(time.time())
-    div_number = re.sub('[.]', '', div_number)
-
-    # set default figure size if none provided
-    if figsize is None:
-        figsize = (7, 5)
-
-    options = {'number_to_keep': 0 if number_to_keep is None else number_to_keep,
-               'sort': sort,
-               'show_legend': 0,
-               'width': int(figsize[0]),
-               'height': int(figsize[1])}
-    if legend:
-        options['show_legend'] = 1
-
-    data_to_plot = []
     if isinstance(data, dict):
         data = [data]
 
     if legend and len(legend) != len(data):
-        raise VisualizationError("Length of legendL (%s) doesn't match number "
-                                 "of input executions: %s" %
-                                 (len(legend), len(data)))
+        raise ValueError("Length of legendL (%s) doesn't match "
+                         "number of input executions: %s" %
+                         (len(legend), len(data)))
 
-    for item, execution in enumerate(data):
-        exec_data = process_data(execution, options['number_to_keep'])
-        out_dict = {'data': exec_data}
-        if legend:
-            out_dict['name'] = legend[item]
-        data_to_plot.append(out_dict)
+    if background_color == 'white':
+        text_color = 'black'
+    elif background_color == 'black':
+        text_color = 'white'
+    else:
+        raise ValueError('Invalid background_color selection.')
 
-    html = html_template.substitute({
-        'divNumber': div_number
-    })
+    labels = list(sorted(
+        functools.reduce(lambda x, y: x.union(y.keys()), data, set())))
+    if number_to_keep is not None:
+        labels.append('rest')
 
-    javascript = javascript_template.substitute({
-        'divNumber': div_number,
-        'executions': data_to_plot,
-        'options': options
-    })
+    if sort in DIST_MEAS.keys():
+        dist = []
+        for item in labels:
+            dist.append(DIST_MEAS[sort](item, target_string))
 
-    display(HTML(html + javascript))
+        labels = [list(x) for x in zip(*sorted(zip(dist, labels),
+                                               key=lambda pair: pair[0]))][1]
+
+    # Set bar colors
+    if color is None:
+        color = ["#003f5c", "#ffa600", "#bc5090", "#58508d", "#ff6361"]
+    elif isinstance(color, str):
+        color = [color]
+
+    width = 1/(len(data)+1)  # the width of the bars
+
+    labels_dict, all_pvalues, _ = _plot_histogram_data(data,
+                                                       labels,
+                                                       number_to_keep)
+
+    fig = go.Figure()
+    for item, _ in enumerate(data):
+        xvals = []
+        yvals = []
+        for idx, val in enumerate(all_pvalues[item]):
+            xvals.append(idx+item*width)
+            yvals.append(val)
+
+        labels = list(labels_dict.keys())
+        hover_template = "<b>{x}</b><br>P = {y}"
+        hover_text = [hover_template.format(x=labels[kk],
+                                            y=np.round(yvals[kk], 3)) for kk in range(len(yvals))]
+
+        fig.add_trace(go.Bar(x=xvals,
+                             y=yvals,
+                             width=width,
+                             hoverinfo="text",
+                             hovertext=hover_text,
+                             marker_color=color[item % len(color)],
+                             name=legend[item] if legend else '',
+                             text=np.round(yvals, 3) if bar_labels else None,
+                             textposition='auto'
+                             ))
+
+    fig.update_xaxes(tickvals=list(range(len(labels_dict.keys()))),
+                     ticktext=list(labels_dict.keys()),
+                     tickfont_size=14,
+                     showline=True, linewidth=1,
+                     linecolor=text_color if text_color == 'white' else None,
+                     )
+
+    fig.update_yaxes(title='Probability',
+                     titlefont_size=18,
+                     tickfont_size=14,
+                     showline=True, linewidth=1,
+                     linecolor=text_color if text_color == 'white' else None,
+                     )
+
+    fig.update_layout(xaxis_tickangle=-70,
+                      showlegend=(legend is not None),
+                      width=figsize[0],
+                      height=figsize[1],
+                      paper_bgcolor=background_color,
+                      margin=dict(t=40, l=50, r=10, b=10),
+                      title=dict(text=title, x=0.5),
+                      title_font_size=20,
+                      font=dict(color=text_color),
+                      )
+    if as_widget:
+        return PlotlyWidget(fig)
+
+    return PlotlyFigure(fig)

--- a/qiskit/visualization/interactive/plotly_wrapper.py
+++ b/qiskit/visualization/interactive/plotly_wrapper.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=import-outside-toplevel
+"""A module of Plotly class wrappers.
+"""
+
+import plotly.graph_objects as go
+
+
+class PlotlyFigure():
+    """A simple wrapper around Plotly Figure class.
+
+    Allows the figures to be more or less drop in replacements
+    for Matplotlib Figures, e.g. savefig is a method here.
+    """
+    def __init__(self, fig):
+        self._fig = fig
+
+    def __repr__(self):
+        return self._fig.__repr__()
+
+    def _ipython_display_(self):
+        import plotly.io as pio
+
+        if pio.renderers.render_on_display and pio.renderers.default:
+            pio.show(self._fig, config={'displayModeBar': False,
+                                        'editable': False})
+        else:
+            print(repr(self))
+
+    def show(self, *args, **kwargs):
+        """Display the figure.
+        """
+        import plotly.io as pio
+
+        config = {}
+        if 'config' not in kwargs.keys():
+            config = {'displayModeBar': False,
+                      'editable': False}
+
+        return pio.show(self._fig, *args, config=config, **kwargs)
+
+    def savefig(self, filename, figsize=(None, None), scale=1, transparent=False):
+        """Save the figure.
+
+        Parameters:
+            filename (str): Filename to save to.
+            figsize (tuple): Figure size (W x H) in pixels.
+            scale (float): Scales the output figure.
+            transparent (bool): Transparent background.
+        """
+        if transparent:
+            plot_color = self._fig.layout['plot_bgcolor']
+            paper_color = self._fig.layout['paper_bgcolor']
+            self._fig.update_layout(paper_bgcolor='rgba(0,0,0,0)',
+                                    plot_bgcolor='rgba(0,0,0,0)')
+        self._fig.write_image(filename, width=figsize[0], height=figsize[1], scale=scale)
+        if transparent:
+            self._fig.update_layout(plot_bgcolor=plot_color,
+                                    paper_bgcolor=paper_color)
+
+
+class PlotlyWidget(go.FigureWidget):
+    """A wrapper around the Plotly widget class.
+    """
+    def show(self, *args, **kwargs):
+        """Display the figure.
+        """
+        import plotly.io as pio
+
+        config = {}
+        if 'config' not in kwargs.keys():
+            config = {'displayModeBar': False,
+                      'editable': False}
+
+        return pio.show(self, *args, config=config, **kwargs)
+
+    def savefig(self, filename, figsize=(None, None), scale=1, transparent=False):
+        """Safe the figure as a static image.
+
+        Parameters:
+            filename (str): Name of the file to which the image is saved.
+            figsize (tuple): Size of figure in pixels.
+            scale (float): Scale factor for non-vectorized image formats.
+            transparent (bool): Set the background to transparent.
+        """
+        if transparent:
+            plot_color = self.layout['plot_bgcolor']
+            paper_color = self.layout['paper_bgcolor']
+            self.update_layout(paper_bgcolor='rgba(0,0,0,0)',
+                               plot_bgcolor='rgba(0,0,0,0)')
+
+        self.write_image(filename, width=figsize[0], height=figsize[1], scale=scale)
+        if transparent:
+            self.update_layout(plot_bgcolor=plot_color,
+                               paper_bgcolor=paper_color)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints
 jupyter-sphinx
+plotly >= 4.4

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
     extras_require={
         'visualization': ['matplotlib>=2.1', 'ipywidgets>=7.3.0',
                           'pydot', "pillow>=4.2.1", "pylatexenc>=1.4",
-                          "seaborn>=0.9.0"],
+                          "seaborn>=0.9.0", "plotly>=4.4"],
         'full-featured-simulators': ['qiskit-aer>=0.1'],
         'crosstalk-pass': ['z3-solver>=4.7'],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,12 @@ minversion = 2.1
 envlist = py35, py36, py37, py38, lint
 skipsdist = True
 
+[pycodestyle]
+count = False
+ignore = E121,E123,E126,E226,E241,E242,E704,E741,W503,W504,W505
+max-line-length = 100
+statistics = True
+
 [testenv]
 usedevelop = True
 install_command = pip install -c{toxinidir}/constraints.txt -U {opts} {packages}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This replaces the current `iplot_histogram` function with a `plotly` based one, so that an internet connection is no longer required.  It also adds an `as_widget` option that renders the figure as an `ipywidget` so that it may be embedded in a notebook, or rendered in the documentation.


### Details and comments
These figures can be saved, however given that the figures are JS, saving requires an additional add-on that can be installed only via `conda` or manually:

```
conda config --append channels plotly
conda install plotly-orca
```

The reason for this is because it is binary executable, much like `GraphViz` we use in the DAG drawer.