### PR TITLE
Add ``from_int`` method to ``Statevector`` and ``DensityMatrix``

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -357,6 +357,23 @@ class DensityMatrix(QuantumState):
         """
         return DensityMatrix(Statevector.from_label(label))
 
+    @staticmethod
+    def from_int(i, dims):
+        """Return a computational basis state density matrix.
+
+        Args:
+            i (int): the basis state element.
+            dims (int or list): the subsystem ``dims`` value for the
+                                returned density matrix.
+
+        Returns:
+            DensityMatrix: The computational basis state :math:`|i\\rangle\\!\\langle i|`.
+        """
+        size = np.product(dims)
+        state = np.zeros((size, size), dtype=complex)
+        state[i, i] = 1.0
+        return DensityMatrix(state, dims=dims)
+
     @classmethod
     def from_instruction(cls, instruction):
         """Return the output density matrix of an instruction.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -37,7 +37,28 @@ class DensityMatrix(QuantumState):
     """DensityMatrix class"""
 
     def __init__(self, data, dims=None):
-        """Initialize a state object."""
+        """Initialize a density matrix object.
+
+        Args:
+            data (matrix_like or vector_like): a density matrix or
+                statevector. If a vector the density matrix is constructed
+                as the projector of that vector.
+            dims (int or tuple or list): Optional. The subsystem dimension
+                    of the state (See additional information).
+
+        Additional Information:
+            The ``dims`` kwarg can be None, an integer, or an iterable of
+            integers.
+
+            * ``Iterable`` -- the subsystem dimensions are the values in the list
+              with the total number of subsystems given by the length of the list.
+
+            * ``Int`` or ``None`` -- the leading dimension of the input matrix
+              specifies the total dimension of the density matrix. If it is a
+              power of two the state will be initialized as an N-qubit state.
+              If it is not a power of two the state will have a single
+              d-dimensional subsystem.
+        """
         if isinstance(data, (list, np.ndarray)):
             # Finally we check if the input is a raw matrix in either a
             # python list or numpy array format.
@@ -363,11 +384,22 @@ class DensityMatrix(QuantumState):
 
         Args:
             i (int): the basis state element.
-            dims (int or list): the subsystem ``dims`` value for the
-                                returned density matrix.
+            dims (int or tuple or list): The subsystem dimensions of the statevector
+                                         (See additional information).
 
         Returns:
             DensityMatrix: The computational basis state :math:`|i\\rangle\\!\\langle i|`.
+
+        Additional Information:
+            The ``dims`` kwarg can be an integer or an iterable of integers.
+
+            * ``Iterable`` -- the subsystem dimensions are the values in the list
+              with the total number of subsystems given by the length of the list.
+
+            * ``Int`` -- the integer specifies the total dimension of the
+              state. If it is a power of two the state will be initialized
+              as an N-qubit state. If it is not a power of  two the state
+              will have a single d-dimensional subsystem.
         """
         size = np.product(dims)
         state = np.zeros((size, size), dtype=complex)

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -46,6 +46,9 @@ class DensityMatrix(QuantumState):
             dims (int or tuple or list): Optional. The subsystem dimension
                     of the state (See additional information).
 
+        Raises:
+            QiskitError: if input data is not valid.
+
         Additional Information:
             The ``dims`` kwarg can be None, an integer, or an iterable of
             integers.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -34,7 +34,26 @@ class Statevector(QuantumState):
     """Statevector class"""
 
     def __init__(self, data, dims=None):
-        """Initialize a state object."""
+        """Initialize a statevector object.
+
+        Args:
+            data (vector_like): a complex statevector.
+            dims (int or tuple or list): Optional. The subsystem dimension of
+                                         the state (See additional information).
+
+        Additional Information:
+            The ``dims`` kwarg can be None, an integer, or an iterable of
+            integers.
+
+            * ``Iterable`` -- the subsystem dimensions are the values in the list
+              with the total number of subsystems given by the length of the list.
+
+            * ``Int`` or ``None`` -- the length of the input vector
+              specifies the total dimension of the density matrix. If it is a
+              power of two the state will be initialized as an N-qubit state.
+              If it is not a power of two the state will have a single
+              d-dimensional subsystem.
+        """
         if isinstance(data, (list, np.ndarray)):
             # Finally we check if the input is a raw vector in either a
             # python list or numpy array format.
@@ -454,11 +473,22 @@ class Statevector(QuantumState):
 
         Args:
             i (int): the basis state element.
-            dims (int or list): the subsystem ``dims`` value for the
-                                returned statevector.
+            dims (int or tuple or list): The subsystem dimensions of the statevector
+                                         (See additional information).
 
         Returns:
             Statevector: The computational basis state :math:`|i\\rangle`.
+
+        Additional Information:
+            The ``dims`` kwarg can be an integer or an iterable of integers.
+
+            * ``Iterable`` -- the subsystem dimensions are the values in the list
+              with the total number of subsystems given by the length of the list.
+
+            * ``Int`` -- the integer specifies the total dimension of the
+              state. If it is a power of two the state will be initialized
+              as an N-qubit state. If it is not a power of  two the state
+              will have a single d-dimensional subsystem.
         """
         size = np.product(dims)
         state = np.zeros(size, dtype=complex)

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -41,6 +41,9 @@ class Statevector(QuantumState):
             dims (int or tuple or list): Optional. The subsystem dimension of
                                          the state (See additional information).
 
