### PR TITLE
Circuit reverse_bits operation

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -32,6 +32,7 @@ Instructions are identified by the following:
 Instructions do not have any context about where they are in a circuit (which qubits/clbits).
 The circuit itself keeps this context.
 """
+import warnings
 import copy
 from itertools import zip_longest
 
@@ -220,6 +221,17 @@ class Instruction:
             instruction._condition = self.condition
         return instruction
 
+    def mirror(self):
+        """DEPRECATED: use instruction.reverse.
+
+        Return:
+            qiskit.circuit.Instruction: a new instruction with sub-instructions
+                reversed.
+        """
+        warnings.warn('instruction.mirror() is deprecated. Use circuit.reverse()'
+                      'to reverse the order of gates.', DeprecationWarning)
+        return self.reverse()
+
     def reverse(self):
         """For a composite instruction, reverse the order of sub-gates.
 
@@ -238,30 +250,6 @@ class Instruction:
         for inst, qargs, cargs in reversed(self._definition):
             reverse_inst._definition.append((inst.reverse(), qargs, cargs))
         return reverse_inst
-
-    def reverse_bits(self):
-        """Return an instruction by permuting wires.
-
-        This "vertically" flips the instruction.
-
-        Returns:
-            qiskit.circuit.Instruction: vertically mirrored instruction.
-        """
-        if not self._definition:
-            new_inst = self.copy()
-            new_inst.condition = self.condition
-            return new_inst
-
-        inst_r = self.copy(name=self.name + '_r')
-        inst_r.definition = []
-
-        n = self.num_qubits
-
-        for inst, qargs, cargs in self._definition:
-            new_qargs = [q.register[n - q.index - 1] for q in qargs]
-            new_cargs = [c.register[n - c.index - 1] for c in cargs]
-            inst_r._definition.append((inst.reverse_bits(), new_qargs, new_cargs))
-        return inst_r
 
     def inverse(self):
         """Invert this instruction.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -220,23 +220,48 @@ class Instruction:
             instruction._condition = self.condition
         return instruction
 
-    def mirror(self):
+    def reverse(self):
         """For a composite instruction, reverse the order of sub-gates.
 
-        This is done by recursively mirroring all sub-instructions.
+        This is done by recursively reversing all sub-instructions.
         It does not invert any gate.
 
         Returns:
-            qiskit.circuit.Instruction: a fresh gate with sub-gates reversed
+            qiskit.circuit.Instruction: a new instruction with
+                sub-instructions reversed.
         """
         if not self._definition:
             return self.copy()
 
-        reverse_inst = self.copy(name=self.name + '_mirror')
+        reverse_inst = self.copy(name=self.name + '_reverse')
         reverse_inst.definition = []
         for inst, qargs, cargs in reversed(self._definition):
-            reverse_inst._definition.append((inst.mirror(), qargs, cargs))
+            reverse_inst._definition.append((inst.reverse(), qargs, cargs))
         return reverse_inst
+
+    def reverse_bits(self):
+        """Return an instruction by permuting wires.
+
+        This "vertically" flips the instruction.
+
+        Returns:
+            qiskit.circuit.Instruction: vertically mirrored instruction.
+        """
+        if not self._definition:
+            new_inst = self.copy()
+            new_inst.condition = self.condition
+            return new_inst
+
+        inst_r = self.copy(name=self.name + '_r')
+        inst_r.definition = []
+
+        n = self.num_qubits
+
+        for inst, qargs, cargs in self._definition:
+            new_qargs = [q.register[n - q.index - 1] for q in qargs]
+            new_cargs = [c.register[n - c.index - 1] for c in cargs]
+            inst_r._definition.append((inst.reverse_bits(), new_qargs, new_cargs))
+        return inst_r
 
     def inverse(self):
         """Invert this instruction.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -222,18 +222,18 @@ class Instruction:
         return instruction
 
     def mirror(self):
