### PR TITLE
Parameter conjugate

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -45,6 +45,10 @@ class ParameterExpression():
         """Returns a set of the unbound Parameters in the expression."""
         return set(self._parameter_symbols.keys())
 
+    def conjugate(self):
+        """Return the conjugate, which is the ParameterExpression itself, since it is real."""
+        return self
+
     def bind(self, parameter_values):
         """Binds the provided set of parameters to their corresponding values.
 

--- a/releasenotes/notes/parameter-conjugate-a16fd7ae0dc18ede.yaml
+++ b/releasenotes/notes/parameter-conjugate-a16fd7ae0dc18ede.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Add a ``conjugate`` method to the ``ParameterExpression`` to allow
+    calling ``numpy.conj()`` without raising an error. Since the 
+    ``ParameterExpression`` is real, it returns itself.
+    This behaviour is analogous to Python floats/ints.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1189,6 +1189,11 @@ class TestParameterExpressions(QiskitTestCase):
 
         self.assertEqual(updated_expr, expected)
 
+    def test_conjugate(self):
+        """Test calling conjugate on a ParameterExpression."""
+        x = Parameter('x')
+        self.assertEqual(x, x.conjugate())  # Parameters are real, therefore conjugate returns self
+
 
 class TestParameterEquality(QiskitTestCase):
     """Test equality of Parameters and ParameterExpressions."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds `conjugate` to the `ParameterExpression`. Since they are real, conjugate returns self. 
This adds flexibility and convenience, since real numbers in Python (such as float) also support this.

### Details and comments

This is analogous to real numbers in Python,
```python
>>> import numpy
>>> numpy.conj(float(1)) 
1.0
>>> numpy.conj(Parameter('x'))  
x  # before: TypeError: loop of ufunc does not support argument 0 of type Parameter which has no callable conjugate method
```