### PR TITLE
refactoring latex.py

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -90,6 +90,9 @@ class QCircuitImage:
         # Map from registers to the list they appear in the image
         self.img_regs = {}
 
+        # Map from a bit to the row which it signifies
+        self.bit_row = {}
+
         # Array to hold the \\LaTeX commands to generate a circuit image.
         self._latex = []
 
@@ -121,19 +124,34 @@ class QCircuitImage:
 
         #################################
         self.qregs = _get_register_specs(qubits)
+        self.num_qregs = len(self.qregs)
         self.qubit_list = qubits
-        self.ordered_regs = qubits + clbits
+        self.num_qubits = len(self.qubit_list)
+
         self.cregs = _get_register_specs(clbits)
+        self.num_cregs = len(self.cregs)
         self.clbit_list = clbits
+        self.num_clbits = len(self.clbit_list)
+
+        self.ordered_regs = qubits + clbits
         self.img_regs = {bit: ind for ind, bit in
                          enumerate(self.ordered_regs)}
+
         if cregbundle:
             self.img_width = len(qubits) + len(self.cregs)
+
+            self.bit_row = {bit: ind for ind, bit in enumerate(self.qubit_list)}
+
+            for num_reg_added, cl_register in enumerate(self.cregs):
+                for bit_in_register in cl_register._bits:
+                    self.bit_row[bit_in_register] = \
+                        num_reg_added + self.num_qubits
         else:
             self.img_width = len(self.img_regs)
-        self.wire_type = {}
-        for bit in self.ordered_regs:
-            self.wire_type[bit] = bit.register in self.cregs.keys()
+
+            self.bit_row = {bit: ind for ind, bit in
+                            enumerate(self.ordered_regs)}
+
         self.cregbundle = cregbundle
 
     def latex(self, aliases=None):
