### PR TITLE
Fix citation in pulse_lib/discrete

### DIFF
--- a/qiskit/pulse/pulse_lib/discrete.py
+++ b/qiskit/pulse/pulse_lib/discrete.py
@@ -446,9 +446,14 @@ def drag(duration: int, amp: complex, sigma: float, beta: float,
 
     If ``zero_ends == True``, the samples from :math:`g(x)` are remapped as in :meth:`gaussian`.
 
-    [1] Gambetta, J. M., Motzoi, F., Merkel, S. T. & Wilhelm, F. K.
-    Analytic control methods for high-fidelity unitary operations
-    in a weakly nonlinear oscillator. Phys. Rev. A 83, 012308 (2011).
+    References:
+        1. |citation1|_
+
+        .. _citation1: http://dx.doi.org/10.1103/PhysRevA.83.012308
+
+        .. |citation1| replace:: *Gambetta, J. M., Motzoi, F., Merkel, S. T. & Wilhelm, F. K.
+           "Analytic control methods for high-fidelity unitary operations
+           in a weakly nonlinear oscillator." Phys. Rev. A 83, 012308 (2011).*
 
     Args:
         duration: Duration of pulse. Must be greater than zero.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the citation syntax in `qiskit/pulse/pulse_lib/discrete.py`.

### Screenshot

<img width="1170" alt="image" src="https://user-images.githubusercontent.com/11485594/74568747-ae5f2f00-4f46-11ea-87b0-a231ef777660.png">


