### PR TITLE
Made DAGNode a flat class instead of dict wrapper

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -214,8 +214,8 @@ class DAGCircuit:
 
             wire_name = "%s[%s]" % (wire.register.name, wire.index)
 
-            inp_node = DAGNode(data_dict={'type': 'in', 'name': wire_name, 'wire': wire})
-            outp_node = DAGNode(data_dict={'type': 'out', 'name': wire_name, 'wire': wire})
+            inp_node = DAGNode(type='in', name=wire_name, wire=wire)
+            outp_node = DAGNode(type='out', name=wire_name, wire=wire)
 
             inp_node_id = self._add_multi_graph_node(inp_node)
             outp_node_id = self._add_multi_graph_node(outp_node)
@@ -283,17 +283,9 @@ class DAGCircuit:
         Returns:
             DAGNode: The node for the new op on the DAG
         """
-        node_properties = {
-            "type": "op",
-            "op": op,
-            "name": op.name,
-            "qargs": qargs,
-            "cargs": cargs,
-            "condition": condition
-        }
-
         # Add a new operation node to the graph
-        new_node = DAGNode(data_dict=node_properties)
+        new_node = DAGNode(type="op", op=op, name=op.name, qargs=qargs,
+                           cargs=cargs, condition=condition)
         self._add_multi_graph_node(new_node)
         return new_node
 
@@ -876,14 +868,13 @@ class DAGCircuit:
                     op.num_qubits, op.num_clbits))
 
         if inplace:
-            node.data_dict['op'] = op
-            node.data_dict['name'] = op.name
+            node.op = op
+            node.name = op.name
             return node
 
-        new_data_dict = node.data_dict.copy()
-        new_data_dict['op'] = op
-        new_data_dict['name'] = op.name
-        new_node = DAGNode(new_data_dict)
+        new_node = copy.copy(node)
+        new_node.op = op
+        new_node.name = op.name
 
         node_index = self._add_multi_graph_node(new_node)
 

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -12,6 +12,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=redefined-builtin
+
 """Object to represent the information at a node in the DAGCircuit."""
 
 import warnings
@@ -26,70 +28,72 @@ class DAGNode:
     be supplied to functions that take a node.
     """
 
-    def __init__(self, data_dict, nid=-1):
-        """Create a node """
-        self._node_id = nid
-        self.data_dict = data_dict
-        self.sort_key = str(self.qargs)
+    __slots__ = ['type', '_op', 'name', '_qargs', 'cargs', 'condition', '_wire',
+                 'sort_key', '_node_id']
 
-    @property
-    def type(self):
-        """Returns a str that is the type of the node, else None"""
-        return self.data_dict.get('type')
+    def __init__(self, type=None, op=None, name=None, qargs=None, cargs=None,
+                 condition=None, wire=None, nid=-1):
+        """Create a node """
+        if isinstance(type, dict):
+            warnings.warn("Using data_dict as a a parameter to create a "
+                          "DAGNode object is deprecated. Instead pass each "
+                          "field in the dictionary as a kwarg",
+                          DeprecationWarning, stacklevel=2)
+            data_dict = type
+            self.type = data_dict.get('type')
+            self._op = data_dict.get('op')
+            self.name = data_dict.get('name')
+            self._qargs = data_dict.get('qargs')
+            self.cargs = data_dict.get('cargs')
+            self.condition = data_dict.get('condition')
+            self._wire = data_dict.get('wire')
+        else:
+            self.type = type
+            self._op = op
+            self.name = name
+            self._qargs = qargs if qargs is not None else []
+            self.cargs = cargs if cargs is not None else []
+            self.condition = condition
+            self._wire = wire
+        self._node_id = nid
+        self.sort_key = str(self._qargs)
 
     @property
     def op(self):
         """Returns the Instruction object corresponding to the op for the node, else None"""
-        if 'type' not in self.data_dict or self.data_dict['type'] != 'op':
+        if not self.type or self.type != 'op':
             raise QiskitError("The node %s is not an op node" % (str(self)))
-        return self.data_dict.get('op')
+        return self._op
 
-    @property
-    def name(self):
-        """Returns a str that is the name of the node, else None"""
-        return self.data_dict.get('name')
-
-    @name.setter
-    def name(self, new_name):
-        """Sets the name of the node to be the given value"""
-        self.data_dict['name'] = new_name
+    @op.setter
+    def op(self, data):
+        self._op = data
 
     @property
     def qargs(self):
         """
         Returns list of Qubit, else an empty list.
         """
-        return self.data_dict.get('qargs', [])
+        return self._qargs
 
     @qargs.setter
     def qargs(self, new_qargs):
         """Sets the qargs to be the given list of qargs."""
-        self.data_dict['qargs'] = new_qargs
+        self._qargs = new_qargs
         self.sort_key = str(new_qargs)
-
-    @property
-    def cargs(self):
-        """
-        Returns list of Clbit, else an empty list.
-        """
-        return self.data_dict.get('cargs', [])
-
-    @property
-    def condition(self):
-        """
-        Returns a tuple (ClassicalRegister, int) where the int is the
-        value of the condition, else None.
-        """
-        return self.data_dict.get('condition')
 
     @property
     def wire(self):
         """
         Returns the Bit object, else None.
         """
-        if self.data_dict['type'] not in ['in', 'out']:
+        if self.type not in ['in', 'out']:
             raise QiskitError('The node %s is not an input/output node' % str(self))
-        return self.data_dict.get('wire')
+        return self._wire
+
+    @wire.setter
+    def wire(self, data):
+        self._wire = data
 
     def __lt__(self, other):
         return self._node_id < other._node_id
@@ -108,11 +112,6 @@ class DAGNode:
         # needs to be unique as it is what pydot uses to distinguish nodes
         return str(id(self))
 
-    def pop(self, val):
-        """Remove the provided value from the dictionary."""
-        warnings.warn('DAGNode.pop has been deprecated.', DeprecationWarning)
-        del self.data_dict[val]
-
     @staticmethod
     def semantic_eq(node1, node2):
         """
@@ -127,5 +126,14 @@ class DAGNode:
         """
         # For barriers, qarg order is not significant so compare as sets
         if 'barrier' == node1.name == node2.name:
-            return set(node1.qargs) == set(node2.qargs)
-        return node1.data_dict == node2.data_dict
+            return set(node1._qargs) == set(node2._qargs)
+        result = False
+        if node1.type == node2.type:
+            if node1._op == node2._op:
+                if node1.name == node2.name:
+                    if node1._qargs == node2._qargs:
+                        if node1.cargs == node2.cargs:
+                            if node1.condition == node2.condition:
+                                if node1._wire == node2._wire:
+                                    result = True
+        return result

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -287,5 +287,5 @@ def _swap_ops_from_edge(edge, layout):
 
     # TODO shouldn't be making other nodes not by the DAG!!
     return [
-        DAGNode({'op': SwapGate(), 'qargs': qreg_edge, 'cargs': [], 'type': 'op'})
+        DAGNode(op=SwapGate(), qargs=qreg_edge, cargs=[], type='op')
     ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently the DAGNode class is a thin wrapper around an inner
dictionary. However, this is unecessary because the data in the class is
well defined and fits inside a set number of attributes. Using a dict
adds unnecessary overhead to the DAGNode class to maintain the
flexibility we never use. This commit adjusts the DAGNode class to be
flat and defined with fixed slots so that access and creation is faster.

### Details and comments