### PR TITLE
[WIP] Set tolerance on isometry conversion

### DIFF
--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -53,7 +53,7 @@ class Isometry(Instruction):
 
         num_ancillas_dirty (int): number of additional ancillas that start in an arbitrary state
 
-        eps (float): used as a tolerance to chop very small numbers to zero
+        eps (float) (optional): used as a tolerance to chop very small numbers to zero
     """
 
     # Notation: In the following decomposition we label the qubit by
@@ -214,7 +214,8 @@ class Isometry(Instruction):
             i_start = _a(k, s + 1) + 1
         id_list = [np.eye(2, 2) for i in range(i_start)]
         squs = [_reverse_qubit_state([v[2 * l * 2 ** s + _b(k, s), k_prime],
-                                      v[(2 * l + 1) * 2 ** s + _b(k, s), k_prime]], _k_s(k, s), eps=self.eps)
+                                      v[(2 * l + 1) * 2 ** s + _b(k, s), k_prime]], _k_s(k, s), 
+                                      eps=self.eps)
                 for l in range(i_start, 2 ** (n - s - 1))]
         return id_list + squs
 

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -33,6 +33,7 @@ from qiskit.quantum_info.operators.predicates import is_isometry
 from qiskit.extensions.quantum_initializer.ucg import UCG
 from qiskit.extensions.quantum_initializer.mcg_up_to_diagonal import MCGupDiag
 
+
 class Isometry(Instruction):
     """
     Decomposition of arbitrary isometries from m to n qubits. In particular, this allows to
@@ -214,8 +215,8 @@ class Isometry(Instruction):
             i_start = _a(k, s + 1) + 1
         id_list = [np.eye(2, 2) for i in range(i_start)]
         squs = [_reverse_qubit_state([v[2 * l * 2 ** s + _b(k, s), k_prime],
-                                      v[(2 * l + 1) * 2 ** s + _b(k, s), k_prime]], _k_s(k, s), 
-                                      eps=self.eps)
+                                      v[(2 * l + 1) * 2 ** s + _b(k, s), k_prime]], _k_s(k, s),
+                                     eps=self.eps)
                 for l in range(i_start, 2 ** (n - s - 1))]
         return id_list + squs
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [0] I have added the tests to cover my changes.
- [0] I have updated the documentation accordingly.
- [1] I have read the CONTRIBUTING document.
-->

### Summary
Added a tolerance to the `Isometry` class so that users have the option to define for themselves instead of stuck with hard-coded value of `1e-10`.

Fixes [https://github.com/Qiskit/qiskit-terra/issues/3789](https://github.com/Qiskit/qiskit-terra/issues/3789)


### Details and comments
The `Isometry` class has a new `eps` attribute that can be passed in during initialisation. 

I could do with some guidance on:
- if the structure of this change "fits" the repos code-style.
- whether or not this needs additional tests (the current `test_isometry.py` file doesn't use the `Isometry` class explicitly anywhere?)
- Where should this change be documented?

