### PR TITLE
Pin sphinx version temporarily

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
 reno>=3.1.0;python_version>'3.5'
-Sphinx>=1.8.3
+Sphinx>=1.8.3,<3.1.0
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11
 sphinx-autodoc-typehints


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Sphinx released 3.1.0 yesterday which has introduced 1821 warnings to
the terra docs builds. Until these can all be fixed the CI jobs are
failing because we enforce no warnings as sphinx warnings almost always
point to real docs bugs. This commit pins the sphinx version we use for
testing and local builds until we can fix all the newly introduced
warnings.

### Details and comments


