### PR TITLE
Drawing CCZ now consistent

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -373,7 +373,7 @@ class QCircuitImage:
                     if_value = format(op.condition[1],
                                       'b').zfill(self.cregs[if_reg])[::-1]
                 if isinstance(op.op, ControlledGate) and op.name not in [
-                        'ccx', 'cx', 'cz', 'cu1', 'ccz', 'cu3', 'crz',
+                        'ccx', 'cx', 'cz', 'cu1', 'cu3', 'crz',
                         'cswap']:
                     qarglist = op.qargs
                     name = generate_latex_label(
@@ -407,7 +407,10 @@ class QCircuitImage:
                         for index, pos in enumerate(ctrl_pos):
                             self._latex[pos][column] = "\\ctrl{" + str(
                                 pos_array[index + 1] - pos_array[index]) + "}"
-                        self._latex[pos_array[-1]][column] = "\\gate{%s}" % name
+                        if name == 'Z':
+                            self._latex[pos_array[-1]][column] = "\\control\\qw"
+                        else:
+                            self._latex[pos_array[-1]][column] = "\\gate{%s}" % name
                     else:
                         pos_start = min(pos_qargs)
                         pos_stop = max(pos_qargs)

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -841,7 +841,7 @@ class MatplotlibDrawer:
                     self._custom_multiqubit_gate(q_xy, wide=_iswide,
                                                  text="Unitary")
                 elif isinstance(op.op, ControlledGate) and op.name not in [
-                        'ccx', 'cx', 'cz', 'cu1', 'ccz', 'cu3', 'crz',
+                        'ccx', 'cx', 'cz', 'cu1', 'cu3', 'crz',
                         'cswap']:
                     disp = op.op.base_gate.name
                     num_ctrl_qubits = op.op.num_ctrl_qubits
@@ -852,7 +852,10 @@ class MatplotlibDrawer:
                                          ec=self._style.dispcol['multi'])
                     # add qubit-qubit wiring
                     self._line(qreg_b, qreg_t, lc=self._style.dispcol['multi'])
-                    if num_qargs == 1:
+                    if disp == 'z':
+                        self._ctrl_qubit(q_xy[i+1], fc=self._style.dispcol['multi'],
+                                         ec=self._style.dispcol['multi'])
+                    elif num_qargs == 1:
                         self._gate(q_xy[-1], wide=_iswide, text=disp)
                     else:
                         self._custom_multiqubit_gate(
@@ -900,9 +903,12 @@ class MatplotlibDrawer:
                             self._ctrl_qubit(q_xy[0],
                                              fc=color,
                                              ec=color)
+                            self._ctrl_qubit(q_xy[1],
+                                             fc=color,
+                                             ec=color)
                         else:
                             self._ctrl_qubit(q_xy[0])
-                        self._gate(q_xy[1], wide=_iswide, text=disp, fc=color)
+                            self._ctrl_qubit(q_xy[1])
                         # add qubit-qubit wiring
                         if self._style.name != 'bw':
                             self._line(qreg_b, qreg_t,

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -952,7 +952,7 @@ class TextDrawing():
                     gates.append(Bullet(conditional=conditional))
                 else:
                     gates.append(OpenBullet(conditional=conditional))
-            if label == 'Z':
+            if instruction.op.base_gate.name == 'z':
                 gates.append(Bullet(conditional=conditional))
             elif len(rest) > 1:
                 top_connect = '┴' if controlled_top else None

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -952,7 +952,9 @@ class TextDrawing():
                     gates.append(Bullet(conditional=conditional))
                 else:
                     gates.append(OpenBullet(conditional=conditional))
-            if len(rest) > 1:
+            if label == 'Z':
+                gates.append(Bullet(conditional=conditional))
+            elif len(rest) > 1:
                 top_connect = '┴' if controlled_top else None
                 bot_connect = '┬' if controlled_bot else None
                 indexes = layer.set_qu_multibox(rest, label,

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1910,6 +1910,30 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(ZGate().control(1, ctrl_state=0), [qr[0], qr[1]])
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
+    def test_ccz_bot(self):
+        """Closed-Open controlled Z (bottom)"""
+        expected = '\n'.join(["           ",
+                              "q_0: |0>─■─",
+                              "         │ ",
+                              "q_1: |0>─o─",
+                              "         │ ",
+                              "q_2: |0>─■─",
+                              "           "])
+        qr = QuantumRegister(3, 'q')
+        circuit = QuantumCircuit(qr)
+        circuit.append(ZGate().control(2, ctrl_state='01'), [qr[0], qr[1], qr[2]])
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_cccz_conditional(self):
+        """Closed-Open controlled Z (with conditional)"""
+        expected = '\n'.join([])
+        qr = QuantumRegister(4, 'q')
+        cr = ClassicalRegister(1, 'c')
+        circuit = QuantumCircuit(qr, cr)
+        circuit.append(ZGate().control(3, ctrl_state='101').c_if(cr, 1),
+                       [qr[0], qr[1], qr[2], qr[3]])
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
     def test_cch_bot(self):
         """Controlled CH (bottom)"""
         expected = '\n'.join(["             ",

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1926,7 +1926,17 @@ class TestTextOpenControlledGate(QiskitTestCase):
 
     def test_cccz_conditional(self):
         """Closed-Open controlled Z (with conditional)"""
-        expected = '\n'.join([])
+        expected = '\n'.join(["               ",
+                              "q_0: |0>───■───",
+                              "           │   ",
+                              "q_1: |0>───o───",
+                              "           │   ",
+                              "q_2: |0>───■───",
+                              "           │   ",
+                              "q_3: |0>───■───",
+                              "        ┌──┴──┐",
+                              " c_0: 0 ╡ = 1 ╞",
+                              "        └─────┘"])
         qr = QuantumRegister(4, 'q')
         cr = ClassicalRegister(1, 'c')
         circuit = QuantumCircuit(qr, cr)

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1900,11 +1900,11 @@ class TestTextOpenControlledGate(QiskitTestCase):
 
     def test_cz_bot(self):
         """Open controlled Z (bottom)"""
-        expected = '\n'.join(["             ",
-                              "q_0: |0>──o──",
-                              "        ┌─┴─┐",
-                              "q_1: |0>┤ Z ├",
-                              "        └───┘"])
+        expected = '\n'.join(["           ",
+                              "q_0: |0>─o─",
+                              "         │ ",
+                              "q_1: |0>─■─",
+                              "           "])
         qr = QuantumRegister(2, 'q')
         circuit = QuantumCircuit(qr)
         circuit.append(ZGate().control(1, ctrl_state=0), [qr[0], qr[1]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3968 .

### Details and comments

The CCZ gate was previously drawn as a double controlled box gate. It has been changed to be drawn as follows:

![2020-03-16 (6)](https://user-images.githubusercontent.com/51048173/76743987-865b2980-6799-11ea-99d2-b203d67638fa.png)

![mpl_img](https://user-images.githubusercontent.com/51048173/76743655-f917d500-6798-11ea-9bb8-a92ad956ab9b.jpg)

![2020-03-16 (4)](https://user-images.githubusercontent.com/51048173/76743866-4d22b980-6799-11ea-91a3-0723c50f7950.png)

Additionally the 'mpl' version of CZ  gate was drawn as a controlled box gate. It has been updated to be drawn as below:

![mpl_img](https://user-images.githubusercontent.com/51048173/76744282-fe295400-6799-11ea-97f3-10db4dab82d7.png)



