### PR TITLE
Add __len__ to Schedule in Pulse along with related tests.

### DIFF
--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -556,7 +556,7 @@ class Schedule(ScheduleComponent):
         return self.shift(time)
 
     def __len__(self) -> int:
-        """Return number of instruction in the schedule."""
+        """Return number of instructions in the schedule."""
         return len(self.instructions)
 
     def __repr__(self):

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -555,6 +555,10 @@ class Schedule(ScheduleComponent):
         """Return a new schedule which is shifted forward by ``time``."""
         return self.shift(time)
 
+    def __len__(self) -> int:
+        """Return number of instruction in the schedule."""
+        return len(self.instructions)
+
     def __repr__(self):
         name = format(self._name) if self._name else ""
         instructions = ", ".join([repr(instr) for instr in self.instructions[:50]])

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -532,7 +532,7 @@ class TestScheduleBuilding(BaseTestSchedule):
         self.assertEqual(
             reference_sched.timeslots[DriveChannel(1)], [(10, 60), (100, 100)])
 
-    def test_len_methods(self):
+    def test_len(self):
         """Test __len__ method"""
         sched = Schedule()
         self.assertEqual(len(sched), 0)

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -186,9 +186,11 @@ class TestScheduleBuilding(BaseTestSchedule):
         self.assertEqual(0, sched.start_time)
         self.assertEqual(0, sched.stop_time)
         self.assertEqual(0, sched.duration)
+        self.assertEqual(0, len(sched))
         self.assertEqual((), sched._children)
         self.assertEqual({}, sched.timeslots)
         self.assertEqual([], list(sched.instructions))
+        self.assertFalse(sched)
 
     def test_overlapping_schedules(self):
         """Test overlapping schedules."""
@@ -529,6 +531,16 @@ class TestScheduleBuilding(BaseTestSchedule):
             reference_sched.timeslots[DriveChannel(0)], [(10, 10), (10, 20)])
         self.assertEqual(
             reference_sched.timeslots[DriveChannel(1)], [(10, 60), (100, 100)])
+
+    def test_len_methods(self):
+        """Test __len__ method"""
+        sched = Schedule()
+        self.assertEqual(len(sched), 0)
+
+        lp0 = self.linear(duration=3, slope=0.2, intercept=0.1)
+        for j in range(1, 10):
+            sched = sched.append(Play(lp0, self.config.drive(0)))
+            self.assertEqual(len(sched), j)
 
 
 class TestDelay(BaseTestSchedule):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Issue: #4171

This commit adds a ```__len__``` function to the ```Schedule``` class in Pulse, allowing users to obtain the number of instructions present in that ```Schedule``` object with ```len()```.

Enabling the use of ```len()``` on a ```Schedule``` object also allows for checking if a schedule is empty. It acts as a replacement for bool() in the following situation - ```if not Schedule(): print('Empty')```, which will now print 'Empty'.

Tests related to the above were written in ```test/python/pulse/test_schedule.py``` by asserting that an empty schedule is ```False``` and ```len()``` equal to zero. Asserting the equality of ```len()``` and number of instructions appended to a schedule at each step were also tested.

### Details and comments
Although ```__len__``` being based on ```self.instructions``` is a bit inefficient, I was assured that it will be mitigated in a new refactor.


