### PR TITLE
start of a circuit library

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Module for builtin library of circuits."""
+
+from .boolean_logic import permutation, shift, inner_product

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,4 +14,4 @@
 
 """Module for builtin library of circuits."""
 
-from .boolean_logic import Permutation, Shift, InnerProduct
+from .boolean_logic import Permutation, XOR, InnerProduct

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -14,4 +14,4 @@
 
 """Module for builtin library of circuits."""
 
-from .boolean_logic import permutation, shift, inner_product
+from .boolean_logic import Permutation, Shift, InnerProduct

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=no-member
+
 """Implementations of boolean logic quantum circuits.
 """
 

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Implementations of boolean logic quantum circuits.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+from qiskit.circuit import QuantumRegister, QuantumCircuit
+from qiskit.circuit.exceptions import CircuitError
+
+
+def permutation(n_qubits: int,
+                pattern: Optional[List[int]] = None,
+                seed: Optional[int] = None) -> QuantumCircuit:
+    """Return an n_qubit circuit that permutes qubits using SWAPs.
+
+    Args:
+        n_qubits: circuit width.
+        pattern: permutation pattern. If None, permute randomly.
+        seed: random seed in case a random permutation is requested.
+
+    Returns:
+        A permutation circuit.
+
+    Raises:
+        CircuitError: if permutation pattern is malformed.
+    """
+    circuit = QuantumCircuit(n_qubits, name="permutation")
+
+    if pattern is not None:
+        if sorted(pattern) != list(range(n_qubits)):
+            raise CircuitError("Permutation pattern must be some "
+                               "ordering of 0..n_qubits-1 in a list.")
+        pattern = np.array(pattern)
+    else:
+        rng = np.random.RandomState(seed)
+        pattern = np.arange(n_qubits)
+        rng.shuffle(pattern)
+
+    for i in range(n_qubits):
+        if (pattern[i] != -1) and (pattern[i] != i):
+            circuit.swap(i, int(pattern[i]))
+            pattern[pattern[i]] = -1
+
+    return circuit
+
+
+def shift(n_qubits: int, shift: int) -> QuantumCircuit:
+    """Return a circuit implementing bitwise xor (shift over Z_2).
+
+    Args:
+        n_qubits: the width of circuit.
+        shift: shift amount in decimal form.
+
+    Returns:
+        A boolean shift circuit.
+
+    Raises:
+        CircuitError: if the shift amount exceeds available qubits.
+    """
+    if len(bin(shift)[2:]) > n_qubits:
+        raise Exception("Bits in 'shift' exceed circuit width")
+
+    circuit = QuantumCircuit(n_qubits, name="shift")
+
+    for i in range(n_qubits):
+        bit = shift & 1
+        shift = shift >> 1
+        if bit == 1:
+            circuit.x(i)
+
+    return circuit
+
+
+def inner_product(n_qubits: int) -> QuantumCircuit:
+    """Return a circuit to compute the inner product of 2 n-qubit registers.
+
+    Args:
+        n_qubits: width of top and bottom registers (half total circuit width)
+
+    Returns:
+        A circuit computing inner product of two registers.
+    """
+    qr_a = QuantumRegister(n_qubits)
+    qr_b = QuantumRegister(n_qubits)
+    circuit = QuantumCircuit(qr_a, qr_b, name="inner_product")
+
+    for i in range(n_qubits):
+        circuit.cz(i, i + n_qubits)
+
+    return circuit

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -14,8 +14,7 @@
 
 # pylint: disable=no-member
 
-"""Implementations of boolean logic quantum circuits.
-"""
+"""Implementations of boolean logic quantum circuits."""
 
 from typing import List, Optional
 
@@ -31,7 +30,7 @@ class Permutation(QuantumCircuit):
                  n_qubits: int,
                  pattern: Optional[List[int]] = None,
                  seed: Optional[int] = None) -> QuantumCircuit:
-        """Return an n_qubit permutation circuit impelemented using SWAPs.
+        """Return an n_qubit permutation circuit implemented using SWAPs.
 
         Args:
             n_qubits: circuit width.
@@ -62,27 +61,32 @@ class Permutation(QuantumCircuit):
                 pattern[pattern[i]] = -1
 
 
-class Shift(QuantumCircuit):
-    """An n_qubit circuit that shifts inputs over Z2."""
+class XOR(QuantumCircuit):
+    """An n_qubit circuit for bitwise xor-ing the input with some integer ``amount``.
+
+    The ``amount`` is xor-ed in bitstring form with the input.
+
+    This circuit can also represent addition by ``amount`` over the finite field GF(2).
+    """
 
     def __init__(self,
                  n_qubits: int,
                  amount: Optional[int] = None,
                  seed: Optional[int] = None) -> QuantumCircuit:
-        """Return a circuit implementing bitwise xor (shift over Z_2).
+        """Return a circuit implementing bitwise xor.
 
         Args:
             n_qubits: the width of circuit.
-            amount: shift amount in decimal form.
-            seed: random seed in case a random shift amount is requested.
+            amount: the xor amount in decimal form.
+            seed: random seed in case a random xor is requested.
 
         Returns:
-            A boolean shift circuit.
+            A circuit for bitwise XOR.
 
         Raises:
-            CircuitError: if the shift amount exceeds available qubits.
+            CircuitError: if the xor bitstring exceeds available qubits.
         """
