### PR TITLE
Add a statevector method to QuantumCircuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1002,7 +1002,8 @@ class QuantumCircuit:
         if possible.
 
         This routine will ignore final measurements in the circuit
-        if they exist.
+        if they exist, i.e. it returns the statevector BEFORE the
+        measurements.
 
         Returns:
             Statevector: A Statevector object containing circuit output.
@@ -1026,7 +1027,7 @@ class QuantumCircuit:
         # are loaded when the Operator class is invoked and
         # they rely on the QuantumCircuit so there is a
         # circular import that is impossible to remove.
-        from ..quantum_info import Statevector
+        from ..quantum_info import Statevector  # pylint: disable=cyclic-import
         new_circ = self.remove_final_measurements(inplace=False)
         return Statevector.from_instruction(new_circ)
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -997,6 +997,40 @@ class QuantumCircuit:
         """
         return sum(reg.size for reg in self.qregs + self.cregs)
 
+
+    def statevector(self):
+        """Return the resulting statevector for the circuit
+        if possible.
+
+        This routine will ignore final measurements in the circuit
+        if they exist.
+
+        Returns:
+            Statevector: A Statevector object containing circuit output.
+
+        Example:
+            .. jupyter-execute::
+
+                from qiskit import QuantumCircuit
+
+                bv_circ = QuantumCircuit(5)
+                bv_circ.x(4)
+                bv_circ.h(range(5))
+                bv_circ.cx(range(4), 4)
+                bv_circ.h(range(5))
+                bv_circ.measure_all()
+
+                bv_circ.statevector()       
+
+        """
+        # This import needs to be here because the extensions
+        # are loaded when the Operator class is invoked and
+        # they rely on the QuantumCircuit so there is a
+        # circular import that is impossible to remove.
+        from ..quantum_info import Statevector
+        new_circ = self.remove_final_measurements(inplace=False)
+        return Statevector.from_instruction(new_circ)
+
     @property
     def num_qubits(self):
         """Return number of qubits."""

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -997,7 +997,6 @@ class QuantumCircuit:
         """
         return sum(reg.size for reg in self.qregs + self.cregs)
 
-
     def statevector(self):
         """Return the resulting statevector for the circuit
         if possible.
@@ -1020,7 +1019,7 @@ class QuantumCircuit:
                 bv_circ.h(range(5))
                 bv_circ.measure_all()
 
-                bv_circ.statevector()       
+                bv_circ.statevector()
 
         """
         # This import needs to be here because the extensions

--- a/releasenotes/notes/statevec_meth-165bbe2ea0f7b8a0.yaml
+++ b/releasenotes/notes/statevec_meth-165bbe2ea0f7b8a0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Adds a `statevector` method to `QuantumCircuit` that allows for a
+    statevector to be computed directly from the circuit, if possible.

--- a/test/python/circuit/test_circuit_properties.py
+++ b/test/python/circuit/test_circuit_properties.py
@@ -19,6 +19,7 @@
 import unittest
 import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.quantum_info import Statevector
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.exceptions import CircuitError
 # pylint: disable=unused-import
@@ -557,6 +558,25 @@ class TestCircuitProperties(QiskitTestCase):
         qc.measure(q[2], c[0])
         qc.measure(q[3], c[0])
         self.assertEqual(qc.num_unitary_factors(), 5)
+
+    def test_circuit_statevector(self):
+        """Test circuit returns correct statevector.
+        """
+        bv_circ = QuantumCircuit(5)
+        bv_circ.x(4)
+        bv_circ.h(range(5))
+        bv_circ.cx(range(1, 3), 4)
+        bv_circ.h(range(5))
+        bv_circ.barrier()
+        bv_circ.measure_all()
+        statevec = bv_circ.statevector()
+        ans = Statevector([0, 0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0, 0, 0, 0,
+                           0, 1, 0, 0, 0, 0, 0,
+                           0, 0, 0, 0],
+                          dims=(2, 2, 2, 2, 2))
+        self.assertEqual(statevec, ans)
 
     def test_num_qubits_qubitless_circuit(self):
         """Check output in absence of qubits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Adds a `statevector` method to `QuantumCircuit` so that a statevector can be computed directly from a circuit without going to `Aer`, if possible.  The routine ignores final measurements in the circuit as this is functionally much more useful, and inline with actual use cases, rather than a random statevector after measurement.


### Details and comments
`circuit.statevector()`

