### PR TITLE
Fixed #4078 by checking for numpy int and added test to TestDelay

### DIFF
--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -28,6 +28,7 @@ import warnings
 from abc import ABC
 
 from typing import Tuple, List, Iterable, Callable, Optional, Union
+import numpy as np
 
 from ..channels import Channel
 from ..interfaces import ScheduleComponent
@@ -58,7 +59,7 @@ class Instruction(ScheduleComponent, ABC):
             name: Optional display name for this instruction.
         """
         self._command = None
-        if not isinstance(duration, int):
+        if not isinstance(duration, (int, np.integer)):
             warnings.warn("Commands have been deprecated. Use `qiskit.pulse.instructions` instead.",
                           DeprecationWarning)
             self._command = duration

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -14,6 +14,7 @@
 
 """Unit tests for pulse instructions."""
 
+import numpy as np
 from qiskit.pulse import DriveChannel, AcquireChannel, MemorySlot, pulse_lib
 from qiskit.pulse import Delay, Play, ShiftPhase, Snapshot, SetFrequency, Acquire
 from qiskit.pulse.configuration import Kernel, Discriminator
@@ -61,10 +62,16 @@ class TestDelay(QiskitTestCase):
         self.assertIsInstance(delay.id, int)
         self.assertEqual(delay.name, 'test_name')
         self.assertEqual(delay.duration, 10)
+        self.assertIsInstance(delay.duration, int)
         self.assertEqual(delay.operands, (10, DriveChannel(0)))
         self.assertEqual(delay, Delay(10, DriveChannel(0)))
         self.assertNotEqual(delay, Delay(11, DriveChannel(1)))
         self.assertEqual(repr(delay), "Delay(10, DriveChannel(0), name='test_name')")
+
+        # Test numpy int for duration
+        delay = Delay(np.int32(10), DriveChannel(0), name='test_name2')
+        self.assertEqual(delay.duration, 10)
+        self.assertIsInstance(delay.duration, np.integer)
 
 
 class TestSetFrequency(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed #4078 

### Details and comments

Added a check in instructions.py __init__ to accept a numpy int for the duration value that was passed from a Delay instance.

Modified test_instructions.py to add a second call to Delay with a numpy int instead of a python int for duration.
