### PR TITLE
[WIP] Two qubit fake NV-center backend for testing qubit operations using OpenPulse

### DIFF
--- a/qiskit/test/mock/fake_nvcenters_2q.py
+++ b/qiskit/test/mock/fake_nvcenters_2q.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Fake backend supporting OpenPulse.
+"""
+
+import datetime
+
+from scipy import signal
+from scipy.fftpack import fft,fftshift
+import matplotlib.pyplot as plt 
+import numpy as np
+from qiskit.providers.models import (GateConfig, PulseBackendConfiguration,
+                                     PulseDefaults, Command, UchannelLO)
+from qiskit.providers.models.backendproperties import Nduv, Gate, BackendProperties                                    
+from qiskit.qobj import PulseLibraryItem, PulseQobjInstruction 
+from qiskit.pulse.commands import DelayInstruction
+from qiskit.test.mock.fake_backend import FakeBackend
+
+
+class FakeNVCenters2Q(FakeBackend):
+    """Trivial extension of the FakeOpenPulse2Q to a fake 2 qubit NVCenter backend for pulse test."""
+
+    def __init__(self):
+        configuration = PulseBackendConfiguration(
+            backend_name='fake_nvcenters_2q',
+            backend_version='0.0.0',
+            n_qubits=2,
+            meas_levels=[0, 1, 2],
+            basis_gates=['u1', 'u2', 'u3', 'cx', 'conditional_x', 'conditional_y', 'unconditional_x', 'unconditional_y', 'id'],
+            simulator=False,
+            local=True,
+            conditional=True,
+            open_pulse=True,
+            memory=False,
+            max_shots=65536,
+            gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
+            coupling_map= [[0, 1]],
+            n_registers=2,
+            n_uchannels=2,
+            u_channel_lo=[ [UchannelLO(q=0, scale=1. + 0.j)],
+                [UchannelLO(q=0, scale=-1. + 0.j), UchannelLO(q=1, scale=1. + 0.j)],
+                [UchannelLO(q=0, scale=1. + 0.j)]
+            ],
+            meas_level=[0, 1, 2],
+            qubit_lo_range=[[2.5, 3.0], [2.5, 3.0]],
+            meas_lo_range=[[3.2, 4.0], [3.2, 4.0]],
+            dt=0.348,
+            dtm=3.0,
+            rep_times=[100, 250, 500, 1000],
+            meas_map=[[0, 1]],
+            channel_bandwidth=[
+                [-0.2, 0.4], [-0.3, 0.3], [-0.3, 0.3],
+                [-0.02, 0.02], [-0.02, 0.02], [-0.02, 0.02],
+                [-0.2, 0.4], [-0.3, 0.3], [-0.3, 0.3]
+            ],
+            meas_kernels=['default'],
+            discriminators=['max_2Q_fidelity'],
+            acquisition_latency=[[100, 100], [100, 100], [100, 100]],
+            conditional_latency=[
+                [100, 1000], [1000, 100], [100, 1000],
+                [100, 1000], [1000, 100], [100, 1000],
+                [1000, 100], [100, 1000], [1000, 100]
+            ]
+        )
+
+        self._defaults = PulseDefaults(
+            qubit_freq_est=[2.87, 3.0, 2.75],
+            meas_freq_est=[3.5, 4.0, 3.2],
+            buffer=10,
+            pulse_library=[PulseLibraryItem(name='test_pulse_1', samples=[0.j, 0.1j]),
+                           PulseLibraryItem(name='test_pulse_2', samples=[0.j, 0.1j, 1j]),
+                           PulseLibraryItem(name='test_pulse_3', samples=[0.j, 0.1j, 1j, 0.5 + 0j]),
+                           PulseLibraryItem(name='test_pulse_4', samples=7*[0.j, 0.1j, 1j, 0.5 + 0j]),
+                           PulseLibraryItem(name='conditional_x', samples=[0.5j]*2656),
+                           PulseLibraryItem(name='conditional_y', samples=[0.5j]*2656*2),
+                           PulseLibraryItem(name='unconditional_x', samples=[0.5j]*3186),
+                           PulseLibraryItem(name='unconditional_y', samples=[0.5j]*3186*2)],
+            cmd_def=[Command(name='conditional_x', qubits=[0, 1],
+                             sequence=[PulseQobjInstruction(name='conditional_x', ch='u0',t0=0, phase='0')]),
+                    Command(name='conditional_y', qubits=[0, 1],
+                             sequence=[PulseQobjInstruction(name='conditional_y', ch='u0',t0=0, phase='np.pi/2')]),
+                    Command(name='uconditional_x',qubits=[0, 1],
+                              sequence=[PulseQobjInstruction(name='unconditional_x', ch='u0',t0=0, phase='0')]),
+                    Command(name='unconditional_y', qubits=[0, 1],
+                              sequence=[PulseQobjInstruction(name='unconditional_y', ch='u0',t0=0, phase='np.pi/2')]),
+                    Command(name='u1', qubits=[0],
+                             sequence=[PulseQobjInstruction(name='fc', ch='d0',
+                                                            t0=0, phase='-P1*np.pi')]),
+                    Command(name='u1', qubits=[1],
+                             sequence=[PulseQobjInstruction(name='fc', ch='d1',
+                                                            t0=0, phase='-P1*np.pi')]),
+                    Command(name='u2', qubits=[0],
+                             sequence=[PulseQobjInstruction(name='fc', ch='d0',
+                                                            t0=0, phase='-P0*np.pi'),
+                                       PulseQobjInstruction(name='test_pulse_4', ch='d0', t0=0),
+                                       PulseQobjInstruction(name='fc', ch='d0',
+                                                            t0=0, phase='-P1*np.pi')]),
+                    Command(name='u2', qubits=[1],
+                             sequence=[PulseQobjInstruction(name='fc', ch='d1',
+                                                            t0=0, phase='-P0*np.pi'),
+                                       PulseQobjInstruction(name='test_pulse_4', ch='d1', t0=0),
+                                       PulseQobjInstruction(name='fc', ch='d1',
+                                                            t0=0, phase='-P0*np.pi')]),
+                    Command(name='u2', qubits=[0],
+                             sequence=[PulseQobjInstruction(name='test_pulse_1', ch='d0', t0=0)]),
+                    Command(name='u3', qubits=[1],
+                             sequence=[PulseQobjInstruction(name='test_pulse_3', ch='d1', t0=0)]),
+                    Command(name='ParametrizedGate', qubits=[0, 1],
+                             sequence=[PulseQobjInstruction(name='test_pulse_1', ch='d0', t0=0),
+                                       PulseQobjInstruction(name='test_pulse_2', ch='u0', t0=10),
+                                       PulseQobjInstruction(name='pv', ch='d1',
+                                                            t0=2, val='cos(P2)'),
+                                       PulseQobjInstruction(name='test_pulse_1', ch='d1', t0=20),
+                                       PulseQobjInstruction(name='fc', ch='d1',
+                                                            t0=20, phase=2.1)]),
+                    Command(name='measure', qubits=[0, 1],
+                             sequence=[PulseQobjInstruction(name='test_pulse_1', ch='m0', t0=0),
+                                       PulseQobjInstruction(name='test_pulse_1', ch='m1', t0=0),
+                                       PulseQobjInstruction(name='acquire', duration=10, t0=0,
+                                                            qubits=[0, 1], memory_slot=[0, 1])])]
+        )
+
+        mock_time = datetime.datetime.now()
+        dt = 0.348  # pylint: disable=invalid-name
+        self._properties = BackendProperties(
+            backend_name='fake_nvcenters_2q',
+            backend_version='0.0.0',
+            last_update_date=mock_time,
+            qubits=[
+                [Nduv(date=mock_time, name='T1', unit='µs', value=2530.9500421005539),
+                 Nduv(date=mock_time, name='frequency', unit='MHz', value=2.84600000000)],
+                [Nduv(date=mock_time, name='T1', unit='µs', value=2860.00000000000),
+                 Nduv(date=mock_time, name='frequency', unit='GHz', value=0.03125000000)]
+            ],
+            gates=[
+                Gate(gate='u1', name='u1_0', qubits=[0],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=0.)]),
+                Gate(gate='u3', name='u3_0', qubits=[0],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=2 * dt)]),
+                Gate(gate='u3', name='u3_1', qubits=[1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=4 * dt)]),
+                Gate(gate='cx', name='cx0_1', qubits=[0, 1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=22 * dt)]),
+                Gate(gate='conditional_x', name='conditional_x0_1', qubits=[0, 1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=22 * dt)]),
+                Gate(gate='conditional_y', name='conditional_y0_1', qubits=[0, 1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=22 * dt)]),
+                Gate(gate='unconditional_x', name='unconditional_x0_1', qubits=[0, 1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=22 * dt)]),
+                Gate(gate='unconditional_y', name='unconditional_y0_1', qubits=[0, 1],
+                     parameters=[
+                         Nduv(date=mock_time, name='gate_error', unit='', value=1.0),
+                         Nduv(date=mock_time, name='gate_length', unit='ns', value=22 * dt)]),
+            ],
+            general=[]
+        )
+        super().__init__(configuration)
+
+
+    def defaults(self):  # pylint: disable=missing-docstring
+        return self._defaults

--- a/qiskit/visualization/pulse/interpolation.py
+++ b/qiskit/visualization/pulse/interpolation.py
@@ -49,6 +49,7 @@ def interp1d(time, samples, nop, kind='linear'):
 
     return time_, cs_ry(time_), cs_iy(time_)
 
+
 def step_wise(time, samples, nop):
     """Scipy interpolation wrapper.
 ​
