### PR TITLE
Deprecate some unneeded methods of QuantumState

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -147,7 +147,7 @@ class DensityMatrix(QuantumState):
         data = np.kron(other._data, self._data)
         return DensityMatrix(data, dims)
 
-    def add(self, other):
+    def _add(self, other):
         """Return the linear combination self + other.
 
         Args:
@@ -166,33 +166,14 @@ class DensityMatrix(QuantumState):
             raise QiskitError("other DensityMatrix has different dimensions.")
         return DensityMatrix(self.data + other.data, self.dims())
 
-    def subtract(self, other):
-        """Return the linear operator self - other.
-
-        Args:
-            other (DensityMatrix): a quantum state object.
-
-        Returns:
-            DensityMatrix: the linear combination self - other.
-
-        Raises:
-            QiskitError: if other is not a quantum state, or has
-                         incompatible dimensions.
-        """
-        if not isinstance(other, DensityMatrix):
-            other = DensityMatrix(other)
-        if self.dim != other.dim:
-            raise QiskitError("other DensityMatrix has different dimensions.")
-        return DensityMatrix(self.data - other.data, self.dims())
-
-    def multiply(self, other):
-        """Return the linear operator self * other.
+    def _multiply(self, other):
+        """Return the scalar multiplied state other * self.
 
         Args:
             other (complex): a complex number.
 
         Returns:
-            DensityMatrix: the linear combination other * self.
+            DensityMatrix: the scalar multiplied state other * self.
 
         Raises:
             QiskitError: if other is not a valid complex number.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -56,11 +56,11 @@ class DensityMatrix(QuantumState):
             # If no 'to_operator' attribute exists we next look for a
             # 'to_matrix' attribute to a matrix that will be cast into
             # a complex numpy matrix.
-            mat = np.array(data.to_matrix(), dtype=complex)
+            mat = np.asarray(data.to_matrix(), dtype=complex)
         elif isinstance(data, (list, np.ndarray)):
             # Finally we check if the input is a raw matrix in either a
             # python list or numpy array format.
-            mat = np.array(data, dtype=complex)
+            mat = np.asarray(data, dtype=complex)
         else:
             raise QiskitError("Invalid input data format for DensityMatrix")
         # Convert statevector into a density matrix
@@ -72,8 +72,25 @@ class DensityMatrix(QuantumState):
         if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
             raise QiskitError(
                 "Invalid DensityMatrix input: not a square matrix.")
-        subsystem_dims = self._automatic_dims(dims, mat.shape[0])
-        super().__init__('DensityMatrix', mat, subsystem_dims)
+        self._data = mat
+        super().__init__(self._automatic_dims(dims, self._data.shape[0]))
+
+    def __eq__(self, other):
+        return super().__eq__(other) and np.allclose(
+            self._data, other._data, rtol=self.rtol, atol=self.atol)
+
+    def __repr__(self):
+        prefix = 'DensityMatrix('
+        pad = len(prefix) * ' '
+        return '{}{},\n{}dims={})'.format(
+            prefix, np.array2string(
+                self._data, separator=', ', prefix=prefix),
+            pad, self._dims)
+
+    @property
+    def data(self):
+        """Return data."""
+        return self._data
 
     def is_valid(self, atol=None, rtol=None):
         """Return True if trace 1 and positive semidefinite."""

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -16,6 +16,7 @@
 Abstract QuantumState class.
 """
 
+import copy
 import warnings
 from abc import ABC, abstractmethod
 
@@ -34,14 +35,8 @@ class QuantumState(ABC):
     _RTOL_DEFAULT = RTOL_DEFAULT
     _MAX_TOL = 1e-4
 
-    def __init__(self, rep, data, dims):
+    def __init__(self, dims):
         """Initialize a state object."""
-        if not isinstance(rep, str):
-            raise QiskitError("rep must be a string not a {}".format(
-                rep.__class__))
-        self._rep = rep
-        self._data = data
-
         # Dimension attributes
         # Note that the tuples of input and output dims are ordered
         # from least-significant to most-significant subsystems
@@ -53,19 +48,7 @@ class QuantumState(ABC):
         self._rng = np.random.RandomState()
 
     def __eq__(self, other):
