### PR TITLE
Set autoCancel on azure pipelines pr trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ trigger:
     include:
       - '*'
 pr:
+  autoCancel: true
   branches:
     include:
     - '*'  # must quote since "*" is a YAML reserved character; we want a string


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently the azure pipelines jobs are not being cancelled for PR
updates before a job finishes. According to the docs [1] this is
supposed to be default 'true' however we have had issues with implicit
defaults in the past on azure. This commit makes the configuration
explicit in the hope that it will re-enable the feature and improve
CI throughput.

### Details and comments

[1] https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#multiple-pr-updates
