### PR TITLE
Fix bug in random_clifford

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -151,7 +151,7 @@ def _sample_qmallows(n, rng=None):
         m = n - i
         eps = 4 ** (-m)
         r = rng.uniform(0, 1)
-        index = int(np.ceil(np.log2(1 + (1 - r) * eps)))
+        index = -int(np.ceil(np.log2(r + (1 - r) * eps)))
         had[i] = index < m
         if index < m:
             k = index

--- a/releasenotes/notes/fix-random-clifford-cff2b266c8ad7e2d.yaml
+++ b/releasenotes/notes/fix-random-clifford-cff2b266c8ad7e2d.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed bug in :func:`~qiskit.quantum_info.random_clifford` that stopped it
+    from sampling the full Clifford group.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4271 

### Details and comments

A typo in `_sample_qmallows` function was preventing `random_clifford` from sampling the full Clifford group.

Running 10k samples for N=1 and N=2 now samples the full group:

![randomcliff1](https://user-images.githubusercontent.com/2235104/80392360-0a1a3280-887d-11ea-806d-ec9ba243cc7e.png)
![randomcliff2](https://user-images.githubusercontent.com/2235104/80392362-0a1a3280-887d-11ea-88d7-77ead1987b73.png)
