### PR TITLE
[Stable] fix bug in unrolling open controlled basis gates. (#4444)

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -133,8 +133,10 @@ class UnitaryGate(Gate):
         """
         cmat = _compute_control_matrix(self.to_matrix(), num_ctrl_qubits)
         iso = isometry.Isometry(cmat, 0, 0)
-        return ControlledGate('c-unitary', self.num_qubits + num_ctrl_qubits, cmat,
-                              definition=iso.definition, label=label)
+        cunitary = ControlledGate('c-unitary', self.num_qubits + num_ctrl_qubits, cmat,
+                                  definition=iso.definition, label=label)
+        cunitary.base_gate = self.copy()
+        return cunitary
 
     def qasm(self):
         """ The qasm for a custom unitary gate

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -17,6 +17,7 @@
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.exceptions import QiskitError
+from qiskit.circuit import ControlledGate
 
 
 class Unroller(TransformationPass):
@@ -61,7 +62,10 @@ class Unroller(TransformationPass):
                 #  backend reports "measure", for example.
                 continue
             if node.name in self.basis:  # If already a base, ignore.
-                continue
+                if isinstance(node.op, ControlledGate) and node.op._open_ctrl:
+                    pass
+                else:
+                    continue
 
             # TODO: allow choosing other possible decompositions
             try:

--- a/releasenotes/notes/fix-unrolling-open-ctrl-gate-4a72116526afb1fd.yaml
+++ b/releasenotes/notes/fix-unrolling-open-ctrl-gate-4a72116526afb1fd.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Open controls were implemented by modifying a gate\'s 
+    definition. However, when the gate already exists in the basis,
+    this definition is not used, which yields incorrect circuits sent
+    to a backend. This modifies the unroller to output the definition
+    if it encounters a controlled gate with open controls.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -667,6 +667,76 @@ class TestControlledGate(QiskitTestCase):
                          (output_target != cond_output)) or
                         output_ctrl != input_ctrl)
 
+    def test_open_control_cx_unrolling(self):
+        """test unrolling of open control gates when gate is in basis"""
+        qc = QuantumCircuit(2)
+        qc.cx(0, 1, ctrl_state=0)
+        dag = circuit_to_dag(qc)
+        unroller = Unroller(['u3', 'cx'])
+        uqc = dag_to_circuit(unroller.run(dag))
+
+        ref_circuit = QuantumCircuit(2)
+        ref_circuit.u3(np.pi, 0, np.pi, 0)
+        ref_circuit.cx(0, 1)
+        ref_circuit.u3(np.pi, 0, np.pi, 0)
+        self.assertEqual(uqc, ref_circuit)
+
+    def test_open_control_cy_unrolling(self):
+        """test unrolling of open control gates when gate is in basis"""
+        qc = QuantumCircuit(2)
+        qc.cy(0, 1, ctrl_state=0)
+        dag = circuit_to_dag(qc)
+        unroller = Unroller(['u3', 'cy'])
+        uqc = dag_to_circuit(unroller.run(dag))
+
+        ref_circuit = QuantumCircuit(2)
+        ref_circuit.u3(np.pi, 0, np.pi, 0)
+        ref_circuit.cy(0, 1)
+        ref_circuit.u3(np.pi, 0, np.pi, 0)
+        self.assertEqual(uqc, ref_circuit)
+
+    def test_open_control_cxx_unrolling(self):
+        """test unrolling of open control gates when gate is in basis"""
+        qreg = QuantumRegister(3)
+        qc = QuantumCircuit(qreg)
+        ccx = CCXGate(ctrl_state=0)
+        qc.append(ccx, [0, 1, 2])
+        dag = circuit_to_dag(qc)
+        unroller = Unroller(['x', 'ccx'])
+        unrolled_dag = unroller.run(dag)
+
+        ref_circuit = QuantumCircuit(qreg)
+        ref_circuit.x(qreg[0])
+        ref_circuit.x(qreg[1])
+        ref_circuit.ccx(qreg[0], qreg[1], qreg[2])
+        ref_circuit.x(qreg[0])
+        ref_circuit.x(qreg[1])
+        ref_dag = circuit_to_dag(ref_circuit)
+        self.assertEqual(unrolled_dag, ref_dag)
+
+    def test_open_control_composite_unrolling(self):
+        """test unrolling of open control gates when gate is in basis"""
+        # create composite gate
+        qreg = QuantumRegister(2)
+        qcomp = QuantumCircuit(qreg, name='bell')
+        qcomp.h(qreg[0])
+        qcomp.cx(qreg[0], qreg[1])
+        bell = qcomp.to_gate()
+        # create controlled composite gate
+        cqreg = QuantumRegister(3)
+        qc = QuantumCircuit(cqreg)
+        qc.append(bell.control(ctrl_state=0), qc.qregs[0][:])
+        dag = circuit_to_dag(qc)
+        unroller = Unroller(['x', 'u1', 'cbell'])
+        unrolled_dag = unroller.run(dag)
+        # create reference circuit
+        ref_circuit = QuantumCircuit(cqreg)
+        ref_circuit.x(cqreg[0])
+        ref_circuit.append(bell.control(), [cqreg[0], cqreg[1], cqreg[2]])
+        ref_circuit.x(cqreg[0])
+        ref_dag = circuit_to_dag(ref_circuit)
+        self.assertEqual(unrolled_dag, ref_dag)
+
     @data(*ControlledGate.__subclasses__())
     def test_base_gate_setting(self, gate_class):
         """Test all gates in standard extensions which are of type ControlledGate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This addresses a bug where unrolling would not be correct for open controlled gates within the set of basis gates.

fixes #4437

* resolve unrolling bug

* linting

* fix controlled gate def

* add release notes

* simplify open tests and update unroll_custom_definitions.py

* update release notes

* Update qiskit/transpiler/passes/basis/unroll_custom_definitions.py

Co-authored-by: Kevin Krsulich <kevin@krsulich.net>

* add import of ControlledGate

Co-authored-by: Kevin Krsulich <kevin@krsulich.net>
Co-authored-by: Kevin Krsulich <kevin.krsulich@ibm.com>
Co-authored-by: mergify[bot] <37929162+mergify[bot]@users.noreply.github.com>

### Details and comments

Backrported from: #4444
(cherry picked from commit 63449c4dc49a9e0267fb15f95cd697b11ee3ee59)

Conflicts:
    qiskit/extensions/unitary.py
    qiskit/transpiler/passes/basis/unroll_custom_definitions.py
