### PR TITLE
Gate.to_matrix implementation

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -46,7 +46,15 @@ class Gate(Instruction):
             CircuitError: If a Gate subclass does not implement this method an
                 exception will be raised when this base class method is called.
         """
-        raise CircuitError("to_matrix not defined for this {}".format(type(self)))
+        if self.definition:
+            # Initialize an identity operator of the correct size of the circuit
+            from qiskit.quantum_info import Operator
+            op = Operator(np.eye(2 ** self.num_qubits))
+            op._definition_to_matrix(self.definition)
+            return op.data
+        else:
+            raise CircuitError('neither to_matrix nor definition defined '
+                               'for gate "{}": {}'.format(self.name, repr(self)))
 
     def power(self, exponent: float):
         """Creates a unitary gate as `gate^exponent`.

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -42,15 +42,19 @@ class Gate(Instruction):
     def to_matrix(self) -> np.ndarray:
         """Return a Numpy.array for the gate unitary matrix.
 
+        Returns:
+            ndarray: Matrix representation of gate.
+
         Raises:
             CircuitError: If a Gate subclass does not implement this method an
                 exception will be raised when this base class method is called.
         """
         if self.definition:
             # Initialize an identity operator of the correct size of the circuit
+            # pylint: disable=cyclic-import
             from qiskit.quantum_info import Operator
             op = Operator(np.eye(2 ** self.num_qubits))
