### PR TITLE
Fix infinite recursion in controlled gate definition

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -14,6 +14,7 @@
 
 """Controlled unitary gate."""
 
+import copy
 from typing import Tuple, List, Optional, Union
 from qiskit.circuit.exceptions import CircuitError
 
@@ -125,7 +126,7 @@ class ControlledGate(Gate):
             if val == '0':
                 open_rules.append([XGate(), [qreg[qind]], []])
         if open_rules:
-            return open_rules + definition + open_rules
+            return open_rules + copy.copy(definition) + open_rules
         else:
             return self._definition
 

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -781,6 +781,14 @@ class TestControlledGate(QiskitTestCase):
         with self.assertRaises(CircuitError):
             base_gate.control(num_ctrl_qubits, ctrl_state='201')
 
+    def test_open_controlled_x_gate_eq(self):
+        """Test open control x gate equality."""
+        circuit1 = QuantumCircuit(2)
+        circuit1.append(XGate().control(1, ctrl_state='1'), [0, 1])
+        circuit2 = QuantumCircuit(2)
+        circuit2.append(XGate().control(1, ctrl_state='1'), [0, 1])
+        self.assertEqual(circuit1, circuit2)
+
 
 @ddt
 class TestSingleControlledRotationGates(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The controlled gate definition property was being evaluated and it was
an controlled X gate with an open control the generated definition
would reference itself because the working definition becomes defined
with self as an element in the list. That meant whenever the definition
was fully expanded ControlledGate.definition would infinitely recurse.
To workaround this issue this commit adds a shallow copy to break the
reference loop.

### Details and comments

Fixes #4512 