### PR TITLE
Less parameters in the RXX gate

### DIFF
--- a/qiskit/extensions/standard/rxx.py
+++ b/qiskit/extensions/standard/rxx.py
@@ -15,7 +15,6 @@
 """
 Two-qubit XX-rotation gate.
 """
-import numpy as np
 from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
@@ -25,6 +24,7 @@ class RXXGate(Gate):
     """Two-qubit XX-rotation gate.
 
     This gate corresponds to the rotation U(θ) = exp(-1j * θ * X⊗X / 2)
+    up to the phase exp(-1j * θ/2).
     """
 
     def __init__(self, theta):
@@ -35,20 +35,18 @@ class RXXGate(Gate):
         """Calculate a subcircuit that implements this unitary."""
         from qiskit.extensions.standard.x import CXGate
         from qiskit.extensions.standard.u1 import U1Gate
-        from qiskit.extensions.standard.u2 import U2Gate
-        from qiskit.extensions.standard.u3 import U3Gate
         from qiskit.extensions.standard.h import HGate
         definition = []
         q = QuantumRegister(2, 'q')
         theta = self.params[0]
         rule = [
-            (U3Gate(np.pi / 2, theta, 0), [q[0]], []),
+            (HGate(), [q[0]], []),
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (U1Gate(-theta), [q[1]], []),
+            (U1Gate(theta), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], []),
-            (U2Gate(-np.pi, np.pi - theta), [q[0]], []),
+            (HGate(), [q[0]], []),
         ]
         for inst in rule:
             definition.append(inst)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The current version of the `RXX(θ)` gate uses 3 gates parameterized by `θ` and is up to a phase of `exp(iθ/2)`. There is a more efficient implementation with the same amount of gates but only 1 gate parameterized on `θ` with a phase of `exp(-iθ/2)`. Less parameters are desirable e.g. for gradient computation or parameter binding. 

This PR implements this more efficient version. 

### Details and comments

The gate sequence changes as follows.
```
(HGate(), [q[0]], []),  # was: U3Gate(np.pi / 2, theta, 0)         
(HGate(), [q[1]], []),
(CnotGate(), [q[0], q[1]], []),
(U1Gate(theta), [q[1]], []),  # was: U1Gate(-theta)
(CnotGate(), [q[0], q[1]], []),
(HGate(), [q[1]], []),
(HGate(), [q[0]], []), # was: U2Gate(-np.pi, np.pi - theta)
```

