### PR TITLE
Fix global phase coming from optimize_1q_gates

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -12,7 +12,10 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Optimize chains of single-qubit u1, u2, u3 gates by combining them into a single gate."""
+"""
+Optimize chains of single-qubit u1, u2, u3 gates
+by combining them into a single gate.
+"""
 
 from itertools import groupby
 
@@ -28,6 +31,7 @@ from qiskit.quantum_info.operators import Quaternion
 
 _CHOP_THRESHOLD = 1e-15
 
+
 class Node:
     """
     Operator description in Optimize1qGates(TransformationPass)
@@ -42,7 +46,10 @@ class Node:
 
 
 class Optimize1qGates(TransformationPass):
-    """Optimize chains of single-qubit u1, u2, u3 gates by combining them into a single gate."""
+    """
+    Optimize chains of single-qubit u1, u2, u3 gates
+    by combining them into a single gate.
+    """
 
     def define_left_node(self, current_node):
         """
@@ -79,24 +86,30 @@ class Optimize1qGates(TransformationPass):
         """
         u1(lambda1) * u2(phi2, lambda2) = u2(phi2 + lambda1, lambda2)
         """
-        right_node.parameters = (np.pi / 2, right_node.parameters[1] +
-                                 left_node.parameters[2], right_node.parameters[2])
+        right_node.parameters = (np.pi / 2,
+                                 right_node.parameters[1] +
+                                 left_node.parameters[2],
+                                 right_node.parameters[2])
 
     def combine_u1u3_into_right_node(self, left_node, right_node):
         """
         u1(lambda1) * u3(theta2, phi2, lambda2) =
              u3(theta2, phi2 + lambda1, lambda2)
         """
-        right_node.parameters = (right_node.parameters[0], right_node.parameters[1] +
-                                 left_node.parameters[2], right_node.parameters[2])
+        right_node.parameters = (right_node.parameters[0],
+                                 right_node.parameters[1] +
+                                 left_node.parameters[2],
+                                 right_node.parameters[2])
 
     def combine_u2u1_into_right_node(self, left_node, right_node):
         """
         u2(phi1, lambda1) * u1(lambda2) = u2(phi1, lambda1 + lambda2)
         """
         right_node.name = "u2"
-        right_node.parameters = (np.pi / 2, left_node.parameters[1],
-                                 right_node.parameters[2] + left_node.parameters[2])
+        right_node.parameters = (np.pi / 2,
+                                 left_node.parameters[1],
+                                 right_node.parameters[2] +
+                                 left_node.parameters[2])
 
     def combine_u2u2_into_right_node(self, left_node, right_node):
         """
@@ -107,8 +120,9 @@ class Optimize1qGates(TransformationPass):
         """
         right_node.name = "u3"
         right_node.parameters = (np.pi - left_node.parameters[2] -
-                                 right_node.parameters[1], left_node.parameters[1] +
-                                 np.pi / 2, right_node.parameters[2] +
+                                 right_node.parameters[1],
+                                 left_node.parameters[1] + np.pi / 2,
+                                 right_node.parameters[2] +
                                  np.pi / 2)
 
     def combine_u3u1_into_right_node(self, left_node, right_node):
@@ -117,8 +131,10 @@ class Optimize1qGates(TransformationPass):
             u3(theta1, phi1, lambda1 + lambda2)
         """
         right_node.name = "u3"
-        right_node.parameters = (left_node.parameters[0], left_node.parameters[1],
-                                 right_node.parameters[2] + left_node.parameters[2])
+        right_node.parameters = (left_node.parameters[0],
+                                 left_node.parameters[1],
+                                 right_node.parameters[2] +
+                                 left_node.parameters[2])
 
     def combine_u2oru3u3_into_right_node(self, left_node, right_node):
         """
@@ -128,12 +144,13 @@ class Optimize1qGates(TransformationPass):
         """
         right_node.name = "u3"
         # Evaluate the symbolic expressions for efficiency
-        right_node.parameters = Optimize1qGates.compose_u3(left_node.parameters[0],
-                                                           left_node.parameters[1],
-                                                           left_node.parameters[2],
-                                                           right_node.parameters[0],
-                                                           right_node.parameters[1],
-                                                           right_node.parameters[2])
+        right_node.parameters = \
+            Optimize1qGates.compose_u3(left_node.parameters[0],
+                                       left_node.parameters[1],
+                                       left_node.parameters[2],
+                                       right_node.parameters[0],
+                                       right_node.parameters[1],
+                                       right_node.parameters[2])
 
     def combine_gates_into_right_node(self, left_node, right_node):
         """
@@ -195,7 +212,8 @@ class Optimize1qGates(TransformationPass):
 
     def can_combine(self, left_node, right_node):
         """
