### PR TITLE
Transpiler should raise when conflicting parameters, not just ignore them silently

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -169,10 +169,12 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         warnings.warn("Transpiling schedules is not supported yet.", UserWarning)
         return circuits
 
-    if pass_manager and optimization_level:
-        raise TranspilerError("The parameters pass_manager and optimization_level are conflicting.")
-
     if pass_manager:
+        _check_conflicting_argument(optimization_level=optimization_level, basis_gates=basis_gates,
+                                    coupling_map=coupling_map, seed_transpiler=seed_transpiler,
+                                    backend_properties=backend_properties,
+                                    initial_layout=initial_layout, layout_method=layout_method,
+                                    routing_method=routing_method, backend=backend)
         return pass_manager.run(circuits, output_name=output_name, callback=callback)
 
     if optimization_level is None:
@@ -195,6 +197,14 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
     if len(circuits) == 1:
         return circuits[0]
     return circuits
+
+
+def _check_conflicting_argument(**kargs):
+    conflicting_args = [arg for arg, value in kargs.items() if value]
+    if conflicting_args:
+        raise TranspilerError("The parameters pass_manager conflicts with the following "
+                              "parameter(s): {}.".format(', '.join(conflicting_args)))
+
 
 def _check_circuits_coupling_map(circuits, transpile_args, backend):
     # Check circuit width against number of qubits in coupling_map(s)

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -175,6 +175,10 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                                     backend_properties=backend_properties,
                                     initial_layout=initial_layout, layout_method=layout_method,
                                     routing_method=routing_method, backend=backend)
+
+        warnings.warn("The parameter pass_manager in transpile is being deprecated. "
+                      "The preferred way to tranpile a circuit using a custom pass manager is"
+                      " pass_manager.run(circuit)", DeprecationWarning, stacklevel=2)
         return pass_manager.run(circuits, output_name=output_name, callback=callback)
 
     if optimization_level is None:

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -169,7 +169,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         warnings.warn("Transpiling schedules is not supported yet.", UserWarning)
         return circuits
 
-    if pass_manager:
+    if pass_manager is not None:
         _check_conflicting_argument(optimization_level=optimization_level, basis_gates=basis_gates,
                                     coupling_map=coupling_map, seed_transpiler=seed_transpiler,
                                     backend_properties=backend_properties,

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -227,6 +227,7 @@ def _check_circuits_coupling_map(circuits, transpile_args, backend):
                                   'is greater than maximum ({}) '.format(max_qubits) +
                                   'in the coupling_map')
 
+
 def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> QuantumCircuit:
     """Select a PassManager and run a single circuit through it.
     Args:

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -176,8 +176,9 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
         return pass_manager.run(circuits, output_name=output_name, callback=callback)
 
     if optimization_level is None:
+        # Take optimization level from the configuration or 1 as default.
         config = user_config.get_config()
-        optimization_level = config.get('transpile_optimization_level', None)
+        optimization_level = config.get('transpile_optimization_level', 1)
 
     # Get transpile_args to configure the circuit transpilation job(s)
     transpile_args = _parse_transpile_args(circuits, backend, basis_gates, coupling_map,
@@ -249,11 +250,8 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
         pass_manager_config.basis_gates = list(
             set(['u3', 'cx']).union(pass_manager_config.basis_gates))
 
-    # we choose an appropriate one based on desired optimization level (default: level 1)
-    if transpile_config['optimization_level'] is not None:
-        level = transpile_config['optimization_level']
-    else:
-        level = 1
+    # we choose an appropriate one based on desired optimization level
+    level = transpile_config['optimization_level']
 
     if level == 0:
         pass_manager = level_0_pass_manager(pass_manager_config)

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -167,6 +167,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
     # transpiling schedules is not supported yet.
     if all(isinstance(c, Schedule) for c in circuits):
         warnings.warn("Transpiling schedules is not supported yet.", UserWarning)
+        if len(circuits) == 1:
+            return circuits[0]
         return circuits
 
     if pass_manager is not None:

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -271,4 +271,4 @@ def _check_conflicting_argument(**kargs):
     conflicting_args = [arg for arg, value in kargs.items() if value]
     if conflicting_args:
         raise QiskitError("The parameters pass_manager conflicts with the following "
-                              "parameter(s): {}.".format(', '.join(conflicting_args)))
+                          "parameter(s): {}.".format(', '.join(conflicting_args)))

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -216,16 +216,21 @@ def execute(experiments, backend,
     """
 
     # transpiling the circuits using given transpile options