+        Raises:
+            QiskitError: if input data is not valid.
+
         Additional Information:
             The ``dims`` kwarg can be None, an integer, or an iterable of
             integers.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -448,6 +448,23 @@ class Statevector(QuantumState):
                     state = state.evolve(y_mat, qargs=[qubit])
         return state
 
+    @staticmethod
+    def from_int(i, dims):
+        """Return a computational basis statevector.
+
+        Args:
+            i (int): the basis state element.
+            dims (int or list): the subsystem ``dims`` value for the
+                                returned statevector.
+
+        Returns:
+            Statevector: The computational basis state :math:`|i\\rangle`.
+        """
+        size = np.product(dims)
+        state = np.zeros(size, dtype=complex)
+        state[i] = 1.0
+        return Statevector(state, dims=dims)
+
     @classmethod
     def from_instruction(cls, instruction):
         """Return the output statevector of an instruction.

--- a/releasenotes/notes/quantum-state-from-int-20a91dc5d4c62dbb.yaml
+++ b/releasenotes/notes/quantum-state-from-int-20a91dc5d4c62dbb.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds :meth:`qiskit.quantum_info.Statevector.from_int` and
+    :meth:`qiskit.quantum_info.DensityMatrix.from_int` methods that allow
+    constructing a computational basis state for specified system dimensions.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -824,6 +824,24 @@ class TestDensityMatrix(QiskitTestCase):
                 target = DensityMatrix(np.diag([0, 0, 1]))
                 self.assertEqual(value, target)
 
+    def test_from_int(self):
+        """Test from_int method"""
+
+        with self.subTest(msg='from_int(0, 4)'):
+            target = DensityMatrix([1, 0, 0, 0])
+            value = DensityMatrix.from_int(0, 4)
+            self.assertEqual(target, value)
+
+        with self.subTest(msg='from_int(3, 4)'):
+            target = DensityMatrix([0, 0, 0, 1])
+            value = DensityMatrix.from_int(3, 4)
+            self.assertEqual(target, value)
+
+        with self.subTest(msg='from_int(8, (3, 3))'):
+            target = DensityMatrix([0, 0, 0, 0, 0, 0, 0, 0, 1], dims=(3, 3))
+            value = DensityMatrix.from_int(8, (3, 3))
+            self.assertEqual(target, value)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -812,6 +812,24 @@ class TestStatevector(QiskitTestCase):
                 target = Statevector([0, 0, 1])
                 self.assertEqual(value, target)
 
+    def test_from_int(self):
+        """Test from_int method"""
+
+        with self.subTest(msg='from_int(0, 4)'):
+            target = Statevector([1, 0, 0, 0])
+            value = Statevector.from_int(0, 4)
+            self.assertEqual(target, value)
+
+        with self.subTest(msg='from_int(3, 4)'):
+            target = Statevector([0, 0, 0, 1])
+            value = Statevector.from_int(3, 4)
+            self.assertEqual(target, value)
+
+        with self.subTest(msg='from_int(8, (3, 3))'):
+            target = Statevector([0, 0, 0, 0, 0, 0, 0, 0, 1], dims=(3, 3))
+            value = Statevector.from_int(8, (3, 3))
+            self.assertEqual(target, value)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Allows initializing a statevector in the state |i>, and density matrix in state |i><i| for specified subsystem dimensions.

### Details and comments


