### PR TITLE
Fix preset pass managers to not always decompose Swaps

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1058,7 +1058,7 @@ class DAGCircuit:
         warnings.warn('deprecated function, use dag.two_q_ops', DeprecationWarning)
         two_q_ops = []
         for node in self.op_nodes(include_directives=False):
-            if len(node.qargs) == 3:
+            if len(node.qargs) == 2:
                 two_q_ops.append(node)
         return two_q_ops
 

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1038,6 +1038,7 @@ class DAGCircuit:
 
     def twoQ_gates(self):
         """Get list of 2-qubit gates. Ignore snapshot, barriers, and the like."""
+        warnings.warn('deprecated function, use dag.two_qubit_ops', DeprecationWarning)
         two_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) == 2:
@@ -1046,29 +1047,28 @@ class DAGCircuit:
 
     def threeQ_or_more_gates(self):
         """Get list of 3-or-more-qubit gates: (id, data)."""
-        warnings.warn('deprecated function, use dag.multi_q_ops', DeprecationWarning)
+        warnings.warn('deprecated function, use dag.multi_qubit_ops', DeprecationWarning)
         three_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) >= 3:
                 three_q_gates.append(node)
         return three_q_gates
 
-    def two_q_ops(self):
+    def two_qubit_ops(self):
         """Get list of 2 qubit operations. Ignore directives like snapshot and barrier."""
-        warnings.warn('deprecated function, use dag.two_q_ops', DeprecationWarning)
-        two_q_ops = []
+        ops = []
         for node in self.op_nodes(include_directives=False):
             if len(node.qargs) == 2:
-                two_q_ops.append(node)
-        return two_q_ops
+                ops.append(node)
+        return ops
 
-    def multi_q_ops(self):
+    def multi_qubit_ops(self):
         """Get list of 3+ qubit operations. Ignore directives like snapshot and barrier."""
-        multi_q_ops = []
+        ops = []
         for node in self.op_nodes(include_directives=False):
             if len(node.qargs) >= 3:
-                multi_q_ops.append(node)
-        return multi_q_ops
+                ops.append(node)
+        return ops
 
     def longest_path(self):
         """Returns the longest path in the dag as a list of DAGNodes."""

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1038,7 +1038,9 @@ class DAGCircuit:
 
     def twoQ_gates(self):
         """Get list of 2-qubit gates. Ignore snapshot, barriers, and the like."""
-        warnings.warn('deprecated function, use dag.two_qubit_ops', DeprecationWarning)
+        warnings.warn('deprecated function, use dag.two_qubit_ops(). '
+                      'filter output by isinstance(op, Gate) to only get unitary Gates.',
+                      DeprecationWarning)
         two_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) == 2:
@@ -1047,7 +1049,9 @@ class DAGCircuit:
 
     def threeQ_or_more_gates(self):
         """Get list of 3-or-more-qubit gates: (id, data)."""
-        warnings.warn('deprecated function, use dag.multi_qubit_ops', DeprecationWarning)
+        warnings.warn('deprecated function, use dag.multi_qubit_ops(). '
+                      'filter output by isinstance(op, Gate) to only get unitary Gates.',
+                      DeprecationWarning)
         three_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) >= 3:

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1001,7 +1001,8 @@ class DAGCircuit:
         """Get the list of "op" nodes in the dag.
 
         Args:
-            op (Instruction): op nodes to return. if None, return all op nodes.
+            op (qiskit.circuit.Instruction): op nodes to return.
+                If None, return all op nodes.
             include_directives (bool): include `barrier`, `snapshot` etc.
 
         Returns:

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1053,6 +1053,15 @@ class DAGCircuit:
                 three_q_gates.append(node)
         return three_q_gates
 
+    def two_q_ops(self):
+        """Get list of 2 qubit operations. Ignore directives like snapshot and barrier."""
+        warnings.warn('deprecated function, use dag.two_q_ops', DeprecationWarning)
+        two_q_ops = []
+        for node in self.op_nodes(include_directives=False):
+            if len(node.qargs) == 3:
+                two_q_ops.append(node)
+        return two_q_ops
+
     def multi_q_ops(self):
         """Get list of 3+ qubit operations. Ignore directives like snapshot and barrier."""
         multi_q_ops = []

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -32,7 +32,7 @@ class Unroll3qOrMore(TransformationPass):
         Raises:
             QiskitError: if a 3q+ gate is not decomposable
         """
