### PR TITLE
Use RZGate in RZXGate definition

### DIFF
--- a/qiskit/extensions/standard/rzx.py
+++ b/qiskit/extensions/standard/rzx.py
@@ -122,16 +122,16 @@ class RZXGate(Gate):
 
     def _define(self):
         """
-        gate rzx(theta) a, b { h b; cx a, b; u1(theta) b; cx a, b; h b;}
+        gate rzx(theta) a, b { h b; cx a, b; rz(theta) b; cx a, b; h b;}
         """
-        from qiskit.extensions.standard.u1 import U1Gate
+        from qiskit.extensions.standard.rz import RZGate
         from qiskit.extensions.standard.h import HGate
         from qiskit.extensions.standard.x import CXGate
         q = QuantumRegister(2, 'q')
         self.definition = [
             (HGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
-            (U1Gate(self.params[0]), [q[1]], []),
+            (RZGate(self.params[0]), [q[1]], []),
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], [])
         ]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes definition of `RZXGate` to use `RZGate` in its definition rather than `U1Gate`. 

### Details and comments

This is to be consistent with the other Pauli rotation gates which use `RZGate`. It also means that the phase-difference in the canonical matrix definition and the unrolled gate matrix from `Operator(gate)` is localized to the `RZGate`.