-        """DEPRECATED: use instruction.reverse.
+        """DEPRECATED: use instruction.reverse_ops().
 
         Return:
             qiskit.circuit.Instruction: a new instruction with sub-instructions
                 reversed.
         """
-        warnings.warn('instruction.mirror() is deprecated. Use circuit.reverse()'
+        warnings.warn('instruction.mirror() is deprecated. Use circuit.reverse_ops()'
                       'to reverse the order of gates.', DeprecationWarning)
-        return self.reverse()
+        return self.reverse_ops()
 
-    def reverse(self):
-        """For a composite instruction, reverse the order of sub-gates.
+    def reverse_ops(self):
+        """For a composite instruction, reverse the order of sub-instructions.
 
         This is done by recursively reversing all sub-instructions.
         It does not invert any gate.
@@ -248,7 +248,7 @@ class Instruction:
         reverse_inst = self.copy(name=self.name + '_reverse')
         reverse_inst.definition = []
         for inst, qargs, cargs in reversed(self._definition):
-            reverse_inst._definition.append((inst.reverse(), qargs, cargs))
+            reverse_inst._definition.append((inst.reverse_ops(), qargs, cargs))
         return reverse_inst
 
     def inverse(self):

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -15,7 +15,7 @@
 # pylint: disable=no-member
 
 """Polynomially controlled Pauli-rotations."""
-
+import warnings
 from typing import List, Optional, Dict, Sequence
 
 from itertools import product
@@ -179,6 +179,10 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
         # set default internal parameters
         self._coeffs = coeffs or [0, 1]
         self._reverse = reverse
+        if self._reverse is True:
+            warnings.warn('The reverse flag has been deprecated. '
+                          'Use circuit.reverse_bits() to reverse order of qubits.',
+                          DeprecationWarning)
 
         # initialize super (after setting coeffs)
         super().__init__(num_state_qubits=num_state_qubits, basis=basis, name=name)
@@ -228,17 +232,6 @@ class PolynomialPauliRotations(FunctionalPauliRotations):
             True, if the rotations are applied on the reversed list, False otherwise.
         """
         return self._reverse
-
-    @reverse.setter
-    def reverse(self, reverse: bool) -> None:
-        """Set to True to reverse the list of qubits.
-
-        Args:
-            reverse: If True, the rotations are applied on the reversed list. If False, then not.
-        """
-        if self._reverse is None or reverse != self._reverse:
-            self._invalidate()
-            self._reverse = reverse
 
     @property
     def num_ancilla_qubits(self) -> int:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -243,48 +243,91 @@ class QuantumCircuit:
             has_reg = True
         return has_reg
 
+    def mirror(self):
+        """DEPRECATED: use circuit.reverse.
+        """
+        warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse() to
+                      reverse the order of gates.', DeprecationWarning)
+        return circuit.reverse()
+
     def reverse(self):
         """Reverse the circuit by reversing the order of instructions.
 
         This is done by recursively reversing all instructions.
-        It does not invert any gate.
+        It does not invert (adjoint) any gate.
 
         Returns:
-            QuantumCircuit: the reversed circuit
+            QuantumCircuit: the reversed circuit.
+
+        Examples:
+
+            input:
+                 ┌───┐
+            q_0: ┤ H ├─────■──────
+                 └───┘┌────┴─────┐
+            q_1: ─────┤ RX(1.57) ├
+                      └──────────┘
+
+            output:
+                             ┌───┐
+            q_0: ─────■──────┤ H ├
+                 ┌────┴─────┐└───┘
+            q_1: ┤ RX(1.57) ├─────
+                 └──────────┘
         """
         reverse_circ = QuantumCircuit(*self.qregs, *self.cregs,
                                       name=self.name + '_reverse')
 
         for inst, qargs, cargs in reversed(self.data):
-            reverse_circ._append(inst.mirror(), qargs, cargs)
+            reverse_circ._append(inst.reverse(), qargs, cargs)
         return reverse_circ
 
-    def mirror(self):
-        """Returns a mirrored circuit by permuting qubits and clbits.
+    def reverse_bits(self):
+        """Return a circuit with the opposite order of wires.
 
