### PR TITLE
Compress built docs before upload

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -230,6 +230,8 @@ stages:
           inputs:
             pathtoPublish: 'docs/_build/html'
             artifactName: 'html_docs'
+            Parallel: true
+            ParallelCount: 8
     - job: 'MacOS_Catalina_Tests'
       pool: {vmImage: 'macOS-10.15'}
       condition: not(startsWith(variables['Build.SourceBranch'], 'refs/tags'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,10 +225,16 @@ stages:
         - bash: |
             tox -edocs
           displayName: 'Run Docs build'
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: 'docs/_build/html'
+            archiveType: tar
+            archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
+            verbose: true
         - task: PublishBuildArtifacts@1
           displayName: 'Publish docs'
           inputs:
-            pathtoPublish: 'docs/_build/html'
+            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
             artifactName: 'html_docs'
             Parallel: true
             ParallelCount: 8


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now the compiled docs upload to the artifact store is a bottleneck
for a CI throughput. In an attempt to speed it up this commit sets the
parallel option on the task [1]. This will hopefully reduce the amount
of time spent uploading files to the artifact store.

### Details and comments

[1] https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops