### PR TITLE
remove identity insertion in gate decomposition

### DIFF
--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -99,19 +99,11 @@ class Isometry(Instruction):
         # call to generate the circuit that takes the isometry to the first 2^m columns
         # of the 2^n identity matrix
         iso_circuit = self._gates_to_uncompute()
-        num_gates = len(iso_circuit.data)
         # invert the circuit to create the circuit implementing the isometry
-        if not num_gates == 0:
-            # ToDo: Allow to inverse empty circuits.
-            gate = iso_circuit.to_instruction().inverse()
+        gate = iso_circuit.to_instruction().inverse()
         q = QuantumRegister(self.num_qubits)
         iso_circuit = QuantumCircuit(q)
-        if num_gates == 0:
-            # ToDo: improve handling of empty circuit, such that the following line
-            # ToDo: is not required.
-            iso_circuit.i(q[0])
-        else:
-            iso_circuit.append(gate, q[:])
+        iso_circuit.append(gate, q[:])
         self.definition = iso_circuit.data
 
     def _gates_to_uncompute(self):

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -94,12 +94,6 @@ class SingleQubitUnitary(Gate):
                 diag = [np.exp(-1j * c / 2.), np.exp(1j * c / 2.)]
             else:
                 circuit.rz(c, q[0])
-<<<<<<< HEAD
-                is_identity = False
-        if is_identity:
-            circuit.i(q[0])
-=======
->>>>>>> no id in isometry
         return circuit, diag
 
     def _zyz_dec(self):

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -84,22 +84,22 @@ class SingleQubitUnitary(Gate):
         circuit = QuantumCircuit(q)
         # First, we find the rotation angles (where we can ignore the global phase)
         (a, b, c, _) = self._zyz_dec()
-        # Add the gates to o the circuit
-        is_identity = True
+        # Add the gates to the circuit
         if abs(a) > _EPS:
             circuit.rz(a, q[0])
-            is_identity = False
         if abs(b) > _EPS:
             circuit.ry(b, q[0])
-            is_identity = False
         if abs(c) > _EPS:
             if self.up_to_diagonal:
                 diag = [np.exp(-1j * c / 2.), np.exp(1j * c / 2.)]
             else:
                 circuit.rz(c, q[0])
+<<<<<<< HEAD
                 is_identity = False
         if is_identity:
             circuit.i(q[0])
+=======
+>>>>>>> no id in isometry
         return circuit, diag
 
     def _zyz_dec(self):

--- a/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
+++ b/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
@@ -85,13 +85,7 @@ class UCPauliRotGate(Gate, metaclass=UCPauliRotMeta):
         gate = ucr_circuit.to_instruction()
         q = QuantumRegister(self.num_qubits)
         ucr_circuit = QuantumCircuit(q)
-        if gate_num == 0:
-            # ToDo: if we would not add the identity here, this would lead to troubles
-            # ToDo: simulating the circuit afterwards.
-            # this should probably be fixed in the behavior of QuantumCircuit.
-            ucr_circuit.i(q[0])
-        else:
-            ucr_circuit.append(gate, q[:])
+        ucr_circuit.append(gate, q[:])
         self.definition = ucr_circuit.data
 
     def _dec_ucrot(self):

--- a/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
+++ b/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
@@ -81,7 +81,6 @@ class UCPauliRotGate(Gate, metaclass=UCPauliRotMeta):
 
     def _define(self):
         ucr_circuit = self._dec_ucrot()
-        gate_num = len(ucr_circuit.data)
         gate = ucr_circuit.to_instruction()
         q = QuantumRegister(self.num_qubits)
         ucr_circuit = QuantumCircuit(q)


### PR DESCRIPTION
There were unnecessary Identity gates being inserted in the decomposition of some gates. This was due to a bug which was fixed by #3274. So removing the Identities.