### PR TITLE
Add ``phase`` property to ``Gate`` class

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -52,9 +52,11 @@ class Gate(Instruction):
     def to_matrix(self) -> np.ndarray:
         """Return a Numpy.array for the gate unitary matrix.
 
+        Returns:
+            np.ndarray: the matrix representaiton of the gate.
+
         Raises:
-            CircuitError: If a Gate subclass does not implement this method an
-                exception will be raised when this base class method is called.
+            CircuitError: If a Gate subclass does not have a _matrix_definition.
         """
         # pylint: disable=assignment-from-none
         mat = self._matrix_definition()

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -60,7 +60,12 @@ class Gate(Instruction):
         mat = self._matrix_definition()
         if mat is None:
             raise CircuitError("to_matrix not defined for this {}".format(type(self)))
-        return cmath.exp(1j * self._phase) * mat if self._phase else mat
+        # Call float to enable conversion of bound ParameterExpressions
+        phase = float(self._phase)
+        if phase == 0:
+            # Case for default value to avoid numerical error
+            return mat
+        return cmath.exp(1j * phase) * mat
 
     def power(self, exponent: float):
         """Creates a unitary gate as `gate^exponent`.

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -24,34 +24,30 @@ from qiskit.circuit.quantumregister import QuantumRegister
 class RGate(Gate):
     """Rotation θ around the cos(φ)x + sin(φ)y axis."""
 
-    def __init__(self, theta, phi):
+    def __init__(self, theta, phi, phase=0):
         """Create new r single-qubit gate."""
-        super().__init__('r', 1, [theta, phi])
+        super().__init__('r', 1, [theta, phi], phase=phase)
 
     def _define(self):
         """
         gate r(θ, φ) a {u3(θ, φ - π/2, -φ + π/2) a;}
         """
         from .u3 import U3Gate
-        definition = []
         q = QuantumRegister(1, 'q')
         theta = self.params[0]
         phi = self.params[1]
-        rule = [
-            (U3Gate(theta, phi - pi / 2, -phi + pi / 2), [q[0]], [])
+        self.definition = [
+            (U3Gate(theta, phi - pi / 2, -phi + pi / 2, phase=self.phase), [q[0]], [])
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def inverse(self):
         """Invert this gate.
 
         r(θ, φ)^dagger = r(-θ, φ)
         """
-        return RGate(-self.params[0], self.params[1])
+        return RGate(-self.params[0], self.params[1], phase=-self.phase)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a numpy.array for the R gate."""
         cos = math.cos(self.params[0] / 2)
         sin = math.sin(self.params[0] / 2)

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -46,23 +46,19 @@ class RXGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, phase=0, label=None):
         """Create new RX gate."""
-        super().__init__('rx', 1, [theta], label=label)
+        super().__init__('rx', 1, [theta], phase=phase, label=label)
 
     def _define(self):
         """
         gate rx(theta) a {r(theta, 0) a;}
         """
         from .r import RGate
-        definition = []
         q = QuantumRegister(1, 'q')
