### PR TITLE
Handle aer's current return format

### DIFF
--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -187,9 +187,12 @@ def format_statevector(vec, decimals=None):
     if isinstance(vec, np.ndarray):
         return vec
     num_basis = len(vec)
-    vec_complex = np.zeros(num_basis, dtype=complex)
-    for i in range(num_basis):
-        vec_complex[i] = vec[i][0] + 1j * vec[i][1]
+    if vec and isinstance(vec[0], complex):
+        vec_complex = np.array(vec, dtype=complex)
+    else:
+        vec_complex = np.zeros(num_basis, dtype=complex)
+        for i in range(num_basis):
+            vec_complex[i] = vec[i][0] + 1j * vec[i][1]
     if decimals:
         vec_complex = np.around(vec_complex, decimals=decimals)
     return vec_complex


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently aer is returning a list of complex numbers instead of a numpy
array for statevectors in it's result class. Now that marshmallow isn't
coercing the types anymore this is not getting coverted to a list of
lists of complex components and the postprocessing to normalize
statevectors is incorrectly trying to convert the complex numbers to
complex numbers. This commit fixes this by handling the case where we
receieve a list of complex numbers. Ideally longer term aer will be
updated to return a numpy array for statevectors so that the post
processing just gets skipped.

### Details and comments