-        for node in dag.threeQ_or_more_gates():
+        for node in dag.multi_q_ops():
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -32,7 +32,7 @@ class Unroll3qOrMore(TransformationPass):
         Raises:
             QiskitError: if a 3q+ gate is not decomposable
         """
-        for node in dag.multi_q_ops():
+        for node in dag.multi_qubit_ops():
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:

--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -105,7 +105,7 @@ class CSPLayout(AnalysisPass):
         qubits = dag.qubits()
         cxs = set()
 
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             cxs.add((qubits.index(gate.qargs[0]),
                      qubits.index(gate.qargs[1])))
         edges = self.coupling_map.get_edges()

--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -105,7 +105,7 @@ class CSPLayout(AnalysisPass):
         qubits = dag.qubits()
         cxs = set()
 
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             cxs.add((qubits.index(gate.qargs[0]),
                      qubits.index(gate.qargs[1])))
         edges = self.coupling_map.get_edges()

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -55,7 +55,7 @@ class Layout2qDistance(AnalysisPass):
 
         sum_distance = 0
 
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             physical_q0 = layout[gate.qargs[0]]
             physical_q1 = layout[gate.qargs[1]]
 

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -55,7 +55,7 @@ class Layout2qDistance(AnalysisPass):
 
         sum_distance = 0
 
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             physical_q0 = layout[gate.qargs[0]]
             physical_q1 = layout[gate.qargs[1]]
 

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -143,7 +143,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         for q in dag.qubits():
             self.qarg_to_id[q.register.name + str(q.index)] = idx
             idx += 1
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             qid1 = self._qarg_to_id(gate.qargs[0])
             qid2 = self._qarg_to_id(gate.qargs[1])
             min_q = min(qid1, qid2)

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -143,7 +143,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         for q in dag.qubits():
             self.qarg_to_id[q.register.name + str(q.index)] = idx
             idx += 1
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             qid1 = self._qarg_to_id(gate.qargs[0])
             qid2 = self._qarg_to_id(gate.qargs[1])
             min_q = min(qid1, qid2)

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -220,7 +220,7 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
         Currenty overlaps (A,B) are considered when A is a 2q gate and
         B is either 2q or 1q gate.
         """
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             overlap_set = []
             descendants = dag.descendants(gate)
             ancestors = dag.ancestors(gate)

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -220,7 +220,7 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
         Currenty overlaps (A,B) are considered when A is a 2q gate and
         B is either 2q or 1q gate.
         """
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             overlap_set = []
             descendants = dag.descendants(gate)
             ancestors = dag.ancestors(gate)

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -66,7 +66,7 @@ class BasicSwap(TransformationPass):
         for layer in dag.serial_layers():
             subdag = layer['graph']
 
-            for gate in subdag.two_q_ops():
+            for gate in subdag.two_qubit_ops():
                 physical_q0 = current_layout[gate.qargs[0]]
                 physical_q1 = current_layout[gate.qargs[1]]
                 if self.coupling_map.distance(physical_q0, physical_q1) != 1:

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -66,7 +66,7 @@ class BasicSwap(TransformationPass):
         for layer in dag.serial_layers():
             subdag = layer['graph']
 
-            for gate in subdag.twoQ_gates():
+            for gate in subdag.two_q_ops():
                 physical_q0 = current_layout[gate.qargs[0]]
                 physical_q1 = current_layout[gate.qargs[1]]
                 if self.coupling_map.distance(physical_q0, physical_q1) != 1:

--- a/qiskit/transpiler/passes/utils/check_cx_direction.py
+++ b/qiskit/transpiler/passes/utils/check_cx_direction.py
@@ -49,7 +49,7 @@ class CheckCXDirection(AnalysisPass):
         self.property_set['is_direction_mapped'] = True
         edges = self.coupling_map.get_edges()
 
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             physical_q0 = gate.qargs[0].index
             physical_q1 = gate.qargs[1].index
 

--- a/qiskit/transpiler/passes/utils/check_cx_direction.py
+++ b/qiskit/transpiler/passes/utils/check_cx_direction.py
@@ -49,7 +49,7 @@ class CheckCXDirection(AnalysisPass):
         self.property_set['is_direction_mapped'] = True
         edges = self.coupling_map.get_edges()
 
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             physical_q0 = gate.qargs[0].index
             physical_q1 = gate.qargs[1].index
 

--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -45,7 +45,7 @@ class CheckMap(AnalysisPass):
         """
         self.property_set['is_swap_mapped'] = True
 
