### PR TITLE
Fix deprecations coming from circuit.OR

### DIFF
--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from qiskit.circuit import QuantumRegister
 from qiskit.circuit.exceptions import CircuitError
+from ..boolean_logic import OR
 from ..blueprintcircuit import BlueprintCircuit
 
 
@@ -197,14 +198,16 @@ class IntegerComparator(BlueprintCircuit):
                             self.cx(qr_state[i], qr_ancilla[i])
                     elif i < self.num_state_qubits - 1:
                         if twos[i] == 1:
-                            self.OR([qr_state[i], qr_ancilla[i - 1]], qr_ancilla[i], None)
+                            self.compose(OR(2), [qr_state[i], qr_ancilla[i - 1], qr_ancilla[i]],
+                                         inplace=True)
                         else:
                             self.ccx(qr_state[i], qr_ancilla[i - 1], qr_ancilla[i])
                     else:
                         if twos[i] == 1:
                             # OR needs the result argument as qubit not register, thus
                             # access the index [0]
-                            self.OR([qr_state[i], qr_ancilla[i - 1]], q_compare, None)
+                            self.compose(OR(2), [qr_state[i], qr_ancilla[i - 1], q_compare],
+                                         inplace=True)
                         else:
                             self.ccx(qr_state[i], qr_ancilla[i - 1], q_compare)
 
@@ -219,7 +222,8 @@ class IntegerComparator(BlueprintCircuit):
                             self.cx(qr_state[i], qr_ancilla[i])
                     else:
                         if twos[i] == 1:
-                            self.OR([qr_state[i], qr_ancilla[i - 1]], qr_ancilla[i], None)
+                            self.compose(OR(2), [qr_state[i], qr_ancilla[i - 1], qr_ancilla[i]],
+                                         inplace=True)
                         else:
                             self.ccx(qr_state[i], qr_ancilla[i - 1], qr_ancilla[i])
             else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The `IntegerComparator` circuit uses the `circuit.OR` (deprecated) instead of the `OR` boolean logic circuit and leads to a lot of deprecation warnings in both Terra and Aqua.

### Details and comments

Use `OR(num_qubits)` instead of `self.OR`

