### PR TITLE
Switch from std::set to std::unordered set in swap_trial

### DIFF
--- a/qiskit/transpiler/passes/routing/cython/stochastic_swap/swap_trial.pyx
+++ b/qiskit/transpiler/passes/routing/cython/stochastic_swap/swap_trial.pyx
@@ -16,7 +16,7 @@
 # that they have been altered from the originals.
 
 cimport cython
-from libcpp.set cimport set as cset
+from libcpp.unordered_set cimport unordered_set as cset
 from .utils cimport NLayout, EdgeCollection
 
 @cython.boundscheck(False)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit switches the set data structure we use for a set in the
stochastic swap trial. C++'s std::set is backed by an RB Tree while
std::unordered_set is a hashset. For the use in swap_trial all we ever
do is a lookup via `count()` and `erase()` to remove elements from the set
after it's initially constructed. The lookup for an RB tree is O(log n)
vs O(1) for a hash set. While for small number of qubits this doesn't
matter too much, but as the number of qubits grows this makes a
noticeable difference.


### Details and comments