-        if (isinstance(other, self.__class__)
-                and self.dims() == other.dims()):
-            return np.allclose(
-                self.data, other.data, rtol=self.rtol, atol=self.atol)
-        return False
-
-    def __repr__(self):
-        prefix = '{}('.format(self._rep)
-        pad = len(prefix) * ' '
-        return '{}{},\n{}dims={})'.format(
-            prefix, np.array2string(
-                self.data, separator=', ', prefix=prefix),
-            pad, self._dims)
+        return isinstance(other, self.__class__) and self.dims() == other.dims()
 
     @property
     def dim(self):
@@ -76,11 +59,6 @@ class QuantumState(ABC):
     def num_qubits(self):
         """Return the number of qubits if a N-qubit state or None otherwise."""
         return self._num_qubits
-
-    @property
-    def data(self):
-        """Return data."""
-        return self._data
 
     @property
     def atol(self):
@@ -144,9 +122,7 @@ class QuantumState(ABC):
 
     def copy(self):
         """Make a copy of current operator."""
-        # pylint: disable=no-value-for-parameter
-        # The constructor of subclasses from raw data should be a copy
-        return self.__class__(self.data, self.dims())
+        return copy.deepcopy(self)
 
     def seed(self, value=None):
         """Set the seed for the quantum state RNG."""

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -36,31 +36,47 @@ class Statevector(QuantumState):
     def __init__(self, data, dims=None):
         """Initialize a state object."""
         if isinstance(data, Statevector):
-            # Shallow copy constructor
-            vec = data.data
+            self._data = data._data
             if dims is None:
-                dims = data.dims()
+                dims = data._dims
         elif isinstance(data, Operator):
             # We allow conversion of column-vector operators to Statevectors
             input_dim, output_dim = data.dim
             if input_dim != 1:
                 raise QiskitError("Input Operator is not a column-vector.")
-            vec = np.reshape(data.data, output_dim)
+            self._data = np.ravel(data.data)
         elif isinstance(data, (list, np.ndarray)):
             # Finally we check if the input is a raw vector in either a
             # python list or numpy array format.
-            vec = np.array(data, dtype=complex)
+            self._data = np.asarray(data, dtype=complex)
         else:
             raise QiskitError("Invalid input data format for Statevector")
         # Check that the input is a numpy vector or column-vector numpy
         # matrix. If it is a column-vector matrix reshape to a vector.
-        if vec.ndim not in [1, 2] or (vec.ndim == 2 and vec.shape[1] != 1):
+        ndim = self._data.ndim
+        shape = self._data.shape
+        if ndim not in [1, 2] or (ndim == 2 and shape[1] != 1):
             raise QiskitError("Invalid input: not a vector or column-vector.")
-        if vec.ndim == 2 and vec.shape[1] == 1:
-            vec = np.reshape(vec, vec.shape[0])
-        dim = vec.shape[0]
-        subsystem_dims = self._automatic_dims(dims, dim)
-        super().__init__('Statevector', vec, subsystem_dims)
+        if ndim == 2 and shape[1] == 1:
+            self._data = np.reshape(self._data, shape[0])
+        super().__init__(self._automatic_dims(dims, shape[0]))
+
+    def __eq__(self, other):
+        return super().__eq__(other) and np.allclose(
+            self._data, other._data, rtol=self.rtol, atol=self.atol)
+
+    def __repr__(self):
+        prefix = 'Statevector('
+        pad = len(prefix) * ' '
+        return '{}{},\n{}dims={})'.format(
+            prefix, np.array2string(
+                self.data, separator=', ', prefix=prefix),
+            pad, self._dims)
+
+    @property
+    def data(self):
+        """Return data."""
+        return self._data
 
     def is_valid(self, atol=None, rtol=None):
         """Return True if a Statevector has norm 1."""

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -128,14 +128,14 @@ class Statevector(QuantumState):
         data = np.kron(other._data, self._data)
         return Statevector(data, dims)
 