-            op._definition_to_matrix(self.definition)
+            op._definition_to_matrix(self)
             return op.data
         else:
             raise CircuitError('neither to_matrix nor definition defined '

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -512,7 +512,6 @@ class Operator(BaseOperator):
         # If the instruction doesn't have a matrix defined we use its
         # circuit decomposition definition if it exists, otherwise we
         # cannot compose this gate and raise an error.
-        #import ipdb;ipdb.set_trace()
         if obj.definition is None:
             raise QiskitError('Cannot apply Instruction: {}'.format(obj.name))
         for instr, qregs, cregs in obj.definition:

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -512,6 +512,7 @@ class Operator(BaseOperator):
         # If the instruction doesn't have a matrix defined we use its
         # circuit decomposition definition if it exists, otherwise we
         # cannot compose this gate and raise an error.
+        #import ipdb;ipdb.set_trace()
         if obj.definition is None:
             raise QiskitError('Cannot apply Instruction: {}'.format(obj.name))
         for instr, qregs, cregs in obj.definition:
@@ -535,4 +536,4 @@ class Operator(BaseOperator):
             op = self.compose(mat, qargs=qargs)
             self._data = op.data
         else:
-            self._definition_to_matrix(obj.definition, qargs=qargs)
+            self._definition_to_matrix(obj, qargs=qargs)

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -508,13 +508,13 @@ class Operator(BaseOperator):
                 pass
         return mat
 
-    def _definition_to_matrix(self, definition, qargs=None):
+    def _definition_to_matrix(self, obj, qargs=None):
         # If the instruction doesn't have a matrix defined we use its
         # circuit decomposition definition if it exists, otherwise we
         # cannot compose this gate and raise an error.
-        if definition is None:
+        if obj.definition is None:
             raise QiskitError('Cannot apply Instruction: {}'.format(obj.name))
-        for instr, qregs, cregs in definition:
+        for instr, qregs, cregs in obj.definition:
             if cregs:
                 raise QiskitError(
                     'Cannot apply instruction with classical registers: {}'.format(

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1354,8 +1354,7 @@ class TestStandardMethods(QiskitTestCase):
         self.params = [0.1 * i for i in range(10)]
         self.simulator = BasicAer.get_backend('unitary_simulator')
 
-    @data(*[gate for gate in
-            Gate.__subclasses__() + ControlledGate.__subclasses__()])
+    @data(*(Gate.__subclasses__() + ControlledGate.__subclasses__()))
     def test_to_matrix(self, gate_class):
         """test gates implementing to_matrix generate matrix which matches
         definition."""

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1345,6 +1345,7 @@ class TestStandard3Q(QiskitTestCase):
                          [self.qr[1], self.qr2[1], self.qr3[1]])
         self.assertEqual(instruction_set.instructions[2].params, [])
 
+
 @ddt
 class TestStandardMethods(QiskitTestCase):
     """Standard Extension Test."""
@@ -1388,8 +1389,6 @@ class TestStandardMethods(QiskitTestCase):
             return
         definition_unitary = execute([circ],
                                      self.simulator).result().get_unitary()
-        if not matrix_equal(definition_unitary, gate_matrix):
-            import ipdb;ipdb.set_trace()
         self.assertTrue(matrix_equal(definition_unitary, gate_matrix))
         self.assertTrue(is_unitary_matrix(gate_matrix))
 

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1358,35 +1358,38 @@ class TestStandardMethods(QiskitTestCase):
         gate_class_list = Gate.__subclasses__() + ControlledGate.__subclasses__()
         simulator = BasicAer.get_backend('unitary_simulator')
         for gate_class in gate_class_list:
-            sig = signature(gate_class)
-            if gate_class == MSGate:
-                # due to the signature (num_qubits, theta, *, n_qubits=Noe) the signature detects
-                # 3 arguments but really its only 2. This if can be removed once the deprecated
-                # n_qubits argument is no longer supported.
-                free_params = 2
-            else:
-                free_params = len([p for p in sig.parameters.values() if p != p.POSITIONAL_ONLY])
-            try:
-                gate = gate_class(*params[0:free_params])
-            except (CircuitError, QiskitError, AttributeError):
-                self.log.info(
-                    'Cannot init gate with params only. Skipping %s',
-                    gate_class)
-                continue
-            if gate.name in ['U', 'CX']:
-                continue
-            circ = QuantumCircuit(gate.num_qubits)
-            circ.append(gate, range(gate.num_qubits))
-            try:
-                gate_matrix = gate.to_matrix()
-            except CircuitError:
-                # gate doesn't implement to_matrix method: skip
-                self.log.info('to_matrix method FAILED for "%s" gate',
-                              gate.name)
-                continue
-            definition_unitary = execute([circ], simulator).result().get_unitary()
-            self.assertTrue(matrix_equal(definition_unitary, gate_matrix))
-            self.assertTrue(is_unitary_matrix(gate_matrix))
+            with self.subTest(i=gate_class):
+                sig = signature(gate_class)
+                if gate_class == MSGate:
+                    # due to the signature (num_qubits, theta, *, n_qubits=Noe) the signature
+                    # detects 3 arguments but really its only 2. This if can be removed once
+                    # the deprecated qubits argument is no longer supported.
+                    free_params = 2
+                else:
+                    free_params = len([p for p in sig.parameters.values()
+                                       if p != p.POSITIONAL_ONLY])
+                try:
+                    gate = gate_class(*params[0:free_params])
+                except (CircuitError, QiskitError, AttributeError):
+                    self.log.info(
+                        'Cannot init gate with params only. Skipping %s',
+                        gate_class)
+                    continue
+                if gate.name in ['U', 'CX']:
+                    continue
+                circ = QuantumCircuit(gate.num_qubits)
+                circ.append(gate, range(gate.num_qubits))
+                try:
+                    gate_matrix = gate.to_matrix()
+                except CircuitError:
+                    # gate doesn't implement to_matrix method: skip
+                    self.log.info('to_matrix method FAILED for "%s" gate',
+                                  gate.name)
+                    continue
+                definition_unitary = execute([circ],
+                                             simulator).result().get_unitary()
+                self.assertTrue(matrix_equal(definition_unitary, gate_matrix))
+                self.assertTrue(is_unitary_matrix(gate_matrix))
 
 
 @ddt

--- a/test/python/circuit/test_gate.py
+++ b/test/python/circuit/test_gate.py
@@ -14,16 +14,13 @@
 
 """Test Qiskit's Gate class."""
 
-import unittest
 
 import numpy as np
 
 from qiskit.circuit import Gate
 from qiskit.circuit import Parameter
-from qiskit.circuit import Instruction
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit import QuantumRegister, ClassicalRegister
-from qiskit.quantum_info import Operator
+from qiskit.circuit import QuantumRegister
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.exceptions import CircuitError
 
@@ -40,6 +37,17 @@ class TestGate(QiskitTestCase):
         gate_matrix = circ.to_gate().to_matrix()
         self.assertIsInstance(gate_matrix, np.ndarray)
         self.assertEqual(gate_matrix.shape, (4, 4))
+
+    def test_to_matrix_from_parameterized_definition(self):
+        """Test generating matrix from definition."""
+        # Although this currently fails it could be allowed if Operator
+        # could do symbolic composition.
+        qr = QuantumRegister(1)
+        angle = Parameter('α')
+        circ = QuantumCircuit(qr, name='circ')
+        circ.u1(angle, qr[0])
+        with self.assertRaises(TypeError):
+            circ.to_gate().to_matrix()
 
     def test_to_matrix_from_opaque_gate(self):
         """Test to_matrix raises for opaque gate."""

--- a/test/python/circuit/test_gate.py
+++ b/test/python/circuit/test_gate.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test Qiskit's Gate class."""
+
+import unittest
+
+import numpy as np
+
+from qiskit.circuit import Gate
+from qiskit.circuit import Parameter
+from qiskit.circuit import Instruction
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumRegister, ClassicalRegister
+from qiskit.quantum_info import Operator
+from qiskit.test import QiskitTestCase
+from qiskit.circuit.exceptions import CircuitError
+
+
+class TestGate(QiskitTestCase):
+    """Gate class tests."""
+
+    def test_to_matrix_from_definition(self):
+        """Test generating matrix from definition."""
+        qr = QuantumRegister(2)
+        circ = QuantumCircuit(qr, name='circ')
+        circ.t(qr[1])
+        circ.u3(0.1, 0.2, -0.2, qr[0])
+        gate_matrix = circ.to_gate().to_matrix()
+        self.assertIsInstance(gate_matrix, np.ndarray)
+        self.assertEqual(gate_matrix.shape, (4, 4))
+
+    def test_to_matrix_from_opaque_gate(self):
+        """Test to_matrix raises for opaque gate."""
+        opaque = Gate('opaque', 2, [])
+        with self.assertRaises(CircuitError):
+            opaque.to_matrix()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
By default Gate objects do not define implement `to_matrix`, however if the gate includes a definition the Operator class can be used to compute the matrix representation. Perhaps some care will have to be taken when using this due to the method's computational overhead.

fixes #4448 
### Details and comments


