### PR TITLE
Optimize1qGates should allow rounding when calculating theta

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -26,7 +26,8 @@ from qiskit.circuit.gate import Gate
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.quantum_info.operators import Quaternion
 
-_CHOP_THRESHOLD = 1e-15
+_DECIMAL_ROUND = 15
+_CHOP_THRESHOLD = 10 ** -(_DECIMAL_ROUND)
 
 
 class Optimize1qGates(TransformationPass):
@@ -145,7 +146,7 @@ class Optimize1qGates(TransformationPass):
                 # exact and approximate rewriting.
 
                 # Y rotation is 0 mod 2*pi, so the gate is a u1
-                if np.mod(right_parameters[0], (2 * np.pi)) == 0 \
+                if np.mod(np.round(right_parameters[0], _DECIMAL_ROUND), (2 * np.pi)) == 0 \
                         and right_name != "u1":
                     right_name = "u1"
                     right_parameters = (0, 0, right_parameters[1] +
@@ -154,20 +155,23 @@ class Optimize1qGates(TransformationPass):
                 # Y rotation is pi/2 or -pi/2 mod 2*pi, so the gate is a u2
                 if right_name == "u3":
                     # theta = pi/2 + 2*k*pi
-                    if np.mod((right_parameters[0] - np.pi / 2), (2 * np.pi)) == 0:
+                    if np.mod(np.round(right_parameters[0] - np.pi / 2, _DECIMAL_ROUND),
+                              (2 * np.pi)) == 0:
                         right_name = "u2"
                         right_parameters = (np.pi / 2, right_parameters[1],
                                             right_parameters[2] +
                                             (right_parameters[0] - np.pi / 2))
                     # theta = -pi/2 + 2*k*pi
-                    if np.mod((right_parameters[0] + np.pi / 2), (2 * np.pi)) == 0:
+                    if np.mod(np.round(right_parameters[0] + np.pi / 2, _DECIMAL_ROUND),
+                              (2 * np.pi)) == 0:
                         right_name = "u2"
                         right_parameters = (np.pi / 2, right_parameters[1] +
                                             np.pi, right_parameters[2] -
                                             np.pi + (right_parameters[0] +
                                                      np.pi / 2))
                 # u1 and lambda is 0 mod 2*pi so gate is nop (up to a global phase)
-                if right_name == "u1" and np.mod(right_parameters[2], (2 * np.pi)) == 0:
+                if right_name == "u1" and np.mod(np.round(right_parameters[2], _DECIMAL_ROUND),
+                                                 (2 * np.pi)) == 0:
                     right_name = "nop"
 
             new_op = Gate(name="", num_qubits=1, params=[])

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -78,7 +78,7 @@ class TestOptimize1qGates(QiskitTestCase):
         qc.u1(2 * np.pi, qr[0])
         qc.cx(qr[1], qr[0])
         qc.u1(np.pi / 2, qr[0])  # these three should combine
-        qc.u1(np.pi, qr[0])      # to identity then
+        qc.u1(np.pi, qr[0])  # to identity then
         qc.u1(np.pi / 2, qr[0])  # optimized away.
         qc.cx(qr[1], qr[0])
         qc.u1(np.pi, qr[1])
@@ -133,7 +133,7 @@ class TestOptimize1qGates(QiskitTestCase):
         circuit.h(qr)
         dag = circuit_to_dag(circuit)
 
-        expected = QuantumCircuit(qr,)
+        expected = QuantumCircuit(qr, )
         expected.u1(0.7, qr)
         expected.h(qr)
 
@@ -224,6 +224,37 @@ class TestOptimize1qGates(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(expected), after)
 
+
+class TestOptimize1qGatesParamReduction(QiskitTestCase):
+    """Test for 1q gate optimizations parameter reduction, reduce n in Un """
+
+    def test_optimize_u3_to_u2(self):
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.u3(np.pi/2, np.pi/3, np.pi/4, qr[0])
+
+        expected = QuantumCircuit(qr)
+        expected.u2(np.pi/3, np.pi/4, qr[0])
+
+        passmanager = PassManager()
+        passmanager.append(Optimize1qGates())
+        result = passmanager.run(circuit)
+
+        self.assertEqual(expected, result)
+
+    def test_optimize_u3_to_u2_round(self):
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr)
+        circuit.u3(1.5707963267948961, 1.0471975511965971, 0.7853981633974489, qr[0])
+
+        expected = QuantumCircuit(qr)
+        expected.u2(np.pi/3, np.pi/4, qr[0])
+
+        passmanager = PassManager()
+        passmanager.append(Optimize1qGates())
+        result = passmanager.run(circuit)
+
+        self.assertEqual(expected, result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -78,7 +78,7 @@ class TestOptimize1qGates(QiskitTestCase):
         qc.u1(2 * np.pi, qr[0])
         qc.cx(qr[1], qr[0])
         qc.u1(np.pi / 2, qr[0])  # these three should combine
-        qc.u1(np.pi, qr[0])  # to identity then
+        qc.u1(np.pi, qr[0])      # to identity then
         qc.u1(np.pi / 2, qr[0])  # optimized away.
         qc.cx(qr[1], qr[0])
         qc.u1(np.pi, qr[1])
@@ -133,7 +133,7 @@ class TestOptimize1qGates(QiskitTestCase):
         circuit.h(qr)
         dag = circuit_to_dag(circuit)
 
-        expected = QuantumCircuit(qr, )
+        expected = QuantumCircuit(qr)
         expected.u1(0.7, qr)
         expected.h(qr)
 
@@ -229,6 +229,7 @@ class TestOptimize1qGatesParamReduction(QiskitTestCase):
     """Test for 1q gate optimizations parameter reduction, reduce n in Un """
 
     def test_optimize_u3_to_u2(self):
+        """U3(pi/2, pi/3, pi/4) ->  U2(pi/3, pi/4)"""
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr)
         circuit.u3(np.pi/2, np.pi/3, np.pi/4, qr[0])
@@ -243,6 +244,7 @@ class TestOptimize1qGatesParamReduction(QiskitTestCase):
         self.assertEqual(expected, result)
 
     def test_optimize_u3_to_u2_round(self):
+        """U3(1.5707963267948961, 1.0471975511965971, 0.7853981633974489) ->  U2(pi/3, pi/4)"""
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr)
         circuit.u3(1.5707963267948961, 1.0471975511965971, 0.7853981633974489, qr[0])


### PR DESCRIPTION
I noticed floating error makes `Optimize1qGates` missing some situations to reduce the U-gate arity. For example:
```
        circuit.u3(1.5707963267948961, 1.0471975511965971, 0.7853981633974489, qr[0])
```
is "almost"
```
        circuit.u2(np.pi/3, np.pi/4, qr[0])
```

This PR fixes that.
