### PR TITLE
Ancilla qubit type

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -31,6 +31,7 @@ from qiskit.exceptions import QiskitError
 # The main qiskit operators
 from qiskit.circuit import ClassicalRegister
 from qiskit.circuit import QuantumRegister
+from qiskit.circuit import AncillaRegister
 from qiskit.circuit import QuantumCircuit
 
 # user config

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -215,7 +215,7 @@ Random Circuits
 """
 from .quantumcircuit import QuantumCircuit
 from .classicalregister import ClassicalRegister, Clbit
-from .quantumregister import QuantumRegister, Qubit
+from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
 from .gate import Gate
 # pylint: disable=cyclic-import
 from .controlledgate import ControlledGate

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -29,7 +29,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.qasm.qasm import Qasm
 from qiskit.circuit.exceptions import CircuitError
 from .parameterexpression import ParameterExpression
-from .quantumregister import QuantumRegister, Qubit
+from .quantumregister import QuantumRegister, Qubit, AncillaQubit
 from .classicalregister import ClassicalRegister, Clbit
 from .parametertable import ParameterTable
 from .parametervector import ParameterVector
@@ -575,6 +575,13 @@ class QuantumCircuit:
         Returns a list of classical bits in the order that the registers were added.
         """
         return [cbit for creg in self.cregs for cbit in creg]
+
+    @property
+    def ancillas(self):
+        """
+        Returns a list of quantum bits in the order that the registers were added.
+        """
+        return [qbit for qreg in self.qregs for qbit in qreg if isinstance(qbit, AncillaQubit)]
 
     def __add__(self, rhs):
         """Overload + to implement self.combine."""
@@ -1280,6 +1287,11 @@ class QuantumCircuit:
         for reg in self.qregs:
             qubits += reg.size
         return qubits
+
+    @property
+    def num_ancillas(self):
+        """Return the number of ancilla qubits."""
+        return len(self.ancillas)
 
     @property
     def n_qubits(self):

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -54,3 +54,17 @@ class QuantumRegister(Register):
     def qasm(self):
         """Return OPENQASM string for this register."""
         return "qreg %s[%d];" % (self.name, self.size)
+
+
+class AncillaQubit(Qubit):
+    """A qubit used as ancillary qubit."""
+    pass
+
+
+class AncillaRegister(QuantumRegister):
+    """Implement an ancilla register."""
+    # Counter for the number of instances in this class.
+    instances_counter = itertools.count()
+    # Prefix to use for auto naming.
+    prefix = 'a'
+    bit_type = AncillaQubit

--- a/releasenotes/notes/ancilla-qubit-cdf5fb28373b8553.yaml
+++ b/releasenotes/notes/ancilla-qubit-cdf5fb28373b8553.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Add the concept of ancilla qubits, which wrap the qubit type but allow 
+    to mark certain qubits as ancillas. This allows to re-use these work qubits 
+    in larger circuits and algorithms or during transpilation. 
+    The types are called ``AncillaRegister`` and ``AncillaQubit``.

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -16,7 +16,10 @@
 
 import numpy as np
 
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Qubit, Clbit, Gate
+from qiskit.circuit import (
+    QuantumRegister, ClassicalRegister, AncillaRegister, QuantumCircuit, Qubit, Clbit, AncillaQubit,
+    Gate
+)
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.test import QiskitTestCase
 
@@ -33,12 +36,20 @@ class TestCircuitRegisters(QiskitTestCase):
         self.assertEqual(type(qr1), QuantumRegister)
 
     def test_cregs(self):
-        """Test getting quantum registers from circuit.
+        """Test getting classical registers from circuit.
         """
         cr1 = ClassicalRegister(10, "c")
         self.assertEqual(cr1.name, "c")
         self.assertEqual(cr1.size, 10)
         self.assertEqual(type(cr1), ClassicalRegister)
+
+    def test_aregs(self):
+        """Test getting ancilla registers from circuit.
+        """
+        ar1 = AncillaRegister(10, "a")
+        self.assertEqual(ar1.name, "a")
+        self.assertEqual(ar1.size, 10)
+        self.assertEqual(type(ar1), AncillaRegister)
 
     def test_qarg_negative_size(self):
         """Test attempt to create a negative size QuantumRegister.
