### PR TITLE
Add missing stacklevel param from dagcircuit DeprecationWarnings

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -473,7 +473,7 @@ class DAGCircuit:
         """DEPRECATED: Add `dag` at the end of `self`, using `edge_map`.
         """
         warnings.warn("dag.extend_back is deprecated, please use dag.compose.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         edge_map = edge_map or {}
         for qreg in dag.qregs.values():
             if qreg.name not in self.qregs:
@@ -491,7 +491,7 @@ class DAGCircuit:
         """DEPRECATED: use DAGCircuit.compose() instead.
         """
         warnings.warn("dag.compose_back is deprecated, please use dag.compose.",
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         self.compose(input_circuit, edge_map)
 
     def compose(self, other, edge_map=None, qubits=None, clbits=None, front=False, inplace=True):
@@ -529,7 +529,8 @@ class DAGCircuit:
         if edge_map is not None:
             warnings.warn("edge_map arg as a dictionary is deprecated. "
                           "Use qubits and clbits args to specify a list of "
-                          "self edges to compose onto.", DeprecationWarning)
+                          "self edges to compose onto.", DeprecationWarning,
+                          stacklevel=2)
         if qubits is None:
             qubits = []
         if clbits is None:
@@ -1001,7 +1002,7 @@ class DAGCircuit:
         """Get list of 2-qubit gates. Ignore snapshot, barriers, and the like."""
         warnings.warn('deprecated function, use dag.two_qubit_ops(). '
                       'filter output by isinstance(op, Gate) to only get unitary Gates.',
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         two_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) == 2:
@@ -1012,7 +1013,7 @@ class DAGCircuit:
         """Get list of 3-or-more-qubit gates: (id, data)."""
         warnings.warn('deprecated function, use dag.multi_qubit_ops(). '
                       'filter output by isinstance(op, Gate) to only get unitary Gates.',
-                      DeprecationWarning)
+                      DeprecationWarning, stacklevel=2)
         three_q_gates = []
         for node in self.gate_nodes():
             if len(node.qargs) >= 3:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There were several places deprecation warnings are emitted in the
DAGCircuit class. However, none of these deprecations set a stacklevel
kwarg which means the default of 1 is used. This means the deprecation
warnings refer to the warn() line as the source of the deprecation
instead of the caller of the function. This commit corrects this
oversight by adding stacklevel=2 which will show the caller as the
source of the deprecation warning.

### Details and comments


