### PR TITLE
[Stable] Unblock CI with fix for new jupyter execute and pin ddt (#4407)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx_tabs.tabs',
-    'jupyter_sphinx.execute',
+    'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ PyGithub
 wheel
 cython>=0.27.1
 pylatexenc>=1.4
-ddt>=1.2.0
+ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
 reno>=2.11.0
 Sphinx>=1.8.3


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* fix for new jupyter execute

* Pin ddt to avoid broken release

The recent ddt 1.4.0 release does not work (see datadriventests/ddt#83)
and is blocking CI. This commit blacklists the new version in the
dev requirements list so we can run tests again.

Co-authored-by: Matthew Treinish <mtreinish@kortar.org>


### Details and comments

Backported from #4407
(cherry picked from commit 534d70a322184f94c446aee740b5db383049efbf)