### PR TITLE
deepcopy(Instruction) to use Instruction.copy.

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -309,6 +309,9 @@ class Instruction:
             cpy.name = name
         return cpy
 
+    def __deepcopy__(self, memo=None):
+        return self.copy()
+
     def _qasmif(self, string):
         """Print an if statement if needed."""
         if self.condition is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

To partially address the regression introduced in #3773 and the issue raised in #3800 , updates `deepcopy(Instruction)` to return `Instruction.copy()` which shallow copies the instruction instance and its `params`.

### Details and comments


