### PR TITLE
Fix pickling for provider models by removing SimpleNamespace

### DIFF
--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -16,7 +16,6 @@
 import re
 import copy
 import warnings
-from types import SimpleNamespace
 from typing import Dict, List, Any, Iterable, Union
 from collections import defaultdict
 
@@ -184,7 +183,7 @@ class UchannelLO:
         return "UchannelLO(%s, %s)" % (self.q, self.scale)
 
 
-class QasmBackendConfiguration(SimpleNamespace):
+class QasmBackendConfiguration:
     """Class representing a Qasm Backend Configuration.
 
     Attributes:
@@ -200,6 +199,8 @@ class QasmBackendConfiguration(SimpleNamespace):
         memory: backend supports memory.
         max_shots: maximum number of shots supported.
     """
+
+    _data = {}
 
     def __init__(self, backend_name, backend_version, n_qubits,
                  basis_gates, gates, local, simulator,
@@ -243,6 +244,7 @@ class QasmBackendConfiguration(SimpleNamespace):
             tags (list): A list of string tags to describe the backend
             **kwargs: optional fields
         """
+        self._data = {}
 
         self.backend_name = backend_name
         self.backend_version = backend_version
@@ -299,20 +301,13 @@ class QasmBackendConfiguration(SimpleNamespace):
         if 'rep_times' in kwargs.keys():
             kwargs['rep_times'] = [_rt * 1e-6 for _rt in kwargs['rep_times']]
 
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
 
-    def __getstate__(self):
-        return self.to_dict()
-
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.backend_name, self.backend_version,
-                                 self.n_qubits, self.basis_gates, self.gates,
-                                 self.local, self.simulator, self.conditional,
-                                 self.open_pulse, self.memory, self.max_shots,
-                                 self.coupling_map))
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)
 
     @classmethod
     def from_dict(cls, data):
@@ -337,8 +332,27 @@ class QasmBackendConfiguration(SimpleNamespace):
         Returns:
             dict: The dictionary form of the GateConfig.
         """
-        out_dict = copy.copy(self.__dict__)
-        out_dict['gates'] = [x.to_dict() for x in self.gates]
+        out_dict = {
+            'backend_name': self.backend_name,
+            'backend_version': self.backend_version,
+            'n_qubits': self.n_qubits,
+            'basis_gates': self.basis_gates,
+            'gates': [x.to_dict() for x in self.gates],
+            'local': self.local,
+            'simulator': self.simulator,
+            'conditional': self.conditional,
+            'open_pulse': self.open_pulse,
+            'memory': self.memory,
+            'max_shots': self.max_shots,
+            'coupling_map': self.coupling_map,
+        }
+        for kwarg in ['max_experiments', 'sample_name', 'n_registers',
+                      'register_map', 'configurable', 'credits_required',
+                      'online_date', 'display_name', 'description',
+                      'tags']:
+            if hasattr(self, kwarg):
+                out_dict[kwarg] = getattr(self, kwarg)
+        out_dict.update(self._data)
         return out_dict
 
     @property

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -16,7 +16,6 @@
 
 import copy
 import datetime
-from types import SimpleNamespace
 from typing import Any, Iterable, Tuple, Union
 import dateutil.parser
 
@@ -85,7 +84,7 @@ class Nduv:
                                          self.value)
 
 
-class Gate(SimpleNamespace):
+class Gate:
     """Class representing a gate's properties
 
           Attributes:
@@ -93,6 +92,8 @@ class Gate(SimpleNamespace):
           gate: gate.
           parameters: parameters.
     """
+
+    _data = {}
 
     def __init__(self, qubits, gate, parameters, **kwargs):
         """Initialize a new Gate object
@@ -104,10 +105,18 @@ class Gate(SimpleNamespace):
                 name-date-unit-value for the gate
             kwargs: Optional additional fields
         """
+        self._data = {}
         self.qubits = qubits
         self.gate = gate
         self.parameters = parameters
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
+
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)
+
 
     @classmethod
     def from_dict(cls, data):
@@ -138,6 +147,7 @@ class Gate(SimpleNamespace):
         out_dict['qubits'] = self.qubits
         out_dict['gate'] = self.gate
         out_dict['parameters'] = [x.to_dict() for x in self.parameters]
