### PR TITLE
Isolate ci test environment with virtualenvs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,7 +148,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
@@ -158,6 +160,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
@@ -176,6 +179,7 @@ stages:
             artifactName: 'drop_linux'
         - bash: |
             set -e
+            source test-job/bin/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
@@ -210,7 +214,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
@@ -218,6 +224,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             pycodestyle --max-line-length=100 qiskit test
             pylint -rn qiskit test
             tools/verify_headers.py qiskit test
@@ -294,7 +301,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
@@ -303,6 +312,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
@@ -321,6 +331,7 @@ stages:
             artifactName: 'drop_macos'
         - bash: |
             set -e
+            source test-job/bin/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
@@ -365,7 +376,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
@@ -374,6 +387,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
@@ -392,6 +406,7 @@ stages:
             artifactName: 'drop_windows'
         - bash: |
             set -e
+            source test-job/bin/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
@@ -431,7 +446,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
@@ -441,6 +458,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
@@ -459,6 +477,7 @@ stages:
             artifactName: 'drop_linux'
         - bash: |
             set -e
+            source test-job/bin/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
@@ -498,7 +517,9 @@ stages:
           displayName: Cache pip
         - bash: |
             set -e
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" -c constraints.txt
@@ -507,6 +528,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run --concurrency 2
@@ -525,6 +547,7 @@ stages:
             artifactName: 'drop_macos'
         - bash: |
             set -e
+            source test-job/bin/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -378,7 +378,7 @@ stages:
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
             virtualenv test-job
-            source test-job/bin/activate
+            source test-job/Scripts/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
@@ -387,7 +387,7 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            source test-job/bin/activate
+            source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
@@ -406,7 +406,7 @@ stages:
             artifactName: 'drop_windows'
         - bash: |
             set -e
-            source test-job/bin/activate
+            source test-job/Scripts/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now CI jobs are failing because of the dep solver because of a
version conflict between 'aws-sam-cli' and the dateutil version terra
requires. We're not installing aws-sam-cli as it's not in the dependency
tree for terra, so presumably it's coming from the system python
environment. This commit uses virtualenv to create an isolated
environment for running tests to avoid these types of interactions in
the future.

### Details and comments
