### PR TITLE
Make pygments an optional dependency

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -24,7 +24,6 @@ import numpy as np
 from qiskit.util import is_main_process
 from qiskit.circuit.instruction import Instruction
 from qiskit.qasm.qasm import Qasm
-
 from qiskit.circuit.exceptions import CircuitError
 from .parameterexpression import ParameterExpression
 from .quantumregister import QuantumRegister, Qubit
@@ -39,7 +38,8 @@ from .quantumcircuitdata import QuantumCircuitData
 try:
     import pygments
     from pygments.formatters import Terminal256Formatter  # pylint: disable=no-name-in-module
-    from qiskit.qasm.pygments import OpenQASMLexer, QasmTerminalStyle
+    from qiskit.qasm.pygments import OpenQASMLexer  # pylint: disable=ungrouped-imports
+    from qiskit.qasm.pygments import QasmTerminalStyle  # pylint: disable=ungrouped-imports
     HAS_PYGMENTS = True
 except ImportError:
     HAS_PYGMENTS = False
@@ -642,6 +642,10 @@ class QuantumCircuit:
 
         Returns:
             str: If formatted=False.
+
+        Raises:
+            ImportError: If pygments is not installed and ``formatted`` is
+                ``True``.
         """
         string_temp = self.header + "\n"
         string_temp += self.extension_lib + "\n"

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -20,13 +20,11 @@ import sys
 import warnings
 import multiprocessing as mp
 from collections import OrderedDict
-import pygments
-from pygments.formatters import Terminal256Formatter  # pylint: disable=no-name-in-module
 import numpy as np
 from qiskit.util import is_main_process
 from qiskit.circuit.instruction import Instruction
 from qiskit.qasm.qasm import Qasm
-from qiskit.qasm.pygments import OpenQASMLexer, QasmTerminalStyle
+
 from qiskit.circuit.exceptions import CircuitError
 from .parameterexpression import ParameterExpression
 from .quantumregister import QuantumRegister, Qubit
@@ -37,6 +35,14 @@ from .instructionset import InstructionSet
 from .register import Register
 from .bit import Bit
 from .quantumcircuitdata import QuantumCircuitData
+
+try:
+    import pygments
+    from pygments.formatters import Terminal256Formatter  # pylint: disable=no-name-in-module
+    from qiskit.qasm.pygments import OpenQASMLexer, QasmTerminalStyle
+    HAS_PYGMENTS = True
+except ImportError:
+    HAS_PYGMENTS = False
 
 
 class QuantumCircuit:
@@ -668,6 +674,10 @@ class QuantumCircuit:
             file.close()
 
         if formatted:
+            if not HAS_PYGMENTS:
+                raise ImportError("To use the formatted output pygments must "
+                                  'be installed. To install run "pip install '
+                                  'pygments".')
             code = pygments.highlight(string_temp,
                                       OpenQASMLexer(),
                                       Terminal256Formatter(style=QasmTerminalStyle))

--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -45,6 +45,11 @@ from numpy import pi
 
 from .qasm import Qasm
 from .exceptions import QasmError
-from .pygments import HAS_PYGMENTS
+try:
+    import pygments
+    HAS_PYGMENTS = True
+except ImportError:
+    HAS_PYGMENTS = False
+
 if HAS_PYGMENTS:
     from .pygments import OpenQASMLexer, QasmHTMLStyle, QasmTerminalStyle

--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -45,4 +45,6 @@ from numpy import pi
 
 from .qasm import Qasm
 from .exceptions import QasmError
-from .pygments import OpenQASMLexer, QasmHTMLStyle, QasmTerminalStyle
+from .pygments import HAS_PYGMENTS
+if HAS_PYGMENTS:
+    from .pygments import OpenQASMLexer, QasmHTMLStyle, QasmTerminalStyle

--- a/qiskit/qasm/pygments/__init__.py
+++ b/qiskit/qasm/pygments/__init__.py
@@ -26,6 +26,11 @@ Qasm Pygments tools (:mod:`qiskit.qasm.pygments`)
    QasmTerminalStyle
    QasmHTMLStyle
 """
