### PR TITLE
Add circuit.repeat

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -276,6 +276,27 @@ class QuantumCircuit:
             inverse_circ._append(inst.inverse(), qargs, cargs)
         return inverse_circ
 
+    def repeat(self, reps):
+        """Repeat this circuit ``reps`` times.
+
+        Args:
+            reps (int): How often this circuit should be repeated.
+
+        Returns:
+            QuantumCircuit: A circuit containing ``reps`` repetitions of this circuit.
+        """
+        repeated_circ = QuantumCircuit(*self.qregs, *self.cregs,
+                                       name=self.name + '**{}'.format(reps))
+
+        # benefit of appending instructions: decomposing shows the subparts, i.e. the power
+        # is actually `reps` times this circuit, and it is currently much faster than `compose`.
+        if reps > 0:
+            inst = self.to_instruction()
+            for _ in range(reps):
+                repeated_circ.append(inst, self.qubits, self.clbits)
+
+        return repeated_circ
+
     def combine(self, rhs):
         """Append rhs to self if self contains compatible registers.
 

--- a/releasenotes/notes/circuit-repeat-8db21ef8d8c21cda.yaml
+++ b/releasenotes/notes/circuit-repeat-8db21ef8d8c21cda.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add a ``QuantumCircuit.repeat`` method, which returns a new circuit object containing
+    a specified number of repetitions of the original circuit. The parameters are copied by
+    reference.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -370,6 +370,29 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(qc.mirror(), expected)
 
+    def test_repeat(self):
+        """Test repeating the circuit works."""
+        qr = QuantumRegister(2)
+        cr = ClassicalRegister(2)
+        qc = QuantumCircuit(qr, cr)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.barrier()
+        qc.h(0).c_if(cr, 1)
+
+        with self.subTest('repeat 0 times'):
+            rep = qc.repeat(0)
+            self.assertEqual(rep, QuantumCircuit(qr, cr))
+
+        with self.subTest('repeat 3 times'):
+            inst = qc.to_instruction()
+            ref = QuantumCircuit(qr, cr)
+            for _ in range(3):
+                ref.append(inst, ref.qubits, ref.clbits)
+
+            rep = qc.repeat(3)
+            self.assertEqual(rep, ref)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -731,6 +731,15 @@ class TestParameters(QiskitTestCase):
         inv_instr = qc.inverse().to_instruction()
         self.assertIsInstance(inv_instr, Instruction)
 
+    def test_repeated_circuit(self):
+        """Test repeating a circuit maintains the parameters."""
+        qc = QuantumCircuit(1)
+        theta = Parameter('theta')
+        qc.rz(theta, 0)
+        rep = qc.repeat(3)
+
+        self.assertEqual(rep.parameters, {theta})
+
     def test_copy_after_inverse(self):
         """Verify circuit.inverse generates a valid ParameterTable."""
         qc = QuantumCircuit(1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Implement `circuit.repeat(reps)` to return a circuit containing `reps` repetitions of the original.

### Details and comments

Use-cases:
1. Avoid explicitly casting to an Instruction to do this
2. Circuit library objects may know an efficient way of repeating themselves, so we need to be able to overwrite `repeat`
