### PR TITLE
Import the multi-controlled Gates from Terra, not Aqua

### DIFF
--- a/qiskit/extensions/standard/__init__.py
+++ b/qiskit/extensions/standard/__init__.py
@@ -35,6 +35,11 @@ from .x import XGate, CXGate, CCXGate
 from .y import YGate, CYGate
 from .z import ZGate, CZGate
 
+# to be converted to gates
+from .multi_control_u1_gate import mcu1
+from .multi_control_toffoli_gate import mct
+from .multi_control_rotation_gates import mcrx, mcry, mcrz
+
 # deprecated gates, to be removed
 from .i import IdGate
 from .x import ToffoliGate

--- a/qiskit/extensions/standard/multi_control_rotation_gates.py
+++ b/qiskit/extensions/standard/multi_control_rotation_gates.py
@@ -18,7 +18,7 @@ Multiple-Controlled U3 gate. Not using ancillary qubits.
 import logging
 from math import pi
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Qubit
-from qiskit import QiskitError
+from qiskit.exceptions import QiskitError
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/extensions/standard/multi_control_toffoli_gate.py
+++ b/qiskit/extensions/standard/multi_control_toffoli_gate.py
@@ -20,8 +20,7 @@ import logging
 from math import pi, ceil
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Qubit
-
-from qiskit import QiskitError
+from qiskit.exceptions import QiskitError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Several multi-controlled gates (see below) have been copied to Terra, but are not included in any `__init__` and therefore only imported through Aqua, where they are included in an `__init__` file.
If they already exist in Terra we should also include them from there, so we can finally remove these duplicate gate implementations from Aqua.

Two files remain in Aqua, namely the multi-control multi-target Toffoli and some boolean logic gates. Is there a reason why only part of the gates have been moved here?

### Details and comments

This affects:
```
multi_controlled_u1_gate -> mcu1
multi_controlled_toffoli_gate -> mct
multi_controlled_rotation_gates -> mcrx, mcry, mcrz
```

These gates exist in Aqua: https://github.com/Qiskit/qiskit-aqua/tree/master/qiskit/aqua/circuits/gates
The three files named above also co-exist in Terra.