### PR TITLE
Promote Instruction metadata to class attributes.

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -24,6 +24,8 @@ from .instruction import Instruction
 class Gate(Instruction):
     """Unitary gate."""
 
+    num_clbits = 0
+
     def __init__(self, name, num_qubits, params, label=None):
         """Create a new gate.
 
@@ -35,7 +37,7 @@ class Gate(Instruction):
         """
         self._label = label
         self.definition = None
-        super().__init__(name, num_qubits, 0, params)
+        super().__init__(name, num_qubits, self.num_clbits, params)
 
     def to_matrix(self):
         """Return a Numpy.array for the gate unitary matrix.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -51,6 +51,11 @@ _CUTOFF_PRECISION = 1E-10
 class Instruction:
     """Generic quantum instruction."""
 
+    name = None
+    num_qubits = None
+    num_clbits = None
+    num_params = None
+
     def __init__(self, name, num_qubits, num_clbits, params):
         """Create a new instruction.
 

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -23,9 +23,16 @@ from qiskit.circuit.exceptions import CircuitError
 class Measure(Instruction):
     """Quantum measurement in the computational basis."""
 
+    name = 'measure'
+    num_qubits = 1
+    num_clbits = 1
+
     def __init__(self):
         """Create new measurement instruction."""
-        super().__init__("measure", 1, 1, [])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         self.num_clbits,
+                         [])
 
     def broadcast_arguments(self, qargs, cargs):
         qarg = qargs[0]

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -22,9 +22,16 @@ from qiskit.circuit.instruction import Instruction
 class Reset(Instruction):
     """Qubit reset."""
 
+    name = 'reset'
+    num_qubits = 1
+    num_clbits = 0
+
     def __init__(self):
         """Create new reset instruction."""
-        super().__init__("reset", 1, 0, [])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         self.num_clbits,
+                         [])
 
     def broadcast_arguments(self, qargs, cargs):
         for qarg in qargs[0]:

--- a/qiskit/extensions/quantum_initializer/diagonal.py
+++ b/qiskit/extensions/quantum_initializer/diagonal.py
@@ -50,6 +50,9 @@ class DiagonalGate(Gate, metaclass=DiagonalMeta):
     least two entries.
     """
 
+    name = 'diagonal'
+    num_params = 1
+
     def __init__(self, diag):
         """Check types"""
         # Check if diag has type "list"
@@ -69,7 +72,7 @@ class DiagonalGate(Gate, metaclass=DiagonalMeta):
             if not np.abs(z) - 1 < _EPS:
                 raise QiskitError("A diagonal entry has not absolute value one.")
         # Create new gate.
-        super().__init__("diagonal", int(num_action_qubits), diag)
+        super().__init__(self.name, int(num_action_qubits), diag)
 
     def _define(self):
         diag_circuit = self._dec_diag()

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -41,6 +41,9 @@ class Initialize(Instruction):
     which is not unitary.
     """
 
+    name = 'initialize'
+    num_clbits = 0
+
     def __init__(self, params):
         """Create new initialize composite.
 
@@ -59,7 +62,7 @@ class Initialize(Instruction):
 
         num_qubits = int(num_qubits)
 
-        super().__init__("initialize", num_qubits, 0, params)
+        super().__init__(self.name, num_qubits, self.num_clbits, params)
 
     def _define(self):
         """Calculate a subcircuit that implements this initialization

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -57,6 +57,10 @@ class Isometry(Instruction):
         num_ancillas_dirty (int): number of additional ancillas that start in an arbitrary state
     """
 
+    name = 'isometry'
+    num_clbits = 0
+    num_params = 1
+
     # Notation: In the following decomposition we label the qubit by
     # 0 -> most significant one
     # ...
@@ -93,7 +97,10 @@ class Isometry(Instruction):
 
         num_qubits = int(n) + num_ancillas_zero + num_ancillas_dirty
 
-        super().__init__("isometry", num_qubits, 0, [isometry])
+        super().__init__(self.name,
+                         num_qubits,
+                         self.num_clbits,
+                         [isometry])
 
     def _define(self):
         # call to generate the circuit that takes the isometry to the first 2^m columns

--- a/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
+++ b/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
@@ -41,6 +41,9 @@ class MCGupDiag(Gate):
     such that u=d.u'.
     """
 
