### PR TITLE
Optimized clifford synthesis for up to 3 qubits

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -344,9 +344,6 @@ class Clifford(BaseOperator):
         from reference [1]. For N > 3 qubits this is done using the general
         non-optimal compilation routine from reference [2].
 
-        Args:
-            clifford (Clifford): a clifford operator.
-
         Return:
             QuantumCircuit: a circuit implementation of the Clifford.
 

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -338,7 +338,27 @@ class Clifford(BaseOperator):
         return Operator(self.to_instruction())
 
     def to_circuit(self):
-        """Return a QuantumCircuit implementing the Clifford."""
+        """Return a QuantumCircuit implementing the Clifford.
+
+        For N <= 3 qubits this is based on optimal CX cost decomposition
+        from reference [1]. For N > 3 qubits this is done using the general
+        non-optimal compilation routine from reference [2].
+
+        Args:
+            clifford (Clifford): a clifford operator.
+
+        Return:
+            QuantumCircuit: a circuit implementation of the Clifford.
+
+        References:
+            1. S. Bravyi, D. Maslov, *Hadamard-free circuits expose the
+               structure of the Clifford group*,
+               `arXiv:2003.09412 [quant-ph] <https://arxiv.org/abs/2003.09412>`_
+
+            2. S. Aaronson, D. Gottesman, *Improved Simulation of Stabilizer Circuits*,
+               Phys. Rev. A 70, 052328 (2004).
+               `arXiv:quant-ph/0406196 <https://arxiv.org/abs/quant-ph/0406196>`_
+        """
         return decompose_clifford(self)
 
     def to_instruction(self):

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -46,7 +46,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     basis_1q = {
         'i': _append_i, 'id': _append_i, 'iden': _append_i,
         'x': _append_x, 'y': _append_y, 'z': _append_z, 'h': _append_h,
-        's': _append_s, 'sdg': __append_sdg, 'sinv': __append_sdg,
+        's': _append_s, 'sdg': _append_sdg, 'sinv': _append_sdg,
         'v': _append_v, 'w': _append_w
     }
     basis_2q = {
@@ -194,7 +194,7 @@ def _append_s(clifford, qubit):
     return clifford
 
 
-def __append_sdg(clifford, qubit):
+def _append_sdg(clifford, qubit):
     """Apply an Sdg gate to a Clifford.
 
     Args:

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -16,13 +16,87 @@ Circuit synthesis for the Clifford class.
 """
 # pylint: disable=invalid-name
 
+from itertools import product
 import numpy as np
+from qiskit.exceptions import QiskitError
 from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info.operators.symplectic.clifford_circuits import (
-    _append_z, _append_x, _append_h, _append_s, _append_cx, _append_swap)
+    _append_z, _append_x, _append_h, _append_s, _append_v, _append_w, _append_cx, _append_swap)
 
 
 def decompose_clifford(clifford):
