### PR TITLE
Fix use of deprecated argument in ``iden``

### DIFF
--- a/qiskit/extensions/standard/i.py
+++ b/qiskit/extensions/standard/i.py
@@ -101,7 +101,7 @@ def iden(self, qubit, *, q=None):  # pylint: disable=unused-argument
                   'will be removed no earlier than 3 months after that release date. '
                   'You should use the QuantumCircuit.i() method instead.',
                   DeprecationWarning, stacklevel=2)
-    return self.append(IGate(), [q], [])
+    return self.append(IGate(), [qubit], [])
 
 
 # support both i and id as methods of QuantumCircuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
As noted by @mtreinish, the deprecated `iden` method of `QuantumCircuit` fails. 
This is due to the use of a deprecated argument in the method itself.


### Details and comments
The traceback is:
```
File "D:\a\1\s\test\terra\decorators.py", line 31, in is_method_available
    dummy_circ.iden(0)
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\util.py", line 108, in wrapper
    return func(*args, **kwargs)
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\extensions\standard\i.py", line 104, in iden
    return self.append(IGate(), [q], [])
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\circuit\quantumcircuit.py", line 462, in append
    expanded_qargs = [self.qbit_argument_conversion(qarg) for qarg in qargs or []]
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\circuit\quantumcircuit.py", line 462, in <listcomp>
    expanded_qargs = [self.qbit_argument_conversion(qarg) for qarg in qargs or []]
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\circuit\quantumcircuit.py", line 431, in qbit_argument_conversion
    return QuantumCircuit._bit_argument_conversion(qubit_representation, self.qubits)
  File "c:\miniconda\envs\qiskit-aer-20200224.3\lib\site-packages\qiskit\circuit\quantumcircuit.py", line 411, in _bit_argument_conversion
    raise CircuitError('Not able to expand a %s (%s)' % (bit_representation,
qiskit.circuit.exceptions.CircuitError: "Not able to expand a None (<class 'NoneType'>)"
```
This is caused by the use of the argument `q` as qubit argument, which has been deprecated and thus is `None` by default.
Changing
```python
    return self.append(IGate(), [q], [])
```
to
```python
    return self.append(IGate(), [qubit], [])
```
should fix the issue.