+    name = 'MCGupDiag'
+    num_params = 1
+
     def __init__(self, gate, num_controls, num_ancillas_zero, num_ancillas_dirty):
         """Initialize a multi controlled gate.
 
@@ -65,7 +68,7 @@ class MCGupDiag(Gate):
             raise QiskitError("The controlled gate is not unitary.")
         # Create new gate.
         num_qubits = 1 + num_controls + num_ancillas_zero + num_ancillas_dirty
-        super().__init__("MCGupDiag", num_qubits, [gate])
+        super().__init__(self.name, num_qubits, [gate])
 
     def _define(self):
         mcg_up_diag_circuit, _ = self._dec_mcg_up_diag()

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -46,6 +46,10 @@ class SingleQubitUnitary(Gate):
                      gate d with u = d.dot(u').
     """
 
+    name = 'unitary'
+    num_qubits = 1
+    num_params = 1
+
     def __init__(self, u, mode="ZYZ", up_to_diagonal=False):
         if mode != "ZYZ":
             raise QiskitError("The decomposition mode is not known.")
@@ -57,7 +61,9 @@ class SingleQubitUnitary(Gate):
         self.mode = mode
         self.up_to_diagonal = up_to_diagonal
         # Create new gate
-        super().__init__("unitary", 1, [u])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [u])
 
     # Returns the diagonal gate D up to which the single-qubit unitary u is implemented,
     # i.e., u=D.u', where u' is the unitary implemented by the found circuit.

--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -68,6 +68,8 @@ class UCGate(Gate, metaclass=UCMeta):
     The decomposition is based on: https://arxiv.org/pdf/quant-ph/0410066.pdf.
     """
 
+    name = 'multiplexer'
+
     def __init__(self, gate_list, up_to_diagonal=False):
         """UCGate Gate initializer.
 
@@ -104,7 +106,7 @@ class UCGate(Gate, metaclass=UCMeta):
                 raise QiskitError("A controlled gate is not unitary.")
 
         # Create new gate.
-        super().__init__("multiplexer", int(num_contr) + 1, gate_list)
+        super().__init__(self.name, int(num_contr) + 1, gate_list)
         self.up_to_diagonal = up_to_diagonal
 
     def _get_diagonal(self):

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -24,6 +24,8 @@ from qiskit.extensions.exceptions import QiskitError, ExtensionError
 class Snapshot(Instruction):
     """Simulator snapshot instruction."""
 
+    name = 'snapshot'
+
     def __init__(self,
                  label,
                  snapshot_type='statevector',
@@ -48,7 +50,7 @@ class Snapshot(Instruction):
         self._snapshot_type = snapshot_type
         if params is None:
             params = []
-        super().__init__('snapshot', num_qubits, num_clbits, params)
+        super().__init__(self.name, num_qubits, num_clbits, params)
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""

--- a/qiskit/extensions/standard/barrier.py
+++ b/qiskit/extensions/standard/barrier.py
@@ -24,9 +24,15 @@ from qiskit.exceptions import QiskitError
 class Barrier(Instruction):
     """Barrier instruction."""
 
+    name = 'barrier'
+    num_clbits = 0
+
     def __init__(self, num_qubits):
         """Create new barrier instruction."""
-        super().__init__("barrier", num_qubits, 0, [])
+        super().__init__(self.name,
+                         num_qubits,
+                         self.num_clbits,
+                         [])
 
     def inverse(self):
         """Special case. Return self."""

--- a/qiskit/extensions/standard/h.py
+++ b/qiskit/extensions/standard/h.py
@@ -30,9 +30,16 @@ from qiskit.util import deprecate_arguments
 class HGate(Gate):
     """Hadamard gate."""
 
+    name = 'h'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new Hadamard gate."""
-        super().__init__('h', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """
@@ -116,9 +123,16 @@ QuantumCircuit.h = h
 class CHGate(ControlledGate):
     """The controlled-H gate."""
 
+    name = 'ch'
+    num_qubits = 2
+    num_params = 0
+
     def __init__(self):
         """Create new CH gate."""
-        super().__init__('ch', 2, [], num_ctrl_qubits=1)
+        super().__init__('ch',
+                         self.num_qubits,
+                         [],
+                         num_ctrl_qubits=1)
         self.base_gate = HGate()
 
     def _define(self):

--- a/qiskit/extensions/standard/i.py
+++ b/qiskit/extensions/standard/i.py
@@ -39,9 +39,16 @@ class IGate(Gate, metaclass=IMeta):
     and should not be optimized or unrolled (it is an opaque gate).
     """
 
+    name = 'id'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new Identity gate."""
-        super().__init__('id', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def inverse(self):
         """Invert this gate."""

--- a/qiskit/extensions/standard/ms.py
+++ b/qiskit/extensions/standard/ms.py
@@ -33,9 +33,14 @@ from qiskit.circuit import QuantumRegister
 class MSGate(Gate):
     """Global Molmer-Sorensen gate."""
 
+    name = 'ms'
+    num_params = 1
+
     def __init__(self, n_qubits, theta):
         """Create new MS gate."""
-        super().__init__('ms', n_qubits, [theta])
+        super().__init__(self.name,
+                         n_qubits,
+                         [theta])
 
     def _define(self):
         from qiskit.extensions.standard.rxx import RXXGate

--- a/qiskit/extensions/standard/r.py
+++ b/qiskit/extensions/standard/r.py
@@ -27,9 +27,15 @@ from qiskit.util import deprecate_arguments
 class RGate(Gate):
     """Rotation θ around the cos(φ)x + sin(φ)y axis."""
 
+    name = 'r'
+    num_qubits = 1
+    num_params = 2
+
     def __init__(self, theta, phi):
         """Create new r single-qubit gate."""
-        super().__init__('r', 1, [theta, phi])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta, phi])
 
     def _define(self):
         """

--- a/qiskit/extensions/standard/rx.py
+++ b/qiskit/extensions/standard/rx.py
@@ -28,9 +28,15 @@ from qiskit.util import deprecate_arguments
 class RXGate(Gate):
     """The rotation around the x-axis."""
 
+    name = 'rx'
+    num_qubits = 1
+    num_params = 1
+
     def __init__(self, theta):
         """Create new rx single qubit gate."""
-        super().__init__('rx', 1, [theta])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta])
 
     def _define(self):
         """
