### PR TITLE
Make z3-solver opt-in for testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,7 +141,7 @@ stages:
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
+            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
@@ -311,7 +311,7 @@ stages:
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
+            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'
@@ -368,7 +368,7 @@ stages:
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
+            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,5 +22,4 @@ sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints
 jupyter-sphinx
-z3-solver
 pygments>=2.4

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -22,7 +22,6 @@ from qiskit.converters import circuit_to_dag
 from qiskit import QuantumCircuit
 from qiskit.test import QiskitTestCase
 from qiskit.extensions.standard import XGate, RZGate, CSwapGate, SwapGate
-from qiskit.extensions.unitary import UnitaryGate
 from qiskit.dagcircuit import DAGNode
 from qiskit.quantum_info import Statevector
 

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -16,6 +16,7 @@
 
 import unittest
 from numpy import pi
+from qiskit.transpiler.passes.optimization.hoare_opt import HAS_Z3
 from qiskit.transpiler.passes import HoareOptimizer
 from qiskit.converters import circuit_to_dag
 from qiskit import QuantumCircuit
@@ -26,6 +27,8 @@ from qiskit.dagcircuit import DAGNode
 from qiskit.quantum_info import Statevector
 
 
+@unittest.skipUnless(HAS_Z3,
+                     'z3-solver needs to be installed to run these tests')
 class TestHoareOptimizer(QiskitTestCase):
     """Test the HoareOptimizer pass"""
 
@@ -314,7 +317,6 @@ class TestHoareOptimizer(QiskitTestCase):
                                                          [0, 1j]]).control()}),
                DAGNode({'type': 'op', 'op': UnitaryGate([[1, 0],
                                                          [0, -1j]])})]
-        # self.assertTrue(HoareOptimizer()._is_identity(seq))
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -27,8 +27,7 @@ from qiskit.dagcircuit import DAGNode
 from qiskit.quantum_info import Statevector
 
 
-@unittest.skipUnless(HAS_Z3,
-                     'z3-solver needs to be installed to run these tests')
+@unittest.skipUnless(HAS_Z3, 'z3-solver needs to be installed to run these tests')
 class TestHoareOptimizer(QiskitTestCase):
     """Test the HoareOptimizer pass"""
 

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -312,11 +312,6 @@ class TestHoareOptimizer(QiskitTestCase):
                DAGNode({'type': 'op', 'op': SwapGate()})]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
-        seq = [DAGNode({'type': 'op', 'op': UnitaryGate([[1, 0],
-                                                         [0, 1j]]).control()}),
-               DAGNode({'type': 'op', 'op': UnitaryGate([[1, 0],
-                                                         [0, -1j]])})]
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The z3-solver package isn't precompiled on macOS (there is an open issue
about this Z3Prover/z3#2800) so on CI jobs when running on macOS we spend a
great deal of time (typically >10min for each macOS job) building z3 from
source. This is delaying everyone's development and is just wasting time. This
commit removes z3-solver from the requriements-dev.txt list and manually
installs it on linux and windows CI jobs where precompiled binaries are
available.

### Details and comments