### PR TITLE
Fix reno indentation errors that shows up during `tox -edocs`

### DIFF
--- a/releasenotes/notes/0.9/changes-on-upgrade-6fcd573269a8ebc5.yaml
+++ b/releasenotes/notes/0.9/changes-on-upgrade-6fcd573269a8ebc5.yaml
@@ -35,6 +35,7 @@ upgrade:
   - |
     The following deprecated ``qiskit.dagcircuit.DAGCircuit`` methods have been
     removed:
+
      * ``DAGCircuit.get_qubits()`` - Use ``DAGCircuit.qubits()`` instead
      * ``DAGCircuit.get_bits()`` - Use ``DAGCircuit.clbits()`` instead
      * ``DAGCircuit.qasm()`` - Use a combination of
@@ -70,6 +71,7 @@ upgrade:
     The following ``qiskit.dagcircuit.DAGCircuit`` methods had deprecated
     support for accepting a ``node_id`` as a parameter. This has been removed
     and now only ``DAGNode`` objects are accepted as input:
+
      * ``successors()``
      * ``predecessors()``
      * ``ancestors()``
@@ -77,7 +79,7 @@ upgrade:
      * ``bfs_successors()``
      * ``quantum_successors()``
      * ``remove_op_node()``
-     * ``remove_ancestors_of()
+     * ``remove_ancestors_of()``
      * ``remove_descendants_of()``
      * ``remove_nonancestors_of()``
      * ``remove_nondescendants_of()``

--- a/releasenotes/notes/0.9/missing-changelog-d8129ba95dde3156.yaml
+++ b/releasenotes/notes/0.9/missing-changelog-d8129ba95dde3156.yaml
@@ -21,6 +21,7 @@ upgrade:
   - |
     The deprecated ``qiskit.mapper`` module has been removed. The list of
     functions and classes with their alternatives are:
+
      * ``qiskit.mapper.CouplingMap``: ``qiskit.transpiler.CouplingMap`` should
        be used instead.
      * ``qiskit.mapper.Layout``: ``qiskit.transpiler.Layout`` should be used
@@ -31,6 +32,7 @@ upgrade:
      * ``qiskit.mapper.compiling.two_qubit_kak()``:
        ``qiskit.quantum_info.synthesis.two_qubit_cnot_decompose()`` should be
        used instead.
+
     The deprecated exception classes ``qiskit.mapper.exceptions.CouplingError``
     and ``qiskit.mapper.exceptions.LayoutError`` don't have an alternative
     since they serve no purpose without a ``qiskit.mapper`` module.
@@ -58,11 +60,13 @@ deprecations:
   - |
     The module ``qiskit.pulse.ops`` has been deprecated. All the functions it
     provided:
+
      * ``union``
      * ``flatten``
      * ``shift``
      * ``insert``
      * ``append``
+
     have equivalent methods available directly on the ``qiskit.pulse.Schedule``
     and ``qiskit.pulse.Instruction`` classes. Those methods should be used
     instead.

--- a/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
+++ b/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
@@ -64,7 +64,7 @@ features:
     passed a set of kwargs on each call with the state of the pass maanger after
     each pass execution. Currently these kwargs are:
 
-     * pass_ (Pass): the pass being run
+     * pass (Pass): the pass being run
      * dag (DAGCircuit): the dag output of the pass
      * time (float): the time to execute the pass
      * property_set (PropertySet): the property set
@@ -126,7 +126,7 @@ features:
     +--------------------------------+---------------------------------------+
     | ``QuantumCircuit.squ()``       | Decompose an arbitrary 2x2 unitary    |
     |                                | into three rotation gates and add to  |
-    |                                |  a circuit                            |
+    |                                | a circuit                             |
     +--------------------------------+---------------------------------------+
     | ``QuantumCircuit.ucg()``       | Attach an uniformly controlled gate   |
     |                                | (also called a multiplexed gate) to a |

--- a/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
+++ b/releasenotes/notes/0.9/new-features-0.9-159645f977a139f7.yaml
@@ -64,7 +64,7 @@ features:
     passed a set of kwargs on each call with the state of the pass maanger after
     each pass execution. Currently these kwargs are:
 
-     * pass (Pass): the pass being run
+     * pass\_ (Pass): the pass being run
      * dag (DAGCircuit): the dag output of the pass
      * time (float): the time to execute the pass
      * property_set (PropertySet): the property set


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Few reno indentation errors show up sometimes when running `tox -edocs`. 

### Details and comments


