### PR TITLE
Fix initializing operators from circuits containing barriers

### DIFF
--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -378,12 +378,16 @@ class SuperOp(QuantumChannel):
 
     def _append_instruction(self, obj, qargs=None):
         """Update the current Operator by apply an instruction."""
+        from qiskit.circuit.barrier import Barrier
+
         chan = self._instruction_to_superop(obj)
         if chan is not None:
             # Perform the composition and inplace update the current state
             # of the operator
             op = self.compose(chan, qargs=qargs)
             self._data = op.data
+        elif isinstance(obj, Barrier):
+            return
         else:
             # If the instruction doesn't have a matrix defined we use its
             # circuit decomposition definition if it exists, otherwise we

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -510,12 +510,16 @@ class Operator(BaseOperator):
 
     def _append_instruction(self, obj, qargs=None):
         """Update the current Operator by apply an instruction."""
+        from qiskit.circuit.barrier import Barrier
+
         mat = self._instruction_to_matrix(obj)
         if mat is not None:
             # Perform the composition and inplace update the current state
             # of the operator
             op = self.compose(mat, qargs=qargs)
             self._data = op.data
+        elif isinstance(obj, Barrier):
+            return
         else:
             # If the instruction doesn't have a matrix defined we use its
             # circuit decomposition definition if it exists, otherwise we

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -18,6 +18,7 @@ Circuit simulation for the Clifford class.
 
 from qiskit.exceptions import QiskitError
 from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.barrier import Barrier
 
 
 def _append_circuit(clifford, circuit, qargs=None):
@@ -34,6 +35,9 @@ def _append_circuit(clifford, circuit, qargs=None):
     Raises:
         QiskitError: if input gate cannot be decomposed into Clifford gates.
     """
+    if isinstance(circuit, Barrier):
+        return clifford
+
     if qargs is None:
         qargs = list(range(clifford.num_qubits))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4590 

Includes handling for barriers when constructing operators (Operator, Clifford, QuantumChannel types) from circuits.

### Details and comments


