### PR TITLE
[text-drawer] Fix for CX (and others) open controlled qubtis < 3

### DIFF
--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -895,11 +895,6 @@ class TextDrawing():
         elif instruction.name == 'reset':
             layer.set_qubit(instruction.qargs[0], Reset(conditional=conditional))
 
-        elif instruction.name == 'cz' and instruction.op.ctrl_state == 1:
-            # cz TODO: only supports one closed controlled for now
-            gates = [Bullet(conditional=conditional), Bullet(conditional=conditional)]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
         elif instruction.name == 'cu1':
             # cu1
             connection_label = TextDrawing.params_for_label(instruction)[0]

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -895,12 +895,6 @@ class TextDrawing():
         elif instruction.name == 'reset':
             layer.set_qubit(instruction.qargs[0], Reset(conditional=conditional))
 
-        elif instruction.name == 'cu1':
-            # cu1
-            connection_label = TextDrawing.params_for_label(instruction)[0]
-            gates = [Bullet(conditional=conditional), Bullet(conditional=conditional)]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
         elif instruction.name == 'rzz':
             # rzz
             connection_label = "zz(%s)" % TextDrawing.params_for_label(instruction)[0]
@@ -938,6 +932,11 @@ class TextDrawing():
                 else:
                     gates.append(OpenBullet(conditional=conditional))
             if instruction.op.base_gate.name == 'z':
+                # cz
+                gates.append(Bullet(conditional=conditional))
+            elif instruction.op.base_gate.name == 'u1':
+                # cu1
+                connection_label = TextDrawing.params_for_label(instruction)[0]
                 gates.append(Bullet(conditional=conditional))
             elif len(rest) > 1:
                 top_connect = '┴' if controlled_top else None

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -901,19 +901,6 @@ class TextDrawing():
             gates = [Bullet(conditional=conditional), Bullet(conditional=conditional)]
             add_connected_gate(instruction, gates, layer, current_cons)
 
