### PR TITLE
Check circuit.mcx() ancilla input

### DIFF
--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -397,7 +397,7 @@ class CCXGate(ControlledGate, metaclass=CCXMeta):
             ControlledGate: controlled version of this gate.
         """
         if ctrl_state is None:
-            if num_ctrl_qubits == 1:
+            if num_ctrl_qubit1:
                 return C3XGate()
             if num_ctrl_qubits == 2:
                 return C4XGate()
@@ -1044,6 +1044,10 @@ def mcx(self, control_qubits, target_qubit, ancilla_qubits=None, mode='noancilla
         'basic': MCXVChain(num_ctrl_qubits, dirty_ancillas=False),
         'basic-dirty-ancilla': MCXVChain(num_ctrl_qubits, dirty_ancillas=True)
     }
+
+    # check ancilla input
+    if ancilla_qubits:
+        _ = self.qbit_argument_conversion(ancilla_qubits)
 
     try:
         gate = available_implementations[mode]

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -397,7 +397,7 @@ class CCXGate(ControlledGate, metaclass=CCXMeta):
             ControlledGate: controlled version of this gate.
         """
         if ctrl_state is None:
-            if num_ctrl_qubit1:
+            if num_ctrl_qubits == 1:
                 return C3XGate()
             if num_ctrl_qubits == 2:
                 return C4XGate()

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -588,7 +588,7 @@ class QCircuitImage:
                                 self._latex[pos_1][column] = ("\\gate{%s}" % nm)
 
                     elif len(qarglist) == 2:
-                        if op.name not in ['swap', 'rzz']:
+                        if isinstance(op.op, ControlledGate):
                             cond = str(op.op.ctrl_state)
                         pos_1 = self.img_regs[qarglist[0]]
                         pos_2 = self.img_regs[qarglist[1]]
@@ -793,7 +793,7 @@ class QCircuitImage:
                                                                      nm)
 
                     elif len(qarglist) == 3:
-                        if op.name in ['ccx', 'cswap']:
+                        if isinstance(op.op, ControlledGate):
                             ctrl_state = "{0:b}".format(op.op.ctrl_state).rjust(2, '0')[::-1]
                             cond_1 = ctrl_state[0]
                             cond_2 = ctrl_state[1]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4039.

### Details and comments

Add a check on the ancilla input on the `QuantumCircuit.mcx` and `mct` methods by calling `QuantumCircuit.qbit_argument_conversion(q_ancillas)`.
