### PR TITLE
Fix compatibility for plot_state_hinton with mpl 3.3.0

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -143,7 +143,9 @@ def plot_state_hinton(rho, title='', figsize=None, ax_real=None, ax_imag=None):
 
         ax1.set_xticks(np.arange(0, lx+0.5, 1))
         ax1.set_yticks(np.arange(0, ly+0.5, 1))
+        row_names.append('')
         ax1.set_yticklabels(row_names, fontsize=14)
+        column_names.append('')
         ax1.set_xticklabels(column_names, fontsize=14, rotation=90)
         ax1.autoscale_view()
         ax1.invert_yaxis()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently released matplotlib 3.3.0 release matplotlib started
enforcing that the number of ticklabels matches the number of tick
locations. [1] This ends up breaking on the plot_state_hinton()
visualization function because the hinton plot was not setting a label
for the implicit tick at the top of the graph, even though there is no
value for it. This commit fixes this by just setting a blank label for
the unused tick so that the visualization will still work on matplotlib
3.3.0.


### Details and comments

[1] https://matplotlib.org/3.3.0/api/api_changes.html#axis-set-ticklabels-must-match-fixedlocator-locs