-            Check if left_node and right_node can be combined preserving global phase
+            Check if left_node and right_node can
+            be combined preserving global phase
         """
         if left_node.name == 'u1' or right_node.name == 'u1':
             return True
@@ -207,7 +225,8 @@ class Optimize1qGates(TransformationPass):
 
         if left_node.name == 'u2' and right_node.name == 'u3':
             temp = - 0.707106781186547 * \
-                   np.e**((left_node.parameters[2] + right_node.parameters[1])*1j) * \
+                   np.e**((left_node.parameters[2] +
+                           right_node.parameters[1])*1j) * \
                    np.sin(right_node.parameters[0] / 2) + \
                    0.707106781186548 * np.cos(right_node.parameters[0]/2)
 
@@ -216,16 +235,21 @@ class Optimize1qGates(TransformationPass):
 
         if left_node.name == 'u3' and right_node.name == 'u2':
             temp = - 0.707106781186547 * \
-                   np.e**((left_node.parameters[2] + right_node.parameters[1])*1j) \
+                   np.e**((left_node.parameters[2] +
+                           right_node.parameters[1])*1j) \
                    * np.sin(left_node.parameters[0] / 2) + \
                    0.707106781186548 * np.cos(left_node.parameters[0]/2)
             if np.abs(np.imag(temp) < _CHOP_THRESHOLD) and np.real(temp) >= 0:
                 return True
 
         if left_node.name == 'u3' and right_node.name == 'u3':
-            temp = -np.e**((left_node.parameters[2] + right_node.parameters[1])*1j) \
-                   * np.sin(left_node.parameters[0] / 2) * np.sin(right_node.parameters[0] / 2) + \
-                   np.cos(left_node.parameters[0]/2) * np.cos(right_node.parameters[0]/2)
+            temp = -np.e**((left_node.parameters[2] +
+                            right_node.parameters[1])*1j) \
+                   * np.sin(left_node.parameters[0] / 2) \
+                   * np.sin(right_node.parameters[0] / 2) \
+                   + np.cos(left_node.parameters[0]/2) \
+                   * np.cos(right_node.parameters[0]/2)
+
             if np.abs(np.imag(temp) < _CHOP_THRESHOLD) and np.real(temp) >= 0:
                 return True
 
@@ -241,14 +265,15 @@ class Optimize1qGates(TransformationPass):
                     DAGCircuit: the optimized DAG.
 
                 Raises:
-                    TranspilerError: if YZY and ZYZ angles do not give same rotation matrix.
+                    TranspilerError: if YZY and ZYZ angles do not
+                     give same rotation matrix.
                 """
 
         runs = dag.collect_runs(["u1", "u2", "u3"])
         runs = _split_runs_on_parameters(runs)
 
         for run in runs:
-            num_gates = 0 # pylint: disable = attribute-defined-outside-init
+            num_gates = 0
             final_gates = []
             final_nodes = []
             right_node = Node("u1", (0, 0, 0))
@@ -259,15 +284,14 @@ class Optimize1qGates(TransformationPass):
                     self.combine_gates_into_right_node(left_node, right_node)
                 else:
                     new_op = self.generate_gate(right_node)
-                    final_nodes.append(Node(right_node.name, right_node.parameters))
+                    new_node = Node(right_node.name, right_node.parameters)
+                    final_nodes.append(new_node)
                     final_gates.append(new_op)
                     right_node.name = left_node.name
                     right_node.parameters = left_node.parameters
                     num_gates = num_gates + 1
 
-
                 self.simplify_right_node(right_node)
-
 
             new_op = self.generate_gate(right_node)
             final_gates.append(new_op)
@@ -275,7 +299,6 @@ class Optimize1qGates(TransformationPass):
             self.add_right_node_to_dag(dag, final_gates, run)
             self.extract_simplified_gates(dag, run, num_gates)
             self.check(run, dag)
-
 
         return dag
 
@@ -286,7 +309,6 @@ class Optimize1qGates(TransformationPass):
         for node_op in run:
             if node_op.name == '':
                 dag.remove_op_node(node_op)
