### PR TITLE
Add ``expectation_value`` function to ``Statevector`` and ``DensityMatrix``

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -254,6 +254,20 @@ class DensityMatrix(QuantumState):
             other = Operator(other)
         return self._evolve_operator(other, qargs=qargs)
 
+    def expectation_value(self, oper, qargs=None):
+        """Compute the expectation value of an operator.
+
+        Args:
+            oper (Operator): an operator to evaluate expval.
+            qargs (None or list): subsystems to apply the operator on.
+
+        Returns:
+            complex: the expectation value.
+        """
+        if not isinstance(oper, Operator):
+            oper = Operator(oper)
+        return np.trace(Operator(self).dot(oper.adjoint(), qargs=qargs).data)
+
     def probabilities(self, qargs=None, decimals=None):
         """Return the subsystem measurement probability vector.
 

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -302,6 +302,19 @@ class QuantumState(ABC):
         pass
 
     @abstractmethod
+    def expectation_value(self, oper, qargs=None):
+        """Compute the expectation value of an operator.
+
+        Args:
+            oper (BaseOperator): an operator to evaluate expval.
+            qargs (None or list): subsystems to apply the operator on.
+
+        Returns:
+            complex: the expectation value.
+        """
+        pass
+
+    @abstractmethod
     def probabilities(self, qargs=None, decimals=None):
         """Return the subsystem measurement probability vector.
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -268,6 +268,20 @@ class Statevector(QuantumState):
         return matrix_equal(self.data, other.data, ignore_phase=True,
                             rtol=rtol, atol=atol)
 
+    def expectation_value(self, oper, qargs=None):
+        """Compute the expectation value of an operator.
+
+        Args:
+            oper (Operator): an operator to evaluate expval of.
+            qargs (None or list): subsystems to apply operator on.
+
+        Returns:
+            complex: the expectation value.
+        """
+        val = self.evolve(oper, qargs=qargs)
+        conj = self.conjugate()
+        return np.dot(conj.data, val.data)
+
     def probabilities(self, qargs=None, decimals=None):
         """Return the subsystem measurement probability vector.
 

--- a/releasenotes/notes/quantum_state_expval-18359552aab42343.yaml
+++ b/releasenotes/notes/quantum_state_expval-18359552aab42343.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add :meth:`qiskit.quantum_info.Statevector.expectation_value` and 
+    :meth:`qiskit.quantum_info.DensityMatrix.expectation_value` methods for
+    computing the expectation value of an :class:`qiskit.quantum_info.Operator`.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -874,6 +874,19 @@ class TestDensityMatrix(QiskitTestCase):
             value = DensityMatrix.from_int(8, (3, 3))
             self.assertEqual(target, value)
 
+    def test_expval(self):
+        """Test expectation_value method"""
+
+        psi = Statevector([1, 0, 0, 1]) / np.sqrt(2)
+        rho = DensityMatrix(psi)
+        for label, target in [
+                ('II', 1), ('XX', 1), ('YY', -1), ('ZZ', 1),
+                ('IX', 0), ('YZ', 0), ('ZX', 0), ('YI', 0)]:
+            with self.subTest(msg="<{}>".format(label)):
+                op = Operator.from_label(label)
+                expval = rho.expectation_value(op)
+                self.assertAlmostEqual(expval, target)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -845,6 +845,18 @@ class TestStatevector(QiskitTestCase):
             value = Statevector.from_int(8, (3, 3))
             self.assertEqual(target, value)
 
+    def test_expval(self):
+        """Test expectation_value method"""
+
+        psi = Statevector([1, 0, 0, 1]) / np.sqrt(2)
+        for label, target in [
+                ('II', 1), ('XX', 1), ('YY', -1), ('ZZ', 1),
+                ('IX', 0), ('YZ', 0), ('ZX', 0), ('YI', 0)]:
+            with self.subTest(msg="<{}>".format(label)):
+                op = Operator.from_label(label)
+                expval = psi.expectation_value(op)
+                self.assertAlmostEqual(expval, target)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds expectation value method to Statevector and density matrix classes for computing the expectation value of an operator.

### Details and comments

This is a simple implementation which leaves room for future optimizations for different operator types.