-        elif instruction.name == 'cu3':
-            # cu3
-            params = TextDrawing.params_for_label(instruction)
-            gates = [Bullet(conditional=conditional),
-                     BoxOnQuWire("U3(%s)" % ','.join(params), conditional=conditional)]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
-        elif instruction.name == 'crz':
-            # crz
-            label = "Rz(%s)" % TextDrawing.params_for_label(instruction)[0]
-            gates = [Bullet(conditional=conditional), BoxOnQuWire(label, conditional=conditional)]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
         elif len(instruction.qargs) == 1 and not instruction.cargs:
             # unitary gate
             layer.set_qubit(instruction.qargs[0],

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -895,17 +895,6 @@ class TextDrawing():
         elif instruction.name == 'reset':
             layer.set_qubit(instruction.qargs[0], Reset(conditional=conditional))
 
-        elif instruction.name in ['cx', 'CX', 'ccx']:
-            # cx/ccx
-            gates = [Bullet(conditional=conditional) for _ in range(len(instruction.qargs) - 1)]
-            gates.append(BoxOnQuWire('X', conditional=conditional))
-            add_connected_gate(instruction, gates, layer, current_cons)
-
-        elif instruction.name == 'cy':
-            # cy
-            gates = [Bullet(conditional=conditional), BoxOnQuWire('Y')]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
         elif instruction.name == 'cz' and instruction.op.ctrl_state == 1:
             # cz TODO: only supports one closed controlled for now
             gates = [Bullet(conditional=conditional), Bullet(conditional=conditional)]

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -922,6 +922,10 @@ class TextDrawing():
                 # cswap
                 gates += [Ex(conditional=conditional), Ex(conditional=conditional)]
                 add_connected_gate(instruction, gates, layer, current_cons)
+            elif instruction.op.base_gate.name == 'rzz':
+                # crzz
+                connection_label = "zz(%s)" % TextDrawing.params_for_label(instruction)[0]
+                gates += [Bullet(conditional=conditional), Bullet(conditional=conditional)]
             elif len(rest) > 1:
                 top_connect = '┴' if controlled_top else None
                 bot_connect = '┬' if controlled_bot else None

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -885,13 +885,6 @@ class TextDrawing():
             gates = [Ex(conditional=conditional) for _ in range(len(instruction.qargs))]
             add_connected_gate(instruction, gates, layer, current_cons)
 
-        elif instruction.name == 'cswap':
-            # cswap
-            gates = [Bullet(conditional=conditional),
-                     Ex(conditional=conditional),
-                     Ex(conditional=conditional)]
-            add_connected_gate(instruction, gates, layer, current_cons)
-
         elif instruction.name == 'reset':
             layer.set_qubit(instruction.qargs[0], Reset(conditional=conditional))
 
@@ -925,6 +918,10 @@ class TextDrawing():
                 # cu1
                 connection_label = TextDrawing.params_for_label(instruction)[0]
                 gates.append(Bullet(conditional=conditional))
+            elif instruction.op.base_gate.name == 'swap':
+                # cswap
+                gates += [Ex(conditional=conditional), Ex(conditional=conditional)]
+                add_connected_gate(instruction, gates, layer, current_cons)
             elif len(rest) > 1:
                 top_connect = '┴' if controlled_top else None
                 bot_connect = '┬' if controlled_bot else None

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -29,7 +29,7 @@ from qiskit.transpiler import Layout
 from qiskit.visualization import text as elements
 from qiskit.visualization.circuit_visualization import _text_circuit_drawer
 from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate, U1Gate, \
-    SwapGate
+    SwapGate, RZZGate
 
 
 class TestTextDrawerElement(QiskitTestCase):
@@ -2268,7 +2268,7 @@ class TestTextOpenControlledGate(QiskitTestCase):
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
     def test_open_controlled_swap(self):
-        """Controlled U1 gates."""
+        """Controlled SWAP gates."""
         expected = '\n'.join(["                     ",
                               "qr_0: |0>─o──o──o──o─",
                               "          │  │  │  │ ",
@@ -2289,6 +2289,32 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control2_2 = SwapGate().control(2, ctrl_state='10')
         circuit.append(control2_2, [0, 1, 2, 3])
         control3 = SwapGate().control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3, 4])
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_open_controlled_swap(self):
+        """Controlled RZZ gates."""
+        expected = '\n'.join(["                                         ",
+                              "qr_0: |0>─o───────o───────o───────o──────",
+                              "          │       │       │       │      ",
+                              "qr_1: |0>─■───────o───────■───────■──────",
+                              "          │zz(1)  │       │       │      ",
+                              "qr_2: |0>─■───────■───────■───────o──────",
+                              "                  │zz(1)  │zz(1)  │      ",
+                              "qr_3: |0>─────────■───────■───────■──────",
+                              "                                  │zz(1) ",
+                              "qr_4: |0>─────────────────────────■──────",
+                              "                                         "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = RZZGate(1).control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1, 2])
+        control2 = RZZGate(1).control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2, 3])
+        control2_2 = RZZGate(1).control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2, 3])
+        control3 = RZZGate(1).control(3, ctrl_state='010')
         circuit.append(control3, [0, 1, 2, 3, 4])
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -2212,6 +2212,35 @@ class TestTextOpenControlledGate(QiskitTestCase):
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
+    def test_open_controlled_z(self):
+        """Controlled Z gates."""
+        expected = '\n'.join(["                        ",
+                              "qr_0: |0>─o──o──o──o──■─",
+                              "          │  │  │  │  │ ",
+                              "qr_1: |0>─■──o──■──■──o─",
+                              "             │  │  │  │ ",
+                              "qr_2: |0>────■──■──o──■─",
+                              "                   │  │ ",
+                              "qr_3: |0>──────────■──■─",
+                              "                      │ ",
+                              "qr_4: |0>─────────────o─",
+                              "                        "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = ZGate().control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1])
+        control2 = ZGate().control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2])
+        control2_2 = ZGate().control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2])
+        control3 = ZGate().control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3])
+        control3 = ZGate().control(4, ctrl_state='0101')
+        circuit.append(control3, [0, 1, 4, 2, 3])
+        circuit.draw()
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
 
 class TestTextWithLayout(QiskitTestCase):
     """The with_layout option"""

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -28,7 +28,8 @@ from qiskit.test import QiskitTestCase
 from qiskit.transpiler import Layout
 from qiskit.visualization import text as elements
 from qiskit.visualization.circuit_visualization import _text_circuit_drawer
