### PR TITLE
Fix cannot deep copy the configuration of a pulse enabled backend

### DIFF
--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -115,7 +115,7 @@ class PulseBackendConfigurationSchema(QasmBackendConfigurationSchema):
                                             validate=Length(equal=2)), required=True)
     dt = fields.Float(required=True, validate=Range(min=0))  # pylint: disable=invalid-name
     dtm = fields.Float(required=True, validate=Range(min=0))
-    rep_times = fields.List(fields.Integer(validate=Range(min=0)), required=True)
+    rep_times = fields.List(fields.Raw(validate=Range(min=0)), required=True)
     meas_kernels = fields.List(fields.String(), required=True)
     discriminators = fields.List(fields.String(), required=True)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The configuration of a pulse backend has `rep_times` as a float, but the schema says it must be an `int`, so the deepcopy fails.  Here I make the field `Raw` as I am unsure as to how to do an or type statement in marshmallow.  I am guessing that this is due to the units conversion.


### Details and comments


