### PR TITLE
BarrierBeforeFinalMeasurements pass to insert device-wide barrier.

### DIFF
--- a/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
@@ -57,7 +57,9 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
         for creg in dag.cregs.values():
             barrier_layer.add_creg(creg)
 
-        final_qubits = {final_op.qargs[0] for final_op in final_ops}
+        # Add a barrier across all qubits so swap mapper doesn't add a swap
+        # from an unmeasured qubit after a measure.
+        final_qubits = dag.qubits()
 
         barrier_layer.apply_operation_back(
             Barrier(len(final_qubits)), list(final_qubits), [])

--- a/releasenotes/notes/3937-transpiler-pushes-gates-behind-measurements-3799753c21878237.yaml
+++ b/releasenotes/notes/3937-transpiler-pushes-gates-behind-measurements-3799753c21878237.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    The `BarrierBeforeFinalMeasurements` transpiler pass, included in
+    the preset transpiler levels when targeting a physical device,
+    previously inserted a barrier across only measured qubits. In some
+    cases, this allowed the transpiler to insert a swap after a
+    measure operation, rendering the circuit invalid for current
+    devices. The pass has been updated so that the inserted barrier
+    will span all qubits on the device.
+    

--- a/test/python/transpiler/test_barrier_before_final_measurements.py
+++ b/test/python/transpiler/test_barrier_before_final_measurements.py
@@ -159,8 +159,8 @@ class TestBarrierBeforeFinalMeasurements(QiskitTestCase):
     def test_preserve_measure_for_conditional(self):
         """Test barrier is inserted after any measurements used for conditionals
 
-         q0:--[H]--[m]------------     q0:--[H]--[m]---------------
-                    |                             |
+         q0:--[H]--[m]------------     q0:--[H]--[m]-------|-------
+                    |                             |        |
          q1:--------|--[ z]--[m]--  -> q1:--------|--[ z]--|--[m]--
                     |    |    |                   |    |       |
          c0:--------.--[=1]---|---     c0:--------.--[=1]------|---
@@ -182,7 +182,7 @@ class TestBarrierBeforeFinalMeasurements(QiskitTestCase):
         expected.h(qr0)
         expected.measure(qr0, cr0)
         expected.z(qr1).c_if(cr0, 1)
-        expected.barrier(qr1)
+        expected.barrier(qr0, qr1)
         expected.measure(qr1, cr1)
 
         pass_ = BarrierBeforeFinalMeasurements()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3937 by extending the barrier added by `BarrierBeforeFinalMeasurements` to cover all dag qubits.


### Details and comments


