### PR TITLE
Add random circuit function to api docs

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -54,6 +54,13 @@ Parametric Quantum Circuits
     ParameterVector
     ParameterExpression
 
+Random Circuits
+===============
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   random.random_circuit
 """
 from .quantumcircuit import QuantumCircuit
 from .classicalregister import ClassicalRegister, Clbit

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -31,6 +31,16 @@ def random_circuit(n_qubits, depth, max_operands=3, measure=False,
                    conditional=False, reset=False, seed=None):
     """Generate random circuit of arbitrary size and form.
 
+    This function will generate a random circuit by randomly selecting gates
+    from the set of standard gates in :mod:`qiskit.extensions`. For example:
+
+    .. jupyter-execute::
+
+        from qiskit.circuit.random import random_circuit
+
+        circ = random_circuit(2, 2, measure=True)
+        circ.draw(output='mpl')
+
     Args:
         n_qubits (int): number of quantum wires
         depth (int): layers of operations (i.e. critical path length)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the docs for random_circuit to the Quantum Circuit docs
so that the docstring is usable from the rendered docs. It previously
was not being included in any documentation which meant the only
documentation about it was in the code.

### Details and comments