+        out_dict.update(self._data)
         return out_dict
 
     def __eq__(self, other):
@@ -146,23 +156,16 @@ class Gate(SimpleNamespace):
                 return True
         return False
 
-    def __getstate__(self):
-        return self.to_dict()
 
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.qubits, self.gate, self.parameters))
-
-
-class BackendProperties(SimpleNamespace):
+class BackendProperties:
     """Class representing backend properties
 
     This holds backend properties measured by the provider. All properties
     which are provided optionally. These properties may describe qubits, gates,
     or other general propeties of the backend.
     """
+
+    _data = {}
 
     def __init__(self, backend_name, backend_version, last_update_date, qubits,
                  gates, general, **kwargs):
@@ -181,6 +184,7 @@ class BackendProperties(SimpleNamespace):
                             objects
             kwargs: optional additional fields
         """
+        self._data = {}
         self.backend_name = backend_name
         self.backend_version = backend_version
         if isinstance(last_update_date, str):
@@ -207,18 +211,13 @@ class BackendProperties(SimpleNamespace):
                 value = self._apply_prefix(param.value, param.unit)
                 formatted_props[param.name] = (value, param.date)
             self._gates[gate.gate][tuple(gate.qubits)] = formatted_props
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
 
-    def __getstate__(self):
-        return self.to_dict()
-
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.backend_name, self.backend_version,
-                                 self.last_update_date, self.qubits,
-                                 self.gates, self.general))
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)
 
     @classmethod
     def from_dict(cls, data):
@@ -272,6 +271,7 @@ class BackendProperties(SimpleNamespace):
                            'last_update_date', 'qubits', 'general', 'gates',
                            '_gates', '_qubits']:
                 out_dict[key] = value
+        out_dict.update(self._data)
         return out_dict
 
     def __eq__(self, other):

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -265,11 +265,6 @@ class BackendProperties:
             out_dict['qubits'].append(qubit_props)
         out_dict['gates'] = [x.to_dict() for x in self.gates]
         out_dict['general'] = [x.to_dict() for x in self.general]
-        for key, value in self.__dict__.items():
-            if key not in ['backend_name', 'backend_version',
-                           'last_update_date', 'qubits', 'general', 'gates',
-                           '_gates', '_qubits']:
-                out_dict[key] = value
         out_dict.update(self._data)
         return out_dict
 

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -117,7 +117,6 @@ class Gate:
         except KeyError:
             raise AttributeError('Attribute %s is not defined' % name)
 
-
     @classmethod
     def from_dict(cls, data):
         """Create a new Gate object from a dictionary.

--- a/qiskit/providers/models/jobstatus.py
+++ b/qiskit/providers/models/jobstatus.py
@@ -14,10 +14,8 @@
 
 """Class for job status."""
 
-from types import SimpleNamespace
 
-
-class JobStatus(SimpleNamespace):
+class JobStatus:
     """Model for JobStatus.
 
     Attributes:
@@ -26,11 +24,14 @@ class JobStatus(SimpleNamespace):
         status_msg (str): status message.
     """
 
+    _data = {}
+
     def __init__(self, job_id, status, status_msg, **kwargs):
+        self._data = {}
         self.job_id = job_id
         self.status = status
         self.status_msg = status_msg
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
 
     @classmethod
     def from_dict(cls, data):
@@ -53,13 +54,16 @@ class JobStatus(SimpleNamespace):
         Returns:
             dict: The dictionary form of the JobStatus.
         """
-        return self.__dict__
+        out_dict = {
+            'job_id': self.job_id,
+            'status': self.status,
+            'status_msg': self.status_msg,
+        }
+        out_dict.update(self._data)
+        return out_dict
 
-    def __getstate__(self):
-        return self.to_dict()
-
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.job_id, self.status, self.status_msg))
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -18,8 +18,6 @@
 import copy
 from typing import Any, Dict, List
 
-import numpy as np
-
 from qiskit.qobj import PulseLibraryItem, PulseQobjInstruction
 from qiskit.qobj.converters import QobjToInstructionConverter
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -16,8 +16,9 @@
 
 """Model and schema for pulse defaults."""
 import copy
-from types import SimpleNamespace
 from typing import Any, Dict, List
+
+import numpy as np
 
 from qiskit.qobj import PulseLibraryItem, PulseQobjInstruction
 from qiskit.qobj.converters import QobjToInstructionConverter
@@ -97,12 +98,14 @@ class Discriminator:
         return cls(**data)
 
 
-class Command(SimpleNamespace):
+class Command:
     """Class representing a Command.
 
     Attributes:
         name: Pulse command name.
     """
+    _data = {}
+
     def __init__(self, name: str, qubits=None, sequence=None, **kwargs):
         """Initialize a Command object
 
