### PR TITLE
add circuit.compose() method

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -349,6 +349,35 @@ class QuantumCircuit:
             self._append(*instruction_context)
         return self
 
+    def compose(self, other, qubits=None, clbits=None, front=False):
+        """Compose circuit with ``other`` circuit, optionally permuting wires.
+
+        ``other`` can be narrower or of equal width to ``self``.
+
+        Args:
+            other (QuantumCircuit): circuit to compose with self.
+            front (bool): If True, front composition will be performed (not implemented yet).
+
+        Returns:
+            QuantumCircuit: Returns a new QuantumCircuit object.
+
+        Raises:
+            CircuitError: if ``other`` is wider or there are duplicate edge mappings.
+        """
+        from qiskit.converters.circuit_to_dag import circuit_to_dag
+        from qiskit.converters.dag_to_circuit import dag_to_circuit
+        dag_self = circuit_to_dag(self)
+        dag_other = circuit_to_dag(other)
+        if qubits is None:
+            qubits = []
+        if clbits is None:
+            clbits = []
+        qubit_map = {self.qubits[i]: (other.qubits[q] if isinstance(q, int) else q) for i, q in enumerate(qubits)}
+        clbit_map = {self.clbits[i]: (other.clbits[c] if isinstance(c, int) else c) for i, c in enumerate(clbits)}
+        print({**qubit_map, **clbit_map})
+        dag_self.compose(dag_other, edge_map={**qubit_map, **clbit_map})
+        return dag_to_circuit(dag_self)
+
     @property
     def qubits(self):
         """

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -349,14 +349,17 @@ class QuantumCircuit:
             self._append(*instruction_context)
         return self
 
-    def compose(self, other, qubits=None, clbits=None, front=False):
+    def compose(self, other, qubits=None, clbits=None, wire_map=None, front=False, inplace=False):
         """Compose circuit with ``other`` circuit, optionally permuting wires.
 
         ``other`` can be narrower or of equal width to ``self``.
 
         Args:
             other (QuantumCircuit): circuit to compose with self.
+            qubits (list[Qubit|int]): qubits of self to compose onto.
+            clbits (list[Clbit|int]): clbits of self to compose onto.
             front (bool): If True, front composition will be performed (not implemented yet).
+            inplace (bool): If True, modify the object. Otherwise return composed circuit.
 
         Returns:
             QuantumCircuit: Returns a new QuantumCircuit object.
@@ -366,16 +369,22 @@ class QuantumCircuit:
         """
         from qiskit.converters.circuit_to_dag import circuit_to_dag
         from qiskit.converters.dag_to_circuit import dag_to_circuit
+        if inplace:
+            raise CircuitError("Inplace composition of QuantumCircuit not supported yet.")
+
         dag_self = circuit_to_dag(self)
         dag_other = circuit_to_dag(other)
         if qubits is None:
             qubits = []
         if clbits is None:
             clbits = []
-        qubit_map = {self.qubits[i]: (other.qubits[q] if isinstance(q, int) else q) for i, q in enumerate(qubits)}
-        clbit_map = {self.clbits[i]: (other.clbits[c] if isinstance(c, int) else c) for i, c in enumerate(clbits)}
-        print({**qubit_map, **clbit_map})
-        dag_self.compose(dag_other, edge_map={**qubit_map, **clbit_map})
+        if not wire_map and (qubits or clbits):
+            qubit_map = {self.qubits[i]: (other.qubits[q] if isinstance(q, int) else q)
+                         for i, q in enumerate(qubits)}
+            clbit_map = {self.clbits[i]: (other.clbits[c] if isinstance(c, int) else c)
+                         for i, c in enumerate(clbits)}
+            wire_map = {**qubit_map, **clbit_map}
+        dag_self.compose(dag_other, edge_map=wire_map, front=front)
         return dag_to_circuit(dag_self)
 
     @property

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -365,7 +365,8 @@ class QuantumCircuit:
             QuantumCircuit: the composed circuit (returns None if inplace==True).
 
         Raises:
-            CircuitError: if ``other`` is wider or there are duplicate edge mappings.
+            CircuitError: if composing on the front.
+            QiskitError: if ``other`` is wider or there are duplicate edge mappings.
         """
         from qiskit.converters.circuit_to_dag import circuit_to_dag
         from qiskit.converters.dag_to_circuit import dag_to_circuit
