### PR TITLE
* Fixed SetFrequency name sf -> setf in pulse instructions.

### DIFF
--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -266,7 +266,7 @@ class InstructionToQobjConverter:
             dict: Dictionary of required parameters.
         """
         command_dict = {
-            'name': 'sf',
+            'name': 'setf',
             't0': shift+instruction.start_time,
             'ch': instruction.channel.name,
             'frequency': instruction.frequency

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -521,7 +521,7 @@ class QobjToInstructionConverter:
 
         return instructions.ShiftPhase(phase, channel) << t0
 
-    @bind_name('sf')
+    @bind_name('setf')
     def convert_set_frequency(self, instruction):
         """Return converted `SetFrequencyInstruction`.
 

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -96,6 +96,7 @@
                                 "enum": [
                                     "pv",
                                     "fc",
+                                    "setf",
                                     "acquire",
                                     "parametric_pulse"
                                 ]
@@ -152,6 +153,26 @@
                         "ch"
                     ],
                     "title": "Frame change pulse"
+                },
+                {
+                    "properties": {
+                        "name": {
+                            "enum": [
+                                "setf"
+                            ]
+                        },
+                        "frequency": {
+                            "OneOf":[
+                            {"type": "number"},
+                            {"type": "string"}]
+                        }
+                    },
+                    "required": [
+                        "frequency",
+                        "t0",
+                        "ch"
+                    ],
+                    "title": "Set frequency"
                 },
                 {
                     "properties": {

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -149,7 +149,7 @@ class TestInstructionToQobjConverter(QiskitTestCase):
         instruction = SetFrequency(8.0, DriveChannel(0))
 
         valid_qobj = PulseQobjInstruction(
-            name='sf',
+            name='setf',
             ch='d0',
             t0=0,
             frequency=8.0
@@ -302,7 +302,7 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         """Test converted qobj from FrameChangeInstruction."""
         instruction = SetFrequency(8.0, DriveChannel(0))
 
-        qobj = PulseQobjInstruction(name='sf', ch='d0', t0=0, frequency=8.0)
+        qobj = PulseQobjInstruction(name='setf', ch='d0', t0=0, frequency=8.0)
         converted_instruction = self.converter(qobj)
 
         self.assertEqual(converted_instruction.timeslots, instruction.timeslots)


### PR DESCRIPTION
### Summary
pulse_instruction.py and pulse2sq2.py did not have the same name for SetFrequency.


### Details and comments
* Changed name from `sf` to `setf`
* Added SetFrequency to the schemas


