### PR TITLE
Bugfix: Instruction name / pulse library name mismatch

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -188,9 +188,9 @@ def _assemble_instructions(
 
         if isinstance(instruction, Play) and isinstance(instruction.pulse, SamplePulse):
             name = hashlib.sha256(instruction.pulse.samples).hexdigest()
-            instruction =  Play(SamplePulse(name=name, samples=instruction.pulse.samples),
-                                channel=instruction.channel,
-                                name=name)
+            instruction = Play(SamplePulse(name=name, samples=instruction.pulse.samples),
+                               channel=instruction.channel,
+                               name=name)
             user_pulselib[name] = instruction.pulse.samples
 
         if isinstance(instruction, (AcquireInstruction, Acquire)):

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -191,8 +191,6 @@ def _assemble_instructions(
             instruction =  Play(SamplePulse(name=name, samples=instruction.pulse.samples),
                                 channel=instruction.channel,
                                 name=name)
-            if name in user_pulselib and not np.allclose(user_pulselib[name], instruction.pulse.samples):
-                name += str(instruction.pulse.id)
             user_pulselib[name] = instruction.pulse.samples
 
         if isinstance(instruction, (AcquireInstruction, Acquire)):

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -379,6 +379,40 @@ class TestPulseAssembler(QiskitTestCase):
             'backend_version': '0.0.0'
         }
 
+    def test_assemble_sample_pulse(self):
+        """Test that the pulse lib and qobj instruction can be paired up."""
+        schedule = pulse.Schedule()
+        schedule += pulse.Play(pulse.SamplePulse([0.1]*16, name='test0'),
+                               pulse.DriveChannel(0),
+                               name='test1')
+        schedule += pulse.Play(pulse.SamplePulse([0.1]*16, name='test1'),
+                               pulse.DriveChannel(0),
+                               name='test2')
+        schedule += pulse.Play(pulse.SamplePulse([0.5]*16, name='test0'),
+                               pulse.DriveChannel(0),
+                               name='test1')
+        qobj = assemble(schedule,
+                        qobj_header=self.header,
+                        qubit_lo_freq=self.default_qubit_lo_freq,
+                        meas_lo_freq=self.default_meas_lo_freq,
+                        schedule_los=[],
+                        **self.config)
+        validate_qobj_against_schema(qobj)
+
+        test_dict = qobj.to_dict()
+        experiment = test_dict['experiments'][0]
+        inst0_name = experiment['instructions'][0]['name']
+        inst1_name = experiment['instructions'][1]['name']
+        inst2_name = experiment['instructions'][2]['name']
+        pulses = {}
+        for item in test_dict['config']['pulse_library']:
+            pulses[item['name']] = item['samples']
+        self.assertTrue(all(name in pulses for name in [inst0_name, inst1_name, inst2_name]))
+        # Their pulses are the same
+        self.assertEqual(inst0_name, inst1_name)
+        self.assertTrue(np.allclose(pulses[inst0_name], [0.1]*16))
+        self.assertTrue(np.allclose(pulses[inst2_name], [0.5]*16))
+
     def test_assemble_single_schedule_without_lo_config(self):
         """Test assembling a single schedule, no lo config."""
         qobj = assemble(self.schedule,


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix a critical bug where the Qobj sample pulse instruction did not have the same name as the pulse library pulse

Fix #4047 

### Details and comments


