### PR TITLE
Correct typo in deprecation warning

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -59,7 +59,7 @@ def euler_angles_1q(unitary_matrix):
     Raises:
         QiskitError: if unitary_matrix not 2x2, or failure
     """
-    warnings.warn("euler_angles_q1` is deprecated. "
+    warnings.warn("euler_angles_1q` is deprecated. "
                   "Use `synthesis.OneQubitEulerDecomposer().angles instead.",
                   DeprecationWarning)
     if unitary_matrix.shape != (2, 2):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Deprecration notice for 'euler_angles_1q' said 'euler_angles_q1'.


