### PR TITLE
Fix #4120 - Remove renaming the schedule after using `exclude` and `filter`

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -291,7 +291,7 @@ class Schedule(ScheduleComponent):
                                                  time_ranges=time_ranges,
                                                  intervals=intervals)
         return self._apply_filter(composed_filter,
-                                  new_sched_name="{name}-filtered".format(name=self.name))
+                                  new_sched_name="{name}".format(name=self.name))
 
     def exclude(self, *filter_funcs: List[Callable],
                 channels: Optional[Iterable[Channel]] = None,
@@ -318,7 +318,7 @@ class Schedule(ScheduleComponent):
                                                  time_ranges=time_ranges,
                                                  intervals=intervals)
         return self._apply_filter(lambda x: not composed_filter(x),
-                                  new_sched_name="{name}-excluded".format(name=self.name))
+                                  new_sched_name="{name}".format(name=self.name))
 
     def _apply_filter(self, filter_func: Callable, new_sched_name: str) -> 'Schedule':
         """Return a Schedule containing only the instructions from this Schedule for which

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -521,6 +521,18 @@ class TestScheduleFilter(BaseTestSchedule):
         for _, inst in excluded.instructions:
             self.assertFalse(any([chan in channels for chan in inst.channels]))
 
+    def test_filter_exclude_name(self):
+        """Test the name of the schedules after applying filter and exclude functions."""
+        sched = Schedule(name='test-schedule')
+        sched = sched.insert(10, Acquire(5, AcquireChannel(0), MemorySlot(0)))
+        sched = sched.insert(10, Acquire(5, AcquireChannel(1), MemorySlot(1)))
+        excluded = sched.exclude(channels=[AcquireChannel(0)])
+        filtered = sched.filter(channels=[AcquireChannel(1)])
+
+        # check if the excluded and filtered schedule have the same name as sched
+        self.assertEqual(sched.name, filtered.name)
+        self.assertEqual(sched.name, excluded.name)
+
     def test_filter_inst_types(self):
         """Test filtering on instruction types."""
         lp0 = self.linear(duration=3, slope=0.2, intercept=0.1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4120 

### Details and comments


