### PR TITLE
Label support for controlled unitary

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -133,8 +133,10 @@ class UnitaryGate(Gate):
         """
         cmat = _compute_control_matrix(self.to_matrix(), num_ctrl_qubits)
         iso = isometry.Isometry(cmat, 0, 0)
-        return ControlledGate('c-unitary', self.num_qubits + num_ctrl_qubits, cmat,
-                              definition=iso.definition, label=label)
+        cunitary = ControlledGate('c-unitary', self.num_qubits + num_ctrl_qubits, cmat,
+                                  definition=iso.definition, label=label)
+        cunitary.base_gate.label = self.label
+        return cunitary
 
     def qasm(self):
         """ The qasm for a custom unitary gate


### PR DESCRIPTION
@ajavadia found the following issue in master:
```python
from qiskit import QuantumCircuit
from qiskit.extensions import UnitaryGate

circ = QuantumCircuit(2)
u = UnitaryGate([[1,0], [0,1]], label='my gate')
circ.compose(u.control(1), [0,1], inplace=True)
print(circ)
```
```
q_0: ───────■────────
     ┌──────┴───────┐
q_1: ┤ circuit57_dg ├
     └──────────────┘
```
With this PR, here is the output:
```
q_0: ─────■─────
     ┌────┴────┐
q_1: ┤ my gate ├
     └─────────┘
```