+    """Decompose a Clifford operator into a QuantumCircuit.
+
+    For N <= 3 qubits this is based on optimal CX cost decomposition
+    from reference [1]. For N > 3 qubits this is done using the general
+    non-optimal compilation routine from reference [2].
+
+    Args:
+        clifford (Clifford): a clifford operator.
+
+    Return:
+        QuantumCircuit: a circuit implementation of the Clifford.
+
+    References:
+        1. S. Bravyi, D. Maslov, *Hadamard-free circuits expose the
+           structure of the Clifford group*,
+           `arXiv:2003.09412 [quant-ph] <https://arxiv.org/abs/2003.09412>`_
+
+        2. S. Aaronson, D. Gottesman, *Improved Simulation of Stabilizer Circuits*,
+           Phys. Rev. A 70, 052328 (2004).
+           `arXiv:quant-ph/0406196 <https://arxiv.org/abs/quant-ph/0406196>`_
+    """
+    num_qubits = clifford.num_qubits
+
+    if num_qubits <= 3:
+        return decompose_clifford_bm(clifford)
+
+    return decompose_clifford_ag(clifford)
+
+
+# ---------------------------------------------------------------------
+# Synthesis based on Bravyi & Maslov decomposition
+# ---------------------------------------------------------------------
+
+def decompose_clifford_bm(clifford):
+    """Decompose a clifford"""
+    num_qubits = clifford.num_qubits
+
+    if num_qubits == 1:
+        return _decompose_clifford_1q(
+            clifford.table.array, clifford.table.phase)
+
+    # Inverse of final decomposed circuit
+    inv_circuit = QuantumCircuit(num_qubits, name='inv_circ')
+
+    # CNOT cost of clifford
+    cost = _cx_cost(clifford)
+
+    # Find composition of circuits with CX and (H.S)^a gates to reduce CNOT count
+    while cost > 0:
+        clifford, inv_circuit, cost = _reduce_cost(clifford, inv_circuit, cost)
+
+    # Decompose the remaining product of 1-qubit cliffords
+    ret_circ = QuantumCircuit(num_qubits, name=str(clifford))
+    for qubit in range(num_qubits):
+        pos = [qubit, qubit + num_qubits]
+        table = clifford.table.array[pos][:, pos]
+        phase = clifford.table.phase[pos]
+        circ = _decompose_clifford_1q(table, phase)
+        if len(circ):
+            ret_circ.append(_decompose_clifford_1q(table, phase), [qubit])
+
+    # Add the inverse of the 2-qubit reductions circuit
+    if len(inv_circuit):
+        ret_circ.append(inv_circuit.inverse(), range(num_qubits))
+    return ret_circ.decompose()
+
+
+# ---------------------------------------------------------------------
+# Synthesis based on Aaronson & Gottesman decomposition
+# ---------------------------------------------------------------------
+
+def decompose_clifford_ag(clifford):
     """Decompose a Clifford operator into a QuantumCircuit.
 
     Args:
@@ -31,6 +105,11 @@ def decompose_clifford(clifford):
     Return:
         QuantumCircuit: a circuit implementation of the Clifford.
     """
+    # Use 1-qubit decomposition method
+    if clifford.num_qubits == 1:
+        return _decompose_clifford_1q(
+            clifford.table.array, clifford.table.phase)
+
     # Compose a circuit which we will convert to an instruction
     circuit = QuantumCircuit(clifford.num_qubits,
                              name=str(clifford))
@@ -61,7 +140,194 @@ def decompose_clifford(clifford):
 
 
 # ---------------------------------------------------------------------