@@ -72,6 +73,7 @@ def step_wise(time, samples, nop):
     time_ = np.linspace(time[0], time[-1], nop)
 
     return time_, cs_ry_(time_), cs_iy_(time_)
+
 
 linear = partial(interp1d, kind='linear')
 

--- a/qiskit/visualization/pulse/interpolation.py
+++ b/qiskit/visualization/pulse/interpolation.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 # This code is part of Qiskit.
 #
@@ -41,6 +41,7 @@ def interp1d(time, samples, nop, kind='linear'):
     dt = time[1] - time[0]
 
     time += 0.5 * dt
+
     cs_ry = interpolate.interp1d(time[:-1], re_y, kind=kind, bounds_error=False)
     cs_iy = interpolate.interp1d(time[:-1], im_y, kind=kind, bounds_error=False)
 
@@ -48,9 +49,34 @@ def interp1d(time, samples, nop, kind='linear'):
 
     return time_, cs_ry(time_), cs_iy(time_)
 
+def step_wise(time, samples, nop, kind='nearest'):
+    """Scipy interpolation wrapper.
+​
+    Args:
+        time (ndarray): time.
+        samples (ndarray): complex pulse envelope.
+        nop (int): data points for interpolation.
+        kind (str): Scipy interpolation type. See `scipy.interpolate.interp1d` documentation
+            for more information.
+    Returns:
+        ndarray: interpolated waveform.
+    """
+
+    samples_ = np.repeat(samples, 2)
+    re_y_ = np.real(samples_)
+    im_y_ = np.imag(samples_)
+
+    time__ = np.concatenate(([time[0]], np.repeat(time[1:-1], 2), [time[-1]]))
+
+    cs_ry_ = interpolate.interp1d(time__, re_y_, bounds_error=False)
+    cs_iy_ = interpolate.interp1d(time__, im_y_, bounds_error=False)
+
+    time_ = np.linspace(time[0], time[-1], nop)
+
+    return time_, cs_ry_(time_), cs_iy_(time_)
 
 linear = partial(interp1d, kind='linear')
 
 cubic_spline = partial(interp1d, kind='cubic')
 
