### PR TITLE
Adds BasisTanslator, UnrollCustomDefinitions to default levels.

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -416,6 +416,37 @@ for plus_ry in [False, True]:
         cx_to_rxx = cnot_rxx_decompose(plus_ry, plus_rxx)
         _sel.add_equivalence(CXGate(), cx_to_rxx)
 
+q = QuantumRegister(2, 'q')
+cx_to_cz = QuantumCircuit(q)
+for inst, qargs, cargs in [
+        (HGate(), [q[1]], []),
+        (CZGate(), [q[0], q[1]], []),
+        (HGate(), [q[1]], [])
+]:
+    cx_to_cz.append(inst, qargs, cargs)
+_sel.add_equivalence(CXGate(), cx_to_cz)
+
+q = QuantumRegister(2, 'q')
+cx_to_iswap = QuantumCircuit(q)
+for inst, qargs, cargs in [
+        (HGate(), [q[0]], []),
+        (XGate(), [q[1]], []),
+        (HGate(), [q[1]], []),
+        (iSwapGate(), [q[0], q[1]], []),
+        (XGate(), [q[0]], []),
+        (XGate(), [q[1]], []),
+        (HGate(), [q[1]], []),
+        (iSwapGate(), [q[0], q[1]], []),
+        (HGate(), [q[0]], []),
+        (SGate(), [q[0]], []),
+        (SGate(), [q[1]], []),
+        (XGate(), [q[1]], []),
+        (HGate(), [q[1]], []),
+]:
+    cx_to_iswap.append(inst, qargs, cargs)
+_sel.add_equivalence(CXGate(), cx_to_iswap)
+
+
 # CCXGate
 
 q = QuantumRegister(3, 'q')

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -20,6 +20,8 @@
 from qiskit.qasm import pi
 from qiskit.circuit import EquivalenceLibrary, Parameter, QuantumCircuit, QuantumRegister
 