-        The mirrored circuit is "vertically" flipped. This operation flattens
-        the registers and the original registers will not be maintained.
+        The circuit is "vertically" flipped. If a circuit is
+        defined over multiple registers, the resulting circuit will have
+        the same registers but with their order flipped.
+
+        This method is useful for converting a circuit written in little-endian
+        convention to the big-endian equivalent, and vice versa.
 
         Returns:
-            QuantumCircuit: the mirrored circuit.
+            QuantumCircuit: the circuit with reversed bit order.
+
+        Examples:
+
+            input:
+                 ┌───┐
+            q_0: ┤ H ├─────■──────
+                 └───┘┌────┴─────┐
+            q_1: ─────┤ RX(1.57) ├
+                      └──────────┘
+
+            output:
+                      ┌──────────┐
+            q_0: ─────┤ RX(1.57) ├
+                 ┌───┐└────┬─────┘
+            q_1: ┤ H ├─────■──────
+                 └───┘
         """
-        mirror_circ = QuantumCircuit(self.width(),
-                                     name=self.name + '_mirror')
+        circ = QuantumCircuit(*reversed(self.qregs), *reversed(self.cregs),
+                              name=self.name + '_r')
         num_qubits = self.num_qubits
+        num_clbits = self.num_clbits
         old_qubits = self.qubits
         old_clbits = self.clbits
-        new_qubits = mirror_circ.qubits
-        new_clbits = mirror_circ.clbits
+        new_qubits = circ.qubits
+        new_clbits = circ.clbits
 
         for inst, qargs, cargs in self.data:
             new_qargs = [new_qubits[num_qubits - old_qubits.index(q) - 1] for q in qargs]
             new_cargs = [new_clbits[num_clbits - old_clbits.index(c) - 1] for c in cargs]
-
-            mirror_circ._append(inst, new_qargs, new_cargs)
-        return mirror_circ
+            circ._append(inst.reverse_bits(), new_qargs, new_cargs)
+        return circ
 
     def inverse(self):
-        """Invert this circuit.
+        """Invert (take adjoint of) this circuit.
 
         This is done by recursively inverting all gates.
 
@@ -293,6 +336,22 @@ class QuantumCircuit:
 
         Raises:
             CircuitError: if the circuit cannot be inverted.
+
+        Examples:
+
+            input:
+                 ┌───┐
+            q_0: ┤ H ├─────■──────
+                 └───┘┌────┴─────┐
+            q_1: ─────┤ RX(1.57) ├
+                      └──────────┘
+
+            output:
+                              ┌───┐
+            q_0: ──────■──────┤ H ├
+                 ┌─────┴─────┐└───┘
+            q_1: ┤ RX(-1.57) ├─────
+                 └───────────┘
         """
         inverse_circ = QuantumCircuit(*self.qregs, *self.cregs,
                                       name=self.name + '_dg')

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -245,10 +245,13 @@ class QuantumCircuit:
 
     def mirror(self):
         """DEPRECATED: use circuit.reverse.
+
+        Returns:
+            QuantumCircuit: the reversed circuit.
         """
-        warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse() to
-                      reverse the order of gates.', DeprecationWarning)
-        return circuit.reverse()
+        warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse() to '
+                      'reverse the order of gates.', DeprecationWarning)
+        return self.reverse()
 
     def reverse(self):
         """Reverse the circuit by reversing the order of instructions.
@@ -312,7 +315,7 @@ class QuantumCircuit:
                  └───┘
         """
         circ = QuantumCircuit(*reversed(self.qregs), *reversed(self.cregs),
-                              name=self.name + '_r')
+                              name=self.name)
         num_qubits = self.num_qubits
         num_clbits = self.num_clbits
         old_qubits = self.qubits
@@ -323,7 +326,7 @@ class QuantumCircuit:
         for inst, qargs, cargs in self.data:
             new_qargs = [new_qubits[num_qubits - old_qubits.index(q) - 1] for q in qargs]
             new_cargs = [new_clbits[num_clbits - old_clbits.index(c) - 1] for c in cargs]
