### PR TITLE
Clean up default class atol and rtol for operators and states

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -85,22 +85,17 @@ class BaseOperator(ABC):
         return self._num_qubits
 
     @property
-    def _atol(self):
+    def atol(self):
         """The default absolute tolerance parameter for float comparisons."""
         return self.__class__._ATOL_DEFAULT
 
-    @_atol.setter
-    def _atol(self, value):
-        """Set the class default absolute tolerance parameter for float comparisons."""
-        warnings.warn(
-            'Setting default atol default value with `_atol` is deprecated as'
-            ' of 0.13.0, and will be removed no earlier than 3 months after'
-            ' that release date. You should use the `set_atol` class method'
-            ' instead.', DeprecationWarning, stacklevel=2)
-        self.__class__._set_atol(value)
+    @property
+    def rtol(self):
+        """The relative tolerance parameter for float comparisons."""
+        return self.__class__._RTOL_DEFAULT
 
     @classmethod
-    def _set_atol(cls, value):
+    def set_atol(cls, value):
         """Set the class default absolute tolerance parameter for float comparisons."""
         if value < 0:
             raise QiskitError(
@@ -111,23 +106,8 @@ class BaseOperator(ABC):
                     value, cls._MAX_TOL))
         cls._ATOL_DEFAULT = value
 
-    @property
-    def _rtol(self):
-        """The relative tolerance parameter for float comparisons."""
-        return self.__class__._RTOL_DEFAULT
-
-    @_rtol.setter
-    def _rtol(self, value):
-        """Set the class default relative tolerance parameter for float comparisons."""
-        warnings.warn(
-            'Setting default rtol default value with `_rtol` is deprecated as'
-            ' of 0.13.0, and will be removed no earlier than 3 months after'
-            ' that release date. You should use the `set_rtol` class method'
-            ' instead.', DeprecationWarning, stacklevel=2)
-        self.__class__._set_rtol(value)
-
     @classmethod
-    def _set_rtol(cls, value):
+    def set_rtol(cls, value):
         """Set the class default relative tolerance parameter for float comparisons."""
         if value < 0:
             raise QiskitError(

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -29,9 +29,9 @@ from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 class BaseOperator(ABC):
     """Abstract linear operator base class."""
 
-    ATOL = ATOL_DEFAULT
-    RTOL = RTOL_DEFAULT
-    MAX_TOL = 1e-4
+    _ATOL_DEFAULT = ATOL_DEFAULT
+    _RTOL_DEFAULT = RTOL_DEFAULT
+    _MAX_TOL = 1e-4
 
     def __init__(self, input_dims, output_dims):
         """Initialize an operator object."""
@@ -86,39 +86,57 @@ class BaseOperator(ABC):
 
     @property
     def _atol(self):
-        """The absolute tolerance parameter for float comparisons."""
-        return self.__class__.ATOL
+        """The default absolute tolerance parameter for float comparisons."""
+        return self.__class__._ATOL_DEFAULT
 
     @_atol.setter
-    def _atol(self, atol):
-        """Set the absolute tolerance parameter for float comparisons."""
-        # NOTE: that this overrides the class value so applies to all
-        # instances of the class.
-        max_tol = self.__class__.MAX_TOL
-        if atol < 0:
-            raise QiskitError("Invalid atol: must be non-negative.")
-        if atol > max_tol:
+    def _atol(self, value):
+        """Set the class default absolute tolerance parameter for float comparisons."""
+        warnings.warn(
+            'Setting default atol default value with `_atol` is deprecated as'
+            ' of 0.13.0, and will be removed no earlier than 3 months after'
+            ' that release date. You should use the `set_atol` class method'
+            ' instead.', DeprecationWarning, stacklevel=2)
+        self.__class__._set_atol(value)
+
+    @classmethod
+    def _set_atol(cls, value):
+        """Set the class default absolute tolerance parameter for float comparisons."""
+        if value < 0:
             raise QiskitError(
-                "Invalid atol: must be less than {}.".format(max_tol))
-        self.__class__.ATOL = atol
+                "Invalid atol ({}) must be non-negative.".format(value))
+        if value > cls._MAX_TOL:
+            raise QiskitError(
+                "Invalid atol ({}) must be less than {}.".format(
+                    value, cls._MAX_TOL))
+        cls._ATOL_DEFAULT = value
 
     @property
     def _rtol(self):
         """The relative tolerance parameter for float comparisons."""