@@ -374,16 +375,7 @@ class QuantumCircuit:
 
         dag_self = circuit_to_dag(self)
         dag_other = circuit_to_dag(other)
-        if qubits is None:
-            qubits = []
-        if clbits is None:
-            clbits = []
-        qubit_map = {other.qubits[i]: (self.qubits[q] if isinstance(q, int) else q)
-                     for i, q in enumerate(qubits)}
-        clbit_map = {other.clbits[i]: (self.clbits[c] if isinstance(c, int) else c)
-                     for i, c in enumerate(clbits)}
-        wire_map = {**qubit_map, **clbit_map} or None
-        dag_self.compose(dag_other, edge_map=wire_map, front=front)
+        dag_self.compose(dag_other, qubits=qubits, clbits=clbits, front=front)
         composed_circuit = dag_to_circuit(dag_self)
         if inplace:  # FIXME: this is just a hack for inplace to work. Still copies.
             self.__dict__.update(composed_circuit.__dict__)

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -511,7 +511,7 @@ class DAGCircuit:
             inplace (bool): If True, modify the object. Otherwise return composed circuit.
 
         Returns:
-            DAGCircuit: the composed dag (no return if inplace=True).
+            DAGCircuit: the composed dag (returns None if inplace==True).
 
         Raises:
             DAGCircuitError: if ``other`` is wider or there are duplicate edge mappings.
@@ -539,7 +539,7 @@ class DAGCircuit:
             dag = self
         else:
             dag = copy.deepcopy(self)
-        
+
         for nd in other.topological_nodes():
             if nd.type == "in":
                 # if in edge_map, get new name, else use existing name
@@ -565,6 +565,8 @@ class DAGCircuit:
 
         if not inplace:
             return dag