@@ -125,9 +131,16 @@ class CRXMeta(type):
 class CRXGate(ControlledGate, metaclass=CRXMeta):
     """The controlled-rx gate."""
 
+    name = 'crx'
+    num_qubits = 2
+    num_params = 1
+
     def __init__(self, theta):
         """Create new crx gate."""
-        super().__init__('crx', 2, [theta], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta],
+                         num_ctrl_qubits=1)
         self.base_gate = RXGate(theta)
 
     def _define(self):

--- a/qiskit/extensions/standard/ry.py
+++ b/qiskit/extensions/standard/ry.py
@@ -28,9 +28,15 @@ from qiskit.util import deprecate_arguments
 class RYGate(Gate):
     """The rotation around the y-axis."""
 
+    name = 'ry'
+    num_qubits = 1
+    num_params = 1
+
     def __init__(self, theta):
         """Create new RY single qubit gate."""
-        super().__init__('ry', 1, [theta])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta])
 
     def _define(self):
         """
@@ -125,9 +131,16 @@ class CRYMeta(type):
 class CRYGate(ControlledGate, metaclass=CRYMeta):
     """The controlled-ry gate."""
 
+    name = 'cry'
+    num_qubits = 2
+    num_params = 1
+
     def __init__(self, theta):
         """Create new cry gate."""
-        super().__init__('cry', 2, [theta], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta],
+                         num_ctrl_qubits=1)
         self.base_gate = RYGate(theta)
 
     def _define(self):

--- a/qiskit/extensions/standard/rz.py
+++ b/qiskit/extensions/standard/rz.py
@@ -25,9 +25,15 @@ from qiskit.util import deprecate_arguments
 class RZGate(Gate):
     """The rotation around the z-axis."""
 
+    name = 'rz'
+    num_qubits = 1
+    num_params = 1
+
     def __init__(self, phi):
         """Create new RZ single qubit gate."""
-        super().__init__('rz', 1, [phi])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [phi])
 
     def _define(self):
         """
@@ -109,9 +115,16 @@ class CRZMeta(type):
 class CRZGate(ControlledGate, metaclass=CRZMeta):
     """The controlled-rz gate."""
 
+    name = 'crz'
+    num_qubits = 2
+    num_params = 1
+
     def __init__(self, theta):
         """Create new crz gate."""
-        super().__init__('crz', 2, [theta], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta],
+                         num_ctrl_qubits=1)
         self.base_gate = RZGate(theta)
 
     def _define(self):

--- a/qiskit/extensions/standard/s.py
+++ b/qiskit/extensions/standard/s.py
@@ -26,9 +26,16 @@ from qiskit.util import deprecate_arguments
 class SGate(Gate):
     """The S gate, also called Clifford phase gate."""
 
+    name = 's'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create a new S gate."""
-        super().__init__('s', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """
@@ -57,9 +64,16 @@ class SGate(Gate):
 class SdgGate(Gate):
     """Sdg=diag(1,-i) Clifford adjoint phase gate."""
 