-from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate, U1Gate
+from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate, U1Gate, \
+    SwapGate
 
 
 class TestTextDrawerElement(QiskitTestCase):
@@ -2178,7 +2179,6 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(control3, [0, 1, 2, 3])
         control3 = XGate().control(4, ctrl_state='0101')
         circuit.append(control3, [0, 1, 4, 2, 3])
-        circuit.draw()
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
@@ -2208,7 +2208,6 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(control3, [0, 1, 2, 3])
         control3 = YGate().control(4, ctrl_state='0101')
         circuit.append(control3, [0, 1, 4, 2, 3])
-        circuit.draw()
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
@@ -2237,7 +2236,6 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(control3, [0, 1, 2, 3])
         control3 = ZGate().control(4, ctrl_state='0101')
         circuit.append(control3, [0, 1, 4, 2, 3])
-        circuit.draw()
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
@@ -2266,7 +2264,32 @@ class TestTextOpenControlledGate(QiskitTestCase):
         circuit.append(control3, [0, 1, 2, 3])
         control3 = U1Gate(0.5).control(4, ctrl_state='0101')
         circuit.append(control3, [0, 1, 4, 2, 3])
-        circuit.draw()
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_open_controlled_swap(self):
+        """Controlled U1 gates."""
+        expected = '\n'.join(["                     ",
+                              "qr_0: |0>─o──o──o──o─",
+                              "          │  │  │  │ ",
+                              "qr_1: |0>─X──o──■──■─",
+                              "          │  │  │  │ ",
+                              "qr_2: |0>─X──X──X──o─",
+                              "             │  │  │ ",
+                              "qr_3: |0>────X──X──X─",
+                              "                   │ ",
+                              "qr_4: |0>──────────X─",
+                              "                     "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = SwapGate().control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1, 2])
+        control2 = SwapGate().control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2, 3])
+        control2_2 = SwapGate().control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2, 3])
+        control3 = SwapGate().control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3, 4])
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -28,7 +28,7 @@ from qiskit.test import QiskitTestCase
 from qiskit.transpiler import Layout
 from qiskit.visualization import text as elements
 from qiskit.visualization.circuit_visualization import _text_circuit_drawer
-from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate
+from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate
 
 
 class TestTextDrawerElement(QiskitTestCase):
