### PR TITLE
Fix deprecation warnings in hoare optimization tests

### DIFF
--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -299,16 +299,16 @@ class TestHoareOptimizer(QiskitTestCase):
         """ The is_identity function determines whether a pair of gates
             forms the identity, when ignoring control qubits.
         """
-        seq = [DAGNode({'type': 'op', 'op': XGate().control()}),
-               DAGNode({'type': 'op', 'op': XGate().control(2)})]
+        seq = [DAGNode(type='op', op=XGate().control()),
+               DAGNode(type='op', op=XGate().control(2))]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
-        seq = [DAGNode({'type': 'op', 'op': RZGate(-pi/2).control()}),
-               DAGNode({'type': 'op', 'op': RZGate(pi/2).control(2)})]
+        seq = [DAGNode(type='op', op=RZGate(-pi/2).control()),
+               DAGNode(type='op', op=RZGate(pi/2).control(2))]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
-        seq = [DAGNode({'type': 'op', 'op': CSwapGate()}),
-               DAGNode({'type': 'op', 'op': SwapGate()})]
+        seq = [DAGNode(type='op', op=CSwapGate()),
+               DAGNode(type='op', op=SwapGate())]
         self.assertTrue(HoareOptimizer()._is_identity(seq))
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The tests for the hoare optimization pass were emitting deprecation
warnings because they were manually creating DAGNode objects and
passing in the parameters as a dictionary instead of kwargs. This was
deprecated in #4086 and actually adds some overhead. This commit fixes
this oversight and uses kwargs for the test's DAGNode creation.

### Details and comments