-        return self.__class__.RTOL
+        return self.__class__._RTOL_DEFAULT
 
     @_rtol.setter
-    def _rtol(self, rtol):
-        """Set the relative tolerance parameter for float comparisons."""
-        # NOTE: that this overrides the class value so applies to all
-        # instances of the class.
-        max_tol = self.__class__.MAX_TOL
-        if rtol < 0:
-            raise QiskitError("Invalid rtol: must be non-negative.")
-        if rtol > max_tol:
+    def _rtol(self, value):
+        """Set the class default relative tolerance parameter for float comparisons."""
+        warnings.warn(
+            'Setting default rtol default value with `_rtol` is deprecated as'
+            ' of 0.13.0, and will be removed no earlier than 3 months after'
+            ' that release date. You should use the `set_rtol` class method'
+            ' instead.', DeprecationWarning, stacklevel=2)
+        self.__class__._set_rtol(value)
+
+    @classmethod
+    def _set_rtol(cls, value):
+        """Set the class default relative tolerance parameter for float comparisons."""
+        if value < 0:
             raise QiskitError(
-                "Invalid rtol: must be less than {}.".format(max_tol))
-        self.__class__.RTOL = rtol
+                "Invalid atol ({}) must be non-negative.".format(value))
+        if value > cls._MAX_TOL:
+            raise QiskitError(
+                "Invalid atol ({}) must be less than {}.".format(
+                    value, cls._MAX_TOL))
+        cls._RTOL_DEFAULT = value
 
     def reshape(self, input_dims=None, output_dims=None):
         """Return a shallow copy with reshaped input and output subsystem dimensions.

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -188,9 +188,9 @@ class Kraus(QuantumChannel):
         if self._data[1] is not None:
             return False
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         accum = 0j
         for op in self._data[0]:
             accum += np.dot(np.transpose(np.conj(op)), op)

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -71,7 +71,7 @@ class QuantumChannel(BaseOperator):
         if not super().__eq__(other):
             return False
         return np.allclose(
-            self.data, other.data, rtol=self._rtol, atol=self._atol)
+            self.data, other.data, rtol=self.rtol, atol=self.atol)
 
     @property
     def data(self):
@@ -225,17 +225,17 @@ class QuantumChannel(BaseOperator):
     def _is_cp_helper(self, choi, atol, rtol):
         """Test if a channel is completely-positive (CP)"""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         return is_positive_semidefinite_matrix(choi, rtol=rtol, atol=atol)
 
     def _is_tp_helper(self, choi, atol, rtol):
         """Test if Choi-matrix is trace-preserving (TP)"""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         # Check if the partial trace is the identity matrix
         d_in, d_out = self.dim
         mat = np.trace(

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -158,13 +158,13 @@ class Stinespring(QuantumChannel):
     def is_cptp(self, atol=None, rtol=None):
         """Return True if completely-positive trace-preserving."""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         if self._data[1] is not None:
             return False
         check = np.dot(np.transpose(np.conj(self._data[0])), self._data[0])
-        return is_identity_matrix(check, rtol=self._rtol, atol=self._atol)
+        return is_identity_matrix(check, rtol=self.rtol, atol=self.atol)
 
     def conjugate(self):
         """Return the conjugate of the QuantumChannel."""

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -120,7 +120,7 @@ class Operator(BaseOperator):
         if not super().__eq__(other):
             return False
         return np.allclose(
-            self.data, other.data, rtol=self._rtol, atol=self._atol)
+            self.data, other.data, rtol=self.rtol, atol=self.atol)
 
     @property
     def data(self):
@@ -187,9 +187,9 @@ class Operator(BaseOperator):
     def is_unitary(self, atol=None, rtol=None):
         """Return True if operator is a unitary matrix."""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         return is_unitary_matrix(self._data, rtol=rtol, atol=atol)
 
     def to_operator(self):
@@ -434,9 +434,9 @@ class Operator(BaseOperator):
         if self.dim != other.dim:
             return False
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         return matrix_equal(self.data, other.data, ignore_phase=True,
                             rtol=rtol, atol=atol)
 

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -73,9 +73,9 @@ class ScalarOp(BaseOperator):
     def is_unitary(self, atol=None, rtol=None):
         """Return True if operator is a unitary matrix."""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         return np.isclose(np.abs(self.coeff), 1, atol=atol, rtol=rtol)
 
     def to_matrix(self):

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -77,9 +77,9 @@ class DensityMatrix(QuantumState):
     def is_valid(self, atol=None, rtol=None):
         """Return True if trace 1 and positive semidefinite."""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         # Check trace == 1
         if not np.allclose(self.trace(), 1, rtol=rtol, atol=atol):
             return False

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -16,6 +16,7 @@
 Abstract QuantumState class.
 """
 