+        else:
+            return None
 
     def idle_wires(self):
         """Return idle wires.

--- a/releasenotes/notes/circuit-compose-c320c4057cd2bb8f.yaml
+++ b/releasenotes/notes/circuit-compose-c320c4057cd2bb8f.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    A new ``compose`` method is added to ``QuantumCircuit``. It allows
+    composition of two quantum circuits without having to turn one into
+    a gate or instruction. It also allows permutations of qubits/clbits
+    at the point of composition, as well as optional inplace modification.
+deprecations:
+  - |
+    The ``DAGCircuit.compose()`` method now takes a list of qubits/clbits
+    that specify the positional order of bits to compose onto. The
+    dictionary-based method of mapping using ``edge_map`` arg is
+    deprecated.

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -1,0 +1,355 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test QuantumCircuit.compose()."""
+
+import unittest
+
+from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.test import QiskitTestCase
+
+
+class TestCircuitCompose(QiskitTestCase):
+    """Test composition of two circuits."""
+
+    def setUp(self):
+        qreg1 = QuantumRegister(3, 'lqr_1')
+        qreg2 = QuantumRegister(2, 'lqr_2')
+        creg = ClassicalRegister(2, 'lcr')
+
+        self.circuit_left = QuantumCircuit(qreg1, qreg2, creg)
+        self.circuit_left.h(qreg1[0])
+        self.circuit_left.x(qreg1[1])
+        self.circuit_left.u1(0.1, qreg1[2])
+        self.circuit_left.cx(qreg2[0], qreg2[1])
+
+        self.left_qubit0 = qreg1[0]
+        self.left_qubit1 = qreg1[1]
+        self.left_qubit2 = qreg1[2]
+        self.left_qubit3 = qreg2[0]
+        self.left_qubit4 = qreg2[1]
+        self.left_clbit0 = creg[0]
+        self.left_clbit1 = creg[1]
+        self.condition = (creg, 3)
+
+    def test_compose_inorder(self):
+        """Composing two circuits of the same width, default order.
+
+                       ┌───┐
+        lqr_1_0: |0>───┤ H ├───     rqr_0: |0>──■───────
+                       ├───┤                    │  ┌───┐
+        lqr_1_1: |0>───┤ X ├───     rqr_1: |0>──┼──┤ X ├
+                    ┌──┴───┴──┐                 │  ├───┤
+        lqr_1_2: |0>┤ U1(0.1) ├  +  rqr_2: |0>──┼──┤ Y ├  =
+                    └─────────┘               ┌─┴─┐└───┘
+        lqr_2_0: |0>─────■─────     rqr_3: |0>┤ X ├─────
+                       ┌─┴─┐                  └───┘┌───┐
+        lqr_2_1: |0>───┤ X ├───     rqr_4: |0>─────┤ Z ├
+                       └───┘                       └───┘
+        lcr_0: 0 ═══════════
+
+        lcr_1: 0 ═══════════
+
+
+                        ┌───┐
+         lqr_1_0: |0>───┤ H ├─────■───────
+                        ├───┤     │  ┌───┐
+         lqr_1_1: |0>───┤ X ├─────┼──┤ X ├
+                     ┌──┴───┴──┐  │  ├───┤
+         lqr_1_2: |0>┤ U1(0.1) ├──┼──┤ Y ├
+                     └─────────┘┌─┴─┐└───┘
+         lqr_2_0: |0>─────■─────┤ X ├─────
+                        ┌─┴─┐   └───┘┌───┐
+         lqr_2_1: |0>───┤ X ├────────┤ Z ├
+                        └───┘        └───┘
+         lcr_0: 0 ════════════════════════
+
+         lcr_1: 0 ════════════════════════
+
+        """
+        qreg = QuantumRegister(5, 'rqr')
+        circuit_right = QuantumCircuit(qreg)
+        circuit_right.cx(qreg[0], qreg[3])
+        circuit_right.x(qreg[1])
+        circuit_right.y(qreg[2])
+        circuit_right.z(qreg[4])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.cx(self.left_qubit0, self.left_qubit3)
+        circuit_expected.x(self.left_qubit1)
+        circuit_expected.y(self.left_qubit2)
+        circuit_expected.z(self.left_qubit4)
+
+        circuit_composed = self.circuit_left.compose(circuit_right, inplace=False)
+        self.assertEqual(circuit_composed, circuit_expected)
+
+    def test_compose_inorder_inplace(self):
+        """Composing two circuits of the same width, default order, inplace.
+
+                       ┌───┐
+        lqr_1_0: |0>───┤ H ├───     rqr_0: |0>──■───────
+                       ├───┤                    │  ┌───┐
+        lqr_1_1: |0>───┤ X ├───     rqr_1: |0>──┼──┤ X ├
+                    ┌──┴───┴──┐                 │  ├───┤
+        lqr_1_2: |0>┤ U1(0.1) ├  +  rqr_2: |0>──┼──┤ Y ├  =
+                    └─────────┘               ┌─┴─┐└───┘
+        lqr_2_0: |0>─────■─────     rqr_3: |0>┤ X ├─────
+                       ┌─┴─┐                  └───┘┌───┐
+        lqr_2_1: |0>───┤ X ├───     rqr_4: |0>─────┤ Z ├
+                       └───┘                       └───┘
+        lcr_0: 0 ═══════════
+
+        lcr_1: 0 ═══════════
+
+
+                        ┌───┐
+         lqr_1_0: |0>───┤ H ├─────■───────
+                        ├───┤     │  ┌───┐
+         lqr_1_1: |0>───┤ X ├─────┼──┤ X ├
+                     ┌──┴───┴──┐  │  ├───┤
+         lqr_1_2: |0>┤ U1(0.1) ├──┼──┤ Y ├
+                     └─────────┘┌─┴─┐└───┘
+         lqr_2_0: |0>─────■─────┤ X ├─────
+                        ┌─┴─┐   └───┘┌───┐
+         lqr_2_1: |0>───┤ X ├────────┤ Z ├
+                        └───┘        └───┘
+         lcr_0: 0 ════════════════════════
+
+         lcr_1: 0 ════════════════════════
+
+        """
+        qreg = QuantumRegister(5, 'rqr')
+        circuit_right = QuantumCircuit(qreg)
+        circuit_right.cx(qreg[0], qreg[3])
+        circuit_right.x(qreg[1])
+        circuit_right.y(qreg[2])
+        circuit_right.z(qreg[4])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.cx(self.left_qubit0, self.left_qubit3)
+        circuit_expected.x(self.left_qubit1)
+        circuit_expected.y(self.left_qubit2)
+        circuit_expected.z(self.left_qubit4)
+
+        # inplace
+        circuit_left = self.circuit_left.copy()
+        circuit_left.compose(circuit_right, inplace=True)
+        self.assertEqual(circuit_left, circuit_expected)
+
+    def test_compose_inorder_smaller(self):
+        """Composing with a smaller RHS dag, default order.
+
+                       ┌───┐                       ┌─────┐
+        lqr_1_0: |0>───┤ H ├───     rqr_0: |0>──■──┤ Tdg ├
+                       ├───┤                  ┌─┴─┐└─────┘
+        lqr_1_1: |0>───┤ X ├───     rqr_1: |0>┤ X ├───────
+                    ┌──┴───┴──┐               └───┘
+        lqr_1_2: |0>┤ U1(0.1) ├  +                          =
+                    └─────────┘
+        lqr_2_0: |0>─────■─────
+                       ┌─┴─┐
+        lqr_2_1: |0>───┤ X ├───
+                       └───┘
+        lcr_0: 0 ══════════════
+
+        lcr_1: 0 ══════════════
+
+                        ┌───┐        ┌─────┐
+         lqr_1_0: |0>───┤ H ├─────■──┤ Tdg ├
+                        ├───┤   ┌─┴─┐└─────┘
+         lqr_1_1: |0>───┤ X ├───┤ X ├───────
+                     ┌──┴───┴──┐└───┘
+         lqr_1_2: |0>┤ U1(0.1) ├────────────
+                     └─────────┘
+         lqr_2_0: |0>─────■─────────────────
+                        ┌─┴─┐
+         lqr_2_1: |0>───┤ X ├───────────────
+                        └───┘
+         lcr_0: 0 ══════════════════════════
+
+         lcr_1: 0 ══════════════════════════
+
+        """
+        qreg = QuantumRegister(2, 'rqr')
+
+        circuit_right = QuantumCircuit(qreg)
+        circuit_right.cx(qreg[0], qreg[1])
+        circuit_right.tdg(qreg[0])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.cx(self.left_qubit0, self.left_qubit1)
+        circuit_expected.tdg(self.left_qubit0)
+
+        circuit_composed = self.circuit_left.compose(circuit_right)
+        self.assertEqual(circuit_composed, circuit_expected)
+
+    def test_compose_permuted(self):
+        """Composing two dags of the same width, permuted wires.
+                        ┌───┐
+         lqr_1_0: |0>───┤ H ├───      rqr_0: |0>──■───────
+                        ├───┤                     │  ┌───┐
+         lqr_1_1: |0>───┤ X ├───      rqr_1: |0>──┼──┤ X ├
+                     ┌──┴───┴──┐                  │  ├───┤
+         lqr_1_2: |0>┤ U1(0.1) ├      rqr_2: |0>──┼──┤ Y ├
+                     └─────────┘                ┌─┴─┐└───┘
+         lqr_2_0: |0>─────■─────  +   rqr_3: |0>┤ X ├─────   =
+                        ┌─┴─┐                   └───┘┌───┐
+         lqr_2_1: |0>───┤ X ├───      rqr_4: |0>─────┤ Z ├
+                        └───┘                        └───┘
+         lcr_0: 0 ══════════════
+
+         lcr_1: 0 ══════════════
+
+                        ┌───┐   ┌───┐
+         lqr_1_0: |0>───┤ H ├───┤ Z ├
+                        ├───┤   ├───┤
+         lqr_1_1: |0>───┤ X ├───┤ X ├
+                     ┌──┴───┴──┐├───┤
+         lqr_1_2: |0>┤ U1(0.1) ├┤ Y ├
+                     └─────────┘└───┘
+         lqr_2_0: |0>─────■───────■──
+                        ┌─┴─┐   ┌─┴─┐
+         lqr_2_1: |0>───┤ X ├───┤ X ├
+                        └───┘   └───┘
+         lcr_0: 0 ═══════════════════
+
+         lcr_1: 0 ═══════════════════
+        """
+        qreg = QuantumRegister(5, 'rqr')
+
+        circuit_right = QuantumCircuit(qreg)
+        circuit_right.cx(qreg[0], qreg[3])
+        circuit_right.x(qreg[1])
+        circuit_right.y(qreg[2])
+        circuit_right.z(qreg[4])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.z(self.left_qubit0)
+        circuit_expected.x(self.left_qubit1)
+        circuit_expected.y(self.left_qubit2)
+        circuit_expected.cx(self.left_qubit3, self.left_qubit4)
+
+        # permuted wiring
+        circuit_composed = self.circuit_left.compose(circuit_right,
+                                                     qubits=[self.left_qubit3,
+                                                             self.left_qubit1,
+                                                             self.left_qubit2,
+                                                             self.left_qubit4,
+                                                             self.left_qubit0],
+                                                     inplace=False)
+        self.assertEqual(circuit_composed, circuit_expected)
+
+    def test_compose_permuted_smaller(self):
+        """Composing with a smaller RHS dag, and permuted wires.
+        Compose using indices.
+
+                       ┌───┐                       ┌─────┐
+        lqr_1_0: |0>───┤ H ├───     rqr_0: |0>──■──┤ Tdg ├
+                       ├───┤                  ┌─┴─┐└─────┘
+        lqr_1_1: |0>───┤ X ├───     rqr_1: |0>┤ X ├───────
+                    ┌──┴───┴──┐               └───┘
+        lqr_1_2: |0>┤ U1(0.1) ├  +                          =
+                    └─────────┘
+        lqr_2_0: |0>─────■─────
+                       ┌─┴─┐
+        lqr_2_1: |0>───┤ X ├───
+                       └───┘
+        lcr_0: 0 ══════════════
+
+        lcr_1: 0 ══════════════
+
+                        ┌───┐
+         lqr_1_0: |0>───┤ H ├───────────────
+                        ├───┤
+         lqr_1_1: |0>───┤ X ├───────────────
+                     ┌──┴───┴──┐┌───┐
+         lqr_1_2: |0>┤ U1(0.1) ├┤ X ├───────
+                     └─────────┘└─┬─┘┌─────┐
+         lqr_2_0: |0>─────■───────■──┤ Tdg ├
+                        ┌─┴─┐        └─────┘
+         lqr_2_1: |0>───┤ X ├───────────────
+                        └───┘
+         lcr_0: 0 ══════════════════════════
+
+         lcr_1: 0 ══════════════════════════
+        """
+        qreg = QuantumRegister(2, 'rqr')
+        circuit_right = QuantumCircuit(qreg)
+        circuit_right.cx(qreg[0], qreg[1])
+        circuit_right.tdg(qreg[0])
+
+        # permuted wiring of subset
+        circuit_composed = self.circuit_left.compose(circuit_right, qubits=[3, 2])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.cx(self.left_qubit3, self.left_qubit2)
+        circuit_expected.tdg(self.left_qubit3)
+
+        self.assertEqual(circuit_composed, circuit_expected)
+
+    def test_compose_classical(self):
+        """Composing on classical bits.
+
+                       ┌───┐                       ┌─────┐┌─┐
+        lqr_1_0: |0>───┤ H ├───     rqr_0: |0>──■──┤ Tdg ├┤M├
+                       ├───┤                  ┌─┴─┐└─┬─┬─┘└╥┘
+        lqr_1_1: |0>───┤ X ├───     rqr_1: |0>┤ X ├──┤M├───╫─
+                    ┌──┴───┴──┐               └───┘  └╥┘   ║
+        lqr_1_2: |0>┤ U1(0.1) ├  +   rcr_0: 0 ════════╬════╩═  =
+                    └─────────┘                       ║
+        lqr_2_0: |0>─────■─────      rcr_1: 0 ════════╩══════
+                       ┌─┴─┐
+        lqr_2_1: |0>───┤ X ├───
+                       └───┘
+        lcr_0: 0 ══════════════
+
+        lcr_1: 0 ══════════════
+
+                       ┌───┐
+        lqr_1_0: |0>───┤ H ├──────────────────
+                       ├───┤        ┌─────┐┌─┐
+        lqr_1_1: |0>───┤ X ├─────■──┤ Tdg ├┤M├
+                    ┌──┴───┴──┐  │  └─────┘└╥┘
+        lqr_1_2: |0>┤ U1(0.1) ├──┼──────────╫─
+                    └─────────┘  │          ║
+        lqr_2_0: |0>─────■───────┼──────────╫─
+                       ┌─┴─┐   ┌─┴─┐  ┌─┐   ║
+        lqr_2_1: |0>───┤ X ├───┤ X ├──┤M├───╫─
+                       └───┘   └───┘  └╥┘   ║
+           lcr_0: 0 ═══════════════════╩════╬═
+                                            ║
+           lcr_1: 0 ════════════════════════╩═
+        """
+        qreg = QuantumRegister(2, 'rqr')
+        creg = ClassicalRegister(2, 'rcr')
+
+        circuit_right = QuantumCircuit(qreg, creg)
+        circuit_right.cx(qreg[0], qreg[1])
+        circuit_right.tdg(qreg[0])
+        circuit_right.measure(qreg, creg)
+
+        # permuted subset of qubits and clbits
+        circuit_composed = self.circuit_left.compose(circuit_right, qubits=[1, 4], clbits=[1, 0])
+
+        circuit_expected = self.circuit_left.copy()
+        circuit_expected.cx(self.left_qubit1, self.left_qubit4)
+        circuit_expected.tdg(self.left_qubit1)
+        circuit_expected.measure(self.left_qubit4, self.left_clbit0)
+        circuit_expected.measure(self.left_qubit1, self.left_clbit1)
+
+        self.assertEqual(circuit_composed, circuit_expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/dagcircuit/test_compose.py
+++ b/test/python/dagcircuit/test_compose.py
@@ -16,28 +16,9 @@
 
 import unittest
 
-from ddt import ddt, data
-
-import networkx as nx
-
-from qiskit.dagcircuit import DAGCircuit
-from qiskit.circuit import QuantumRegister
-from qiskit.circuit import ClassicalRegister, Clbit
-from qiskit.circuit import QuantumCircuit
-from qiskit.circuit import Measure
-from qiskit.circuit import Reset
-from qiskit.circuit import Gate, Instruction
-from qiskit.extensions.standard.iden import IdGate
-from qiskit.extensions.standard.h import HGate
-from qiskit.extensions.standard.x import CnotGate
-from qiskit.extensions.standard.z import CzGate
-from qiskit.extensions.standard.x import XGate
-from qiskit.extensions.standard.u1 import U1Gate
-from qiskit.extensions.standard.barrier import Barrier
-from qiskit.dagcircuit.exceptions import DAGCircuitError
+from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.test import QiskitTestCase
-from .test_dagcircuit import raise_if_dagcircuit_invalid
 
 
 class TestDagCompose(QiskitTestCase):


### PR DESCRIPTION
Compose two circuits (without having to turn one into a gate). Uses dag.compose() under the hood.