### PR TITLE
Fix sphinx warning in wait_for_final_state

### DIFF
--- a/qiskit/providers/basejob.py
+++ b/qiskit/providers/basejob.py
@@ -62,11 +62,13 @@ class BaseJob(ABC):
             wait: seconds between queries. Default: 5.
             callback: callback function invoked after each query. Default: None.
                 The following positional arguments are provided to the callback function:
-                    * job_id: job ID
-                    * job_status: status of the job from the last query
-                    * job: this BaseJob instance
+
+                * job_id: job ID
+                * job_status: status of the job from the last query
+                * job: this BaseJob instance
+
                 Note: different subclass might provide different arguments to
-                    the callback function.
+                the callback function.
 
         Raises:
             JobTimeoutError: if the job does not reach a final state before the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now warnings aren't fatal for terra's doc builds, but other
elements are ahead of it in that regard and they catch many more docs
issues and formatting bugs because of it. However, because of this
disparity it is possible for terra to introduce a warning on something
that is used as a parent class for another element which will be fatal
for that project's docs jobs. This happened in #3731 which broke the
docs job of Aer because of incorrect formatting in the docstring (which
would result in poorly formatted output). This commit fixes this and
updates the docstring to not cause a warning. A necessary follow-on here
is to fix all the sphinx warnings emitted by terra during a docs build.

### Details and comments

Fixes #3898