### PR TITLE
Cache lexicographical topological sort key in DAGNode

### DIFF
--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -30,6 +30,7 @@ class DAGNode:
         """Create a node """
         self._node_id = nid
         self.data_dict = data_dict
+        self.sort_key = str(self.qargs)
 
     @property
     def type(self):
@@ -64,6 +65,7 @@ class DAGNode:
     def qargs(self, new_qargs):
         """Sets the qargs to be the given list of qargs."""
         self.data_dict['qargs'] = new_qargs
+        self.sort_key = str(new_qargs)
 
     @property
     def cargs(self):

--- a/qiskit/dagcircuit/retworkx_dagcircuit.py
+++ b/qiskit/dagcircuit/retworkx_dagcircuit.py
@@ -107,7 +107,7 @@ class RetworkxDAGCircuit(DAGCircuit):
             generator(DAGNode): node in topological order
         """
         def _key(x):
-            return str(x.qargs)
+            return x.sort_key
 
         return iter(rx.lexicographical_topological_sort(
             self._multi_graph,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit caches the string sort key used for lexicographical
topological sort as an attribute in DAGNode objects. Currently when
retworkx's lexicographical topological sort call is called it needs to
call the python callable provided to get a string used for sorting.
Prior to this commit about ~70% of the cumulative time spent in the
lexicographical topological sort function is spent in python. This is
because every time it is sorting a DAGNode it has to call
str(x.qargs) which spends all that time constructing the string
including a dict.get() and bit and register repr() calls, etc. To avoid
this unnecessary overhead at run time this commit adds a sort_key
attribute to the DAGNode class which is set during `__init__()` and
updates to the qargs property. Then the DAGCircuit lexicographical
topological sort wrapper method changes the callable to use this
attribute. Doing this eliminates all the overhead from calling back to
python because it simply becomes attribute access.

### Details and comments