-step_wise = partial(interp1d, kind='nearest')
+step_wise = partial(step_wise, kind='nearest')

--- a/qiskit/visualization/pulse/interpolation.py
+++ b/qiskit/visualization/pulse/interpolation.py
@@ -49,15 +49,13 @@ def interp1d(time, samples, nop, kind='linear'):
 
     return time_, cs_ry(time_), cs_iy(time_)
 
-def step_wise(time, samples, nop, kind='nearest'):
+def step_wise(time, samples, nop):
     """Scipy interpolation wrapper.
 ​
     Args:
         time (ndarray): time.
         samples (ndarray): complex pulse envelope.
         nop (int): data points for interpolation.
-        kind (str): Scipy interpolation type. See `scipy.interpolate.interp1d` documentation
-            for more information.
     Returns:
         ndarray: interpolated waveform.
     """
@@ -68,8 +66,8 @@ def step_wise(time, samples, nop, kind='nearest'):
 
     time__ = np.concatenate(([time[0]], np.repeat(time[1:-1], 2), [time[-1]]))
 
-    cs_ry_ = interpolate.interp1d(time__, re_y_, bounds_error=False)
-    cs_iy_ = interpolate.interp1d(time__, im_y_, bounds_error=False)
+    cs_ry_ = interpolate.interp1d(time__, re_y_, kind='nearest', bounds_error=False)
+    cs_iy_ = interpolate.interp1d(time__, im_y_, kind='nearest', bounds_error=False)
 
     time_ = np.linspace(time[0], time[-1], nop)
 
@@ -78,5 +76,3 @@ def step_wise(time, samples, nop, kind='nearest'):
 linear = partial(interp1d, kind='linear')
 
 cubic_spline = partial(interp1d, kind='cubic')
-
-step_wise = partial(step_wise, kind='nearest')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
In pulse, faked backends are crucial as they enable the testing of qubit operations. Faked backends, unlike real devices, eliminate external dependencies. 
This is work in progress [WIP] and a good opportunity to understand the backend attributes of a different but promising quantum hardware platform based on spin. 

### Details and comments
Mock backends for different devices are crucial as they allow the deployment of fake devices to test aspects of viability and learn about possible gate operations. Fake backends are important for both researchers and hardware providers to optimize real hardware. How pulses are used to build quantum gates in nitrogen-vacancy centers in diamond is different from how that is achieved with superconducting qubits. Having pulse level access allows closer interaction with quantum hardware and improves the execution of quantum programs and applications.

This work is an important contribution to the growth of the quantum community on Qiskit. The availability of different quantum hardware and simulation devices is invaluable to diverse users.

### References
[Universal-control-and-error-correction-in-multi-qubit-spin-registers-in-diamond.pdf](https://github.com/Qiskit/qiskit-terra/files/4230796/Universal-control-and-error-correction-in-multi-qubit-spin-registers-in-diamond.pdf)