+from qiskit.quantum_info.synthesis.ion_decompose import cnot_rxx_decompose
+
 from . import (
     HGate,
     CHGate,
@@ -296,6 +298,14 @@ def_rz = QuantumCircuit(q)
 def_rz.append(U1Gate(theta), [q[0]], [])
 _sel.add_equivalence(RZGate(theta), def_rz)
 
+q = QuantumRegister(1, 'q')
+theta = Parameter('theta')
+rz_to_rxry = QuantumCircuit(q)
+rz_to_rxry.append(RXGate(pi/2), [q[0]], [])
+rz_to_rxry.append(RYGate(-theta), [q[0]], [])
+rz_to_rxry.append(RXGate(-pi/2), [q[0]], [])
+_sel.add_equivalence(RZGate(theta), rz_to_rxry)
+
 # CRZGate
 
 q = QuantumRegister(2, 'q')
@@ -447,6 +457,18 @@ _sel.add_equivalence(U1Gate(theta), def_u1)
 
 # U3Gate
 
+q = QuantumRegister(1, 'q')
+theta = Parameter('theta')
+phi = Parameter('phi')
+lam = Parameter('lam')
+u3_qasm_def = QuantumCircuit(q)
+u3_qasm_def.rz(lam, 0)
+u3_qasm_def.rx(pi/2, 0)
+u3_qasm_def.rz(theta+pi, 0)
+u3_qasm_def.rx(pi/2, 0)
+u3_qasm_def.rz(phi+3*pi, 0)
+_sel.add_equivalence(U3Gate(theta, phi, lam), u3_qasm_def)
+
 # CU3Gate
 
 q = QuantumRegister(2, 'q')
@@ -473,6 +495,11 @@ def_x.append(U3Gate(pi, 0, pi), [q[0]], [])
 _sel.add_equivalence(XGate(), def_x)
 
 # CXGate
+
+for plus_ry in [False, True]:
+    for plus_rxx in [False, True]:
+        cx_to_rxx = cnot_rxx_decompose(plus_ry, plus_rxx)
+        _sel.add_equivalence(CXGate(), cx_to_rxx)
 
 # CCXGate
 

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -28,9 +28,6 @@ from . import (
     MSGate,
     RGate,
     RCCXGate,
-    RC3XGate,
-    C3XGate,
-    C4XGate,
     RXGate,
     CRXGate,
     RXXGate,
@@ -128,88 +125,6 @@ for inst, qargs, cargs in [
 ]:
     def_rccx.append(inst, qargs, cargs)
 _sel.add_equivalence(RCCXGate(), def_rccx)
-
-# RC3XGate
-
-q = QuantumRegister(4, 'q')
-def_rc3x = QuantumCircuit(q)
-for inst, qargs, cargs in [
-        (HGate(), [q[3]], []),
-        (TGate(), [q[3]], []),
-        (CXGate(), [q[2], q[3]], []),
-        (TdgGate(), [q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[0], q[3]], []),
-        (TGate(), [q[3]], []),
-        (CXGate(), [q[1], q[3]], []),
-        (TdgGate(), [q[3]], []),
-        (CXGate(), [q[0], q[3]], []),
-        (TGate(), [q[3]], []),
-        (CXGate(), [q[1], q[3]], []),
-        (TdgGate(), [q[3]], []),
-        (HGate(), [q[3]], []),
-        (TGate(), [q[3]], []),
-        (CXGate(), [q[2], q[3]], []),
-        (TdgGate(), [q[3]], []),
-        (HGate(), [q[3]], []),
-]:
-    def_rc3x.append(inst, qargs, cargs)
-_sel.add_equivalence(RC3XGate(), def_rc3x)
-
-# C3XGate
-
-q = QuantumRegister(4, 'q')
-def_c3x = QuantumCircuit(q)
-for inst, qargs, cargs in [
-        (HGate(), [q[3]], []),
-        (CU1Gate(-pi/4), [q[0], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[0], q[1]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(pi/4), [q[1], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[0], q[1]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(-pi/4), [q[1], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[1], q[2]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(pi/4), [q[2], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[0], q[2]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(-pi/4), [q[2], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[1], q[2]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(pi/4), [q[2], q[3]], []),
-        (HGate(), [q[3]], []),
-        (CXGate(), [q[0], q[2]], []),
-        (HGate(), [q[3]], []),
-        (CU1Gate(-pi/4), [q[2], q[3]], []),
-        (HGate(), [q[3]], [])
-]:
-    def_c3x.append(inst, qargs, cargs)
-_sel.add_equivalence(C3XGate(), def_c3x)
-
-
-# C4XGate
-
-q = QuantumRegister(5, 'q')
-def_c4x = QuantumCircuit(q)
-for inst, qargs, cargs in [
-        (HGate(), [q[4]], []),
-        (CU1Gate(-pi / 2), [q[3], q[4]], []),
-        (HGate(), [q[4]], []),
-        (C3XGate(), [q[0], q[1], q[2], q[3]], []),
-        (HGate(), [q[4]], []),
-        (CU1Gate(pi / 2), [q[3], q[4]], []),
-        (HGate(), [q[4]], []),
-        (C3XGate(), [q[0], q[1], q[2], q[3]], []),
-        (C3XGate(pi / 8), [q[0], q[1], q[2], q[4]], []),
-]:
-    def_c4x.append(inst, qargs, cargs)
-_sel.add_equivalence(C4XGate(), def_c4x)
 
 # RXGate
 

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -47,6 +47,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
               initial_layout: Optional[Union[Layout, Dict, List]] = None,
               layout_method: Optional[str] = None,
               routing_method: Optional[str] = None,
+              translation_method: Optional[str] = None,
               seed_transpiler: Optional[int] = None,
               optimization_level: Optional[int] = None,
               pass_manager: Optional[PassManager] = None,
@@ -119,6 +120,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             Sometimes a perfect layout can be available in which case the layout_method
             may not run.
         routing_method: Name of routing pass ('basic', 'lookahead', 'stochastic', 'sabre')
+        translation_method: Name of translation pass ('unroller', 'translator')
         seed_transpiler: Sets random seed for the stochastic parts of the transpiler
         optimization_level: How much optimization to perform on the circuits.
             Higher levels generate more optimized circuits,
@@ -185,7 +187,9 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
                                     coupling_map=coupling_map, seed_transpiler=seed_transpiler,
                                     backend_properties=backend_properties,
                                     initial_layout=initial_layout, layout_method=layout_method,
-                                    routing_method=routing_method, backend=backend)
+                                    routing_method=routing_method,
+                                    translation_method=translation_method,
+                                    backend=backend)
 
         warnings.warn("The parameter pass_manager in transpile is being deprecated. "
                       "The preferred way to tranpile a circuit using a custom pass manager is"
@@ -200,7 +204,7 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
     # Get transpile_args to configure the circuit transpilation job(s)
     transpile_args = _parse_transpile_args(circuits, backend, basis_gates, coupling_map,
                                            backend_properties, initial_layout,
-                                           layout_method, routing_method,
+                                           layout_method, routing_method, translation_method,
                                            seed_transpiler, optimization_level,
                                            callback, output_name)
 
@@ -274,7 +278,8 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
     pass_manager_config = transpile_config['pass_manager_config']
 
     ms_basis_swap = None
-    if pass_manager_config.basis_gates is not None:
+    if (pass_manager_config.translation_method == 'unroller'
+            and pass_manager_config.basis_gates is not None):
         # Workaround for ion trap support: If basis gates includes
         # Mølmer-Sørensen (rxx) and the circuit includes gates outside the basis,
         # first unroll to u3, cx, then run MSBasisDecomposer to target basis.
@@ -309,7 +314,7 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
 
 def _parse_transpile_args(circuits, backend,
                           basis_gates, coupling_map, backend_properties,
-                          initial_layout, layout_method, routing_method,
+                          initial_layout, layout_method, routing_method, translation_method,
                           seed_transpiler, optimization_level,
                           callback, output_name) -> List[Dict]:
     """Resolve the various types of args allowed to the transpile() function through
@@ -336,6 +341,7 @@ def _parse_transpile_args(circuits, backend,
     initial_layout = _parse_initial_layout(initial_layout, circuits)
     layout_method = _parse_layout_method(layout_method, num_circuits)
     routing_method = _parse_routing_method(routing_method, num_circuits)
+    translation_method = _parse_translation_method(translation_method, num_circuits)
     seed_transpiler = _parse_seed_transpiler(seed_transpiler, num_circuits)
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
     output_name = _parse_output_name(output_name, circuits)
@@ -343,7 +349,7 @@ def _parse_transpile_args(circuits, backend,
 
     list_transpile_args = []
     for args in zip(basis_gates, coupling_map, backend_properties,
-                    initial_layout, layout_method, routing_method,
+                    initial_layout, layout_method, routing_method, translation_method,
                     seed_transpiler, optimization_level,
                     output_name, callback):
         transpile_args = {'pass_manager_config': PassManagerConfig(basis_gates=args[0],
@@ -352,10 +358,11 @@ def _parse_transpile_args(circuits, backend,
                                                                    initial_layout=args[3],
                                                                    layout_method=args[4],
                                                                    routing_method=args[5],
-                                                                   seed_transpiler=args[6]),
-                          'optimization_level': args[7],
-                          'output_name': args[8],
-                          'callback': args[9]}
+                                                                   translation_method=args[6],
+                                                                   seed_transpiler=args[7]),
+                          'optimization_level': args[8],
+                          'output_name': args[9],
+                          'callback': args[10]}
         list_transpile_args.append(transpile_args)
 
     return list_transpile_args
@@ -444,6 +451,12 @@ def _parse_routing_method(routing_method, num_circuits):
     if not isinstance(routing_method, list):
         routing_method = [routing_method] * num_circuits
     return routing_method
+
+
+def _parse_translation_method(translation_method, num_circuits):
+    if not isinstance(translation_method, list):
+        translation_method = [translation_method] * num_circuits
+    return translation_method
 
 
 def _parse_seed_transpiler(seed_transpiler, num_circuits):

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -36,6 +36,7 @@ from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates.u3 import U3Gate
 from qiskit.circuit.library.standard_gates.x import CXGate
 from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
 from qiskit.quantum_info.synthesis.weyl import weyl_coordinates
 from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
@@ -284,7 +285,8 @@ class TwoQubitBasisDecomposer():
     def __init__(self, gate, basis_fidelity=1.0):
         self.gate = gate
         self.basis_fidelity = basis_fidelity
-        basis = self.basis = TwoQubitWeylDecomposition(gate.to_matrix())
+
+        basis = self.basis = TwoQubitWeylDecomposition(Operator(gate).data)
 
         # FIXME: find good tolerances
         self.is_supercontrolled = np.isclose(basis.a, np.pi/4) and np.isclose(basis.c, 0.)

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -25,6 +25,7 @@ class PassManagerConfig:
                  coupling_map=None,
                  layout_method=None,
                  routing_method=None,
+                 translation_method=None,
                  backend_properties=None,
                  seed_transpiler=None):
         """Initialize a PassManagerConfig object
@@ -39,6 +40,8 @@ class PassManagerConfig:
                 placement.
             routing_method (str): the pass to use for routing qubits on the
                 architecture.
+            translation_method (str): the pass to use for translating gates to
+                basis_gates.
             backend_properties (BackendProperties): Properties returned by a
                 backend, including information on gate errors, readout errors,
                 qubit coherence times, etc.
@@ -50,5 +53,6 @@ class PassManagerConfig:
         self.coupling_map = coupling_map
         self.layout_method = layout_method
         self.routing_method = routing_method
+        self.translation_method = translation_method
         self.backend_properties = backend_properties
         self.seed_transpiler = seed_transpiler

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -21,6 +21,8 @@ from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
 
 from qiskit.transpiler.passes import Unroller
+from qiskit.transpiler.passes import BasisTranslator
+from qiskit.transpiler.passes import UnrollCustomDefinitions
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
@@ -70,6 +72,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     initial_layout = pass_manager_config.initial_layout
     layout_method = pass_manager_config.layout_method or 'trivial'
     routing_method = pass_manager_config.routing_method or 'stochastic'
+    translation_method = pass_manager_config.translation_method or 'translator'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -115,7 +118,14 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 5. Unroll to the basis
-    _unroll = Unroller(basis_gates)
+    if translation_method == 'unroller':
+        _unroll = [Unroller(basis_gates)]
+    elif translation_method == 'translator':
+        from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
+        _unroll = [UnrollCustomDefinitions(sel, basis_gates),
+                   BasisTranslator(sel, basis_gates)]
+    else:
+        raise TranspilerError("Invalid translation method %s." % translation_method)
 
     # 6. Fix any bad CX directions
     _direction_check = [CheckCXDirection(coupling_map)]

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -22,6 +22,8 @@ from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
 
 from qiskit.transpiler.passes import Unroller
+from qiskit.transpiler.passes import BasisTranslator
+from qiskit.transpiler.passes import UnrollCustomDefinitions
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
@@ -81,6 +83,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     initial_layout = pass_manager_config.initial_layout
     layout_method = pass_manager_config.layout_method or 'dense'
     routing_method = pass_manager_config.routing_method or 'stochastic'
+    translation_method = pass_manager_config.translation_method or 'translator'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -127,7 +130,14 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 5. Unroll to the basis
-    _unroll = Unroller(basis_gates)
+    if translation_method == 'unroller':
+        _unroll = [Unroller(basis_gates)]
+    elif translation_method == 'translator':
+        from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
+        _unroll = [UnrollCustomDefinitions(sel, basis_gates),
+                   BasisTranslator(sel, basis_gates)]
+    else:
+        raise TranspilerError("Invalid translation method %s." % translation_method)
 
     # 6. Fix any bad CX directions
     _direction_check = [CheckCXDirection(coupling_map)]

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -22,6 +22,8 @@ from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
 
 from qiskit.transpiler.passes import Unroller
+from qiskit.transpiler.passes import BasisTranslator
+from qiskit.transpiler.passes import UnrollCustomDefinitions
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import CXDirection
@@ -85,6 +87,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     initial_layout = pass_manager_config.initial_layout
     layout_method = pass_manager_config.layout_method or 'dense'
     routing_method = pass_manager_config.routing_method or 'stochastic'
+    translation_method = pass_manager_config.translation_method or 'translator'
     seed_transpiler = pass_manager_config.seed_transpiler
     backend_properties = pass_manager_config.backend_properties
 
@@ -131,7 +134,14 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         raise TranspilerError("Invalid routing method %s." % routing_method)
 
     # 5. Unroll to the basis
-    _unroll = [Unroller(basis_gates)]
+    if translation_method == 'unroller':
+        _unroll = [Unroller(basis_gates)]
+    elif translation_method == 'translator':
+        from qiskit.circuit.equivalence_library import SessionEquivalenceLibrary as sel
+        _unroll = [UnrollCustomDefinitions(sel, basis_gates),
+                   BasisTranslator(sel, basis_gates)]
+    else:
+        raise TranspilerError("Invalid translation method %s." % translation_method)
 
     # 6. Fix any CX direction mismatch
     _direction_check = [CheckCXDirection(coupling_map)]

--- a/releasenotes/notes/add-basistranslator-to-default-levels-1c0de250f8ca4a59.yaml
+++ b/releasenotes/notes/add-basistranslator-to-default-levels-1c0de250f8ca4a59.yaml
@@ -1,0 +1,14 @@
+---
+prelude:
+    The transpiler now supports directly targeting a broader range of
+    device basis sets, including backends implementing the CZ and
+    iSwap gates.
+features:
+  - |
+    A new ``translation_method`` keyword argument has been added to
+    ``qiskit.transpile`` to allow selection of the method to be used
+    for translating circuits to the available device gates. For example,
+    ``transpile(circ, backend, translation_method='translator')``. Valid
+    choices are ``'unroller'`` to use the ``Unroller`` pass and
+    ``'translator'`` to use the ``BasisTranslator`` pass. The default value
+    is ``'translator'``.

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1365,7 +1365,7 @@ class TestStandardMethods(QiskitTestCase):
                 # n_qubits argument is no longer supported.
                 free_params = 2
             else:
-                free_params = len([p for p in sig.parameters.values() if p != p.POSITIONAL_ONLY])
+                free_params = len(set(sig.parameters) - {'label'})
             try:
                 gate = gate_class(*params[0:free_params])
             except (CircuitError, QiskitError, AttributeError):

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -137,18 +137,10 @@ class TestStandardEquivalenceLibrary(QiskitTestCase):
         float_entry = std_eqlib.get_entry(float_gate)
 
         if not param_gate.definition:
-            self.assertEqual(len(param_entry), 0)
-            self.assertEqual(len(float_entry), 0)
             return
 
-        if gate_class is CXGate:
-            # CXGate currently has a definition in terms of CXGate.
-            self.assertEqual(len(param_entry), 0)
-            self.assertEqual(len(float_entry), 0)
-            return
-
-        self.assertEqual(len(param_entry), 1)
-        self.assertEqual(len(float_entry), 1)
+        self.assertGreaterEqual(len(param_entry), 1)
+        self.assertGreaterEqual(len(float_entry), 1)
 
         param_qc = QuantumCircuit(param_gate.num_qubits)
         float_qc = QuantumCircuit(float_gate.num_qubits)
@@ -156,5 +148,7 @@ class TestStandardEquivalenceLibrary(QiskitTestCase):
         param_qc.append(param_gate, param_qc.qregs[0])
         float_qc.append(float_gate, float_qc.qregs[0])
 
-        self.assertEqual(param_entry[0], param_qc.decompose())
-        self.assertEqual(float_entry[0], float_qc.decompose())
+        self.assertTrue(any(equiv == param_qc.decompose()
+                            for equiv in param_entry))
+        self.assertTrue(any(equiv == float_qc.decompose()
+                            for equiv in float_entry))

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -14,11 +14,13 @@
 
 """Tests basic functionality of the transpile function"""
 
-import math
 import io
+import sys
+import math
+
 from logging import StreamHandler, getLogger
 from unittest.mock import patch
-import sys
+
 from ddt import ddt, data
 
 from qiskit import BasicAer
@@ -695,6 +697,27 @@ class TestTranspile(QiskitTestCase):
         out = transpile(qc, basis_gates=['rx', 'ry', 'rxx'], optimization_level=optimization_level)
 
         self.assertEqual(qc, out)
+
+    @data(
+        ['cx', 'u3'],
+        ['cz', 'u3'],
+        ['cz', 'rx', 'rz'],
+        ['rxx', 'rx', 'ry'],
+        ['iswap', 'rx', 'rz'],
+    )
+    def test_block_collection_runs_for_non_cx_bases(self, basis_gates):
+        """Verify block collection is run when a single two qubit gate is in the basis."""
+        twoq_gate, *_ = basis_gates
+
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1)
+        qc.cx(1, 0)
+        qc.cx(0, 1)
+        qc.cx(0, 1)
+
+        out = transpile(qc, basis_gates=basis_gates, optimization_level=3)
+
+        self.assertLessEqual(out.count_ops()[twoq_gate], 2)
 
 
 class StreamHandlerRaiseException(StreamHandler):

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -21,8 +21,9 @@ from numpy import pi
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.test import QiskitTestCase
 from qiskit.circuit import Gate, Parameter, EquivalenceLibrary
-from qiskit.converters import circuit_to_dag, circuit_to_instruction
+from qiskit.converters import circuit_to_dag, dag_to_circuit, circuit_to_instruction
 from qiskit.exceptions import QiskitError
+from qiskit.quantum_info import Operator
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes.basis import BasisTranslator, UnrollCustomDefinitions
 
@@ -359,8 +360,8 @@ class TestUnrollerCompatability(QiskitTestCase):
         circuit.x(qr[2])
         circuit.y(qr[1])
         circuit.z(qr[0])
-        circuit.snapshot('0')
-        circuit.measure(qr, cr)
+        # circuit.snapshot('0')
+        # circuit.measure(qr, cr)
         dag = circuit_to_dag(circuit)
         pass_ = UnrollCustomDefinitions(std_eqlib, ['u3', 'cx', 'id'])
         dag = pass_.run(dag)
@@ -460,11 +461,12 @@ class TestUnrollerCompatability(QiskitTestCase):
         ref_circuit.u3(0, 0, pi/4, qr[2])
         ref_circuit.u3(0.3, 0.0, -0.1, qr[2])
         ref_circuit.u3(pi, 0, pi, qr[2])
-        ref_circuit.snapshot('0')
-        ref_circuit.measure(qr, cr)
-        ref_dag = circuit_to_dag(ref_circuit)
+        # ref_circuit.snapshot('0')
+        # ref_circuit.measure(qr, cr)
+        # ref_dag = circuit_to_dag(ref_circuit)
 
-        self.assertEqual(unrolled_dag, ref_dag)
+        self.assertTrue(
+            Operator(dag_to_circuit(unrolled_dag)).equiv(ref_circuit))
 
     def test_simple_unroll_parameterized_without_expressions(self):
         """Verify unrolling parameterized gates without expressions."""

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -25,6 +25,7 @@ from qiskit.converters import circuit_to_dag
 from qiskit.execute import execute
 from qiskit.transpiler.passes import ConsolidateBlocks
 from qiskit.providers.basicaer import UnitarySimulatorPy
+from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.measures import process_fidelity
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler import PassManager
@@ -53,7 +54,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         result = execute(qc, sim).result()
         unitary = UnitaryGate(result.get_unitary())
         self.assertEqual(len(new_dag.op_nodes()), 1)
-        fidelity = process_fidelity(new_dag.op_nodes()[0].op.to_matrix(), unitary.to_matrix())
+        fidelity = process_fidelity(Operator(new_dag.op_nodes()[0].op), unitary.to_matrix())
         self.assertAlmostEqual(fidelity, 1.0, places=7)
 
     def test_wire_order(self):
@@ -71,10 +72,10 @@ class TestConsolidateBlocks(QiskitTestCase):
         self.assertEqual(new_node.qargs, [qr[0], qr[1]])
         # the canonical CNOT matrix occurs when the control is more
         # significant than target, which is the case here
-        fidelity = process_fidelity(new_node.op.to_matrix(), np.array([[1, 0, 0, 0],
-                                                                       [0, 1, 0, 0],
-                                                                       [0, 0, 0, 1],
-                                                                       [0, 0, 1, 0]]))
+        fidelity = process_fidelity(Operator(new_node.op), np.array([[1, 0, 0, 0],
+                                                                     [0, 1, 0, 0],
+                                                                     [0, 0, 0, 1],
+                                                                     [0, 0, 1, 0]]))
         self.assertAlmostEqual(fidelity, 1.0, places=7)
 
     def test_topological_order_preserved(self):
@@ -124,7 +125,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         result = execute(qc, sim).result()
         unitary = UnitaryGate(result.get_unitary())
         self.assertEqual(len(new_dag.op_nodes()), 1)
-        fidelity = process_fidelity(new_dag.op_nodes()[0].op.to_matrix(), unitary.to_matrix())
+        fidelity = process_fidelity(Operator(new_dag.op_nodes()[0].op), unitary.to_matrix())
         self.assertAlmostEqual(fidelity, 1.0, places=7)
 
     def test_block_spanning_two_regs(self):
@@ -145,7 +146,7 @@ class TestConsolidateBlocks(QiskitTestCase):
         result = execute(qc, sim).result()
         unitary = UnitaryGate(result.get_unitary())
         self.assertEqual(len(new_dag.op_nodes()), 1)
-        fidelity = process_fidelity(new_dag.op_nodes()[0].op.to_matrix(), unitary.to_matrix())
+        fidelity = process_fidelity(Operator(new_dag.op_nodes()[0].op), unitary.to_matrix())
         self.assertAlmostEqual(fidelity, 1.0, places=7)
 
     def test_block_spanning_two_regs_different_index(self):


### PR DESCRIPTION
Resolves #3146
Resolves #3086

# Summary
- Fix free param calculation in standard gates to_matrix test.

Previous code mis-calculated the number of available free parameters
from the gate signature, resulting in creation of gates like
XGate(label=0.1). These would cause errors if the circuits containing
these gates were drawn.

-  Remove definition for C3XGate, C4XGate due to name conflict with MCXGate.

-  Add Rz->RX,RY, U3->RX,RY, CX->RXX to StandardEquivalenceLibrary.

Updates BasisTranslator-Unroller compatability test
test_basis_translator.TestUnrollerCompatibility.test_unroll_all_instructions
to verify the generated circuit is equivalent (with snapshot,
measure instructions removed) as the circuit transpiled by the
BasisTranslator is no longer gate-for-gate equal with that of the
Unroller.

- Add SynthesizeUnitaries and BasisTranslator into default levels.

~on-hold for #4442 .~

### Details and comments