-# Helper functions for decomposition
+# 1-qubit Clifford decomposition
+# ---------------------------------------------------------------------
+
+def _decompose_clifford_1q(pauli, phase):
+    """Decompose a single-qubit clifford"""
+    circuit = QuantumCircuit(1, name='temp')
+
+    # Add phase correction
+    destab_phase, stab_phase = phase
+    if destab_phase and not stab_phase:
+        circuit.z(0)
+    elif not destab_phase and stab_phase:
+        circuit.x(0)
+    elif destab_phase and stab_phase:
+        circuit.y(0)
+    destab_phase_label = '-' if destab_phase else '+'
+    stab_phase_label = '-' if stab_phase else '+'
+
+    destab_x, destab_z = pauli[0]
+    stab_x, stab_z = pauli[1]
+
+    if stab_z and not stab_x:
+        stab_label = 'Z'
+        if destab_z:
+            destab_label = 'Y'
+            circuit.s(0)
+        else:
+            destab_label = 'X'
+
+    elif not stab_z and stab_x:
+        stab_label = 'X'
+        if destab_x:
+            destab_label = 'Y'
+            circuit.sdg(0)
+        else:
+            destab_label = 'Z'
+        circuit.h(0)
+
+    else:
+        stab_label = 'Y'
+        circuit.h(0)
+        if destab_z:
+            destab_label = 'Z'
+            circuit.s(0)
+        else:
+            destab_label = 'X'
+            circuit.sdg(0)
+            circuit.h(0)
+
+    # Add circuit name
+    name_destab = "Destabilizer = ['{}{}']".format(destab_phase_label, destab_label)
+    name_stab = "Stabilizer = ['{}{}']".format(stab_phase_label, stab_label)
+    circuit.name = "Clifford: {}, {}".format(name_stab, name_destab)
+    return circuit
+
+
+# ---------------------------------------------------------------------
+# Helper functions for Bravyi & Maslov decomposition
+# ---------------------------------------------------------------------
+
+def _reduce_cost(clifford, inv_circuit, cost):
+    """Two-qubit cost reduction step"""
+    num_qubits = clifford.num_qubits
+    for qubit0 in range(num_qubits):
+        for qubit1 in range(qubit0 + 1, num_qubits):
+            for n0, n1 in product(range(3), repeat=2):
+
+                # Apply a 2-qubit block
+                reduced = clifford.copy()
+                for qubit, n in [(qubit0, n0), (qubit1, n1)]:
+                    if n == 1:
+                        _append_v(reduced, qubit)
+                    elif n == 2:
+                        _append_w(reduced, qubit)
+                _append_cx(reduced, qubit0, qubit1)
+
+                # Compute new cost
+                new_cost = _cx_cost(reduced)
+
+                if new_cost == cost - 1:
+                    # Add decomposition to inverse circuit
+                    for qubit, n in [(qubit0, n0), (qubit1, n1)]:
+                        if n == 1:
+                            inv_circuit.sdg(qubit)
+                            inv_circuit.h(qubit)
+                        elif n == 2:
+                            inv_circuit.h(qubit)
+                            inv_circuit.s(qubit)
+                    inv_circuit.cx(qubit0, qubit1)
+
+                    return reduced, inv_circuit, new_cost
+
+    # If we didn't reduce cost
+    raise QiskitError("Failed to reduce Clifford CX cost.")
+
+
+def _cx_cost(clifford):
+    """Return the number of CX gates required for Clifford decomposition."""
+    if clifford.num_qubits == 2:
+        return _cx_cost2(clifford)
+    if clifford.num_qubits == 3:
+        return _cx_cost3(clifford)
+    raise Exception("No Clifford CX cost function for num_qubits > 3.")
+
+
+def _rank2(a, b, c, d):
+    """Return rank of 2x2 boolean matrix."""
+    if (a & d) ^ (b & c):
+        return 2
+    if a or b or c or d:
+        return 1
+    return 0
+
+
+def _cx_cost2(clifford):
+    """Return CX cost of a 2-qubit clifford."""
+    U = clifford.table.array
+    r00 = _rank2(U[0, 0], U[0, 2], U[2, 0], U[2, 2])
+    r01 = _rank2(U[0, 1], U[0, 3], U[2, 1], U[2, 3])
+    if r00 == 2:
+        return r01
+    return r01 + 1 - r00
+
+
+def _cx_cost3(clifford):
+    """Return CX cost of a 3-qubit clifford."""
+    U = clifford.table.array
+    n = 3
+    # create information transfer matrices R1, R2
+    R1 = np.zeros((n, n), dtype=np.int8)
+    R2 = np.zeros((n, n), dtype=np.int8)
+    for q1 in range(n):
+        for q2 in range(n):
+            R2[q1, q2] = _rank2(U[q1, q2], U[q1, q2 + n], U[q1 + n, q2], U[q1 + n, q2 + n])
+            mask = np.zeros(2 * n, dtype=np.int8)
+            mask[[q2, q2 + n]] = 1
+            isLocX = np.array_equal(U[q1, :] & mask, U[q1, :])
+            isLocZ = np.array_equal(U[q1 + n, :] & mask, U[q1 + n, :])
+            isLocY = np.array_equal((U[q1, :] ^ U[q1 + n, :]) & mask,
+                                    (U[q1, :] ^ U[q1 + n, :]))
+            R1[q1, q2] = 1 * (isLocX or isLocZ or isLocY) + 1 * (isLocX and isLocZ and isLocY)
+
+    diag1 = np.sort(np.diag(R1))
+    diag2 = np.sort(np.diag(R2))
+
+    nz1 = np.count_nonzero(R1)
+    nz2 = np.count_nonzero(R2)
+
+    if np.array_equal(diag1, np.array([2, 2, 2])):
+        return 0
+
+    if np.array_equal(diag1, np.array([1, 1, 2])):
+        return 1
+
+    if (np.array_equal(diag1, [0, 1, 1])
+            or (np.array_equal(diag1, [1, 1, 1]) and nz2 < 9)
+            or (np.array_equal(diag1, [0, 0, 2]) and np.array_equal(
+                diag2, np.array([1, 1, 2])))):
+        return 2
+
+    if ((np.array_equal(diag1, [1, 1, 1]) and nz2 == 9)
+            or (np.array_equal(diag1, [0, 0, 1])
+                and np.array_equal(diag2, [2, 2, 2]))
+            or (np.array_equal(diag1, [0, 0, 1])
+                and np.array_equal(diag2, [1, 1, 2]) and nz2 < 9)
+            or (np.array_equal(diag1, [0, 0, 1]) and nz1 == 1)
+            or (np.array_equal(diag1, [0, 0, 2])
+                and np.array_equal(diag2, [0, 0, 2]))
+            or (nz1 == 0 and np.array_equal(diag2, [1, 2, 2]))):
+        return 3
+
+    if (np.array_equal(diag2, [0, 0, 1])
+            or (np.array_equal(diag1, [0, 0, 0])
+                and np.array_equal(diag2, [1, 1, 1])
+                and nz2 == 9 and nz1 == 3)
+            or (np.array_equal(diag1, [0, 0, 0])
+                and np.array_equal(diag2, [0, 1, 1])
+                and nz2 == 8 and nz1 == 2)):
+        return 5
+
+    if nz1 == 3 and nz2 == 3:
+        return 6
+
+    return 4
+
+
+# ---------------------------------------------------------------------
+# Helper functions for Aaronson & Gottesman decomposition
 # ---------------------------------------------------------------------
 
 def _set_qubit_x_true(clifford, circuit, qubit):

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -84,7 +84,7 @@ def decompose_clifford_bm(clifford):
         phase = clifford.table.phase[pos]
         circ = _decompose_clifford_1q(table, phase)
         if len(circ) > 0:
