### PR TITLE
Use DAGCircuit._wires for set lookup in EnlargeWithAncilla

### DIFF
--- a/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
+++ b/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
@@ -45,7 +45,7 @@ class EnlargeWithAncilla(TransformationPass):
 
         layout_virtual_qubits = layout.get_virtual_bits().keys()
         new_qregs = {virtual_qubit.register for virtual_qubit in layout_virtual_qubits
-                     if virtual_qubit not in dag.wires}
+                     if virtual_qubit not in dag._wires}
 
         for qreg in new_qregs:
             dag.add_qreg(qreg)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3934 we changed the DAGCircuit.wires property to be built around an
inner _wires attribute which is a set instead of a list. This was done
because we do far more lookups for a bit being present in wires than
traversing all wires. For backwards compatibility though we maintained
the insertion orders wires property which comes with a small overhead
to reconstruct the insertion order as a list and return that. In the
EnlargeWithAncilla pass we do a lookup on the wires but neglected to
change the attribute accessed so it was still using DAGCircuit.wires
instead of DAGCircuit._wires. This has a noticeable performance
regression [1] because besides having to traverse the whole list we
spend the time constructing it. This is very noticeable in
EnlargeWithAncilla because it's a very fast executing pass. To address
this issue this commit updates the pass to use ._wires which will both
avoid the overhead of constructing the list and also make the lookup
faster because it does not have to check every element.

### Details and comments

[1] https://qiskit.github.io/qiskit/#mapping_passes.PassBenchmarks.time_enlarge_with_ancilla?p-n_qubits=20&p-depth=1024&commits=05355b10
