### PR TITLE
Convert ParameterExpression to float in QasmQobjInstruction.to_dict()

### DIFF
--- a/qiskit/qobj/qasm_qobj.py
+++ b/qiskit/qobj/qasm_qobj.py
@@ -22,6 +22,8 @@ from types import SimpleNamespace
 import json
 import fastjsonschema
 
+from qiskit.circuit.parameterexpression import ParameterExpression
+
 
 path_part = 'schemas/qobj_schema.json'
 path = os.path.join(
@@ -105,7 +107,18 @@ class QasmQobjInstruction:
                      'conditional', 'label', 'mask', 'relation', 'val',
                      'snapshot_type']:
             if hasattr(self, attr):
-                out_dict[attr] = getattr(self, attr)
+                # TODO: Remove the param type conversion when Aer understands
+                # ParameterExpression type
+                if attr == 'params':
+                    params = []
+                    for param in list(getattr(self, attr)):
+                        if isinstance(param, ParameterExpression):
+                            params.append(float(param))
+                        else:
+                            params.append(param)
+                    out_dict[attr] = params
+                else:
+                    out_dict[attr] = getattr(self, attr)
 
         return out_dict
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3383 we removed marshmallow from the qobj objects a side effect of
this was the type coercion to something that was serializable with a
bare json.dumps() call was removed. In the majority of cases this wasn't
necessary as this was either something easily handled in a json
serializer class, or for aer (and other local simulators) are native
types that casting adds unnecessary overhead. However, there was one
edge case missed, the ParameterExpression class which is used for
parameterized circuits. This is a terra class and while it's easy to fix
in the ibmq provider for json serialization (although it hasn't been
yet, a PR will be pushed for this shortly) Aer doesn't have native
handling of this class. As a workaround until this is fixed the
QasmQobjInstruction's to_dict() method will loop over gate parameters to
check if there are any ParameterExpression objects and convert them to a
float. There is likely a performance penalty for doing this, and when a
more longstanding fix is built we should remove this.

### Details and comments