### PR TITLE
Add required items to fake backends

### DIFF
--- a/qiskit/test/mock/backends/boeblingen/fake_boeblingen.py
+++ b/qiskit/test/mock/backends/boeblingen/fake_boeblingen.py
@@ -57,6 +57,7 @@ class FakeBoeblingen(FakeBackend):
             open_pulse=False,
             memory=True,
             max_shots=8192,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/johannesburg/fake_johannesburg.py
+++ b/qiskit/test/mock/backends/johannesburg/fake_johannesburg.py
@@ -55,6 +55,7 @@ class FakeJohannesburg(FakeBackend):
             open_pulse=False,
             memory=True,
             max_shots=8192,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/melbourne/fake_melbourne.py
+++ b/qiskit/test/mock/backends/melbourne/fake_melbourne.py
@@ -48,6 +48,7 @@ class FakeMelbourne(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/ourense/fake_ourense.py
+++ b/qiskit/test/mock/backends/ourense/fake_ourense.py
@@ -46,6 +46,7 @@ class FakeOurense(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/poughkeepsie/fake_poughkeepsie.py
+++ b/qiskit/test/mock/backends/poughkeepsie/fake_poughkeepsie.py
@@ -55,6 +55,7 @@ class FakePoughkeepsie(FakeBackend):
             open_pulse=False,
             memory=True,
             max_shots=8192,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/rochester/fake_rochester.py
+++ b/qiskit/test/mock/backends/rochester/fake_rochester.py
@@ -55,6 +55,7 @@ class FakeRochester(FakeBackend):
             open_pulse=False,
             memory=True,
             max_shots=8192,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/rueschlikon/fake_rueschlikon.py
+++ b/qiskit/test/mock/backends/rueschlikon/fake_rueschlikon.py
@@ -45,6 +45,7 @@ class FakeRueschlikon(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/singapore/fake_singapore.py
+++ b/qiskit/test/mock/backends/singapore/fake_singapore.py
@@ -57,6 +57,7 @@ class FakeSingapore(FakeBackend):
             open_pulse=False,
             memory=True,
             max_shots=8192,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/tenerife/fake_tenerife.py
+++ b/qiskit/test/mock/backends/tenerife/fake_tenerife.py
@@ -48,6 +48,7 @@ class FakeTenerife(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/tokyo/fake_tokyo.py
+++ b/qiskit/test/mock/backends/tokyo/fake_tokyo.py
@@ -61,6 +61,7 @@ class FakeTokyo(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=900,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/vigo/fake_vigo.py
+++ b/qiskit/test/mock/backends/vigo/fake_vigo.py
@@ -46,6 +46,7 @@ class FakeVigo(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=75,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/backends/yorktown/fake_yorktown.py
+++ b/qiskit/test/mock/backends/yorktown/fake_yorktown.py
@@ -48,6 +48,7 @@ class FakeYorktown(FakeBackend):
             open_pulse=False,
             memory=False,
             max_shots=65536,
+            max_experiments=75,
             gates=[GateConfig(name='TODO', parameters=[], qasm_def='TODO')],
             coupling_map=cmap,
         )

--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -32,15 +32,6 @@ except ImportError:
     from qiskit.providers.basicaer import BasicAer
 
 
-class _Credentials():
-    def __init__(self, token='123456', url='https://'):
-        self.token = token
-        self.url = url
-        self.hub = 'hub'
-        self.group = 'group'
-        self.project = 'project'
-
-
 class FakeBackend(BaseBackend):
     """This is a dummy backend just for testing purposes."""
 
@@ -53,7 +44,6 @@ class FakeBackend(BaseBackend):
         """
         super().__init__(configuration)
         self.time_alive = time_alive
-        self._credentials = _Credentials()
 
     def properties(self):
         """Return backend properties"""

--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -32,6 +32,15 @@ except ImportError:
     from qiskit.providers.basicaer import BasicAer
 
 
+class _Credentials():
+    def __init__(self, token='123456', url='https://'):
+        self.token = token
+        self.url = url
+        self.hub = 'hub'
+        self.group = 'group'
+        self.project = 'project'
+
+
 class FakeBackend(BaseBackend):
     """This is a dummy backend just for testing purposes."""
 
@@ -44,6 +53,7 @@ class FakeBackend(BaseBackend):
         """
         super().__init__(configuration)
         self.time_alive = time_alive
+        self._credentials = _Credentials()
 
     def properties(self):
         """Return backend properties"""

--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -135,3 +135,7 @@ class FakeBackend(BaseBackend):
             sim = BasicAer.get_backend('qasm_simulator')
             job = sim.run(qobj)
         return job
+
+    def jobs(self, **kwargs):  # pylint: disable=unused-argument
+        """Fake a job history"""
+        return []

--- a/qiskit/test/mock/fake_provider.py
+++ b/qiskit/test/mock/fake_provider.py
@@ -27,15 +27,6 @@ from .fake_openpulse_2q import FakeOpenPulse2Q
 from .fake_openpulse_3q import FakeOpenPulse3Q
 
 
-class _Credentials():
-    def __init__(self, token='123456', url='https://'):
-        self.token = token
-        self.url = url
-        self.hub = 'hub'
-        self.group = 'group'
-        self.project = 'project'
-
-
 class FakeProvider(BaseProvider):
     """Dummy provider just for testing purposes.
 
@@ -77,5 +68,3 @@ class FakeProvider(BaseProvider):
                           FakeRochester()]
 
         super().__init__()
-
-        self._credentials = _Credentials()

--- a/qiskit/test/mock/fake_provider.py
+++ b/qiskit/test/mock/fake_provider.py
@@ -27,6 +27,15 @@ from .fake_openpulse_2q import FakeOpenPulse2Q
 from .fake_openpulse_3q import FakeOpenPulse3Q
 
 
+class _Credentials():
+    def __init__(self, token='123456', url='https://'):
+        self.token = token
+        self.url = url
+        self.hub = 'hub'
+        self.group = 'group'
+        self.project = 'project'
+
+
 class FakeProvider(BaseProvider):
     """Dummy provider just for testing purposes.
 
@@ -68,3 +77,5 @@ class FakeProvider(BaseProvider):
                           FakeRochester()]
 
         super().__init__()
+
+        self._credentials = _Credentials()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The fake backends were missing attributes (`max_experiments`, `_credentials`) and methods (`jobs`) that limited the usefulness of these tools, e.g. https://github.com/Qiskit/qiskit/issues/836.  This fixes that.


### Details and comments


