### PR TITLE
Colouring in controlled gates now consistent

### DIFF
--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -964,6 +964,12 @@ class MatplotlibDrawer:
                         self._swap(q_xy[1])
                         # add qubit-qubit wiring
                         self._line(qreg_b, qreg_t, lc=self._style.dispcol['swap'])
+
+                    # dcx and iswap gate
+                    elif op.name in ['dcx', 'iswap']:
+                        self._custom_multiqubit_gate(q_xy, c_xy, wide=_iswide,
+                                                     fc=self._style.dispcol[op.name], text=op.name)
+
                     # Custom gate
                     else:
                         self._custom_multiqubit_gate(q_xy, c_xy, wide=_iswide,

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -847,23 +847,21 @@ class MatplotlibDrawer:
                     num_ctrl_qubits = op.op.num_ctrl_qubits
                     num_qargs = len(q_xy) - num_ctrl_qubits
 
-                    if disp in ['y', 'h', 's', 'sdg']:
-                        gatecol = self._style.dispcol[disp]
-                    else:
-                        gatecol = self._style.dispcol['multi']
                     for i in range(num_ctrl_qubits):
-                        self._ctrl_qubit(q_xy[i], fc=gatecol,
-                                         ec=gatecol)
+                        self._ctrl_qubit(q_xy[i], fc=self._style.dispcol['multi'],
+                                         ec=self._style.dispcol['multi'])
                     # add qubit-qubit wiring
-                    self._line(qreg_b, qreg_t, lc=gatecol)
+                    self._line(qreg_b, qreg_t, lc=self._style.dispcol['multi'])
                     if disp == 'z':
-                        self._ctrl_qubit(q_xy[i+1], fc=gatecol,
-                                         ec=gatecol)
+                        self._ctrl_qubit(q_xy[i+1], fc=self._style.dispcol['multi'],
+                                         ec=self._style.dispcol['multi'])
                     elif num_qargs == 1:
-                        self._gate(q_xy[-1], wide=_iswide, text=disp)
+                        self._gate(q_xy[-1], wide=_iswide, fc=self._style.dispcol['multi'],
+                                   text=disp)
                     else:
                         self._custom_multiqubit_gate(
-                            q_xy[num_ctrl_qubits:], wide=_iswide, text=disp)
+                            q_xy[num_ctrl_qubits:], wide=_iswide, fc=self._style.dispcol['multi'],
+                            text=disp)
 
                 #
                 # draw single qubit gates
@@ -903,7 +901,7 @@ class MatplotlibDrawer:
                     elif op.name == 'cz':
                         disp = op.name.replace('c', '')
                         if self._style.name != 'bw':
-                            color = self._style.dispcol['multi']
+                            color = self._style.dispcol['cz']
                             self._ctrl_qubit(q_xy[0],
                                              fc=color,
                                              ec=color)
@@ -916,7 +914,7 @@ class MatplotlibDrawer:
                         # add qubit-qubit wiring
                         if self._style.name != 'bw':
                             self._line(qreg_b, qreg_t,
-                                       lc=self._style.dispcol['multi'])
+                                       lc=color)
                         else:
                             self._line(qreg_b, qreg_t, zorder=PORDER_LINE + 1)
                     # control gate
@@ -924,10 +922,11 @@ class MatplotlibDrawer:
                         disp = op.name.replace('c', '')
 
                         color = None
-                        if disp in ['y', 'h']:
-                            color = self._style.dispcol[disp]
-                        elif self._style.name != 'bw':
-                            color = self._style.dispcol['multi']
+                        if self._style.name != 'bw':
+                            if op.name == 'cy':
+                                color = self._style.dispcol['cy']
+                            else:
+                                color = self._style.dispcol['multi']
 
                         self._ctrl_qubit(q_xy[0], fc=color, ec=color)
                         if param:

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -841,20 +841,24 @@ class MatplotlibDrawer:
                     self._custom_multiqubit_gate(q_xy, wide=_iswide,
                                                  text="Unitary")
                 elif isinstance(op.op, ControlledGate) and op.name not in [
-                        'ccx', 'cx', 'cz', 'cu1', 'cu3', 'crz',
+                        'ccx', 'cx', 'cy', 'cz', 'ch', 'cu1', 'cu3', 'crz',
                         'cswap']:
                     disp = op.op.base_gate.name
                     num_ctrl_qubits = op.op.num_ctrl_qubits
                     num_qargs = len(q_xy) - num_ctrl_qubits
 
+                    if disp in ['y', 'h', 's', 'sdg']:
+                        gatecol = self._style.dispcol[disp]
+                    else:
+                        gatecol = self._style.dispcol['multi']
                     for i in range(num_ctrl_qubits):
-                        self._ctrl_qubit(q_xy[i], fc=self._style.dispcol['multi'],
-                                         ec=self._style.dispcol['multi'])
+                        self._ctrl_qubit(q_xy[i], fc=gatecol,
+                                         ec=gatecol)
                     # add qubit-qubit wiring
-                    self._line(qreg_b, qreg_t, lc=self._style.dispcol['multi'])
+                    self._line(qreg_b, qreg_t, lc=gatecol)
                     if disp == 'z':
-                        self._ctrl_qubit(q_xy[i+1], fc=self._style.dispcol['multi'],
-                                         ec=self._style.dispcol['multi'])
+                        self._ctrl_qubit(q_xy[i+1], fc=gatecol,
+                                         ec=gatecol)
                     elif num_qargs == 1:
                         self._gate(q_xy[-1], wide=_iswide, text=disp)
                     else:
@@ -920,7 +924,9 @@ class MatplotlibDrawer:
                         disp = op.name.replace('c', '')
 
                         color = None
-                        if self._style.name != 'bw':
+                        if disp in ['y', 'h']:
+                            color = self._style.dispcol[disp]
+                        elif self._style.name != 'bw':
                             color = self._style.dispcol['multi']
 
                         self._ctrl_qubit(q_xy[0], fc=color, ec=color)

--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -77,6 +77,9 @@ class DefaultStyle:
             'z': pauli_color,
             'h': clifford_color,
             'cx': clifford_color,
+            'cy': clifford_color,
+            'cz': clifford_color,
+            'swap': clifford_color,
             's': clifford_color,
             'sdg': clifford_color,
             't': other_color,
@@ -87,7 +90,6 @@ class DefaultStyle:
             'rz': other_color,
             'reset': non_gate_color,
             'target': '#ffffff',
-            'swap': other_color,
             'multi': other_color,
             'meas': non_gate_color
         }

--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -82,6 +82,8 @@ class DefaultStyle:
             'swap': clifford_color,
             's': clifford_color,
             'sdg': clifford_color,
+            'dcx': clifford_color,
+            'iswap': clifford_color,
             't': other_color,
             'tdg': other_color,
             'r': other_color,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4012 .

### Details and comments

The colour of the box and the control wires were different for ch, cy gates. matplotlib has been updated to get consistent colouring. Inconsistencies were also found in multi-control gates and have now been corrected.

The inconsistencies in colouring looked like:

![pre_correction](https://user-images.githubusercontent.com/51048173/77851683-0c468e00-71f8-11ea-8660-15bcd81ce183.png)

The gates now look like:

![post_corection](https://user-images.githubusercontent.com/51048173/77851690-136d9c00-71f8-11ea-979a-e54d2f27c3ef.png)

