### PR TITLE
Small improvement to count_ops

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -984,10 +984,7 @@ class QuantumCircuit:
         """
         count_ops = {}
         for instr, _, _ in self._data:
-            if instr.name in count_ops.keys():
-                count_ops[instr.name] += 1
-            else:
-                count_ops[instr.name] = 1
+            count_ops[instr.name] = count_ops.get(instr.name, 0) + 1
         return OrderedDict(sorted(count_ops.items(), key=lambda kv: kv[1], reverse=True))
 
     def num_connected_components(self, unitary_only=False):


### PR DESCRIPTION
More efficient way to get current count when going through loop

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Very small clean up/efficiency improvement in the count_ops() method in the QuantumCircuit class. No change in functionality.

### Details and comments
The clean up made the code slightly shorter and (in my opinion) slightly more readable, and slightly more efficient in traversing the for loop. I am working on a different PR and thought of this small optimization so I thought I would create a separate PR for this before submitting my bigger PR. Thanks!