-            circ._append(inst.reverse_bits(), new_qargs, new_cargs)
+            circ._append(inst, new_qargs, new_cargs)
         return circ
 
     def inverse(self):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -251,7 +251,7 @@ class QuantumCircuit:
         """
         warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse_ops() to '
                       'reverse the order of gates.', DeprecationWarning)
-        return self.reverse()
+        return self.reverse_ops()
 
     def reverse_ops(self):
         """Reverse the circuit by reversing the order of instructions.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -244,16 +244,16 @@ class QuantumCircuit:
         return has_reg
 
     def mirror(self):
-        """DEPRECATED: use circuit.reverse.
+        """DEPRECATED: use circuit.reverse_ops().
 
         Returns:
             QuantumCircuit: the reversed circuit.
         """
-        warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse() to '
+        warnings.warn('circuit.mirror() is deprecated. Use circuit.reverse_ops() to '
                       'reverse the order of gates.', DeprecationWarning)
         return self.reverse()
 
-    def reverse(self):
+    def reverse_ops(self):
         """Reverse the circuit by reversing the order of instructions.
 
         This is done by recursively reversing all instructions.
@@ -282,7 +282,7 @@ class QuantumCircuit:
                                       name=self.name + '_reverse')
 
         for inst, qargs, cargs in reversed(self.data):
-            reverse_circ._append(inst.reverse(), qargs, cargs)
+            reverse_circ._append(inst.reverse_ops(), qargs, cargs)
         return reverse_circ
 
     def reverse_bits(self):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -243,21 +243,45 @@ class QuantumCircuit:
             has_reg = True
         return has_reg
 
-    def mirror(self):
-        """Mirror the circuit by reversing the instructions.
+    def reverse(self):
+        """Reverse the circuit by reversing the order of instructions.
 
-        This is done by recursively mirroring all instructions.
+        This is done by recursively reversing all instructions.
         It does not invert any gate.
 
         Returns:
