### PR TITLE
Remove deprecated multi-qubit acquire instructions

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -195,8 +195,8 @@ def _assemble_instructions(
             user_pulselib[name] = instruction.pulse.samples
 
         if isinstance(instruction, (AcquireInstruction, Acquire)):
-            max_memory_slot = max(max_memory_slot,
-                                  *[slot.index for slot in instruction.mem_slots])
+            if instruction.mem_slot:
+                max_memory_slot = max(max_memory_slot, instruction.mem_slot.index)
             # Acquires have a single AcquireChannel per inst, but we have to bundle them
             # together into the Qobj as one instruction with many channels
             acquire_instruction_map[(time, instruction.command)].append(instruction)
@@ -265,8 +265,10 @@ def _bundle_channel_indices(
     reg_slots = []
     for inst in instructions:
         qubits.append(inst.channel.index)
-        mem_slots.append(inst.mem_slot.index)
-        reg_slots.append(inst.reg_slot.index)
+        if inst.mem_slot:
+            mem_slots.append(inst.mem_slot.index)
+        if inst.reg_slot:
+            reg_slots.append(inst.reg_slot.index)
     return qubits, mem_slots, reg_slots
 
 

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -239,7 +239,7 @@ def _validate_meas_map(instruction_map: Dict[Tuple[int, Acquire], List[AcquireIn
     for _, instructions in instruction_map.items():
         measured_qubits = set()
         for inst in instructions:
-            measured_qubits.update([acq.index for acq in inst.acquires])
+            measured_qubits.add(inst.channel.index)
 
         for meas_set in meas_map_sets:
             intersection = measured_qubits.intersection(meas_set)
@@ -264,9 +264,9 @@ def _bundle_channel_indices(
     mem_slots = []
     reg_slots = []
     for inst in instructions:
-        qubits.extend(aq.index for aq in inst.acquires)
-        mem_slots.extend(mem_slot.index for mem_slot in inst.mem_slots)
-        reg_slots.extend(reg.index for reg in inst.reg_slots)
+        qubits.append(inst.channel.index)
+        mem_slots.append(inst.mem_slot.index)
+        reg_slots.append(inst.reg_slot.index)
     return qubits, mem_slots, reg_slots
 
 

--- a/qiskit/pulse/instructions/acquire.py
+++ b/qiskit/pulse/instructions/acquire.py
@@ -16,9 +16,8 @@
 some metadata for the acquisition process; for example, where to store classified readout data.
 """
 import warnings
-import itertools
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from ..channels import MemorySlot, RegisterSlot, AcquireChannel
 from ..configuration import Kernel, Discriminator
@@ -45,10 +44,8 @@ class Acquire(Instruction):
 
     def __init__(self,
                  duration: int,
-                 channel: Optional[Union[AcquireChannel, List[AcquireChannel]]] = None,
-                 mem_slot: Optional[Union[MemorySlot, List[MemorySlot]]] = None,
-                 reg_slots: Optional[Union[RegisterSlot, List[RegisterSlot]]] = None,
-                 mem_slots: Optional[Union[List[MemorySlot]]] = None,
+                 channel: Optional[AcquireChannel] = None,
+                 mem_slot: Optional[MemorySlot] = None,
                  reg_slot: Optional[RegisterSlot] = None,
                  kernel: Optional[Kernel] = None,
                  discriminator: Optional[Discriminator] = None,
@@ -59,8 +56,6 @@ class Acquire(Instruction):
             duration: Length of time to acquire data in terms of dt.
             channel: The channel that will acquire data.
             mem_slot: The classical memory slot in which to store the classified readout result.
-            mem_slots: Deprecated list form of ``mem_slot``.
-            reg_slots: Deprecated list form of ``reg_slot``.
             reg_slot: The fast-access register slot in which to store the classified readout
                       result for fast feedback.
             kernel: A ``Kernel`` for integrating raw data.
@@ -72,57 +67,26 @@ class Acquire(Instruction):
             PulseError: If channels are supplied, and the number of register and/or memory slots
                         does not equal the number of channels.
         """
-        if isinstance(channel, list) or isinstance(mem_slot, list) or reg_slots or mem_slots:
-            warnings.warn('The AcquireInstruction on multiple qubits, multiple '
-                          'memory slots and multiple reg slots is deprecated. The '
-                          'parameter "mem_slots" has been replaced by "mem_slot" and '
-                          '"reg_slots" has been replaced by "reg_slot"', DeprecationWarning, 3)
+        if isinstance(channel, list) or isinstance(mem_slot, list) or isinstance(reg_slot, list):
+            raise PulseError("The Acquire instruction takes only one AcquireChannel and one "
+                             "classical memory destination for the measurement result.")
 
-        if not isinstance(channel, list):
-            channels = [channel] if channel else None
-        else:
-            channels = channel
-
-        if mem_slot and not isinstance(mem_slot, list):
-            mem_slot = [mem_slot]
-        elif mem_slots:
-            mem_slot = mem_slots
-
-        if reg_slot:
-            reg_slot = [reg_slot]
-        elif reg_slots and not isinstance(reg_slots, list):
-            reg_slot = [reg_slots]
-        else:
-            reg_slot = reg_slots
-
-        if channels and not (mem_slot or reg_slot):
+        if channel and not (mem_slot or reg_slot):
             raise PulseError('Neither MemorySlots nor RegisterSlots were supplied.')
 
-        if channels and mem_slot and len(channels) != len(mem_slot):
-            raise PulseError("The number of mem_slots must be equal to the number of channels.")
-
-        if channels and reg_slot:
-            if len(channels) != len(reg_slot):
-                raise PulseError("The number of reg_slots must be equal to the number of "
-                                 "channels.")
-        else:
-            reg_slot = []
-
-        self._acquires = channels
-        self._channel = channels[0] if channels else None
-        self._mem_slots = mem_slot
-        self._reg_slots = reg_slot
+        self._channel = channel
+        self._mem_slot = mem_slot
+        self._reg_slot = reg_slot
         self._kernel = kernel
         self._discriminator = discriminator
 
-        if channels is None:
+        if channel is None:
             warnings.warn("Usage of Acquire without specifying a channel is deprecated. For "
                           "example, Acquire(1200)(AcquireChannel(0)) should be replaced by "
                           "Acquire(1200, AcquireChannel(0)).", DeprecationWarning)
-        all_channels = [group for group in [channels, mem_slot, reg_slot] if group is not None]
-        flattened_channels = tuple(itertools.chain.from_iterable(all_channels))
+        all_channels = [chan for chan in [channel, mem_slot, reg_slot] if chan is not None]
         super().__init__((duration, self.channel, self.mem_slot, self.reg_slot),
-                         duration, flattened_channels, name=name)
+                         duration, all_channels, name=name)
 
     @property
     def channel(self) -> AcquireChannel:
@@ -146,50 +110,54 @@ class Acquire(Instruction):
         """Acquire channel to acquire data. The ``AcquireChannel`` index maps trivially to
         qubit index.
         """
-        return self._acquires[0] if self._acquires else None
+        return self._channel
 
     @property
     def mem_slot(self) -> MemorySlot:
         """The classical memory slot which will store the classified readout result."""
-        return self._mem_slots[0] if self._mem_slots else None
+        return self._mem_slot
 
     @property
     def reg_slot(self) -> RegisterSlot:
         """The fast-access register slot which will store the classified readout result for
         fast-feedback computation.
         """
-        return self._reg_slots[0] if self._reg_slots else None
+        return self._reg_slot
 
     @property
     def acquires(self) -> List[AcquireChannel]:
         """Acquire channels to be acquired on."""
-        return self._acquires
+        warnings.warn("Acquire.acquires is deprecated. Use the channel attribute instead.",
+                      DeprecationWarning)
+        return [self._channel]
 
     @property
     def mem_slots(self) -> List[MemorySlot]:
         """MemorySlots."""
-        return self._mem_slots
+        warnings.warn("Acquire.mem_slots is deprecated. Use the mem_slot attribute instead.",
+                      DeprecationWarning)
+        return [self._mem_slot]
 
     @property
     def reg_slots(self) -> List[RegisterSlot]:
         """RegisterSlots."""
-        return self._reg_slots
+        warnings.warn("Acquire.reg_slots is deprecated. Use the reg_slot attribute instead.",
+                      DeprecationWarning)
+        return [self._reg_slot]
 
     def __repr__(self) -> str:
         return "{}({}{}{}{}{}{})".format(
             self.__class__.__name__,
             self.duration,
-            ', ' + ', '.join(str(ch) for ch in self.acquires) if self.acquires else '',
+            ', ' + str(self.channel) if self.channel else '',
             ', ' + str(self.mem_slot) if self.mem_slot else '',
             ', ' + str(self.reg_slot) if self.reg_slot else '',
             ', ' + str(self.kernel) if self.kernel else '',
             ', ' + str(self.discriminator) if self.discriminator else '')
 
     def __call__(self,
-                 channel: Optional[Union[AcquireChannel, List[AcquireChannel]]] = None,
-                 mem_slot: Optional[Union[MemorySlot, List[MemorySlot]]] = None,
-                 reg_slots: Optional[Union[RegisterSlot, List[RegisterSlot]]] = None,
-                 mem_slots: Optional[Union[List[MemorySlot]]] = None,
+                 channel: AcquireChannel,
+                 mem_slot: Optional[MemorySlot] = None,
                  reg_slot: Optional[RegisterSlot] = None,
                  kernel: Optional[Kernel] = None,
                  discriminator: Optional[Discriminator] = None,
@@ -199,8 +167,6 @@ class Acquire(Instruction):
         Args:
             channel: The channel that will acquire data.
             mem_slot: The classical memory slot in which to store the classified readout result.
-            mem_slots: Deprecated list form of ``mem_slot``.
-            reg_slots: Deprecated list form of ``reg_slot``.
             reg_slot: The fast-access register slot in which to store the classified readout
                       result for fast feedback.
             kernel: A ``Kernel`` for integrating raw data.
@@ -221,8 +187,6 @@ class Acquire(Instruction):
         return Acquire(self.duration,
                        channel=channel,
                        mem_slot=mem_slot,
-                       reg_slots=reg_slots,
-                       mem_slots=mem_slots,
                        reg_slot=reg_slot,
                        kernel=kernel,
                        discriminator=discriminator,

--- a/qiskit/pulse/transforms.py
+++ b/qiskit/pulse/transforms.py
@@ -138,7 +138,7 @@ def add_implicit_acquires(schedule: ScheduleComponent, meas_map: List[List[int]]
 
     for time, inst in schedule.instructions:
         if isinstance(inst, (Acquire, AcquireInstruction)):
-            if inst.channel.index != inst.mem_slot.index:
+            if inst.mem_slot and inst.mem_slot.index != inst.channel.index:
                 warnings.warn("One of your acquires was mapped to a memory slot which didn't match"
                               " the qubit index. I'm relabeling them to match.")
 

--- a/qiskit/pulse/transforms.py
+++ b/qiskit/pulse/transforms.py
@@ -107,7 +107,7 @@ def align_measures(schedules: Iterable[ScheduleComponent],
                     warnings.warn("You provided an align_time which is scheduling an acquire "
                                   "sooner than it was scheduled for in the original Schedule.")
                 new_schedule |= inst << align_time
-                acquired_channels.update({a.index for a in inst.acquires})
+                acquired_channels.add(inst.channel.index)
             elif isinstance(inst.channels[0], MeasureChannel):
                 new_schedule |= inst << align_time
                 measured_channels.update({a.index for a in inst.channels})
@@ -138,15 +138,14 @@ def add_implicit_acquires(schedule: ScheduleComponent, meas_map: List[List[int]]
 
     for time, inst in schedule.instructions:
         if isinstance(inst, (Acquire, AcquireInstruction)):
-            if any([acq.index != mem.index for acq, mem in zip(inst.acquires, inst.mem_slots)]):
+            if inst.channel.index != inst.mem_slot.index:
                 warnings.warn("One of your acquires was mapped to a memory slot which didn't match"
                               " the qubit index. I'm relabeling them to match.")
 
             # Get the label of all qubits that are measured with the qubit(s) in this instruction
-            existing_qubits = {chan.index for chan in inst.acquires}
             all_qubits = []
             for sublist in meas_map:
-                if existing_qubits.intersection(set(sublist)):
+                if inst.channel.index in sublist:
                     all_qubits.extend(sublist)
             # Replace the old acquire instruction by a new one explicitly acquiring all qubits in
             # the measurement group.

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -135,8 +135,8 @@ class InstructionToQobjConverter:
             'name': 'acquire',
             't0': shift + instruction.start_time,
             'duration': instruction.duration,
-            'qubits': [q.index for q in instruction.acquires],
-            'memory_slot': [m.index for m in instruction.mem_slots]
+            'qubits': [instruction.acquire.index],
+            'memory_slot': [instruction.mem_slot.index]
         }
         if meas_level == MeasLevel.CLASSIFIED:
             # setup discriminators
@@ -149,9 +149,9 @@ class InstructionToQobjConverter:
                     ]
                 })
             # setup register_slots
-            if instruction.reg_slots:
+            if instruction.reg_slot:
                 command_dict.update({
-                    'register_slot': [regs.index for regs in instruction.reg_slots]
+                    'register_slot': [instruction.reg_slot.index]
                 })
         if meas_level in [MeasLevel.KERNELED, MeasLevel.CLASSIFIED]:
             # setup kernels
@@ -181,8 +181,8 @@ class InstructionToQobjConverter:
             'name': 'acquire',
             't0': shift + instruction.start_time,
             'duration': instruction.duration,
-            'qubits': [q.index for q in instruction.acquires],
-            'memory_slot': [m.index for m in instruction.mem_slots]
+            'qubits': [instruction.channel.index],
+            'memory_slot': [instruction.mem_slot.index]
         }
         if meas_level == MeasLevel.CLASSIFIED:
             # setup discriminators
@@ -195,9 +195,9 @@ class InstructionToQobjConverter:
                     ]
                 })
             # setup register_slots
-            if instruction.reg_slots:
+            if instruction.reg_slot:
                 command_dict.update({
-                    'register_slot': [regs.index for regs in instruction.reg_slots]
+                    'register_slot': [instruction.reg_slot.index]
                 })
         if meas_level in [MeasLevel.KERNELED, MeasLevel.CLASSIFIED]:
             # setup kernels

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -130,13 +130,16 @@ class InstructionToQobjConverter:
             dict: Dictionary of required parameters.
         """
         meas_level = self._run_config.get('meas_level', 2)
+        mem_slot = []
+        if instruction.mem_slot:
+            mem_slot = [instruction.mem_slot.index]
 
         command_dict = {
             'name': 'acquire',
             't0': shift + instruction.start_time,
             'duration': instruction.duration,
             'qubits': [instruction.acquire.index],
-            'memory_slot': [instruction.mem_slot.index]
+            'memory_slot': mem_slot
         }
         if meas_level == MeasLevel.CLASSIFIED:
             # setup discriminators
@@ -176,13 +179,16 @@ class InstructionToQobjConverter:
             dict: Dictionary of required parameters.
         """
         meas_level = self._run_config.get('meas_level', 2)
+        mem_slot = []
+        if instruction.mem_slot:
+            mem_slot = [instruction.mem_slot.index]
 
         command_dict = {
             'name': 'acquire',
             't0': shift + instruction.start_time,
             'duration': instruction.duration,
             'qubits': [instruction.channel.index],
-            'memory_slot': [instruction.mem_slot.index]
+            'memory_slot': mem_slot
         }
         if meas_level == MeasLevel.CLASSIFIED:
             # setup discriminators

--- a/qiskit/scheduler/utils.py
+++ b/qiskit/scheduler/utils.py
@@ -94,14 +94,13 @@ def measure(qubits: List[int],
 
         for time, inst in default_sched.instructions:
             if qubit_mem_slots and isinstance(inst, (Acquire, AcquireInstruction)):
-                for channel in inst.acquires:
-                    if channel.index in qubit_mem_slots:
-                        mem_slot = MemorySlot(qubit_mem_slots[channel.index])
-                    else:
-                        mem_slot = MemorySlot(unused_mem_slots.pop())
-                    schedule = schedule.insert(time, Acquire(inst.duration,
-                                                             channel,
-                                                             mem_slot=mem_slot))
+                if inst.channel.index in qubit_mem_slots:
+                    mem_slot = MemorySlot(qubit_mem_slots[inst.channel.index])
+                else:
+                    mem_slot = MemorySlot(unused_mem_slots.pop())
+                schedule = schedule.insert(time, Acquire(inst.duration,
+                                                         inst.channel,
+                                                         mem_slot=mem_slot))
             elif qubit_mem_slots is None and isinstance(inst, (Acquire, AcquireInstruction)):
                 schedule = schedule.insert(time, inst)
             # Measurement pulses should only be added if its qubit was measured by the user

--- a/releasenotes/notes/remove-multi-acquires-747701103ddd816c.yaml
+++ b/releasenotes/notes/remove-multi-acquires-747701103ddd816c.yaml
@@ -1,0 +1,13 @@
+---
+deprecations:
+  - |
+    The properties ``acquires``, ``mem_slots``, and ``reg_slots`` of the
+    :class:`qiskit.pulse.instructions.Acquire` pulse instruction have been
+    deprecated.
+other:
+  - |
+    The option to Acquire multiple qubits at once was deprecated in Terra
+    release 0.12.0 and is now removed. Specifically, the init args
+    ``mem_slots`` and ``reg_slots`` have been removed from 
+    :class:`qiskit.pulse.instructions.Acquire`, and ``channel``, ``mem_slot``
+    and ``reg_slot`` will raise an error if a list is provided as input.

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -864,8 +864,8 @@ class TestPulseAssemblerMissingKwargs(QiskitTestCase):
 
         deprecated_style_schedule = Schedule()
         with self.assertWarns(DeprecationWarning):
-            deprecated_style_schedule += Acquire(1200)([AcquireChannel(i) for i in range(5)],
-                                                       [MemorySlot(i) for i in range(5)])
+            for i in range(5):
+                deprecated_style_schedule += Acquire(1200)(AcquireChannel(i), MemorySlot(i))
 
         # The Qobj IDs will be different
         n_qobj = assemble(new_style_schedule, backend)

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -121,7 +121,7 @@ class TestScheduleBuilding(BaseTestSchedule):
         sched = sched.insert(90, Acquire(10,
                                          self.config.acquire(0),
                                          MemorySlot(0),
-                                         RegisterSlot(0)))  # TODO: this shouldn't raise a warning
+                                         RegisterSlot(0)))
         self.assertEqual(0, sched.start_time)
         self.assertEqual(100, sched.stop_time)
         self.assertEqual(100, sched.duration)
@@ -372,38 +372,6 @@ class TestScheduleBuilding(BaseTestSchedule):
         self.assertEqual(len(sched_single.instructions), 2)
         self.assertEqual(len(sched_single.channels), 6)
 
-    def test_schedule_with_acquire_on_multiple_qubits(self):
-        """Test schedule with acquire on multiple qubits."""
-        sched_multiple = Schedule()
-        qubits = [self.config.acquire(i) for i in range(self.config.n_qubits)]
-        mem_slots = [MemorySlot(i) for i in range(self.config.n_qubits)]
-        reg_slots = [RegisterSlot(i) for i in range(self.config.n_qubits)]
-        with self.assertWarns(DeprecationWarning):
-            sched_multiple = sched_multiple.insert(10, Acquire(10, qubits, mem_slots, reg_slots))
-
-        self.assertEqual(len(sched_multiple.instructions), 1)
-        self.assertEqual(len(sched_multiple.channels), 6)
-
-    def test_schedule_with_acquire_for_back_and_forward_compatibility(self):
-        """Test schedule with acquire for back and forward compatibility."""
-        dur = 10
-        with self.assertWarns(DeprecationWarning):
-            # mem_slots and reg_slots are deprecated kwargs
-            cmds = [
-                Acquire(dur, AcquireChannel(0), MemorySlot(0)),
-                Acquire(dur, [AcquireChannel(0)], MemorySlot(0)),
-                Acquire(dur, AcquireChannel(0), [MemorySlot(0)]),
-                Acquire(dur, [AcquireChannel(0)], mem_slots=[MemorySlot(0)]),
-                Acquire(dur, AcquireChannel(0), MemorySlot(0), [RegisterSlot(0)]),
-                Acquire(dur, AcquireChannel(0), MemorySlot(0), reg_slot=RegisterSlot(0))
-            ]
-        for cmd in cmds:
-            mixed_schedule = Schedule()
-            mixed_schedule = mixed_schedule.insert(dur, cmd)
-
-            self.assertEqual(len(mixed_schedule.instructions), 1)
-            self.assertTrue(MemorySlot(0) in mixed_schedule.channels)
-
     def test_parametric_commands_in_sched(self):
         """Test that schedules can be built with parametric commands."""
         sched = Schedule(name='test_parametric')
@@ -414,9 +382,6 @@ class TestScheduleBuilding(BaseTestSchedule):
         sched += Play(GaussianSquare(duration=1500, amp=0.2,
                                      sigma=8, width=140),
                       MeasureChannel(0)) << sched_duration
-        with self.assertWarns(DeprecationWarning):
-            # MemorySlots as list is deprecated
-            sched += Acquire(1500, AcquireChannel(0), [MemorySlot(0)]) << sched_duration
         self.assertEqual(sched.duration, 1525)
         self.assertTrue('sigma' in sched.instructions[0][1].pulse.parameters)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

    The properties ``acquires``, ``mem_slots``, and ``reg_slots`` of the
    :class:`qiskit.pulse.instructions.Acquire` pulse instruction have been
    deprecated.

    The option to Acquire multiple qubits at once was deprecated in Terra
    release 0.12.0 and is now removed. Specifically, the init args
    ``mem_slots`` and ``reg_slots`` have been removed from 
    :class:`qiskit.pulse.instructions.Acquire`, and ``channel``, ``mem_slot``
    and ``reg_slot`` will raise an error if a list is provided as input.


### Details and comments