-        for gate in dag.twoQ_gates():
+        for gate in dag.two_q_ops():
             physical_q0 = gate.qargs[0].index
             physical_q1 = gate.qargs[1].index
 

--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -45,7 +45,7 @@ class CheckMap(AnalysisPass):
         """
         self.property_set['is_swap_mapped'] = True
 
-        for gate in dag.two_q_ops():
+        for gate in dag.two_qubit_ops():
             physical_q0 = gate.qargs[0].index
             physical_q1 = gate.qargs[1].index
 

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -72,7 +72,8 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     _given_layout = SetLayout(initial_layout)
 
     _choose_layout_and_score = [TrivialLayout(coupling_map),
-            Layout2qDistance(coupling_map, property_name='trivial_layout_score')]
+                                Layout2qDistance(coupling_map,
+                                                 property_name='trivial_layout_score')]
 
     def _choose_layout_condition(property_set):
         return not property_set['layout']

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -19,12 +19,10 @@ Level 1 pass manager: light optimization by simple adjacent gate collapsing.
 
 from qiskit.transpiler.pass_manager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
-from qiskit.extensions.standard import SwapGate
 
 from qiskit.transpiler.passes import Unroller
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CXCancellation
-from qiskit.transpiler.passes import Decompose
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
@@ -71,12 +69,17 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     backend_properties = pass_manager_config.backend_properties
 
     # 1. Use trivial layout if no layout given
-    _set_initial_layout = SetLayout(initial_layout)
+    _given_layout = SetLayout(initial_layout)
+
+    _choose_layout_and_score = [TrivialLayout(coupling_map),
+            Layout2qDistance(coupling_map, property_name='trivial_layout_score')]
 
     def _choose_layout_condition(property_set):
         return not property_set['layout']
 
     # 2. Use a better layout on densely connected qubits, if circuit needs swaps
+    _improve_layout = DenseLayout(coupling_map, backend_properties)
+
     def _not_perfect_yet(property_set):
         return property_set['trivial_layout_score'] is not None and \
                property_set['trivial_layout_score'] != 0
@@ -84,8 +87,8 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     # 3. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
 
-    # 4. Unroll to the basis
-    _unroll = Unroller(basis_gates)
+    # 4. Decompose so only 1-qubit and 2-qubit gates remain
+    _unroll3q = Unroll3qOrMore()
 
     # 5. Swap to fit the coupling map
     _swap_check = CheckMap(coupling_map)
@@ -94,11 +97,12 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         return not property_set['is_swap_mapped']
 
     _swap = [BarrierBeforeFinalMeasurements(),
-             Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler),
-             Decompose(SwapGate)]
+             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
 
-    # 6. Fix any bad CX directions
+    # 6. Unroll to the basis
+    _unroll = Unroller(basis_gates)
+
+    # 7. Fix any bad CX directions
     _direction_check = [CheckCXDirection(coupling_map)]
 
     def _direction_condition(property_set):
@@ -106,10 +110,10 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _direction = [CXDirection(coupling_map)]
 
-    # 7. Remove zero-state reset
+    # 8. Remove zero-state reset
     _reset = RemoveResetInZeroState()
 
-    # 8. Merge 1q rotations and cancel CNOT gates iteratively until no more change in depth
+    # 9. Merge 1q rotations and cancel CNOT gates iteratively until no more change in depth
     _depth_check = [Depth(), FixedPoint('depth')]
 
     def _opt_control(property_set):
@@ -117,21 +121,20 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _opt = [Optimize1qGates(), CXCancellation()]
 
+    # Build pass manager
     pm1 = PassManager()
     if coupling_map:
-        pm1.append(_set_initial_layout)
-        pm1.append([TrivialLayout(coupling_map),
-                    Layout2qDistance(coupling_map, property_name='trivial_layout_score')],
-                   condition=_choose_layout_condition)
-        pm1.append(DenseLayout(coupling_map, backend_properties), condition=_not_perfect_yet)
+        pm1.append(_given_layout)
+        pm1.append(_choose_layout_and_score, condition=_choose_layout_condition)
+        pm1.append(_improve_layout, condition=_not_perfect_yet)
         pm1.append(_embed)
-    pm1.append(_unroll)
-    if coupling_map:
+        pm1.append(_unroll3q)
         pm1.append(_swap_check)
         pm1.append(_swap, condition=_swap_condition)
-        if not coupling_map.is_symmetric:
-            pm1.append(_direction_check)
-            pm1.append(_direction, condition=_direction_condition)
+    pm1.append(_unroll)
+    if coupling_map and not coupling_map.is_symmetric:
+        pm1.append(_direction_check)
+        pm1.append(_direction, condition=_direction_condition)
     pm1.append(_reset)
     pm1.append(_depth_check + _opt, do_while=_opt_control)
 

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -20,11 +20,9 @@ gate cancellation using commutativity rules.
 
 from qiskit.transpiler.pass_manager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
-from qiskit.extensions.standard import SwapGate
 
 from qiskit.transpiler.passes import Unroller
 from qiskit.transpiler.passes import Unroll3qOrMore
-from qiskit.transpiler.passes import Decompose
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
@@ -44,13 +42,12 @@ from qiskit.transpiler.passes import CheckCXDirection
 
 
 def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
-    """Level 2 pass manager: medium optimization by noise adaptive qubit mapping and
+    """Level 2 pass manager: medium optimization by initial layout selection and
     gate cancellation using commutativity rules.
 
-    This pass manager applies the user-given initial layout. If none is given, and
-    device calibration information is available, the circuit is mapped to the qubits
-    with best readouts and to CX gates with highest fidelity. Otherwise, a layout on
-    the most densely connected qubits is used.
+    This pass manager applies the user-given initial layout. If none is given, a search
+    for a perfect layout (i.e. one that satisfies all 2-qubit interactions) is conducted.
+    If no such layout is found, qubits are laid out on the most densely connected subset.
     The pass manager then transforms the circuit to match the coupling constraints.
     It is then unrolled to the basis, and any flipped cx directions are fixed.
     Finally, optimizations in the form of commutative gate cancellation and redundant
@@ -72,32 +69,34 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
-    # 1. Unroll to the basis first, to prepare for noise-adaptive layout
-    _unroll = Unroller(basis_gates)
-
-    # 2. Layout on good qubits if calibration info available, otherwise on dense links
+    # 1. Search for a perfect layout, or choose a dense layout, if no layout given
     _given_layout = SetLayout(initial_layout)
 
     def _choose_layout_condition(property_set):
         return not property_set['layout']
 
-    _choose_layout = DenseLayout(coupling_map, backend_properties)
+    _choose_layout_1 = CSPLayout(coupling_map, call_limit=1000, time_limit=10)
+    _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
 
-    # 3. Extend dag/layout with ancillas using the full coupling map
+    # 2. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
 
-    # 4. Unroll to 1q or 2q gates, swap to fit the coupling map
+    # 3. Unroll to 1q or 2q gates
+    _unroll3q = Unroll3qOrMore()
+
+    # 4. Swap to fit the coupling map
     _swap_check = CheckMap(coupling_map)
 
     def _swap_condition(property_set):
         return not property_set['is_swap_mapped']
 
     _swap = [BarrierBeforeFinalMeasurements(),
-             Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler),
-             Decompose(SwapGate)]
+             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
 
-    # 5. Fix any bad CX directions
+    # 5. Unroll to the basis
+    _unroll = Unroller(basis_gates)
+
+    # 6. Fix any bad CX directions
     _direction_check = [CheckCXDirection(coupling_map)]
 
     def _direction_condition(property_set):
@@ -105,10 +104,10 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _direction = [CXDirection(coupling_map)]
 
-    # 6. Remove zero-state reset
+    # 7. Remove zero-state reset
     _reset = RemoveResetInZeroState()
 
-    # 7. 1q rotation merge and commutative cancellation iteratively until no more change in depth
+    # 8. 1q rotation merge and commutative cancellation iteratively until no more change in depth
     _depth_check = [Depth(), FixedPoint('depth')]
 
     def _opt_control(property_set):
@@ -116,19 +115,20 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _opt = [Optimize1qGates(), CommutativeCancellation()]
 
+    # Build pass manager
     pm2 = PassManager()
-    pm2.append(_unroll)
     if coupling_map:
         pm2.append(_given_layout)
-        pm2.append(CSPLayout(coupling_map, call_limit=1000, time_limit=10),
-                   condition=_choose_layout_condition)
-        pm2.append(_choose_layout, condition=_choose_layout_condition)
+        pm2.append(_choose_layout_1, condition=_choose_layout_condition)
+        pm2.append(_choose_layout_2, condition=_choose_layout_condition)
         pm2.append(_embed)
+        pm2.append(_unroll3q)
         pm2.append(_swap_check)
         pm2.append(_swap, condition=_swap_condition)
-        if not coupling_map.is_symmetric:
-            pm2.append(_direction_check)
-            pm2.append(_direction, condition=_direction_condition)
+    pm2.append(_unroll)
+    if coupling_map and not coupling_map.is_symmetric:
+        pm2.append(_direction_check)
+        pm2.append(_direction, condition=_direction_condition)
     pm2.append(_reset)
     pm2.append(_depth_check + _opt, do_while=_opt_control)
 

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -47,7 +47,9 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     This pass manager applies the user-given initial layout. If none is given, a search
     for a perfect layout (i.e. one that satisfies all 2-qubit interactions) is conducted.
-    If no such layout is found, qubits are laid out on the most densely connected subset.
+    If no such layout is found, qubits are laid out on the most densely connected subset
+    which also exhibits the best gate fidelitites.
+
     The pass manager then transforms the circuit to match the coupling constraints.
     It is then unrolled to the basis, and any flipped cx directions are fixed.
     Finally, optimizations in the form of commutative gate cancellation and redundant

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -26,7 +26,6 @@ from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
-from qiskit.transpiler.passes import DenseLayout
 from qiskit.transpiler.passes import CSPLayout
 from qiskit.transpiler.passes import NoiseAdaptiveLayout
 from qiskit.transpiler.passes import StochasticSwap

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -27,7 +27,7 @@ from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler.passes import CSPLayout
-from qiskit.transpiler.passes import NoiseAdaptiveLayout
+from qiskit.transpiler.passes import DenseLayout
 from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
 from qiskit.transpiler.passes import FullAncillaAllocation
@@ -85,7 +85,8 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         return not property_set['layout']
 
     _choose_layout_1 = CSPLayout(coupling_map, call_limit=10000, time_limit=60)
-    _choose_layout_2 = NoiseAdaptiveLayout(backend_properties)
+    # TODO: benchmark DenseLayout vs. NoiseAdaptiveLayout in terms of noise aware mapping
+    _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
 
     # 3. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -120,7 +120,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         # test of text drawer
         self.log.info(qc2)
         dag = circuit_to_dag(qc)
-        nodes = dag.twoQ_gates()
+        nodes = dag.two_q_ops()
         self.assertTrue(len(nodes) == 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -144,7 +144,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         # test of text drawer
         self.log.info(qc)
         dag = circuit_to_dag(qc)
-        nodes = dag.threeQ_or_more_gates()
+        nodes = dag.multi_q_ops()
         self.assertTrue(len(nodes) == 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -60,7 +60,7 @@ class TestUnitaryGate(QiskitTestCase):
         """test instantiation of new unitary with another one (copy)"""
         uni1 = UnitaryGate([[0, 1], [1, 0]])
         uni2 = UnitaryGate(uni1)
-        self.assertTrue(uni1 == uni2)
+        self.assertEqual(uni1, uni2)
         self.assertFalse(uni1 is uni2)
 
     def test_conjugate(self):
@@ -97,7 +97,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         dnode = dag_nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)
         for qubit in dnode.qargs:
-            self.assertTrue(qubit.index in [0, 1])
+            self.assertIn(qubit.index, [0, 1])
         assert_allclose(dnode.op.to_matrix(), matrix)
 
     def test_2q_unitary(self):
@@ -121,11 +121,11 @@ class TestUnitaryCircuit(QiskitTestCase):
         self.log.info(qc2)
         dag = circuit_to_dag(qc)
         nodes = dag.two_q_ops()
-        self.assertTrue(len(nodes) == 1)
+        self.assertEqual(len(nodes), 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)
         for qubit in dnode.qargs:
-            self.assertTrue(qubit.index in [0, 1])
+            self.assertIn(qubit.index, [0, 1])
         assert_allclose(dnode.op.to_matrix(), matrix)
         qc3 = dag_to_circuit(dag)
         self.assertEqual(qc2, qc3)
@@ -145,11 +145,11 @@ class TestUnitaryCircuit(QiskitTestCase):
         self.log.info(qc)
         dag = circuit_to_dag(qc)
         nodes = dag.multi_q_ops()
-        self.assertTrue(len(nodes) == 1)
+        self.assertEqual(len(nodes), 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)
         for qubit in dnode.qargs:
-            self.assertTrue(qubit.index in [0, 1, 3])
+            self.assertIn(qubit.index, [0, 1, 3])
         assert_allclose(dnode.op.to_matrix(), matrix)
 
     def test_qobj_with_unitary_matrix(self):

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -120,7 +120,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         # test of text drawer
         self.log.info(qc2)
         dag = circuit_to_dag(qc)
-        nodes = dag.two_q_ops()
+        nodes = dag.two_qubit_ops()
         self.assertEqual(len(nodes), 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)
@@ -144,7 +144,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         # test of text drawer
         self.log.info(qc)
         dag = circuit_to_dag(qc)
-        nodes = dag.multi_q_ops()
+        nodes = dag.multi_qubit_ops()
         self.assertEqual(len(nodes), 1)
         dnode = nodes[0]
         self.assertIsInstance(dnode.op, UnitaryGate)

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -481,13 +481,13 @@ class TestDagOperations(QiskitTestCase):
         self.assertIsInstance(op_node_2.op, Gate)
 
     def test_two_q_gates(self):
-        """The method dag.twoQ_gates() returns all 2Q gate nodes"""
+        """The method dag.two_q_ops() returns all 2Q gate operation nodes"""
         self.dag.apply_operation_back(HGate(), [self.qubit0], [])
         self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(Barrier(2), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(Reset(), [self.qubit0], [])
 
-        op_nodes = self.dag.twoQ_gates()
+        op_nodes = self.dag.two_q_ops()
         self.assertEqual(len(op_nodes), 1)
 
         op_node = op_nodes.pop()

--- a/test/python/test_dagcircuit.py
+++ b/test/python/test_dagcircuit.py
@@ -481,13 +481,13 @@ class TestDagOperations(QiskitTestCase):
         self.assertIsInstance(op_node_2.op, Gate)
 
     def test_two_q_gates(self):
-        """The method dag.two_q_ops() returns all 2Q gate operation nodes"""
+        """The method dag.two_qubit_ops() returns all 2Q gate operation nodes"""
         self.dag.apply_operation_back(HGate(), [self.qubit0], [])
         self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(Barrier(2), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(Reset(), [self.qubit0], [])
 
-        op_nodes = self.dag.two_q_ops()
+        op_nodes = self.dag.two_qubit_ops()
         self.assertEqual(len(op_nodes), 1)
 
         op_node = op_nodes.pop()

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -249,7 +249,7 @@ class TestCSPLayout(QiskitTestCase):
         pass_.run(dag)
         runtime = process_time() - start
 
-        self.assertLess(runtime, 2)
+        self.assertLess(runtime, 3)
         self.assertEqual(pass_.property_set['CSPLayout_stop_reason'], 'time limit reached')
 
     def test_call_limit(self):

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -328,8 +328,7 @@ class TestFinalLayouts(QiskitTestCase):
         # Dense layout
         expected_layout_level1 = dense_layout
         expected_layout_level2 = dense_layout
-        # Noise adaptive layout
-        expected_layout_level3 = noise_adaptive_layout
+        expected_layout_level3 = dense_layout
 
         expected_layouts = [expected_layout_level0,
                             expected_layout_level1,

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -409,11 +409,34 @@ class TestTranspileLevelsSwap(QiskitTestCase):
              level=[0, 1, 2, 3],
              dsc='circuit: {circuit.__name__}, level: {level}',
              name='{circuit.__name__}_level{level}')
-    def test(self, circuit, level):
+    def test_1(self, circuit, level):
         """Simple coupling map (linear 5 qubits)."""
         basis = ['u1', 'u2', 'cx', 'swap']
         coupling_map = CouplingMap([(0, 1), (1, 2), (2, 3), (3, 4)])
         result = transpile(circuit(),
+                           optimization_level=level,
+                           basis_gates=basis,
+                           coupling_map=coupling_map,
+                           seed_transpiler=42)
+        self.assertIsInstance(result, QuantumCircuit)
+        resulting_basis = {node.name for node in circuit_to_dag(result).op_nodes()}
+        self.assertIn('swap', resulting_basis)
+
+    @combine(level=[0, 1, 2, 3],
+             dsc='If swap in basis, do not decompose it. level: {level}',
+             name='level{level}')
+    def test_2(self, level):
+        """Simple coupling map (linear 5 qubits).
+        The circuit requires a swap and that swap should exit at the end
+        for the transpilation"""
+        basis = ['u1', 'u2', 'cx', 'swap']
+        circuit = QuantumCircuit(5)
+        circuit.cx(0, 4)
+        circuit.cx(1, 4)
+        circuit.cx(2, 4)
+        circuit.cx(3, 4)
+        coupling_map = CouplingMap([(0, 1), (1, 2), (2, 3), (3, 4)])
+        result = transpile(circuit,
                            optimization_level=level,
                            basis_gates=basis,
                            coupling_map=coupling_map,

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -417,7 +417,8 @@ class TestTranspileLevelsSwap(QiskitTestCase):
                            optimization_level=level,
                            basis_gates=basis,
                            coupling_map=coupling_map,
-                           seed_transpiler=42)
+                           seed_transpiler=42,
+                           initial_layout=[0, 1, 2, 3, 4])
         self.assertIsInstance(result, QuantumCircuit)
         resulting_basis = {node.name for node in circuit_to_dag(result).op_nodes()}
         self.assertIn('swap', resulting_basis)

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -305,6 +305,7 @@ class TestFinalLayouts(QiskitTestCase):
                     qc.cx(qubit_control, qubit_target)
 
         ancilla = QuantumRegister(15, 'ancilla')
+
         trivial_layout = {0: qr[0], 1: qr[1], 2: qr[2], 3: qr[3], 4: qr[4],
                           5: ancilla[0], 6: ancilla[1], 7: ancilla[2], 8: ancilla[3],
                           9: ancilla[4], 10: ancilla[5], 11: ancilla[6], 12: ancilla[7],
@@ -317,15 +318,14 @@ class TestFinalLayouts(QiskitTestCase):
                         15: ancilla[10], 16: ancilla[11], 17: ancilla[12], 18: ancilla[13],
                         19: ancilla[14]}
 
-        noise_adaptive_layout = {6: qr[0], 11: qr[1], 5: qr[2], 10: qr[3], 15: qr[4], 0: ancilla[0],
-                                 1: ancilla[1], 2: ancilla[2], 3: ancilla[3], 4: ancilla[4],
-                                 7: ancilla[5], 8: ancilla[6], 9: ancilla[7], 12: ancilla[8],
-                                 13: ancilla[9], 14: ancilla[10], 16: ancilla[11], 17: ancilla[12],
-                                 18: ancilla[13], 19: ancilla[14]}
+        # noise_adaptive_layout = {6: qr[0], 11: qr[1], 5: qr[2], 10: qr[3], 15: qr[4],
+        #                          0: ancilla[0], 1: ancilla[1], 2: ancilla[2], 3: ancilla[3],
+        #                          4: ancilla[4], 7: ancilla[5], 8: ancilla[6], 9: ancilla[7],
+        #                          12: ancilla[8], 13: ancilla[9], 14: ancilla[10],
+        #                          16: ancilla[11], 17: ancilla[12], 18: ancilla[13],
+        #                          19: ancilla[14]}
 
-        # Trivial layout
         expected_layout_level0 = trivial_layout
-        # Dense layout
         expected_layout_level1 = dense_layout
         expected_layout_level2 = dense_layout
         expected_layout_level3 = dense_layout

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -490,7 +490,7 @@ class TestStochasticSwap(QiskitTestCase):
         valid_couplings = [set([qr[a], qr[b]])
                            for (a, b) in coupling.get_edges()]
 
-        for _2q_gate in after.two_q_ops():
+        for _2q_gate in after.two_qubit_ops():
             self.assertIn(set(_2q_gate.qargs), valid_couplings)
 
     def test_len_cm_vs_dag(self):

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -490,7 +490,7 @@ class TestStochasticSwap(QiskitTestCase):
         valid_couplings = [set([qr[a], qr[b]])
                            for (a, b) in coupling.get_edges()]
 
-        for _2q_gate in after.twoQ_gates():
+        for _2q_gate in after.two_q_ops():
             self.assertIn(set(_2q_gate.qargs), valid_couplings)
 
     def test_len_cm_vs_dag(self):


### PR DESCRIPTION
Preset pass managers were always decomposing swaps, which sometimes you don't want if the Swap is in the basis. This makes sure Unroller is called appropriately and removes an explicit calling of Decompose(Swap).

Furthermore this restructuring exposed a deficiency in `dag.twoQ_gates` and `dag.threeQ_or_more`, since they only find gates, whereas we may want non-gate (non-unitary) operations as well. I deprecated those two methods and added `dag.two_q_ops` and `dag.multi_q_ops`.

I tried to organize things into commits so it's easier to review.