### PR TITLE
Insertion ordered parameters

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1238,7 +1238,9 @@ class QuantumCircuit:
     @property
     def parameters(self):
         """Convenience function to get the parameters defined in the parameter table."""
-        return set(self._parameter_table.keys())
+        if len(set(self._parameter_table.keys())) != len(list(self._parameter_table.keys())):
+            raise ValueError('Some parameters existed twice!')
+        return list(self._parameter_table.keys())
 
     def bind_parameters(self, value_dict):
         """Assign parameters to values yielding a new circuit.
@@ -1255,7 +1257,7 @@ class QuantumCircuit:
         new_circuit = self.copy()
         unrolled_value_dict = self._unroll_param_dict(value_dict)
 
-        if unrolled_value_dict.keys() > self.parameters:
+        if unrolled_value_dict.keys() > set(self.parameters):
             raise CircuitError('Cannot bind parameters ({}) not present in the circuit.'.format(
                 [str(p) for p in value_dict.keys() - self.parameters]))
 

--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -326,7 +326,7 @@ def _expand_parameters(circuits, run_config):
 
         all_bind_parameters = [bind.keys()
                                for bind in parameter_binds]
-        all_circuit_parameters = [circuit.parameters for circuit in circuits]
+        all_circuit_parameters = [set(circuit.parameters) for circuit in circuits]
 
         # Collect set of all unique parameters across all circuits and binds
         unique_parameters = {param

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -56,14 +56,14 @@ def circuit_to_gate(circuit, parameter_map=None):
     else:
         parameter_dict = circuit._unroll_param_dict(parameter_map)
 
-    if parameter_dict.keys() != circuit.parameters:
+    if parameter_dict.keys() != set(circuit.parameters):
         raise QiskitError(('parameter_map should map all circuit parameters. '
                            'Circuit parameters: {}, parameter_map: {}').format(
                                circuit.parameters, parameter_dict))
 
     gate = Gate(name=circuit.name,
                 num_qubits=sum([qreg.size for qreg in circuit.qregs]),
-                params=sorted(parameter_dict.values(), key=lambda p: p.name))
+                params=list(parameter_dict.values()))
     gate.condition = None
 
     def find_bit_position(bit):

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -64,7 +64,7 @@ def circuit_to_instruction(circuit, parameter_map=None):
     else:
         parameter_dict = circuit._unroll_param_dict(parameter_map)
 
-    if parameter_dict.keys() != circuit.parameters:
+    if parameter_dict.keys() != set(circuit.parameters):
         raise QiskitError(('parameter_map should map all circuit parameters. '
                            'Circuit parameters: {}, parameter_map: {}').format(
                                circuit.parameters, parameter_dict))
@@ -72,7 +72,7 @@ def circuit_to_instruction(circuit, parameter_map=None):
     instruction = Instruction(name=circuit.name,
                               num_qubits=sum([qreg.size for qreg in circuit.qregs]),
                               num_clbits=sum([creg.size for creg in circuit.cregs]),
-                              params=sorted(parameter_dict.values(), key=lambda p: p.name))
+                              params=list(parameter_dict.values()))
     instruction.condition = None
 
     def find_bit_position(bit):

--- a/releasenotes/notes/insertion-ordered-parameters-e8a4a44c3912df6f.yaml
+++ b/releasenotes/notes/insertion-ordered-parameters-e8a4a44c3912df6f.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Since Python 3.6 dictionaries are insertion ordered, i.e. retrieving the keys of a
+    dictionary will return an iterable mirroring the order in which the keys are inserted.
+    In the QuantumCircuit, Parameters are stored in a dictionary so the information of
+    the insertion order is present.
+    Currently, we discard this information at two points:
+      1) if ``QuantumCircuit.parameters`` is called we return a set of the parameters,
+         which can change the order
+      2) if we create a ``Gate`` or ``Instruction`` out of a circuit, the parameters are
+         actively sorted by name
+    The new behaviour ensures that parameters are insertion-sorted by
+      1) returning a list, not set, of the parameter dictionary keys
+      2) not re-sorting the parameters of the circuit
+    This feature mirrors the behaviour some users might expect and is necessary for changes
+    in Aqua introduced by the Ansatz object.

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -61,7 +61,7 @@ class TestCircuitToInstruction(QiskitTestCase):
 
         inst = circuit_to_instruction(qc)
 
-        self.assertEqual(inst.params, [phi, theta])
+        self.assertEqual(inst.params, [theta, phi])
         self.assertEqual(inst.definition[0][0].params, [theta])
         self.assertEqual(inst.definition[1][0].params, [phi])
         self.assertEqual(inst.definition[2][0].params, [theta, phi])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The information of the insertion order of parameters is present in the `QuantumCircuit` but actively discarded at several points. This PR changes this behaviour and updates the circuit to return parameters as list in the order of insertion. This is in agreement of dictionaries since Python 3.6, whose content is insertion ordered.

This feature is required for backward compatibility in Aqua's refactor of the variational forms, resp. the Ansatz object.

### Details and comments

Since Python 3.6 dictionaries are insertion ordered, i.e. retrieving the keys of a dictionary will return an iterable mirroring the order in which the keys are inserted. In the `QuantumCircuit`, parameters are stored in a dictionary so the information of the insertion order is present.

Currently, we discard this information at two points:
1. if `QuantumCircuit.parameters` is called we return a set of the parameters, which can change the order
1. if we create a `Gate` or `Instruction` out of a circuit (by calling `to_gate/instruction()`), the parameters are actively sorted by name

The new behaviour ensures that parameters are insertion-sorted by
1. returning a list, not set, of the parameter dictionary keys
1. not re-sorting the parameters of the circuit

This feature mirrors the behaviour some users might expect and is necessary for changes in Aqua introduced by the Ansatz object. 

