### PR TITLE
Remove pformat from stochastic swap log messages

### DIFF
--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -15,7 +15,6 @@
 """Map a DAGCircuit onto a `coupling_map` adding swap gates."""
 
 from logging import getLogger
-from pprint import pformat
 from math import inf
 from collections import OrderedDict
 import numpy as np
@@ -158,8 +157,8 @@ class StochasticSwap(TransformationPass):
             that the _mapper method is building.
         """
         layout = best_layout
-        logger.debug("layer_update: layout = %s", pformat(layout))
-        logger.debug("layer_update: self.trivial_layout = %s", pformat(self.trivial_layout))
+        logger.debug("layer_update: layout = %s", layout)
+        logger.debug("layer_update: self.trivial_layout = %s", self.trivial_layout)
         dagcircuit_output = DAGCircuit()
         for qubit in layout.get_virtual_bits().keys():
             if qubit.register not in dagcircuit_output.qregs.values():
@@ -292,10 +291,10 @@ class StochasticSwap(TransformationPass):
 
         # This is the final edgemap. We might use it to correctly replace
         # any measurements that needed to be removed earlier.
-        logger.debug("mapper: self.trivial_layout = %s", pformat(self.trivial_layout))
-        logger.debug("mapper: layout = %s", pformat(layout))
+        logger.debug("mapper: self.trivial_layout = %s", self.trivial_layout)
+        logger.debug("mapper: layout = %s", layout)
         last_edgemap = layout.combine_into_edge_map(self.trivial_layout)
-        logger.debug("mapper: last_edgemap = %s", pformat(last_edgemap))
+        logger.debug("mapper: last_edgemap = %s", last_edgemap)
 
         return dagcircuit_output
 
@@ -326,11 +325,11 @@ def _layer_permutation(layer_partition, layout, qubit_subset,
         TranspilerError: if anything went wrong.
     """
     logger.debug("layer_permutation: layer_partition = %s",
-                 pformat(layer_partition))
+                 layer_partition)
     logger.debug("layer_permutation: layout = %s",
-                 pformat(layout.get_virtual_bits()))
+                 layout.get_virtual_bits())
     logger.debug("layer_permutation: qubit_subset = %s",
-                 pformat(qubit_subset))
+                 qubit_subset)
     logger.debug("layer_permutation: trials = %s", trials)
 
     # The input dag is on a flat canonical register
@@ -344,7 +343,7 @@ def _layer_permutation(layer_partition, layout, qubit_subset,
             raise TranspilerError("Layer contains > 2-qubit gates")
         if len(gate_args) == 2:
             gates.append(tuple(gate_args))
-    logger.debug("layer_permutation: gates = %s", pformat(gates))
+    logger.debug("layer_permutation: gates = %s", gates)
 
     # Can we already apply the gates? If so, there is no work to do.
     dist = sum([coupling.distance(layout[g[0]], layout[g[1]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When profiling a level 0 transpile of a 20x50 random circuit the timing
data shows that after switching to retworkx the largest chunk of time in
in stochastic swap's _layer_permutation function is spent calling pformat
for log messages. This is just for debugging and is unnecessary, and in a
world where we're no longer bottle-necked on dag operations a significant
cost to the run time.

### Details and comments


