### PR TITLE
Add back full travis config during azure pipelines outage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ cache:
 stage_osx: &stage_osx
   os: osx
   language: python
-  python: 2.7
   cache:
     pip: true
     directories:
@@ -44,7 +43,6 @@ stage_osx: &stage_osx
 os: linux
 dist: bionic
 language: python
-python: 3.7
 install:
   # Install step for jobs that require compilation and qa.
   - pip install -U -r requirements.txt -c constraints.txt
@@ -75,12 +73,14 @@ jobs:
       env:
         - PYTHON_VERSION=3.7.7
     - name: Lint and Style
+      python: 3.7
       script:
           - pycodestyle --max-line-length=100 qiskit test
           - pylint -rn qiskit test
           - reno lint
       stage: lint_and_tests
     - name: Docs
+      python: 3.7
       install:
         - python -m pip install --upgrade pip
         - pip install -U tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ jobs:
           - pylint -rn qiskit test
           - reno lint
       stage: lint_and_tests
+      git:
+        depth: false
     - name: Docs
       python: 3.7
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ cache:
 
 stage_osx: &stage_osx
   os: osx
-  language: python
+  language: generic
   cache:
     pip: true
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,28 @@ cache:
   directories:
     - .stestr
 
+stage_osx: &stage_osx
+  os: osx
+  language: python
+  cache:
+    pip: true
+    directories:
+      - ~/python-interpreters/
+  before_install:
+    # Travis does not provide support for Python 3 under osx - it needs to be
+    # installed manually.
+    - |
+      if [[ ! -d ~/python-interpreters/$PYTHON_VERSION ]]; then
+        git clone git://github.com/pyenv/pyenv.git
+        cd pyenv/plugins/python-build
+        ./install.sh
+        cd ../../..
+        python-build $PYTHON_VERSION ~/python-interpreters/$PYTHON_VERSION
+      fi
+      sudo pip2 install -U virtualenv pip setuptools
+      virtualenv --python ~/python-interpreters/$PYTHON_VERSION/bin/python venv
+      source venv/bin/activate
+    - which python
 os: linux
 dist: bionic
 language: python
@@ -37,11 +59,29 @@ script:
 after_failure:
     - python tools/report_ci_failure.py
 
+stages:
+  - name: lint_and_tests
+  - name: tests
 jobs:
   fast_finish: true
-  allow_failures:
-    - name: Randomized tests
   include:
+    - name: Python 3.7 Tests Linux
+      python: 3.7
+      stage: lint_and_tests
+    - name: Python 3.7 Tests MacOS
+      stage: lint_and_tests
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.7.7
+    - name: Lint and Style
+      script:
+          - pycodestyle --max-line-length=100 qiskit test
+          - pylint -rn qiskit test
+          - reno lint
+      stage: lint_and_tests
+    - name: Python 3.5 Tests Linux
+      python: 3.5
+      stage: tests
     - name: Python 3.6 Tests and Coverage Linux
       python: 3.6
       env:
@@ -52,27 +92,37 @@ jobs:
         - coverage xml || true
         - pip install diff-cover || true
         - diff-cover --compare-branch master coverage.xml || true
-
-    - name: Python 3.6 Tests (Networkx)
-      python: 3.6
-      install:
-        # Install step for jobs that require compilation and qa.
-        - pip install -U -r requirements.txt -c constraints.txt
-        - pip install -U -r requirements-dev.txt coveralls -c constraints.txt
-        - pip install -c constraints.txt -e .
-        - pip install "qiskit-ibmq-provider" -c constraints.txt
-        - pip install "retworkx>=0.3.0"
+    - name: Python 3.8 Tests Linux
+      python: 3.8
+      stage: tests
+    - name: Python 3.5 Tests MacOS
+      stage: tests
+      <<: *stage_osx
       env:
-        - USE_RETWORKX="N"
-
-    # Randomized testing
-    - name: Randomized tests
-      cache:
-        pip: true
-        directories:
-        - .hypothesis
-      script:
-      - pip install -U pip
-      - python setup.py build_ext --inplace
-      - pip install "qiskit-aer"
-      - make test_randomized
+        - PYTHON_VERSION=3.5.9
+    - name: Python 3.6 Tests MacOS
+      stage: tests
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.6.10
+    - name: Python 3.8 Tests MacOS
+      stage: tests
+      <<: *stage_osx
+      env:
+        - PYTHON_VERSION=3.8.2
+    - name: Python 3.5 Test Windows
+      os: windows
+      python: 3.5
+      stage: tests
+    - name: Python 3.6 Test Windows
+      os: windows
+      python: 3.6
+      stage: tests
+    - name: Python 3.7 Test Windows
+      os: windows
+      python: 3.7
+      stage: tests
+    - name: Python 3.8 Test Windows
+      os: windows
+      python: 3.8
+      stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,14 @@ jobs:
           - pylint -rn qiskit test
           - reno lint
       stage: lint_and_tests
+    - name: Docs
+      install:
+        - python -m pip install --upgrade pip
+        - pip install -U tox
+        - python setup.py build_ext --inplace
+        - sudo apt install -y graphviz
+      script:
+        - tox -edocs
     - name: Python 3.5 Tests Linux
       python: 3.5
       stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,19 +124,3 @@ jobs:
       <<: *stage_osx
       env:
         - PYTHON_VERSION=3.8.2
-    - name: Python 3.5 Test Windows
-      os: windows
-      python: 3.5
-      stage: tests
-    - name: Python 3.6 Test Windows
-      os: windows
-      python: 3.6
-      stage: tests
-    - name: Python 3.7 Test Windows
-      os: windows
-      python: 3.7
-      stage: tests
-    - name: Python 3.8 Test Windows
-      os: windows
-      python: 3.8
-      stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,8 @@ jobs:
         - sudo apt-get install -y graphviz
       script:
         - tox -edocs
+      git:
+        depth: false
     - name: Python 3.5 Tests Linux
       python: 3.5
       stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ jobs:
         - python -m pip install --upgrade pip
         - pip install -U tox
         - python setup.py build_ext --inplace
-        - sudo apt install -y graphviz
+        - sudo apt-get update
+        - sudo apt-get install -y graphviz
       script:
         - tox -edocs
     - name: Python 3.5 Tests Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 stage_osx: &stage_osx
   os: osx
   language: python
+  python: 2.7
   cache:
     pip: true
     directories:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds back the full battery of test jobs to the travis ci
config. We're in the middle of an azure pipelines outage and without
any acknowledgment from support or any indication that they're aware
of the issue. We've been blocked for more than 1 day because of this,
and with the 0.13.0 release fast approaching we need to have a
functional ci system running. This commit adds the full test matrix
we're using on azure back to travis which is still working. We can
revert this commit when azure is back running, because it is still
faster and has less resource contention. Azure also has windows jobs
which we can not get coverage for in travis.

### Details and comments