-            ret_circ.append(_decompose_clifford_1q(table, phase), [qubit])
+            ret_circ.append(circ, [qubit])
 
     # Add the inverse of the 2-qubit reductions circuit
     if len(inv_circuit) > 0:

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -83,11 +83,11 @@ def decompose_clifford_bm(clifford):
         table = clifford.table.array[pos][:, pos]
         phase = clifford.table.phase[pos]
         circ = _decompose_clifford_1q(table, phase)
-        if len(circ):
+        if len(circ) > 0:
             ret_circ.append(_decompose_clifford_1q(table, phase), [qubit])
 
     # Add the inverse of the 2-qubit reductions circuit
-    if len(inv_circuit):
+    if len(inv_circuit) > 0:
         ret_circ.append(inv_circuit.inverse(), range(num_qubits))
     return ret_circ.decompose()
 
@@ -266,6 +266,7 @@ def _cx_cost2(clifford):
 
 def _cx_cost3(clifford):
     """Return CX cost of a 3-qubit clifford."""
+    # pylint: disable=too-many-return-statements,too-many-boolean-expressions
     U = clifford.table.array
     n = 3
     # create information transfer matrices R1, R2

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -270,12 +270,12 @@ def _cx_cost3(clifford):
     U = clifford.table.array
     n = 3
     # create information transfer matrices R1, R2
-    R1 = np.zeros((n, n), dtype=np.int8)
-    R2 = np.zeros((n, n), dtype=np.int8)
+    R1 = np.zeros((n, n), dtype=int)
+    R2 = np.zeros((n, n), dtype=int)
     for q1 in range(n):
         for q2 in range(n):
             R2[q1, q2] = _rank2(U[q1, q2], U[q1, q2 + n], U[q1 + n, q2], U[q1 + n, q2 + n])
-            mask = np.zeros(2 * n, dtype=np.int8)
+            mask = np.zeros(2 * n, dtype=int)
             mask[[q2, q2 + n]] = 1
             isLocX = np.array_equal(U[q1, :] & mask, U[q1, :])
             isLocZ = np.array_equal(U[q1 + n, :] & mask, U[q1 + n, :])