-        super().__init__(n_qubits, name="shift")
+        super().__init__(n_qubits, name="xor")
 
         if amount is not None:
             if len(bin(amount)[2:]) > n_qubits:
@@ -104,6 +108,8 @@ class InnerProduct(QuantumCircuit):
     def __init__(self, n_qubits: int) -> QuantumCircuit:
         """Return a circuit to compute the inner product of 2 n-qubit registers.
 
+        This implementation uses CZ gates.
+
         Args:
             n_qubits: width of top and bottom registers (half total circuit width)
 
@@ -115,4 +121,4 @@ class InnerProduct(QuantumCircuit):
         super().__init__(qr_a, qr_b, name="inner_product")
 
         for i in range(n_qubits):
-            self.cz(i, i + n_qubits)
+            self.cz(qr_a[i], qr_b[i])

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -84,7 +84,7 @@ class Shift(QuantumCircuit):
 
         if amount is not None:
             if len(bin(amount)[2:]) > n_qubits:
-                raise Exception("Bits in 'amount' exceed circuit width")
+                raise CircuitError("Bits in 'amount' exceed circuit width")
         else:
             rng = np.random.RandomState(seed)
             amount = rng.randint(0, 2**n_qubits)
@@ -99,7 +99,7 @@ class Shift(QuantumCircuit):
 class InnerProduct(QuantumCircuit):
     """An n_qubit circuit that computes the inner product of two registers."""
 
-    def __init__(self, n_qubits: int) -> QuantumCircuit: 
+    def __init__(self, n_qubits: int) -> QuantumCircuit:
         """Return a circuit to compute the inner product of 2 n-qubit registers.
 
         Args:

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -58,12 +58,15 @@ def permutation(n_qubits: int,
     return circuit
 
 
-def shift(n_qubits: int, shift: int) -> QuantumCircuit:
+def shift(n_qubits: int,
+          amount: Optional[int] = None,
+          seed: Optional[int] = None) -> QuantumCircuit:
     """Return a circuit implementing bitwise xor (shift over Z_2).
 
     Args:
         n_qubits: the width of circuit.
-        shift: shift amount in decimal form.
+        amount: shift amount in decimal form.
+        seed: random seed in case a random shift amount is requested.
 
     Returns:
         A boolean shift circuit.
@@ -71,14 +74,18 @@ def shift(n_qubits: int, shift: int) -> QuantumCircuit:
     Raises:
         CircuitError: if the shift amount exceeds available qubits.
     """
-    if len(bin(shift)[2:]) > n_qubits:
-        raise Exception("Bits in 'shift' exceed circuit width")
-
     circuit = QuantumCircuit(n_qubits, name="shift")
 
+    if amount is not None:
+        if len(bin(amount)[2:]) > n_qubits:
+            raise Exception("Bits in 'amount' exceed circuit width")
+    else:
+        rng = np.random.RandomState(seed)
+        amount = rng.randint(0, 2**n_qubits)
+
     for i in range(n_qubits):
-        bit = shift & 1
-        shift = shift >> 1
+        bit = amount & 1
+        amount = amount >> 1
         if bit == 1:
             circuit.x(i)
 

--- a/qiskit/circuit/library/boolean_logic.py
+++ b/qiskit/circuit/library/boolean_logic.py
@@ -22,90 +22,95 @@ from qiskit.circuit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.exceptions import CircuitError
 
 
-def permutation(n_qubits: int,
-                pattern: Optional[List[int]] = None,
-                seed: Optional[int] = None) -> QuantumCircuit:
-    """Return an n_qubit circuit that permutes qubits using SWAPs.
+class Permutation(QuantumCircuit):
+    """An n_qubit circuit that permutes qubits."""
 
-    Args:
-        n_qubits: circuit width.
-        pattern: permutation pattern. If None, permute randomly.
-        seed: random seed in case a random permutation is requested.
+    def __init__(self,
+                 n_qubits: int,
+                 pattern: Optional[List[int]] = None,
+                 seed: Optional[int] = None) -> QuantumCircuit:
+        """Return an n_qubit permutation circuit impelemented using SWAPs.
 
-    Returns:
-        A permutation circuit.
+        Args:
+            n_qubits: circuit width.
+            pattern: permutation pattern. If None, permute randomly.
+            seed: random seed in case a random permutation is requested.
 
-    Raises:
-        CircuitError: if permutation pattern is malformed.
-    """
-    circuit = QuantumCircuit(n_qubits, name="permutation")
+        Returns:
+            A permutation circuit.
 
-    if pattern is not None:
-        if sorted(pattern) != list(range(n_qubits)):
-            raise CircuitError("Permutation pattern must be some "
-                               "ordering of 0..n_qubits-1 in a list.")
-        pattern = np.array(pattern)
-    else:
-        rng = np.random.RandomState(seed)
-        pattern = np.arange(n_qubits)
-        rng.shuffle(pattern)
+        Raises:
+            CircuitError: if permutation pattern is malformed.
+        """
+        super().__init__(n_qubits, name="permutation")
 
-    for i in range(n_qubits):
-        if (pattern[i] != -1) and (pattern[i] != i):
-            circuit.swap(i, int(pattern[i]))
-            pattern[pattern[i]] = -1
+        if pattern is not None:
+            if sorted(pattern) != list(range(n_qubits)):
+                raise CircuitError("Permutation pattern must be some "
+                                   "ordering of 0..n_qubits-1 in a list.")
+            pattern = np.array(pattern)
+        else:
+            rng = np.random.RandomState(seed)
+            pattern = np.arange(n_qubits)
+            rng.shuffle(pattern)
 
-    return circuit
-
-
-def shift(n_qubits: int,
-          amount: Optional[int] = None,
-          seed: Optional[int] = None) -> QuantumCircuit:
-    """Return a circuit implementing bitwise xor (shift over Z_2).
-
-    Args:
-        n_qubits: the width of circuit.
-        amount: shift amount in decimal form.
-        seed: random seed in case a random shift amount is requested.
-
-    Returns:
-        A boolean shift circuit.
-
-    Raises:
-        CircuitError: if the shift amount exceeds available qubits.
-    """
-    circuit = QuantumCircuit(n_qubits, name="shift")
-
-    if amount is not None:
-        if len(bin(amount)[2:]) > n_qubits:
-            raise Exception("Bits in 'amount' exceed circuit width")
-    else:
-        rng = np.random.RandomState(seed)
-        amount = rng.randint(0, 2**n_qubits)
-
-    for i in range(n_qubits):
-        bit = amount & 1
-        amount = amount >> 1
-        if bit == 1:
-            circuit.x(i)
-
-    return circuit
+        for i in range(n_qubits):
+            if (pattern[i] != -1) and (pattern[i] != i):
+                self.swap(i, int(pattern[i]))
+                pattern[pattern[i]] = -1
 
 
-def inner_product(n_qubits: int) -> QuantumCircuit:
-    """Return a circuit to compute the inner product of 2 n-qubit registers.
+class Shift(QuantumCircuit):
+    """An n_qubit circuit that shifts inputs over Z2."""
 
-    Args:
-        n_qubits: width of top and bottom registers (half total circuit width)
+    def __init__(self,
+                 n_qubits: int,
+                 amount: Optional[int] = None,
+                 seed: Optional[int] = None) -> QuantumCircuit:
+        """Return a circuit implementing bitwise xor (shift over Z_2).
 
-    Returns:
-        A circuit computing inner product of two registers.
-    """
-    qr_a = QuantumRegister(n_qubits)
-    qr_b = QuantumRegister(n_qubits)
-    circuit = QuantumCircuit(qr_a, qr_b, name="inner_product")
+        Args:
+            n_qubits: the width of circuit.
+            amount: shift amount in decimal form.
+            seed: random seed in case a random shift amount is requested.
 
-    for i in range(n_qubits):
-        circuit.cz(i, i + n_qubits)
+        Returns:
+            A boolean shift circuit.
 
-    return circuit
+        Raises:
+            CircuitError: if the shift amount exceeds available qubits.
+        """
+        super().__init__(n_qubits, name="shift")
+
+        if amount is not None:
+            if len(bin(amount)[2:]) > n_qubits:
+                raise Exception("Bits in 'amount' exceed circuit width")
+        else:
+            rng = np.random.RandomState(seed)
+            amount = rng.randint(0, 2**n_qubits)
+
+        for i in range(n_qubits):
+            bit = amount & 1
+            amount = amount >> 1
+            if bit == 1:
+                self.x(i)
+
+
+class InnerProduct(QuantumCircuit):
+    """An n_qubit circuit that computes the inner product of two registers."""
+
+    def __init__(self, n_qubits: int) -> QuantumCircuit: 
+        """Return a circuit to compute the inner product of 2 n-qubit registers.
+
+        Args:
+            n_qubits: width of top and bottom registers (half total circuit width)
+
+        Returns:
+            A circuit computing inner product of two registers.
+        """
+        qr_a = QuantumRegister(n_qubits)
+        qr_b = QuantumRegister(n_qubits)
+        super().__init__(qr_a, qr_b, name="inner_product")
+
+        for i in range(n_qubits):
+            self.cz(i, i + n_qubits)

--- a/releasenotes/notes/boolean-logic-circuit-library-0f913cc04063210b.yaml
+++ b/releasenotes/notes/boolean-logic-circuit-library-0f913cc04063210b.yaml
@@ -1,9 +1,9 @@
 ---
 prelude: >
     A library of quantum circuits is introduced in ``qiskit.circuit.library``.
-    This library contains useful circuits which can be used as-is, or can be
-    used as subcircuits in building up other circuits. The contents of this
-    library will grow over time.
+    This library contains useful circuits which can be used for experiments or
+    be used as subcircuits in building up other circuits. The contents of this
+    library will grow over time and better implementations will be introduced.
 features:
   - |
     A few simple circuits for basic boolean logic operations such as ``shift``,

--- a/releasenotes/notes/boolean-logic-circuit-library-0f913cc04063210b.yaml
+++ b/releasenotes/notes/boolean-logic-circuit-library-0f913cc04063210b.yaml
@@ -1,0 +1,11 @@
+---
+prelude: >
+    A library of quantum circuits is introduced in ``qiskit.circuit.library``.
+    This library contains useful circuits which can be used as-is, or can be
+    used as subcircuits in building up other circuits. The contents of this
+    library will grow over time.
+features:
+  - |
+    A few simple circuits for basic boolean logic operations such as ``shift``,
+    ``permutation``, and ``inner_product`` are added to
+    ``qiskit.circuit.library``.

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -15,7 +15,7 @@
 """Test library of quantum circuits."""
 
 from qiskit.test import QiskitTestCase
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import permutation, shift, inner_product
 
 
@@ -28,4 +28,20 @@ class TestBooleanLogicLibrary(QiskitTestCase):
         expected = QuantumCircuit(4)
         expected.swap(0, 1)
         expected.swap(2, 3)
+        self.assertEqual(circuit, expected)
+
+    def test_shift(self):
+        """Test shift circuit."""
+        circuit = shift(n_qubits=3, shift=4)
+        expected = QuantumCircuit(3)
+        expected.x(2)
+        self.assertEqual(circuit, expected)
+
+    def test_inner_product(self):
+        """Test inner product circuit."""
+        circuit = inner_product(n_qubits=3)
+        expected = QuantumCircuit(*circuit.qregs)
+        expected.cz(0, 3)
+        expected.cz(1, 4)
+        expected.cz(2, 5)
         self.assertEqual(circuit, expected)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test library of quantum circuits."""
+
+from qiskit.test import QiskitTestCase
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import permutation, shift, inner_product
+
+
+class TestBooleanLogicLibrary(QiskitTestCase):
+    """Test library of boolean logic quantum circuits."""
+
+    def test_permutation(self):
+        """Test permutation circuit."""
+        circuit = permutation(n_qubits=4, pattern=[1, 0, 3, 2])
+        expected = QuantumCircuit(4)
+        expected.swap(0, 1)
+        expected.swap(2, 3)
+        self.assertEqual(circuit, expected)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -16,7 +16,7 @@
 
 from qiskit.test import QiskitTestCase
 from qiskit.circuit import QuantumRegister, QuantumCircuit
-from qiskit.circuit.library import permutation, shift, inner_product
+from qiskit.circuit.library import Permutation, Shift, InnerProduct
 
 
 class TestBooleanLogicLibrary(QiskitTestCase):
@@ -24,7 +24,7 @@ class TestBooleanLogicLibrary(QiskitTestCase):
 
     def test_permutation(self):
         """Test permutation circuit."""
-        circuit = permutation(n_qubits=4, pattern=[1, 0, 3, 2])
+        circuit = Permutation(n_qubits=4, pattern=[1, 0, 3, 2])
         expected = QuantumCircuit(4)
         expected.swap(0, 1)
         expected.swap(2, 3)
@@ -32,14 +32,14 @@ class TestBooleanLogicLibrary(QiskitTestCase):
 
     def test_shift(self):
         """Test shift circuit."""
-        circuit = shift(n_qubits=3, amount=4)
+        circuit = Shift(n_qubits=3, amount=4)
         expected = QuantumCircuit(3)
         expected.x(2)
         self.assertEqual(circuit, expected)
 
     def test_inner_product(self):
         """Test inner product circuit."""
-        circuit = inner_product(n_qubits=3)
+        circuit = InnerProduct(n_qubits=3)
         expected = QuantumCircuit(*circuit.qregs)
         expected.cz(0, 3)
         expected.cz(1, 4)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,8 @@
 
 from qiskit.test import QiskitTestCase
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library import Permutation, Shift, InnerProduct
+from qiskit.circuit.exceptions import CircuitError
+from qiskit.circuit.library import Permutation, XOR, InnerProduct
 
 
 class TestBooleanLogicLibrary(QiskitTestCase):
@@ -30,9 +31,13 @@ class TestBooleanLogicLibrary(QiskitTestCase):
         expected.swap(2, 3)
         self.assertEqual(circuit, expected)
 
-    def test_shift(self):
-        """Test shift circuit."""
-        circuit = Shift(n_qubits=3, amount=4)
+    def test_permutation_bad(self):
+        """Test that [0,..,n-1] permutation is required (no -1 for last element)"""
+        self.assertRaises(CircuitError, Permutation, 4, [1, 0, -1, 2])
+
+    def test_xor(self):
+        """Test xor circuit."""
+        circuit = XOR(n_qubits=3, amount=4)
         expected = QuantumCircuit(3)
         expected.x(2)
         self.assertEqual(circuit, expected)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -32,7 +32,7 @@ class TestBooleanLogicLibrary(QiskitTestCase):
 
     def test_shift(self):
         """Test shift circuit."""
-        circuit = shift(n_qubits=3, shift=4)
+        circuit = shift(n_qubits=3, amount=4)
         expected = QuantumCircuit(3)
         expected.x(2)
         self.assertEqual(circuit, expected)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -15,7 +15,7 @@
 """Test library of quantum circuits."""
 
 from qiskit.test import QiskitTestCase
-from qiskit.circuit import QuantumRegister, QuantumCircuit
+from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import Permutation, Shift, InnerProduct
 
 


### PR DESCRIPTION
add a `qiskit.circuit.library` namespace and add some basic boolean logic circuits.

It would be nice to converge on the same name for libraries of different kinds.

I propose:
```
qiskit.circuit.library
qiskit.pulse.library  # instead of current pulse_lib
qiskit.transpiler.library  # instead of current preset_passmanagers
```