### PR TITLE
Remove QuantumCircuit instance from UnitaryGate.definition.

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -109,7 +109,7 @@ class UnitaryGate(Gate):
             theta, phi, lam = _DECOMPOSER1Q.angles(self.to_matrix())
             self.definition = [(U3Gate(theta, phi, lam), [q[0]], [])]
         elif self.num_qubits == 2:
-            self.definition = two_qubit_cnot_decompose(self.to_matrix())
+            self.definition = two_qubit_cnot_decompose(self.to_matrix()).data
         else:
             raise NotImplementedError("Not able to generate a subcircuit for "
                                       "a {}-qubit unitary".format(self.num_qubits))
@@ -229,7 +229,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
 
 
 def unitary(self, obj, qubits, label=None):
-    """Apply u2 to q."""
+    """Apply unitary gate to q."""
     if isinstance(qubits, QuantumRegister):
         qubits = qubits[:]
     return self.append(UnitaryGate(obj, label=label), qubits, [])


### PR DESCRIPTION

### Summary

The `._definition`s of two-qubit `UnitaryGate`s are currently `QuantumCircuit` instances, instead of the list of `(inst, qargs, cargs)` tuples used for other gates. This passes the `Unroller` because `QuantumCircuit` has a `__len__` and a `__getitem__` that will iterate through `qc.data`.

This PR sets the definition to be a list of `(inst, qargs, cargs)` tuples, in line with how definitions are set for other gates.

### Details and comments


