### PR TITLE
Update mergify config to require travis not azure

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: automatic merge on CI success and review
     conditions:
-      - status-success=Qiskit.qiskit-terra
+      - status-success=Travis CI - Pull Request
       - "#approved-reviews-by>=1"
       - label=automerge
       - label!=on hold


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since we're in the middle of an azure pipelines outage we've temporarily
switched to using travis as our sole ci provider (see #3973) until the
situation is resolve. However, the mergify config is hard coded to check
for azure pipelines to report success before continuing. This commit
updates the mergify config so that the automerge tag will continue to
work while we're relying on travis for all of our ci.

### Details and comments