@@ -112,12 +115,19 @@ class Command(SimpleNamespace):
             sequence (PulseQobjInstruction): The sequence for the Command
             kwargs: Optional additional fields
         """
+        self._data = {}
         self.name = name
         if qubits is not None:
             self.qubits = qubits
         if sequence is not None:
             self.sequence = sequence
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
+
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)
 
     def to_dict(self):
         """Return a dictionary format representation of the Command.
@@ -133,6 +143,7 @@ class Command(SimpleNamespace):
         for key, value in self.__dict__.items():
             if key not in ['name', 'qubits', 'sequence']:
                 out_dict[key] = value
+        out_dict.update(self._data)
         return out_dict
 
     @classmethod
@@ -155,21 +166,14 @@ class Command(SimpleNamespace):
                     'sequence')]
         return cls(**in_data)
 
-    def __getstate__(self):
-        return self.to_dict()
 
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.name))
-
-
-class PulseDefaults(SimpleNamespace):
+class PulseDefaults:
     """Description of default settings for Pulse systems. These are instructions or settings that
     may be good starting points for the Pulse user. The user may modify these defaults for custom
     scheduling.
     """
+
+    _data = {}
 
     def __init__(self,
                  qubit_freq_est: List[float],
@@ -193,6 +197,7 @@ class PulseDefaults(SimpleNamespace):
             discriminator: The discriminators
             **kwargs: Other attributes for the super class.
         """
+        self._data = {}
         self.buffer = buffer
         self.qubit_freq_est = [freq * 1e9 for freq in qubit_freq_est]
         """Qubit frequencies in Hertz."""
@@ -213,7 +218,13 @@ class PulseDefaults(SimpleNamespace):
         if discriminator is not None:
             self.discriminator = discriminator
 
-        self.__dict__.update(kwargs)
+        self._data.update(kwargs)
+
+    def __getattr__(self, name):
+        try:
+            return self._data[name]
+        except KeyError:
+            raise AttributeError('Attribute %s is not defined' % name)
 
     def to_dict(self):
         """Return a dictionary format representation of the PulseDefaults.
@@ -238,6 +249,7 @@ class PulseDefaults(SimpleNamespace):
                            'discriminator', 'converter',
                            'instruction_schedule_map']:
                 out_dict[key] = value
+        out_dict.update(self._data)
         return out_dict
 
     @classmethod
@@ -264,17 +276,6 @@ class PulseDefaults(SimpleNamespace):
             in_data['discriminator'] = Discriminator.from_dict(
                 in_data.pop('discriminator'))
         return cls(**in_data)
-
-    def __getstate__(self):
-        return self.to_dict()
-
-    def __setstate__(self, state):
-        return self.from_dict(state)
-
-    def __reduce__(self):
-        return (self.__class__, (self.qubit_freq_est, self.meas_freq_est,
-                                 self.buffer, self.pulse_library,
-                                 self.cmd_def))
 
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -138,9 +138,6 @@ class Command:
             out_dict['qubits'] = self.qubits
         if hasattr(self, 'sequence'):
             out_dict['sequence'] = [x.to_dict() for x in self.sequence]
-        for key, value in self.__dict__.items():
-            if key not in ['name', 'qubits', 'sequence']:
-                out_dict[key] = value
         out_dict.update(self._data)
         return out_dict
 