@@ -105,11 +116,11 @@ class TestCircuitRegisters(QiskitTestCase):
         qr2 = QuantumRegister(2, "q2")
         qc = QuantumCircuit(qr2, cr1, qr1)
 
-        qubtis = qc.qubits
+        qubits = qc.qubits
 
-        self.assertEqual(qubtis[0], qr2[0])
-        self.assertEqual(qubtis[1], qr2[1])
-        self.assertEqual(qubtis[2], qr1[0])
+        self.assertEqual(qubits[0], qr2[0])
+        self.assertEqual(qubits[1], qr2[1])
+        self.assertEqual(qubits[2], qr1[0])
 
     def test_clbits(self):
         """Test clbits() method.
@@ -120,11 +131,48 @@ class TestCircuitRegisters(QiskitTestCase):
         cr2 = ClassicalRegister(1, "c2")
         qc = QuantumCircuit(qr2, cr2, qr1, cr1)
 
-        clbtis = qc.clbits
+        clbits = qc.clbits
 
-        self.assertEqual(clbtis[0], cr2[0])
-        self.assertEqual(clbtis[1], cr1[0])
-        self.assertEqual(clbtis[2], cr1[1])
+        self.assertEqual(clbits[0], cr2[0])
+        self.assertEqual(clbits[1], cr1[0])
+        self.assertEqual(clbits[2], cr1[1])
+
+    def test_ancillas(self):
+        """Test ancillas() method.
+        """
+        qr1 = QuantumRegister(1, "q1")
+        cr1 = ClassicalRegister(2, "c1")
+        ar1 = AncillaRegister(2, "a1")
+        qr2 = QuantumRegister(2, "q2")
+        cr2 = ClassicalRegister(1, "c2")
+        ar2 = AncillaRegister(1, "a2")
+        qc = QuantumCircuit(qr2, cr2, ar2, qr1, cr1, ar1)
+
+        ancillas = qc.ancillas
+
+        self.assertEqual(qc.num_ancillas, 3)
+
+        self.assertEqual(ancillas[0], ar2[0])
+        self.assertEqual(ancillas[1], ar1[0])
+        self.assertEqual(ancillas[2], ar1[1])
+
+    def test_ancilla_qubit(self):
+        """Test ancilla type and that it can be accessed as ordinary qubit."""
+        qr, ar = QuantumRegister(2), AncillaRegister(2)
+        qc = QuantumCircuit(qr, ar)
+
+        with self.subTest('num ancillas and qubits'):
+            self.assertEqual(qc.num_ancillas, 2)
+            self.assertEqual(qc.num_qubits, 4)
+
+        with self.subTest('ancilla is a qubit'):
+            for ancilla in qc.ancillas:
+                self.assertIsInstance(ancilla, AncillaQubit)
+                self.assertIsInstance(ancilla, Qubit)
+
+        with self.subTest('qubit is not an ancilla'):
+            action_qubits = [qubit for qubit in qc.qubits if not isinstance(qubit, AncillaQubit)]
+            self.assertEqual(len(action_qubits), 2)
 
     def test_qregs_circuit(self):
         """Test getting quantum registers from circuit.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add the concept of ancilla qubits, which wrap the qubit type but allow 
to mark certain qubits as ancillas. This allows to re-use these work qubits 
in larger circuits and algorithms or during transpilation. 

### Details and comments

Ancilla qubits are qubits. They can be acted on as usual qubits and asking the circuit for its qubits will return the 
ancillas as well. This type is just an additional information that can be used in circuit construction and optimization.

This is also useful for circuits in the library where the circuit can explicitly mark which qubits are only used 
as intermediary work-qubits whose state is again `|0>` after the circuit operation.

The types are called ``AncillaRegister`` and ``AncillaQubit``.
With ``QuantumCircuit.num_ancillas`` the number of ancilla qubits is returned and 
``QuantumCircuit.ancillas`` yields the ancilla qubits as list. 

Note that this is not a complete concept of how ancillas can be used in the transpilation process but it tries to kick off this process. Also this feature is needed to proceed with the refactor of the finance module in Aqua.