@@ -283,42 +283,33 @@ def _cx_cost3(clifford):
                                     (U[q1, :] ^ U[q1 + n, :]))
             R1[q1, q2] = 1 * (isLocX or isLocZ or isLocY) + 1 * (isLocX and isLocZ and isLocY)
 
-    diag1 = np.sort(np.diag(R1))
-    diag2 = np.sort(np.diag(R2))
+    diag1 = np.sort(np.diag(R1)).tolist()
+    diag2 = np.sort(np.diag(R2)).tolist()
 
     nz1 = np.count_nonzero(R1)
     nz2 = np.count_nonzero(R2)
 
-    if np.array_equal(diag1, np.array([2, 2, 2])):
+    if diag1 == [2, 2, 2]:
         return 0
 
-    if np.array_equal(diag1, np.array([1, 1, 2])):
+    if diag1 == [1, 1, 2]:
         return 1
 
-    if (np.array_equal(diag1, [0, 1, 1])
-            or (np.array_equal(diag1, [1, 1, 1]) and nz2 < 9)
-            or (np.array_equal(diag1, [0, 0, 2]) and np.array_equal(
-                diag2, np.array([1, 1, 2])))):
+    if (diag1 == [0, 1, 1]
+            or (diag1 == [1, 1, 1] and nz2 < 9)
+            or (diag1 == [0, 0, 2] and diag2 == [1, 1, 2])):
         return 2
 
-    if ((np.array_equal(diag1, [1, 1, 1]) and nz2 == 9)
-            or (np.array_equal(diag1, [0, 0, 1])
-                and np.array_equal(diag2, [2, 2, 2]))
-            or (np.array_equal(diag1, [0, 0, 1])
-                and np.array_equal(diag2, [1, 1, 2]) and nz2 < 9)
-            or (np.array_equal(diag1, [0, 0, 1]) and nz1 == 1)
-            or (np.array_equal(diag1, [0, 0, 2])
-                and np.array_equal(diag2, [0, 0, 2]))
-            or (nz1 == 0 and np.array_equal(diag2, [1, 2, 2]))):
+    if ((diag1 == [1, 1, 1] and nz2 == 9)
+            or (diag1 == [0, 0, 1] and (
+                nz1 == 1 or diag2 == [2, 2, 2] or (diag2 == [1, 1, 2] and nz2 < 9)))
+            or (diag1 == [0, 0, 2] and diag2 == [0, 0, 2])
+            or (diag2 == [1, 2, 2] and nz1 == 0)):
         return 3
 
-    if (np.array_equal(diag2, [0, 0, 1])
-            or (np.array_equal(diag1, [0, 0, 0])
-                and np.array_equal(diag2, [1, 1, 1])
-                and nz2 == 9 and nz1 == 3)
-            or (np.array_equal(diag1, [0, 0, 0])
-                and np.array_equal(diag2, [0, 1, 1])
-                and nz2 == 8 and nz1 == 2)):
+    if (diag2 == [0, 0, 1] or (diag1 == [0, 0, 0] and (
+            (diag2 == [1, 1, 1] and nz2 == 9 and nz1 == 3)
+            or (diag2 == [0, 1, 1] and nz2 == 8 and nz1 == 2)))):
         return 5
 
     if nz1 == 3 and nz2 == 3:

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -161,6 +161,7 @@ def _decompose_clifford_1q(pauli, phase):
     destab_x, destab_z = pauli[0]
     stab_x, stab_z = pauli[1]
 
+    # Z-stabilizer
     if stab_z and not stab_x:
         stab_label = 'Z'
         if destab_z:
@@ -169,6 +170,7 @@ def _decompose_clifford_1q(pauli, phase):
         else:
             destab_label = 'X'
 
+    # X-stabilizer
     elif not stab_z and stab_x:
         stab_label = 'X'
         if destab_x:
@@ -178,16 +180,16 @@ def _decompose_clifford_1q(pauli, phase):
             destab_label = 'Z'
         circuit.h(0)
 
+    # Y-stabilizer
     else:
         stab_label = 'Y'
-        circuit.h(0)
         if destab_z:
             destab_label = 'Z'
-            circuit.s(0)
         else:
             destab_label = 'X'