-            QuantumCircuit: the mirrored circuit
+            QuantumCircuit: the reversed circuit
         """
         reverse_circ = QuantumCircuit(*self.qregs, *self.cregs,
-                                      name=self.name + '_mirror')
+                                      name=self.name + '_reverse')
 
         for inst, qargs, cargs in reversed(self.data):
             reverse_circ._append(inst.mirror(), qargs, cargs)
         return reverse_circ
+
+    def mirror(self):
+        """Returns a mirrored circuit by permuting qubits and clbits.
+
+        The mirrored circuit is "vertically" flipped. This operation flattens
+        the registers and the original registers will not be maintained.
+
+        Returns:
+            QuantumCircuit: the mirrored circuit.
+        """
+        mirror_circ = QuantumCircuit(self.width(),
+                                     name=self.name + '_mirror')
+        num_qubits = self.num_qubits
+        old_qubits = self.qubits
+        old_clbits = self.clbits
+        new_qubits = mirror_circ.qubits
+        new_clbits = mirror_circ.clbits
+
+        for inst, qargs, cargs in self.data:
+            new_qargs = [new_qubits[num_qubits - old_qubits.index(q) - 1] for q in qargs]
+            new_cargs = [new_clbits[num_clbits - old_clbits.index(c) - 1] for c in cargs]
+
+            mirror_circ._append(inst, new_qargs, new_cargs)
+        return mirror_circ
 
     def inverse(self):
         """Invert this circuit.

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -238,7 +238,7 @@ class Initialize(Instruction):
         # second lower-level multiplex)
         multiplex_2 = self._multiplex(target_gate, list_of_angles[(list_len // 2):], False)
         if list_len > 1:
-            circuit.append(multiplex_2.to_instruction().reverse(), q[0:-1])
+            circuit.append(multiplex_2.to_instruction().reverse_ops(), q[0:-1])
         else:
             circuit.append(multiplex_2.to_instruction(), q[0:-1])
 

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -238,7 +238,7 @@ class Initialize(Instruction):
         # second lower-level multiplex)
         multiplex_2 = self._multiplex(target_gate, list_of_angles[(list_len // 2):], False)
         if list_len > 1:
-            circuit.append(multiplex_2.to_instruction().mirror(), q[0:-1])
+            circuit.append(multiplex_2.to_instruction().reverse(), q[0:-1])
         else:
             circuit.append(multiplex_2.to_instruction(), q[0:-1])
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -218,30 +218,6 @@ class Operator(BaseOperator):
         ret._set_dims(self._output_dims, self._input_dims)
         return ret
 
-    def mirror(self):
-        """Return the mirrored operator."""
-        def get_mirror_index(i, n):
-            """Return mirror of index i, in n entries."""
-            little_endian = '{0:0{1}b}'.format(i, n)
-            big_endian = little_endian[::-1]
-            return int(big_endian, 2)
-
-        # Make a shallow copy and update array
-        ret = copy.deepcopy(self)
-        num_rows = ret._data.shape[0]
-        num_cols = ret._data.shape[1]
-        num_qubits = int(np.log2(num_rows))
-
-        for i in range(int(num_rows/2)):
-            j = get_mirror_index(i, num_qubits)
-            if i != j:
-                ret._data[[i, j]] = ret._data[[j, i]]
-        for i in range(int(num_cols/2)):
-            j = get_mirror_index(i, num_qubits)
-            if i != j:
-                ret._data[:, [i, j]] = ret._data[:, [j, i]]
-        return ret
-
     def compose(self, other, qargs=None, front=False):
         """Return the composed operator.
 

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -218,6 +218,30 @@ class Operator(BaseOperator):
         ret._set_dims(self._output_dims, self._input_dims)
         return ret
 
+    def mirror(self):
+        """Return the mirrored operator."""
+        def get_mirror_index(i, n):
+            """Return mirror of index i, in n entries."""
+            little_endian = '{0:0{1}b}'.format(i, n)
+            big_endian = little_endian[::-1]
+            return int(big_endian, 2)
+
+        # Make a shallow copy and update array
+        ret = copy.deepcopy(self)
+        num_rows = ret._data.shape[0]
+        num_cols = ret._data.shape[1]
+        num_qubits = int(np.log2(num_rows))
+
+        for i in range(int(num_rows/2)):
+            j = get_mirror_index(i, num_qubits)
+            if i != j:
+                ret._data[[i, j]] = ret._data[[j, i]]
+        for i in range(int(num_cols/2)):
+            j = get_mirror_index(i, num_qubits)
+            if i != j:
+                ret._data[:, [i, j]] = ret._data[:, [j, i]]
+        return ret
+
     def compose(self, other, qargs=None, front=False):
         """Return the composed operator.
 

--- a/releasenotes/notes/circuit-reverse-bits-ce1873a89b06e3df.yaml
+++ b/releasenotes/notes/circuit-reverse-bits-ce1873a89b06e3df.yaml
@@ -8,6 +8,6 @@ features:
 deprecations:
   - |
     :meth:`~qiskit.circuit.QuantumCircuit.mirror` has been deprecated in favor
-    of :meth:`~qiskit.circuit.QuantumCircuit.reverse` since mirroring could be
+    of :meth:`~qiskit.circuit.QuantumCircuit.reverse_ops` since mirroring could be
     confused with swapping the output qubits of the circuit. Instead this method
     only reverses the order of gates that are applied.

--- a/releasenotes/notes/circuit-reverse-bits-ce1873a89b06e3df.yaml
+++ b/releasenotes/notes/circuit-reverse-bits-ce1873a89b06e3df.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    A new method :meth:`~qiskit.circuit.QuantumCircuit.reverse_bits` has been
+    added to reverse the order of bits in a circuit (both quantum and classical
+    bits). This can be used to switch a circuit from little-endian to big-endian
+    and vice-versa.
+deprecations:
+  - |
+    :meth:`~qiskit.circuit.QuantumCircuit.mirror` has been deprecated in favor
+    of :meth:`~qiskit.circuit.QuantumCircuit.reverse` since mirroring could be
+    confused with swapping the output qubits of the circuit. Instead this method
+    only reverses the order of gates that are applied.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -466,6 +466,26 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(cx_box_box.reverse_bits().decompose().decompose(), expected2)
 
+    def test_reverse_bits_with_registers(self):
+        """Test reversing order of bits when registers are present."""
+        a = QuantumRegister(3, 'a')
+        b = QuantumRegister(2, 'b')
+        qc = QuantumCircuit(a, b)
+        qc.h(a[0])
+        qc.cx(a[0], a[1])
+        qc.cx(a[1], a[2])
+        qc.cx(a[2], b[0])
+        qc.cx(b[0], b[1])
+
+        expected = QuantumCircuit(b, a)
+        expected.h(a[2])
+        expected.cx(a[2], a[1])
+        expected.cx(a[1], a[0])
+        expected.cx(a[0], b[1])
+        expected.cx(b[1], b[0])
+
+        self.assertEqual(qc.reverse_bits(), expected)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -371,7 +371,7 @@ class TestCircuitOperations(QiskitTestCase):
         expected.s(1)
         expected.h(0)
 
-        self.assertEqual(qc.reverse(), expected)
+        self.assertEqual(qc.reverse_ops(), expected)
 
     def test_repeat(self):
         """Test repeating the circuit works."""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -416,6 +416,56 @@ class TestCircuitOperations(QiskitTestCase):
         else:
             self.assertTrue(all(isinstance(op[0], Instruction) for op in rep.data))
 
+    def test_reverse_bits(self):
+        """Test reversing order of bits."""
+        qc = QuantumCircuit(3, 2)
+        qc.h(0)
+        qc.s(1)
+        qc.cx(0, 1)
+        qc.measure(0, 1)
+        qc.x(0)
+        qc.y(1)
+
+        expected = QuantumCircuit(3, 2)
+        expected.h(2)
+        expected.s(1)
+        expected.cx(2, 1)
+        expected.measure(2, 0)
+        expected.x(2)
+        expected.y(1)
+
+        self.assertEqual(qc.reverse_bits(), expected)
+
+    def test_reverse_bits_boxed(self):
+        """Test reversing order of bits in a hierarchiecal circuit."""
+        wide_cx = QuantumCircuit(3)
+        wide_cx.cx(0, 1)
+        wide_cx.cx(1, 2)
+
+        wide_cxg = wide_cx.to_gate()
+        cx_box = QuantumCircuit(3)
+        cx_box.append(wide_cxg, [0, 1, 2])
+
+        expected = QuantumCircuit(3)
+        expected.cx(2, 1)
+        expected.cx(1, 0)
+
+        self.assertEqual(cx_box.reverse_bits().decompose(), expected)
+        self.assertEqual(cx_box.decompose().reverse_bits(), expected)
+
+        # box one more layer to be safe.
+        cx_box_g = cx_box.to_gate()
+        cx_box_box = QuantumCircuit(4)
+        cx_box_box.append(cx_box_g, [0, 1, 2])
+        cx_box_box.cx(0, 3)
+
+        expected2 = QuantumCircuit(4)
+        expected2.cx(3, 2)
+        expected2.cx(2, 1)
+        expected2.cx(3, 0)
+
+        self.assertEqual(cx_box_box.reverse_bits().decompose().decompose(), expected2)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -468,21 +468,21 @@ class TestCircuitOperations(QiskitTestCase):
 
     def test_reverse_bits_with_registers(self):
         """Test reversing order of bits when registers are present."""
-        qa = QuantumRegister(3, 'a')
-        qb = QuantumRegister(2, 'b')
-        qc = QuantumCircuit(qa, qb)
-        qc.h(qa[0])
-        qc.cx(qa[0], qa[1])
-        qc.cx(qa[1], qa[2])
-        qc.cx(qa[2], qb[0])
-        qc.cx(qb[0], qb[1])
+        qr1 = QuantumRegister(3, 'a')
+        qr2 = QuantumRegister(2, 'b')
+        qc = QuantumCircuit(qr1, qr2)
+        qc.h(qr1[0])
+        qc.cx(qr1[0], qr1[1])
+        qc.cx(qr1[1], qr1[2])
+        qc.cx(qr1[2], qr2[0])
+        qc.cx(qr2[0], qr2[1])
 
-        expected = QuantumCircuit(qb, qa)
-        expected.h(qa[2])
-        expected.cx(qa[2], qa[1])
-        expected.cx(qa[1], qa[0])
-        expected.cx(qa[0], qb[1])
-        expected.cx(qb[1], qb[0])
+        expected = QuantumCircuit(qr2, qr1)
+        expected.h(qr1[2])
+        expected.cx(qr1[2], qr1[1])
+        expected.cx(qr1[1], qr1[0])
+        expected.cx(qr1[0], qr2[1])
+        expected.cx(qr2[1], qr2[0])
 
         self.assertEqual(qc.reverse_bits(), expected)
 

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -468,21 +468,21 @@ class TestCircuitOperations(QiskitTestCase):
 
     def test_reverse_bits_with_registers(self):
         """Test reversing order of bits when registers are present."""
-        a = QuantumRegister(3, 'a')
-        b = QuantumRegister(2, 'b')
-        qc = QuantumCircuit(a, b)
-        qc.h(a[0])
-        qc.cx(a[0], a[1])
-        qc.cx(a[1], a[2])
-        qc.cx(a[2], b[0])
-        qc.cx(b[0], b[1])
+        qa = QuantumRegister(3, 'a')
+        qb = QuantumRegister(2, 'b')
+        qc = QuantumCircuit(qa, qb)
+        qc.h(qa[0])
+        qc.cx(qa[0], qa[1])
+        qc.cx(qa[1], qa[2])
+        qc.cx(qa[2], qb[0])
+        qc.cx(qb[0], qb[1])
 
-        expected = QuantumCircuit(b, a)
-        expected.h(a[2])
-        expected.cx(a[2], a[1])
-        expected.cx(a[1], a[0])
-        expected.cx(a[0], b[1])
-        expected.cx(b[1], b[0])
+        expected = QuantumCircuit(qb, qa)
+        expected.h(qa[2])
+        expected.cx(qa[2], qa[1])
+        expected.cx(qa[1], qa[0])
+        expected.cx(qa[0], qb[1])
+        expected.cx(qb[1], qb[0])
 
         self.assertEqual(qc.reverse_bits(), expected)
 

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -353,8 +353,8 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(expected, circuit)
 
-    def test_mirror(self):
-        """Test mirror method reverses but does not invert."""
+    def test_reverse(self):
+        """Test reverse method reverses but does not invert."""
         qc = QuantumCircuit(2, 2)
         qc.h(0)
         qc.s(1)
@@ -371,7 +371,7 @@ class TestCircuitOperations(QiskitTestCase):
         expected.s(1)
         expected.h(0)
 
-        self.assertEqual(qc.mirror(), expected)
+        self.assertEqual(qc.reverse(), expected)
 
     def test_repeat(self):
         """Test repeating the circuit works."""

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -204,52 +204,6 @@ class TestInstructions(QiskitTestCase):
         hgate = HGate()
         self.assertEqual(hgate.reverse(), hgate)
 
-    def test_reverse_bits_gate(self):
-        """test reversing bits of a composite gate"""
-        q = QuantumRegister(4)
-        circ = QuantumCircuit(q, name='circ')
-        circ.h(q[0])
-        circ.crz(0.1, q[0], q[1])
-        circ.i(q[1])
-        circ.u3(0.1, 0.2, -0.2, q[0])
-        gate = circ.to_gate()
-
-        circ = QuantumCircuit(q, name='circ')
-        circ.h(q[3])
-        circ.crz(0.1, q[3], q[2])
-        circ.i(q[2])
-        circ.u3(0.1, 0.2, -0.2, q[3])
-        gate_r = circ.to_gate()
-        self.assertEqual(gate.reverse_bits().definition, gate_r.definition)
-
-    def test_reverse_bits_instruction(self):
-        """test reversing bits of an instruction with conditionals"""
-        q = QuantumRegister(4)
-        c = ClassicalRegister(4)
-        circ = QuantumCircuit(q, c, name='circ')
-        circ.t(q[1])
-        circ.u3(0.1, 0.2, -0.2, q[0])
-        circ.barrier([0, 1, 2, 3])
-        circ.measure(q[0], c[0])
-        circ.rz(0.8, q[0]).c_if(c, 4)
-        inst = circ.to_instruction()
-
-        circ = QuantumCircuit(q, c, name='circ')
-        circ.t(q[2])
-        circ.u3(0.1, 0.2, -0.2, q[3])
-        circ.barrier([3, 2, 1, 0])
-        circ.measure(q[3], c[3])
-        circ.rz(0.8, q[3]).c_if(c, 4)
-        inst_reverse_bits = circ.to_instruction()
-        self.assertEqual(inst.reverse_bits().definition, inst_reverse_bits.definition)
-
-    def test_reverse_bits_opaque(self):
-        """test opaque gates reverse bits to itself, in the absence of circuit context."""
-        opaque_gate = Gate(name='crz_2', num_qubits=2, params=[0.5])
-        self.assertEqual(opaque_gate.reverse_bits(), opaque_gate)
-        hgate = HGate()
-        self.assertEqual(hgate.reverse_bits(), hgate)
-
     def test_inverse_and_append(self):
         """test appending inverted gates to circuits"""
         q = QuantumRegister(1)

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -174,7 +174,7 @@ class TestInstructions(QiskitTestCase):
         circ.crz(0.1, q[0], q[1])
         circ.h(q[0])
         gate_reverse = circ.to_gate()
-        self.assertEqual(gate.reverse().definition, gate_reverse.definition)
+        self.assertEqual(gate.reverse_ops().definition, gate_reverse.definition)
 
     def test_reverse_instruction(self):
         """test reverseing an instruction with conditionals"""
@@ -195,14 +195,14 @@ class TestInstructions(QiskitTestCase):
         circ.u3(0.1, 0.2, -0.2, q[0])
         circ.t(q[1])
         inst_reverse = circ.to_instruction()
-        self.assertEqual(inst.reverse().definition, inst_reverse.definition)
+        self.assertEqual(inst.reverse_ops().definition, inst_reverse.definition)
 
     def test_reverse_opaque(self):
         """test opaque gates reverse to themselves"""
         opaque_gate = Gate(name='crz_2', num_qubits=2, params=[0.5])
-        self.assertEqual(opaque_gate.reverse(), opaque_gate)
+        self.assertEqual(opaque_gate.reverse_ops(), opaque_gate)
         hgate = HGate()
-        self.assertEqual(hgate.reverse(), hgate)
+        self.assertEqual(hgate.reverse_ops(), hgate)
 
     def test_inverse_and_append(self):
         """test appending inverted gates to circuits"""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -767,7 +767,7 @@ class TestParameters(QiskitTestCase):
         theta = Parameter('theta')
         qc.rz(theta, 0)
 
-        reverse = qc.reverse()
+        reverse = qc.reverse_ops()
         self.assertIn(theta, reverse.parameters)
         raise_if_parameter_table_invalid(reverse)
 

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -761,15 +761,15 @@ class TestParameters(QiskitTestCase):
         self.assertIn(theta, inverse.parameters)
         raise_if_parameter_table_invalid(inverse)
 
-    def test_copy_after_mirror(self):
-        """Verify circuit.mirror generates a valid ParameterTable."""
+    def test_copy_after_reverse(self):
+        """Verify circuit.reverse generates a valid ParameterTable."""
         qc = QuantumCircuit(1)
         theta = Parameter('theta')
         qc.rz(theta, 0)
 
-        mirror = qc.mirror()
-        self.assertIn(theta, mirror.parameters)
-        raise_if_parameter_table_invalid(mirror)
+        reverse = qc.reverse()
+        self.assertIn(theta, reverse.parameters)
+        raise_if_parameter_table_invalid(reverse)
 
     def test_copy_after_dot_data_setter(self):
         """Verify setting circuit.data generates a valid ParameterTable."""


### PR DESCRIPTION
Adding an operation `reverse_bits` to reverse the order of bits in a circuit. This helps in making circuits written in big-endian convention into little-endian and vice versa.

Also a previous method `mirror()` is now called `reverse()`. This is to avoid confusion with mirror gates (e.g. [here](https://arxiv.org/abs/quant-ph/0407108) and [here](https://arxiv.org/pdf/1811.12926.pdf)).