### PR TITLE
Remove circuit_instruction_map deprecated attribute

### DIFF
--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -16,7 +16,6 @@
 
 """Model and schema for pulse defaults."""
 import copy
-import warnings
 from types import SimpleNamespace
 from typing import Any, Dict, List
 

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -277,13 +277,6 @@ class PulseDefaults(SimpleNamespace):
                                  self.buffer, self.pulse_library,
                                  self.cmd_def))
 
-    @property
-    def circuit_instruction_map(self):
-        """Deprecated property, use ``instruction_schedule_map`` instead."""
-        warnings.warn("The `circuit_instruction_map` attribute has been renamed to "
-                      "`instruction_schedule_map`.", DeprecationWarning)
-        return self.instruction_schedule_map
-
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]
         meas_freqs = [freq / 1e9 for freq in self.meas_freq_est]

--- a/releasenotes/notes/remove-circuit-instruction-map-37fb34c3b5fe033c.yaml
+++ b/releasenotes/notes/remove-circuit-instruction-map-37fb34c3b5fe033c.yaml
@@ -1,0 +1,6 @@
+---
+other:
+  - |
+    Removed ``circuit_instruction_map`` attribute from ``PulseDefaults`` which
+    had been deprecated and replaced with ``instruction_schedule_map`` in
+    Terra release 0.12.0.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Remove `circuit_instruction_map` attribute from `PulseDefaults` which had been deprecated and replaced with `instruction_schedule_map` in Terra release 0.12.0.


### Details and comments