+    name = 'sdg'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create a new Sdg gate."""
-        super().__init__('sdg', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """

--- a/qiskit/extensions/standard/swap.py
+++ b/qiskit/extensions/standard/swap.py
@@ -26,9 +26,15 @@ from qiskit.util import deprecate_arguments
 class SwapGate(Gate):
     """SWAP gate."""
 
+    name = 'swap'
+    num_qubits = 2
+    num_params = 0
+
     def __init__(self):
         """Create new SWAP gate."""
-        super().__init__('swap', 2, [])
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [])
 
     def _define(self):
         """
@@ -118,9 +124,16 @@ class CSwapMeta(type):
 class CSwapGate(ControlledGate, metaclass=CSwapMeta):
     """The controlled-swap gate, also called Fredkin gate."""
 
+    name = 'cswap'
+    num_qubits = 3
+    num_params = 0
+
     def __init__(self):
         """Create new CSWAP gate."""
-        super().__init__('cswap', 3, [], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         num_ctrl_qubits=1)
         self.base_gate = SwapGate()
 
     def _define(self):

--- a/qiskit/extensions/standard/t.py
+++ b/qiskit/extensions/standard/t.py
@@ -26,9 +26,16 @@ from qiskit.util import deprecate_arguments
 class TGate(Gate):
     """T Gate: pi/4 rotation around Z axis."""
 
+    name = 't'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new T gate."""
-        super().__init__('t', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """
@@ -57,9 +64,16 @@ class TGate(Gate):
 class TdgGate(Gate):
     """Tdg Gate: -pi/4 rotation around Z axis."""
 
+    name = 'tdg'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create a new Tdg gate."""
-        super().__init__('tdg', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """

--- a/qiskit/extensions/standard/u1.py
+++ b/qiskit/extensions/standard/u1.py
@@ -27,9 +27,16 @@ from qiskit.util import deprecate_arguments
 class U1Gate(Gate):
     """Diagonal single-qubit gate."""
 
+    name = 'u1'
+    num_qubits = 1
+    num_params = 1
+
     def __init__(self, theta, label=None):
         """Create new diagonal single-qubit gate."""
-        super().__init__('u1', 1, [theta], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta],
+                         label=label)
 
     def _define(self):
         from qiskit.extensions.standard.u3 import U3Gate
@@ -119,9 +126,16 @@ class CU1Meta(type):
 class CU1Gate(ControlledGate, metaclass=CU1Meta):
     """The controlled-u1 gate."""
 
+    name = 'cu1'
+    num_qubits = 2
+    num_params = 1
+
     def __init__(self, theta):
         """Create new cu1 gate."""
-        super().__init__('cu1', 2, [theta], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta],
+                         num_ctrl_qubits=1)
         self.base_gate = U1Gate(theta)
 
     def _define(self):

--- a/qiskit/extensions/standard/u2.py
+++ b/qiskit/extensions/standard/u2.py
@@ -26,9 +26,16 @@ from qiskit.util import deprecate_arguments
 class U2Gate(Gate):
     """One-pulse single-qubit gate."""
 
+    name = 'u2'
+    num_qubits = 1
+    num_params = 2
+
     def __init__(self, phi, lam, label=None):
         """Create new one-pulse single-qubit gate."""
-        super().__init__('u2', 1, [phi, lam], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [phi, lam],
+                         label=label)
 
     def _define(self):
         from qiskit.extensions.standard.u3 import U3Gate

--- a/qiskit/extensions/standard/u3.py
+++ b/qiskit/extensions/standard/u3.py
@@ -28,9 +28,16 @@ from qiskit.util import deprecate_arguments
 class U3Gate(Gate):
     """Two-pulse single-qubit gate."""
 
+    name = 'u3'
+    num_qubits = 1
+    num_params = 3
+
     def __init__(self, theta, phi, lam, label=None):
         """Create new two-pulse single qubit gate."""
-        super().__init__('u3', 1, [theta, phi, lam], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta, phi, lam],
+                         label=label)
 
     def inverse(self):
         """Invert this gate.
@@ -120,9 +127,16 @@ class CU3Meta(type):
 class CU3Gate(ControlledGate, metaclass=CU3Meta):
     """The controlled-u3 gate."""
 
+    name = 'cu3'
+    num_qubits = 2
+    num_params = 3
+
     def __init__(self, theta, phi, lam):
         """Create new cu3 gate."""
-        super().__init__('cu3', 2, [theta, phi, lam], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [theta, phi, lam],
+                         num_ctrl_qubits=1)
         self.base_gate = U3Gate(theta, phi, lam)
 
     def _define(self):

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -30,9 +30,16 @@ from qiskit.util import deprecate_arguments
 class XGate(Gate):
     """Pauli X (bit-flip) gate."""
 
+    name = 'x'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new X gate."""
-        super().__init__('x', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         """
@@ -127,9 +134,16 @@ class CXMeta(type):
 class CXGate(ControlledGate, metaclass=CXMeta):
     """The controlled-X gate."""
 
+    name = 'cx'
+    num_qubits = 2
+    num_params = 0
+
     def __init__(self):
         """Create new cx gate."""
-        super().__init__('cx', 2, [], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         num_ctrl_qubits=1)
         self.base_gate = XGate()
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -227,9 +241,16 @@ class CCXMeta(type):
 class CCXGate(ControlledGate, metaclass=CCXMeta):
     """The double-controlled-not gate, also called Toffoli gate."""
 
+    name = 'ccx'
+    num_qubits = 3
+    num_params = 0
+
     def __init__(self):
         """Create new CCX gate."""
-        super().__init__('ccx', 3, [], num_ctrl_qubits=2)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         num_ctrl_qubits=2)
         self.base_gate = XGate()
 
     def _define(self):

--- a/qiskit/extensions/standard/y.py
+++ b/qiskit/extensions/standard/y.py
@@ -27,9 +27,16 @@ from qiskit.util import deprecate_arguments
 class YGate(Gate):
     """Pauli Y (bit-phase-flip) gate."""
 
+    name = 'y'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new Y gate."""
-        super().__init__('y', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         from qiskit.extensions.standard.u3 import U3Gate
@@ -117,9 +124,16 @@ class CYMeta(type):
 class CYGate(ControlledGate, metaclass=CYMeta):
     """The controlled-Y gate."""
 
+    name = 'cy'
+    num_qubits = 2
+    num_params = 0
+
     def __init__(self):
         """Create a new CY gate."""
-        super().__init__('cy', 2, [], num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         num_ctrl_qubits=1)
         self.base_gate = YGate()
 
     def _define(self):

--- a/qiskit/extensions/standard/z.py
+++ b/qiskit/extensions/standard/z.py
@@ -27,9 +27,16 @@ from qiskit.util import deprecate_arguments
 class ZGate(Gate):
     """Pauli Z (phase-flip) gate."""
 
+    name = 'z'
+    num_qubits = 1
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new Z gate."""
-        super().__init__('z', 1, [], label=label)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label)
 
     def _define(self):
         from qiskit.extensions.standard.u1 import U1Gate
