### PR TITLE
Fix schema bug in `rep_delay` addition

### DIFF
--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -58,7 +58,7 @@ def assemble(experiments: Union[QuantumCircuit, List[QuantumCircuit], Schedule, 
              meas_return: Union[str, MeasReturnType] = MeasReturnType.AVERAGE,
              meas_map: Optional[List[List[Qubit]]] = None,
              memory_slot_size: int = 100,
-             rep_time: Optional[float] = None,
+             rep_time: Optional[int] = None,
              rep_delay: Optional[float] = None,
              parameter_binds: Optional[List[Dict[Parameter, float]]] = None,
              parametric_pulses: Optional[List[str]] = None,
@@ -293,7 +293,7 @@ def _parse_pulse_args(backend, qubit_lo_freq, meas_lo_freq, qubit_lo_range,
                           "used instead, if specified.", RuntimeWarning)
         if isinstance(rep_time, list):
             rep_time = rep_time[0]
-        rep_time = rep_time * 1e6  # convert sec to μs
+        rep_time = int(rep_time * 1e6)  # convert sec to μs
 
     rep_delay = rep_delay or getattr(backend_config, 'rep_delays', None)
     if rep_delay:

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -172,10 +172,10 @@ def execute(experiments, backend,
 
         memory_slot_size (int): Size of each memory slot if the output is Level 0.
 
-        rep_time (list[float]): Time per program execution in sec. Must be from the list provided
+        rep_time (int): Time per program execution in sec. Must be from the list provided
             by the backend (``backend.configuration().rep_times``).
 
-        rep_delay (list[float]): Delay between programs in sec. Only supported on certain
+        rep_delay (float): Delay between programs in sec. Only supported on certain
             backends (``backend.configuration().dynamic_reprate_enabled`` ).
             If supported, ``rep_delay`` will be used instead of ``rep_time``. Must be from the list
             provided by the backend (``backend.configuration().rep_delays``).

--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -249,7 +249,7 @@ class PulseQobjConfig(QobjDictField):
                 measurement driver LO's in GHz.
             memory_slot_size (int): Size of each memory slot if the output is
                 Level 0.
-            rep_time (float): Time per program execution in sec. Must be from the list provided
+            rep_time (int): Time per program execution in sec. Must be from the list provided
                 by the backend (``backend.configuration().rep_times``).
             rep_delay (float): Delay between programs in sec. Only supported on certain
                 backends (``backend.configuration().dynamic_reprate_enabled``).

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -1123,9 +1123,9 @@
                             "type": "array"
                         },
                         "rep_time": {
-                            "minimum": 0,
+                            "minimum": 1,
                             "description": "Execution time of program (microseconds).",
-                            "type": "number"
+                            "type": "integer"
                         },
                         "rep_delay": {
                             "minimum": 0,

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -726,14 +726,14 @@ class TestPulseAssembler(QiskitTestCase):
         # RuntimeWarning bc using ``rep_delay`` when dynamic rep rates not enabled
         with self.assertWarns(RuntimeWarning):
             qobj = assemble(self.schedule, self.backend)
-        self.assertEqual(round(qobj.config.rep_time, 3), rep_times[0]*1e6)
+        self.assertEqual(qobj.config.rep_time, int(rep_times[0]*1e6))
         self.assertEqual(qobj.config.rep_delay, rep_delays[0]*1e6)
 
         # remove rep_delays from backend config and make sure things work
         # now no warning
         del self.backend_config.rep_delays
         qobj = assemble(self.schedule, self.backend)
-        self.assertEqual(round(qobj.config.rep_time, 3), rep_times[0]*1e6)
+        self.assertEqual(qobj.config.rep_time, int(rep_times[0]*1e6))
         self.assertEqual(hasattr(qobj.config, 'rep_delay'), False)
 
     def test_assemble_user_rep_time_delay(self):
@@ -746,7 +746,7 @@ class TestPulseAssembler(QiskitTestCase):
         # RuntimeWarning bc using ``rep_delay`` when dynamic rep rates not enabled
         with self.assertWarns(RuntimeWarning):
             qobj = assemble(self.schedule, self.backend, **self.config)
-        self.assertEqual(qobj.config.rep_time, rep_time*1e6)
+        self.assertEqual(qobj.config.rep_time, int(rep_time*1e6))
         self.assertEqual(qobj.config.rep_delay, rep_delay*1e6)
 
         # now remove rep_delay and set enable dynamic rep rates
@@ -755,7 +755,7 @@ class TestPulseAssembler(QiskitTestCase):
         self.backend_config.dynamic_reprate_enabled = True
         with self.assertWarns(RuntimeWarning):
             qobj = assemble(self.schedule, self.backend, **self.config)
-        self.assertEqual(qobj.config.rep_time, rep_time*1e6)
+        self.assertEqual(qobj.config.rep_time, int(rep_time*1e6))
         self.assertEqual(hasattr(qobj.config, 'rep_delay'), False)
 
         # finally, only use rep_delay and verify that everything runs w/ no warning
@@ -765,7 +765,7 @@ class TestPulseAssembler(QiskitTestCase):
         del self.config['rep_time']
         self.config['rep_delay'] = rep_delay
         qobj = assemble(self.schedule, self.backend, **self.config)
-        self.assertEqual(qobj.config.rep_time, rep_times[0]*1e6)
+        self.assertEqual(qobj.config.rep_time, int(rep_times[0]*1e6))
         self.assertEqual(qobj.config.rep_delay, rep_delay*1e6)
 
 


### PR DESCRIPTION
Fixes #4618

### Summary

Fix a bug causing schema validation to fail from https://github.com/Qiskit/qiskit-terra/pull/4539. 

### Details and comments
- Added back old schema which works w/ IBM Quantum Experience
- Cast `rep_time` to integer as was done previously

