### PR TITLE
Fix Schedule accepting non-integer times

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -75,7 +75,7 @@ class Schedule(ScheduleComponent):
             insert_time, sched = sched_pair
 
             if not isinstance(insert_time, (int, np.integer)):
-                raise PulseError('Instruction scheduled at non-integer')
+                raise PulseError('Instruction scheduled at non-integer time')
 
             sched_timeslots = sched.timeslots
 

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -21,8 +21,10 @@ import abc
 import itertools
 import multiprocessing as mp
 import sys
-from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional
 import warnings
+from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional
+
+import numpy as np
 
 from qiskit.util import is_main_process
 from .timeslots import Interval, TimeslotCollection
@@ -71,9 +73,15 @@ class Schedule(ScheduleComponent):
             # convert to tuple
             sched_pair = tuple(sched_pair)
             insert_time, sched = sched_pair
+
+            if not isinstance(insert_time, (int, np.integer)):
+                raise PulseError('Instruction scheduled at non-integer')
+
             sched_timeslots = sched.timeslots
+
             if insert_time:
                 sched_timeslots = sched_timeslots.shift(insert_time)
+
             timeslots.append(sched_timeslots)
             _children.append(sched_pair)
 
@@ -83,8 +91,8 @@ class Schedule(ScheduleComponent):
             formatted_schedules = []
             for sched_pair in schedules:
                 sched = sched_pair[1] if isinstance(sched_pair, (List, tuple)) else sched_pair
-                formatted_sched = 'Schedule(name="{0}", duration={1})'.format(sched.name,
-                                                                              sched.duration)
+                formatted_sched = 'Schedule(name="{0}", duration={1})'.format(
+                    sched.name, sched.duration)
                 formatted_schedules.append(formatted_sched)
             formatted_schedules = ", ".join(formatted_schedules)
             raise PulseError('Schedules overlap: {0} for {1}'

--- a/qiskit/pulse/timeslots.py
+++ b/qiskit/pulse/timeslots.py
@@ -19,6 +19,8 @@ from collections import defaultdict
 import itertools
 from typing import Tuple, Union, Optional
 
+import numpy as np
+
 from .channels import Channel
 from .exceptions import PulseError
 
@@ -39,12 +41,21 @@ class Interval:
         Raises:
             PulseError: when invalid time or duration is specified
         """
-        if start < 0:
-            raise PulseError("Cannot create Interval with negative starting value")
-        if stop < 0:
-            raise PulseError("Cannot create Interval with negative stopping value")
-        if start > stop:
-            raise PulseError("Cannot create Interval with value start after stop")
+        if not isinstance(start, (int, np.integer)):
+            raise PulseError(
+                "Cannot create Interval with non-integer starting value")
+        elif not isinstance(stop, (int, np.integer)):
+            raise PulseError(
+                "Cannot create Interval with non-integer stopping value")
+        elif start < 0:
+            raise PulseError(
+                "Cannot create Interval with negative starting value")
+        elif stop < 0:
+            raise PulseError(
+                "Cannot create Interval with negative stopping value")
+        elif start > stop:
+            raise PulseError(
+                "Cannot create Interval with value start after stop")
         self._start = start
         self._stop = stop
 

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -419,6 +419,29 @@ class TestScheduleBuilding(BaseTestSchedule):
         self.assertEqual(sched.duration, 1525)
         self.assertTrue('sigma' in sched.instructions[0][1].pulse.parameters)
 
+    def test_negative_time_raises(self):
+        """Test that a negative time will raise an error."""
+        sched = Schedule()
+        sched += Delay(1, DriveChannel(0))
+        with self.assertRaises(PulseError):
+            sched.shift(-10)
+
+    def test_float_time_raises(self):
+        """Test that a floating time will raise an error."""
+        sched = Schedule()
+        sched += Delay(1, DriveChannel(0))
+
+        with self.assertRaises(PulseError):
+            sched.shift(0.1)
+
+    def test_shift_unshift(self):
+        """Test shift and then unshifting of schedule"""
+
+        reference_sched = Schedule()
+        reference_sched += Delay(10, DriveChannel(0))
+        shifted_sched = reference_sched.shift(10).shift(-10)
+        self.assertEqual(shifted_sched, reference_sched)
+
 
 class TestDelay(BaseTestSchedule):
     """Test Delay Instruction"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Closes #4219. This fixes pulses schedules being shifted by non-integer values and instructions, in general, having non-integer values.


### Details and comments