-
 
     def simplify_right_node(self, right_node):
         """
@@ -311,20 +333,25 @@ class Optimize1qGates(TransformationPass):
         # Y rotation is pi/2 or -pi/2 mod 2*pi, so the gate is a u2
         if right_node.name == "u3":
             # theta = pi/2 + 2*k*pi
-            if np.mod((right_node.parameters[0] - np.pi / 2), (2 * np.pi)) == 0:
+            if np.mod((right_node.parameters[0] - np.pi / 2),
+                      (2 * np.pi)) == 0:
                 right_node.name = "u2"
-                right_node.parameters = (np.pi / 2, right_node.parameters[1],
-                                         right_node.parameters[2] +
-                                         (right_node.parameters[0] - np.pi / 2))
+                right_node.parameters = \
+                    (np.pi / 2, right_node.parameters[1],
+                     right_node.parameters[2] +
+                     (right_node.parameters[0] - np.pi / 2))
+
             # theta = -pi/2 + 2*k*pi
-            if np.mod((right_node.parameters[0] + np.pi / 2), (2 * np.pi)) == 0:
+            if np.mod((right_node.parameters[0] + np.pi / 2),
+                      (2 * np.pi)) == 0:
                 right_node.name = "u2"
                 right_node.parameters = (np.pi / 2, right_node.parameters[1] +
                                          np.pi, right_node.parameters[2] -
                                          np.pi + (right_node.parameters[0] +
                                                   np.pi / 2))
         # u1 and lambda is 0 mod 2*pi so gate is nop (up to a global phase)
-        if right_node.name == "u1" and np.mod(right_node.parameters[2], (2 * np.pi)) == 0:
+        if right_node.name == "u1" and \
+                np.mod(right_node.parameters[2], (2 * np.pi)) == 0:
             right_node.name = "nop"
 
     @staticmethod
@@ -340,14 +367,17 @@ class Optimize1qGates(TransformationPass):
         Return theta, phi, lambda.
         """
         # Careful with the factor of two in yzy_to_zyz
-        thetap, phip, lambdap = Optimize1qGates.yzy_to_zyz((lambda1 + phi2), theta1, theta2)
+        thetap, phip, lambdap = \
+            Optimize1qGates.yzy_to_zyz((lambda1 + phi2), theta1, theta2)
+
         (theta, phi, lamb) = (thetap, phi1 + phip, lambda2 + lambdap)
 
         return (theta, phi, lamb)
 
     @staticmethod
-    def yzy_to_zyz(xi, theta1, theta2, eps=1e-9):  # pylint: disable=invalid-name
-        """Express a Y.Z.Y single qubit gate as a Z.Y.Z gate.
+    def yzy_to_zyz(x_i, theta1, theta2, eps=1e-9):
+        """
+        Express a Y.Z.Y single qubit gate as a Z.Y.Z gate.
 
         Solve the equation
 
@@ -359,22 +389,23 @@ class Optimize1qGates(TransformationPass):
 
         Return a solution theta, phi, and lambda.
         """
-        quaternion_yzy = Quaternion.from_euler([theta1, xi, theta2], 'yzy')
+        quaternion_yzy = Quaternion.from_euler([theta1, x_i, theta2], 'yzy')
         euler = quaternion_yzy.to_zyz()
         quaternion_zyz = Quaternion.from_euler(euler, 'zyz')
         # output order different than rotation order
         out_angles = (euler[1], euler[0], euler[2])
         abs_inner = abs(quaternion_zyz.data.dot(quaternion_yzy.data))
         if not np.allclose(abs_inner, 1, eps):
-            raise TranspilerError('YZY and ZYZ angles do not give same rotation matrix.')
+            raise TranspilerError(
+                'YZY and ZYZ angles do not give same rotation matrix.')
         out_angles = tuple(0 if np.abs(angle) < _CHOP_THRESHOLD else angle
                            for angle in out_angles)
         return out_angles
 
 
 def _split_runs_on_parameters(runs):
-    """Finds runs containing parameterized gates and splits them into sequential
-    runs excluding the parameterized gates.
+    """Finds runs containing parameterized gates and splits them into
+    sequential runs excluding the parameterized gates.
     """
 
     out = []

--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -28,9 +28,162 @@ from qiskit.quantum_info.operators import Quaternion
 
 _CHOP_THRESHOLD = 1e-15
 
+class node:
+    def __init__(self, name, parameters):
+        '''
+        # right.name = "gate name in (u1, u2, u3)"
+        # right.parameters = (theta, phi, lambda)
+        '''
+        self.name = name
+        self.parameters = parameters
 
 class Optimize1qGates(TransformationPass):
     """Optimize chains of single-qubit u1, u2, u3 gates by combining them into a single gate."""
