### PR TITLE
Temporarily drop down number of trials for level1 and level2

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -119,7 +119,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     if routing_method == 'basic':
         _swap += [BasicSwap(coupling_map)]
     elif routing_method == 'stochastic':
-        _swap += [StochasticSwap(coupling_map, trials=50, seed=seed_transpiler)]
+        _swap += [StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
         _swap += [LookaheadSwap(coupling_map, search_depth=4, search_width=4)]
     else:

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -114,7 +114,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     if routing_method == 'basic':
         _swap += [BasicSwap(coupling_map)]
     elif routing_method == 'stochastic':
-        _swap += [StochasticSwap(coupling_map, trials=100, seed=seed_transpiler)]
+        _swap += [StochasticSwap(coupling_map, trials=20, seed=seed_transpiler)]
     elif routing_method == 'lookahead':
         _swap += [LookaheadSwap(coupling_map, search_depth=5, search_width=5)]
     else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #3999 we increased the number of trials, but the global benefit from
doing this isn't clear. With the pending release weighing the increased
run time for more trials against this, this commit temporarily reverts
the number of trials for level 1 and level 2 back to their previous
setting of 20. When we get to the bottom of #4094 and have a fix or
change for that we can increase the number of trials again.

### Details and comments

Related #4094