@@ -117,9 +124,17 @@ class CZMeta(type):
 class CZGate(ControlledGate, metaclass=CZMeta):
     """The controlled-Z gate."""
 
+    name = 'cz'
+    num_qubits = 2
+    num_params = 0
+
     def __init__(self, label=None):
         """Create new CZ gate."""
-        super().__init__('cz', 2, [], label=label, num_ctrl_qubits=1)
+        super().__init__(self.name,
+                         self.num_qubits,
+                         [],
+                         label=label,
+                         num_ctrl_qubits=1)
         self.base_gate = ZGate()
 
     def _define(self):

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -36,6 +36,8 @@ _DECOMPOSER1Q = OneQubitEulerDecomposer('U3')
 class UnitaryGate(Gate):
     """Class for representing unitary gates"""
 
+    name = 'unitary'
+
     def __init__(self, data, label=None):
         """Create a gate from a numeric unitary matrix.
 
@@ -71,7 +73,7 @@ class UnitaryGate(Gate):
         self._qasm_definition = None
         self._qasm_def_written = False
         # Store instruction params
-        super().__init__('unitary', n_qubits, [data], label=label)
+        super().__init__(self.name, n_qubits, [data], label=label)
 
     def __eq__(self, other):
         if not isinstance(other, UnitaryGate):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently, some useful details about each instruction or gate class are only available inside each instruction's `__init__` method. e.g.
```
class HGate():
    def __init__(self):
        super().__init__('h', 1, [], num_ctrl_qubits=1)
```
meaning that when given an `Instruction` subclass, the only way to find out which instruction it is is to instantiate it and then query its name, num_qubits, etc. This PR promotes name, num_qubits, num_clbits, and num_parameters to be class attributes when known in advance (defaulting to `None` when these cannot be known until the gate is created.)


### Details and comments


