### PR TITLE
Enable parallel docs builds and bump reno min version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ cython>=0.27.1
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
-reno>=3.1.0
+reno>=3.1.0;python_version>'3.5'
 Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ cython>=0.27.1
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
-reno>=2.11.0
+reno>=3.1.0
 Sphinx>=1.8.3
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11

--- a/tox.ini
+++ b/tox.ini
@@ -44,4 +44,4 @@ deps =
   qiskit-aer
   qiskit-ibmq-provider
 commands =
-  sphinx-build -W -b html docs/ docs/_build/html {posargs}
+  sphinx-build -W -b html -j auto docs/ docs/_build/html {posargs}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recent reno release 3.1.0 the sphinx extension config option
'parallel_read_safe' was set to true. [1] This makes it possible to run
sphinx builds with reno in parallel without a warning being raised. This
commit does just that and adds '-j auto' to the default sphinx build
command in the tox docs job. This should hopefully speed up the docs
builds in CI (although the degree to which is limited by the available
resources in the CI nodes) and for local builds.

### Details and comments

[1] https://opendev.org/openstack/reno/commit/cc09e3d38c2c1046a529270f133de525c0692809