-            circuit.sdg(0)
-            circuit.h(0)
+            circuit.s(0)
+        circuit.h(0)
+        circuit.s(0)
 
     # Add circuit name
     name_destab = "Destabilizer = ['{}{}']".format(destab_phase_label, destab_label)

--- a/releasenotes/notes/clifford-synthesis-42a959703bfc9c9a.yaml
+++ b/releasenotes/notes/clifford-synthesis-42a959703bfc9c9a.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Adds optimized :meth:`~qiskit.quantum_info.Clifford.to_circuit` method for
+    :class:`qiskit.quantum_info.Clifford` compilation into
+    circuits with optimal number of CX gates for up to 3-qubits. Non-optimal
+    compilation is used for > 3 qubits.

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -59,6 +59,7 @@ class WGate(Gate):
 
 def random_clifford_circuit(num_qubits, num_gates, gates='all', seed=None):
     """Generate a pseudo random Clifford circuit."""
+
     if gates == 'all':
         if num_qubits == 1:
             gates = ['i', 'x', 'y', 'z', 'h', 's', 'sdg', 'v', 'w']
@@ -83,7 +84,11 @@ def random_clifford_circuit(num_qubits, num_gates, gates='all', seed=None):
         'swap': (SwapGate(), 2)
     }
 
-    rng = np.random.RandomState(seed=seed)
+    if isinstance(seed, np.random.RandomState):
+        rng = seed
+    else:
+        rng = np.random.RandomState(seed=seed)
+
     samples = rng.choice(gates, num_gates)
 
     circ = QuantumCircuit(num_qubits)
@@ -346,6 +351,68 @@ class TestCliffordGates(QiskitTestCase):
 
 
 @ddt
