### PR TITLE
Fix potential cyclic imports

### DIFF
--- a/qiskit/extensions/quantum_initializer/ucrx.py
+++ b/qiskit/extensions/quantum_initializer/ucrx.py
@@ -25,8 +25,9 @@ a single-qubit rotation R_x(a_i) is applied to the target qubit.
 """
 import math
 
-from qiskit import QuantumRegister, QiskitError
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.exceptions import QiskitError
 from qiskit.extensions.quantum_initializer.uc_pauli_rot import UCPauliRotGate, UCPauliRotMeta
 
 

--- a/qiskit/extensions/quantum_initializer/ucry.py
+++ b/qiskit/extensions/quantum_initializer/ucry.py
@@ -22,8 +22,9 @@ a single-qubit rotation R_y(a_i) is applied to the target qubit.
 """
 import math
 
-from qiskit import QuantumRegister, QiskitError
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.exceptions import QiskitError
 from qiskit.extensions.quantum_initializer.uc_pauli_rot import UCPauliRotGate, UCPauliRotMeta
 
 

--- a/qiskit/extensions/quantum_initializer/ucrz.py
+++ b/qiskit/extensions/quantum_initializer/ucrz.py
@@ -22,8 +22,9 @@ a single-qubit rotation R_z(a_i) is applied to the target qubit.
 """
 import math
 
-from qiskit import QuantumRegister, QiskitError
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.exceptions import QiskitError
 from qiskit.extensions.quantum_initializer.uc_pauli_rot import UCPauliRotGate, UCPauliRotMeta
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As a follow up to #4243 there was a pylint error for a cyclic import
raised by the isometry module which stemmed from importing classes from
the base 'qiskit' namespace. Those aliases are added for end user
convenience and shouldn't be accessed directly in any module from the
code. This commit goes through the remaining places where things are
imported directly from 'qiskit' and updates them to use the full module
path.

### Details and comments