### PR TITLE
Fix bug in visualization/pulse/matplotlib

### DIFF
--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -813,7 +813,7 @@ class ScheduleDrawer:
             # we need to overwrite pulse duration by an integer greater than zero,
             # otherwise waveform returns empty array and matplotlib will be crashed.
             if channels:
-                tf = schedule.timeslots.ch_duration(*channels)
+                tf = schedule.ch_duration(*channels)
             else:
                 tf = schedule.stop_time
             tf = tf or 1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`schedule.draw(channels=channels)` was failing because `schedule.duration` should have been used, not `schedule.timeslots.duration`

### Details and comments


