### PR TITLE
Fix cnot method on QuantumCircuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2036,7 +2036,7 @@ class QuantumCircuit:
     def cnot(self, control_qubit, target_qubit, *, label=None, ctrl_state=None,
              ctl=None, tgt=None):  # pylint: disable=unused-argument
         """Apply :class:`~qiskit.circuit.library.CXGate`."""
-        self.cx(control_qubit, target_qubit, ctl=ctl, tgt=tgt)
+        self.cx(control_qubit, target_qubit)
 
     def dcx(self, qubit1, qubit2):
         """Apply :class:`~qiskit.circuit.library.DCXGate`."""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -530,6 +530,15 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertEqual(qc.reverse_bits(), expected)
 
+    def test_cnot_alias(self):
+        """Test that the cnot method alias adds a cx gate."""
+        qc = QuantumCircuit(2)
+        qc.cnot(0, 1)
+
+        expected = QuantumCircuit(2)
+        expected.cx(0, 1)
+        self.assertEqual(qc, expected)
+
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The cnot method for QuantumCircuit was broken when using positional
arguments that weren't named. This is because it was upassing in the
kwargs which aren't used from deprecated_arguments to the cx method.
The kwargs are only used as a placeholder for passing in args by name
from the old deprecated name and the conversion is handled by the
decorator. This commit fixes this oversight so that QuantumCircuit.cnot
works as expected.

### Details and comments

Fixes #4708