+import warnings
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -28,9 +29,9 @@ from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 class QuantumState(ABC):
     """Abstract quantum state base class"""
 
-    ATOL = ATOL_DEFAULT
-    RTOL = RTOL_DEFAULT
-    MAX_TOL = 1e-4
+    _ATOL_DEFAULT = ATOL_DEFAULT
+    _RTOL_DEFAULT = RTOL_DEFAULT
+    _MAX_TOL = 1e-4
 
     def __init__(self, rep, data, dims):
         """Initialize a state object."""
@@ -86,38 +87,56 @@ class QuantumState(ABC):
     @property
     def _atol(self):
         """The absolute tolerance parameter for float comparisons."""
-        return self.__class__.ATOL
+        return self.__class__._ATOL_DEFAULT
 
     @_atol.setter
-    def _atol(self, atol):
-        """Set the absolute tolerance parameter for float comparisons."""
-        # NOTE: that this overrides the class value so applies to all
-        # instances of the class.
-        max_tol = self.__class__.MAX_TOL
-        if atol < 0:
-            raise QiskitError("Invalid atol: must be non-negative.")
-        if atol > max_tol:
+    def _atol(self, value):
+        """Set the class default absolute tolerance parameter for float comparisons."""
+        warnings.warn(
+            'Setting default atol default value with `_atol` is deprecated as'
+            ' of 0.13.0, and will be removed no earlier than 3 months after'
+            ' that release date. You should use the `set_atol` class method'
+            ' instead.', DeprecationWarning, stacklevel=2)
+        self.__class__._set_atol(value)
+
+    @classmethod
+    def set_atol(cls, value):
+        """Set the class default absolute tolerance parameter for float comparisons."""
+        if value < 0:
             raise QiskitError(
-                "Invalid atol: must be less than {}.".format(max_tol))
-        self.__class__.ATOL = atol
+                "Invalid atol ({}) must be non-negative.".format(value))
+        if value > cls._MAX_TOL:
+            raise QiskitError(
+                "Invalid atol ({}) must be less than {}.".format(
+                    value, cls._MAX_TOL))
+        cls._ATOL_DEFAULT = value
 
     @property
     def _rtol(self):
         """The relative tolerance parameter for float comparisons."""
-        return self.__class__.RTOL
+        return self.__class__._RTOL_DEFAULT
 
     @_rtol.setter
-    def _rtol(self, rtol):
-        """Set the relative tolerance parameter for float comparisons."""
-        # NOTE: that this overrides the class value so applies to all
-        # instances of the class.
-        max_tol = self.__class__.MAX_TOL
-        if rtol < 0:
-            raise QiskitError("Invalid rtol: must be non-negative.")
-        if rtol > max_tol:
+    def _rtol(self, value):
+        """Set the class default relative tolerance parameter for float comparisons."""
+        warnings.warn(
+            'Setting default rtol default value with `_rtol` is deprecated as'
+            ' of 0.13.0, and will be removed no earlier than 3 months after'
+            ' that release date. You should use the `set_rtol` class method'
+            ' instead.', DeprecationWarning, stacklevel=2)
+        self.__class__._set_rtol(value)
+
+    @classmethod
+    def _set_rtol(cls, value):
+        """Set the class default relative tolerance parameter for float comparisons."""
+        if value < 0:
             raise QiskitError(
-                "Invalid rtol: must be less than {}.".format(max_tol))
-        self.__class__.RTOL = rtol
+                "Invalid atol ({}) must be non-negative.".format(value))
+        if value > cls._MAX_TOL:
+            raise QiskitError(
+                "Invalid atol ({}) must be less than {}.".format(
+                    value, cls._MAX_TOL))
+        cls._RTOL_DEFAULT = value
 
     def _reshape(self, dims=None):
         """Reshape dimensions of the state.

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -100,7 +100,7 @@ class QuantumState(ABC):
         self.__class__._set_atol(value)
 
     @classmethod
-    def set_atol(cls, value):
+    def _set_atol(cls, value):
         """Set the class default absolute tolerance parameter for float comparisons."""
         if value < 0:
             raise QiskitError(

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -16,7 +16,6 @@
 Abstract QuantumState class.
 """
 