-    def add(self, other):
+    def _add(self, other):
         """Return the linear combination self + other.
 
         Args:
             other (Statevector): a quantum state object.
 
         Returns:
-            LinearOperator: the linear combination self + other.
+            Statevector: the linear combination self + other.
 
         Raises:
             QiskitError: if other is not a quantum state, or has
@@ -147,33 +147,14 @@ class Statevector(QuantumState):
             raise QiskitError("other Statevector has different dimensions.")
         return Statevector(self.data + other.data, self.dims())
 
-    def subtract(self, other):
-        """Return the linear operator self - other.
-
-        Args:
-            other (Statevector): a quantum state object.
-
-        Returns:
-            LinearOperator: the linear combination self - other.
-
-        Raises:
-            QiskitError: if other is not a quantum state, or has
-                         incompatible dimensions.
-        """
-        if not isinstance(other, Statevector):
-            other = Statevector(other)
-        if self.dim != other.dim:
-            raise QiskitError("other Statevector has different dimensions.")
-        return Statevector(self.data - other.data, self.dims())
-
-    def multiply(self, other):
-        """Return the linear operator self * other.
+    def _multiply(self, other):
+        """Return the scalar multiplied state self * other.
 
         Args:
             other (complex): a complex number.
 
         Returns:
-            Operator: the linear combination other * self.
+            Statevector: the scalar multiplied state other * self.
 
         Raises:
             QiskitError: if other is not a valid complex number.

--- a/releasenotes/notes/states-dep-028ed0ef6a7db02a.yaml
+++ b/releasenotes/notes/states-dep-028ed0ef6a7db02a.yaml
@@ -1,11 +1,16 @@
 ---
+upgrade:
+  - |
+    The :class:`qiskit.quantum_info.Statevector` and 
+    :class:`qiskit.quantum_info.DensityMatrix` classes no longer copy the
+    input array if it is already the correct dtype.
 deprecations:
   - |
     The ``add``, ``subtract``, and ``multiple`` methods of the
-    :class:`~qiskit.quantum_info.Statevector` and 
-    :class:`~qiskit.quantum_info.DensityMatrix` classes are deprecated.
+    :class:`qiskit.quantum_info.Statevector` and 
+    :class:`qiskit.quantum_info.DensityMatrix` classes are deprecated.
     Use ``+``, ``-``, ``*`` binary operators instead.
   - |
-    The ``rep`` method of the :class:`~qiskit.quantum_info.Statevector` and 
-    :class:`~qiskit.quantum_info.DensityMatrix` classes is deprecated. Use
+    The ``rep`` method of the :class:`qiskit.quantum_info.Statevector` and 
+    :class:`qiskit.quantum_info.DensityMatrix` classes is deprecated. Use
     ``isinstance`` to check for type instead.

--- a/releasenotes/notes/states-dep-028ed0ef6a7db02a.yaml
+++ b/releasenotes/notes/states-dep-028ed0ef6a7db02a.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    The ``add``, ``subtract``, and ``multiple`` methods of the
+    :class:`~qiskit.quantum_info.Statevector` and 
+    :class:`~qiskit.quantum_info.DensityMatrix` classes are deprecated.
+    Use ``+``, ``-``, ``*`` binary operators instead.
+  - |
+    The ``rep`` method of the :class:`~qiskit.quantum_info.Statevector` and 
+    :class:`~qiskit.quantum_info.DensityMatrix` classes is deprecated. Use
+    ``isinstance`` to check for type instead.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -173,11 +173,6 @@ class TestDensityMatrix(QiskitTestCase):
             self.assertEqual(DensityMatrix(rho),
                              DensityMatrix(rho.tolist()))
 
-    def test_rep(self):
-        """Test Operator representation string property."""
-        state = DensityMatrix(self.rand_rho(2))
-        self.assertEqual(state.rep, 'DensityMatrix')
-
     def test_copy(self):
         """Test DensityMatrix copy method"""
         for _ in range(5):
@@ -301,14 +296,13 @@ class TestDensityMatrix(QiskitTestCase):
             rho1 = self.rand_rho(4)
             state0 = DensityMatrix(rho0)
             state1 = DensityMatrix(rho1)
-            self.assertEqual(state0.add(state1), DensityMatrix(rho0 + rho1))
             self.assertEqual(state0 + state1, DensityMatrix(rho0 + rho1))
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         state1 = DensityMatrix(self.rand_rho(2))
         state2 = DensityMatrix(self.rand_rho(3))
-        self.assertRaises(QiskitError, state1.add, state2)
+        self.assertRaises(QiskitError, state1.__add__, state2)
 
     def test_subtract(self):
         """Test subtract method."""
@@ -325,7 +319,6 @@ class TestDensityMatrix(QiskitTestCase):
             rho = self.rand_rho(4)
             state = DensityMatrix(rho)
             val = np.random.rand() + 1j * np.random.rand()
-            self.assertEqual(state.multiply(val), DensityMatrix(val * rho))
             self.assertEqual(val * state, DensityMatrix(val * state))
 
     def test_negate(self):

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -165,11 +165,6 @@ class TestStatevector(QiskitTestCase):
             self.assertEqual(Statevector(vec),
                              Statevector(vec.tolist()))
 
-    def test_rep(self):
-        """Test Operator representation string property."""
-        state = Statevector(self.rand_vec(2))
-        self.assertEqual(state.rep, 'Statevector')
-
     def test_copy(self):
         """Test Statevector copy method"""
         for _ in range(5):
@@ -293,14 +288,13 @@ class TestStatevector(QiskitTestCase):
             vec1 = self.rand_vec(4)
             state0 = Statevector(vec0)
             state1 = Statevector(vec1)
-            self.assertEqual(state0.add(state1), Statevector(vec0 + vec1))
             self.assertEqual(state0 + state1, Statevector(vec0 + vec1))
 
     def test_add_except(self):
         """Test add method raises exceptions."""
         state1 = Statevector(self.rand_vec(2))
         state2 = Statevector(self.rand_vec(3))
-        self.assertRaises(QiskitError, state1.add, state2)
+        self.assertRaises(QiskitError, state1.__add__, state2)
 
     def test_subtract(self):
         """Test subtract method."""
@@ -317,7 +311,6 @@ class TestStatevector(QiskitTestCase):
             vec = self.rand_vec(4)
             state = Statevector(vec)
             val = np.random.rand() + 1j * np.random.rand()
-            self.assertEqual(state.multiply(val), Statevector(val * vec))
             self.assertEqual(val * state, Statevector(val * state))
 
     def test_negate(self):

--- a/test/python/quantum_info/test_counts.py
+++ b/test/python/quantum_info/test_counts.py
@@ -37,7 +37,8 @@ class TestStates(QiskitTestCase):
         sim = BasicAer.get_backend('statevector_simulator')
         res = execute(qc, sim).result()
         vec = res.get_statevector()
-        counts = state_to_counts(vec)
+        with self.assertRaises(DeprecationWarning):
+            counts = state_to_counts(vec)
         self.assertAlmostEqual(counts['00000'], 0.5)
         self.assertAlmostEqual(counts['11111'], 0.5)
 

--- a/test/python/quantum_info/test_counts.py
+++ b/test/python/quantum_info/test_counts.py
@@ -37,7 +37,7 @@ class TestStates(QiskitTestCase):
         sim = BasicAer.get_backend('statevector_simulator')
         res = execute(qc, sim).result()
         vec = res.get_statevector()
-        with self.assertRaises(DeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             counts = state_to_counts(vec)
         self.assertAlmostEqual(counts['00000'], 0.5)
         self.assertAlmostEqual(counts['11111'], 0.5)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecate unused or unneeded methods of quantum state class.

### Details and comments
upgrade:
  - |
    The :class:`qiskit.quantum_info.Statevector` and 
    :class:`qiskit.quantum_info.DensityMatrix` classes no longer copy the
    input array if it is already the correct dtype.

deprecations:
  - |
    The ``add``, ``subtract``, and ``multiple`` methods of the
    :class:`~qiskit.quantum_info.Statevector` and 
    :class:`~qiskit.quantum_info.DensityMatrix` classes are deprecated.
    Use ``+``, ``-``, ``*`` binary operators instead.
  - |
    The ``rep`` method of the :class:`~qiskit.quantum_info.Statevector` and 
    :class:`~qiskit.quantum_info.DensityMatrix` classes is deprecated. Use
    ``isinstance`` to check for type instead.
