### PR TITLE
Simplify BaseOperator abstract class

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -35,19 +35,19 @@ class BaseOperator(ABC):
 
     def __init__(self, input_dims, output_dims):
         """Initialize an operator object."""
-        # Class attributes
-        self._input_dim = None
-        self._output_dim = None
-        self._input_dims = None
-        self._output_dims = None
         # Set attributes
+        # _input_dims: tuple of input dimensions of each subsystem
+        # _output_dims: tuple of output dimensions of each subsystem
+        # _input_dim: combined input dimension of all subsystems
+        # _output_dim: combined output dimension of all subsystems
+        # Note that the tuples of input and output dims are ordered
+        # from least-significant to most-significant subsystems
         self._set_dims(input_dims, output_dims)
 
     def __eq__(self, other):
-        """Check subsystem dimensions are equal"""
-        if not isinstance(other, self.__class__):
-            return False
-        return (self._input_dims == other._input_dims and
+        """Check types and subsystem dimensions are equal"""
+        return (type(self) == type(other) and
+                self._input_dims == other._input_dims and
                 self._output_dims == other._output_dims)
 
     @property

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -155,16 +155,6 @@ class BaseOperator(ABC):
         return self.conjugate().transpose()
 
     @abstractmethod
-    def is_unitary(self, atol=None, rtol=None):
-        """Return True if operator is a unitary matrix."""
-        pass
-
-    @abstractmethod
-    def to_operator(self):
-        """Convert operator to matrix operator class"""
-        pass
-
-    @abstractmethod
     def conjugate(self):
         """Return the conjugate of the operator."""
         pass

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -35,6 +35,23 @@ class BaseOperator(ABC):
 
     def __init__(self, input_dims, output_dims):
         """Initialize an operator object."""
+        # Class attributes
+        self._input_dim = None
+        self._output_dim = None
+        self._input_dims = None
+        self._output_dims = None
+        # Set attributes
+        self._set_dims(input_dims, output_dims)
+
+    def __eq__(self, other):
+        """Check subsystem dimensions are equal"""
+        if not isinstance(other, self.__class__):
+            return False
+        return (self._input_dims == other._input_dims and
+                self._output_dims == other._output_dims)
+
+    def _set_dims(self, input_dims, output_dims):
+        """Set dimension attributes"""
         # Shape lists the dimension of each subsystem starting from
         # least significant through to most significant.
         self._input_dims = tuple(input_dims)
@@ -43,13 +60,6 @@ class BaseOperator(ABC):
         # of all subsystem dimension in the input_dims/output_dims.
         self._input_dim = np.product(input_dims)
         self._output_dim = np.product(output_dims)
-
-    def __eq__(self, other):
-        """Check subsystem dimensions are equal"""
-        if not isinstance(other, self.__class__):
-            return False
-        return (self._input_dims == other._input_dims and
-                self._output_dims == other._output_dims)
 
     @property
     def dim(self):

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -33,9 +33,8 @@ class BaseOperator(ABC):
     RTOL = RTOL_DEFAULT
     MAX_TOL = 1e-4
 
-    def __init__(self, data, input_dims, output_dims):
+    def __init__(self, input_dims, output_dims):
         """Initialize an operator object."""
-        self._data = data
         # Shape lists the dimension of each subsystem starting from
         # least significant through to most significant.
         self._input_dims = tuple(input_dims)
@@ -46,22 +45,16 @@ class BaseOperator(ABC):
         self._output_dim = np.product(output_dims)
 
     def __eq__(self, other):
-        if (isinstance(other, self.__class__)
-                and self.input_dims() == other.input_dims()
-                and self.output_dims() == other.output_dims()):
-            return np.allclose(
-                self.data, other.data, rtol=self._rtol, atol=self._atol)
-        return False
+        """Check subsystem dimensions are equal"""
+        if not isinstance(other, self.__class__):
+            return False
+        return (self._input_dims == other._input_dims and
+                self._output_dims == other._output_dims)
 
     @property
     def dim(self):
         """Return tuple (input_shape, output_shape)."""
         return self._input_dim, self._output_dim
-
-    @property
-    def data(self):
-        """Return data."""
-        return self._data
 
     @property
     def _atol(self):

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -35,18 +35,18 @@ class BaseOperator(ABC):
 
     def __init__(self, input_dims, output_dims):
         """Initialize an operator object."""
-        # Set attributes
-        # _input_dims: tuple of input dimensions of each subsystem
-        # _output_dims: tuple of output dimensions of each subsystem
-        # _input_dim: combined input dimension of all subsystems
-        # _output_dim: combined output dimension of all subsystems
+        # Dimension attributes
         # Note that the tuples of input and output dims are ordered
         # from least-significant to most-significant subsystems
+        self._input_dims = None   # tuple of input dimensions of each subsystem
+        self._output_dims = None  # tuple of output dimensions of each subsystem
+        self._input_dim = None    # combined input dimension of all subsystems
+        self._output_dim = None   # combined output dimension of all subsystems
         self._set_dims(input_dims, output_dims)
 
     def __eq__(self, other):
         """Check types and subsystem dimensions are equal"""
-        return (type(self) == type(other) and
+        return (isinstance(other, self.__class__) and
                 self._input_dims == other._input_dims and
                 self._output_dims == other._output_dims)
 

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -33,12 +33,8 @@ class BaseOperator(ABC):
     RTOL = RTOL_DEFAULT
     MAX_TOL = 1e-4
 
-    def __init__(self, rep, data, input_dims, output_dims):
+    def __init__(self, data, input_dims, output_dims):
         """Initialize an operator object."""
-        if not isinstance(rep, str):
-            raise QiskitError("rep must be a string not a {}".format(
-                rep.__class__))
-        self._rep = rep
         self._data = data
         # Shape lists the dimension of each subsystem starting from
         # least significant through to most significant.
@@ -56,15 +52,6 @@ class BaseOperator(ABC):
             return np.allclose(
                 self.data, other.data, rtol=self._rtol, atol=self._atol)
         return False
-
-    def __repr__(self):
-        return '{}({}, input_dims={}, output_dims={})'.format(
-            self.rep, self.data, self._input_dims, self._output_dims)
-
-    @property
-    def rep(self):
-        """Return operator representation string."""
-        return self._rep
 
     @property
     def dim(self):

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -124,7 +124,7 @@ class Chi(QuantumChannel):
         # Check and format input and output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
         output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__('Chi', chi_mat, input_dims, output_dims)
+        super().__init__(chi_mat, input_dims, output_dims, 'Chi')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -79,7 +79,7 @@ class Chi(QuantumChannel):
         # already a Chi matrix.
         if isinstance(data, (list, np.ndarray)):
             # Initialize from raw numpy or list matrix.
-            chi_mat = np.array(data, dtype=complex)
+            chi_mat = np.asarray(data, dtype=complex)
             # Determine input and output dimensions
             dim_l, dim_r = chi_mat.shape
             if dim_l != dim_r:

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -111,7 +111,8 @@ class Chi(QuantumChannel):
                 data = self._init_transformer(data)
             input_dim, output_dim = data.dim
             # Now that the input is an operator we convert it to a Chi object
-            chi_mat = _to_chi(data.rep, data._data, input_dim, output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            chi_mat = _to_chi(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -18,7 +18,6 @@
 Chi-matrix representation of a Quantum Channel.
 """
 
-from numbers import Number
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -146,48 +145,6 @@ class Chi(QuantumChannel):
         # conjugate channel
         return Chi(Choi(self).transpose())
 
-    def compose(self, other, qargs=None, front=False):
-        """Return the composed quantum channel self @ other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list or None): a list of subsystem positions to apply
-                                  other on. If None apply on all
-                                  subsystems [default: None].
-            front (bool): If True compose using right operator multiplication,
-                          instead of left multiplication [default: False].
-
-        Returns:
-            Chi: The quantum channel self @ other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a Chi or has
-            incompatible dimensions.
-
-        Additional Information:
-            Composition (``@``) is defined as `left` matrix multiplication for
-            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
-            Setting ``front=True`` returns `right` matrix multiplication
-            ``A * B`` and is equivalent to the :meth:`dot` method.
-        """
-        return super().compose(other, qargs=qargs, front=front)
-
-    def dot(self, other, qargs=None):
-        """Return the right multiplied quantum channel self * other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-
-        Returns:
-            Chi: The quantum channel self * other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a Chi or has
-            incompatible dimensions.
-        """
-        return super().dot(other, qargs=qargs)
-
     def power(self, n):
         """The matrix power of the channel.
 
@@ -242,62 +199,6 @@ class Chi(QuantumChannel):
         output_dims = self.output_dims() + other.output_dims()
         data = np.kron(other.data, self._data)
         return Chi(data, input_dims, output_dims)
-
-    def add(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            Chi: the linear addition self + other as a Chi object.
-
-        Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, Chi):
-            other = Chi(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return Chi(self._data + other.data, self._input_dims,
-                   self._output_dims)
-
-    def subtract(self, other):
-        """Return the QuantumChannel self - other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            Chi: the linear subtraction self - other as Chi object.
-
-        Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, Chi):
-            other = Chi(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return Chi(self._data - other.data, self._input_dims,
-                   self._output_dims)
-
-    def multiply(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (complex): a complex number.
-
-        Returns:
-            Chi: the scalar multiplication other * self as a Chi object.
-
-        Raises:
-            QiskitError: if other is not a valid scalar.
-        """
-        if not isinstance(other, Number):
-            raise QiskitError("other is not a number")
-        return Chi(other * self._data, self._input_dims, self._output_dims)
 
     def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the quantum channel.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -119,7 +119,8 @@ class Choi(QuantumChannel):
                 data = self._init_transformer(data)
             input_dim, output_dim = data.dim
             # Now that the input is an operator we convert it to a Choi object
-            choi_mat = _to_choi(data.rep, data._data, input_dim, output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            choi_mat = _to_choi(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -128,7 +128,7 @@ class Choi(QuantumChannel):
         # Check and format input and output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
         output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__('Choi', choi_mat, input_dims, output_dims)
+        super().__init__(choi_mat, input_dims, output_dims, 'Choi')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -18,7 +18,6 @@
 Choi-matrix representation of a Quantum Channel.
 """
 
-from numbers import Number
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -153,50 +152,6 @@ class Choi(QuantumChannel):
                     input_dims=self.output_dims(),
                     output_dims=self.input_dims())
 
-    def compose(self, other, qargs=None, front=False):
-        """Return the composed quantum channel self @ other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list or None): a list of subsystem positions to apply
-                                  other on. If None apply on all
-                                  subsystems [default: None].
-            front (bool): If True compose using right operator multiplication,
-                          instead of left multiplication [default: False].
-
-        Returns:
-            Choi: The quantum channel self @ other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a Choi or has
-            incompatible dimensions.
-
-        Additional Information:
-            Composition (``@``) is defined as `left` matrix multiplication for
-            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
-            Setting ``front=True`` returns `right` matrix multiplication
-            ``A * B`` and is equivalent to the :meth:`dot` method.
-        """
-        return super().compose(other, qargs=qargs, front=front)
-
-    def dot(self, other, qargs=None):
-        """Return the right multiplied quantum channel self * other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list or None): a list of subsystem positions to apply
-                                  other on. If None apply on all
-                                  subsystems [default: None].
-
-        Returns:
-            Choi: The quantum channel self * other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a Choi or has
-            incompatible dimensions.
-        """
-        return super().dot(other, qargs=qargs)
-
     def power(self, n):
         """The matrix power of the channel.
 
@@ -261,62 +216,6 @@ class Choi(QuantumChannel):
                                  shape1=other._bipartite_shape,
                                  shape2=self._bipartite_shape)
         return Choi(data, input_dims, output_dims)
-
-    def add(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            Choi: the linear addition self + other as a Choi object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, Choi):
-            other = Choi(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return Choi(self._data + other.data, self._input_dims,
-                    self._output_dims)
-
-    def subtract(self, other):
-        """Return the QuantumChannel self - other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            Choi: the linear subtraction self - other as Choi object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, Choi):
-            other = Choi(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return Choi(self._data - other.data, self._input_dims,
-                    self._output_dims)
-
-    def multiply(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (complex): a complex number.
-
-        Returns:
-            Choi: the scalar multiplication other * self as a Choi object.
-
-        Raises:
-            QiskitError: if other is not a valid scalar.
-        """
-        if not isinstance(other, Number):
-            raise QiskitError("other is not a number")
-        return Choi(other * self._data, self._input_dims, self._output_dims)
 
     def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the quantum channel.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -87,7 +87,7 @@ class Choi(QuantumChannel):
         # already a Choi matrix.
         if isinstance(data, (list, np.ndarray)):
             # Initialize from raw numpy or list matrix.
-            choi_mat = np.array(data, dtype=complex)
+            choi_mat = np.asarray(data, dtype=complex)
             # Determine input and output dimensions
             dim_l, dim_r = choi_mat.shape
             if dim_l != dim_r:

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -165,11 +165,11 @@ class Kraus(QuantumChannel):
         # Initialize either single or general Kraus
         if kraus[1] is None or np.allclose(kraus[0], kraus[1]):
             # Standard Kraus map
-            super().__init__('Kraus', (kraus[0], None), input_dims,
-                             output_dims)
+            super().__init__((kraus[0], None), input_dims,
+                             output_dims, 'Kraus')
         else:
             # General (non-CPTP) Kraus map
-            super().__init__('Kraus', kraus, input_dims, output_dims)
+            super().__init__(kraus, input_dims, output_dims, 'Kraus')
 
     @property
     def data(self):

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -94,18 +94,18 @@ class Kraus(QuantumChannel):
             # E(rho) = A * rho * A^\dagger
             if isinstance(data, np.ndarray) or np.array(data).ndim == 2:
                 # Convert single Kraus op to general Kraus pair
-                kraus = ([np.array(data, dtype=complex)], None)
+                kraus = ([np.asarray(data, dtype=complex)], None)
                 shape = kraus[0][0].shape
 
             # Check if single Kraus set [A_i] for channel:
             # E(rho) = sum_i A_i * rho * A_i^dagger
             elif isinstance(data, list) and len(data) > 0:
                 # Get dimensions from first Kraus op
-                kraus = [np.array(data[0], dtype=complex)]
+                kraus = [np.asarray(data[0], dtype=complex)]
                 shape = kraus[0].shape
                 # Iterate over remaining ops and check they are same shape
                 for i in data[1:]:
-                    op = np.array(i, dtype=complex)
+                    op = np.asarray(i, dtype=complex)
                     if op.shape != shape:
                         raise QiskitError(
                             "Kraus operators are different dimensions.")
@@ -120,7 +120,7 @@ class Kraus(QuantumChannel):
                 kraus_left = [np.array(data[0][0], dtype=complex)]
                 shape = kraus_left[0].shape
                 for i in data[0][1:]:
-                    op = np.array(i, dtype=complex)
+                    op = np.asarray(i, dtype=complex)
                     if op.shape != shape:
                         raise QiskitError(
                             "Kraus operators are different dimensions.")
@@ -130,7 +130,7 @@ class Kraus(QuantumChannel):
                 else:
                     kraus_right = []
                     for i in data[1]:
-                        op = np.array(i, dtype=complex)
+                        op = np.asarray(i, dtype=complex)
                         if op.shape != shape:
                             raise QiskitError(
                                 "Kraus operators are different dimensions.")

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -151,7 +151,8 @@ class Kraus(QuantumChannel):
                 data = self._init_transformer(data)
             input_dim, output_dim = data.dim
             # Now that the input is an operator we convert it to a Kraus
-            kraus = _to_kraus(data.rep, data._data, input_dim, output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            kraus = _to_kraus(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -237,7 +237,31 @@ class Kraus(QuantumChannel):
             Setting ``front=True`` returns `right` matrix multiplication
             ``A * B`` and is equivalent to the :meth:`dot` method.
         """
-        return super().compose(other, qargs=qargs, front=front)
+        if qargs is not None:
+            return Kraus(
+                SuperOp(self).compose(other, qargs=qargs, front=front))
+
+        if not isinstance(other, Kraus):
+            other = Kraus(other)
+        input_dims, output_dims = self._get_compose_dims(other, qargs, front)
+
+        if front:
+            ka_l, ka_r = self._data
+            kb_l, kb_r = other._data
+        else:
+            ka_l, ka_r = other._data
+            kb_l, kb_r = self._data
+
+        kab_l = [np.dot(a, b) for a in ka_l for b in kb_l]
+        if ka_r is None and kb_r is None:
+            kab_r = None
+        elif ka_r is None:
+            kab_r = [np.dot(a, b) for a in ka_l for b in kb_r]
+        elif kb_r is None:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_l]
+        else:
+            kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
+        return Kraus((kab_l, kab_r), input_dims, output_dims)
 
     def dot(self, other, qargs=None):
         """Return the right multiplied quantum channel self * other.
@@ -408,57 +432,3 @@ class Kraus(QuantumChannel):
                 kab_r = [np.kron(a, b) for a in ka_r for b in kb_r]
         data = (kab_l, kab_r)
         return Kraus(data, input_dims, output_dims)
-
-    def _chanmul(self, other, qargs=None, left_multiply=False):
-        """Multiply two quantum channels.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            left_multiply (bool): If True return other * self
-                                  If False return self * other [Default:False]
-
-        Returns:
-            Kraus: The composition channel as a Kraus object.
-
-        Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or
-            has incompatible dimensions.
-        """
-        if qargs is not None:
-            return Kraus(
-                SuperOp(self)._chanmul(other,
-                                       qargs=qargs,
-                                       left_multiply=left_multiply))
-
-        if not isinstance(other, Kraus):
-            other = Kraus(other)
-        # Check dimensions match up
-        if not left_multiply and self._input_dim != other._output_dim:
-            raise QiskitError(
-                'input_dim of self must match output_dim of other')
-        if left_multiply and self._output_dim != other._input_dim:
-            raise QiskitError(
-                'input_dim of other must match output_dim of self')
-
-        if left_multiply:
-            ka_l, ka_r = other._data
-            kb_l, kb_r = self._data
-            input_dim = self._input_dim
-            output_dim = other._output_dim
-        else:
-            ka_l, ka_r = self._data
-            kb_l, kb_r = other._data
-            input_dim = other._input_dim
-            output_dim = self._output_dim
-
-        kab_l = [np.dot(a, b) for a in ka_l for b in kb_l]
-        if ka_r is None and kb_r is None:
-            kab_r = None
-        elif ka_r is None:
-            kab_r = [np.dot(a, b) for a in ka_l for b in kb_r]
-        elif kb_r is None:
-            kab_r = [np.dot(a, b) for a in ka_r for b in kb_l]
-        else:
-            kab_r = [np.dot(a, b) for a in ka_r for b in kb_r]
-        return Kraus((kab_l, kab_r), input_dim, output_dim)

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -303,14 +303,14 @@ class Kraus(QuantumChannel):
         """
         return self._tensor_product(other, reverse=True)
 
-    def add(self, other):
+    def _add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
             other (QuantumChannel): a quantum channel subclass.
 
         Returns:
-            Kraus: the linear addition self + other as a Kraus object.
+            Kraus: the linear addition channel self + other.
 
         Raises:
             QiskitError: if other cannot be converted to a channel, or
@@ -321,26 +321,8 @@ class Kraus(QuantumChannel):
         # or convert to the Choi representation
         return Kraus(Choi(self).add(other))
 
-    def subtract(self, other):
-        """Return the QuantumChannel self - other.
-
-        Args:
-            other (QuantumChannel): a quantum channel subclass.
-
-        Returns:
-            Kraus: the linear subtraction self - other as Kraus object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel, or
-            has incompatible dimensions.
-        """
-        # Since we cannot directly subtract two channels in the Kraus
-        # representation we try and use the other channels method
-        # or convert to the Choi representation
-        return Kraus(Choi(self).subtract(other))
-
-    def multiply(self, other):
-        """Return the QuantumChannel self + other.
+    def _multiply(self, other):
+        """Return the QuantumChannel other * self.
 
         Args:
             other (complex): a complex number.
@@ -357,7 +339,7 @@ class Kraus(QuantumChannel):
         # kraus channel so we multiply via Choi representation
         if isinstance(other, complex) or other < 0:
             # Convert to Choi-matrix
-            return Kraus(Choi(self).multiply(other))
+            return Kraus(Choi(self)._multiply(other))
         # If the number is real we can update the Kraus operators
         # directly
         val = np.sqrt(other)

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -128,7 +128,7 @@ class PTM(QuantumChannel):
         # Check and format input and output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
         output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__('PTM', ptm, input_dims, output_dims)
+        super().__init__(ptm, input_dims, output_dims, 'PTM')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -18,7 +18,6 @@
 Pauli Transfer Matrix (PTM) representation of a Quantum Channel.
 """
 
-from numbers import Number
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -150,50 +149,6 @@ class PTM(QuantumChannel):
         # conjugate channel
         return PTM(SuperOp(self).transpose())
 
-    def compose(self, other, qargs=None, front=False):
-        """Return the composed quantum channel self @ other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list or None): a list of subsystem positions to apply
-                                  other on. If None apply on all
-                                  subsystems [default: None].
-            front (bool): If True compose using right operator multiplication,
-                          instead of left multiplication [default: False].
-
-        Returns:
-            PTM: The quantum channel self @ other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a PTM or has
-            incompatible dimensions.
-
-        Additional Information:
-            Composition (``@``) is defined as `left` matrix multiplication for
-            :class:`SuperOp` matrices. That is that ``A @ B`` is equal to ``B * A``.
-            Setting ``front=True`` returns `right` matrix multiplication
-            ``A * B`` and is equivalent to the :meth:`dot` method.
-        """
-        return super().compose(other, qargs=qargs, front=front)
-
-    def dot(self, other, qargs=None):
-        """Return the right multiplied quantum channel self * other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list or None): a list of subsystem positions to apply
-                                  other on. If None apply on all
-                                  subsystems [default: None].
-
-        Returns:
-            PTM: The quantum channel self * other.
-
-        Raises:
-            QiskitError: if other cannot be converted to a PTM or has
-            incompatible dimensions.
-        """
-        return super().dot(other, qargs=qargs)
-
     def power(self, n):
         """The matrix power of the channel.
 
@@ -248,62 +203,6 @@ class PTM(QuantumChannel):
         output_dims = self.output_dims() + other.output_dims()
         data = np.kron(other.data, self._data)
         return PTM(data, input_dims, output_dims)
-
-    def add(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            PTM: the linear addition self + other as a PTM object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, PTM):
-            other = PTM(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return PTM(self._data + other.data, self._input_dims,
-                   self._output_dims)
-
-    def subtract(self, other):
-        """Return the QuantumChannel self - other.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-
-        Returns:
-            PTM: the linear subtraction self - other as PTM object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
-        """
-        if not isinstance(other, PTM):
-            other = PTM(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
-        return PTM(self._data - other.data, self._input_dims,
-                   self._output_dims)
-
-    def multiply(self, other):
-        """Return the QuantumChannel self + other.
-
-        Args:
-            other (complex): a complex number.
-
-        Returns:
-            PTM: the scalar multiplication other * self as a PTM object.
-
-        Raises:
-            QiskitError: if other is not a valid scalar.
-        """
-        if not isinstance(other, Number):
-            raise QiskitError("other is not a number")
-        return PTM(other * self._data, self._input_dims, self._output_dims)
 
     def _evolve(self, state, qargs=None):
         """Evolve a quantum state by the quantum channel.

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -115,7 +115,8 @@ class PTM(QuantumChannel):
                 data = self._init_transformer(data)
             input_dim, output_dim = data.dim
             # Now that the input is an operator we convert it to a PTM object
-            ptm = _to_ptm(data.rep, data._data, input_dim, output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            ptm = _to_ptm(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -89,7 +89,7 @@ class PTM(QuantumChannel):
         # already a Chi matrix.
         if isinstance(data, (list, np.ndarray)):
             # Should we force this to be real?
-            ptm = np.array(data, dtype=complex)
+            ptm = np.asarray(data, dtype=complex)
             # Determine input and output dimensions
             dout, din = ptm.shape
             if input_dims:

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -16,6 +16,7 @@
 Abstract base class for Quantum Channels.
 """
 
+import copy
 from abc import abstractmethod
 from numbers import Number
 import numpy as np
@@ -117,9 +118,9 @@ class QuantumChannel(BaseOperator):
         if not isinstance(other, self.__class__):
             other = self.__class__(other)
         self._validate_add_dims(other)
-        return self.__class__(self._data + other.data,
-                              self._input_dims,
-                              self._output_dims)
+        ret = copy.copy(self)
+        ret._data = self._data + other._data
+        return ret
 
     def _multiply(self, other):
         """Return the QuantumChannel other * self.
@@ -138,9 +139,9 @@ class QuantumChannel(BaseOperator):
         # ie Kraus and Stinespring
         if not isinstance(other, Number):
             raise QiskitError("other is not a number")
-        return self.__class__(other * self._data,
-                              self._input_dims,
-                              self._output_dims)
+        ret = copy.copy(self)
+        ret._data = other * self._data
+        return ret
 
     def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving (CPTP)."""

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -34,25 +34,26 @@ from qiskit.quantum_info.operators.channel.transformations import _to_operator
 class QuantumChannel(BaseOperator):
     """Quantum channel representation base class."""
 
-    def __init__(self, rep, data, input_dims=None, output_dims=None):
+    def __init__(self, data, input_dims=None, output_dims=None,
+                 channel_rep=None):
         """Initialize a quantum channel Superoperator operator.
 
-        Args:
-            rep (str): quantum channel representation name string.
+        Args: 
             data (array or list): quantum channel data array.
             input_dims (tuple): the input subsystem dimensions.
                                 [Default: None]
             output_dims (tuple): the output subsystem dimensions.
                                  [Default: None]
+            channel_rep (str): quantum channel representation name string.
 
         Raises:
             QiskitError: if arguments are invalid.
         """
         # Set channel representation string
-        if not isinstance(rep, str):
+        if not isinstance(channel_rep, str):
             raise QiskitError("rep must be a string not a {}".format(
-                rep.__class__))
-        self._channel_rep = rep
+                channel_rep.__class__))
+        self._channel_rep = channel_rep
         self._data = data
         super().__init__(input_dims, output_dims)
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -51,12 +51,25 @@ class QuantumChannel(BaseOperator):
             raise QiskitError("rep must be a string not a {}".format(
                 rep.__class__))
         self._channel_rep = rep
-        super().__init__(data, input_dims, output_dims)
+        self._data = data
+        super().__init__(input_dims, output_dims)
 
     def __repr__(self):
         return '{}({}, input_dims={}, output_dims={})'.format(
             self._channel_rep, self._data, self._input_dims,
             self._output_dims)
+
+    def __eq__(self, other):
+        """Test if two QuantumChannels are equal."""
+        if not super().__eq__(other):
+            return False
+        return np.allclose(
+            self.data, other.data, rtol=self._rtol, atol=self._atol)
+
+    @property
+    def data(self):
+        """Return data."""
+        return self._data
 
     def compose(self, other, qargs=None, front=False):
         """Return the composed quantum channel self @ other.

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -37,14 +37,15 @@ class QuantumChannel(BaseOperator):
         """Initialize a quantum channel Superoperator operator.
 
         Args:
-            data (QuantumCircuit or
-                  Instruction or
-                  BaseOperator or
-                  matrix): data to initialize superoperator.
+            rep (str): quantum channel representation name string.
+            data (array or list): quantum channel data array.
             input_dims (tuple): the input subsystem dimensions.
                                 [Default: None]
             output_dims (tuple): the output subsystem dimensions.
                                  [Default: None]
+
+        Raises:
+            QiskitError: if arguments are invalid.
         """
         # Set channel representation string
         if not isinstance(rep, str):
@@ -71,6 +72,7 @@ class QuantumChannel(BaseOperator):
         """Return data."""
         return self._data
 
+    @abstractmethod
     def compose(self, other, qargs=None, front=False):
         """Return the composed quantum channel self @ other.
 
@@ -86,8 +88,7 @@ class QuantumChannel(BaseOperator):
             QuantumChannel: The quantum channel self @ other.
 
         Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or has
-            incompatible dimensions.
+            QiskitError: if other has incompatible dimensions.
 
         Additional Information:
             Composition (``@``) is defined as `left` matrix multiplication for
@@ -95,9 +96,7 @@ class QuantumChannel(BaseOperator):
             Setting ``front=True`` returns `right` matrix multiplication
             ``A * B`` and is equivalent to the :meth:`dot` method.
         """
-        if front:
-            return self._chanmul(other, qargs, left_multiply=False)
-        return self._chanmul(other, qargs, left_multiply=True)
+        pass
 
     def _add(self, other):
         """Return the QuantumChannel self + other.
@@ -117,8 +116,7 @@ class QuantumChannel(BaseOperator):
         # ie Kraus and Stinespring
         if not isinstance(other, self.__class__):
             other = self.__class__(other)
-        if self.dim != other.dim:
-            raise QiskitError("other QuantumChannel dimensions are not equal")
+        self._validate_add_dims(other)
         return self.__class__(self._data + other.data,
                               self._input_dims,
                               self._output_dims)
@@ -260,25 +258,6 @@ class QuantumChannel(BaseOperator):
         Raises:
             QiskitError: if the quantum channel dimension does not match the
             specified quantum state subsystem dimensions.
-        """
-        pass
-
-    @abstractmethod
-    def _chanmul(self, other, qargs=None, left_multiply=False):
-        """Multiply two quantum channels.
-
-        Args:
-            other (QuantumChannel): a quantum channel.
-            qargs (list): a list of subsystem positions to compose other on.
-            left_multiply (bool): If True return other * self
-                                  If False return self * other [Default:False]
-
-        Returns:
-            QuantumChannel: The composition channel.
-
-        Raises:
-            QiskitError: if other is not a QuantumChannel subclass, or
-            has incompatible dimensions.
         """
         pass
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -38,7 +38,7 @@ class QuantumChannel(BaseOperator):
                  channel_rep=None):
         """Initialize a quantum channel Superoperator operator.
 
-        Args: 
+        Args:
             data (array or list): quantum channel data array.
             input_dims (tuple): the input subsystem dimensions.
                                 [Default: None]

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -281,15 +281,14 @@ class Stinespring(QuantumChannel):
         """
         return self._tensor_product(other, reverse=True)
 
-    def add(self, other):
+    def _add(self, other):
         """Return the QuantumChannel self + other.
 
         Args:
             other (QuantumChannel): a quantum channel subclass.
 
         Returns:
-            Stinespring: the linear addition self + other as a
-            Stinespring object.
+            Stinespring: the linear addition channel self + other.
 
         Raises:
             QiskitError: if other cannot be converted to a channel or
@@ -299,33 +298,14 @@ class Stinespring(QuantumChannel):
         # representation we convert to the Choi representation
         return Stinespring(Choi(self).add(other))
 
-    def subtract(self, other):
-        """Return the QuantumChannel self - other.
-
-        Args:
-            other (QuantumChannel): a quantum channel subclass.
-
-        Returns:
-            Stinespring: the linear subtraction self - other as
-            Stinespring object.
-
-        Raises:
-            QiskitError: if other cannot be converted to a channel or
-            has incompatible dimensions.
-        """
-        # Since we cannot directly subtract two channels in the Stinespring
-        # representation we convert to the Choi representation
-        return Stinespring(Choi(self).subtract(other))
-
-    def multiply(self, other):
-        """Return the QuantumChannel self + other.
+    def _multiply(self, other):
+        """Return the QuantumChannel other * self.
 
         Args:
             other (complex): a complex number.
 
         Returns:
-            Stinespring: the scalar multiplication other * self as a
-            Stinespring object.
+            Stinespring: the scalar multiplication other * self.
 
         Raises:
             QiskitError: if other is not a valid scalar.
@@ -337,7 +317,7 @@ class Stinespring(QuantumChannel):
         # the Choi representation
         if isinstance(other, complex) or other < 1:
             # Convert to Choi-matrix
-            return Stinespring(Choi(self).multiply(other))
+            return Stinespring(Choi(self)._multiply(other))
         # If the number is real we can update the Kraus operators
         # directly
         num = np.sqrt(other)

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -136,15 +136,16 @@ class Stinespring(QuantumChannel):
         # Initialize either single or general Stinespring
         if stine[1] is None or (stine[1] == stine[0]).all():
             # Standard Stinespring map
-            super().__init__('Stinespring', (stine[0], None),
+            super().__init__((stine[0], None),
                              input_dims=input_dims,
-                             output_dims=output_dims)
+                             output_dims=output_dims,
+                             channel_rep='Stinespring')
         else:
             # General (non-CPTP) Stinespring map
-            super().__init__('Stinespring',
-                             stine,
+            super().__init__(stine,
                              input_dims=input_dims,
-                             output_dims=output_dims)
+                             output_dims=output_dims,
+                             channel_rep='Stinespring')
 
     @property
     def data(self):

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -123,8 +123,8 @@ class Stinespring(QuantumChannel):
             input_dim, output_dim = data.dim
             # Now that the input is an operator we convert it to a
             # Stinespring operator
-            stine = _to_stinespring(data.rep, data._data, input_dim,
-                                    output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            stine = _to_stinespring(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -88,13 +88,13 @@ class Stinespring(QuantumChannel):
         if isinstance(data, (list, tuple, np.ndarray)):
             if not isinstance(data, tuple):
                 # Convert single Stinespring set to length 1 tuple
-                stine = (np.array(data, dtype=complex), None)
+                stine = (np.asarray(data, dtype=complex), None)
             if isinstance(data, tuple) and len(data) == 2:
                 if data[1] is None:
-                    stine = (np.array(data[0], dtype=complex), None)
+                    stine = (np.asarray(data[0], dtype=complex), None)
                 else:
-                    stine = (np.array(data[0], dtype=complex),
-                             np.array(data[1], dtype=complex))
+                    stine = (np.asarray(data[0], dtype=complex),
+                             np.asarray(data[1], dtype=complex))
 
             dim_left, dim_right = stine[0].shape
             # If two Stinespring matrices check they are same shape

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -116,7 +116,7 @@ class SuperOp(QuantumChannel):
         # output dimensions
         input_dims = self._automatic_dims(input_dims, input_dim)
         output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__('SuperOp', super_mat, input_dims, output_dims)
+        super().__init__(super_mat, input_dims, output_dims, 'SuperOp')
 
     @property
     def _shape(self):

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -106,8 +106,8 @@ class SuperOp(QuantumChannel):
             # Now that the input is an operator we convert it to a
             # SuperOp object
             input_dim, output_dim = data.dim
-            super_mat = _to_superop(data.rep, data._data, input_dim,
-                                    output_dim)
+            rep = getattr(data, '_channel_rep', 'Operator')
+            super_mat = _to_superop(rep, data._data, input_dim, output_dim)
             if input_dims is None:
                 input_dims = data.input_dims()
             if output_dims is None:

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -80,7 +80,7 @@ class SuperOp(QuantumChannel):
         # already a superoperator.
         if isinstance(data, (list, np.ndarray)):
             # We initialize directly from superoperator matrix
-            super_mat = np.array(data, dtype=complex)
+            super_mat = np.asarray(data, dtype=complex)
             # Determine total input and output dimensions
             dout, din = super_mat.shape
             input_dim = int(np.sqrt(din))

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -106,7 +106,11 @@ class Operator(BaseOperator):
         dout, din = mat.shape
         output_dims = self._automatic_dims(output_dims, dout)
         input_dims = self._automatic_dims(input_dims, din)
-        super().__init__('Operator', mat, input_dims, output_dims)
+        super().__init__(mat, input_dims, output_dims)
+
+    def __repr__(self):
+        return 'Operator({}, input_dims={}, output_dims={})'.format(
+            self._data, self._input_dims, self._output_dims)
 
     @classmethod
     def from_label(cls, label):

--- a/releasenotes/notes/base-operator-update-b0d824738b4bfd4d.yaml
+++ b/releasenotes/notes/base-operator-update-b0d824738b4bfd4d.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Adds a `reshape` method to the `BaseOperator` class that allows return a
+    shallow copy of an operator subclass with reshaped subsystem input or
+    output dimensions. The combined dimensions of all subsystems must be the
+    same as the original operator or an exception will be raised.
+  - |
+    Simplifies BaseOperator class so that addition, subtraction and scalar
+    multiplication are no longer abstract methods. Their base class definitions
+    now raise a NotImplementedError, so subclasses don't need to implement
+    these methods if they don't support them.
+deprecations:
+  - |
+    The `BaseOperator` methods have been deprecated: `add`,
+    `subtract`, `multiply`. Use operators `+`, `-`, `*` to obtain previous
+    functionality.

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -246,52 +246,37 @@ class TestChi(ChannelTestCase):
         """Test add method."""
         mat1 = 0.5 * self.chiI
         mat2 = 0.5 * self.depol_chi(1)
-        targ = Chi(mat1 + mat2)
-
         chan1 = Chi(mat1)
         chan2 = Chi(mat2)
-        self.assertEqual(chan1.add(chan2), targ)
+
+        targ = Chi(mat1 + mat2)
+        self.assertEqual(chan1._add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
+
+        targ = Chi(mat1 - mat2)
+        self.assertEqual(chan1 - chan2, targ)
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = Chi(self.chiI)
         chan2 = Chi(np.eye(16))
-        self.assertRaises(QiskitError, chan1.add, chan2)
-        self.assertRaises(QiskitError, chan1.add, 5)
-
-    def test_subtract(self):
-        """Test subtract method."""
-        mat1 = 0.5 * self.chiI
-        mat2 = 0.5 * self.depol_chi(1)
-        targ = Chi(mat1 - mat2)
-
-        chan1 = Chi(mat1)
-        chan2 = Chi(mat2)
-        self.assertEqual(chan1.subtract(chan2), targ)
-        self.assertEqual(chan1 - chan2, targ)
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        chan1 = Chi(self.chiI)
-        chan2 = Chi(np.eye(16))
-        self.assertRaises(QiskitError, chan1.subtract, chan2)
-        self.assertRaises(QiskitError, chan1.subtract, 5)
+        self.assertRaises(QiskitError, chan1._add, chan2)
+        self.assertRaises(QiskitError, chan1._add, 5)
 
     def test_multiply(self):
         """Test multiply method."""
         chan = Chi(self.chiI)
         val = 0.5
         targ = Chi(val * self.chiI)
-        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(chan._multiply(val), targ)
         self.assertEqual(val * chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Chi(self.chiI)
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/channel/test_choi.py
+++ b/test/python/quantum_info/operators/channel/test_choi.py
@@ -328,52 +328,35 @@ class TestChoi(ChannelTestCase):
         """Test add method."""
         mat1 = 0.5 * self.choiI
         mat2 = 0.5 * self.depol_choi(1)
-        targ = Choi(mat1 + mat2)
-
         chan1 = Choi(mat1)
         chan2 = Choi(mat2)
-        self.assertEqual(chan1.add(chan2), targ)
+        targ = Choi(mat1 + mat2)
+        self.assertEqual(chan1._add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
+        targ = Choi(mat1 - mat2)
+        self.assertEqual(chan1 - chan2, targ)
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = Choi(self.choiI)
         chan2 = Choi(np.eye(8))
-        self.assertRaises(QiskitError, chan1.add, chan2)
-        self.assertRaises(QiskitError, chan1.add, 5)
-
-    def test_subtract(self):
-        """Test subtract method."""
-        mat1 = 0.5 * self.choiI
-        mat2 = 0.5 * self.depol_choi(1)
-        targ = Choi(mat1 - mat2)
-
-        chan1 = Choi(mat1)
-        chan2 = Choi(mat2)
-        self.assertEqual(chan1.subtract(chan2), targ)
-        self.assertEqual(chan1 - chan2, targ)
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        chan1 = Choi(self.choiI)
-        chan2 = Choi(np.eye(8))
-        self.assertRaises(QiskitError, chan1.subtract, chan2)
-        self.assertRaises(QiskitError, chan1.subtract, 5)
+        self.assertRaises(QiskitError, chan1._add, chan2)
+        self.assertRaises(QiskitError, chan1._add, 5)
 
     def test_multiply(self):
         """Test multiply method."""
         chan = Choi(self.choiI)
         val = 0.5
         targ = Choi(val * self.choiI)
-        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(chan._multiply(val), targ)
         self.assertEqual(val * chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Choi(self.choiI)
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/channel/test_kraus.py
+++ b/test/python/quantum_info/operators/channel/test_kraus.py
@@ -316,7 +316,7 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
         targ = (rho @ chan1) + (rho @ chan2)
-        chan = chan1.add(chan2)
+        chan = chan1._add(chan2)
         self.assertEqual(rho @ chan, targ)
         chan = chan1 + chan2
         self.assertEqual(rho @ chan, targ)
@@ -324,7 +324,7 @@ class TestKraus(ChannelTestCase):
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
         targ = 2 * (rho @ chan)
-        chan = chan.add(chan)
+        chan = chan._add(chan)
         self.assertEqual(rho @ chan, targ)
 
     def test_subtract(self):
@@ -337,15 +337,13 @@ class TestKraus(ChannelTestCase):
         chan1 = Kraus(kraus1)
         chan2 = Kraus(kraus2)
         targ = (rho @ chan1) - (rho @ chan2)
-        chan = chan1.subtract(chan2)
-        self.assertEqual(rho @ chan, targ)
         chan = chan1 - chan2
         self.assertEqual(rho @ chan, targ)
 
         # Random Single-Kraus maps
         chan = Kraus((kraus1, kraus2))
         targ = 0 * (rho @ chan)
-        chan = chan.subtract(chan)
+        chan = chan - chan
         self.assertEqual(rho @ chan, targ)
 
     def test_multiply(self):
@@ -358,7 +356,7 @@ class TestKraus(ChannelTestCase):
         # Single Kraus set
         chan1 = Kraus(kraus1)
         targ = val * (rho @ chan1)
-        chan = chan1.multiply(val)
+        chan = chan1._multiply(val)
         self.assertEqual(rho @ chan, targ)
         chan = val * chan1
         self.assertEqual(rho @ chan, targ)
@@ -366,7 +364,7 @@ class TestKraus(ChannelTestCase):
         # Double Kraus set
         chan2 = Kraus((kraus1, kraus2))
         targ = val * (rho @ chan2)
-        chan = chan2.multiply(val)
+        chan = chan2._multiply(val)
         self.assertEqual(rho @ chan, targ)
         chan = val * chan2
         self.assertEqual(rho @ chan, targ)
@@ -374,9 +372,9 @@ class TestKraus(ChannelTestCase):
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Kraus(self.depol_kraus(1))
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/channel/test_linearops.py
+++ b/test/python/quantum_info/operators/channel/test_linearops.py
@@ -49,7 +49,7 @@ class TestEquivalence(ChannelTestCase):
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
             targ = SuperOp(sop1 + sop2)
-            channel = SuperOp(rep(SuperOp(sop1)).add(rep(SuperOp(sop2))))
+            channel = SuperOp(rep(SuperOp(sop1))._add(rep(SuperOp(sop2))))
             self.assertEqual(channel, targ)
 
     def _compare_subtract_to_superop(self, rep, dim, samples, unitary=False):
@@ -64,7 +64,7 @@ class TestEquivalence(ChannelTestCase):
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
             targ = SuperOp(sop1 - sop2)
-            channel = SuperOp(rep(SuperOp(sop1)).subtract(rep(SuperOp(sop2))))
+            channel = SuperOp(rep(SuperOp(sop1))._add(rep(-SuperOp(sop2))))
             self.assertEqual(channel, targ)
 
     def _compare_multiply_to_superop(self, rep, dim, samples, unitary=False):
@@ -77,7 +77,7 @@ class TestEquivalence(ChannelTestCase):
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
             val = 0.7
             targ = SuperOp(val * sop1)
-            channel = SuperOp(rep(SuperOp(sop1)).multiply(val))
+            channel = SuperOp(rep(SuperOp(sop1))._multiply(val))
             self.assertEqual(channel, targ)
 
     def _compare_negate_to_superop(self, rep, dim, samples, unitary=False):
@@ -97,14 +97,14 @@ class TestEquivalence(ChannelTestCase):
         current_rep = chan.__class__
         other_reps = [Operator, Choi, SuperOp, Kraus, Stinespring, Chi, PTM]
         for rep in other_reps:
-            self.assertEqual(current_rep, chan.add(rep(chan)).__class__)
+            self.assertEqual(current_rep, chan._add(rep(chan)).__class__)
 
     def _check_subtract_other_reps(self, chan):
         """Check subtraction works for other representations"""
         current_rep = chan.__class__
         other_reps = [Operator, Choi, SuperOp, Kraus, Stinespring, Chi, PTM]
         for rep in other_reps:
-            self.assertEqual(current_rep, chan.subtract(rep(chan)).__class__)
+            self.assertEqual(current_rep, chan._add(-rep(chan)).__class__)
 
     def test_choi_add(self):
         """Test addition of Choi matrices is correct."""

--- a/test/python/quantum_info/operators/channel/test_ptm.py
+++ b/test/python/quantum_info/operators/channel/test_ptm.py
@@ -231,52 +231,37 @@ class TestPTM(ChannelTestCase):
         """Test add method."""
         mat1 = 0.5 * self.ptmI
         mat2 = 0.5 * self.depol_ptm(1)
-        targ = PTM(mat1 + mat2)
 
         chan1 = PTM(mat1)
         chan2 = PTM(mat2)
-        self.assertEqual(chan1.add(chan2), targ)
+
+        targ = PTM(mat1 + mat2)
+        self.assertEqual(chan1._add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
+        targ = PTM(mat1 - mat2)
+        self.assertEqual(chan1 - chan2, targ)
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = PTM(self.ptmI)
         chan2 = PTM(np.eye(16))
-        self.assertRaises(QiskitError, chan1.add, chan2)
-        self.assertRaises(QiskitError, chan1.add, 5)
-
-    def test_subtract(self):
-        """Test subtract method."""
-        mat1 = 0.5 * self.ptmI
-        mat2 = 0.5 * self.depol_ptm(1)
-        targ = PTM(mat1 - mat2)
-
-        chan1 = PTM(mat1)
-        chan2 = PTM(mat2)
-        self.assertEqual(chan1.subtract(chan2), targ)
-        self.assertEqual(chan1 - chan2, targ)
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        chan1 = PTM(self.ptmI)
-        chan2 = PTM(np.eye(16))
-        self.assertRaises(QiskitError, chan1.subtract, chan2)
-        self.assertRaises(QiskitError, chan1.subtract, 5)
+        self.assertRaises(QiskitError, chan1._add, chan2)
+        self.assertRaises(QiskitError, chan1._add, 5)
 
     def test_multiply(self):
         """Test multiply method."""
         chan = PTM(self.ptmI)
         val = 0.5
         targ = PTM(val * self.ptmI)
-        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(chan._multiply(val), targ)
         self.assertEqual(val * chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = PTM(self.ptmI)
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/channel/test_stinespring.py
+++ b/test/python/quantum_info/operators/channel/test_stinespring.py
@@ -309,7 +309,7 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(stine1, input_dims=2, output_dims=4)
         chan2 = Stinespring(stine2, input_dims=2, output_dims=4)
         rho_targ = (rho_init @ chan1) + (rho_init @ chan2)
-        chan = chan1.add(chan2)
+        chan = chan1._add(chan2)
         self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = chan1 + chan2
         self.assertEqual(rho_init.evolve(chan), rho_targ)
@@ -317,7 +317,7 @@ class TestStinespring(ChannelTestCase):
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
         rho_targ = 2 * (rho_init @ chan)
-        chan = chan.add(chan)
+        chan = chan._add(chan)
         self.assertEqual(rho_init.evolve(chan), rho_targ)
 
     def test_subtract(self):
@@ -330,15 +330,13 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(stine1, input_dims=2, output_dims=4)
         chan2 = Stinespring(stine2, input_dims=2, output_dims=4)
         rho_targ = (rho_init @ chan1) - (rho_init @ chan2)
-        chan = chan1.subtract(chan2)
-        self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = chan1 - chan2
         self.assertEqual(rho_init.evolve(chan), rho_targ)
 
         # Random Single-Stinespring maps
         chan = Stinespring((stine1, stine2))
         rho_targ = 0 * (rho_init @ chan)
-        chan = chan.subtract(chan)
+        chan = chan - chan
         self.assertEqual(rho_init.evolve(chan), rho_targ)
 
     def test_multiply(self):
@@ -351,7 +349,7 @@ class TestStinespring(ChannelTestCase):
         # Single Stinespring set
         chan1 = Stinespring(stine1, input_dims=2, output_dims=4)
         rho_targ = val * (rho_init @ chan1)
-        chan = chan1.multiply(val)
+        chan = chan1._multiply(val)
         self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = val * chan1
         self.assertEqual(rho_init.evolve(chan), rho_targ)
@@ -359,7 +357,7 @@ class TestStinespring(ChannelTestCase):
         # Double Stinespring set
         chan2 = Stinespring((stine1, stine2), input_dims=2, output_dims=4)
         rho_targ = val * (rho_init @ chan2)
-        chan = chan2.multiply(val)
+        chan = chan2._multiply(val)
         self.assertEqual(rho_init.evolve(chan), rho_targ)
         chan = val * chan2
         self.assertEqual(rho_init.evolve(chan), rho_targ)
@@ -367,9 +365,9 @@ class TestStinespring(ChannelTestCase):
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = Stinespring(self.depol_stine(1))
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -522,51 +522,35 @@ class TestSuperOp(ChannelTestCase):
         """Test add method."""
         mat1 = 0.5 * self.sopI
         mat2 = 0.5 * self.depol_sop(1)
-        targ = SuperOp(mat1 + mat2)
-
         chan1 = SuperOp(mat1)
         chan2 = SuperOp(mat2)
-        self.assertEqual(chan1.add(chan2), targ)
+        targ = SuperOp(mat1 + mat2)
+        self.assertEqual(chan1._add(chan2), targ)
         self.assertEqual(chan1 + chan2, targ)
+        targ = SuperOp(mat1 - mat2)
+        self.assertEqual(chan1 - chan2, targ)
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         chan1 = SuperOp(self.sopI)
         chan2 = SuperOp(np.eye(16))
-        self.assertRaises(QiskitError, chan1.add, chan2)
-        self.assertRaises(QiskitError, chan1.add, 5)
-
-    def test_subtract(self):
-        """Test subtract method."""
-        mat1 = 0.5 * self.sopI
-        mat2 = 0.5 * self.depol_sop(1)
-        targ = SuperOp(mat1 - mat2)
-
-        chan1 = SuperOp(mat1)
-        chan2 = SuperOp(mat2)
-        self.assertEqual(chan1.subtract(chan2), targ)
-        self.assertEqual(chan1 - chan2, targ)
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        chan1 = SuperOp(self.sopI)
-        chan2 = SuperOp(np.eye(16))
-        self.assertRaises(QiskitError, chan1.subtract, chan2)
-        self.assertRaises(QiskitError, chan1.subtract, 5)
+        self.assertRaises(QiskitError, chan1._add, chan2)
+        self.assertRaises(QiskitError, chan1._add, 5)
 
     def test_multiply(self):
         """Test multiply method."""
         chan = SuperOp(self.sopI)
         val = 0.5
         targ = SuperOp(val * self.sopI)
-        self.assertEqual(chan.multiply(val), targ)
+        self.assertEqual(chan._multiply(val), targ)
+        self.assertEqual(val * chan, targ)
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         chan = SuperOp(self.sopI)
-        self.assertRaises(QiskitError, chan.multiply, 's')
+        self.assertRaises(QiskitError, chan._multiply, 's')
         self.assertRaises(QiskitError, chan.__rmul__, 's')
-        self.assertRaises(QiskitError, chan.multiply, chan)
+        self.assertRaises(QiskitError, chan._multiply, chan)
         self.assertRaises(QiskitError, chan.__rmul__, chan)
 
     def test_negate(self):

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -201,11 +201,6 @@ class TestOperator(OperatorTestCase):
         self.assertEqual(Operator(mat.tolist()),
                          Operator(mat))
 
-    def test_rep(self):
-        """Test Operator representation string property."""
-        op = Operator(self.rand_matrix(2, 2))
-        self.assertEqual(op.rep, 'Operator')
-
     def test_data(self):
         """Test Operator representation string property."""
         mat = self.rand_matrix(2, 2)

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -244,16 +244,16 @@ class TestOperator(OperatorTestCase):
         self.assertEqual(op.output_dims(qargs=[2, 0]), (4, 2))
 
     def test_reshape(self):
-        """Test Operator _reshape method."""
+        """Test Operator reshape method."""
         op = Operator(self.rand_matrix(8, 8))
+        reshaped1 = op.reshape(input_dims=[8], output_dims=[8])
+        reshaped2 = op.reshape(input_dims=[4, 2], output_dims=[2, 4])
         self.assertEqual(op.output_dims(), (2, 2, 2))
         self.assertEqual(op.input_dims(), (2, 2, 2))
-        op._reshape(input_dims=[8], output_dims=[8])
-        self.assertEqual(op.output_dims(), (8,))
-        self.assertEqual(op.input_dims(), (8,))
-        op._reshape(input_dims=[4, 2], output_dims=[2, 4])
-        self.assertEqual(op.output_dims(), (2, 4))
-        self.assertEqual(op.input_dims(), (4, 2))
+        self.assertEqual(reshaped1.output_dims(), (8,))
+        self.assertEqual(reshaped1.input_dims(), (8,))
+        self.assertEqual(reshaped2.output_dims(), (2, 4))
+        self.assertEqual(reshaped2.input_dims(), (4, 2))
 
     def test_copy(self):
         """Test Operator copy method"""
@@ -510,44 +510,30 @@ class TestOperator(OperatorTestCase):
         mat2 = self.rand_matrix(4, 4)
         op1 = Operator(mat1)
         op2 = Operator(mat2)
-        self.assertEqual(op1.add(op2), Operator(mat1 + mat2))
+        self.assertEqual(op1._add(op2), Operator(mat1 + mat2))
         self.assertEqual(op1 + op2, Operator(mat1 + mat2))
+        self.assertEqual(op1 - op2, Operator(mat1 - mat2))
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         op1 = Operator(self.rand_matrix(2, 2))
         op2 = Operator(self.rand_matrix(3, 3))
-        self.assertRaises(QiskitError, op1.add, op2)
-
-    def test_subtract(self):
-        """Test subtract method."""
-        mat1 = self.rand_matrix(4, 4)
-        mat2 = self.rand_matrix(4, 4)
-        op1 = Operator(mat1)
-        op2 = Operator(mat2)
-        self.assertEqual(op1.subtract(op2), Operator(mat1 - mat2))
-        self.assertEqual(op1 - op2, Operator(mat1 - mat2))
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        op1 = Operator(self.rand_matrix(2, 2))
-        op2 = Operator(self.rand_matrix(3, 3))
-        self.assertRaises(QiskitError, op1.subtract, op2)
+        self.assertRaises(QiskitError, op1._add, op2)
 
     def test_multiply(self):
         """Test multiply method."""
         mat = self.rand_matrix(4, 4)
         val = np.exp(5j)
         op = Operator(mat)
-        self.assertEqual(op.multiply(val), Operator(val * mat))
+        self.assertEqual(op._multiply(val), Operator(val * mat))
         self.assertEqual(val * op, Operator(val * mat))
 
     def test_multiply_except(self):
         """Test multiply method raises exceptions."""
         op = Operator(self.rand_matrix(2, 2))
-        self.assertRaises(QiskitError, op.multiply, 's')
+        self.assertRaises(QiskitError, op._multiply, 's')
         self.assertRaises(QiskitError, op.__rmul__, 's')
-        self.assertRaises(QiskitError, op.multiply, op)
+        self.assertRaises(QiskitError, op._multiply, op)
         self.assertRaises(QiskitError, op.__rmul__, op)
 
     def test_negate(self):

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -315,14 +315,7 @@ class TestDensityMatrix(QiskitTestCase):
             rho1 = self.rand_rho(4)
             state0 = DensityMatrix(rho0)
             state1 = DensityMatrix(rho1)
-            self.assertEqual(state0.subtract(state1), DensityMatrix(rho0 - rho1))
             self.assertEqual(state0 - state1, DensityMatrix(rho0 - rho1))
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        state1 = DensityMatrix(self.rand_rho(2))
-        state2 = DensityMatrix(self.rand_rho(3))
-        self.assertRaises(QiskitError, state1.subtract, state2)
 
     def test_multiply(self):
         """Test multiply method."""

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -306,14 +306,7 @@ class TestStatevector(QiskitTestCase):
             vec1 = self.rand_vec(4)
             state0 = Statevector(vec0)
             state1 = Statevector(vec1)
-            self.assertEqual(state0.subtract(state1), Statevector(vec0 - vec1))
             self.assertEqual(state0 - state1, Statevector(vec0 - vec1))
-
-    def test_subtract_except(self):
-        """Test subtract method raises exceptions."""
-        state1 = Statevector(self.rand_vec(2))
-        state2 = Statevector(self.rand_vec(3))
-        self.assertRaises(QiskitError, state1.subtract, state2)
 
     def test_multiply(self):
         """Test multiply method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Simplifies some methods of the base class to make inheritance in derived classes easier. Removes a lot of duplicated code by adding common functions to BaseOperator and QuantumChannel base classes. Deprecates base methods for addition, subtraction, and scalar multiplication that should be done using binary operators +, -, *. 

### Details and comments

* Deprecate `add` (replaced with `_add`)
* Deprecate `subtract` (replaced with `_add(-other)`)
* Deprecate `multiply` (replaced with `_multiply`)
* Make _add and _multiply non abstract base methods that raise a
NotImplementedError so if subclasses don't have to implement these methods
if they don't support them.
* Move some common functionality from linear channel classes into the base
QuantumChannel class to avoid code duplication.
* Make internal `_reshape` method public `reshape` method and have it return a shallow copy with reshaped dimensions rather than changing the dimensions of the current object