### PR TITLE
Instruction.is_parameterized to return False when fully bound.

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -163,7 +163,9 @@ class Instruction:
 
     def is_parameterized(self):
         """Return True .IFF. instruction is parameterized else False"""
-        return any(isinstance(param, ParameterExpression) for param in self.params)
+        return any(isinstance(param, ParameterExpression)
+                   and param.parameters
+                   for param in self.params)
 
     @property
     def definition(self):

--- a/releasenotes/notes/instruction.is_parameterized-to-check-if-fully-bound-f1004abf10f15930.yaml
+++ b/releasenotes/notes/instruction.is_parameterized-to-check-if-fully-bound-f1004abf10f15930.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The ``Instruction.is_parameterized`` method had previously returned ``True``
+    for any ``Instruction`` instance which had a ``Parameter`` in any element
+    if its ``params`` array, even if that ``Parameter`` had been fully bound.
+    This has been corrected so that ``.is_parameterized`` will return ``False``
+    when the instruction is fully bound.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -77,7 +77,7 @@ class TestParameters(QiskitTestCase):
         self.assertTrue(rxg.is_parameterized())
         theta_bound = theta.bind({theta: 3.14})
         rxg = RXGate(theta_bound)
-        self.assertTrue(rxg.is_parameterized())
+        self.assertFalse(rxg.is_parameterized())
         h_gate = HGate()
         self.assertFalse(h_gate.is_parameterized())
 


### PR DESCRIPTION
This causes a failure of TestKAKOverOptim.test_cu1_optimization after
switching to BasisTranslator. For CU1, the Unroller will generate
U1Gate(pi/2), ..., but the BasisTranslator will generate a (still
valid) U1Gate(ParameterExpression(pi/2)).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