--- a/test/python/providers/test_backendconfiguration.py
+++ b/test/python/providers/test_backendconfiguration.py
@@ -15,6 +15,8 @@
 Test that the PulseBackendConfiguration methods work as expected with a mocked Pulse backend.
 """
 import collections
+import copy
+
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeProvider
 
@@ -113,3 +115,11 @@ class TestBackendConfiguration(QiskitTestCase):
     def _test_lists_equal(self, actual, expected):
         """Test if 2 lists are equal. It returns ``True`` is lists are equal."""
         return collections.Counter(actual) == collections.Counter(expected)
+
+    def test_deepcopy(self):
+        """Ensure that a deepcopy succeeds and results in an identical object."""
+        copy_config = copy.deepcopy(self.config)
+        print(copy_config.to_dict())
+        print("Original:")
+        print(self.config.to_dict())
+        self.assertEqual(copy_config, self.config)

--- a/test/python/providers/test_backendproperties.py
+++ b/test/python/providers/test_backendproperties.py
@@ -14,6 +14,8 @@
 
 """Base TestCase for testing Providers."""
 
+import copy
+
 from qiskit.test.mock import FakeOurense
 from qiskit.test.mock import FakeProvider
 from qiskit.test import QiskitTestCase
@@ -105,3 +107,8 @@ class BackendpropertiesTestCase(QiskitTestCase):
     def test_operational(self):
         """Test operation status of a given qubit."""
         self.assertTrue(self.properties.is_qubit_operational(0))
+
+    def test_deepcopy(self):
+        """Test that deepcopy creates an identical object."""
+        copy_prop = copy.deepcopy(self.properties)
+        self.assertEqual(copy_prop, self.properties)

--- a/test/python/providers/test_pulse_defaults.py
+++ b/test/python/providers/test_pulse_defaults.py
@@ -15,6 +15,7 @@
 # pylint: disable=missing-docstring
 
 """Test the PulseDefaults part of the backend."""
+import copy
 import warnings
 
 import numpy as np
@@ -61,3 +62,9 @@ class TestPulseDefaults(QiskitTestCase):
         self.assertTrue("Multi qubit instructions:\n  (0, 1): " in str(self.defs)[70:])
         self.assertTrue("Qubit Frequencies [GHz]\n[4.9, 5.0]\nMeasurement Frequencies [GHz]\n[6.5, "
                         "6.6] )>" in str(self.defs)[100:])
+
+    def test_deepcopy(self):
+        """Test that deepcopy creates an identical object."""
+        copy_defs = copy.deepcopy(self.defs)
+        self.assertEqual(list(copy_defs.to_dict().keys()),
+                         list(self.defs.to_dict().keys()))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The provider model classes were built as subclasses for
`SimpleNamespace`, primarily because they allow attribute access for
arbitrary kwargs from the constructor and `SimpleNamespace` makes that
easy. Unfortunately this adds a great deal of complexity if the subclass
has required positional arguments, since the parent class signature for
`SimpleNamespace` is just **kwargs. For example, when using pickle to
serialize the object (often as part of a deecopy or multiprocessing) it
relies on the `__reduce__` from the parent class which is configured to
only handle **kwargs and it will fail because of missing required
positional arguments. `QasmBackendConfiguration `attempted to fix this by
defining a custom `__reduce__` method to pass in the required args, but
then pickle would miss the kwargs resulting in only a partial copy. This
wasn't an issue in practice because there were not too many extra kwargs
being passed in practice (although there were some edge cases caused by
this). Where this came into play more was for the `PulseBackendConfiguration`
class. It  was not defining it's own `__reduce__` method so it was relying on
the definition in it's parent class `QasmBackendConfiguration`. However,
because `PulseBackendConfiguration` has additional required position arguments
on top of what `QasmBackendConfiguration` requires pickle was not able to
create a new object when loading. When adding a custom `__reduce__` method
with the extra required args for pulse it appears to work, but the loss
of arbitrary kwargs causes an issue in practice since they're heavily
used in pulse.

This commit fixes this by removing the `SiimpleNamespace` usage and making
the provider model classes just a bare object. The kwarg based
attribute flow is built manually by storing everything in a private dict and
having a custom `_getattr__` method to handle attribute access. This
maintains compatibility with the expected access patterns, but fixes the
deepcopy issue.

### Details and comments

Fixes #4550