### PR TITLE
Docathon: Module level docs for Pulse

### DIFF
--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -35,7 +35,7 @@ system.
 
 .. _pulse-commands:
 
-Commands (:mod:`~qiskit.pulse.commands.command`)
+Commands (:mod:`~qiskit.pulse.commands`)
 ================================================
 
 .. autosummary::
@@ -77,8 +77,8 @@ Schedules
 =========
 
 Schedules are Pulse programs. They describe instruction sequences for the control hardware.
-An :class:`~qiskit.pulse.Instruction` is a :class:`~qiskit.pulse.commands.Command` which has been
-assigned to its :class:`~qiskit.pulse.channels.Channel` (s).
+An :class:`~qiskit.pulse.Instruction` is a :py:class:`~qiskit.pulse.commands.Command` which has
+been assigned to its :class:`~qiskit.pulse.channels.Channel` (s).
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -22,7 +22,7 @@ Pulse (:mod:`qiskit.pulse`)
 Qiskit-Pulse is a pulse-level quantum programming kit. This lower level of programming offers the
 user more control than programming with :py:class:`~qiskit.circuit.QuantumCircuit` s.
 
-Extracting the greatest performance out from quantum hardware requires real-time pulse-level
+Extracting the greatest performance from quantum hardware requires real-time pulse-level
 instructions. Pulse answers that need: it enables the quantum physicist *user* to specify the
 exact time dynamics of an experiment. It is especially powerful for error mitigation techniques.
 
@@ -61,7 +61,7 @@ low-level control. Therefore, our signal channels are  *virtual* hardware channe
 which executes our programs is responsible for mapping these virtual channels to the proper
 physical channel within the quantum control hardware.
 
-Channels are characterized by their type and their index. See each of the below to learn more.
+Channels are characterized by their type and their index. See each channel type below to learn more.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -77,7 +77,8 @@ Schedules
 =========
 
 Schedules are Pulse programs. They describe instruction sequences for the control hardware.
-An ``Instruction`` is a ``Command`` which has been assigned to its ``Channel`` (s).
+An :class:`~qiskit.pulse.Instruction` is a :class:`~qiskit.pulse.Command` which has been 
+assigned to its :class:`~qiskit.pulse.Channel` (s).
 
 .. autosummary::
    :toctree: ../stubs/
@@ -96,7 +97,7 @@ Configuration
 Rescheduling Utilities
 ======================
 
