### PR TITLE
ConsolidateBlocks should not fail because "failed to diagonalize M2"

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -118,12 +118,11 @@ class ConsolidateBlocks(TransformationPass):
                     subcirc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
                 unitary = UnitaryGate(Operator(subcirc))  # simulates the circuit
                 try:
-                    unitary_num_basis_gates = self.decomposer.num_basis_gates(unitary)
+                    consolidate = self.force_consolidate or unitary.num_qubits > 2 or \
+                                  self.decomposer.num_basis_gates(unitary) != basis_count
                 except QiskitError:
-                    unitary_num_basis_gates = -1
-                if self.force_consolidate or unitary.num_qubits > 2 or \
-                        unitary_num_basis_gates != basis_count:
-
+                    consolidate = False
+                if consolidate:
                     new_dag.apply_operation_back(
                         unitary, sorted(block_qargs, key=lambda x: block_index_map[x]))
                 else:

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -22,7 +22,7 @@ from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.synthesis import TwoQubitBasisDecomposer
 from qiskit.extensions import UnitaryGate, CXGate
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.exceptions import TranspilerError, QiskitError
 
 
 class ConsolidateBlocks(TransformationPass):
@@ -117,8 +117,12 @@ class ConsolidateBlocks(TransformationPass):
                         basis_count += 1
                     subcirc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
                 unitary = UnitaryGate(Operator(subcirc))  # simulates the circuit
+                try:
+                    unitary_num_basis_gates = self.decomposer.num_basis_gates(unitary)
+                except QiskitError:
+                    unitary_num_basis_gates = -1
                 if self.force_consolidate or unitary.num_qubits > 2 or \
-                        self.decomposer.num_basis_gates(unitary) != basis_count:
+                        unitary_num_basis_gates != basis_count:
 
                     new_dag.apply_operation_back(
                         unitary, sorted(block_qargs, key=lambda x: block_index_map[x]))

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -204,6 +204,29 @@ class TestConsolidateBlocks(QiskitTestCase):
 
         self.assertEqual(qc, qc1)
 
+    def test_consolidate_blocks_big(self):
+        """Test ConsolidateBlocks with U2(<big numbers>)
+        https://github.com/Qiskit/qiskit-terra/issues/3637#issuecomment-612954865
+
+             ┌────────────────┐     ┌───┐
+        q_0: ┤ U2(-804.15,pi) ├──■──┤ X ├
+             ├────────────────┤┌─┴─┐└─┬─┘
+        q_1: ┤ U2(-6433.2,pi) ├┤ X ├──■──
+             └────────────────┘└───┘
+        """
+        circuit = QuantumCircuit(2)
+        circuit.u2(-804.15, np.pi, 0)
+        circuit.u2(-6433.2, np.pi, 1)
+        circuit.cx(0, 1)
+        circuit.cx(1, 0)
+
+        pass_manager = PassManager()
+        pass_manager.append(Collect2qBlocks())
+        pass_manager.append(ConsolidateBlocks())
+        result = pass_manager.run(circuit)
+
+        self.assertEqual(circuit, result)
+
     def test_node_added_after_block(self):
         """Test that a node after the block remains after the block
 


### PR DESCRIPTION
Besides the problem with `weyl_coordinates` (see https://github.com/Qiskit/qiskit-terra/issues/3637#issuecomment-612970960), `ConsolidateBlocks` should not fail because the synthesis fails.

This PR considers that and continues even when synthesis fails.