### PR TITLE
add DensityMatrix.to_statevector() for pure states

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -585,6 +585,24 @@ class DensityMatrix(QuantumState):
         vec._append_instruction(obj, qargs=qargs)
         return vec
 
+    def to_statevector(self):
+        """Return a statevector from a pure density matrix.
+        
+        Returns:
+            Statevector: The pure density matrix's corresponding statevector.
+                Corresponds to the eigenvector of the only non-zero eigenvalue.
+        
+        Raises:
+            QiskitError: if the state is not pure.
+        """
+        if not np.isclose(self.purity(), 1):
+            raise QiskitError(
+                    "Cannot obtain statevector from non-pure density matrix.")
+
+        eigvals, eigvecs = np.linalg.eig(self.data)
+        psi = eigvecs[:, np.argmax(eigvals)]  # eigenvector are in columns.
+        return Statevector(psi)
+
     def to_counts(self):
         """Returns the density matrix as a counts dict of probabilities.
 

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -610,7 +610,7 @@ class DensityMatrix(QuantumState):
                                                      atol=atol, rtol=rtol):
             raise QiskitError("Density matrix is not a pure state")
 
-        psi = evecs[:, np.argmax(evals)]  # eigenvalues returned in columns.
+        psi = evecs[:, np.argmax(evals)]  # eigenvectors returned in columns.
         return Statevector(psi)
 
     def to_counts(self):

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -606,11 +606,12 @@ class DensityMatrix(QuantumState):
         evals, evecs = np.linalg.eig(self._data)
 
         nonzero_evals = evals[abs(evals) > atol]
-        if len(nonzero_evals) != 1 or not np.isclose(abs(nonzero_evals[0]), 1,
+        if len(nonzero_evals) != 1 or not np.isclose(nonzero_evals[0], 1,
                                                      atol=atol, rtol=rtol):
             raise QiskitError("Density matrix is not a pure state")
 
-        return Statevector(np.sqrt(np.max(evals)) * evals[:, np.argmax(evals)])
+        psi = evecs[:, np.argmax(evals)]  # eigenvalues returned in columns.
+        return Statevector(psi)
 
     def to_counts(self):
         """Returns the density matrix as a counts dict of probabilities.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -591,6 +591,8 @@ class DensityMatrix(QuantumState):
         Returns:
             Statevector: The pure density matrix's corresponding statevector.
                 Corresponds to the eigenvector of the only non-zero eigenvalue.
+            atol (float): Absolute tolerance for checking operation validity.
+            rtol (float): Relative tolerance for checking operation validity.
 
         Raises:
             QiskitError: if the state is not pure.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -588,11 +588,13 @@ class DensityMatrix(QuantumState):
     def to_statevector(self, atol=None, rtol=None):
         """Return a statevector from a pure density matrix.
 
+        Args:
+            atol (float): Absolute tolerance for checking operation validity.
+            rtol (float): Relative tolerance for checking operation validity.
+
         Returns:
             Statevector: The pure density matrix's corresponding statevector.
                 Corresponds to the eigenvector of the only non-zero eigenvalue.
-            atol (float): Absolute tolerance for checking operation validity.
-            rtol (float): Relative tolerance for checking operation validity.
 
         Raises:
             QiskitError: if the state is not pure.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -587,11 +587,11 @@ class DensityMatrix(QuantumState):
 
     def to_statevector(self):
         """Return a statevector from a pure density matrix.
-        
+
         Returns:
             Statevector: The pure density matrix's corresponding statevector.
                 Corresponds to the eigenvector of the only non-zero eigenvalue.
-        
+
         Raises:
             QiskitError: if the state is not pure.
         """

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -359,6 +359,22 @@ class TestDensityMatrix(QiskitTestCase):
                     target[key] = 2 * j + i + 1
             self.assertDictAlmostEqual(target, vec.to_dict())
 
+    def test_densitymatrix_to_statevector_pure(self):
+        """Test converting a pure density matrix to statevector."""
+        state = 1/np.sqrt(2) * (np.array([1, 0, 0, 0, 0, 0, 0, 1]))
+        psi = Statevector(state)
+        rho = DensityMatrix(psi)
+        phi = rho.to_statevector()
+        self.assertAlmostEqual(psi, phi)
+
+    def test_densitymatrix_to_statevector_mixed(self):
+        """Test converting a pure density matrix to statevector."""
+        state_1 = 1/np.sqrt(2) * (np.array([1, 0, 0, 0, 0, 0, 0, 1]))
+        state_2 = 1/np.sqrt(2) * (np.array([0, 0, 0, 0, 0, 0, 1, 1]))
+        psi = 0.5 * (Statevector(state_1) + Statevector(state_2))
+        rho = DensityMatrix(psi)
+        self.assertRaises(QiskitError, rho.to_statevector)
+
     def test_probabilities_product(self):
         """Test probabilities method for product state"""
 

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -365,7 +365,7 @@ class TestDensityMatrix(QiskitTestCase):
         psi = Statevector(state)
         rho = DensityMatrix(psi)
         phi = rho.to_statevector()
-        self.assertAlmostEqual(psi, phi)
+        self.assertTrue(psi.equiv(phi))
 
     def test_densitymatrix_to_statevector_mixed(self):
         """Test converting a pure density matrix to statevector."""


### PR DESCRIPTION
This is handy when you have a circuit in a product state and you want the reduced state as a statevector (e.g. discarding an uncomputed ancilla).