### PR TITLE
Small tweaks to EquivalenceLibrary.draw()

### DIFF
--- a/releasenotes/notes/equiv-lib-draw-8f3c4bd897a2fa6c.yaml
+++ b/releasenotes/notes/equiv-lib-draw-8f3c4bd897a2fa6c.yaml
@@ -1,0 +1,33 @@
+---
+features:
+  - |
+    A new method :meth:`~qiskit.circuit.EquivalenceLibrary.draw` has been
+    added to the :class:`qiskit.circuit.EquivalenceLibrary` class. This
+    method can be used for drawing the contents of an equivalence library,
+    which can be useful for debugging. For example:
+
+    .. jupyter-execute:
+
+      from qiskit.circuit import EquivalenceLibrary
+      from qiskit.circuit import QuantumCircuit
+      from qiskit.circuit import QuantumRegister
+      from qiskit.circuit import Parameter
+      from qiskit.circuit.library import HGate
+      from qiskit.circuit.library import U2Gate
+      from qiskit.circuit.library import U3Gate
+
+      my_equiv_library = EquivalenceLibrary()
+
+      q = QuantumRegister(1, 'q')
+      def_h = QuantumCircuit(q)
+      def_h.append(U2Gate(0, pi), [q[0]], [])
+      my_equiv_library.add_equivalence(HGate(), def_h)
+
+      theta = Parameter('theta')
+      phi = Parameter('phi')
+      lam = Parameter('lam')
+      def_u2 = QuantumCircuit(q)
+      def_u2.append(U3Gate(pi / 2, phi, lam), [q[0]], [])
+      my_equiv_library.add_equivalence(U2Gate(phi, lam), def_u2)
+
+      my_equiv_library.draw()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The EquivalenceLibrary.draw() method was recently added in #4196, but
was missing a few things. Most critically was the ImportError message
for handling the missing optional visualization dependencies. This
commit reworks the import structure so that run time imports are avoided
and instead the optional dependencies missing are handled at import time
and at runtime if they're not present but are required a descriptive
error message is raised. At the same time a filename kwarg is added so
that instead of just outputting a pillow Image object a user can write
the visualization to disk. Then a release note is added to document the
new feature when it comes time to release 0.15.0.

### Details and comments