### PR TITLE
Fix import exception of Z3 package to be compatible with python 3.5

### DIFF
--- a/qiskit/transpiler/passes/optimization/_gate_extension.py
+++ b/qiskit/transpiler/passes/optimization/_gate_extension.py
@@ -23,7 +23,7 @@ non-trivial and/or have unknown post-conditions.
 try:
     from z3 import Not, And
     HAS_Z3 = True
-except ModuleNotFoundError:
+except ImportError:
     HAS_Z3 = False
 from qiskit.extensions.standard import IGate, XGate, YGate, ZGate
 from qiskit.extensions.standard import CXGate, CCXGate, CYGate, CZGate

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -22,7 +22,7 @@ from . import _gate_extension  # pylint: disable=W0611
 try:
     from z3 import And, Or, Not, Implies, Solver, Bool, unsat
     HAS_Z3 = True
-except ModuleNotFoundError:
+except ImportError:
     HAS_Z3 = False
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
On Python 3.5, a non existing module will raise `ImportError` instead of `ModuleNotFoundError`




