### PR TITLE
Seed in examples/python/stochastic_swap.py reverted to 13

### DIFF
--- a/examples/python/stochastic_swap.py
+++ b/examples/python/stochastic_swap.py
@@ -93,7 +93,7 @@ expected.measure(qr[0], cr[1])
 expected_dag = circuit_to_dag(expected)
 
 # Run the pass on the dag from the input circuit
-pass_ = StochasticSwap(coupling, 20, 999)
+pass_ = StochasticSwap(coupling, 20, 13)
 after = pass_.run(dag)
 # Verify the output of the pass matches our expectation
 assert expected_dag == after


### PR DESCRIPTION
In PR #4297 changes the seed for the stochastic swapper in https://github.com/Qiskit/qiskit-terra/pull/4297/files#diff-b886ec7d2737688a7a519a5ec5b0ceccL96-R96

This makes the test `test.python.test_examples.TestPythonExamples.test_all_examples` failing in a MacOS with python 3.7.

I'm setting the seed back.