### PR TITLE
Add pygments to requirements list in setup.py and document it

### DIFF
--- a/releasenotes/notes/add-pygments-dfe2cd949c237deb.yaml
+++ b/releasenotes/notes/add-pygments-dfe2cd949c237deb.yaml
@@ -1,0 +1,29 @@
+---
+features:
+  - |
+    A new jupyter widget, ``%circuit_library_info`` for visualizing
+    details about circuits built from the circuit library. For example
+
+    .. jupyter-execute::
+
+        from qiskit.circuit.library import XOR
+        import qiskit.tools.jupyter
+        circuit = XOR(5, seed=42)
+        %circuit_library_info circuit
+
+  - |
+    A new kwarg option, ``formatted`` ,  has been added to
+    :meth:`qiskit.circuit.QuantumCircuit.qasm` . When set to ``True`` the
+    the method will print a syntax highlighted version (using pygments) to
+    stdout and return ``None`` (which differs from the normal behavior of
+    returning the QASM code as a string)
+  - |
+    A new kwarg option, ``filename`` , has been added to
+    :meth:`qiskit.circuit.QuantumCircuit.qasm`. When set to a path the method
+    will write the QASM code to that file. It will then continue to output as
+    normal
+upgrade:
+  - |
+    A new requirement, `pygments <https://pygments.org/>`_ , has been added
+    to the requirements list. It is used for providing syntax highlighting
+    of OpenQASM 2.0 code in Jupyter widgets.

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ REQUIREMENTS = [
     "scipy>=1.0",
     "sympy>=1.3",
     "dill>=0.3",
+    "pygments>=2.2",
     "fastjsonschema>=2.10",
     "python-constraint>=1.4",
 ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3861 a new requirement was added pygments used to do syntax
highlighting of QASM files. While that PR added it to the
requirements.txt file that isn't actually used by pip (see #1586) and
it needed to be added to the setup.py file too. This commit corrects
the oversight and adds pygments to the requirements list in setup.py.
Additionally this commit adds a release note documenting the addition of
a new dependency because it is a potential upgrade issue for users that
they'll need to be aware of when installing the next release.

### Details and comments


