### PR TITLE
No C3X and C4X by default

### DIFF
--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -794,8 +794,6 @@ class MCXGate(ControlledGate):
         explicit = {
             1: CXGate,
             2: CCXGate,
-            3: C3XGate,
-            4: C4XGate
         }
         if num_ctrl_qubits == 0:
             return XGate(label=label)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #4076 the multi-controlled X was changed to use the default no-ancilla versions of the 3-controlled and 4-controlled X gate. If ancilla qubits are available, these are not the most efficient implementations in terms of gate count, therefore they should not be chosen by default.

### Details and comments

Additionally to that, for a reason yet not clear, this breaks the `v-chain` mode if used in Grover search and it's oracles. 
