### PR TITLE
CouplingMap.name -> CouplingMap.description

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -36,16 +36,16 @@ class CouplingMap:
     to permitted CNOT gates
     """
 
-    def __init__(self, couplinglist=None, name=None):
+    def __init__(self, couplinglist=None, description=None):
         """
         Create coupling graph. By default, the generated coupling has no nodes.
 
         Args:
             couplinglist (list or None): An initial coupling graph, specified as
                 an adjacency list containing couplings, e.g. [[0,1], [0,2], [1,2]].
-            name (str): A string to identify the coupling map.
+            description (str): A string to describe the coupling map.
         """
-        self.name = name
+        self.description = description
         # the coupling map graph
         self.graph = nx.DiGraph()
         # a dict of dicts from node pairs to distances
@@ -253,7 +253,7 @@ class CouplingMap:
     @classmethod
     def from_full(cls, num_qubits, bidirectional=True):
         """Return a fully connected coupling map on n qubits."""
-        cmap = cls(name='full')
+        cmap = cls(description='full')
         for i in range(num_qubits):
             for j in range(i):
                 cmap.add_edge(j, i)
@@ -264,7 +264,7 @@ class CouplingMap:
     @classmethod
     def from_line(cls, num_qubits, bidirectional=True):
         """Return a fully connected coupling map on n qubits."""
-        cmap = cls(name='line')
+        cmap = cls(description='line')
         for i in range(num_qubits-1):
             cmap.add_edge(i, i+1)
             if bidirectional:
@@ -274,7 +274,7 @@ class CouplingMap:
     @classmethod
     def from_ring(cls, num_qubits, bidirectional=True):
         """Return a fully connected coupling map on n qubits."""
-        cmap = cls(name='ring')
+        cmap = cls(description='ring')
         for i in range(num_qubits):
             if i == num_qubits - 1:
                 k = 0
@@ -288,7 +288,7 @@ class CouplingMap:
     @classmethod
     def from_grid(cls, num_rows, num_columns, bidirectional=True):
         """Return qubits connected on a grid of num_rows x num_columns."""
-        cmap = cls(name='grid')
+        cmap = cls(description='grid')
         for i in range(num_rows):
             for j in range(num_columns):
                 node = i * num_columns + j

--- a/releasenotes/notes/coupling-map-name-b3bde705196bfe15.yaml
+++ b/releasenotes/notes/coupling-map-name-b3bde705196bfe15.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    A ``name`` attribute has been added to the
+    A ``description`` attribute has been added to the
     :class:`~qiskit.transpiler.CouplingMap` class for storing a short
     description for different coupling maps (e.g. full, grid, line, etc.).


### PR DESCRIPTION
Follow up #4103, I think there is a risk of start using `CouplingMap.name` as an identificator. Using strings to identify objects showed to be a bad idea in the past. My suggestion is to rename the attribute to `description` to mitigate that possibility.