-        rule = [
-            (RGate(self.params[0], 0), [q[0]], [])
+        self.definition = [
+            (RGate(self.params[0], 0, phase=self.phase), [q[0]], [])
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (mutli-)controlled-RX gate.
@@ -76,7 +72,7 @@ class RXGate(Gate):
         Returns:
             ControlledGate: controlled version of this gate.
         """
-        if num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1 and self.phase == 0:
             gate = CRXGate(self.params[0], label=label, ctrl_state=ctrl_state)
             gate.base_gate.label = self.label
             return gate
@@ -87,9 +83,9 @@ class RXGate(Gate):
 
         :math:`RX(\lambda)^{\dagger} = RX(-\lambda)`
         """
-        return RXGate(-self.params[0])
+        return RXGate(-self.params[0], phase=-self.phase)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a numpy.array for the RX gate."""
         cos = math.cos(self.params[0] / 2)
         sin = math.sin(self.params[0] / 2)

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -98,8 +98,7 @@ class RXXGate(Gate):
     def _matrix_definition(self):
         """Return a Numpy.array for the RXX gate."""
         theta = float(self.params[0])
-        return np.array([
-           [np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
-           [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
-           [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
-           [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)
+        return np.array([[np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
+                         [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
+                         [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
+                         [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -14,6 +14,8 @@
 
 """Two-qubit XX-rotation gate."""
 
+import numpy as np
+
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 
@@ -68,43 +70,36 @@ class RXXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, phase=0):
         """Create new RXX gate."""
-        super().__init__('rxx', 2, [theta])
+        super().__init__('rxx', 2, [theta], phase=phase)
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
         from .x import CXGate
-        from .u1 import U1Gate
+        from .rz import RZGate
         from .h import HGate
-        definition = []
         q = QuantumRegister(2, 'q')
         theta = self.params[0]
-        rule = [
+        self.definition = [
             (HGate(), [q[0]], []),
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (U1Gate(theta), [q[1]], []),
+            (RZGate(theta, phase=self.phase), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], []),
             (HGate(), [q[0]], []),
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def inverse(self):
         """Return inverse RXX gate (i.e. with the negative rotation angle)."""
-        return RXXGate(-self.params[0])
+        return RXXGate(-self.params[0], phase=-self.phase)
 
-    # NOTE: we should use the following as the canonical matrix
-    # definition but we don't include it yet since it differs from
-    # the circuit decomposition matrix by a global phase
-    # def to_matrix(self):
-    #   """Return a Numpy.array for the RXX gate."""
-    #    theta = float(self.params[0])
-    #    return np.array([
-    #        [np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
-    #        [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
-    #        [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
-    #        [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)
+    def _matrix_definition(self):
+        """Return a Numpy.array for the RXX gate."""
+        theta = float(self.params[0])
+        return np.array([
+           [np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
+           [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
+           [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
+           [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -14,8 +14,6 @@
 
 """Two-qubit XX-rotation gate."""
 
-import numpy as np
-
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 
@@ -70,35 +68,43 @@ class RXXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta, phase=0):
+    def __init__(self, theta):
         """Create new RXX gate."""
-        super().__init__('rxx', 2, [theta], phase=phase)
+        super().__init__('rxx', 2, [theta])
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
         from .x import CXGate
-        from .rz import RZGate
+        from .u1 import U1Gate
         from .h import HGate
+        definition = []
         q = QuantumRegister(2, 'q')
         theta = self.params[0]
-        self.definition = [
+        rule = [
             (HGate(), [q[0]], []),
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(theta, phase=self.phase), [q[1]], []),
+            (U1Gate(theta), [q[1]], []),  # Should be RZGate
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], []),
             (HGate(), [q[0]], []),
         ]
+        for inst in rule:
+            definition.append(inst)
+        self.definition = definition
 
     def inverse(self):
         """Return inverse RXX gate (i.e. with the negative rotation angle)."""
-        return RXXGate(-self.params[0], phase=-self.phase)
+        return RXXGate(-self.params[0])
 
-    def _matrix_definition(self):
-        """Return a Numpy.array for the RXX gate."""
-        theta = float(self.params[0])
-        return np.array([[np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
-                         [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
-                         [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
-                         [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)
+    # NOTE: we should use the following as the canonical matrix
+    # definition but we don't include it yet since it differs from
+    # the circuit decomposition matrix by a global phase
+    # def to_matrix(self):
+    #   """Return a Numpy.array for the RXX gate."""
+    #    theta = float(self.params[0])
+    #    return np.array([
+    #        [np.cos(theta / 2), 0, 0, -1j * np.sin(theta / 2)],
+    #        [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
+    #        [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
+    #        [-1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -46,23 +46,19 @@ class RYGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, phase=0, label=None):
         """Create new RY gate."""
-        super().__init__('ry', 1, [theta], label=label)
+        super().__init__('ry', 1, [theta], phase=phase, label=label)
 
     def _define(self):
         """
         gate ry(theta) a { r(theta, pi/2) a; }
         """
         from .r import RGate
-        definition = []
         q = QuantumRegister(1, 'q')
-        rule = [
-            (RGate(self.params[0], pi / 2), [q[0]], [])
+        self.definition = [
+            (RGate(self.params[0], pi / 2, phase=self.phase), [q[0]], [])
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (mutli-)controlled-RY gate.
@@ -76,7 +72,7 @@ class RYGate(Gate):
         Returns:
             ControlledGate: controlled version of this gate.
         """
-        if num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1 and self.phase == 0:
             gate = CRYGate(self.params[0], label=label, ctrl_state=ctrl_state)
             gate.base_gate.label = self.label
             return gate
@@ -87,9 +83,9 @@ class RYGate(Gate):
 
         :math:`RY(\lambda){\dagger} = RY(-\lambda)`
         """
-        return RYGate(-self.params[0])
+        return RYGate(-self.params[0], phase=-self.phase)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a numpy.array for the RY gate."""
         cos = math.cos(self.params[0] / 2)
         sin = math.sin(self.params[0] / 2)

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -69,36 +69,44 @@ class RYYGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta, phase=0):
+    def __init__(self, theta):
         """Create new RYY gate."""
-        super().__init__('ryy', 2, [theta], phase=phase)
+        super().__init__('ryy', 2, [theta])
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
         from .x import CXGate
         from .rx import RXGate
-        from .rz import RZGate
+        from .u1 import U1Gate
+
+        definition = []
         q = QuantumRegister(2, 'q')
         theta = self.params[0]
-        self.definition = [
+        rule = [
             (RXGate(np.pi / 2), [q[0]], []),
             (RXGate(np.pi / 2), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(theta, phase=self.phase), [q[1]], []),
+            (U1Gate(theta), [q[1]], []),  # Should be RZGate
             (CXGate(), [q[0], q[1]], []),
             (RXGate(-np.pi / 2), [q[0]], []),
             (RXGate(-np.pi / 2), [q[1]], []),
         ]
+        for inst in rule:
+            definition.append(inst)
+        self.definition = definition
 
     def inverse(self):
         """Return inverse RYY gate (i.e. with the negative rotation angle)."""
-        return RYYGate(-self.params[0], phase=-self.phase)
+        return RYYGate(-self.params[0])
 
-    def _matrix_definition(self):
-        """Return a numpy.array for the RYY gate."""
-        theta = self.params[0]
-        return np.array([
-            [np.cos(theta / 2), 0, 0, 1j * np.sin(theta / 2)],
-            [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
-            [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
-            [1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)
+    # TODO: this is the correct matrix and is equal to the definition above,
+    # however the control mechanism cannot distinguish U1 and RZ yet.
+    # def to_matrix(self):
+    #     """Return a numpy.array for the RYY gate."""
+    #     theta = self.params[0]
+    #     return np.exp(0.5j * theta) * np.array([
+    #         [np.cos(theta / 2), 0, 0, 1j * np.sin(theta / 2)],
+    #         [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
+    #         [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
+    #         [1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]
+    #     ], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -69,44 +69,36 @@ class RYYGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, phase=0):
         """Create new RYY gate."""
-        super().__init__('ryy', 2, [theta])
+        super().__init__('ryy', 2, [theta], phase=phase)
 
     def _define(self):
         """Calculate a subcircuit that implements this unitary."""
         from .x import CXGate
         from .rx import RXGate
         from .rz import RZGate
-
-        definition = []
         q = QuantumRegister(2, 'q')
         theta = self.params[0]
-        rule = [
+        self.definition = [
             (RXGate(np.pi / 2), [q[0]], []),
             (RXGate(np.pi / 2), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(theta), [q[1]], []),
+            (RZGate(theta, phase=self.phase), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
             (RXGate(-np.pi / 2), [q[0]], []),
             (RXGate(-np.pi / 2), [q[1]], []),
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def inverse(self):
         """Return inverse RYY gate (i.e. with the negative rotation angle)."""
-        return RYYGate(-self.params[0])
+        return RYYGate(-self.params[0], phase=-self.phase)
 
-    # TODO: this is the correct matrix and is equal to the definition above,
-    # however the control mechanism cannot distinguish U1 and RZ yet.
-    # def to_matrix(self):
-    #     """Return a numpy.array for the RYY gate."""
-    #     theta = self.params[0]
-    #     return np.exp(0.5j * theta) * np.array([
-    #         [np.cos(theta / 2), 0, 0, 1j * np.sin(theta / 2)],
-    #         [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
-    #         [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
-    #         [1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]
-    #     ], dtype=complex)
+    def _matrix_definition(self):
+        """Return a numpy.array for the RYY gate."""
+        theta = self.params[0]
+        return np.array([
+            [np.cos(theta / 2), 0, 0, 1j * np.sin(theta / 2)],
+            [0, np.cos(theta / 2), -1j * np.sin(theta / 2), 0],
+            [0, -1j * np.sin(theta / 2), np.cos(theta / 2), 0],
+            [1j * np.sin(theta / 2), 0, 0, np.cos(theta / 2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -68,7 +68,7 @@ class RZGate(Gate):
         """
         from .u1 import U1Gate
         q = QuantumRegister(1, 'q')
-        phase = self.phase + 0.5 * float(self.params[0])
+        phase = self.phase - 0.5 * float(self.params[0])
         self.definition = [
             (U1Gate(self.params[0], phase=phase), [q[0]], [])
         ]

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -68,7 +68,7 @@ class RZGate(Gate):
         """
         from .u1 import U1Gate
         q = QuantumRegister(1, 'q')
-        phase = self.phase - 0.5 * float(self.params[0])
+        phase = self.phase - 0.5 * self.params[0]
         self.definition = [
             (U1Gate(self.params[0], phase=phase), [q[0]], [])
         ]

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -14,11 +14,9 @@
 
 """Two-qubit ZX-rotation gate."""
 
-import numpy as np
-
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
-from .rz import RZGate
+from .u1 import U1Gate
 from .h import HGate
 from .x import CXGate
 
@@ -119,9 +117,9 @@ class RZXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta, phase=0):
+    def __init__(self, theta):
         """Create new RZX gate."""
-        super().__init__('rzx', 2, [theta], phase=phase)
+        super().__init__('rzx', 2, [theta])
 
     def _define(self):
         """
@@ -131,20 +129,22 @@ class RZXGate(Gate):
         self.definition = [
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(self.params[0], phase=self.phase), [q[1]], []),
+            (U1Gate(self.params[0]), [q[1]], []),  # Should be RZGate
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], [])
         ]
 
     def inverse(self):
         """Return inverse RZX gate (i.e. with the negative rotation angle)."""
-        return RZXGate(-self.params[0], phase=-self.phase)
+        return RZXGate(-self.params[0])
 
-    def _matrix_definition(self):
-        """Return a numpy.array for the RZX gate."""
-        theta = self.params[0]
-        return np.array([[np.cos(theta/2), 0, -1j*np.sin(theta/2), 0],
-                         [0, np.cos(theta/2), 0, 1j*np.sin(theta/2)],
-                         [-1j*np.sin(theta/2), 0, np.cos(theta/2), 0],
-                         [0, 1j*np.sin(theta/2), 0, np.cos(theta/2)]],
-                        dtype=complex)
+    # TODO: this is the correct definition but has a global phase with respect
+    # to the decomposition above. Restore after allowing phase on circuits.
+    # def to_matrix(self):
+    #    """Return a numpy.array for the RZX gate."""
+    #    theta = self.params[0]
+    #    return np.array([[np.cos(theta/2), 0, -1j*np.sin(theta/2), 0],
+    #                     [0, np.cos(theta/2), 0, 1j*np.sin(theta/2)],
+    #                     [-1j*np.sin(theta/2), 0, np.cos(theta/2), 0],
+    #                     [0, 1j*np.sin(theta/2), 0, np.cos(theta/2)]],
+    #                    dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -14,6 +14,8 @@
 
 """Two-qubit ZX-rotation gate."""
 
+import numpy as np
+
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 from .rz import RZGate
@@ -117,9 +119,9 @@ class RZXGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, phase=0):
         """Create new RZX gate."""
-        super().__init__('rzx', 2, [theta])
+        super().__init__('rzx', 2, [theta], phase=phase)
 
     def _define(self):
         """
@@ -129,22 +131,20 @@ class RZXGate(Gate):
         self.definition = [
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(self.params[0]), [q[1]], []),
+            (RZGate(self.params[0], phase=self.phase), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], [])
         ]
 
     def inverse(self):
         """Return inverse RZX gate (i.e. with the negative rotation angle)."""
-        return RZXGate(-self.params[0])
+        return RZXGate(-self.params[0], phase=-self.phase)
 
-    # TODO: this is the correct definition but has a global phase with respect
-    # to the decomposition above. Restore after allowing phase on circuits.
-    # def to_matrix(self):
-    #    """Return a numpy.array for the RZX gate."""
-    #    theta = self.params[0]
-    #    return np.array([[np.cos(theta/2), 0, -1j*np.sin(theta/2), 0],
-    #                     [0, np.cos(theta/2), 0, 1j*np.sin(theta/2)],
-    #                     [-1j*np.sin(theta/2), 0, np.cos(theta/2), 0],
-    #                     [0, 1j*np.sin(theta/2), 0, np.cos(theta/2)]],
-    #                    dtype=complex)
+    def _matrix_definition(self):
+        """Return a numpy.array for the RZX gate."""
+        theta = self.params[0]
+        return np.array([[np.cos(theta/2), 0, -1j*np.sin(theta/2), 0],
+                         [0, np.cos(theta/2), 0, 1j*np.sin(theta/2)],
+                         [-1j*np.sin(theta/2), 0, np.cos(theta/2), 0],
+                         [0, 1j*np.sin(theta/2), 0, np.cos(theta/2)]],
+                        dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -14,8 +14,6 @@
 
 """Two-qubit ZZ-rotation gate."""
 
-import numpy as np
-
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 
@@ -83,31 +81,37 @@ class RZZGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta, phase=0):
+    def __init__(self, theta):
         """Create new RZZ gate."""
-        super().__init__('rzz', 2, [theta], phase=phase)
+        super().__init__('rzz', 2, [theta])
 
     def _define(self):
         """
         gate rzz(theta) a, b { cx a, b; u1(theta) b; cx a, b; }
         """
-        from .rz import RZGate
+        from .u1 import U1Gate
         from .x import CXGate
+        definition = []
         q = QuantumRegister(2, 'q')
-        self.definition = [
+        rule = [
             (CXGate(), [q[0], q[1]], []),
-            (RZGate(self.params[0], phase=self.phase), [q[1]], []),
+            (U1Gate(self.params[0]), [q[1]], []),  # Should be RZGate
             (CXGate(), [q[0], q[1]], [])
         ]
+        for inst in rule:
+            definition.append(inst)
+        self.definition = definition
 
     def inverse(self):
         """Return inverse RZZ gate (i.e. with the negative rotation angle)."""
-        return RZZGate(-self.params[0], phase=-self.phase)
+        return RZZGate(-self.params[0])
 
-    def _matrix_definition(self):
-        """Return a numpy.array for the RZZ gate."""
-        theta = float(self.params[0])
-        return np.array([[np.exp(-1j*theta/2), 0, 0, 0],
-                         [0, np.exp(1j*theta/2), 0, 0],
-                         [0, 0, np.exp(1j*theta/2), 0],
-                         [0, 0, 0, np.exp(-1j*theta/2)]], dtype=complex)
+    # TODO: this is the correct matrix and is equal to the definition above,
+    # however the control mechanism cannot distinguish U1 and RZ yet.
+    # def to_matrix(self):
+    #    """Return a numpy.array for the RZZ gate."""
+    #    theta = float(self.params[0])
+    #    return np.array([[np.exp(-1j*theta/2), 0, 0, 0],
+    #                     [0, np.exp(1j*theta/2), 0, 0],
+    #                     [0, 0, np.exp(1j*theta/2), 0],
+    #                     [0, 0, 0, np.exp(-1j*theta/2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -14,6 +14,8 @@
 
 """Two-qubit ZZ-rotation gate."""
 
+import numpy as np
+
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 
@@ -81,37 +83,31 @@ class RZZGate(Gate):
                                     \end{pmatrix}
     """
 
-    def __init__(self, theta):
+    def __init__(self, theta, phase=0):
         """Create new RZZ gate."""
-        super().__init__('rzz', 2, [theta])
+        super().__init__('rzz', 2, [theta], phase=phase)
 
     def _define(self):
         """
         gate rzz(theta) a, b { cx a, b; u1(theta) b; cx a, b; }
         """
-        from .u1 import U1Gate
+        from .rz import RZGate
         from .x import CXGate
-        definition = []
         q = QuantumRegister(2, 'q')
-        rule = [
+        self.definition = [
             (CXGate(), [q[0], q[1]], []),
-            (U1Gate(self.params[0]), [q[1]], []),
+            (RZGate(self.params[0], phase=self.phase), [q[1]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def inverse(self):
         """Return inverse RZZ gate (i.e. with the negative rotation angle)."""
-        return RZZGate(-self.params[0])
+        return RZZGate(-self.params[0], phase=-self.phase)
 
-    # TODO: this is the correct matrix and is equal to the definition above,
-    # however the control mechanism cannot distinguish U1 and RZ yet.
-    # def to_matrix(self):
-    #    """Return a numpy.array for the RZZ gate."""
-    #    theta = float(self.params[0])
-    #    return np.array([[np.exp(-1j*theta/2), 0, 0, 0],
-    #                     [0, np.exp(1j*theta/2), 0, 0],
-    #                     [0, 0, np.exp(1j*theta/2), 0],
-    #                     [0, 0, 0, np.exp(-1j*theta/2)]], dtype=complex)
+    def _matrix_definition(self):
+        """Return a numpy.array for the RZZ gate."""
+        theta = float(self.params[0])
+        return np.array([[np.exp(-1j*theta/2), 0, 0, 0],
+                         [0, np.exp(1j*theta/2), 0, 0],
+                         [0, 0, np.exp(1j*theta/2), 0],
+                         [0, 0, 0, np.exp(-1j*theta/2)]], dtype=complex)

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -75,20 +75,16 @@ class U1Gate(Gate):
         `1612.00858 <https://arxiv.org/abs/1612.00858>`_
     """
 
-    def __init__(self, theta, label=None):
+    def __init__(self, theta, phase=0, label=None):
         """Create new U1 gate."""
-        super().__init__('u1', 1, [theta], label=label)
+        super().__init__('u1', 1, [theta], phase=phase, label=label)
 
     def _define(self):
         from .u3 import U3Gate  # pylint: disable=cyclic-import
-        definition = []
         q = QuantumRegister(1, 'q')
-        rule = [
-            (U3Gate(0, 0, self.params[0]), [q[0]], [])
+        self.definition = [
+            (U3Gate(0, 0, self.params[0], phase=self.phase), [q[0]], [])
         ]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (mutli-)controlled-U1 gate.
@@ -114,9 +110,9 @@ class U1Gate(Gate):
 
     def inverse(self):
         r"""Return inverted U1 gate (:math:`U1(\lambda){\dagger} = U1(-\lambda)`)"""
-        return U1Gate(-self.params[0])
+        return U1Gate(-self.params[0], phase=-self.phase)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a numpy.array for the U1 gate."""
         lam = self.params[0]
         lam = float(lam)

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -59,27 +59,25 @@ class U2Gate(Gate):
         using two X90 pulses.
     """
 
-    def __init__(self, phi, lam, label=None):
+    def __init__(self, phi, lam, phase=0, label=None):
         """Create new U2 gate."""
-        super().__init__('u2', 1, [phi, lam], label=label)
+        super().__init__('u2', 1, [phi, lam], phase=0, label=label)
 
     def _define(self):
         from .u3 import U3Gate
-        definition = []
         q = QuantumRegister(1, 'q')
-        rule = [(U3Gate(pi / 2, self.params[0], self.params[1]), [q[0]], [])]
-        for inst in rule:
-            definition.append(inst)
-        self.definition = definition
+        self.definition = [
+            (U3Gate(pi / 2, self.params[0], self.params[1], phase=self.phase), [q[0]], [])
+        ]
 
     def inverse(self):
         r"""Return inverted U2 gate.
 
         :math:`U2(\phi, \lambda)^{\dagger} =U2(-\lambda-\pi, -\phi+\pi)`)
         """
-        return U2Gate(-self.params[1] - pi, -self.params[0] + pi)
+        return U2Gate(-self.params[1] - pi, -self.params[0] + pi, phase=-self.phase)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a Numpy.array for the U2 gate."""
         isqrt2 = 1 / numpy.sqrt(2)
         phi, lam = self.params

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -59,16 +59,16 @@ class U3Gate(Gate):
         U3(\theta, 0, 0) = RY(\theta)
     """
 
-    def __init__(self, theta, phi, lam, label=None):
+    def __init__(self, theta, phi, lam, phase=0, label=None):
         """Create new U3 gate."""
-        super().__init__('u3', 1, [theta, phi, lam], label=label)
+        super().__init__('u3', 1, [theta, phi, lam], phase=phase, label=label)
 
     def inverse(self):
         r"""Return inverted U3 gate.
 
         :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\phi,-\lambda)`)
         """
-        return U3Gate(-self.params[0], -self.params[2], -self.params[1])
+        return U3Gate(-self.params[0], -self.params[2], -self.params[1], phase=-self.phase)
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (mutli-)controlled-U3 gate.
@@ -82,13 +82,13 @@ class U3Gate(Gate):
         Returns:
             ControlledGate: controlled version of this gate.
         """
-        if num_ctrl_qubits == 1:
+        if num_ctrl_qubits == 1 and self.phase == 0:
             gate = CU3Gate(*self.params, label=label, ctrl_state=ctrl_state)
             gate.base_gate.label = self.label
             return gate
         return super().control(num_ctrl_qubits=num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
 
-    def to_matrix(self):
+    def _matrix_definition(self):
         """Return a Numpy.array for the U3 gate."""
         theta, phi, lam = self.params
         theta, phi, lam = float(theta), float(phi), float(lam)

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -119,8 +119,8 @@ class OneQubitEulerDecomposer:
         if not is_unitary_matrix(unitary):
             raise QiskitError("OneQubitEulerDecomposer: "
                               "input matrix is not unitary.")
-        theta, phi, lam, _ = self._params(unitary)
-        circuit = self._circuit(theta, phi, lam,
+        theta, phi, lam, phase = self._params(unitary)
+        circuit = self._circuit(theta, phi, lam, phase=phase,
                                 simplify=simplify,
                                 atol=atol)
         return circuit
@@ -236,16 +236,17 @@ class OneQubitEulerDecomposer:
     def _circuit_zyz(theta,
                      phi,
                      lam,
+                     phase=0,
                      simplify=True,
                      atol=DEFAULT_ATOL):
         circuit = QuantumCircuit(1)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RZGate(phi + lam), [0])
+            circuit.append(RZGate(phi + lam, phase=phase), [0])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
             circuit.append(RZGate(lam), [0])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit.append(RYGate(theta, phase=phase), [0])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
             circuit.append(RZGate(phi), [0])
         return circuit
@@ -254,17 +255,18 @@ class OneQubitEulerDecomposer:
     def _circuit_zxz(theta,
                      phi,
                      lam,
+                     phase=0,
                      simplify=False,
                      atol=DEFAULT_ATOL):
         if simplify and np.isclose(theta, 0.0, atol=atol):
             circuit = QuantumCircuit(1)
-            circuit.append(RZGate(phi + lam), [0])
+            circuit.append(RZGate(phi + lam, phase=phase), [0])
             return circuit
         circuit = QuantumCircuit(1)
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
             circuit.append(RZGate(lam), [0])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(theta), [0])
+            circuit.append(RXGate(theta, phase=phase), [0])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
             circuit.append(RZGate(phi), [0])
         return circuit
@@ -273,16 +275,17 @@ class OneQubitEulerDecomposer:
     def _circuit_xyx(theta,
                      phi,
                      lam,
+                     phase=0,
                      simplify=True,
                      atol=DEFAULT_ATOL):
         circuit = QuantumCircuit(1)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(phi + lam), [0])
+            circuit.append(RXGate(phi + lam, phase=phase), [0])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
             circuit.append(RXGate(lam), [0])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit.append(RYGate(theta, phase=phase), [0])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
             circuit.append(RXGate(phi), [0])
         return circuit
@@ -291,17 +294,19 @@ class OneQubitEulerDecomposer:
     def _circuit_u3(theta,
                     phi,
                     lam,
+                    phase=0,
                     simplify=True,
                     atol=DEFAULT_ATOL):
         # pylint: disable=unused-argument
         circuit = QuantumCircuit(1)
-        circuit.append(U3Gate(theta, phi, lam), [0])
+        circuit.append(U3Gate(theta, phi, lam, phase=phase), [0])
         return circuit
 
     @staticmethod
     def _circuit_u1x(theta,
                      phi,
                      lam,
+                     phase=0,
                      simplify=True,
                      atol=DEFAULT_ATOL):
         # Shift theta and phi so decomposition is
@@ -312,18 +317,18 @@ class OneQubitEulerDecomposer:
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             # Zero X90 gate decomposition
             circuit = QuantumCircuit(1)
-            circuit.append(U1Gate(lam + phi + theta), [0])
+            circuit.append(U1Gate(lam + phi + theta, phase=phase), [0])
             return circuit
         if simplify and np.isclose(abs(theta), np.pi/2, atol=atol):
             # Single X90 gate decomposition
             circuit = QuantumCircuit(1)
-            circuit.append(U1Gate(lam + theta), [0])
+            circuit.append(U1Gate(lam + theta, phase=phase), [0])
             circuit.append(RXGate(np.pi / 2), [0])
             circuit.append(U1Gate(phi + theta), [0])
             return circuit
         # General two-X90 gate decomposition
         circuit = QuantumCircuit(1)
-        circuit.append(U1Gate(lam), [0])
+        circuit.append(U1Gate(lam, phase=phase), [0])
         circuit.append(RXGate(np.pi / 2), [0])
         circuit.append(U1Gate(theta), [0])
         circuit.append(RXGate(np.pi / 2), [0])
@@ -334,10 +339,11 @@ class OneQubitEulerDecomposer:
     def _circuit_rr(theta,
                     phi,
                     lam,
+                    phase=0,
                     simplify=True,
                     atol=DEFAULT_ATOL):
         circuit = QuantumCircuit(1)
         if not simplify or not np.isclose(theta, -np.pi, atol=atol):
             circuit.append(RGate(theta + np.pi, np.pi / 2 - lam), [0])
-        circuit.append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [0])
+        circuit.append(RGate(-np.pi, 0.5 * (phi - lam + np.pi), phase=phase), [0])
         return circuit

--- a/releasenotes/notes/gate-phase-ff6549a85b545638.yaml
+++ b/releasenotes/notes/gate-phase-ff6549a85b545638.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    Adds `phase` attribute to the :class:`qiskit.circuit.Gate` class that can be
+    used set a custom phase coefficient to a gate. This will be reflected in
+    the :meth:`~qiskit.circuit.Gate.to_matrix` method which will return the
+    matrix :math:`e^{-i \theta} U` where :math:`U` is the canonical matrix
+    definition of the gate.
+  - |
+    Updates :class:`qiskit.circuit.library.RZGate` to have correct phase
+    when unrolled to a :class:`qiskit.circuit.library.U1Gate`.
+  - |
+    Updates :class:`qiskit.quantum_info.synthesis.OneQubitEulerDecomposer` to
+    perform phase correct synthesis of any single-qubit unitary matrix.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -114,7 +114,7 @@ class TestOneQubitEulerDecomposer(QiskitTestCase):
 
     def check_one_qubit_euler_angles(self, operator, basis='U3',
                                      tolerance=1e-12,
-                                     phase_equal=False):
+                                     phase_equal=True):
         """Check euler_angles_1q works for the given unitary"""
         decomposer = OneQubitEulerDecomposer(basis)
         with self.subTest(operator=operator):


### PR DESCRIPTION
Fixes #3304

### Summary

* Adds `phase` properties to `Gate` class for storing a gate phase
* Adds `Gate._matrix_definition` function to standard gates that returns canonical (phase=0) gate
* Changes `Gate.to_matrix` to return the matrix definition times the phase
* Updates U1, U2, U3 gates and RX, RY, RZ rotation to use phase correctly (in init and inverse).
* Adds phase correct matrix and definitions for RZ.
* Make `OneQubitEulerDecomposer` have phase-correct synthesis

### Details and comments

When constructing a gate a `phase` can be set using `phase=theta` kwarg. `theta` will be stored as a float `[-2*pi, 2*pi]` in the gate object, representing a complex coefficient `exp(i theta)` on the matrix definition of the gate.

After construction a gate object can have its phase modified using `gate.phase = theta`.

When calling `to_matrix` the returned matrix will be `exp(i theta) * U_def` where `U_def` is the matrix definition of the gate.

When unrolling any set phase parameter will be passed to one of the gates in the definition so that the unrolled circuit has the same global phase as the original gate.

### Follow up PR work

* Updating the rest of the standard gates with phases (in particular controlled gates)
* Updating 2-qubit synthesis to preserve phase
* Fixing transpiler passes to preserve phase where possible