### PR TITLE
Use reverse_ops instead of mirror in initializer

### DIFF
--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -118,7 +118,7 @@ class Initialize(Instruction):
 
             if np.linalg.norm(thetas) != 0:
                 ry_mult = self._multiplex(RYGate, thetas, last_cnot=add_last_cnot)
-                circuit.append(ry_mult.to_instruction().mirror(), q[i:self.num_qubits])
+                circuit.append(ry_mult.to_instruction().reverse_ops(), q[i:self.num_qubits])
 
         return circuit
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`Instruction.mirror` is deprecated by `reverse_ops`, this emits a lot of deprecation warnings depending on the application.