@@ -2149,6 +2149,66 @@ class TestTextOpenControlledGate(QiskitTestCase):
         ccghz = ghz.control(3, ctrl_state='000')
         circuit = QuantumCircuit(6)
         circuit.append(ccghz, [0, 2, 5, 1, 3, 4])
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_open_controlled_x(self):
+        """Controlled X gates.
+        See https://github.com/Qiskit/qiskit-terra/issues/4180"""
+        expected = '\n'.join(["                                  ",
+                              "qr_0: |0>──o────o────o────o────■──",
+                              "         ┌─┴─┐  │    │    │    │  ",
+                              "qr_1: |0>┤ X ├──o────■────■────o──",
+                              "         └───┘┌─┴─┐┌─┴─┐  │    │  ",
+                              "qr_2: |0>─────┤ X ├┤ X ├──o────■──",
+                              "              └───┘└───┘┌─┴─┐┌─┴─┐",
+                              "qr_3: |0>───────────────┤ X ├┤ X ├",
+                              "                        └───┘└─┬─┘",
+                              "qr_4: |0>──────────────────────o──",
+                              "                                  "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = XGate().control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1])
+        control2 = XGate().control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2])
+        control2_2 = XGate().control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2])
+        control3 = XGate().control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3])
+        control3 = XGate().control(4, ctrl_state='0101')
+        circuit.append(control3, [0, 1, 4, 2, 3])
+        circuit.draw()
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_open_controlled_y(self):
+        """Controlled Y gates.
+        See https://github.com/Qiskit/qiskit-terra/issues/4180"""
+        expected = '\n'.join(["                                  ",
+                              "qr_0: |0>──o────o────o────o────■──",
+                              "         ┌─┴─┐  │    │    │    │  ",
+                              "qr_1: |0>┤ Y ├──o────■────■────o──",
+                              "         └───┘┌─┴─┐┌─┴─┐  │    │  ",
+                              "qr_2: |0>─────┤ Y ├┤ Y ├──o────■──",
+                              "              └───┘└───┘┌─┴─┐┌─┴─┐",
+                              "qr_3: |0>───────────────┤ Y ├┤ Y ├",
+                              "                        └───┘└─┬─┘",
+                              "qr_4: |0>──────────────────────o──",
+                              "                                  "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = YGate().control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1])
+        control2 = YGate().control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2])
+        control2_2 = YGate().control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2])
+        control3 = YGate().control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3])
+        control3 = YGate().control(4, ctrl_state='0101')
+        circuit.append(control3, [0, 1, 4, 2, 3])
+        circuit.draw()
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -28,7 +28,7 @@ from qiskit.test import QiskitTestCase
 from qiskit.transpiler import Layout
 from qiskit.visualization import text as elements
 from qiskit.visualization.circuit_visualization import _text_circuit_drawer
-from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate
+from qiskit.extensions import HGate, U2Gate, XGate, UnitaryGate, CZGate, ZGate, YGate, U1Gate
 
 
 class TestTextDrawerElement(QiskitTestCase):
@@ -2236,6 +2236,35 @@ class TestTextOpenControlledGate(QiskitTestCase):
         control3 = ZGate().control(3, ctrl_state='010')
         circuit.append(control3, [0, 1, 2, 3])
         control3 = ZGate().control(4, ctrl_state='0101')
+        circuit.append(control3, [0, 1, 4, 2, 3])
+        circuit.draw()
+
+        self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
+
+    def test_open_controlled_u1(self):
+        """Controlled U1 gates."""
+        expected = '\n'.join(["                                       ",
+                              "qr_0: |0>─o─────o─────o─────o─────■────",
+                              "          │0.1  │     │     │     │    ",
+                              "qr_1: |0>─■─────o─────■─────■─────o────",
+                              "                │0.2  │0.3  │     │    ",
+                              "qr_2: |0>───────■─────■─────o─────■────",
+                              "                            │0.4  │    ",
+                              "qr_3: |0>───────────────────■─────■────",
+                              "                                  │0.5 ",
+                              "qr_4: |0>─────────────────────────o────",
+                              "                                       "])
+        qreg = QuantumRegister(5, 'qr')
+        circuit = QuantumCircuit(qreg)
+        control1 = U1Gate(0.1).control(1, ctrl_state='0')
+        circuit.append(control1, [0, 1])
+        control2 = U1Gate(0.2).control(2, ctrl_state='00')
+        circuit.append(control2, [0, 1, 2])
+        control2_2 = U1Gate(0.3).control(2, ctrl_state='10')
+        circuit.append(control2_2, [0, 1, 2])
+        control3 = U1Gate(0.4).control(3, ctrl_state='010')
+        circuit.append(control3, [0, 1, 2, 3])
+        control3 = U1Gate(0.5).control(4, ctrl_state='0101')
         circuit.append(control3, [0, 1, 4, 2, 3])
         circuit.draw()
 


### PR DESCRIPTION
Fixes #4180
Fixes #4052

Since we fully support controlled arbitrary gates, CX, CY, CU1, and CU3 are not special cases any more. I removed that code so they fall in the general case which support open controlled gates nicely. I also improved the support for CSWAP, CRZZ, and CRZ.