### PR TITLE
Bump retworkx minimum

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ marshmallow>=3,<4
 marshmallow_polyfield>=5.7,<6
 networkx>=2.2;python_version>'3.5'
 networkx>=2.2,<2.4;python_version=='3.5'
-retworkx>=0.3.0
+retworkx>=0.3.2
 numpy>=1.13
 ply>=3.10
 psutil>=5

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIREMENTS = [
     "networkx>=2.2;python_version>'3.5'",
     # Networkx 2.4 is the final version with python 3.5 support.
     "networkx>=2.2,<2.4;python_version=='3.5'",
-    "retworkx>=0.3.0",
+    "retworkx>=0.3.2",
     "numpy>=1.13",
     "ply>=3.10",
     "psutil>=5",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Retworkx 0.3.2 has been released[1] which fixed a perforamnce issue with
the ancestors and descendants functions (see mtreinish/retworkx#41 for
more details). As part of that fix the return type for the functions was
changed from a list to a set. This commit bumps the minimum to ensure
end users always get he performance fix.

### Details and comments

[1] https://github.com/mtreinish/retworkx/releases/tag/0.3.2