### PR TITLE
Add ``sample_measure`` to ``Statevector`` and ``DensityMatrix``

### DIFF
--- a/releasenotes/notes/state-sample-measure-9710a22dfcb01ed6.yaml
+++ b/releasenotes/notes/state-sample-measure-9710a22dfcb01ed6.yaml
@@ -1,0 +1,50 @@
+---
+features:
+  - |
+    Add ``sample_measure`` methods to the :class:`~qiskit.quantum_info.Statevector`
+    and :class:`~qiskit.quantum_info.DensityMatrix` classes for sampling
+    measurement outcomes on subsystems.
+
+    Example:
+
+      Generate a counts dictionary by sampling from a statevector
+
+      .. jupyter-execute::
+
+        from qiskit.quantum_info import Statevector
+
+        psi = Statevector.from_label('+0')
+        shots = 1024
+  
+        # Sample counts dictionary
+        counts = psi.sample_measure(shots=shots)
+        print('Measure both:', counts)
+
+        # Qubit-0
+        counts0 = psi.sample_measure([0], shots=shots)
+        print('Measure Qubit-0:', counts0)
+
+        # Qubit-1
+        counts1 = psi.sample_measure([1], shots=shots)
+        print('Measure Qubit-1:', counts1)
+
+      Return the array of measurement outcomes for each sample
+    
+      .. jupyter-execute::
+
+        from qiskit.quantum_info import Statevector
+
+        psi = Statevector.from_label('-1')
+        shots = 10
+  
+        # Sample memory
+        mem = psi.sample_measure(shots=shots, memory=True)
+        print('Measure both:', mem)
+
+        # Qubit-0
+        mem0 = psi.sample_measure([0], shots=shots, memory=True)
+        print('Measure Qubit-0:', mem0)
+
+        # Qubit-1
+        mem1 = psi.sample_measure([1], shots=shots, memory=True)
+        print('Measure Qubit-1:', mem1)

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -545,6 +545,121 @@ class TestDensityMatrix(QiskitTestCase):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
+    def test_sample_measure_ghz(self):
+        """Test sample measure method for GHZ state"""
+
+        shots = 2000
+        threshold = 0.02 * shots
+        state = DensityMatrix((
+            Statevector.from_label('000') +
+            Statevector.from_label('111')) / np.sqrt(2))
+        state.seed(100)
+
+        # 3-qubit qargs
+        target = {'000': shots / 2, '111': shots / 2}
+        for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 2-qubit qargs
+        target = {'00': shots / 2, '11': shots / 2}
+        for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 1-qubit qargs
+        target = {'0': shots / 2, '1': shots / 2}
+        for qargs in [[0], [1], [2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+    def test_sample_measure_w(self):
+        """Test sample measure method for W state"""
+        shots = 3000
+        threshold = 0.02 * shots
+        state = DensityMatrix((
+            Statevector.from_label('001') +
+            Statevector.from_label('010') +
+            Statevector.from_label('100')) / np.sqrt(3))
+        state.seed(100)
+
+        target = {'001': shots / 3, '010': shots / 3, '100': shots / 3}
+        for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 2-qubit qargs
+        target = {'00': shots / 3, '01': shots / 3, '10': shots / 3}
+        for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 1-qubit qargs
+        target = {'0': 2 * shots / 3, '1': shots / 3}
+        for qargs in [[0], [1], [2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+    def test_sample_measure_qutrit(self):
+        """Test sample measure method for qutrit state"""
+        p = 0.3
+        shots = 1000
+        threshold = 0.02 * shots
+        state = DensityMatrix(np.diag([p, 0, 1 - p]))
+        state.seed(100)
+
+        with self.subTest(msg='counts'):
+            target = {'0': shots * p, '2': shots * (1 - p)}
+            counts = state.sample_measure(shots=shots)
+            self.assertDictAlmostEqual(counts, target, threshold)
+
+        with self.subTest(msg='memory'):
+            memory = state.sample_measure(shots=shots, memory=True)
+            self.assertEqual(len(memory), shots)
+            self.assertEqual(set(memory), set(['0', '2']))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -533,6 +533,119 @@ class TestStatevector(QiskitTestCase):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
+    def test_sample_measure_ghz(self):
+        """Test sample measure method for GHZ state"""
+
+        shots = 2000
+        threshold = 0.02 * shots
+        state = (Statevector.from_label('000') +
+                 Statevector.from_label('111')) / np.sqrt(2)
+        state.seed(100)
+
+        # 3-qubit qargs
+        target = {'000': shots / 2, '111': shots / 2}
+        for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 2-qubit qargs
+        target = {'00': shots / 2, '11': shots / 2}
+        for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 1-qubit qargs
+        target = {'0': shots / 2, '1': shots / 2}
+        for qargs in [[0], [1], [2]]:
+
+            with self.subTest(msg='counts (qargs={})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+    def test_sample_measure_w(self):
+        """Test sample measure method for W state"""
+        shots = 3000
+        threshold = 0.02 * shots
+        state = (Statevector.from_label('001') +
+                 Statevector.from_label('010') +
+                 Statevector.from_label('100')) / np.sqrt(3)
+        state.seed(100)
+
+        target = {'001': shots / 3, '010': shots / 3, '100': shots / 3}
+        for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 2-qubit qargs
+        target = {'00': shots / 3, '01': shots / 3, '10': shots / 3}
+        for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+        # 1-qubit qargs
+        target = {'0': 2 * shots / 3, '1': shots / 3}
+        for qargs in [[0], [1], [2]]:
+
+            with self.subTest(msg='P({})'.format(qargs)):
+                counts = state.sample_measure(qargs=qargs, shots=shots)
+                self.assertDictAlmostEqual(counts, target, threshold)
+
+            with self.subTest(msg='memory (qargs={})'.format(qargs)):
+                memory = state.sample_measure(qargs=qargs, shots=shots, memory=True)
+                self.assertEqual(len(memory), shots)
+                self.assertEqual(set(memory), set(target))
+
+    def test_sample_measure_qutrit(self):
+        """Test sample measure method for qutrit state"""
+        p = 0.3
+        shots = 1000
+        threshold = 0.02 * shots
+        state = Statevector([np.sqrt(p), 0, np.sqrt(1 - p)])
+        state.seed(100)
+
+        with self.subTest(msg='counts'):
+            target = {'0': shots * p, '2': shots * (1 - p)}
+            counts = state.sample_measure(shots=shots)
+            self.assertDictAlmostEqual(counts, target, threshold)
+
+        with self.subTest(msg='memory'):
+            memory = state.sample_measure(shots=shots, memory=True)
+            self.assertEqual(len(memory), shots)
+            self.assertEqual(set(memory), set(['0', '2']))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

* [x] Depends on #3952 (on-hold until it is merged)

* Adds `sample_measure` function to `Statevector` and `DensityMatrix` for sampling measurement outcomes from the current state.

* Adds `seed` method to QuantumState for setting the seed of the objects internal RNG used for sampling measure outcomes.

### Details and comments


