### PR TITLE
change tolerance check on DiagonalGate to match UnitaryGate.

### DIFF
--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1368,7 +1368,8 @@ class TestStandardMethods(QiskitTestCase):
                 free_params = len([p for p in sig.parameters.values() if p != p.POSITIONAL_ONLY])
             try:
                 gate = gate_class(*params[0:free_params])
-            except (CircuitError, QiskitError, AttributeError):
+            except (CircuitError, QiskitError, AttributeError, TypeError):
+                # TypeError: skips DiagonalGate
                 self.log.info(
                     'Cannot init gate with params only. Skipping %s',
                     gate_class)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This fixes a bug where it was possible to create a valid UnitaryGate which could be converted to an Isometry but would fail to decompose. The error was due to a difference in tolerances used for validating UnitaryGate and DiagonalGate.

Fixes #4369 
### Details and comments
In the case of UnitaryGate, numpy.allclose with atol=1e-8 and rtol=1e-5 was used while DiagonalGate used it's own implementation with a tolerance of 1e-10. This PR makes DiagonalGate with numpy.allclose and references the same tolerances referenced by UnitaryGate.

