### PR TITLE
Unblock CI with fix for new jupyter execute and pin ddt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',
-    'jupyter_sphinx.execute',
+    'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ PyGithub
 wheel
 cython>=0.27.1
 pylatexenc>=1.4
-ddt>=1.2.0
+ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
 reno>=2.11.0
 Sphinx>=1.8.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`jupyter_sphinx` has a new version that gives a warning in docs.  Since warnings are fatal, this is not good.  This should fix that. Additionally, a new ddt release has been pushed which is broken (see datadriventests/ddt#83) which is blocking the CI too. This commit combines the fixes for both so CI can be unblocked again.

### Details and comments