### PR TITLE
Add correct inverse functionality to QFT

### DIFF
--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -81,6 +81,7 @@ class QFT(QuantumCircuit):
                  num_qubits: Optional[int] = None,
                  approximation_degree: int = 0,
                  do_swaps: bool = True,
+                 inverse: bool = False,
                  insert_barriers: bool = False,
                  name: str = 'qft') -> None:
         """Construct a new QFT circuit.
@@ -89,6 +90,7 @@ class QFT(QuantumCircuit):
             num_qubits: The number of qubits on which the QFT acts.
             approximation_degree: The degree of approximation (0 for no approximation).
             do_swaps: Whether to include the final swaps in the QFT.
+            inverse: If True, the inverse Fourier transform is constructed.
             insert_barriers: If True, barriers are inserted as visualization improvement.
             name: The name of the circuit.
         """
@@ -96,6 +98,7 @@ class QFT(QuantumCircuit):
         self._approximation_degree = approximation_degree
         self._do_swaps = do_swaps
         self._insert_barriers = insert_barriers
+        self._inverse = inverse
         self._data = None
         self.num_qubits = num_qubits
 
@@ -205,9 +208,27 @@ class QFT(QuantumCircuit):
             self._invalidate()
             self._do_swaps = do_swaps
 
+    def is_inverse(self) -> bool:
+        """Whether the inverse Fourier transform is implemented.
+
+        Returns:
+            True, if the inverse Fourier transform is implemented, False otherwise.
+        """
+        return self._inverse
+
     def _invalidate(self) -> None:
         """Invalidate the current build of the circuit."""
         self._data = None
+
+    def inverse(self) -> 'QFT':
+        """Invert this circuit.
+
+        Returns:
+            The inverted circuit.
+        """
+        inverted = super().inverse()
+        inverted._inverse = not self._inverse
+        return inverted
 
     def _swap_qubits(self):
         num_qubits = self.num_qubits
@@ -233,6 +254,9 @@ class QFT(QuantumCircuit):
 
         if self._do_swaps:
             self._swap_qubits()
+
+        if self._inverse:
+            self._data = super().inverse()
 
     @property
     def data(self):

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -195,6 +195,21 @@ class TestBasisChanges(QiskitTestCase):
             qft = qft.inverse()
         self.assertQFTIsCorrect(qft, inverse=inverse)
 
+    def test_qft_is_inverse(self):
+        """Test the is_inverse() method."""
+        qft = QFT(2)
+
+        with self.subTest(msg='initial object is not inverse'):
+            self.assertFalse(qft.is_inverse())
+
+        qft = qft.inverse()
+        with self.subTest(msg='inverted'):
+            self.assertTrue(qft.is_inverse())
+
+        qft = qft.inverse()
+        with self.subTest(msg='re-inverted'):
+            self.assertFalse(qft.is_inverse())
+
     def test_qft_mutability(self):
         """Test the mutability of the QFT circuit."""
         qft = QFT()
@@ -215,6 +230,15 @@ class TestBasisChanges(QiskitTestCase):
             qft.num_qubits = 4
             qft.do_swaps = False
             self.assertQFTIsCorrect(qft, add_swaps_at_end=True)
+
+        with self.subTest(msg='inverse'):
+            qft = qft.inverse()
+            qft.do_swaps = True
+            self.assertQFTIsCorrect(qft, inverse=True)
+
+        with self.subTest(msg='double inverse'):
+            qft = qft.inverse()
+            self.assertQFTIsCorrect(qft)
 
         with self.subTest(msg='set approximation'):
             qft.approximation_degree = 2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add `is_inverse` to the QFT and allow to directly build the inverse QFT.

### Details and comments

We need to be able to distinguish between the inverse and non-inverse QFT, also this fixes the potential bug 
```python
iqft = QFT(2).inverse()
iqft.do_swaps = False  # is reset and the normal QFT, not IQFT, is built
```
