### PR TITLE
Stop using dag.qubits() and dag.clbits() while testing, as deprecated in #4535

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -102,7 +102,8 @@ class DAGCircuit:
             """
             def __call__(self):
                 warnings.warn('dag.qubits() and dag.clbits() are no longer methods. Use '
-                              'dag.qubits and dag.clbits properties instead.', DeprecationWarning)
+                              'dag.qubits and dag.clbits properties instead.', DeprecationWarning,
+                              stacklevel=2)
                 return self
         self._qubits = DummyCallableList()  # TODO: make these a regular empty list [] after the
         self._clbits = DummyCallableList()  # DeprecationWarning period, and remove name underscore.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -156,12 +156,12 @@ class TestDagRegisters(QiskitTestCase):
         dag.add_qreg(QuantumRegister(1, 'qr3'))
         dag.add_qreg(QuantumRegister(1, 'qr4'))
         dag.add_qreg(QuantumRegister(1, 'qr6'))
-        self.assertListEqual(dag.qubits(), [QuantumRegister(1, 'qr1')[0],
-                                            QuantumRegister(1, 'qr10')[0],
-                                            QuantumRegister(1, 'qr0')[0],
-                                            QuantumRegister(1, 'qr3')[0],
-                                            QuantumRegister(1, 'qr4')[0],
-                                            QuantumRegister(1, 'qr6')[0]])
+        self.assertListEqual(dag.qubits, [QuantumRegister(1, 'qr1')[0],
+                                          QuantumRegister(1, 'qr10')[0],
+                                          QuantumRegister(1, 'qr0')[0],
+                                          QuantumRegister(1, 'qr3')[0],
+                                          QuantumRegister(1, 'qr4')[0],
+                                          QuantumRegister(1, 'qr6')[0]])
 
     def test_add_reg_duplicate(self):
         """add_qreg with the same register twice is not allowed."""
@@ -582,12 +582,12 @@ class TestDagNodeSelection(QiskitTestCase):
         self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
         self.dag.apply_operation_back(HGate(), [self.qubit0], [])
 
-        qbit = self.dag.qubits()[0]
+        qbit = self.dag.qubits[0]
         self.assertEqual([0, 10, 11, 1], [i._node_id for i in self.dag.nodes_on_wire(qbit)])
         self.assertEqual([10, 11],
                          [i._node_id for i in self.dag.nodes_on_wire(qbit, only_ops=True)])
 
-        cbit = self.dag.clbits()[0]
+        cbit = self.dag.clbits[0]
         self.assertEqual([6, 7], [i._node_id for i in self.dag.nodes_on_wire(cbit)])
         self.assertEqual([], [i._node_id for i in self.dag.nodes_on_wire(cbit, only_ops=True)])
 
@@ -610,7 +610,7 @@ class TestDagNodeSelection(QiskitTestCase):
         self.dag.apply_operation_back(HGate(), [self.qubit1], [])
         self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
 
-        nodes = self.dag.nodes_on_wire(self.dag.qubits()[1], only_ops=True)
+        nodes = self.dag.nodes_on_wire(self.dag.qubits[1], only_ops=True)
         node_names = [nd.name for nd in nodes]
 
         self.assertEqual(node_names, ['cx', 'h', 'cx'])
@@ -1007,6 +1007,7 @@ class TestDagSubstituteNode(QiskitTestCase):
 class TestDagProperties(QiskitTestCase):
     """Test the DAG properties.
     """
+
     def setUp(self):
         qr1 = QuantumRegister(4)
         qr2 = QuantumRegister(2)

--- a/test/python/transpiler/test_layout_transformation.py
+++ b/test/python/transpiler/test_layout_transformation.py
@@ -42,7 +42,7 @@ class TestLayoutTransformation(QiskitTestCase):
                                       to_layout=to_layout)
         qc = QuantumCircuit(3)  # input (empty) physical circuit
         dag = circuit_to_dag(qc)
-        q = dag.qubits()
+        q = dag.qubits
         output_dag = ltpass.run(dag)
         # output_dag.draw()
         # Check that only two swaps were performed


### PR DESCRIPTION
In #4535 `dag.qubits()` and `dag.clbits()` are being deprecated. We should stop using them in our tests.