@@ -145,62 +163,34 @@ class QCircuitImage:
         Returns:
             string: for writing to a LaTeX file.
         """
+        self._set_dimensions()
+
         self._initialize_latex_array()
+        self._write_labels()
         self._build_latex_array(aliases)
-        header_1 = r"""% \documentclass[preview]{standalone}
-% If the image is too large to fit on this documentclass use
-\documentclass[draft]{beamer}
-"""
-        beamer_line = "\\usepackage[size=custom,height=%d,width=%d,scale=%.1f]{beamerposter}\n"
-        header_2 = r"""% instead and customize the height and width (in cm) to fit.
-% Large images may run out of memory quickly.
-% To fix this use the LuaLaTeX compiler, which dynamically
-% allocates memory.
-\usepackage[braket, qm]{qcircuit}
-\usepackage{amsmath}
-\pdfmapfile{+sansmathaccent.map}
-% \usepackage[landscape]{geometry}
-% Comment out the above line if using the beamer documentclass.
-\begin{document}
-\begin{equation*}"""
-        qcircuit_line = r"""
-    \Qcircuit @C=%.1fem @R=%.1fem @!R {
-"""
+
         output = io.StringIO()
-        output.write(header_1)
-        output.write('%% img_width = %d, img_depth = %d\n' % (self.img_width, self.img_depth))
-        output.write(beamer_line % self._get_beamer_page())
-        output.write(header_2)
-        output.write(qcircuit_line %
-                     (self.column_separation, self.row_separation))
-        for i in range(self.img_width):
-            output.write("\t \t")
-            for j in range(self.img_depth + 1):
-                cell_str = self._latex[i][j]
-                # Don't truncate offset float if drawing a barrier
-                if 'barrier' in cell_str:
-                    output.write(cell_str)
-                else:
-                    # floats can cause "Dimension too large" latex error in
-                    # xymatrix this truncates floats to avoid issue.
-                    cell_str = re.sub(r'[-+]?\d*\.\d{2,}|\d{2,}',
-                                      _truncate_float,
-                                      cell_str)
-                    output.write(cell_str)
-                if j != self.img_depth:
-                    output.write(" & ")
-                else:
-                    output.write(r'\\' + '\n')
+
+        self._write_header(output)
+
+        self._write_array(output)
+
         output.write('\t }\n')
         output.write('\\end{equation*}\n\n')
         output.write('\\end{document}')
+
         contents = output.getvalue()
         output.close()
+
         return contents
 
-    def _initialize_latex_array(self):
-        self.img_depth, self.sum_column_widths = self._get_image_depth()
-        self.sum_row_heights = self.img_width
+    def _set_dimensions(self):
+        """ setting sizing information
+        """
+        self._set_has_box_has_target()
+        self._set_image_depth()
+        self._set_sum_column_width()
+
         # choose the most compact row spacing, while not squashing them
         if self.has_box:
             self.row_separation = 0.0
@@ -208,163 +198,70 @@ class QCircuitImage:
             self.row_separation = 0.2
         else:
             self.row_separation = 1.0
-        self._latex = [
-            ["\\cw" if self.wire_type[self.ordered_regs[j]]
-             else "\\qw" for _ in range(self.img_depth + 1)]
-            for j in range(self.img_width)]
-        self._latex.append([" "] * (self.img_depth + 1))
+
+    def _initialize_latex_array(self):
+        """ Create self._latex with the proper dimensions and the right
+            type of wire
+
+        """
+
+        # initializes with "\\qw" in quantum rows and "\\cw" in classical
+        self._latex = [["\\qw"] * (self.img_depth + 1)
+                       for i in range(self.num_qubits)]
+
         if self.cregbundle:
-            offset = 0
-        for i in range(self.img_width):
-            if self.wire_type[self.ordered_regs[i]]:
-                if self.cregbundle:
-                    self._latex[i][0] = \
-                        "\\lstick{" + self.ordered_regs[i + offset].register.name + ":"
-                    clbitsize = self.cregs[self.ordered_regs[i + offset].register]
-                    self._latex[i][1] = "{/_{_{" + str(clbitsize) + "}}} \\cw"
-                    offset += clbitsize - 1
-                else:
-                    self._latex[i][0] = "\\lstick{" + self.ordered_regs[i].register.name + \
-                                            "_{" + str(self.ordered_regs[i].index) + "}:"
-                if self.initial_state:
-                    self._latex[i][0] += "0"
-                self._latex[i][0] += "}"
+            self._latex += [["\\cw"] * (self.img_depth + 1)
+                            for i in range(self.num_cregs)]
+        else:
+            self._latex += [["\\cw"] * (self.img_depth + 1)
+                            for i in range(self.num_clbits)]
+
+        self._latex.append([" "] * (self.img_depth + 1))
+
+    def _write_labels(self):
+        """ Adds labels to the first column of self._latex array
+        """
+
+        # Note: Using old string formatting % to keep clear with LaTeX {}
+
+        # first add the qbit labels
+        if self.layout:
+            for i, qubit in enumerate(self.qubit_list):
+                self._latex[i][0] = r'\lstick{ {%s}_{%d}\mapsto{%d} : ' % (
+                    self.layout[qubit.index].register.name,
+                    self.layout[qubit.index].index,
+                    qubit.index)
+        else:
+            for i, qubit in enumerate(self.qubit_list):
+                self._latex[i][0] = "\\lstick{ {%s}_{%d} : " % (
+                    qubit.register.name, qubit.index)
+
+        # then adding the classical labels
+        if self.cregbundle:
+            # adding labels for the registers
+            for i, reg in enumerate(self.cregs, self.num_qubits):
+                self._latex[i][0] = "\\lstick{ %s :" % reg.name
+                self._latex[i][1] = "{/_{_{%d} }} \\cw" % (reg.size)
+        else:
+            # adding labels for all clbits
+            for i, bit in enumerate(self.clbit_list, self.num_qubits):
+                self._latex[i][0] = "\\lstick{ { %s }_{ %d } :" % (
+                    bit.register.name, bit.index)
+
+        # Adding the initial state on
+        if self.initial_state:
+            for i in range(self.num_qubits):
+                self._latex[i][0] += " \\ket{0} "
+
+            if self.cregbundle:
+                for i in range(self.num_cregs):
+                    self._latex[i+self.num_qubits] += " 0 "
             else:
-                if self.layout is None:
-                    label = "\\lstick{{ {{{}}}_{{{}}} : ".format(
-                        self.ordered_regs[i].register.name, self.ordered_regs[i].index)
-                else:
-                    label = "\\lstick{{ {{{}}}_{{{}}}\\mapsto{{{}}} : ".format(
-                        self.layout[self.ordered_regs[i].index].register.name,
-                        self.layout[self.ordered_regs[i].index].index,
-                        self.ordered_regs[i].index)
-                if self.initial_state:
-                    label += "\\ket{{0}}"
-                label += " }"
-                self._latex[i][0] = label
+                for i in range(self.num_clbits):
+                    self._latex[i+self.num_qubits] += " 0 "
 
-    def _get_image_depth(self):
-        """Get depth information for the circuit.
-
-        Returns:
-            int: number of columns in the circuit
-            int: total size of columns in the circuit
-        """
-
-        max_column_widths = []
-        # Determine row spacing before image depth
-        for layer in self.ops:
-            for op in layer:
-                # useful information for determining row spacing
-                boxed_gates = ['u0', 'u1', 'u2', 'u3', 'x', 'y', 'z', 'h', 's',
-                               'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'ch', 'cy',
-                               'crz', 'cu3', 'id']
-                target_gates = ['cx', 'ccx']
-                if op.name in boxed_gates:
-                    self.has_box = True
-                if op.name in target_gates:
-                    self.has_target = True
-                if isinstance(op.op, ControlledGate):
-                    self.has_target = True
-
-        for layer in self.ops:
-
-            # store the max width for the layer
-            current_max = 0
-
-            for op in layer:
-
-                # update current op width
-                arg_str_len = 0
-
-                # the wide gates
-                for arg in op.op.params:
-                    arg_str = re.sub(r'[-+]?\d*\.\d{2,}|\d{2,}',
-                                     _truncate_float, str(arg))
-                    arg_str_len += len(arg_str)
-
-                # the width of the column is the max of all the gates in the column
-                current_max = max(arg_str_len, current_max)
-
-            max_column_widths.append(current_max)
-
-        # wires in the beginning and end
-        columns = 2
-
-        # add extra column if needed
-        if self.cregbundle and (self.ops[0][0].name == "measure" or self.ops[0][0].condition):
-            columns += 1
-
-        # all gates take up 1 column except from those with labels (ie cu1)
-        # which take 2 columns
-        for layer in self.ops:
-            column_width = 1
-            for nd in layer:
-                if nd.name in ['cu1', 'rzz']:
-                    column_width = 2
-            columns += column_width
-
-        # every 3 characters is roughly one extra 'unit' of width in the cell
-        # the gate name is 1 extra 'unit'
-        # the qubit/cbit labels plus initial states is 2 more
-        # the wires poking out at the ends is 2 more
-        sum_column_widths = sum(1 + v / 3 for v in max_column_widths)
-
-        max_reg_name = 3
-        for reg in self.ordered_regs:
-            max_reg_name = max(max_reg_name,
-                               len(reg.register.name))
-        sum_column_widths += 5 + max_reg_name / 3
-
-        # could be a fraction so ceil
-        return columns, math.ceil(sum_column_widths)
-
-    def _get_beamer_page(self):
-        """Get height, width & scale attributes for the beamer page.
-
-        Returns:
-            tuple: (height, width, scale) desirable page attributes
-        """
-        # PIL python package limits image size to around a quarter gigabyte
-        # this means the beamer image should be limited to < 50000
-        # if you want to avoid a "warning" too, set it to < 25000
-        PIL_limit = 40000
-
-        # the beamer latex template limits each dimension to < 19 feet
-        # (i.e. 575cm)
-        beamer_limit = 550
-
-        # columns are roughly twice as big as rows
-        aspect_ratio = self.sum_row_heights / self.sum_column_widths
-
-        # choose a page margin so circuit is not cropped
-        margin_factor = 1.5
-        height = min(self.sum_row_heights * margin_factor, beamer_limit)
-        width = min(self.sum_column_widths * margin_factor, beamer_limit)
-
-        # if too large, make it fit
-        if height * width > PIL_limit:
-            height = min(np.sqrt(PIL_limit * aspect_ratio), beamer_limit)
-            width = min(np.sqrt(PIL_limit / aspect_ratio), beamer_limit)
-
-        # if too small, give it a minimum size
-        height = max(height, 10)
-        width = max(width, 10)
-
-        return (height, width, self.scale)
-
-    def _get_mask(self, creg_name):
-        mask = 0
-        for index, cbit in enumerate(self.clbit_list):
-            if creg_name == cbit.register:
-                mask |= (1 << index)
-        return mask
-
-    def parse_params(self, param):
-        """Parse parameters."""
-        if isinstance(param, (ParameterExpression, str)):
-            return generate_latex_label(str(param))
-        return pi_check(param, output='latex')
+        for i in range(self.img_width):
+            self._latex[i][0] += "}"
 
     def _build_latex_array(self, aliases=None):
         """Returns an array of strings containing \\LaTeX for this circuit.
@@ -385,6 +282,8 @@ class QCircuitImage:
         else:
             qregdata = self.qregs
 
+        gate_latex_dict = _create_gate_dictionary()
+
         column = 1
         # Leave a column to display number of classical registers if needed
         if self.cregbundle and (self.ops[0][0].name == "measure" or self.ops[0][0].condition):
@@ -395,7 +294,7 @@ class QCircuitImage:
             for op in layer:
                 if op.condition:
                     mask = self._get_mask(op.condition[0])
-                    cl_reg = self.clbit_list[self._ffs(mask)]
+                    cl_reg = self.clbit_list[_ffs(mask)]
                     if_reg = cl_reg.register
                     pos_2 = self.img_regs[cl_reg]
                     if_value = format(op.condition[1],
@@ -416,7 +315,7 @@ class QCircuitImage:
                     ctrl_state = "{0:b}".format(op.op.ctrl_state).rjust(num_ctrl_qubits, '0')[::-1]
                     if op.condition:
                         mask = self._get_mask(op.condition[0])
-                        cl_reg = self.clbit_list[self._ffs(mask)]
+                        cl_reg = self.clbit_list[_ffs(mask)]
                         if_reg = cl_reg.register
                         pos_cond = self.img_regs[if_reg[0]]
                         temp = pos_array + [pos_cond]
@@ -496,62 +395,33 @@ class QCircuitImage:
                                      'save', 'noise']:
                     nm = generate_latex_label(op.name).replace(" ", "\\,")
                     qarglist = op.qargs
+
                     if aliases is not None:
                         qarglist = map(lambda x: aliases[x], qarglist)
+
                     if len(qarglist) == 1:
-                        pos_1 = self.img_regs[qarglist[0]]
+                        op_row = self.bit_row[qarglist[0]]
+
+                        parsed_params = [_parse_params(param) for param in op.op.params]
+
+                        gate_latex = gate_latex_dict.get(op.name, None)
+                        if gate_latex:
+                            self._latex[op_row][column] = gate_latex % tuple(parsed_params)
+                        else:  # name not standard
+                            if parsed_params:
+                                joined_params = ",".join(parsed_params)
+                                name_parts = ["\\gate{", op.name, "(", joined_params, ")}"]
+                                self._latex[op_row][column] = "".join(name_parts)
+                            else:
+                                self._latex[op_row][column] = "\\gate{%s}" % op.name
 
                         if op.condition:
                             mask = self._get_mask(op.condition[0])
-                            cl_reg = self.clbit_list[self._ffs(mask)]
+                            cl_reg = self.clbit_list[_ffs(mask)]
                             if_reg = cl_reg.register
                             pos_2 = self.img_regs[cl_reg]
 
-                            if nm == "x":
-                                self._latex[pos_1][column] = "\\gate{X}"
-                            elif nm == "y":
-                                self._latex[pos_1][column] = "\\gate{Y}"
-                            elif nm == "z":
-                                self._latex[pos_1][column] = "\\gate{Z}"
-                            elif nm == "h":
-                                self._latex[pos_1][column] = "\\gate{H}"
-                            elif nm == "s":
-                                self._latex[pos_1][column] = "\\gate{S}"
-                            elif nm == "sdg":
-                                self._latex[pos_1][column] = "\\gate{S^\\dag}"
-                            elif nm == "t":
-                                self._latex[pos_1][column] = "\\gate{T}"
-                            elif nm == "tdg":
-                                self._latex[pos_1][column] = "\\gate{T^\\dag}"
-                            elif nm == "u0":
-                                self._latex[pos_1][column] = "\\gate{U_0(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "u1":
-                                self._latex[pos_1][column] = "\\gate{U_1(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "u2":
-                                self._latex[pos_1][column] = \
-                                    "\\gate{U_2\\left(%s,%s\\right)}" % (
-                                        self.parse_params(op.op.params[0]),
-                                        self.parse_params(op.op.params[1]))
-                            elif nm == "u3":
-                                self._latex[pos_1][column] = ("\\gate{U_3(%s,%s,%s)}" % (
-                                    self.parse_params(op.op.params[0]),
-                                    self.parse_params(op.op.params[1]),
-                                    self.parse_params(op.op.params[2])))
-                            elif nm == "rx":
-                                self._latex[pos_1][column] = "\\gate{R_x(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "ry":
-                                self._latex[pos_1][column] = "\\gate{R_y(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "rz":
-                                self._latex[pos_1][column] = "\\gate{R_z(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            else:
-                                self._latex[pos_1][column] = ("\\gate{%s}" % nm)
-
-                            gap = pos_2 - pos_1
+                            gap = pos_2 - op_row
                             creg_rng = 1 if self.cregbundle else self.cregs[if_reg]
                             for i in range(creg_rng):
                                 if (if_value[i] == '1' or (self.cregbundle and int(if_value) > 0)):
@@ -562,55 +432,6 @@ class QCircuitImage:
                                     self._latex[pos_2 + i][column] = \
                                         "\\controlo \\cw \\cwx[-" + str(gap) + "]"
                                     gap = 1
-
-                        else:
-                            if nm == "x":
-                                self._latex[pos_1][column] = "\\gate{X}"
-                            elif nm == "y":
-                                self._latex[pos_1][column] = "\\gate{Y}"
-                            elif nm == "z":
-                                self._latex[pos_1][column] = "\\gate{Z}"
-                            elif nm == "h":
-                                self._latex[pos_1][column] = "\\gate{H}"
-                            elif nm == "s":
-                                self._latex[pos_1][column] = "\\gate{S}"
-                            elif nm == "sdg":
-                                self._latex[pos_1][column] = "\\gate{S^\\dag}"
-                            elif nm == "t":
-                                self._latex[pos_1][column] = "\\gate{T}"
-                            elif nm == "tdg":
-                                self._latex[pos_1][column] = "\\gate{T^\\dag}"
-                            elif nm == "u0":
-                                self._latex[pos_1][column] = "\\gate{U_0(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "u1":
-                                self._latex[pos_1][column] = "\\gate{U_1(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "u2":
-                                self._latex[pos_1][column] = \
-                                    "\\gate{U_2\\left(%s,%s\\right)}" % (
-                                        self.parse_params(op.op.params[0]),
-                                        self.parse_params(op.op.params[1]))
-                            elif nm == "u3":
-                                self._latex[pos_1][column] = ("\\gate{U_3(%s,%s,%s)}" % (
-                                    self.parse_params(op.op.params[0]),
-                                    self.parse_params(op.op.params[1]),
-                                    self.parse_params(op.op.params[2])))
-                            elif nm == "rx":
-                                self._latex[pos_1][column] = "\\gate{R_x(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "ry":
-                                self._latex[pos_1][column] = "\\gate{R_y(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "rz":
-                                self._latex[pos_1][column] = "\\gate{R_z(%s)}" % (
-                                    self.parse_params(op.op.params[0]))
-                            elif nm == "reset":
-                                self._latex[pos_1][column] = (
-                                    "\\push{\\rule{.6em}{0em}\\ket{0}\\"
-                                    "rule{.2em}{0em}} \\qw")
-                            else:
-                                self._latex[pos_1][column] = ("\\gate{%s}" % nm)
 
                     elif len(qarglist) == 2:
                         if isinstance(op.op, ControlledGate):
@@ -680,7 +501,7 @@ class QCircuitImage:
                                     self._latex[pos_1][column] = \
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = \
-                                    "\\gate{R_z(%s)}" % (self.parse_params(op.op.params[0]))
+                                    "\\gate{R_z(%s)}" % (_parse_params(op.op.params[0]))
                             elif nm == "cu1":
                                 if cond == '0':
                                     self._latex[pos_1][column] = \
@@ -690,7 +511,7 @@ class QCircuitImage:
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = "\\control \\qw"
                                 self._latex[min(pos_1, pos_2)][column + 1] = \
-                                    "\\dstick{%s}\\qw" % (self.parse_params(op.op.params[0]))
+                                    "\\dstick{%s}\\qw" % (_parse_params(op.op.params[0]))
                                 self._latex[max(pos_1, pos_2)][column + 1] = "\\qw"
                                 # this is because this gate takes up 2 columns,
                                 # and we have just written to the next column
@@ -704,9 +525,9 @@ class QCircuitImage:
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = \
                                     "\\gate{U_3(%s,%s,%s)}" % \
-                                    (self.parse_params(op.op.params[0]),
-                                     self.parse_params(op.op.params[1]),
-                                     self.parse_params(op.op.params[2]))
+                                    (_parse_params(op.op.params[0]),
+                                     _parse_params(op.op.params[1]),
+                                     _parse_params(op.op.params[2]))
                             elif nm == "rzz":
                                 self._latex[pos_1][column] = "\\ctrl{" + str(
                                     pos_2 - pos_1) + "}"
@@ -715,7 +536,7 @@ class QCircuitImage:
                                 self._latex[min(pos_1, pos_2)][column + 1] = \
                                     "*+<0em,0em>{\\hphantom{zz()}} \\POS [0,0].[%d,0]=" \
                                     "\"e\",!C *{zz(%s)};\"e\"+ R \\qw" % \
-                                    (max(pos_1, pos_2), self.parse_params(op.op.params[0]))
+                                    (max(pos_1, pos_2), _parse_params(op.op.params[0]))
                                 self._latex[max(pos_1, pos_2)][column + 1] = "\\qw"
                                 num_cols_used = 2
                         else:
@@ -766,7 +587,7 @@ class QCircuitImage:
                                     self._latex[pos_1][column] = \
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = \
-                                    "\\gate{R_z(%s)}" % (self.parse_params(op.op.params[0]))
+                                    "\\gate{R_z(%s)}" % (_parse_params(op.op.params[0]))
                             elif nm == "cu1":
                                 if cond == '0':
                                     self._latex[pos_1][column] = \
@@ -776,7 +597,7 @@ class QCircuitImage:
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = "\\control \\qw"
                                 self._latex[min(pos_1, pos_2)][column + 1] = \
-                                    "\\dstick{%s}\\qw" % (self.parse_params(op.op.params[0]))
+                                    "\\dstick{%s}\\qw" % (_parse_params(op.op.params[0]))
                                 self._latex[max(pos_1, pos_2)][column + 1] = "\\qw"
                                 num_cols_used = 2
                             elif nm == "cu3":
@@ -788,9 +609,9 @@ class QCircuitImage:
                                         "\\ctrl{" + str(pos_2 - pos_1) + "}"
                                 self._latex[pos_2][column] = \
                                     ("\\gate{U_3(%s,%s,%s)}" %
-                                     (self.parse_params(op.op.params[0]),
-                                      self.parse_params(op.op.params[1]),
-                                      self.parse_params(op.op.params[2])))
+                                     (_parse_params(op.op.params[0]),
+                                      _parse_params(op.op.params[1]),
+                                      _parse_params(op.op.params[2])))
                             elif nm == "rzz":
                                 self._latex[pos_1][column] = "\\ctrl{" + str(
                                     pos_2 - pos_1) + "}"
