### PR TITLE
Fix ZZFeatureMap barriers

### DIFF
--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -82,4 +82,5 @@ class ZZFeatureMap(PauliFeatureMap):
                          reps=reps,
                          entanglement=entanglement,
                          paulis=['Z', 'ZZ'],
-                         data_map_func=data_map_func)
+                         data_map_func=data_map_func,
+                         insert_barriers=insert_barriers)

--- a/releasenotes/notes/fix-zz-feature-map-barriers-ab1a2d930a6b5af1.yaml
+++ b/releasenotes/notes/fix-zz-feature-map-barriers-ab1a2d930a6b5af1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The ``insert_barriers`` keyword argument in the ``ZZFeatureMap`` class
+    didn't actually insert barriers in between the Hadamard layers and 
+    evolution layers. This has been fixed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

 The ``insert_barriers`` keyword argument in the ``ZZFeatureMap`` class
 didn't actually insert barriers in between the Hadamard layers and 
 evolution layers. This has been fixed.



