### PR TITLE
Fix issue #4064 by changing error msg in circuit_to_gate

### DIFF
--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -49,8 +49,8 @@ def circuit_to_gate(circuit, parameter_map=None):
     for inst, _, _ in circuit.data:
         if not isinstance(inst, Gate):
             raise QiskitError(('One or more instructions cannot be converted to'
-                              ' a gate. "{}" is not a gate instruction').format(
-                              inst.name))
+                               ' a gate. "{}" is not a gate instruction').format(
+                                   inst.name))
 
     if parameter_map is None:
         parameter_dict = {p: p for p in circuit.parameters}

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -48,8 +48,10 @@ def circuit_to_gate(circuit, parameter_map=None):
 
     for inst, _, _ in circuit.data:
         if not isinstance(inst, Gate):
-            raise QiskitError('One or more instructions in this instruction '
-                              'cannot be converted to a gate')
+            print("\nINSTRUCTION ",inst.name)
+            raise QiskitError('One or more instructions cannot be converted '
+                              'to a gate. \"',inst.name,'\" is not a gate '
+                              'instruction')
 
     if parameter_map is None:
         parameter_dict = {p: p for p in circuit.parameters}

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -48,10 +48,9 @@ def circuit_to_gate(circuit, parameter_map=None):
 
     for inst, _, _ in circuit.data:
         if not isinstance(inst, Gate):
-            print("\nINSTRUCTION ",inst.name)
-            raise QiskitError('One or more instructions cannot be converted '
-                              'to a gate. \"',inst.name,'\" is not a gate '
-                              'instruction')
+            raise QiskitError(('One or more instructions cannot be converted to'
+                              ' a gate. "{}" is not a gate instruction').format(
+                              inst.name))
 
     if parameter_map is None:
         parameter_dict = {p: p for p in circuit.parameters}

--- a/qiskit/schemas/backend_configuration_schema.json
+++ b/qiskit/schemas/backend_configuration_schema.json
@@ -255,7 +255,25 @@
                                 "type": "array",
                                 "minItems": 0,
                                 "description": "A list of available parametric pulse shapes",
-                                "items": {"type": "string"}}
+                                "items": {"type": "string"}},
+                            "channels": {
+                                "type": "object",
+                                "patternProperties": {
+                                    "^[a-z0-9]+$": {
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {"type": "string"},
+                                            "purpose": {"type": "string"},
+                                            "operates": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "qubits": {"type": "array", "items": {"type": "integer", "minimum": 0}}
+                                                }
+                                            }
+                                        }}
+                                    },
+                                "description": "A dictionary where each entry represents a channel configuration and contains configuration values such as the channel's mapping to qubits."
+                                }
                             }},
         "gateconfig": {
             "type": "object",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4064

### Details and comments

When a user tries to convert a circuit to a gate and an instruction in the circuit is not a Gate, an error message appears. The code was changed to display which instruction caused the error message.
