### PR TITLE
Fix substitute parameters when decomposing composite gates

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1294,7 +1294,10 @@ class QuantumCircuit:
             for op, _, _ in instruction._definition:
                 for idx, param in enumerate(op.params):
                     if isinstance(param, ParameterExpression) and parameter in param.parameters:
-                        op.params[idx] = param.bind({parameter: value})
+                        if isinstance(value, ParameterExpression):
+                            op.params[idx] = param.subs({parameter: value})
+                        else:
+                            op.params[idx] = param.bind({parameter: value})
                         self._rebind_definition(op, parameter, value)
 
     def _substitute_parameters(self, parameter_map):
@@ -1306,6 +1309,7 @@ class QuantumCircuit:
             for (instr, param_index) in self._parameter_table[old_parameter]:
                 new_param = instr.params[param_index].subs({old_parameter: new_parameter})
                 instr.params[param_index] = new_param
+                self._rebind_definition(instr, old_parameter, new_parameter)
             self._parameter_table[new_parameter] = self._parameter_table.pop(old_parameter)
 
 

--- a/releasenotes/notes/fix-propagation-of-substituted-parameters-78bc9ece47013dbb.yaml
+++ b/releasenotes/notes/fix-propagation-of-substituted-parameters-78bc9ece47013dbb.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Previously, _substitute_parameters (i.e. replacing Parameter objects in a circuit with
+    new Parameter objects) prior to decomposing a circuit would result in
+    the substituted values not correctly being substituted into the decomposed gates.
+    This has been resolved such that binding and decomposition may occur in any order.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Analogously to #3729, which fixes the propagation of binding floats to Parameter objects, this PR fixes the binding of Parameter objects to Parameter objects.

This is a required functionality for refactoring the variational forms, resp. Ansatz class, in the next Aqua release.

### Details and comments

The `Parameter` objects in circuits can be substituted with new parameters by using the `QuantumCircuit._substitute_parameters` method. This, however, only updates the parameter table of the circuit object and doesn't propagate the change to the instructions in defining the circuit (in `QuantumCircuit.data`). When the circuit is then decomposed or transpiled, the parameter change can get lost.

See also https://github.com/Qiskit/qiskit-terra/pull/3729#issue-364995145 for more information.

