### PR TITLE
Removing RemoveResetInZeroState from transpiler optimization level 0

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -34,7 +34,6 @@ from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler.passes import FullAncillaAllocation
 from qiskit.transpiler.passes import EnlargeWithAncilla
-from qiskit.transpiler.passes import RemoveResetInZeroState
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passes import CheckCXDirection
 
@@ -49,7 +48,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     Any unused physical qubit is allocated as ancilla space.
 
     The pass manager then unrolls the circuit to the desired basis, and transforms the
-    circuit to match the coupling map. Finally, extra resets are removed.
+    circuit to match the coupling map.
 
     Note:
         In simulators where ``coupling_map=None``, only the unrolling and
@@ -120,9 +119,6 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _direction = [CXDirection(coupling_map)]
 
-    # 7. Remove zero-state reset
-    _reset = RemoveResetInZeroState()
-
     # Build pass manager
     pm0 = PassManager()
     if coupling_map:
@@ -136,6 +132,5 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     if coupling_map and not coupling_map.is_symmetric:
         pm0.append(_direction_check)
         pm0.append(_direction, condition=_direction_condition)
-    pm0.append(_reset)
 
     return pm0

--- a/releasenotes/notes/level0_RemoveResetInZeroState-942c0fb19cb6c087.yaml
+++ b/releasenotes/notes/level0_RemoveResetInZeroState-942c0fb19cb6c087.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The pass ``RemoveResetInZeroState`` is not run in transpiler optimization level 0 anymore.

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -70,6 +70,7 @@ class TestPresetPassManager(QiskitTestCase):
         result = transpile(circuit, basis_gates=None, optimization_level=0)
         self.assertEqual(result, circuit)
 
+
 @ddt
 class TestTranspileLevels(QiskitTestCase):
     """Test transpiler on fake backend"""

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -61,6 +61,14 @@ class TestPresetPassManager(QiskitTestCase):
         result = transpile(circuit, basis_gates=None, optimization_level=level)
         self.assertEqual(result, circuit)
 
+    def test_level0_keeps_reset(self):
+        """Test level 0 should keep the reset instructions"""
+        q = QuantumRegister(2, name='q')
+        circuit = QuantumCircuit(q)
+        circuit.reset(q[0])
+        circuit.reset(q[0])
+        result = transpile(circuit, basis_gates=None, optimization_level=0)
+        self.assertEqual(result, circuit)
 
 @ddt
 class TestTranspileLevels(QiskitTestCase):
@@ -325,13 +333,6 @@ class TestFinalLayouts(QiskitTestCase):
                         11: ancilla[6], 12: ancilla[7], 13: ancilla[8], 14: ancilla[9],
                         15: ancilla[10], 16: ancilla[11], 17: ancilla[12], 18: ancilla[13],
                         19: ancilla[14]}
-
-        # noise_adaptive_layout = {6: qr[0], 11: qr[1], 5: qr[2], 10: qr[3], 15: qr[4],
-        #                          0: ancilla[0], 1: ancilla[1], 2: ancilla[2], 3: ancilla[3],
-        #                          4: ancilla[4], 7: ancilla[5], 8: ancilla[6], 9: ancilla[7],
-        #                          12: ancilla[8], 13: ancilla[9], 14: ancilla[10],
-        #                          16: ancilla[11], 17: ancilla[12], 18: ancilla[13],
-        #                          19: ancilla[14]}
 
         expected_layout_level0 = trivial_layout
         expected_layout_level1 = dense_layout


### PR DESCRIPTION
Transpiler optimization level 0 should not remove the reset instructions.