### PR TITLE
Fix NLocal __str__ method to always return correct string

### DIFF
--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -918,8 +918,8 @@ class NLocal(BlueprintCircuit):
         basis_gates = ['id', 'x', 'y', 'z', 'h', 's', 't', 'sdg', 'tdg', 'rx', 'ry', 'rz',
                        'rxx', 'ryy', 'cx', 'cy', 'cz', 'ch', 'crx', 'cry', 'crz', 'swap',
                        'cswap', 'ccx', 'cu1', 'cu3', 'u1', 'u2', 'u3']
-        return transpile(self, basis_gates=basis_gates,
-                         optimization_level=0).draw().single_string()
+        return str(transpile(self, basis_gates=basis_gates,
+                             optimization_level=0)).single_string()
 
 
 def get_parameters(block: Union[QuantumCircuit, Instruction]) -> List[Parameter]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The NLocal.__str__ method was relying on the QuantumCircuit.draw()
method to return a text drawer representation of the circuit. However,
this was relying on an implicit default for the circuit_drawer default
method being the text drawer which isn't always true. A user can set an
alternative default backend using a user config file. In such cases the
return from str(NLocal()) will return a mpl figure or pillow image repr
instead of the intent. This commit changes how the text mode
visualization is generated to just casting the transpiled QuantumCircuit
as a string. The __str__ method for the QuantumCircuit calls draw with
the backend explicitly set to text, so that it always returns the
expected ascii art diagram.

### Details and comments