### PR TITLE
Update coverage job to use coverage3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,11 @@ jobs:
   include:
     - name: Python 3.6 Tests and Coverage Linux
       python: 3.6
-      env:
-        - PYTHON=coverage3 run --source qiskit --parallel-mode
+      install:
+        - pip install -U tox setuptools pip virtualenv
+      script:
+        - tox -ecoverage
       after_success:
-        - coverage3 combine || true
         - coveralls || true
         - coverage3 xml || true
         - pip install diff-cover || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Python 3.6 Tests and Coverage Linux
       python: 3.6
       env:
-        - PYTHON="coverage3 run --source qiskit --parallel-mode"
+        - PYTHON=coverage3 run --source qiskit --parallel-mode
       after_success:
         - coverage3 combine || true
         - coveralls || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ jobs:
     - name: Python 3.6 Tests and Coverage Linux
       python: 3.6
       env:
-        - PYTHON="coverage run --source qiskit --parallel-mode"
+        - PYTHON="coverage3 run --source qiskit --parallel-mode"
       after_success:
-        - coverage combine || true
+        - coverage3 combine || true
         - coveralls || true
-        - coverage xml || true
+        - coverage3 xml || true
         - pip install diff-cover || true
         - diff-cover --compare-branch master coverage.xml || true
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We've started encountering failures in the travis coverage job where it
can't find the correct coverage command (or the arguments aren't the
same for whichever version it's using). To avoid this issue this commit
changes the job to use coverage3 instead of coverage to attempt and
prevent this failure mode.

### Details and comments