+
+    def define_left_node(self, current_node):
+        left_name = current_node.name
+        if (current_node.condition is not None
+                or len(current_node.qargs) != 1
+                or left_name not in ["u1", "u2", "u3", "id"]):
+            raise TranspilerError("internal error")
+        if left_name == "u1":
+            left_parameters = (0, 0, current_node.op.params[0])
+        elif left_name == "u2":
+            left_parameters = (np.pi / 2, current_node.op.params[0],
+                               current_node.op.params[1])
+        elif left_name == "u3":
+            left_parameters = tuple(current_node.op.params)
+        else:
+            left_name = "u1"  # replace id with u1
+            left_parameters = (0, 0, 0)
+        # If there are any sympy objects coming from the gate convert
+        # to numpy.
+        left_parameters = tuple([float(x) for x in left_parameters])
+        return node(left_name, left_parameters)
+
+    def combine_u1u1_into_right_node(self, left_node, right_node):
+        '''
+        u1(lambda1) * u1(lambda2) = u1(lambda1 + lambda2)
+        '''
+        right_node.parameters = (0, 0, right_node.parameters[2] +
+                                 left_node.parameters[2])
+
+    def combine_u1u2_into_right_node(self, left_node, right_node):
+        '''
+        u1(lambda1) * u2(phi2, lambda2) = u2(phi2 + lambda1, lambda2)
+        '''
+        right_node.parameters = (np.pi / 2, right_node.parameters[1] +
+                                 left_node.parameters[2], right_node.parameters[2])
+
+    def combine_u1u3_into_right_node(self, left_node, right_node):
+        '''
+        u1(lambda1) * u3(theta2, phi2, lambda2) =
+             u3(theta2, phi2 + lambda1, lambda2)
+        '''
+        right_node.parameters = (right_node.parameters[0], right_node.parameters[1] +
+                                 left_node.parameters[2], right_node.parameters[2])
+
+    def combine_u2u1_into_right_node(self, left_node, right_node):
+        '''
+        u2(phi1, lambda1) * u1(lambda2) = u2(phi1, lambda1 + lambda2)
+        '''
+        right_node.name = "u2"
+        right_node.parameters = (np.pi / 2, left_node.parameters[1],
+                                 right_node.parameters[2] + left_node.parameters[2])
+
+    def combine_u2u2_into_right_node(self, left_node, right_node):
+        '''
+        Using Ry(pi/2).Rz(2*lambda).Ry(pi/2) =
+           Rz(pi/2).Ry(pi-2*lambda).Rz(pi/2),
+        u2(phi1, lambda1) * u2(phi2, lambda2) =
+            u3(pi - lambda1 - phi2, phi1 + pi/2, lambda2 + pi/2)
+        '''
+        right_node.name = "u3"
+        right_node.parameters = (np.pi - left_node.parameters[2] -
+                                 right_node.parameters[1], left_node.parameters[1] +
+                                 np.pi / 2, right_node.parameters[2] +
+                                 np.pi / 2)
+
+    def combine_u3u1_into_right_node(self, left_node, right_node):
+        '''
+        u3(theta1, phi1, lambda1) * u1(lambda2) =
+            u3(theta1, phi1, lambda1 + lambda2)
+        '''
+        right_node.name = "u3"
+        right_node.parameters = (left_node.parameters[0], left_node.parameters[1],
+                                 right_node.parameters[2] + left_node.parameters[2])
+
+    def combine_u2oru3u3_into_right_node(self, left_node, right_node):
+        '''
+        For composing u3's or u2's with u3's, use
+        u2(phi, lambda) = u3(pi/2, phi, lambda)
+        together with the qiskit.mapper.compose_u3 method.
+        '''
+        right_node.name = "u3"
+        # Evaluate the symbolic expressions for efficiency
+        right_node.parameters = Optimize1qGates.compose_u3(left_node.parameters[0],
+                                                           left_node.parameters[1],
+                                                           left_node.parameters[2],
+                                                           right_node.parameters[0],
+                                                           right_node.parameters[1],
+                                                           right_node.parameters[2])
+
+    def combine_gates_into_right_node(self, left_node, right_node):
+        '''
+        Combine left_node and right_node into right_node
+        '''
+        name_tuple = (left_node.name, right_node.name)
+        if name_tuple == ("u1", "u1"):
+            self.combine_u1u1_into_right_node(left_node, right_node)
+
+        elif name_tuple == ("u1", "u2"):
+            self.combine_u1u2_into_right_node(left_node, right_node)
+
+        elif name_tuple == ("u2", "u1"):
+            self.combine_u2u1_into_right_node(left_node, right_node)
+
+        elif name_tuple == ("u1", "u3"):
+            self.combine_u1u3_into_right_node(left_node, right_node)
+
+        elif name_tuple == ("u3", "u1"):
+            self.combine_u3u1_into_right_node(left_node, right_node)
+
+        elif name_tuple == ("u2", "u2"):
+            self.combine_u2u2_into_right_node(left_node, right_node)
+
+        elif name_tuple[1] == "nop":
+            right_node.name = left_node.name
+            right_node.parameters = left_node.parameters
+        else:
+            self.combine_u2oru3u3_into_right_node(left_node, right_node)
+
+    def generate_gate(self, right_node):
+        new_op = Gate(name="", num_qubits=1, params=[])
+        if right_node.name == "u1":
+            new_op = U1Gate(right_node.parameters[2])
+        if right_node.name == "u2":
+            new_op = U2Gate(right_node.parameters[1], right_node.parameters[2])
+        if right_node.name == "u3":
+            new_op = U3Gate(*right_node.parameters)
+        return new_op
+
+    def add_right_node_to_dag(self, dag, new_op, right_node, run):
+        if right_node.name != 'nop':
+            dag.substitute_node(run[0], new_op, inplace=True)
+
+    def extract_simplified_gates(self, dag, right_node, run):
+        '''
+        Delete the other nodes in the run
+        '''
+        for current_node in run[1:]:
+            dag.remove_op_node(current_node)
+        if right_node.name == "nop":
+            dag.remove_op_node(run[0])
+
+    def can_cambine(self, left_node, right_node):
+        # TODO
+        return True
+        
 
     def run(self, dag):
         """Run the Optimize1qGates pass on `dag`.
@@ -47,147 +200,62 @@ class Optimize1qGates(TransformationPass):
         runs = dag.collect_runs(["u1", "u2", "u3"])
         runs = _split_runs_on_parameters(runs)
         for run in runs:
-            right_name = "u1"
-            right_parameters = (0, 0, 0)  # (theta, phi, lambda)
+            right_node = node("u1", (0, 0, 0))
+
 
             for current_node in run:
-                left_name = current_node.name
-                if (current_node.condition is not None
-                        or len(current_node.qargs) != 1
-                        or left_name not in ["u1", "u2", "u3", "id"]):
-                    raise TranspilerError("internal error")
-                if left_name == "u1":
-                    left_parameters = (0, 0, current_node.op.params[0])
-                elif left_name == "u2":
-                    left_parameters = (np.pi / 2, current_node.op.params[0],
-                                       current_node.op.params[1])
-                elif left_name == "u3":
-                    left_parameters = tuple(current_node.op.params)
-                else:
-                    left_name = "u1"  # replace id with u1
-                    left_parameters = (0, 0, 0)
-                # If there are any sympy objects coming from the gate convert
-                # to numpy.
-                left_parameters = tuple([float(x) for x in left_parameters])
-                # Compose gates
-                name_tuple = (left_name, right_name)
-                if name_tuple == ("u1", "u1"):
-                    # u1(lambda1) * u1(lambda2) = u1(lambda1 + lambda2)
-                    right_parameters = (0, 0, right_parameters[2] +
-                                        left_parameters[2])
-                elif name_tuple == ("u1", "u2"):
-                    # u1(lambda1) * u2(phi2, lambda2) = u2(phi2 + lambda1, lambda2)
-                    right_parameters = (np.pi / 2, right_parameters[1] +
-                                        left_parameters[2], right_parameters[2])
-                elif name_tuple == ("u2", "u1"):
-                    # u2(phi1, lambda1) * u1(lambda2) = u2(phi1, lambda1 + lambda2)
-                    right_name = "u2"
-                    right_parameters = (np.pi / 2, left_parameters[1],
-                                        right_parameters[2] + left_parameters[2])
-                elif name_tuple == ("u1", "u3"):
-                    # u1(lambda1) * u3(theta2, phi2, lambda2) =
-                    #     u3(theta2, phi2 + lambda1, lambda2)
-                    right_parameters = (right_parameters[0], right_parameters[1] +
-                                        left_parameters[2], right_parameters[2])
-                elif name_tuple == ("u3", "u1"):
-                    # u3(theta1, phi1, lambda1) * u1(lambda2) =
-                    #     u3(theta1, phi1, lambda1 + lambda2)
-                    right_name = "u3"
-                    right_parameters = (left_parameters[0], left_parameters[1],
-                                        right_parameters[2] + left_parameters[2])
-                elif name_tuple == ("u2", "u2"):
-                    # Using Ry(pi/2).Rz(2*lambda).Ry(pi/2) =
-                    #    Rz(pi/2).Ry(pi-2*lambda).Rz(pi/2),
-                    # u2(phi1, lambda1) * u2(phi2, lambda2) =
-                    #    u3(pi - lambda1 - phi2, phi1 + pi/2, lambda2 + pi/2)
-                    right_name = "u3"
-                    right_parameters = (np.pi - left_parameters[2] -
-                                        right_parameters[1], left_parameters[1] +
-                                        np.pi / 2, right_parameters[2] +
-                                        np.pi / 2)
-                elif name_tuple[1] == "nop":
-                    right_name = left_name
-                    right_parameters = left_parameters
-                else:
-                    # For composing u3's or u2's with u3's, use
-                    # u2(phi, lambda) = u3(pi/2, phi, lambda)
-                    # together with the qiskit.mapper.compose_u3 method.
-                    right_name = "u3"
-                    # Evaluate the symbolic expressions for efficiency
-                    right_parameters = Optimize1qGates.compose_u3(left_parameters[0],
-                                                                  left_parameters[1],
-                                                                  left_parameters[2],
-                                                                  right_parameters[0],
-                                                                  right_parameters[1],
-                                                                  right_parameters[2])
-                    # Why evalf()? This program:
-                    #   OPENQASM 2.0;
-                    #   include "qelib1.inc";
-                    #   qreg q[2];
-                    #   creg c[2];
-                    #   u3(0.518016983430947*pi,1.37051598592907*pi,1.36816383603222*pi) q[0];
-                    #   u3(1.69867232277986*pi,0.371448347747471*pi,0.461117217930936*pi) q[0];
-                    #   u3(0.294319836336836*pi,0.450325871124225*pi,1.46804720442555*pi) q[0];
-                    #   measure q -> c;
-                    # took >630 seconds (did not complete) to optimize without
-                    # calling evalf() at all, 19 seconds to optimize calling
-                    # evalf() AFTER compose_u3, and 1 second to optimize
-                    # calling evalf() BEFORE compose_u3.
-                # 1. Here down, when we simplify, we add f(theta) to lambda to
-                # correct the global phase when f(theta) is 2*pi. This isn't
-                # necessary but the other steps preserve the global phase, so
-                # we continue in that manner.
-                # 2. The final step will remove Z rotations by 2*pi.
-                # 3. Note that is_zero is true only if the expression is exactly
-                # zero. If the input expressions have already been evaluated
-                # then these final simplifications will not occur.
-                # TODO After we refactor, we should have separate passes for
-                # exact and approximate rewriting.
+                left_node = self.define_left_node(current_node)
+                a = self.can_cambine(left_node, right_node)
+                self.combine_gates_into_right_node(left_node, right_node)
+                self.simplify_right_node(right_node)
 
-                # Y rotation is 0 mod 2*pi, so the gate is a u1
-                if np.mod(right_parameters[0], (2 * np.pi)) == 0 \
-                        and right_name != "u1":
-                    right_name = "u1"
-                    right_parameters = (0, 0, right_parameters[1] +
-                                        right_parameters[2] +
-                                        right_parameters[0])
-                # Y rotation is pi/2 or -pi/2 mod 2*pi, so the gate is a u2
-                if right_name == "u3":
-                    # theta = pi/2 + 2*k*pi
-                    if np.mod((right_parameters[0] - np.pi / 2), (2 * np.pi)) == 0:
-                        right_name = "u2"
-                        right_parameters = (np.pi / 2, right_parameters[1],
-                                            right_parameters[2] +
-                                            (right_parameters[0] - np.pi / 2))
-                    # theta = -pi/2 + 2*k*pi
-                    if np.mod((right_parameters[0] + np.pi / 2), (2 * np.pi)) == 0:
-                        right_name = "u2"
-                        right_parameters = (np.pi / 2, right_parameters[1] +
-                                            np.pi, right_parameters[2] -
-                                            np.pi + (right_parameters[0] +
-                                                     np.pi / 2))
-                # u1 and lambda is 0 mod 2*pi so gate is nop (up to a global phase)
-                if right_name == "u1" and np.mod(right_parameters[2], (2 * np.pi)) == 0:
-                    right_name = "nop"
+            new_op = self.generate_gate(right_node)
 
-            new_op = Gate(name="", num_qubits=1, params=[])
-            if right_name == "u1":
-                new_op = U1Gate(right_parameters[2])
-            if right_name == "u2":
-                new_op = U2Gate(right_parameters[1], right_parameters[2])
-            if right_name == "u3":
-                new_op = U3Gate(*right_parameters)
+            self.add_right_node_to_dag(dag, new_op, right_node, run)
 
-            if right_name != 'nop':
-                dag.substitute_node(run[0], new_op, inplace=True)
-
-            # Delete the other nodes in the run
-            for current_node in run[1:]:
-                dag.remove_op_node(current_node)
-            if right_name == "nop":
-                dag.remove_op_node(run[0])
+            self.extract_simplified_gates(dag, right_node, run)
 
         return dag
+
+
+    def simplify_right_node(self, right_node):
+        '''
+        1. Here down, when we simplify, we add f(theta) to lambda to
+        correct the global phase when f(theta) is 2*pi. This isn't
+        necessary but the other steps preserve the global phase, so
+        we continue in that manner.
+        2. The final step will remove Z rotations by 2*pi.
+        3. Note that is_zero is true only if the expression is exactly
+        zero. If the input expressions have already been evaluated
+        then these final simplifications will not occur.
+        TODO After we refactor, we should have separate passes for
+        exact and approximate rewriting.
+        Y rotation is 0 mod 2*pi, so the gate is a u1
+        '''
+        if np.mod(right_node.parameters[0], (2 * np.pi)) == 0 \
+                and right_node.name != "u1":
+            right_node.name = "u1"
+            right_node.parameters = (0, 0, right_node.parameters[1] +
+                                     right_node.parameters[2] +
+                                     right_node.parameters[0])
+        # Y rotation is pi/2 or -pi/2 mod 2*pi, so the gate is a u2
+        if right_node.name == "u3":
+            # theta = pi/2 + 2*k*pi
+            if np.mod((right_node.parameters[0] - np.pi / 2), (2 * np.pi)) == 0:
+                right_node.name = "u2"
+                right_node.parameters = (np.pi / 2, right_node.parameters[1],
+                                         right_node.parameters[2] +
+                                         (right_node.parameters[0] - np.pi / 2))
+            # theta = -pi/2 + 2*k*pi
+            if np.mod((right_node.parameters[0] + np.pi / 2), (2 * np.pi)) == 0:
+                right_node.name = "u2"
+                right_node.parameters = (np.pi / 2, right_node.parameters[1] +
+                                         np.pi, right_node.parameters[2] -
+                                         np.pi + (right_node.parameters[0] +
+                                                  np.pi / 2))
+        # u1 and lambda is 0 mod 2*pi so gate is nop (up to a global phase)
+        if right_node.name == "u1" and np.mod(right_node.parameters[2], (2 * np.pi)) == 0:
+            right_node.name = "nop"
 
     @staticmethod
     def compose_u3(theta1, phi1, lambda1, theta2, phi2, lambda2):

--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -225,8 +225,7 @@ class Optimize1qGates(TransformationPass):
 
         if left_node.name == 'u2' and right_node.name == 'u3':
             temp = - 0.707106781186547 * \
-                   np.e**((left_node.parameters[2] +
-                           right_node.parameters[1])*1j) * \
+                   np.e**((left_node.parameters[2] + right_node.parameters[1])*1j) * \
                    np.sin(right_node.parameters[0] / 2) + \
                    0.707106781186548 * np.cos(right_node.parameters[0]/2)
 
@@ -235,8 +234,7 @@ class Optimize1qGates(TransformationPass):
 
         if left_node.name == 'u3' and right_node.name == 'u2':
             temp = - 0.707106781186547 * \
-                   np.e**((left_node.parameters[2] +
-                           right_node.parameters[1])*1j) \
+                   np.e**((left_node.parameters[2] + right_node.parameters[1])*1j) \
                    * np.sin(left_node.parameters[0] / 2) + \
                    0.707106781186548 * np.cos(left_node.parameters[0]/2)
             if np.abs(np.imag(temp) < _CHOP_THRESHOLD) and np.real(temp) >= 0:

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -33,8 +33,6 @@ from qiskit.transpiler import PassManager
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements, CXDirection
 from qiskit.quantum_info import Operator
-from qiskit.transpiler.pass_manager_config import PassManagerConfig
-from qiskit.transpiler.preset_passmanagers import level_0_pass_manager
 
 
 @ddt
@@ -508,6 +506,9 @@ class TestTranspile(QiskitTestCase):
         circ.x(qr[0])
         circ.y(qr[0])
         circ.z(qr[0])
+        circ.z(qr[0])
+        circ.y(qr[0])
+        circ.x(qr[0])
         circ.cx(qr[0], qr[1])
         circ.h(qr[0])
         circ.cx(qr[0], qr[1])
@@ -647,9 +648,9 @@ class TestTranspile(QiskitTestCase):
         """Verify a Rx,Ry,Rxx circuit transpile to a U3,CX target."""
 
         qc = QuantumCircuit(2)
-        qc.rx(math.pi / 2, 0)
-        qc.ry(math.pi / 4, 1)
-        qc.rxx(math.pi / 4, 0, 1)
+        qc.rx(math.pi/2, 0)
+        qc.ry(math.pi/4, 1)
+        qc.rxx(math.pi/4, 0, 1)
 
         out = transpile(qc, basis_gates=['u3', 'cx'], optimization_level=optimization_level)
 
@@ -660,9 +661,9 @@ class TestTranspile(QiskitTestCase):
         """Verify a Rx,Ry,Rxx circuit can transpile to an Rx,Ry,Rxx target."""
 
         qc = QuantumCircuit(2)
-        qc.rx(math.pi / 2, 0)
-        qc.ry(math.pi / 4, 1)
-        qc.rxx(math.pi / 4, 0, 1)
+        qc.rx(math.pi/2, 0)
+        qc.ry(math.pi/4, 1)
+        qc.rxx(math.pi/4, 0, 1)
 
         out = transpile(qc, basis_gates=['rx', 'ry', 'rxx'], optimization_level=optimization_level)
 
@@ -675,7 +676,7 @@ class TestTranspile(QiskitTestCase):
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.cx(0, 1)
-        qc.rz(math.pi / 4, [0, 1])
+        qc.rz(math.pi/4, [0, 1])
 
         out = transpile(qc, basis_gates=['rx', 'ry', 'rxx'], optimization_level=optimization_level)
 
@@ -686,43 +687,11 @@ class TestTranspile(QiskitTestCase):
         """Verify a measure doesn't cause an Rx,Ry,Rxx circuit to unroll to U3,CX."""
 
         qc = QuantumCircuit(2, 2)
