### PR TITLE
Restrict hello_quantum ibmq example script to backends with at least two qubits

### DIFF
--- a/examples/python/ibmq/hello_quantum.py
+++ b/examples/python/ibmq/hello_quantum.py
@@ -55,8 +55,10 @@ ibmq_backends = provider.backends()
 
 print("Remote backends: ", ibmq_backends)
 # Compile and run the Quantum Program on a real device backend
+# select those with at least 2 qubits
 try:
-    least_busy_device = least_busy(provider.backends(simulator=False))
+    least_busy_device = least_busy(provider.backends(
+        filters=lambda x: x.configuration().n_qubits >= 2, simulator=False))
 except:
     print("All devices are currently unavailable.")
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
Fixes #4510 

- [x ] I have added the tests to cover my changes. 
- [ x] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

The hello_quantum example was repeatedly failing because it usually selected the 1-qubit Armonk provider, but it needs two qubits to run.

### Details and comments

I've added a filter to ensure that only usable providers are selected.

There are no automated tests for this example, but it now runs on my machine. (I know, I know...)

Fixes #4510 