### PR TITLE
Skip TestJupyter tests if ibmq provider is not installed

### DIFF
--- a/test/python/tools/jupyter/test_notebooks.py
+++ b/test/python/tools/jupyter/test_notebooks.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=bad-docstring-quotes
+
 """Tests for the wrapper functionality."""
 
 import os

--- a/test/python/tools/jupyter/test_notebooks.py
+++ b/test/python/tools/jupyter/test_notebooks.py
@@ -20,6 +20,7 @@ import unittest
 
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
+import qiskit
 from qiskit.tools.visualization import HAS_MATPLOTLIB
 from qiskit.test import (Path, QiskitTestCase, online_test, slow_test)
 
@@ -30,6 +31,8 @@ TIMEOUT = 1000
 JUPYTER_KERNEL = 'python3'
 
 
+@unittest.skipUnless(hasattr(qiskit, 'IBMQ'),
+                     'qiskit-ibmq-provider is required for these tests')
 class TestJupyter(QiskitTestCase):
     """Notebooks test case."""
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The tests in test.python.tools.jupyter.TestJupyter rely on the ibmq
provider for the execution of the notebooks. However we don't require
the local installation (or the configuration) of the provider for
running tests anywhere else. In cases where someone is missing either
ibmq or credentials the tests (of which only test_jupyter_jobs_pbars) in
the class will fail because they can't import qiskit.IBMQ. This commit
addresses this issue by adding a skip to the class on
hasattr(qiskit, 'IBMQ') so that if the ibmq provider is not installed
the tests will all skip.

### Details and comments