@@ -799,7 +620,7 @@ class QCircuitImage:
                                 self._latex[min(pos_1, pos_2)][column + 1] = \
                                     "*+<0em,0em>{\\hphantom{zz()}} \\POS [0,0].[%d,0]=" \
                                     "\"e\",!C *{zz(%s)};\"e\"+ R \\qw" % \
-                                    (max(pos_1, pos_2), self.parse_params(op.op.params[0]))
+                                    (max(pos_1, pos_2), _parse_params(op.op.params[0]))
                                 self._latex[max(pos_1, pos_2)][column + 1] = "\\qw"
                                 num_cols_used = 2
                             else:
@@ -996,6 +817,177 @@ class QCircuitImage:
             # increase the number of columns by the number of columns this layer used
             column += num_cols_used
 
+    def _write_header(self, output):
+        """write header information to the output stream
+        """
+        header_1 = ("% \\documentclass[preview]{standalone} \n"
+                    "% If the image is too large to fit on this documentclass use \n"
+                    "\\documentclass[draft]{beamer} \n")
+
+        beamer_line = "\\usepackage[size=custom,height=%d,width=%d,scale=%.1f]{beamerposter}\n"
+
+        header_2 = ("% instead and customize the height and width (in cm) to fit. \n"
+                    "% Large images may run out of memory quickly. \n"
+                    "% To fix this use the LuaLaTeX compiler, which dynamically \n"
+                    "% allocates memory. \n"
+                    "\\usepackage[braket, qm]{qcircuit} \n"
+                    "\\usepackage{amsmath} \n"
+                    "\\pdfmapfile{+sansmathaccent.map} \n"
+                    "% \\usepackage[landscape]{geometry} \n"
+                    "% Comment out the above line if using the beamer documentclass. \n"
+                    "\\begin{document} \n"
+                    "\\begin{equation*} \n")
+
+        qcircuit_line = "\\Qcircuit @C=%.1fem @R=%.1fem @!R { \n"
+
+        output.write(header_1)
+        output.write("%% img_width = %d, img_depth = %d \n" % (self.img_width, self.img_depth))
+        output.write(beamer_line % self._get_beamer_page())
+        output.write(header_2)
+        output.write(qcircuit_line %
+                     (self.column_separation, self.row_separation))
+
+    def _write_array(self, output):
+        """ write the self._latex array to the output stream in latex form
+        """
+        for i in range(self.img_width):
+            output.write("\t \t")
+            for j in range(self.img_depth + 1):
+                cell_str = self._latex[i][j]
+                # Don't truncate offset float if drawing a barrier
+                if 'barrier' in cell_str:
+                    output.write(cell_str)
+                else:
+                    # floats can cause "Dimension too large" latex error in
+                    # xymatrix this truncates floats to avoid issue.
+                    cell_str = re.sub(r'[-+]?\d*\.\d{2,}|\d{2,}',
+                                      _truncate_float,
+                                      cell_str)
+                    output.write(cell_str)
+                if j != self.img_depth:
+                    output.write(" & ")
+                else:
+                    output.write(r'\\' + '\n')
+
+    def _get_beamer_page(self):
+        """Get height, width & scale attributes for the beamer page.
+
+        Returns:
+            tuple: (height, width, scale) desirable page attributes
+        """
+        # PIL python package limits image size to around a quarter gigabyte
+        # this means the beamer image should be limited to < 50000
+        # if you want to avoid a "warning" too, set it to < 25000
+        PIL_limit = 40000
+
+        # the beamer latex template limits each dimension to < 19 feet
+        # (i.e. 575cm)
+        beamer_limit = 550
+
+        # columns are roughly twice as big as rows
+        aspect_ratio = self.sum_row_heights / self.sum_column_widths
+
+        # choose a page margin so circuit is not cropped
+        margin_factor = 1.5
+        height = min(self.sum_row_heights * margin_factor, beamer_limit)
+        width = min(self.sum_column_widths * margin_factor, beamer_limit)
+
+        # if too large, make it fit
+        if height * width > PIL_limit:
+            height = min(np.sqrt(PIL_limit * aspect_ratio), beamer_limit)
+            width = min(np.sqrt(PIL_limit / aspect_ratio), beamer_limit)
+
+        # if too small, give it a minimum size
+        height = max(height, 10)
+        width = max(width, 10)
+
+        return (height, width, self.scale)
+
+    def _set_has_box_has_target(self):
+        """ initialization for variables used in setting dimensions
+            Sets:
+                self.has_box
+                self.has_target
+        """
+
+        # these gates get boxed
+        boxed_gates = ['u0', 'u1', 'u2', 'u3', 'x', 'y', 'z', 'h', 's',
+                       'sdg', 't', 'tdg', 'rx', 'ry', 'rz', 'ch', 'cy',
+                       'crz', 'cu3', 'id']
+
+        # Determine row spacing before image depth
+        for layer in self.ops:
+            for op in layer:
+                if op.name in boxed_gates:
+                    self.has_box = True
+                if isinstance(op.op, ControlledGate):
+                    self.has_target = True
+
+    def _set_image_depth(self):
+        """Get depth information for the circuit.
+
+        Sets:
+            self.img_depth: number of columns in the circuit
+        """
+
+        # wires in the beginning and end
+        columns = 2
+
+        # add extra column if needed
+        if self.cregbundle and (self.ops[0][0].name == "measure" or self.ops[0][0].condition):
+            columns += 1
+
+        # all gates take up 1 column except from those with labels (ie cu1)
+        # which take 2 columns
+        for layer in self.ops:
+            column_width = 1
+            for nd in layer:
+                if nd.name in ['cu1', 'rzz']:
+                    column_width = 2
+            columns += column_width
+
+        self.img_depth = columns
+
+    def _set_sum_column_width(self):
+        """ Pairs with _set_image_depths
+            Sets:
+                self.sum_column_width
+        """
+        max_column_widths = []
+        for layer in self.ops:
+            # store the max width for the layer
+            layer_max = 0
+
+            for op in layer:
+                # update current op width
+                arg_str_len = 0
+
+                # the wide gates
+                for arg in op.op.params:
+                    arg_str = re.sub(r'[-+]?\d*\.\d{2,}|\d{2,}',
+                                     _truncate_float, str(arg))
+                    arg_str_len += len(arg_str)
+
+                # the width of the column is the max of all the gates in the column
+                layer_max = max(arg_str_len, layer_max)
+
+            max_column_widths.append(layer_max)
+
+        # every 3 characters is roughly one extra 'unit' of width in the cell
+        # the gate name is 1 extra 'unit'
+        # the qubit/cbit labels plus initial states is 2 more
+        # the wires poking out at the ends is 2 more
+        sum_column_widths = sum(1 + v / 3 for v in max_column_widths)
+
+        max_reg_name = 3
+        for reg in self.ordered_regs:
+            max_reg_name = max(max_reg_name,
+                               len(reg.register.name))
+        sum_column_widths += 5 + max_reg_name / 3
+
+        # could be a fraction so ceil
+        self.sum_column_widths = math.ceil(sum_column_widths)
+
     def _get_qubit_index(self, qubit):
         """Get the index number for a quantum bit.
 
@@ -1015,16 +1007,66 @@ class QCircuitImage:
             raise exceptions.VisualizationError("unable to find bit for operation")
         return qindex
 
-    def _ffs(self, mask):
-        """Find index of first set bit.
+    def _get_mask(self, creg_name):
+        mask = 0
+        for index, cbit in enumerate(self.clbit_list):
+            if creg_name == cbit.register:
+                mask |= (1 << index)
+        return mask
 