-    experiments = transpile(experiments,
-                            basis_gates=basis_gates,
-                            coupling_map=coupling_map,
-                            backend_properties=backend_properties,
-                            initial_layout=initial_layout,
-                            seed_transpiler=seed_transpiler,
-                            optimization_level=optimization_level,
-                            backend=backend,
-                            pass_manager=pass_manager,
-                            )
+    if pass_manager is not None:
+        _check_conflicting_argument(optimization_level=optimization_level, basis_gates=basis_gates,
+                                    coupling_map=coupling_map, seed_transpiler=seed_transpiler,
+                                    backend_properties=backend_properties,
+                                    initial_layout=initial_layout, backend=backend)
+        experiments = pass_manager.run(experiments)
+    else:
+        experiments = transpile(experiments,
+                                basis_gates=basis_gates,
+                                coupling_map=coupling_map,
+                                backend_properties=backend_properties,
+                                initial_layout=initial_layout,
+                                seed_transpiler=seed_transpiler,
+                                optimization_level=optimization_level,
+                                backend=backend)
 
     if schedule_circuit:
         if isinstance(experiments, Schedule) or isinstance(experiments[0], Schedule):
@@ -260,3 +265,10 @@ def execute(experiments, backend,
 
     # executing the circuits on the backend and returning the job
     return backend.run(qobj, **run_config)
+
+
+def _check_conflicting_argument(**kargs):
+    conflicting_args = [arg for arg, value in kargs.items() if value]
+    if conflicting_args:
+        raise QiskitError("The parameters pass_manager conflicts with the following "
+                              "parameter(s): {}.".format(', '.join(conflicting_args)))

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -212,6 +212,8 @@ class PassManager:
         """
         if isinstance(circuits, QuantumCircuit):
             return self._run_single_circuit(circuits, output_name, callback)
+        elif len(circuits) == 1:
+            return self._run_single_circuit(circuits[0], output_name, callback)
         else:
             return self._run_several_circuits(circuits, output_name, callback)
 

--- a/releasenotes/notes/fix-3925-c0e40ece078f2ce1.yaml
+++ b/releasenotes/notes/fix-3925-c0e40ece078f2ce1.yaml
@@ -1,4 +1,0 @@
----
-fixes:
-  - |
-    A custom pass manager was creating a deadlock when run in on multiple circuits in parallel. 

--- a/releasenotes/notes/parameter_conflict_in_transpile-fc67d76288b480c4.yaml
+++ b/releasenotes/notes/parameter_conflict_in_transpile-fc67d76288b480c4.yaml
@@ -1,0 +1,4 @@
+---
+other:
+  - |
+    The function ```iqiskit.compiler.transpile``` now raises an error when conlicting parameters are passed, instead of ignoring them silently. 

--- a/releasenotes/notes/passmanager_parameter_in_transpile-9768d95afbe9127e.yaml
+++ b/releasenotes/notes/passmanager_parameter_in_transpile-9768d95afbe9127e.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    The parameter ```pass_manager``` in the function ```transpile``` is going to be removed. 
+    The preferred way to transpile a circuit with a custom pass manger is ```pass_manager.run(circuit)```.

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -112,7 +112,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qc.append(uni2q, [qr[0], qr[1]])
         passman = PassManager()
         passman.append(CXCancellation())
-        qc2 = transpile(qc, pass_manager=passman)
+        qc2 = passman.run(qc)
         # test of qasm output
         self.log.info(qc2.qasm())
         # test of text drawer

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -23,7 +23,6 @@ from numpy.testing import assert_allclose
 import qiskit
 from qiskit.extensions.unitary import UnitaryGate
 from qiskit.test import QiskitTestCase
-from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
 from qiskit.compiler import transpile
@@ -102,7 +101,6 @@ class TestUnitaryCircuit(QiskitTestCase):
 
     def test_2q_unitary(self):
         """test 2 qubit unitary matrix"""
-        backend = BasicAer.get_backend('qasm_simulator')
         qr = QuantumRegister(2)
         cr = ClassicalRegister(2)
         qc = QuantumCircuit(qr, cr)
@@ -114,7 +112,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qc.append(uni2q, [qr[0], qr[1]])
         passman = PassManager()
         passman.append(CXCancellation())
-        qc2 = transpile(qc, backend, pass_manager=passman)
+        qc2 = transpile(qc, pass_manager=passman)
         # test of qasm output
         self.log.info(qc2.qasm())
         # test of text drawer

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -25,7 +25,6 @@ from qiskit.extensions.unitary import UnitaryGate
 from qiskit.test import QiskitTestCase
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.transpiler.passes import CXCancellation
 

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -204,9 +204,7 @@ class TestCompiler(QiskitTestCase):
         qrtrue = assemble(transpile(qc, backend, seed_transpiler=8),
                           seed_simulator=42)
         rtrue = backend.run(qrtrue).result()
-        qrfalse = assemble(transpile(qc, backend, seed_transpiler=8,
-                                     pass_manager=PassManager()),
-                           seed_simulator=42)
+        qrfalse = assemble(PassManager().run(qc), seed_simulator=42)
         rfalse = backend.run(qrfalse).result()
         self.assertEqual(rtrue.get_counts(), rfalse.get_counts())
 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -535,7 +535,7 @@ class TestTranspile(QiskitTestCase):
         resources_before = circuit.count_ops()
 
         pass_manager = PassManager()
-        out_circuit = transpile(circuit, pass_manager=pass_manager)
+        out_circuit = pass_manager.run(circuit)
         resources_after = out_circuit.count_ops()
 
         self.assertDictEqual(resources_before, resources_after)
@@ -717,7 +717,7 @@ class TestTranspileCustomPM(QiskitTestCase):
         )
         passmanager = level_0_pass_manager(pm_conf)
 
-        transpiled = transpile([qc, qc], pass_manager=passmanager)
+        transpiled = passmanager.run([qc, qc])
 
         expected = QuantumCircuit(QuantumRegister(2, 'q'))
         expected.u2(0, 3.141592653589793, 0)

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -133,7 +133,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
 
-        transpile(qc, pass_manager=pass_manager)
+        pass_manager.run(qc)
 
         self.assertEqual([['cx']],
                          [[n.name for n in block]
@@ -176,7 +176,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
 
-        transpile(qc, pass_manager=pass_manager)
+        pass_manager.run(qc)
         self.assertEqual([['cx']],
                          [[n.name for n in block]
                           for block in pass_manager.property_set['block_list']])

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -20,7 +20,6 @@ import unittest
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.converters import circuit_to_dag
-from qiskit.compiler import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -24,7 +24,6 @@ from qiskit.compiler import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Collect2qBlocks
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeMelbourne
 
 
 class TestCollect2qBlocks(QiskitTestCase):

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -130,12 +130,11 @@ class TestCollect2qBlocks(QiskitTestCase):
         if(c0==0) u2(0.25*pi, 0.25*pi) q[0];
         """
         qc = QuantumCircuit.from_qasm_str(qasmstr)
-        backend = FakeMelbourne()
 
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
 
-        transpile(qc, backend, pass_manager=pass_manager)
+        transpile(qc, pass_manager=pass_manager)
 
         self.assertEqual([['cx']],
                          [[n.name for n in block]

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -20,7 +20,6 @@ from qiskit.test import QiskitTestCase
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager, PropertySet
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import CommutationAnalysis, CommutativeCancellation, FixedPoint, Size
 
 

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -70,7 +70,7 @@ class TestCommutativeCancellation(QiskitTestCase):
 
         passmanager = PassManager()
         passmanager.append(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(qr)
         expected.u1(2.0, qr[0])
@@ -96,7 +96,7 @@ class TestCommutativeCancellation(QiskitTestCase):
 
         passmanager = PassManager()
         passmanager.append(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
 
         expected = QuantumCircuit(qr)
         expected.h(qr[2])
@@ -118,7 +118,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
 
         self.assertEqual(expected, new_circuit)
@@ -135,12 +135,11 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.rx(np.pi, qr[0])
 
         passmanager = PassManager()
-        # passmanager.append(CommutativeCancellation())
         passmanager.append([CommutationAnalysis(),
                             CommutativeCancellation(),
                             Size(), FixedPoint('size')],
                            do_while=lambda property_set: not property_set['size_fixed_point'])
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
         expected = QuantumCircuit(qr)
 
         self.assertEqual(expected, new_circuit)
@@ -160,7 +159,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[1], qr[0])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.cx(qr[0], qr[1])
         expected.cx(qr[1], qr[0])
@@ -182,7 +181,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.cx(qr[0], qr[1])
         expected.x(qr[0])
@@ -205,7 +204,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.z(qr[0])
 
@@ -226,7 +225,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.t(qr[0])
 
@@ -247,7 +246,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.rz(np.pi / 3, qr[0])
 
@@ -268,7 +267,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.t(qr[0])
 
@@ -290,7 +289,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.cx(qr[0], qr[1])
         expected.z(qr[1])
@@ -313,7 +312,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.cx(qr[0], qr[1])
         expected.t(qr[1])
@@ -336,7 +335,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.cx(qr[0], qr[1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
         expected = QuantumCircuit(qr)
         expected.cx(qr[0], qr[1])
         expected.rz(np.pi / 3, qr[1])
@@ -370,7 +369,7 @@ class TestCommutativeCancellation(QiskitTestCase):
 
         passmanager = PassManager()
         passmanager.append(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
         expected = QuantumCircuit(qr)
         expected.u1(np.pi * 17 / 12, qr[2])
         expected.cx(qr[2], qr[1])
@@ -414,7 +413,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         passmanager.append([CommutationAnalysis(),
                             CommutativeCancellation(), Size(), FixedPoint('size')],
                            do_while=lambda property_set: not property_set['size_fixed_point'])
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
         expected = QuantumCircuit(qr)
         expected.u1(np.pi * 17 / 12, qr[2])
         expected.u1(np.pi * 2 / 3, qr[3])
@@ -454,7 +453,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         passmanager.append([CommutationAnalysis(),
                             CommutativeCancellation(), Size(), FixedPoint('size')],
                            do_while=lambda property_set: not property_set['size_fixed_point'])
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
         expected = QuantumCircuit(qr)
 
         self.assertEqual(expected, new_circuit)
@@ -509,7 +508,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         passmanager.append([CommutationAnalysis(),
                             CommutativeCancellation(), Size(), FixedPoint('size')],
                            do_while=lambda property_set: not property_set['size_fixed_point'])
-        new_circuit = transpile(circuit, pass_manager=passmanager)
+        new_circuit = passmanager.run(circuit)
         expected = QuantumCircuit(qr)
 
         self.assertEqual(expected, new_circuit)
@@ -524,7 +523,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         circuit.measure([1, 2], [0, 1])
 
         new_pm = PassManager(CommutativeCancellation())
-        new_circuit = transpile(circuit, pass_manager=new_pm)
+        new_circuit = new_pm.run(circuit)
 
         self.assertEqual(circuit, new_circuit)
 

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -19,7 +19,6 @@ Tests for the ConsolidateBlocks transpiler pass.
 import unittest
 import numpy as np
 
-from qiskit import transpile
 from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.extensions import UnitaryGate
 from qiskit.converters import circuit_to_dag

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -201,7 +201,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
         pass_manager.append(ConsolidateBlocks())
-        qc1 = transpile(qc, pass_manager=pass_manager)
+        qc1 = pass_manager.run(qc)
 
         self.assertEqual(qc, qc1)
 
@@ -231,7 +231,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
         pass_manager.append(ConsolidateBlocks())
-        qc1 = transpile(qc, pass_manager=pass_manager)
+        qc1 = pass_manager.run(qc)
 
         self.assertEqual(qc, qc1)
 
@@ -268,7 +268,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
         pass_manager.append(ConsolidateBlocks())
-        qc1 = transpile(qc, pass_manager=pass_manager)
+        qc1 = pass_manager.run(qc)
 
         self.assertEqual(qc, qc1)
 
@@ -283,7 +283,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(Collect2qBlocks())
         pass_manager.append(ConsolidateBlocks())
-        qc1 = transpile(qc, pass_manager=pass_manager)
+        qc1 = pass_manager.run(qc)
 
         self.assertEqual(qc, qc1)
 

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -16,7 +16,6 @@
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import CXCancellation
 from qiskit.test import QiskitTestCase
 

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -42,7 +42,7 @@ class TestCXCancellation(QiskitTestCase):
 
         pass_manager = PassManager()
         pass_manager.append(CXCancellation())
-        out_circuit = transpile(circuit, pass_manager=pass_manager)
+        out_circuit = pass_manager.run(circuit)
         resources_after = out_circuit.count_ops()
 
         self.assertNotIn('cx', resources_after)

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -78,7 +78,6 @@ import os
 from qiskit import execute
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, BasicAer
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, StochasticSwap, SetLayout
 from qiskit.transpiler import CouplingMap, Layout
 

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -194,9 +194,7 @@ class SwapperCommonTestCases(CommonUtilitiesMixin):
         circuit.cx(qr[1], qr[2])
         circuit.measure(qr, cr)
 
-        result = transpile(circuit, self.create_backend(), coupling_map=coupling_map,
-                           seed_transpiler=self.seed_transpiler,
-                           pass_manager=self.create_passmanager(coupling_map))
+        result = self.create_passmanager(coupling_map).run(circuit)
         self.assertResult(result, circuit)
 
     def test_initial_layout(self):
@@ -232,9 +230,7 @@ class SwapperCommonTestCases(CommonUtilitiesMixin):
 
         layout = {qr[3]: 0, qr[0]: 1, qr[1]: 2, qr[2]: 3}
 
-        result = transpile(circuit, self.create_backend(), coupling_map=coupling_map,
-                           seed_transpiler=self.seed_transpiler,
-                           pass_manager=self.create_passmanager(coupling_map, layout))
+        result = self.create_passmanager(coupling_map, layout).run(circuit)
         self.assertResult(result, circuit)
 
     def test_handle_measurement(self):
@@ -272,9 +268,7 @@ class SwapperCommonTestCases(CommonUtilitiesMixin):
         circuit.cx(qr[3], qr[0])
         circuit.measure(qr, cr)
 
-        result = transpile(circuit, self.create_backend(), coupling_map=coupling_map,
-                           seed_transpiler=self.seed_transpiler,
-                           pass_manager=self.create_passmanager(coupling_map))
+        result = self.create_passmanager(coupling_map).run(circuit)
         self.assertResult(result, circuit)
 
 

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -19,7 +19,6 @@ import numpy as np
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import Optimize1qGates, Unroller
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -60,7 +60,7 @@ class TestOptimize1qGates(QiskitTestCase):
         passmanager = PassManager()
         passmanager.append(Unroller(['u2']))
         passmanager.append(Optimize1qGates())
-        result = transpile(circuit, pass_manager=passmanager)
+        result = passmanager.run(circuit)
 
         self.assertEqual(expected, result)
 

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -23,7 +23,6 @@ from qiskit.compiler import transpile
 from qiskit.transpiler.passes import Optimize1qGates, Unroller
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeRueschlikon
 from qiskit.circuit import Parameter
 
 

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -61,7 +61,7 @@ class TestOptimize1qGates(QiskitTestCase):
         passmanager = PassManager()
         passmanager.append(Unroller(['u2']))
         passmanager.append(Optimize1qGates())
-        result = transpile(circuit, FakeRueschlikon(), pass_manager=passmanager)
+        result = transpile(circuit, pass_manager=passmanager)
 
         self.assertEqual(expected, result)
 

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -123,7 +123,7 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         pass_manager.append(
             [OptimizeSwapBeforeMeasure(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile(circuit, pass_manager=pass_manager)
+        after = pass_manager.run(circuit)
 
         self.assertEqual(expected, after)
 
@@ -151,7 +151,7 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
         pass_manager.append(
             [OptimizeSwapBeforeMeasure(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile(circuit, pass_manager=pass_manager)
+        after = pass_manager.run(circuit)
 
         self.assertEqual(expected, after)
 

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -18,7 +18,6 @@ import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import OptimizeSwapBeforeMeasure, DAGFixedPoint
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -23,7 +23,6 @@ import sys
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager, TranspilerError
-from qiskit.compiler import transpile
 from qiskit.transpiler.runningpassmanager import DoWhileController, ConditionalController, \
     FlowController
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -48,7 +48,7 @@ class SchedulerTestCase(QiskitTestCase):
         """
         logger = 'LocalLogger'
         with self.assertLogs(logger, level='INFO') as cm:
-            out = transpile(circuit, pass_manager=passmanager)
+            out = passmanager.run(circuit)
         self.assertIsInstance(out, QuantumCircuit)
         self.assertEqual([record.message for record in cm.records], expected)
 
@@ -65,7 +65,7 @@ class SchedulerTestCase(QiskitTestCase):
         """
         logger = 'LocalLogger'
         with self.assertLogs(logger, level='INFO') as cm:
-            self.assertRaises(exception_type, transpile, circuit, pass_manager=passmanager)
+            self.assertRaises(exception_type, passmanager.run, circuit)
         self.assertEqual([record.message for record in cm.records], expected)
 
 
@@ -550,7 +550,7 @@ class TestLogPasses(QiskitTestCase):
     def assertPassLog(self, passmanager, list_of_passes):
         """ Runs the passmanager and checks that the elements in
         passmanager.property_set['pass_log'] match list_of_passes (the names)."""
-        transpile(self.circuit, pass_manager=passmanager)
+        passmanager.run(self.circuit)
         self.output.seek(0)
         # Filter unrelated log lines
         output_lines = self.output.readlines()

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -21,7 +21,6 @@ import numpy as np
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
 from qiskit.transpiler import PropertySet
-from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes import CommutativeCancellation
 from qiskit.transpiler.passes import Optimize1qGates, Unroller

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -25,7 +25,6 @@ from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes import CommutativeCancellation
 from qiskit.transpiler.passes import Optimize1qGates, Unroller
-from qiskit.test.mock import FakeRueschlikon
 from qiskit.test import QiskitTestCase
 
 

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -59,7 +59,7 @@ class TestPassManager(QiskitTestCase):
         passmanager = PassManager()
         passmanager.append(Unroller(['u2']))
         passmanager.append(Optimize1qGates())
-        transpile(circuit, FakeRueschlikon(), pass_manager=passmanager, callback=callback)
+        transpile(circuit, pass_manager=passmanager, callback=callback)
         self.assertEqual(len(calls), 2)
         self.assertEqual(len(calls[0]), 5)
         self.assertEqual(calls[0]['count'], 0)

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -58,7 +58,7 @@ class TestPassManager(QiskitTestCase):
         passmanager = PassManager()
         passmanager.append(Unroller(['u2']))
         passmanager.append(Optimize1qGates())
-        transpile(circuit, pass_manager=passmanager, callback=callback)
+        passmanager.run(circuit, callback=callback)
         self.assertEqual(len(calls), 2)
         self.assertEqual(len(calls[0]), 5)
         self.assertEqual(calls[0]['count'], 0)

--- a/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
+++ b/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
@@ -19,7 +19,6 @@ from copy import deepcopy
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import RemoveDiagonalGatesBeforeMeasure, DAGFixedPoint
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
+++ b/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
@@ -398,7 +398,7 @@ class TestRemoveDiagonalGatesBeforeMeasureFixedPoint(QiskitTestCase):
         pass_manager.append(
             [RemoveDiagonalGatesBeforeMeasure(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile(circuit, pass_manager=pass_manager)
+        after = pass_manager.run(circuit)
 
         self.assertEqual(expected, after)
 

--- a/test/python/transpiler/test_remove_reset_in_zero_state.py
+++ b/test/python/transpiler/test_remove_reset_in_zero_state.py
@@ -99,7 +99,7 @@ class TestRemoveResetInZeroStateFixedPoint(QiskitTestCase):
         pass_manager.append(
             [RemoveResetInZeroState(), DAGFixedPoint()],
             do_while=lambda property_set: not property_set['dag_fixed_point'])
-        after = transpile(circuit, pass_manager=pass_manager)
+        after = pass_manager.run(circuit)
 
         self.assertEqual(expected, after)
 

--- a/test/python/transpiler/test_remove_reset_in_zero_state.py
+++ b/test/python/transpiler/test_remove_reset_in_zero_state.py
@@ -18,7 +18,6 @@ import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import RemoveResetInZeroState, DAGFixedPoint
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase

--- a/test/python/transpiler/test_resource_estimation_pass.py
+++ b/test/python/transpiler/test_resource_estimation_pass.py
@@ -18,7 +18,6 @@ import unittest
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.transpiler import PassManager
-from qiskit.compiler import transpile
 from qiskit.transpiler.passes import ResourceEstimation
 from qiskit.test import QiskitTestCase
 

--- a/test/python/transpiler/test_resource_estimation_pass.py
+++ b/test/python/transpiler/test_resource_estimation_pass.py
@@ -31,7 +31,7 @@ class TestResourceEstimationPass(QiskitTestCase):
         circuit = QuantumCircuit()
         passmanager = PassManager()
         passmanager.append(ResourceEstimation())
-        _ = transpile(circuit, pass_manager=passmanager)
+        passmanager.run(circuit)
 
         self.assertEqual(passmanager.property_set['size'], 0)
         self.assertEqual(passmanager.property_set['depth'], 0)
@@ -53,7 +53,7 @@ class TestResourceEstimationPass(QiskitTestCase):
 
         passmanager = PassManager()
         passmanager.append(ResourceEstimation())
-        _ = transpile(circuit, pass_manager=passmanager)
+        passmanager.run(circuit)
 
         self.assertEqual(passmanager.property_set['size'], 8)
         self.assertEqual(passmanager.property_set['depth'], 7)

--- a/test/python/transpiler/test_resource_estimation_pass.py
+++ b/test/python/transpiler/test_resource_estimation_pass.py
@@ -21,7 +21,6 @@ from qiskit.transpiler import PassManager
 from qiskit.compiler import transpile
 from qiskit.transpiler.passes import ResourceEstimation
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeRueschlikon
 
 
 class TestResourceEstimationPass(QiskitTestCase):
@@ -32,7 +31,7 @@ class TestResourceEstimationPass(QiskitTestCase):
         circuit = QuantumCircuit()
         passmanager = PassManager()
         passmanager.append(ResourceEstimation())
-        _ = transpile(circuit, FakeRueschlikon(), pass_manager=passmanager)
+        _ = transpile(circuit, pass_manager=passmanager)
 
         self.assertEqual(passmanager.property_set['size'], 0)
         self.assertEqual(passmanager.property_set['depth'], 0)
@@ -54,7 +53,7 @@ class TestResourceEstimationPass(QiskitTestCase):
 
         passmanager = PassManager()
         passmanager.append(ResourceEstimation())
-        _ = transpile(circuit, FakeRueschlikon(), pass_manager=passmanager)
+        _ = transpile(circuit, pass_manager=passmanager)
 
         self.assertEqual(passmanager.property_set['size'], 8)
         self.assertEqual(passmanager.property_set['depth'], 7)


### PR DESCRIPTION
If `transpile` is called with `pass_manager`, most of the additional parameters are already embed in the pass manager configuration and they are currently silently ignored.

This PR raises when that happen and includes a small refactor to reorganize the code.