-        qc.rx(math.pi / 2, 0)
-        qc.ry(math.pi / 4, 1)
-        qc.rxx(math.pi / 4, 0, 1)
+        qc.rx(math.pi/2, 0)
+        qc.ry(math.pi/4, 1)
+        qc.rxx(math.pi/4, 0, 1)
         qc.measure([0, 1], [0, 1])
 
         out = transpile(qc, basis_gates=['rx', 'ry', 'rxx'], optimization_level=optimization_level)
 
         self.assertEqual(qc, out)
-
-
-class TestTranspileCustomPM(QiskitTestCase):
-    """Test transpile function with custom pass manager"""
-
-    def test_custom_multiple_circuits(self):
-        """Test transpiling with custom pass manager and multiple circuits.
-        This tests created a deadlock, so it needs to be monitored for timeout.
-        See: https://github.com/Qiskit/qiskit-terra/issues/3925
-        """
-        qc = QuantumCircuit(2)
-        qc.h(0)
-        qc.cx(0, 1)
-
-        pm_conf = PassManagerConfig(
-            initial_layout=None,
-            basis_gates=['u1', 'u2', 'u3', 'cx'],
-            coupling_map=CouplingMap([[0, 1]]),
-            backend_properties=None,
-            seed_transpiler=1
-        )
-        passmanager = level_0_pass_manager(pm_conf)
-
-        transpiled = transpile([qc, qc], pass_manager=passmanager)
-
-        expected = QuantumCircuit(QuantumRegister(2, 'q'))
-        expected.u2(0, 3.141592653589793, 0)
-        expected.cx(0, 1)
-
-        self.assertEqual(len(transpiled), 2)
-        self.assertEqual(transpiled[0], expected)
-        self.assertEqual(transpiled[1], expected)

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -33,7 +33,6 @@ class TestOptimize1qGates(QiskitTestCase):
     def test_global_phase(self):
         """https://github.com/Qiskit/qiskit-terra/issues/3083"""
 