+class TestCliffordSynthesis(QiskitTestCase):
+    """Test Clifford synthesis methods."""
+
+    def _cliffords_1q(self):
+        clifford_dicts = [
+            {"stabilizer": ["+Z"], "destabilizer": ["-X"]},
+            {"stabilizer": ["-Z"], "destabilizer": ["+X"]},
+            {"stabilizer": ["-Z"], "destabilizer": ["-X"]},
+            {"stabilizer": ["+Z"], "destabilizer": ["+Y"]},
+            {"stabilizer": ["+Z"], "destabilizer": ["-Y"]},
+            {"stabilizer": ["-Z"], "destabilizer": ["+Y"]},
+            {"stabilizer": ["-Z"], "destabilizer": ["-Y"]},
+            {"stabilizer": ["+X"], "destabilizer": ["+Z"]},
+            {"stabilizer": ["+X"], "destabilizer": ["-Z"]},
+            {"stabilizer": ["-X"], "destabilizer": ["+Z"]},
+            {"stabilizer": ["-X"], "destabilizer": ["-Z"]},
+            {"stabilizer": ["+X"], "destabilizer": ["+Y"]},
+            {"stabilizer": ["+X"], "destabilizer": ["-Y"]},
+            {"stabilizer": ["-X"], "destabilizer": ["+Y"]},
+            {"stabilizer": ["-X"], "destabilizer": ["-Y"]},
+            {"stabilizer": ["+Y"], "destabilizer": ["+X"]},
+            {"stabilizer": ["+Y"], "destabilizer": ["-X"]},
+            {"stabilizer": ["-Y"], "destabilizer": ["+X"]},
+            {"stabilizer": ["-Y"], "destabilizer": ["-X"]},
+            {"stabilizer": ["+Y"], "destabilizer": ["+Z"]},
+            {"stabilizer": ["+Y"], "destabilizer": ["-Z"]},
+            {"stabilizer": ["-Y"], "destabilizer": ["+Z"]},
+            {"stabilizer": ["-Y"], "destabilizer": ["-Z"]}]
+        return [Clifford.from_dict(i) for i in clifford_dicts]
+
+    def test_decompose_1q(self):
+        """Test synthesis for all 1-qubit Cliffords"""
+        for cliff in self._cliffords_1q():
+            with self.subTest(msg='Test circuit {}'.format(cliff)):
+                target = cliff
+                value = Clifford(cliff.to_circuit())
+                self.assertEqual(target, value)
+
+    @combine(num_qubits=[2, 3])
+    def test_decompose_2q_bm(self, num_qubits):
+        """Test B&M synthesis for set of {num_qubits}-qubit Cliffords"""
+        rng = np.random.RandomState(seed=1234)
+        samples = 50
+        for _ in range(samples):
+            circ = random_clifford_circuit(num_qubits, 5 * num_qubits, seed=rng)
+            target = Clifford(circ)
+            value = Clifford(decompose_clifford_bm(target))
+            self.assertEqual(value, target)
+
+    @combine(num_qubits=[2, 3, 4, 5])
+    def test_decompose_2q_ag(self, num_qubits):
+        """Test A&G synthesis for set of {num_qubits}-qubit Cliffords"""
+        rng = np.random.RandomState(seed=1234)
+        samples = 50
+        for _ in range(samples):
+            circ = random_clifford_circuit(num_qubits, 5 * num_qubits, seed=rng)
+            target = Clifford(circ)
+            value = Clifford(decompose_clifford_ag(target))
+            self.assertEqual(value, target)
+
+
+@ddt
 class TestCliffordDecomposition(QiskitTestCase):
     """Test Clifford decompositions."""
     @combine(gates=[['h', 's'], ['h', 's', 'i', 'x', 'y', 'z'],
@@ -417,7 +484,7 @@ class TestCliffordDecomposition(QiskitTestCase):
             target = Operator(circ)
             self.assertTrue(value.equiv(target))
 
-    @combine(num_qubits=[1, 2, 3])
+    @combine(num_qubits=[1, 2, 3, 4, 5])
     def test_to_circuit(self, num_qubits):
         """Test to_circuit method"""
         samples = 10
@@ -429,14 +496,14 @@ class TestCliffordDecomposition(QiskitTestCase):
                                            num_gates,
                                            gates=gates,
                                            seed=seed + i)
-            decomp = Clifford(circ).to_circuit()
+            target = Clifford(circ)
+            decomp = target.to_circuit()
             self.assertIsInstance(decomp, QuantumCircuit)
             self.assertEqual(decomp.num_qubits, circ.num_qubits)
-            value = Operator(decomp)
-            target = Operator(circ)
-            self.assertTrue(value.equiv(target))
+            # Convert back to clifford and check it is the same
+            self.assertEqual(Clifford(decomp), target)
 
-    @combine(num_qubits=[1, 2, 3])
+    @combine(num_qubits=[1, 2, 3, 4, 5])
     def test_to_instruction(self, num_qubits):
         """Test to_instruction method"""
         samples = 10
@@ -448,12 +515,12 @@ class TestCliffordDecomposition(QiskitTestCase):
                                            num_gates,
                                            gates=gates,
                                            seed=seed + i)
-            decomp = Clifford(circ).to_instruction()
+            target = Clifford(circ)
+            decomp = target.to_instruction()
             self.assertIsInstance(decomp, Gate)
             self.assertEqual(decomp.num_qubits, circ.num_qubits)
-            value = Operator(decomp)
-            target = Operator(circ)
-            self.assertTrue(value.equiv(target))
+            # Convert back to clifford and check it is the same
+            self.assertEqual(Clifford(decomp), target)
 
 
 @ddt

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -29,6 +29,8 @@ from qiskit.extensions.standard import (IGate, XGate, YGate, ZGate, HGate,
                                         SwapGate)
 from qiskit.quantum_info.operators import Clifford, Operator
 from qiskit.quantum_info.operators.symplectic.clifford_circuits import _append_circuit
+from qiskit.quantum_info.synthesis.clifford_decompose import (
+    decompose_clifford_ag, decompose_clifford_bm)
 
 
 class VGate(Gate):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Adds optimal compilation of Cliffords into circuits with the minimal number of CX gates for N <= 3 qubits.

### Details and comments

This method is based on Bravyi & Maslov (arXiv:2003.09412 [quant-ph]), but does not require lookup tables for the 2 and 3 qubit case.

For N > 3 qubits, synthesis is done using general non-optimal decomposition from Aaronson and Gottesman.
