### PR TITLE
Allow list params in Instruction

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -163,7 +163,7 @@ class Instruction:
             # example: snapshot('label')
             elif isinstance(single_param, str):
                 self._params.append(single_param)
-            # example: Aer expectation_value_snapshot
+            # example: Aer expectation_value_snapshot [complex, 'X']
             elif isinstance(single_param, list):
                 self._params.append(single_param)
             # example: numpy.array([[1, 0], [0, 1]])

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -58,7 +58,8 @@ class Instruction:
             name (str): instruction name
             num_qubits (int): instruction's qubit width
             num_clbits (int): instruction's clbit width
-            params (list[int|float|complex|str|ndarray|ParameterExpression]): list of parameters
+            params (list[int|float|complex|str|ndarray|list|ParameterExpression]):
+                list of parameters
 
         Raises:
             CircuitError: when the register is not in the correct format.
@@ -161,6 +162,9 @@ class Instruction:
                 self._params.append(single_param)
             # example: snapshot('label')
             elif isinstance(single_param, str):
+                self._params.append(single_param)
+            # example: Aer expectation_value_snapshot
+            elif isinstance(single_param, list):
                 self._params.append(single_param)
             # example: numpy.array([[1, 0], [0, 1]])
             elif isinstance(single_param, numpy.ndarray):

--- a/releasenotes/notes/list-params-1fa4c3f8b67ff57d.yaml
+++ b/releasenotes/notes/list-params-1fa4c3f8b67ff57d.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Allow quantum circuit Instructions to have list parameter values. This is
+    used in Aer for expectation value snapshot parameters for example:
+      ``params = [[1.0, 'I'], [1.0, 'X']]]`` for :math:`\langle I + X\rangle`.

--- a/releasenotes/notes/list-params-1fa4c3f8b67ff57d.yaml
+++ b/releasenotes/notes/list-params-1fa4c3f8b67ff57d.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Allow quantum circuit Instructions to have list parameter values. This is
-    used in Aer for expectation value snapshot parameters for example:
-      ``params = [[1.0, 'I'], [1.0, 'X']]]`` for :math:`\langle I + X\rangle`.
+    used in Aer for expectation value snapshot parameters for example
+    ``params = [[1.0, 'I'], [1.0, 'X']]]`` for :math:`\langle I + X\rangle`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds `list` param setter case in `Instruction` class. This is used by expectation value snapshots in Aer.

### Details and comments

We previous hacked around this not being supported by wrapping the lists as object Numpy arrays that were later converted back to list during assembly of Qobj, however the recent removal of Marshmallow classes broke this so we should add a proper fix.