-
         q = QuantumRegister(1)
         c = ClassicalRegister(1)
         circuit = QuantumCircuit(q, c)
@@ -50,7 +49,8 @@ class TestOptimize1qGates(QiskitTestCase):
         result1 = job1.result()
         print(result.get_unitary(circuit))
         print(result1.get_unitary(circuit))
-        self.assertTrue(np.allclose(result.get_unitary(circuit), result1.get_unitary(circuit)))
+        self.assertTrue(np.allclose(result.get_unitary(circuit),
+                                    result1.get_unitary(circuit)))
 
     def test_dont_optimize_id(self):
         """Identity gates are like 'wait' commands.

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -17,7 +17,7 @@
 import unittest
 import numpy as np
 
-from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
+from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister, execute, BasicAer
 from qiskit.transpiler import PassManager
 from qiskit.compiler import transpile
 from qiskit.transpiler.passes import Optimize1qGates, Unroller
@@ -29,6 +29,28 @@ from qiskit.circuit import Parameter
 
 class TestOptimize1qGates(QiskitTestCase):
     """Test for 1q gate optimizations. """
+
+    def test_global_phase(self):
+        """https://github.com/Qiskit/qiskit-terra/issues/3083"""
+
+
+        q = QuantumRegister(1)
+        c = ClassicalRegister(1)
+        circuit = QuantumCircuit(q, c)
+        circuit.h(q[0])
+        circuit.z(q[0])
+        circuit.x(q[0])
+
+        backend = BasicAer.get_backend('unitary_simulator')
+
+        job = execute(circuit, backend, optimization_level=0)
+        result = job.result()
+
+        job1 = execute(circuit, backend, optimization_level=1)
+        result1 = job1.result()
+        print(result.get_unitary(circuit))
+        print(result1.get_unitary(circuit))
+        self.assertTrue(np.allclose(result.get_unitary(circuit), result1.get_unitary(circuit)))
 
     def test_dont_optimize_id(self):
         """Identity gates are like 'wait' commands.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes #3083. 

### Details and comments
1. I refactored the function `def run(self, dag)` in several functions to increase readability
2. New function `def can_combine(self, left_node, right_node)` checks if it is possible to combine two nodes preserving the global phase
3. Update `def test_optimize_to_nothing(self)` to respect global phase
4. Included the function `def test_global_phase(self)` to test issue #4036 


