### PR TITLE
Add optional parameters to bind_schema

### DIFF
--- a/qiskit/validation/base.py
+++ b/qiskit/validation/base.py
@@ -166,9 +166,10 @@ class BaseSchema(Schema):
 class _SchemaBinder:
     """Helper class for the parametrized decorator ``bind_schema``."""
 
-    def __init__(self, schema_cls):
+    def __init__(self, schema_cls, **kwargs):
         """Get the schema for the decorated model."""
         self._schema_cls = schema_cls
+        self._kwargs = kwargs
 
     def __call__(self, model_cls):
         """Augment the model class with the validation API.
@@ -184,7 +185,7 @@ class _SchemaBinder:
 
         # Set a reference to the Model in the Schema, and vice versa.
         self._schema_cls.model_cls = model_cls
-        model_cls.schema = self._schema_cls()
+        model_cls.schema = self._schema_cls(**self._kwargs)
 
         # Append the methods to the Model class.
         model_cls.__init__ = self._validate_after_init(model_cls.__init__)
@@ -195,7 +196,7 @@ class _SchemaBinder:
         return model_cls
 
     @staticmethod
-    def _create_validation_schema(schema_cls):
+    def _create_validation_schema(schema_cls, **kwargs):
         """Create a patched Schema for validating models.
 
         Model validation is not part of Marshmallow. Schemas have a ``validate``
@@ -211,7 +212,7 @@ class _SchemaBinder:
             BaseSchema: a copy of the original Schema, overriding the
                 ``_deserialize()`` call of its fields.
         """
-        validation_schema = schema_cls()
+        validation_schema = schema_cls(**kwargs)
         for _, field in validation_schema.fields.items():
             if isinstance(field, ModelTypeValidator):
                 validate_function = field.__class__.check_type
@@ -246,7 +247,7 @@ class _SchemaBinder:
         return _decorated
 
 
-def bind_schema(schema):
+def bind_schema(schema, **kwargs):
     """Class decorator for adding schema validation to its instances.
 
     The decorator acts on the model class by adding:
@@ -277,13 +278,18 @@ def bind_schema(schema):
         instantiation. If ``validate=False`` is passed to the constructor, this
         validation will not be performed.
 
+    Args:
+        schema (class): the schema class used for validation.
+        **kwargs: Additional attributes for the ``marshmallow.Schema``
+            initializer.
+
     Raises:
         ValueError: when trying to bind the same schema more than once.
 
     Return:
         type: the same class with validation capabilities.
     """
-    return _SchemaBinder(schema)
+    return _SchemaBinder(schema, **kwargs)
 
 
 def _base_model_from_kwargs(cls, kwargs):

--- a/test/python/validation/test_schemas.py
+++ b/test/python/validation/test_schemas.py
@@ -53,3 +53,18 @@ class TestSchemas(QiskitTestCase):
                 pass
         except ValueError:
             self.fail('`bind_schema` raised while binding.')
+
+    def test_binding_params(self):
+        """Test using parameters in schema binding."""
+        class _DummySchema(BaseSchema):
+            pass
+
+        # Set `many=True` as an example of a marshmallow parameter.
+        @bind_schema(_DummySchema, many=True)
+        class _DummyModel(BaseModel):
+            pass
+
+        # By using `many=True`, the serialization outputs a list.
+        dummy_models = _DummyModel.from_dict([{}])
+        self.assertIsInstance(dummy_models, list)
+        self.assertTrue(all([isinstance(obj, _DummyModel) for obj in dummy_models]))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Closes #3021.

Add optional `**kwargs` to `bind_schema`, that are propagated into  `_SchemaBinder` and the schema initialization. Even if not used directly, this provides support to custom uses of `bind_schema`, where the user needs finer control of the instantiation parameters.

### Details and comments