-import warnings
 from abc import ABC, abstractmethod
 
 import numpy as np

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -53,7 +53,7 @@ class QuantumState(ABC):
         if (isinstance(other, self.__class__)
                 and self.dims() == other.dims()):
             return np.allclose(
-                self.data, other.data, rtol=self._rtol, atol=self._atol)
+                self.data, other.data, rtol=self.rtol, atol=self.atol)
         return False
 
     def __repr__(self):
@@ -85,22 +85,17 @@ class QuantumState(ABC):
         return self._data
 
     @property
-    def _atol(self):
+    def atol(self):
         """The absolute tolerance parameter for float comparisons."""
         return self.__class__._ATOL_DEFAULT
 
-    @_atol.setter
-    def _atol(self, value):
-        """Set the class default absolute tolerance parameter for float comparisons."""
-        warnings.warn(
-            'Setting default atol default value with `_atol` is deprecated as'
-            ' of 0.13.0, and will be removed no earlier than 3 months after'
-            ' that release date. You should use the `set_atol` class method'
-            ' instead.', DeprecationWarning, stacklevel=2)
-        self.__class__._set_atol(value)
+    @property
+    def rtol(self):
+        """The relative tolerance parameter for float comparisons."""
+        return self.__class__._RTOL_DEFAULT
 
     @classmethod
-    def _set_atol(cls, value):
+    def set_atol(cls, value):
         """Set the class default absolute tolerance parameter for float comparisons."""
         if value < 0:
             raise QiskitError(
@@ -111,23 +106,8 @@ class QuantumState(ABC):
                     value, cls._MAX_TOL))
         cls._ATOL_DEFAULT = value
 
-    @property
-    def _rtol(self):
-        """The relative tolerance parameter for float comparisons."""
-        return self.__class__._RTOL_DEFAULT
-
-    @_rtol.setter
-    def _rtol(self, value):
-        """Set the class default relative tolerance parameter for float comparisons."""
-        warnings.warn(
-            'Setting default rtol default value with `_rtol` is deprecated as'
-            ' of 0.13.0, and will be removed no earlier than 3 months after'
-            ' that release date. You should use the `set_rtol` class method'
-            ' instead.', DeprecationWarning, stacklevel=2)
-        self.__class__._set_rtol(value)
-
     @classmethod
-    def _set_rtol(cls, value):
+    def set_rtol(cls, value):
         """Set the class default relative tolerance parameter for float comparisons."""
         if value < 0:
             raise QiskitError(

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -65,9 +65,9 @@ class Statevector(QuantumState):
     def is_valid(self, atol=None, rtol=None):
         """Return True if a Statevector has norm 1."""
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         norm = np.linalg.norm(self.data)
         return np.allclose(norm, 1, rtol=rtol, atol=atol)
 
@@ -248,9 +248,9 @@ class Statevector(QuantumState):
         if self.dim != other.dim:
             return False
         if atol is None:
-            atol = self._atol
+            atol = self.atol
         if rtol is None:
-            rtol = self._rtol
+            rtol = self.rtol
         return matrix_equal(self.data, other.data, ignore_phase=True,
                             rtol=rtol, atol=atol)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Cleans up some of the internal code for default atol and rtol values used for float comparison in quantum info state and operator classes.

I'm not sure if its really necessary to raise deprecation warning for what was a private method of the classes, of if I should just delete the deprecated setters and be done with it.

### Details and comments

* Changes the class variables (ATOL, RTOL, MAX_TOL) to be private (_ATOL_DEFAULT, _RTOL_DEFAULT, _MAX_TOL)
* Deprecates `_atol` and `_rtol` setters
* Adds class setters `_set_atol` and `_set_rtol` for changing default class values.