-from .lexer import HAS_PYGMENTS
+try:
+    import pygments
+    HAS_PYGMENTS = True
+except ImportError:
+    HAS_PYGMENTS = False
+
 if HAS_PYGMENTS:
     from .lexer import OpenQASMLexer, QasmTerminalStyle, QasmHTMLStyle

--- a/qiskit/qasm/pygments/__init__.py
+++ b/qiskit/qasm/pygments/__init__.py
@@ -26,4 +26,6 @@ Qasm Pygments tools (:mod:`qiskit.qasm.pygments`)
    QasmTerminalStyle
    QasmHTMLStyle
 """
-from .lexer import OpenQASMLexer, QasmTerminalStyle, QasmHTMLStyle
+from .lexer import HAS_PYGMENTS
+if HAS_PYGMENTS:
+    from .lexer import OpenQASMLexer, QasmTerminalStyle, QasmHTMLStyle

--- a/qiskit/qasm/pygments/lexer.py
+++ b/qiskit/qasm/pygments/lexer.py
@@ -13,99 +13,99 @@
 # that they have been altered from the originals.
 """Pygments tools for Qasm.
 """
+
 try:
     from pygments.lexer import RegexLexer
     from pygments.token import (Comment, String, Keyword,
                                 Name, Number, Text)
     from pygments.style import Style
-    HAS_PYGMENTS = True
 except ImportError:
-    HAS_PYGMENTS = False
+    raise ImportError("To use 'qiskit.qasm.pygments' pygments must be "
+                      'installed. To install run "pip install pygments".')
 
-if HAS_PYGMENTS:
-    class QasmTerminalStyle(Style):
-        """A style for OpenQasm in a Terminal env (e.g. Jupyter print)
-        """
-        styles = {
-            String:              'ansibrightred',
-            Number:              'ansibrightcyan',
-            Keyword.Reserved:    'ansibrightgreen',
-            Keyword.Declaration: 'ansibrightgreen',
-            Keyword.Type:        'ansibrightmagenta',
-            Name.Builtin:        'ansibrightblue',
-            Name.Function:       'ansibrightyellow'}
 
-    class QasmHTMLStyle(Style):
-        """A style for OpenQasm in a HTML env (e.g. Jupyter widget)
-        """
-        styles = {
-            String:              'ansired',
-            Number:              'ansicyan',
-            Keyword.Reserved:    'ansigreen',
-            Keyword.Declaration: 'ansigreen',
-            Keyword.Type:        'ansimagenta',
-            Name.Builtin:        'ansiblue',
-            Name.Function:       'ansiyellow'}
+class QasmTerminalStyle(Style):
+    """A style for OpenQasm in a Terminal env (e.g. Jupyter print)."""
+    styles = {
+        String:              'ansibrightred',
+        Number:              'ansibrightcyan',
+        Keyword.Reserved:    'ansibrightgreen',
+        Keyword.Declaration: 'ansibrightgreen',
+        Keyword.Type:        'ansibrightmagenta',
+        Name.Builtin:        'ansibrightblue',
+        Name.Function:       'ansibrightyellow'}
 
-    class OpenQASMLexer(RegexLexer):
-        """A pygments lexer for OpenQasm
-        """
-        name = 'OpenQASM'
-        aliases = ['qasm']
-        filenames = ['*.qasm']
 
-        gates = ['id', 'cx', 'x', 'y', 'z', 's', 'sdg', 'h',
-                 't', 'tdg', 'ccx', 'rx', 'ry', 'rz',
-                 'cz', 'cy', 'ch', 'swap', 'cswap', 'crx',
-                 'cry', 'crz', 'cu1', 'cu3', 'rxx', 'rzz',
-                 'rccx', 'rcccx', 'u1', 'u2', 'u3']
+class QasmHTMLStyle(Style):
+    """A style for OpenQasm in a HTML env (e.g. Jupyter widget)."""
+    styles = {
+        String:              'ansired',
+        Number:              'ansicyan',
+        Keyword.Reserved:    'ansigreen',
+        Keyword.Declaration: 'ansigreen',
+        Keyword.Type:        'ansimagenta',
+        Name.Builtin:        'ansiblue',
+        Name.Function:       'ansiyellow'}
 
-        tokens = {
-            'root': [
-                (r'\n', Text),
-                (r'[^\S\n]+', Text),
-                (r'//\n', Comment),
-                (r'//.*?$', Comment.Single),
 
-                # Keywords
-                (r'(OPENQASM|include)\b', Keyword.Reserved, 'keywords'),
-                (r'(qreg|creg)\b', Keyword.Declaration),
+class OpenQASMLexer(RegexLexer):
+    """A pygments lexer for OpenQasm."""
+    name = 'OpenQASM'
+    aliases = ['qasm']
+    filenames = ['*.qasm']
 
-                # Treat 'if' special
-                (r'(if)\b', Keyword.Reserved, 'if_keywords'),
+    gates = ['id', 'cx', 'x', 'y', 'z', 's', 'sdg', 'h',
+             't', 'tdg', 'ccx', 'rx', 'ry', 'rz',
+             'cz', 'cy', 'ch', 'swap', 'cswap', 'crx',
+             'cry', 'crz', 'cu1', 'cu3', 'rxx', 'rzz',
+             'rccx', 'rcccx', 'u1', 'u2', 'u3']
 
-                # Constants
-                (r'(pi)\b', Name.Constant),
+    tokens = {
+        'root': [
+            (r'\n', Text),
+            (r'[^\S\n]+', Text),
+            (r'//\n', Comment),
+            (r'//.*?$', Comment.Single),
 
-                # Special
-                (r'(barrier|measure|reset)\b', Name.Builtin, 'params'),
+            # Keywords
+            (r'(OPENQASM|include)\b', Keyword.Reserved, 'keywords'),
+            (r'(qreg|creg)\b', Keyword.Declaration),
 
-                # Gates (Types)
-                ('(' + '|'.join(gates) + r')\b', Keyword.Type, 'params'),
-                (r'[unitary\d+]', Keyword.Type),
+            # Treat 'if' special
+            (r'(if)\b', Keyword.Reserved, 'if_keywords'),
 
-                # Functions
-                (r'(gate)\b', Name.Function, 'gate'),
+            # Constants
+            (r'(pi)\b', Name.Constant),
 
-                # Generic text
-                (r"[a-zA-Z_][a-zA-Z0-9_]*", Text, 'index')],
+            # Special
+            (r'(barrier|measure|reset)\b', Name.Builtin, 'params'),
 
-            'keywords': [(r'\s*("([^"]|"")*")', String, '#push'),
-                         (r"\d+", Number, '#push'),
-                         (r'.*\(', Text, 'params')],
+            # Gates (Types)
+            ('(' + '|'.join(gates) + r')\b', Keyword.Type, 'params'),
+            (r'[unitary\d+]', Keyword.Type),
 
-            'if_keywords': [(r'[a-zA-Z0-9_]*', String, '#pop'),
-                            (r"\d+", Number, '#push'),
-                            (r'.*\(', Text, 'params')],
+            # Functions
+            (r'(gate)\b', Name.Function, 'gate'),
 
-            'params': [(r"[a-zA-Z_][a-zA-Z0-9_]*", Text, '#push'),
-                       (r'\d+', Number, '#push'),
-                       (r'(\d+\.\d*|\d*\.\d+)([eEf][+-]?[0-9]+)?',
-                        Number, '#push'),
-                       (r'\)', Text)],
+            # Generic text
+            (r"[a-zA-Z_][a-zA-Z0-9_]*", Text, 'index')],
 
-            'gate': [(r'[unitary\d+]', Keyword.Type, '#push'),
-                     (r'p\d+', Text, '#push')],
+        'keywords': [(r'\s*("([^"]|"")*")', String, '#push'),
+                     (r"\d+", Number, '#push'),
+                     (r'.*\(', Text, 'params')],
 
-            'index': [(r"\d+", Number, '#pop')]
-            }
+        'if_keywords': [(r'[a-zA-Z0-9_]*', String, '#pop'),
+                        (r"\d+", Number, '#push'),
+                        (r'.*\(', Text, 'params')],
+
+        'params': [(r"[a-zA-Z_][a-zA-Z0-9_]*", Text, '#push'),
+                   (r'\d+', Number, '#push'),
+                   (r'(\d+\.\d*|\d*\.\d+)([eEf][+-]?[0-9]+)?',
+                    Number, '#push'),
+                   (r'\)', Text)],
+
+        'gate': [(r'[unitary\d+]', Keyword.Type, '#push'),
+                 (r'p\d+', Text, '#push')],
+
+        'index': [(r"\d+", Number, '#pop')]
+        }

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -17,10 +17,15 @@
 
 import ipywidgets as wid
 from IPython.display import display
-import pygments
-from pygments.formatters import HtmlFormatter
 from qiskit import QuantumCircuit
-from qiskit.qasm.pygments import QasmHTMLStyle, OpenQASMLexer
+
+try:
+    import pygments
+    from pygments.formatters import HtmlFormatter
+    from qiskit.qasm.pygments import QasmHTMLStyle, OpenQASMLexer
+    HAS_PYGMENTS = True
+except ImportError:
+    HAS_PYGMENTS = False
 
 
 def circuit_data_table(circuit: QuantumCircuit) -> wid.HTML:
@@ -114,6 +119,9 @@ def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
         Output widget.
 
     """
