### PR TITLE
set seed for sabre_layout

### DIFF
--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -91,7 +91,7 @@ class SabreLayout(AnalysisPass):
                                  for i, q in enumerate(physical_qubits)})
 
         if self.routing_pass is None:
-            self.routing_pass = SabreSwap(self.coupling_map, 'decay')
+            self.routing_pass = SabreSwap(self.coupling_map, 'decay', seed=self.seed)
 
         # Do forward-backward iterations.
         circ = dag_to_circuit(dag)


### PR DESCRIPTION
The seed was not being set as part of the sabre_layout pass. This commit corrects the oversight.