-        Args:
-            mask (int): integer to search
-        Returns:
-            int: index of the first set bit.
-        """
-        origin = (mask & (-mask)).bit_length()
-        return origin - 1
+# following helper functions do not rely on the class
+
+
+def _create_gate_dictionary():
+    """Used in _build_latex_array to map a gate to corresponding string
+
+    Returns:
+            gate_latex: dictionary mapping gate name to latex string
+    """
+
+    gate_latex = {}
+    gate_latex["x"] = "\\gate{X}"
+    gate_latex["y"] = "\\gate{Y}"
+    gate_latex["z"] = "\\gate{Z}"
+    gate_latex["h"] = "\\gate{H}"
+    gate_latex["s"] = "\\gate{S}"
+    gate_latex["sdg"] = "\\gate{S^\\dag}"
+    gate_latex["t"] = "\\gate{T}"
+    gate_latex["tdg"] = "\\gate{T^\\dag}"
+    gate_latex["u0"] = "\\gate{U_0(%s)}"
+    gate_latex["u1"] = "\\gate{U_1(%s)}"
+    gate_latex["u2"] = "\\gate{U_2\\left(%s,%s\\right)}"
+    gate_latex["u3"] = "\\gate{U_3\\left(%s,%s,%s\\right)}"
+    gate_latex["rx"] = "\\gate{R_x(%s)}"
+    gate_latex["ry"] = "\\gate{R_y(%s)}"
+    gate_latex["rz"] = "\\gate{R_z(%s)}"
+    gate_latex["reset"] = ("\\push{\\rule{.6em}{0em}\\ket{0}\\"
+                           "rule{.2em}{0em}} \\qw")
+
+    return gate_latex
+
+
+def _parse_params(param):
+    """Parse parameters.
+
+    Returns:
+        string: string label for a given parameter
+    """
+    if isinstance(param, (ParameterExpression, str)):
+        return generate_latex_label(str(param))
+    return pi_check(param, output='latex')
+
+
+def _ffs(mask):
+    """Find index of first set bit.
+
+    Args:
+        mask (int): integer to search
+    Returns:
+        int: index of the first set bit.
+    """
+    origin = (mask & (-mask)).bit_length()
+    return origin - 1
 
 
 def _get_register_specs(bits):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Summary

This pull request makes latex.py easier to read.

#### Biggest Changes
* More methods breaking up long code 
         * `self._set_dimensions`
         * `self._write_labels`
         * `self._write_header`
         * `self._write_array`
* Dictionary instead of long elif section (see lines 401-410)
* Moving helper functions that don't depend on the class out of it.  See `_ffs` or `_parse_params`
* Cleaning up and standardizing some strings. Ex: `self._write_header`
* Changing ordering of methods in class.  

#### More minor changes
* Adding `self.bit_row` to eventually replace `self.img_regs` to more naturally work with `cregbundle`
* Eliminating `self.wire_type` as it was only used in one place in the code

### Details and comments

I was intending to fix some bugs in the code.  In order to figure out what was going on that needed fixing, I decided to clean it up a bit first.  Other changes coming.

It has been run through pylint and passes test/visualization/test_visualization.py .