+    if not HAS_PYGMENTS:
+        raise ImportError("pygments must be installed for to use the qasm "
+                          'widget. To install run "pip install pygments"')
     qasm_code = circuit.qasm()
     code = pygments.highlight(qasm_code, OpenQASMLexer(),
                               HtmlFormatter())

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -11,7 +11,8 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-# pylint: disable=invalid-name, no-name-in-module
+
+# pylint: disable=invalid-name,no-name-in-module,ungrouped-imports
 
 """A circuit library widget module"""
 
@@ -118,6 +119,8 @@ def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
     Returns:
         Output widget.
 
+    Raises:
+        ImportError: If pygments is not installed
     """
     if not HAS_PYGMENTS:
         raise ImportError("pygments must be installed for to use the qasm "

--- a/releasenotes/notes/add-pygments-dfe2cd949c237deb.yaml
+++ b/releasenotes/notes/add-pygments-dfe2cd949c237deb.yaml
@@ -24,6 +24,10 @@ features:
     normal
 upgrade:
   - |
-    A new requirement, `pygments <https://pygments.org/>`_ , has been added
-    to the requirements list. It is used for providing syntax highlighting
-    of OpenQASM 2.0 code in Jupyter widgets.
+    A new optional visualization requirement,
+    `pygments <https://pygments.org/>`_ , has been added. It is used for
+    providing syntax highlighting of OpenQASM 2.0 code in Jupyter widgets and
+    optionally for the :meth:`qiskit.circuit.QuantumCircuit.qasm` method. It
+    must be installed (either with ``pip install pygments`` or
+    ``pip install qiskit-terra[visualization]``) prior to using the widget or
+    the ``formatted`` kwarg on the ``qasm()`` method.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,3 +22,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints
 jupyter-sphinx
+pygments>=2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ psutil>=5
 scipy>=1.0
 sympy>=1.3
 dill>=0.3
-pygments>=2.2
 fastjsonschema>=2.10
 python-constraint>=1.4

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ REQUIREMENTS = [
     "scipy>=1.0",
     "sympy>=1.3",
     "dill>=0.3",
-    "pygments>=2.2",
     "fastjsonschema>=2.10",
     "python-constraint>=1.4",
 ]
@@ -114,7 +113,7 @@ setup(
     extras_require={
         'visualization': ['matplotlib>=2.1', 'ipywidgets>=7.3.0',
                           'pydot', "pillow>=4.2.1", "pylatexenc>=1.4",
-                          "seaborn>=0.9.0"],
+                          "seaborn>=0.9.0", "pygments>=2.4"],
         'full-featured-simulators': ['qiskit-aer>=0.1'],
         'crosstalk-pass': ['z3-solver>=4.7'],
     },


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit switches to make pygments an optional dependency. Pygments
is solely a visualization requirement. It is used to provide syntax
highlighting for qasm code either in the qasm() circuit method or in a
jupyter widget. We typically do not add visualization dependencies to
the requirements list, so this commit remvoes it from the requirements
lists and adds it to the optional extras list for visualization. All the
uses of pygments are put behind try except blocks. It is added to
requirements-dev because while there are no tests for the pygments
output the docs build depends on it.

At the same time this bumps the minimum version we specified to a
working version. The minimum version of 2.2 was too low and caused
issues for users on 2.3.

### Details and comments

Fixes #4048