-These utilities return modified ``Schedule`` s.
+These utilities return modified :class:`~qiskit.pulse.Schedule` s.
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -13,14 +13,55 @@
 # that they have been altered from the originals.
 
 """
-===============================
-OpenPulse (:mod:`qiskit.pulse`)
-===============================
-
 .. currentmodule:: qiskit.pulse
 
-Channels
-========
+===========================
+Pulse (:mod:`qiskit.pulse`)
+===========================
+
+Qiskit-Pulse is a pulse-level quantum programming kit. This lower level of programming offers the
+user more control than programming with :py:class:`~qiskit.circuit.QuantumCircuit` s.
+
+Extracting the greatest performance out from quantum hardware requires real-time pulse-level
+instructions. Pulse answers that need: it enables the quantum physicist *user* to specify the
+exact time dynamics of an experiment. It is especially powerful for error mitigation techniques.
+
+The input is given as arbitrary, time-ordered signals (see: :ref:`pulse-commands`) scheduled in
+parallel over multiple virtual hardware or simulator resources (see: :ref:`pulse-channels`). The
+system also allows the user to recover the time dynamics of the measured output.
+
+This is sufficient to allow the quantum physicist to explore and correct for noise in a quantum
+system.
+
+.. _pulse-commands:
+
+Commands (:mod:`~qiskit.pulse.commands.command`)
+================================================
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   SamplePulse
+   Delay
+   FrameChange
+   Gaussian
+   GaussianSquare
+   Drag
+   ConstantPulse
+   Acquire
+   Snapshot
+
+.. _pulse-channels:
+
+Channels (:mod:`~qiskit.pulse.channels`)
+========================================
+
+Pulse is meant to be agnostic to the underlying hardware implementation, while still allowing
+low-level control. Therefore, our signal channels are  *virtual* hardware channels. The backend
+which executes our programs is responsible for mapping these virtual channels to the proper
+physical channel within the quantum control hardware.
+
+Channels are characterized by their type and their index. See each of the below to learn more.
 
 .. autosummary::
    :toctree: ../stubs/
@@ -32,37 +73,17 @@ Channels
    RegisterSlot
    MemorySlot
 
-Commands
-========
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   Instruction
-   Acquire
-   AcquireInstruction
-   FrameChange
-   PersistentValue
-   SamplePulse
-   Snapshot
-   Kernel
-   Discriminator
-   Delay
-   ParametricPulse
-   ParametricInstruction
-   Gaussian
-   GaussianSquare
-   Drag
-   ConstantPulse
-
 Schedules
 =========
+
+Schedules are Pulse programs. They describe instruction sequences for the control hardware.
+An ``Instruction`` is a ``Command`` which has been assigned to its ``Channel`` (s).
 
 .. autosummary::
    :toctree: ../stubs/
 
    Schedule
-   ScheduleComponent
+   Instruction
 
 Configuration
 =============
@@ -71,8 +92,18 @@ Configuration
    :toctree: ../stubs/
 
    InstructionScheduleMap
-   LoConfig
-   LoRange
+
+Rescheduling Utilities
+======================
+
+These utilities return modified ``Schedule`` s.
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   ~reschedule.align_measures
+   ~reschedule.add_implicit_acquires
+   ~reschedule.pad
 
 Pulse Library
 =============
@@ -89,6 +120,7 @@ Exceptions
    :toctree: ../stubs/
 
    PulseError
+
 """
 
 from .channels import (DriveChannel, MeasureChannel, AcquireChannel,

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -77,8 +77,8 @@ Schedules
 =========
 
 Schedules are Pulse programs. They describe instruction sequences for the control hardware.
-An :class:`~qiskit.pulse.Instruction` is a :class:`~qiskit.pulse.Command` which has been 
-assigned to its :class:`~qiskit.pulse.Channel` (s).
+An :class:`~qiskit.pulse.Instruction` is a :class:`~qiskit.pulse.commands.Command` which has been
+assigned to its :class:`~qiskit.pulse.channels.Channel` (s).
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -15,7 +15,7 @@
 """
 This module defines Pulse Channels. Channels include:
 
-  - transmit channels, which should subclass``PulseChannel``
+  - transmit channels, which should subclass ``PulseChannel``
   - receive channels, such as ``AcquireChannel``
   - non-signal "channels" such as ``SnapshotChannel``, ``MemorySlot`` and ``RegisterChannel``.
 
@@ -31,7 +31,7 @@ from qiskit.pulse.exceptions import PulseError
 class Channel(metaclass=ABCMeta):
     """Base class of channels. Channels provide a Qiskit-side label for typical quantum control
     hardware signal channels. The final label -> physical channel mapping is the responsibility
-    of the hardware backend. For instance,``DriveChannel(0)`` holds instructions which the backend
+    of the hardware backend. For instance, ``DriveChannel(0)`` holds instructions which the backend
     should map to the signal line driving gate operations on the qubit labeled (indexed) 0.
     """
 


### PR DESCRIPTION
### Summary
Update the pulse module init file for documentation. This includes adding autosummary references to important parts of the module that were previously unreachable, and providing introductory summaries where appropriate

This also closes #3406.

### Details and comments

 - [x] One bug that @SooluThomas is helping me with: can't seem to link to the `commands` module! (made an issue)

~Also: I will wait on #3838 to merge first, since I anticipate merge conflicts~
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


