### PR TITLE
Add LookaheadSwap condition to prevent hangs

### DIFF
--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -164,7 +164,10 @@ def _search_forward_n_swaps(layout, gates, coupling_map, depth, width):
     if not gates_remaining or depth == 0:
         return base_step
 
-    possible_swaps = coupling_map.get_edges()
+    # Include symmetric 2q gates (e.g coupling maps with both [0,1] and [1,0])
+    # as one available swap.
+    possible_swaps = set(tuple(sorted(edge))
+                         for edge in coupling_map.get_edges())
 
     def _score_swap(swap):
         """Calculate the relative score for a given SWAP."""

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -14,6 +14,7 @@
 
 """Map input circuit onto a backend topology via insertion of SWAPs."""
 
+import logging
 from copy import deepcopy
 
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -23,6 +24,8 @@ from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.layout import Layout
 from qiskit.dagcircuit import DAGNode
+
+logger = logging.getLogger()
 
 
 class LookaheadSwap(TransformationPass):
@@ -102,11 +105,17 @@ class LookaheadSwap(TransformationPass):
         gates_remaining = ordered_virtual_gates.copy()
 
         while gates_remaining:
+            logger.debug('Top-level routing step: %d gates remaining.',
+                         len(gates_remaining))
+
             best_step = _search_forward_n_swaps(current_layout,
                                                 gates_remaining,
                                                 self.coupling_map,
                                                 self.search_depth,
                                                 self.search_width)
+
+            logger.debug('Found best step: mapped %d gates. Added swaps: %s.',
+                         len(best_step['gates_mapped']), best_step['swaps_added'])
 
             current_layout = best_step['layout']
             gates_mapped = best_step['gates_mapped']
@@ -135,6 +144,7 @@ def _search_forward_n_swaps(layout, gates, coupling_map, depth, width):
     Returns:
         dict: Describes solution step found.
             layout (Layout): Virtual to physical qubit map after SWAPs.
+            swaps_added (list): List of qargs of swap gates introduced.
             gates_remaining (list): Gates that could not be mapped.
             gates_mapped (list): Gates that were mapped, including added SWAPs.
 
@@ -142,7 +152,7 @@ def _search_forward_n_swaps(layout, gates, coupling_map, depth, width):
     gates_mapped, gates_remaining = _map_free_gates(layout, gates, coupling_map)
 
     base_step = {'layout': layout,
-                 'swaps_added': 0,
+                 'swaps_added': [],
                  'gates_mapped': gates_mapped,
                  'gates_remaining': gates_remaining}
 
@@ -158,6 +168,8 @@ def _search_forward_n_swaps(layout, gates, coupling_map, depth, width):
         return _calc_layout_distance(gates, coupling_map, trial_layout)
 
     ranked_swaps = sorted(possible_swaps, key=_score_swap)
+    logger.debug('At depth %d, ranked candidate swaps: %s...',
+                 depth, [(swap, _score_swap(swap)) for swap in ranked_swaps[:width*2]])
 
     best_swap, best_step = None, None
     for swap in ranked_swaps[:width]:
@@ -168,12 +180,17 @@ def _search_forward_n_swaps(layout, gates, coupling_map, depth, width):
 
         # ranked_swaps already sorted by distance, so distance is the tie-breaker.
         if best_swap is None or _score_step(next_step) > _score_step(best_step):
+            logger.debug('At depth %d, updating best step: %s (score: %f).',
+                         depth, next_step['swaps_added'], _score_step(next_step))
             best_swap, best_step = swap, next_step
+
+    logger.debug('At depth %d, best swap set (of %d examined): %s.',
+                 depth, min(width, len(ranked_swaps)), best_step['swaps_added'])
 
     best_swap_gate = _swap_ops_from_edge(best_swap, layout)
     return {
         'layout': best_step['layout'],
-        'swaps_added': 1 + best_step['swaps_added'],
+        'swaps_added': [best_swap] + best_step['swaps_added'],
         'gates_remaining': best_step['gates_remaining'],
         'gates_mapped': gates_mapped + best_swap_gate + best_step['gates_mapped'],
     }
@@ -248,7 +265,7 @@ def _score_step(step):
     """Count the mapped two-qubit gates, less the number of added SWAPs."""
     # Each added swap will add 3 ops to gates_mapped, so subtract 3.
     return len([g for g in step['gates_mapped']
-                if len(g.qargs) == 2]) - 3 * step['swaps_added']
+                if len(g.qargs) == 2]) - 3 * len(step['swaps_added'])
 
 
 def _copy_circuit_metadata(source_dag, coupling_map):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Resolves #2171 by adding a check that a candidate swap is able to either map at least one gate or improve the score of the resulting layout before it is considered. A follow up PR is needed to generalize this approach. (Ideally, this should be incorporated into `_score_step`, and we should make sure this does not limit our ability to find a long-range improvement that requires first passing through short-term loss).

Additionally, adds some debug level logging and removes duplicate edges for symmetric 2q gates from the list of available swaps.

### Details and comments


