### PR TITLE
Add missing parameter from QasmQobjInstruction

### DIFF
--- a/qiskit/qobj/qasm_qobj.py
+++ b/qiskit/qobj/qasm_qobj.py
@@ -37,7 +37,7 @@ class QasmQobjInstruction:
 
     def __init__(self, name, params=None, qubits=None, register=None,
                  memory=None, condition=None, conditional=None, label=None,
-                 mask=None, relation=None, val=None):
+                 mask=None, relation=None, val=None, snapshot_type=None):
         """Instatiate a new QasmQobjInstruction object.
 
         Args:
@@ -67,6 +67,8 @@ class QasmQobjInstruction:
                 ``!=`` (not equals).
             val (int): Value to which to compare the masked register. In other
                 words, the output of the function is ``(register AND mask)``
+            snapshot_type (str): For snapshot instructions the type of snapshot
+                to use
         """
         self.name = name
         if params is not None:
@@ -89,6 +91,8 @@ class QasmQobjInstruction:
             self.relation = relation
         if val is not None:
             self.val = val
+        if snapshot_type is not None:
+            self.snapshot_type = snapshot_type
 
     def to_dict(self):
         """Return a dictionary format representation of the Instruction.
@@ -98,7 +102,8 @@ class QasmQobjInstruction:
         """
         out_dict = {'name': self.name}
         for attr in ['params', 'qubits', 'register', 'memory', '_condition',
-                     'conditional', 'label', 'mask', 'relation', 'val']:
+                     'conditional', 'label', 'mask', 'relation', 'val',
+                     'snapshot_type']:
             if hasattr(self, attr):
                 out_dict[attr] = getattr(self, attr)
 

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -132,8 +132,8 @@ class TestQASMQobj(QiskitTestCase):
                     {'name': 'snapshot', 'qubits': [1],
                      'snapshot_type': 'statevector', 'label': 'my_snap'}
                 ],
-                'config': {},
-                'header': {}}
+                 'config': {},
+                 'header': {}}
             ],
         }
         self.assertEqual(expected_dict, res)

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -102,6 +102,75 @@ class TestQASMQobj(QiskitTestCase):
             with self.subTest(msg=str(qobj_class)):
                 self.assertEqual(qobj_item, qobj_class.from_dict(expected_dict))
 
+    def test_snapshot_instruction_to_dict(self):
+        """Test snapshot instruction to dict."""
+        valid_qobj = QasmQobj(
+            qobj_id='12345',
+            header=QobjHeader(),
+            config=QasmQobjConfig(shots=1024, memory_slots=2, max_credits=10),
+            experiments=[
+                QasmQobjExperiment(instructions=[
+                    QasmQobjInstruction(name='u1', qubits=[1], params=[0.4]),
+                    QasmQobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2]),
+                    QasmQobjInstruction(name='snapshot', qubits=[1],
+                                        snapshot_type='statevector',
+                                        label='my_snap')
+                ])
+            ]
+        )
+        res = valid_qobj.to_dict(validate=True)
+        expected_dict = {
+            'qobj_id': '12345',
+            'type': 'QASM',
+            'schema_version': '1.1.0',
+            'header': {},
+            'config': {'max_credits': 10, 'memory_slots': 2, 'shots': 1024},
+            'experiments': [
+                {'instructions': [
+                    {'name': 'u1', 'params': [0.4], 'qubits': [1]},
+                    {'name': 'u2', 'params': [0.4, 0.2], 'qubits': [1]},
+                    {'name': 'snapshot', 'qubits': [1],
+                     'snapshot_type': 'statevector', 'label': 'my_snap'}
+                ],
+                'config': {},
+                'header': {}}
+            ],
+        }
+        self.assertEqual(expected_dict, res)
+
+    def test_snapshot_instruction_from_dict(self):
+        """Test snapshot instruction from dict."""
+        expected_qobj = QasmQobj(
+            qobj_id='12345',
+            header=QobjHeader(),
+            config=QasmQobjConfig(shots=1024, memory_slots=2, max_credits=10),
+            experiments=[
+                QasmQobjExperiment(instructions=[
+                    QasmQobjInstruction(name='u1', qubits=[1], params=[0.4]),
+                    QasmQobjInstruction(name='u2', qubits=[1], params=[0.4, 0.2]),
+                    QasmQobjInstruction(name='snapshot', qubits=[1],
+                                        snapshot_type='statevector',
+                                        label='my_snap')
+                ])
+            ]
+        )
+        qobj_dict = {
+            'qobj_id': '12345',
+            'type': 'QASM',
+            'schema_version': '1.1.0',
+            'header': {},
+            'config': {'max_credits': 10, 'memory_slots': 2, 'shots': 1024},
+            'experiments': [
+                {'instructions': [
+                    {'name': 'u1', 'params': [0.4], 'qubits': [1]},
+                    {'name': 'u2', 'params': [0.4, 0.2], 'qubits': [1]},
+                    {'name': 'snapshot', 'qubits': [1],
+                     'snapshot_type': 'statevector', 'label': 'my_snap'}
+                ]}
+            ],
+        }
+        self.assertEqual(expected_qobj, QasmQobj.from_dict(qobj_dict))
+
     def test_simjob_raises_error_when_sending_bad_qobj(self):
         """Test SimulatorJob is denied resource request access when given an invalid Qobj instance.
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3383 we moved away from using marshmallow for Qobj objects to flat
classes with normal attributes. However, in that migration we missed one
parameter for the qasm qobj instruction class which had no test coverage
in terra (and is only used by Aer), snapshot_type. This commit corrects
the oversight and adds test coverage to ensure we don't miss it in the
future.

### Details and comments