### PR TITLE
improve floating point precision in backend properties

### DIFF
--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -431,20 +431,24 @@ class BackendProperties(SimpleNamespace):
         Raises:
             BackendPropertyError: If the units aren't recognized.
         """
-        prefixes = {
-            'p': 1e-12,
-            'n': 1e-9,
-            'u': 1e-6,
-            'µ': 1e-6,
-            'm': 1e-3,
+        downfactors = {
+            'p': 1e12,
+            'n': 1e9,
+            'u': 1e6,
+            'µ': 1e6,
+            'm': 1e3
+        }
+        upfactors = {
             'k': 1e3,
             'M': 1e6,
             'G': 1e9
         }
         if not unit:
             return value
-        try:
-            return value * prefixes[unit[0]]
-        except KeyError:
+        if unit[0] in downfactors:
+            return value / downfactors[unit[0]]
+        elif unit[0] in upfactors:
+            return value * upfactors[unit[0]]
+        else:
             raise BackendPropertyError(
                 "Could not understand units: {u}".format(u=unit))

--- a/test/python/providers/test_backendproperties.py
+++ b/test/python/providers/test_backendproperties.py
@@ -95,7 +95,7 @@ class BackendpropertiesTestCase(QiskitTestCase):
     def test_apply_prefix(self):
         """Testing unit conversions."""
         self.assertEqual(self.properties._apply_prefix(71.9500421005539, 'µs'),
-                         7.195004210055389e-05)
+                         7.19500421005539e-05)
         self.assertEqual(self.properties._apply_prefix(71.9500421005539, 'ms'),
                          0.0719500421005539)
 


### PR DESCRIPTION
Small change to how conversions to SI are done in Qiskit, so very small numbers (e.g. 1e-12) are never used, which could cause distortions to precision. This was causing some issues when converting `gate_length`s to `dt` (did not become multiple of dt).