### PR TITLE
Add measure and reset methods to QuantumState classes

### DIFF
--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -380,7 +380,7 @@ class QuantumState(ABC):
         inds, counts = np.unique(samples, return_counts=True)
         return dict(zip(inds, counts))
 
-    def measure(self, qargs=None, integer=False):
+    def measure(self, qargs=None):
         """Measure subsystems and return outcome and post-measure state.
 
         Note that this function uses the QuantumStates internal random

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.predicates import ATOL_DEFAULT, RTOL_DEFAULT
 
 
@@ -378,6 +379,46 @@ class QuantumState(ABC):
         # Combine all samples into a counts dictionary
         inds, counts = np.unique(samples, return_counts=True)
         return dict(zip(inds, counts))
+
+    def measure(self, qargs=None, integer=False):
+        """Measure subsystems and return outcome and post-measure state.
+
+        Note that this function uses the QuantumStates internal random
+        number generator for sampling the measurement outcome. The RNG
+        seed can be set using the :meth:`seed` method.
+
+        Args:
+            qargs (list or None): subsystems to sample measurements for,
+                                  if None sample measurement of all
+                                  subsystems (Default: None).
+
+        Returns:
+            tuple: the pair ``(outcome, state)`` where ``outcome`` is the
+                   measurement outcome string label, and ``state`` is the
+                   collapsed post-measurement state for the corresponding
+                   outcome.
+        """
+        # Sample a single measurement outcome from probabilities
+        dims = self.dims(qargs)
+        probs = self.probabilities(qargs)
+        sample = self._rng.choice(len(probs), p=probs, size=1)
+
+        # Format outcome
+        outcome = self._index_to_ket_array(
+            sample, self.dims(qargs), string_labels=True)[0]
+
+        # Convert to projector for state update
+        proj = np.zeros(len(probs), dtype=complex)
+        proj[sample] = 1 / np.sqrt(probs[sample])
+
+        # Update state object
+        # TODO: implement a more efficient state update method for
+        # diagonal matrix multiplication
+        ret = self.evolve(
+            Operator(np.diag(proj), input_dims=dims, output_dims=dims),
+            qargs=qargs)
+
+        return outcome, ret
 
     @classmethod
     def _automatic_dims(cls, dims, size):

--- a/releasenotes/notes/state-measure-reset-8a3f2df197325e9c.yaml
+++ b/releasenotes/notes/state-measure-reset-8a3f2df197325e9c.yaml
@@ -1,0 +1,47 @@
+---
+features:
+  - |
+    Adds a :meth:`~qiskit.quantum_info.Statevector.measure` method to the
+    :class:`qiskit.quantum_info.Statevector` and
+    :class:`qiskit.quantum_info.DensityMatrix` quantum state classes. This
+    allows sampling a single measurement outcome from the specified subsystems
+    and collapsing the statevector to the post-measurement computational basis
+    state. For example
+
+    .. jupyter-execute::
+
+      from qiskit.quantum_info import Statevector
+      
+      psi = Statevector.from_label('+1')
+  
+      # Measure both qubits
+      outcome, psi_meas = psi.measure()
+      print("measure([0, 1]) outcome:", outcome, "Post-measurement state:")
+      print(psi_meas)
+
+      # Measure qubit-1 only
+      outcome, psi_meas = psi.measure([1])
+      print("measure([1]) outcome:", outcome, "Post-measurement state:")
+      print(psi_meas)
+  - |
+    Adds a :meth:`~qiskit.quantum_info.Statevector.reset` method to the
+    :class:`qiskit.quantum_info.Statevector` and
+    :class:`qiskit.quantum_info.DensityMatrix` quantum state classes. This
+    allows reseting some or all subsystems to the :math:`|0\rangle` state.
+    For example
+
+    .. jupyter-execute::
+
+      from qiskit.quantum_info import Statevector
+      
+      psi = Statevector.from_label('+1')
+
+      # Reset both qubits
+      psi_reset = psi.reset()
+      print("Post reset state: ")
+      print(psi_reset)
+
+      # Reset qubit-1 only
+      psi_reset = psi.reset([1])
+      print("Post reset([1]) state: ")
+      print(psi_reset)

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -708,6 +708,129 @@ class TestDensityMatrix(QiskitTestCase):
             self.assertEqual(len(memory), shots)
             self.assertEqual(set(memory), set(['0', '2']))
 
+    def test_reset_2qubit(self):
+        """Test reset method for 2-qubit state"""
+
+        state = DensityMatrix(np.diag([0.5, 0, 0, 0.5]))
+
+        with self.subTest(msg='reset'):
+            rho = state.copy()
+            value = rho.reset()
+            target = DensityMatrix(np.diag([1, 0, 0, 0]))
+            self.assertEqual(value, target)
+
+        with self.subTest(msg='reset'):
+            rho = state.copy()
+            value = rho.reset([0, 1])
+            target = DensityMatrix(np.diag([1, 0, 0, 0]))
+            self.assertEqual(value, target)
+
+        with self.subTest(msg='reset [0]'):
+            rho = state.copy()
+            value = rho.reset([0])
+            target = DensityMatrix(np.diag([0.5, 0, 0.5, 0]))
+            self.assertEqual(value, target)
+
+        with self.subTest(msg='reset [0]'):
+            rho = state.copy()
+            value = rho.reset([1])
+            target = DensityMatrix(np.diag([0.5, 0.5, 0, 0]))
+            self.assertEqual(value, target)
+
+    def test_reset_qutrit(self):
+        """Test reset method for qutrit"""
+
+        state = DensityMatrix(np.diag([1, 1, 1]) / 3)
+        state.seed(200)
+        value = state.reset()
+        target = DensityMatrix(np.diag([1, 0, 0]))
+        self.assertEqual(value, target)
+
+    def test_measure_2qubit(self):
+        """Test measure method for 2-qubit state"""
+
+        state = DensityMatrix.from_label('+0')
+        seed = 200
+        shots = 100
+
+        with self.subTest(msg='measure'):
+            for i in range(shots):
+                rho = state.copy()
+                rho.seed(seed + i)
+                outcome, value = rho.measure()
+                self.assertIn(outcome, ['00', '10'])
+                if outcome == '00':
+                    target = DensityMatrix.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = DensityMatrix.from_label('10')
+                    self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [0, 1]'):
+            for i in range(shots):
+                rho = state.copy()
+                outcome, value = rho.measure([0, 1])
+                self.assertIn(outcome, ['00', '10'])
+                if outcome == '00':
+                    target = DensityMatrix.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = DensityMatrix.from_label('10')
+                    self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [1, 0]'):
+            for i in range(shots):
+                rho = state.copy()
+                outcome, value = rho.measure([1, 0])
+                self.assertIn(outcome, ['00', '01'])
+                if outcome == '00':
+                    target = DensityMatrix.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = DensityMatrix.from_label('10')
+                    self.assertEqual(value, target)
+        with self.subTest(msg='measure [0]'):
+            for i in range(shots):
+                rho = state.copy()
+                outcome, value = rho.measure([0])
+                self.assertEqual(outcome, '0')
+                target = DensityMatrix.from_label('+0')
+                self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [1]'):
+            for i in range(shots):
+                rho = state.copy()
+                outcome, value = rho.measure([1])
+                self.assertIn(outcome, ['0', '1'])
+                if outcome == '0':
+                    target = DensityMatrix.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = DensityMatrix.from_label('10')
+                    self.assertEqual(value, target)
+
+    def test_measure_qutrit(self):
+        """Test measure method for qutrit"""
+
+        state = DensityMatrix(np.diag([1, 1, 1]) / 3)
+        seed = 200
+        shots = 100
+
+        for i in range(shots):
+            rho = state.copy()
+            rho.seed(seed + i)
+            outcome, value = rho.measure()
+            self.assertIn(outcome, ['0', '1', '2'])
+            if outcome == '0':
+                target = DensityMatrix(np.diag([1, 0, 0]))
+                self.assertEqual(value, target)
+            elif outcome == '1':
+                target = DensityMatrix(np.diag([0, 1, 0]))
+                self.assertEqual(value, target)
+            else:
+                target = DensityMatrix(np.diag([0, 0, 1]))
+                self.assertEqual(value, target)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -692,6 +692,133 @@ class TestStatevector(QiskitTestCase):
             self.assertEqual(len(memory), shots)
             self.assertEqual(set(memory), set(['0', '2']))
 
+    def test_reset_2qubit(self):
+        """Test reset method for 2-qubit state"""
+
+        state = Statevector(np.array([1, 0, 0, 1]) / np.sqrt(2))
+        state.seed(100)
+
+        with self.subTest(msg='reset'):
+            psi = state.copy()
+            value = psi.reset()
+            target = Statevector(np.array([1, 0, 0, 0]))
+            self.assertEqual(value, target)
+
+        with self.subTest(msg='reset'):
+            psi = state.copy()
+            value = psi.reset([0, 1])
+            target = Statevector(np.array([1, 0, 0, 0]))
+            self.assertEqual(value, target)
+
+        with self.subTest(msg='reset [0]'):
+            psi = state.copy()
+            value = psi.reset([0])
+            targets = [Statevector(np.array([1, 0, 0, 0])),
+                       Statevector(np.array([0, 0, 1, 0]))]
+            self.assertIn(value, targets)
+
+        with self.subTest(msg='reset [0]'):
+            psi = state.copy()
+            value = psi.reset([1])
+            targets = [Statevector(np.array([1, 0, 0, 0])),
+                       Statevector(np.array([0, 1, 0, 0]))]
+            self.assertIn(value, targets)
+
+    def test_reset_qutrit(self):
+        """Test reset method for qutrit"""
+
+        state = Statevector(np.array([1, 1, 1]) / np.sqrt(3))
+        state.seed(200)
+        value = state.reset()
+        target = Statevector(np.array([1, 0, 0]))
+        self.assertEqual(value, target)
+
+    def test_measure_2qubit(self):
+        """Test measure method for 2-qubit state"""
+
+        state = Statevector.from_label('+0')
+        seed = 200
+        shots = 100
+
+        with self.subTest(msg='measure'):
+            for i in range(shots):
+                psi = state.copy()
+                psi.seed(seed + i)
+                outcome, value = psi.measure()
+                self.assertIn(outcome, ['00', '10'])
+                if outcome == '00':
+                    target = Statevector.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = Statevector.from_label('10')
+                    self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [0, 1]'):
+            for i in range(shots):
+                psi = state.copy()
+                outcome, value = psi.measure([0, 1])
+                self.assertIn(outcome, ['00', '10'])
+                if outcome == '00':
+                    target = Statevector.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = Statevector.from_label('10')
+                    self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [1, 0]'):
+            for i in range(shots):
+                psi = state.copy()
+                outcome, value = psi.measure([1, 0])
+                self.assertIn(outcome, ['00', '01'])
+                if outcome == '00':
+                    target = Statevector.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = Statevector.from_label('10')
+                    self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [0]'):
+            for i in range(shots):
+                psi = state.copy()
+                outcome, value = psi.measure([0])
+                self.assertEqual(outcome, '0')
+                target = Statevector(np.array([1, 0, 1, 0]) / np.sqrt(2))
+                self.assertEqual(value, target)
+
+        with self.subTest(msg='measure [1]'):
+            for i in range(shots):
+                psi = state.copy()
+                outcome, value = psi.measure([1])
+                self.assertIn(outcome, ['0', '1'])
+                if outcome == '0':
+                    target = Statevector.from_label('00')
+                    self.assertEqual(value, target)
+                else:
+                    target = Statevector.from_label('10')
+                    self.assertEqual(value, target)
+
+    def test_measure_qutrit(self):
+        """Test measure method for qutrit"""
+
+        state = Statevector(np.array([1, 1, 1]) / np.sqrt(3))
+        seed = 200
+        shots = 100
+
+        for i in range(shots):
+            psi = state.copy()
+            psi.seed(seed + i)
+            outcome, value = psi.measure()
+            self.assertIn(outcome, ['0', '1', '2'])
+            if outcome == '0':
+                target = Statevector([1, 0, 0])
+                self.assertEqual(value, target)
+            elif outcome == '1':
+                target = Statevector([0, 1, 0])
+                self.assertEqual(value, target)
+            else:
+                target = Statevector([0, 0, 1])
+                self.assertEqual(value, target)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds `measure` and `reset` methods to `Statevector` and `DensityMatrix` classes.

### Details and comments

* `measure` samples a single measurement outcome for the specified subsystems, and collapses those systems to the post-measurement computational basis state.

* `reset` resets the specified subsystems to the |0> computation basis state (for statevectors this involves sampling a measurement outcome so is non-determinisitic).

### TODO

- [x] Statevector reset tests
- [x] Statevector measure tests
- [x] Density matrix reset tests
- [x] Density matrix measure tests