### PR TITLE
[Stable] Cache dag qubits/clbits (#4535)

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -91,11 +91,21 @@ class DAGCircuit:
         # Edges carry wire labels (reg,idx) and each operation has
         # corresponding in- and out-edges with the same wire labels.
 
-        # Map of qreg name to QuantumRegister object
+        # Map of qreg/creg name to Register object.
         self.qregs = OrderedDict()
-
-        # Map of creg name to ClassicalRegister object
         self.cregs = OrderedDict()
+
+        # List of Qubit/Clbit wires that the DAG acts on.
+        class DummyCallableList(list):
+            """Dummy class so we can deprecate dag.qubits() and do
+            dag.qubits as property.
+            """
+            def __call__(self):
+                warnings.warn('dag.qubits() and dag.clbits() are no longer methods. Use '
+                              'dag.qubits and dag.clbits properties instead.', DeprecationWarning)
+                return self
+        self._qubits = DummyCallableList()  # TODO: make these a regular empty list [] after the
+        self._clbits = DummyCallableList()  # DeprecationWarning period, and remove name underscore.
 
         self._id_to_node = {}
 
@@ -152,13 +162,17 @@ class DAGCircuit:
 
         return G
 
+    @property
     def qubits(self):
         """Return a list of qubits (as a list of Qubit instances)."""
-        return [qubit for qreg in self.qregs.values() for qubit in qreg]
+        # TODO: remove this property after DeprecationWarning period (~9/2020)
+        return self._qubits
 
+    @property
     def clbits(self):
         """Return a list of classical bits (as a list of Clbit instances)."""
-        return [clbit for creg in self.cregs.values() for clbit in creg]
+        # TODO: remove this property after DeprecationWarning period (~9/2020)
+        return self._clbits
 
     @property
     def wires(self):
@@ -187,6 +201,7 @@ class DAGCircuit:
             raise DAGCircuitError("duplicate register %s" % qreg.name)
         self.qregs[qreg.name] = qreg
         for j in range(qreg.size):
+            self.qubits.append(qreg[j])
             self._add_wire(qreg[j])
 
     def add_creg(self, creg):
@@ -197,6 +212,7 @@ class DAGCircuit:
             raise DAGCircuitError("duplicate register %s" % creg.name)
         self.cregs[creg.name] = creg
         for j in range(creg.size):
+            self.clbits.append(creg[j])
             self._add_wire(creg[j])
 
     def _add_wire(self, wire):
@@ -521,8 +537,8 @@ class DAGCircuit:
         if front:
             raise DAGCircuitError("Front composition not supported yet.")
 
-        if len(other.qubits()) > len(self.qubits()) or \
-           len(other.clbits()) > len(self.clbits()):
+        if len(other.qubits) > len(self.qubits) or \
+           len(other.clbits) > len(self.clbits):
             raise DAGCircuitError("Trying to compose with another DAGCircuit "
                                   "which has more 'in' edges.")
 
@@ -535,15 +551,15 @@ class DAGCircuit:
             qubits = []
         if clbits is None:
             clbits = []
-        qubit_map = {other.qubits()[i]: (self.qubits()[q] if isinstance(q, int) else q)
+        qubit_map = {other.qubits[i]: (self.qubits[q] if isinstance(q, int) else q)
                      for i, q in enumerate(qubits)}
-        clbit_map = {other.clbits()[i]: (self.clbits()[c] if isinstance(c, int) else c)
+        clbit_map = {other.clbits[i]: (self.clbits[c] if isinstance(c, int) else c)
                      for i, c in enumerate(clbits)}
         edge_map = edge_map or {**qubit_map, **clbit_map} or None
         # if no edge_map, try to do a 1-1 mapping in order
         if edge_map is None:
-            identity_qubit_map = dict(zip(other.qubits(), self.qubits()))
-            identity_clbit_map = dict(zip(other.clbits(), self.clbits()))
+            identity_qubit_map = dict(zip(other.qubits, self.qubits))
+            identity_clbit_map = dict(zip(other.clbits, self.clbits))
             edge_map = {**identity_qubit_map, **identity_clbit_map}
 
         # Check the edge_map for duplicate values

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -101,8 +101,6 @@ class DAGCircuit:
             dag.qubits as property.
             """
             def __call__(self):
-                warnings.warn('dag.qubits() and dag.clbits() are no longer methods. Use '
-                              'dag.qubits and dag.clbits properties instead.', DeprecationWarning)
                 return self
         self._qubits = DummyCallableList()  # TODO: make these a regular empty list [] after the
         self._clbits = DummyCallableList()  # DeprecationWarning period, and remove name underscore.

--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -102,7 +102,7 @@ class CSPLayout(AnalysisPass):
         self.seed = seed
 
     def run(self, dag):
-        qubits = dag.qubits()
+        qubits = dag.qubits
         cxs = set()
 
         for gate in dag.two_qubit_ops():

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -140,7 +140,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         number of CNOTs between the pair.
         """
         idx = 0
-        for q in dag.qubits():
+        for q in dag.qubits:
             self.qarg_to_id[q.register.name + str(q.index)] = idx
             idx += 1
         for gate in dag.two_qubit_ops():
@@ -252,7 +252,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
                 self.prog2hw[qid] = self.available_hw_qubits[0]
                 self.available_hw_qubits.remove(self.prog2hw[qid])
         layout = Layout()
-        for q in dag.qubits():
+        for q in dag.qubits:
             pid = self._qarg_to_id(q)
             hwid = self.prog2hw[pid]
             layout[q] = hwid

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -61,7 +61,7 @@ class ConsolidateBlocks(TransformationPass):
             new_dag.add_creg(creg)
 
         # compute ordered indices for the global circuit wires
-        global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits())}
+        global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
 
         blocks = self.property_set['block_list']
         # just to make checking if a node is in any block easier

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -69,7 +69,7 @@ class HoareOptimizer(TransformationPass):
         Args:
             dag (DAGCircuit): input DAG to get qubits from
         """
-        for qbt in dag.qubits():
+        for qbt in dag.qubits:
             self.gatenum[qbt.index] = 0
             self.variables[qbt.index] = []
             self.gatecache[qbt.index] = []
@@ -338,6 +338,6 @@ class HoareOptimizer(TransformationPass):
         self._initialize(dag)
         self._traverse_dag(dag)
         if self.size > 1:
-            for qbt in dag.qubits():
+            for qbt in dag.qubits:
                 self._multigate_opt(dag, qbt.index)
         return dag

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -60,7 +60,7 @@ class BasicSwap(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get('q', None) is None:
             raise TranspilerError('Basic swap runs on physical circuits only')
 
-        if len(dag.qubits()) > len(self.coupling_map.physical_qubits):
+        if len(dag.qubits) > len(self.coupling_map.physical_qubits):
             raise TranspilerError('The layout does not match the amount of qubits in the DAG')
 
         canonical_register = dag.qregs['q']
@@ -92,14 +92,14 @@ class BasicSwap(TransformationPass):
                                                         cargs=[])
 
                     # layer insertion
-                    order = current_layout.reorder_bits(new_dag.qubits())
+                    order = current_layout.reorder_bits(new_dag.qubits)
                     new_dag.compose(swap_layer, qubits=order)
 
                     # update current_layout
                     for swap in range(len(path) - 2):
                         current_layout.swap(path[swap], path[swap + 1])
 
-            order = current_layout.reorder_bits(new_dag.qubits())
+            order = current_layout.reorder_bits(new_dag.qubits)
             new_dag.compose(subdag, qubits=order)
 
         return new_dag

--- a/qiskit/transpiler/passes/routing/layout_transformation.py
+++ b/qiskit/transpiler/passes/routing/layout_transformation.py
@@ -79,7 +79,7 @@ class LayoutTransformation(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get('q', None) is None:
             raise TranspilerError('LayoutTransform runs on physical circuits only')
 
-        if len(dag.qubits()) > len(self.coupling_map.physical_qubits):
+        if len(dag.qubits) > len(self.coupling_map.physical_qubits):
             raise TranspilerError('The layout does not match the amount of qubits in the DAG')
 
         from_layout = self.from_layout
@@ -102,7 +102,7 @@ class LayoutTransformation(TransformationPass):
 
         perm_circ = self.token_swapper.permutation_circuit(permutation, self.trials)
 
-        edge_map = {vqubit: dag.qubits()[pqubit]
+        edge_map = {vqubit: dag.qubits[pqubit]
                     for (pqubit, vqubit) in perm_circ.inputmap.items()}
         dag.compose(perm_circ.circuit, edge_map=edge_map)
         return dag

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -93,7 +93,7 @@ class LookaheadSwap(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get('q', None) is None:
             raise TranspilerError('Lookahead swap runs on physical circuits only')
 
-        if len(dag.qubits()) > len(self.coupling_map.physical_qubits):
+        if len(dag.qubits) > len(self.coupling_map.physical_qubits):
             raise TranspilerError('The layout does not match the amount of qubits in the DAG')
 
         canonical_register = dag.qregs['q']

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -87,7 +87,7 @@ class StochasticSwap(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get('q', None) is None:
             raise TranspilerError('Basic swap runs on physical circuits only')
 
-        if len(dag.qubits()) > len(self.coupling_map.physical_qubits):
+        if len(dag.qubits) > len(self.coupling_map.physical_qubits):
             raise TranspilerError('The layout does not match the amount of qubits in the DAG')
 
         canonical_register = dag.qregs['q']
@@ -265,7 +265,7 @@ class StochasticSwap(TransformationPass):
         for creg in layer_circuit.cregs.values():
             dagcircuit_output.add_creg(creg)
 
-        order = layout.reorder_bits(dagcircuit_output.qubits())
+        order = layout.reorder_bits(dagcircuit_output.qubits)
         dagcircuit_output.compose(layer_circuit, qubits=order)
 
         return dagcircuit_output

--- a/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
@@ -59,7 +59,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
 
         # Add a barrier across all qubits so swap mapper doesn't add a swap
         # from an unmeasured qubit after a measure.
-        final_qubits = dag.qubits()
+        final_qubits = dag.qubits
 
         barrier_layer.apply_operation_back(
             Barrier(len(final_qubits)), list(final_qubits), [])

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -125,8 +125,8 @@ def _get_layered_instructions(circuit, reverse_bits=False,
 
     dag = circuit_to_dag(circuit)
     ops = []
-    qregs = dag.qubits()
-    cregs = dag.clbits()
+    qregs = dag.qubits
+    cregs = dag.clbits
 
     if justify == 'none':
         for node in dag.topological_op_nodes():
@@ -198,7 +198,7 @@ class _LayerSpooler(list):
         """Create spool"""
         super(_LayerSpooler, self).__init__()
         self.dag = dag
-        self.qregs = dag.qubits()
+        self.qregs = dag.qubits
         self.justification = justification
 
         if self.justification == 'left':

--- a/releasenotes/notes/deprecate-dag-qubits-method-0a61b37fa4a5bcd5.yaml
+++ b/releasenotes/notes/deprecate-dag-qubits-method-0a61b37fa4a5bcd5.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+   :meth:`~qiskit.dagcircuit.DAGCircuit.qubits` and
+   :meth:`~qiskit.dagcircuit.DAGCircuit.clbits` have been deprecated
+   as methods. They are now properties of the dag, and are cached so
+   accessing them is much faster.

--- a/releasenotes/notes/deprecate-dag-qubits-method-0a61b37fa4a5bcd5.yaml
+++ b/releasenotes/notes/deprecate-dag-qubits-method-0a61b37fa4a5bcd5.yaml
@@ -1,7 +1,0 @@
----
-deprecations:
-  - |
-   :meth:`~qiskit.dagcircuit.DAGCircuit.qubits` and
-   :meth:`~qiskit.dagcircuit.DAGCircuit.clbits` have been deprecated
-   as methods. They are now properties of the dag, and are cached so
-   accessing them is much faster.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The list of qubits and clbits of a dag were being recreated every time dag.qubits() and dag.clbits() methods were called, which was slow. Here I make them cached properties. Being properties is also aligned with how they are in QuantumCircuit.

### Details and comments
Fixes #4484
Backported from #4535 
(cherry picked from commit 01cc5a25f58b42f4cc8af4a318545fc07098673b)
    
Conflicts:
            qiskit/dagcircuit/dagcircuit.py
            qiskit/dagcircuit/dagdependency.py
            test/python/dagcircuit/test_dagdependency.py

Also the deprecation added in #4535 as the deprecation timer only starts in 0.15.0 (and would be a breaking change for a stable patch release)