### PR TITLE
layout_method and routing_method selectors in transpile()

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -13,6 +13,7 @@
 # that they have been altered from the originals.
 
 """Circuit transpile function"""
+import warnings
 from typing import List, Union, Dict, Callable, Any, Optional, Tuple
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.providers import BaseBackend
@@ -111,6 +112,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                     [qr[0], None, None, qr[1], None, qr[2]]
 
         layout_method: Name of layout selection pass ('trivial', 'dense', 'noise_adaptive')
+            Sometimes a perfect layout can be available in which case the layout_method
+            may not run.
         routing_method: Name of routing pass ('basic', 'lookahead', 'stochastic')
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
@@ -282,6 +285,9 @@ def _parse_transpile_args(circuits, backend,
     Returns:
         list[dicts]: a list of transpile parameters.
     """
+    if initial_layout is not None and layout_method is not None:
+        warnings.warn("initial_layout provided; layout_method is ignored.",
+                      UserWarning)
     # Each arg could be single or a list. If list, it must be the same size as
     # number of circuits. If single, duplicate to create a list of that size.
     num_circuits = len(circuits)
@@ -300,7 +306,7 @@ def _parse_transpile_args(circuits, backend,
 
     list_transpile_args = []
     for args in zip(basis_gates, coupling_map, backend_properties,
-                    initial_layout, layout_method, routing_method, 
+                    initial_layout, layout_method, routing_method,
                     seed_transpiler, optimization_level,
                     pass_manager, output_name, callback):
         transpile_args = {'pass_manager_config': PassManagerConfig(basis_gates=args[0],

--- a/qiskit/transpiler/pass_manager_config.py
+++ b/qiskit/transpiler/pass_manager_config.py
@@ -2,7 +2,7 @@
 
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2019.
+# (C) Copyright IBM 2017, 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -17,24 +17,14 @@
 
 class PassManagerConfig:
     """Pass Manager Configuration.
-
-    Attributes:
-        initial_layout (Layout): Initial position of virtual qubits on physical
-            qubits.
-        basis_gates (list): List of basis gate names to unroll to.
-        coupling_map (CouplingMap): Directed graph represented a coupling map.
-        backend_properties (BackendProperties): Properties returned by a
-            backend, including
-            information on gate errors, readout errors, qubit coherence times,
-            etc.
-        seed_transpiler (int): Sets random seed for the stochastic parts of the
-            transpiler.
     """
 
     def __init__(self,
                  initial_layout=None,
                  basis_gates=None,
                  coupling_map=None,
+                 layout_method=None,
+                 routing_method=None,
                  backend_properties=None,
                  seed_transpiler=None):
         """Initialize a PassManagerConfig object
@@ -45,6 +35,10 @@ class PassManagerConfig:
             basis_gates (list): List of basis gate names to unroll to.
             coupling_map (CouplingMap): Directed graph represented a coupling
                 map.
+            layout_method (str): the pass to use for choosing initial qubit
+                placement.
+            routing_method (str): the pass to use for routing qubits on the
+                architecture.
             backend_properties (BackendProperties): Properties returned by a
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
@@ -54,5 +48,7 @@ class PassManagerConfig:
         self.initial_layout = initial_layout
         self.basis_gates = basis_gates
         self.coupling_map = coupling_map
+        self.layout_method = layout_method
+        self.routing_method=routing_method,
         self.backend_properties = backend_properties
         self.seed_transpiler = seed_transpiler

--- a/qiskit/transpiler/pass_manager_config.py
+++ b/qiskit/transpiler/pass_manager_config.py
@@ -49,6 +49,6 @@ class PassManagerConfig:
         self.basis_gates = basis_gates
         self.coupling_map = coupling_map
         self.layout_method = layout_method
-        self.routing_method=routing_method,
+        self.routing_method = routing_method
         self.backend_properties = backend_properties
         self.seed_transpiler = seed_transpiler

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -101,7 +101,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'stochastic':
         _swap += [StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
-        _swap += [LookaheadSwap(coupling_map)]
+        _swap += [LookaheadSwap(coupling_map, search_depth=2, search_width=2)]
     else:
         raise TranspilerError("Invalid routing method %s.", routing_method)
 

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -42,16 +42,18 @@ from qiskit.transpiler.passes import Optimize1qGates
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes import CheckCXDirection
 from qiskit.transpiler.passes import Layout2qDistance
-from qiskit.transpiler.passes import DenseLayout
+
+from qiskit.transpiler import TranspilerError
 
 
 def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     """Level 1 pass manager: light optimization by simple adjacent gate collapsing.
 
-    This pass manager applies the user-given initial layout. If none is given, and a trivial
-    layout (i-th virtual -> i-th physical) makes the circuit fit the coupling map, that is used.
-    Otherwise, the circuit is mapped to the most densely connected coupling subgraph, and swaps
-    are inserted to map. Any unused physical qubit is allocated as ancilla space.
+    This pass manager applies the user-given initial layout. If none is given,
+    and a trivial layout (i-th virtual -> i-th physical) makes the circuit fit
+    the coupling map, that is used.
+    Otherwise, the circuit is mapped to the most densely connected coupling subgraph,
+    and swaps are inserted to map. Any unused physical qubit is allocated as ancilla space.
     The pass manager then unrolls the circuit to the desired basis, and transforms the
     circuit to match the coupling map. Finally, optimizations in the form of adjacent
     gate collapse and redundant reset removal are performed.
@@ -65,6 +67,9 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     Returns:
         a level 1 pass manager.
+
+    Raises:
+        TranspilerError: if the passmanager config is invalid.
     """
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
@@ -92,7 +97,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif layout_method == 'noise_adaptive':
         _improve_layout = NoiseAdaptiveLayout(backend_properties)
     else:
-        raise TranspilerError("Invalid layout method %s.", layout_method)
+        raise TranspilerError("Invalid layout method %s." % layout_method)
 
     def _not_perfect_yet(property_set):
         return property_set['trivial_layout_score'] is not None and \
@@ -118,7 +123,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'lookahead':
         _swap += [LookaheadSwap(coupling_map, search_depth=4, search_width=4)]
     else:
-        raise TranspilerError("Invalid routing method %s.", routing_method)
+        raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 6. Unroll to the basis
     _unroll = Unroller(basis_gates)

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -116,7 +116,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'stochastic':
         _swap += [StochasticSwap(coupling_map, trials=50, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
-        _swap += [LookaheadSwap(coupling_map)]
+        _swap += [LookaheadSwap(coupling_map, search_depth=4, search_width=4)]
     else:
         raise TranspilerError("Invalid routing method %s.", routing_method)
 

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -27,7 +27,11 @@ from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler.passes import TrivialLayout
+from qiskit.transpiler.passes import DenseLayout
+from qiskit.transpiler.passes import NoiseAdaptiveLayout
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
+from qiskit.transpiler.passes import BasicSwap
+from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
@@ -65,6 +69,8 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
+    layout_method = pass_manager_config.layout_method or 'dense'
+    routing_method = pass_manager_config.routing_method or 'stochastic'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -79,7 +85,14 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         return not property_set['layout']
 
     # 2. Use a better layout on densely connected qubits, if circuit needs swaps
-    _improve_layout = DenseLayout(coupling_map, backend_properties)
+    if layout_method == 'trivial':
+        _improve_layout = TrivialLayout(coupling_map)
+    elif layout_method == 'dense':
+        _improve_layout = DenseLayout(coupling_map, backend_properties)
+    elif layout_method == 'noise_adaptive':
+        _improve_layout = NoiseAdaptiveLayout(backend_properties)
+    else:
+        raise TranspilerError("Invalid layout method %s.", layout_method)
 
     def _not_perfect_yet(property_set):
         return property_set['trivial_layout_score'] is not None and \
@@ -97,8 +110,15 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     def _swap_condition(property_set):
         return not property_set['is_swap_mapped']
 
-    _swap = [BarrierBeforeFinalMeasurements(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
+    _swap = [BarrierBeforeFinalMeasurements()]
+    if routing_method == 'basic':
+        _swap += [BasicSwap(coupling_map)]
+    elif routing_method == 'stochastic':
+        _swap += [StochasticSwap(coupling_map, trials=50, seed=seed_transpiler)]
+    elif routing_method == 'lookahead':
+        _swap += [LookaheadSwap(coupling_map)]
+    else:
+        raise TranspilerError("Invalid routing method %s.", routing_method)
 
     # 6. Unroll to the basis
     _unroll = Unroller(basis_gates)

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -44,6 +44,8 @@ from qiskit.transpiler.passes import CommutativeCancellation
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes import CheckCXDirection
 
+from qiskit.transpiler import TranspilerError
+
 
 def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     """Level 2 pass manager: medium optimization by initial layout selection and
@@ -68,6 +70,9 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     Returns:
         a level 2 pass manager.
+
+    Raises:
+        TranspilerError: if the passmanager config is invalid.
     """
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
@@ -91,7 +96,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif layout_method == 'noise_adaptive':
         _choose_layout_2 = NoiseAdaptiveLayout(backend_properties)
     else:
-        raise TranspilerError("Invalid layout method %s.", layout_method)
+        raise TranspilerError("Invalid layout method %s." % layout_method)
 
     # 2. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
@@ -113,7 +118,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'lookahead':
         _swap += [LookaheadSwap(coupling_map, search_depth=5, search_width=5)]
     else:
-        raise TranspilerError("Invalid routing method %s.", routing_method)
+        raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 5. Unroll to the basis
     _unroll = Unroller(basis_gates)

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -111,7 +111,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'stochastic':
         _swap += [StochasticSwap(coupling_map, trials=100, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
-        _swap += [LookaheadSwap(coupling_map)]
+        _swap += [LookaheadSwap(coupling_map, search_depth=5, search_width=5)]
     else:
         raise TranspilerError("Invalid routing method %s.", routing_method)
 

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -26,9 +26,13 @@ from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
-from qiskit.transpiler.passes import DenseLayout
 from qiskit.transpiler.passes import CSPLayout
+from qiskit.transpiler.passes import TrivialLayout
+from qiskit.transpiler.passes import DenseLayout
+from qiskit.transpiler.passes import NoiseAdaptiveLayout
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
+from qiskit.transpiler.passes import BasicSwap
+from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
@@ -68,6 +72,8 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
+    layout_method = pass_manager_config.layout_method or 'dense'
+    routing_method = pass_manager_config.routing_method or 'stochastic'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -78,7 +84,14 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         return not property_set['layout']
 
     _choose_layout_1 = CSPLayout(coupling_map, call_limit=1000, time_limit=10)
-    _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
+    if layout_method == 'trivial':
+        _choose_layout_2 = TrivialLayout(coupling_map)
+    elif layout_method == 'dense':
+        _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
+    elif layout_method == 'noise_adaptive':
+        _choose_layout_2 = NoiseAdaptiveLayout(backend_properties)
+    else:
+        raise TranspilerError("Invalid layout method %s.", layout_method)
 
     # 2. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
@@ -92,8 +105,15 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     def _swap_condition(property_set):
         return not property_set['is_swap_mapped']
 
-    _swap = [BarrierBeforeFinalMeasurements(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
+    _swap = [BarrierBeforeFinalMeasurements()]
+    if routing_method == 'basic':
+        _swap += [BasicSwap(coupling_map)]
+    elif routing_method == 'stochastic':
+        _swap += [StochasticSwap(coupling_map, trials=100, seed=seed_transpiler)]
+    elif routing_method == 'lookahead':
+        _swap += [LookaheadSwap(coupling_map)]
+    else:
+        raise TranspilerError("Invalid routing method %s.", routing_method)
 
     # 5. Unroll to the basis
     _unroll = Unroller(basis_gates)

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -27,9 +27,13 @@ from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler.passes import CSPLayout
+from qiskit.transpiler.passes import TrivialLayout
 from qiskit.transpiler.passes import DenseLayout
-from qiskit.transpiler.passes import StochasticSwap
+from qiskit.transpiler.passes import NoiseAdaptiveLayout
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
+from qiskit.transpiler.passes import BasicSwap
+from qiskit.transpiler.passes import LookaheadSwap
+from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
 from qiskit.transpiler.passes import FixedPoint
@@ -72,6 +76,8 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
+    layout_method = pass_manager_config.layout_method or 'dense'
+    routing_method = pass_manager_config.routing_method or 'stochastic'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -85,8 +91,14 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         return not property_set['layout']
 
     _choose_layout_1 = CSPLayout(coupling_map, call_limit=10000, time_limit=60)
-    # TODO: benchmark DenseLayout vs. NoiseAdaptiveLayout in terms of noise aware mapping
-    _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
+    if layout_method == 'trivial':
+        _choose_layout_2 = TrivialLayout(coupling_map)
+    elif layout_method == 'dense':
+        _choose_layout_2 = DenseLayout(coupling_map, backend_properties)
+    elif layout_method == 'noise_adaptive':
+        _choose_layout_2 = NoiseAdaptiveLayout(backend_properties)
+    else:
+        raise TranspilerError("Invalid layout method %s.", layout_method)
 
     # 3. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
@@ -97,9 +109,15 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     def _swap_condition(property_set):
         return not property_set['is_swap_mapped']
 
-    _swap = [BarrierBeforeFinalMeasurements(),
-             Unroll3qOrMore(),
-             StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
+    _swap = [BarrierBeforeFinalMeasurements(), Unroll3qOrMore()]
+    if routing_method == 'basic':
+        _swap += [BasicSwap(coupling_map)]
+    elif routing_method == 'stochastic':
+        _swap += [StochasticSwap(coupling_map, trials=200, seed=seed_transpiler)]
+    elif routing_method == 'lookahead':
+        _swap += [LookaheadSwap(coupling_map)]
+    else:
+        raise TranspilerError("Invalid routing method %s.", routing_method)
 
     # 5. 1q rotation merge and commutative cancellation iteratively until no more change in depth
     _depth_check = [Depth(), FixedPoint('depth')]

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -48,6 +48,8 @@ from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes import CheckCXDirection
 
+from qiskit.transpiler import TranspilerError
+
 
 def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     """Level 3 pass manager: heavy optimization by noise adaptive qubit mapping and
@@ -72,6 +74,9 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     Returns:
         a level 3 pass manager.
+
+    Raises:
+        TranspilerError: if the passmanager config is invalid.
     """
     basis_gates = pass_manager_config.basis_gates
     coupling_map = pass_manager_config.coupling_map
@@ -98,7 +103,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif layout_method == 'noise_adaptive':
         _choose_layout_2 = NoiseAdaptiveLayout(backend_properties)
     else:
-        raise TranspilerError("Invalid layout method %s.", layout_method)
+        raise TranspilerError("Invalid layout method %s." % layout_method)
 
     # 3. Extend dag/layout with ancillas using the full coupling map
     _embed = [FullAncillaAllocation(coupling_map), EnlargeWithAncilla(), ApplyLayout()]
@@ -117,7 +122,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'lookahead':
         _swap += [LookaheadSwap(coupling_map, search_depth=5, search_width=6)]
     else:
-        raise TranspilerError("Invalid routing method %s.", routing_method)
+        raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 5. 1q rotation merge and commutative cancellation iteratively until no more change in depth
     _depth_check = [Depth(), FixedPoint('depth')]

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -115,7 +115,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == 'stochastic':
         _swap += [StochasticSwap(coupling_map, trials=200, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
-        _swap += [LookaheadSwap(coupling_map)]
+        _swap += [LookaheadSwap(coupling_map, search_depth=5, search_width=6)]
     else:
         raise TranspilerError("Invalid routing method %s.", routing_method)
 

--- a/releasenotes/notes/transpile-method-selectors-1c426457743a6fa7.yaml
+++ b/releasenotes/notes/transpile-method-selectors-1c426457743a6fa7.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    ``qiskit.transpile()`` now allows you to pass ``layout_method``
+    and ``routing_method`` to select a particular method for placement and
+    routing of circuits on constrained architectures.
+    e.g. ``transpile(circ, backend,
+                     layout_method='dense', routing_method='lookahead')``

--- a/releasenotes/notes/transpile-method-selectors-1c426457743a6fa7.yaml
+++ b/releasenotes/notes/transpile-method-selectors-1c426457743a6fa7.yaml
@@ -3,6 +3,5 @@ features:
   - |
     ``qiskit.transpile()`` now allows you to pass ``layout_method``
     and ``routing_method`` to select a particular method for placement and
-    routing of circuits on constrained architectures.
-    e.g. ``transpile(circ, backend,
-                     layout_method='dense', routing_method='lookahead')``
+    routing of circuits on constrained architectures. e.g.
+    ``transpile(circ, backend, layout_method='dense', routing_method='lookahead')``


### PR DESCRIPTION
Adding the ability to quickly select `layout_method` and `routing_method` from the top-level `transpile()` call. This configures the level 0-3 passmanagers to use the given methods for layout and routing. 

Something like this using `passmanager.replace()` is also doable but not as convenient due to the issue of conditions, control-flow, etc. surrounding the passes.

Generally I think there are a few basic & key steps to the compilation flow, each of which have several possible methods: optimization, placement, routing, scheduling, pulse selection. 
With `optimization_level`, `layout_method`, `routing_method` we cover the first 3. The 4th is in the form of `schedule(circuit, method)` right now.

Building a passmanager gives you ultimate control over how passes get chained, repeated until convergence, etc. but high-level options are still very useful in allowing the user to quickly explore alternatives. For example right now I don't think the "lookahead swap" is used anywhere or anyone knows how to invoke it.