### PR TITLE
fixes issue of crashing on unroll of 3+ qubit gates (#4577).

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -36,10 +36,9 @@ class Unroll3qOrMore(TransformationPass):
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:
-           
                 if rule == []:  # empty node
-                        dag.remove_op_node(node)
-                        continue
+                    dag.remove_op_node(node)
+                    continue
                 raise QiskitError("Cannot unroll all 3q or more gates. "
                                   "No rule to expand instruction %s." %
                                   node.op.name)

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -36,6 +36,10 @@ class Unroll3qOrMore(TransformationPass):
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:
+           
+                if rule == []:  # empty node
+                        dag.remove_op_node(node)
+                        continue
                 raise QiskitError("Cannot unroll all 3q or more gates. "
                                   "No rule to expand instruction %s." %
                                   node.op.name)

--- a/releasenotes/notes/large_gate_bugfix-cbf0b6f1dcfbd5dd.yaml
+++ b/releasenotes/notes/large_gate_bugfix-cbf0b6f1dcfbd5dd.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed issue where some gates with three or more qubits would fail to compile
+    in certain instances. Refer to 
+    `#4577 <https://github.com/Qiskit/qiskit-terra/issues/4577` for more detail.
+
+

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -20,8 +20,8 @@ from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeLondon
 from qiskit.extensions import UnitaryGate
+
 
 class TestUnroll3qOrMore(QiskitTestCase):
     """Tests the Unroll3qOrMore pass, for unrolling all
@@ -96,5 +96,3 @@ class TestUnroll3qOrMore(QiskitTestCase):
         after_dag = pass_.run(dag)
         after_circ = dag_to_circuit(after_dag)
         self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
-
-

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -13,14 +13,15 @@
 # that they have been altered from the originals.
 
 """Test the Unroll3qOrMore pass"""
-
+import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
-
+from qiskit.test.mock import FakeLondon
+from qiskit.extensions import UnitaryGate
 
 class TestUnroll3qOrMore(QiskitTestCase):
     """Tests the Unroll3qOrMore pass, for unrolling all
@@ -83,3 +84,17 @@ class TestUnroll3qOrMore(QiskitTestCase):
         after_dag = pass_.run(dag)
         after_circ = dag_to_circuit(after_dag)
         self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
+
+    def test_identity(self):
+        """Test unrolling of identity gate over 3qubits."""
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        gate = UnitaryGate(np.eye(2 ** 3))
+        circuit.append(gate, range(3))
+        dag = circuit_to_dag(circuit)
+        pass_ = Unroll3qOrMore()
+        after_dag = pass_.run(dag)
+        after_circ = dag_to_circuit(after_dag)
+        self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
+
+


### PR DESCRIPTION
No longer crashes upon unrolling of some gates with more than 2 qubits. Required simple fix of throwing away empty operations when looping through 3+ qubit gates (used to just crash when it saw this).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


