### PR TITLE
4668 performance regression in unrolling and circuit to instruction

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -90,7 +90,7 @@ class ControlledGate(Gate):
         self.base_gate = None
         if definition:
             self.definition = definition
-            if len(definition.data) == 1:
+            if len(definition) == 1:
                 base_gate = definition.data[0][0]
                 if isinstance(base_gate, ControlledGate):
                     self.base_gate = base_gate.base_gate

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -246,9 +246,9 @@ class Instruction:
             return self.copy()
 
         reverse_inst = self.copy(name=self.name + '_reverse')
-        reverse_inst.definition.data = []
-        for inst, qargs, cargs in reversed(self._definition):
-            reverse_inst._definition.data.append((inst.reverse_ops(), qargs, cargs))
+        reverse_inst.definition._data = [(inst.reverse_ops(), qargs, cargs)
+                                         for inst, qargs, cargs in reversed(self._definition)]
+
         return reverse_inst
 
     def inverse(self):
@@ -270,9 +270,9 @@ class Instruction:
         if self.definition is None:
             raise CircuitError("inverse() not implemented for %s." % self.name)
         inverse_gate = self.copy(name=self.name + '_dg')
-        inverse_gate._definition.data = []
-        for inst, qargs, cargs in reversed(self._definition.data):
-            inverse_gate._definition.data.append((inst.inverse(), qargs, cargs))
+        inverse_gate.definition._data = [(inst.inverse(), qargs, cargs)
+                                         for inst, qargs, cargs in reversed(self._definition)]
+
         return inverse_gate
 
     def c_if(self, classical, val):
@@ -385,6 +385,6 @@ class Instruction:
                 qc.add_register(qargs)
             if cargs:
                 qc.add_register(cargs)
-            qc.data = [(self, qargs[:], cargs[:])] * n
+            qc._data = [(self, qargs[:], cargs[:])] * n
         instruction.definition = qc
         return instruction

--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -63,7 +63,7 @@ class DCXGate(Gate):
             (CXGate(), [q[0], q[1]], []),
             (CXGate(), [q[1], q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def to_matrix(self):

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -65,7 +65,7 @@ class HGate(Gate):
         rules = [
             (U2Gate(0, pi), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -196,7 +196,7 @@ class CHGate(ControlledGate):
             (HGate(), [q[1]], []),
             (SdgGate(), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -107,7 +107,7 @@ class iSwapGate(Gate):
             (CXGate(), [q[1], q[0]], []),
             (HGate(), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def to_matrix(self):

--- a/qiskit/circuit/library/standard_gates/ms.py
+++ b/qiskit/circuit/library/standard_gates/ms.py
@@ -45,5 +45,5 @@ class MSGate(Gate):
         for i in range(self.num_qubits):
             for j in range(i + 1, self.num_qubits):
                 rules += [(RXXGate(self.params[0]), [q[i], q[j]], [])]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -62,7 +62,7 @@ class RGate(Gate):
         rules = [
             (U3Gate(theta, phi - pi / 2, -phi + pi / 2), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -62,7 +62,7 @@ class RXGate(Gate):
         rules = [
             (RGate(self.params[0], 0), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -193,7 +193,7 @@ class CRXGate(ControlledGate, metaclass=CRXMeta):
             (CXGate(), [q[0], q[1]], []),
             (U3Gate(self.params[0] / 2, -pi / 2, 0), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -91,7 +91,7 @@ class RXXGate(Gate):
             (HGate(), [q[1]], []),
             (HGate(), [q[0]], []),
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -62,7 +62,7 @@ class RYGate(Gate):
         rules = [
             (RGate(self.params[0], pi / 2), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -188,7 +188,7 @@ class CRYGate(ControlledGate, metaclass=CRYMeta):
             (U3Gate(-self.params[0] / 2, 0, 0), [q[1]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -93,7 +93,7 @@ class RYYGate(Gate):
             (RXGate(-np.pi / 2), [q[0]], []),
             (RXGate(-np.pi / 2), [q[1]], []),
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -72,7 +72,7 @@ class RZGate(Gate):
         rules = [
             (U1Gate(self.params[0]), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -206,7 +206,7 @@ class CRZGate(ControlledGate, metaclass=CRZMeta):
             (U1Gate(-self.params[0] / 2), [q[1]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -136,7 +136,7 @@ class RZXGate(Gate):
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -100,7 +100,7 @@ class RZZGate(Gate):
             (U1Gate(self.params[0]), [q[1]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -63,7 +63,7 @@ class SGate(Gate):
         rules = [
             (U1Gate(pi / 2), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):
@@ -119,7 +119,7 @@ class SdgGate(Gate):
         rules = [
             (U1Gate(-pi / 2), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -70,7 +70,7 @@ class SwapGate(Gate):
             (CXGate(), [q[1], q[0]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -229,7 +229,7 @@ class CSwapGate(ControlledGate, metaclass=CSwapMeta):
             (CCXGate(), [q[0], q[1], q[2]], []),
             (CXGate(), [q[2], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -64,7 +64,7 @@ class TGate(Gate):
         rules = [
             (U1Gate(pi / 4), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):
@@ -120,7 +120,7 @@ class TdgGate(Gate):
         rules = [
             (U1Gate(-pi / 4), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -88,7 +88,7 @@ class U1Gate(Gate):
         rules = [
             (U3Gate(0, 0, self.params[0]), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -196,7 +196,7 @@ class CU1Gate(ControlledGate, metaclass=CU1Meta):
             (CXGate(), [q[0], q[1]], []),
             (U1Gate(self.params[0] / 2), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -291,7 +291,7 @@ class MCU1Gate(ControlledGate):
             scaled_lam = self.params[0] / (2 ** (self.num_ctrl_qubits - 1))
             bottom_gate = CU1Gate(scaled_lam)
             definition = _gray_code_chain(q, self.num_ctrl_qubits, bottom_gate)
-        qc.data = definition
+        qc._data = definition
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -70,7 +70,7 @@ class U2Gate(Gate):
         q = QuantumRegister(1, 'q')
         qc = QuantumCircuit(q, name=self.name)
         rules = [(U3Gate(pi / 2, self.params[0], self.params[1]), [q[0]], [])]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -205,7 +205,7 @@ class CU3Gate(ControlledGate, metaclass=CU3Meta):
             (CXGate(), [q[0], q[1]], []),
             (U3Gate(self.params[0] / 2, self.params[1], 0), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -86,7 +86,7 @@ class XGate(Gate):
         rules = [
             (U3Gate(pi, 0, pi), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -351,7 +351,7 @@ class CCXGate(ControlledGate, metaclass=CCXMeta):
             (TdgGate(), [q[1]], []),
             (CXGate(), [q[0], q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -442,7 +442,7 @@ class RCCXGate(Gate):
             (U1Gate(-pi / 4), [q[2]], []),  # inverse T gate
             (U2Gate(0, pi), [q[2]], []),  # H gate
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def to_matrix(self):
@@ -533,7 +533,7 @@ class C3XGate(ControlledGate):
             (HGate(), [q[3]], [])
         ]
         qc = QuantumCircuit(q)
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -642,7 +642,7 @@ class RC3XGate(Gate):
             (U1Gate(-pi / 4), [q[3]], []),
             (U2Gate(0, pi), [q[3]], []),
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def to_matrix(self):
@@ -723,7 +723,7 @@ class C4XGate(ControlledGate):
             (C3XGate(), [q[0], q[1], q[2], q[3]], []),
             (C3XGate(numpy.pi / 8), [q[0], q[1], q[2], q[4]], []),
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -801,7 +801,7 @@ class MCXGate(ControlledGate):
         from qiskit.circuit.quantumcircuit import QuantumCircuit
         q = QuantumRegister(self.num_qubits, name='q')
         qc = QuantumCircuit(q)
-        qc.append(MCXGrayCode(self.num_ctrl_qubits), qargs=q[:])
+        qc._append(MCXGrayCode(self.num_ctrl_qubits), q[:], [])
         self.definition = qc
 
     @property
@@ -846,9 +846,9 @@ class MCXGrayCode(MCXGate):
         from .u1 import MCU1Gate
         q = QuantumRegister(self.num_qubits, name='q')
         qc = QuantumCircuit(q, name=self.name)
-        qc.h(q[-1])
-        qc.append(MCU1Gate(numpy.pi, num_ctrl_qubits=self.num_ctrl_qubits), qargs=q[:])
-        qc.h(q[-1])
+        qc._append(HGate(), [q[-1]], [])
+        qc._append(MCU1Gate(numpy.pi, num_ctrl_qubits=self.num_ctrl_qubits), q[:], [])
+        qc._append(HGate(), [q[-1]], [])
         self.definition = qc
 
 
@@ -875,14 +875,14 @@ class MCXRecursive(MCXGate):
         q = QuantumRegister(self.num_qubits, name='q')
         qc = QuantumCircuit(q, name=self.name)
         if self.num_qubits == 4:
-            qc.append(C3XGate(), qargs=q[:])
+            qc._append(C3XGate(), q[:], [])
             self.definition = qc
         elif self.num_qubits == 5:
-            qc.append(C4XGate(), qargs=q[:])
+            qc._append(C4XGate(), q[:], [])
             self.definition = qc
         else:
             self.definition = qc
-            self.definition.data = self._recurse(q[:-1], q_ancilla=q[-1])
+            self.definition._data = self._recurse(q[:-1], q_ancilla=q[-1])
 
     def _recurse(self, q, q_ancilla=None):
         # recursion stop
@@ -994,5 +994,5 @@ class MCXVChain(MCXGate):
                 definition.append(
                     (RCCXGate(), [q_controls[j], q_ancillas[i], q_ancillas[i + 1]], []))
 
-        qc.data = definition
+        qc._data = definition
         self.definition = qc

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -78,7 +78,7 @@ class YGate(Gate):
         rules = [
             (U3Gate(pi, pi / 2, pi / 2), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -204,7 +204,7 @@ class CYGate(ControlledGate, metaclass=CYMeta):
             (CXGate(), [q[0], q[1]], []),
             (SGate(), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -77,7 +77,7 @@ class ZGate(Gate):
         rules = [
             (U1Gate(pi), [q[0]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
@@ -171,7 +171,7 @@ class CZGate(ControlledGate, metaclass=CZMeta):
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[1]], [])
         ]
-        qc.data = rules
+        qc._data = rules
         self.definition = qc
 
     def inverse(self):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -385,7 +385,7 @@ class QuantumCircuit:
             except QiskitError:
                 inst = self.to_instruction()
             for _ in range(reps):
-                repeated_circ.append(inst, self.qubits, self.clbits)
+                repeated_circ._append(inst, self.qubits, self.clbits)
 
         return repeated_circ
 

--- a/qiskit/converters/ast_to_dag.py
+++ b/qiskit/converters/ast_to_dag.py
@@ -390,7 +390,7 @@ class AstInterpreter:
             op = self._create_op(child_op.name, params=eparams)
             rules.append((op, qparams, []))
         circ = QuantumCircuit(qreg)
-        circ.data = rules
+        circ._data = rules
         return circ
 
     def _create_dag_op(self, name, params, qargs):

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -104,6 +104,6 @@ def circuit_to_gate(circuit, parameter_map=None, equivalence_library=None, label
                    []),
         rules))
     qc = QuantumCircuit(q, name=gate.name)
-    qc.data = rules
+    qc._data = rules
     gate.definition = qc
     return gate

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -123,7 +123,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
                                   'multiple classical registers to instruction')
 
     qc = QuantumCircuit(*regs, name=instruction.name)
-    qc.data = definition
+    qc._data = definition
     instruction.definition = qc
 
     return instruction

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -108,7 +108,7 @@ class HamiltonianGate(Gate):
         """Calculate a subcircuit that implements this unitary."""
         q = QuantumRegister(self.num_qubits, 'q')
         qc = QuantumCircuit(q, name=self.name)
-        qc.append(UnitaryGate(self.to_matrix()), qargs=q[:])
+        qc._append(UnitaryGate(self.to_matrix()), q[:], [])
         self.definition = qc
 
     def qasm(self):

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -23,6 +23,7 @@ from qiskit.circuit import Gate, ControlledGate
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit import QuantumRegister
 from qiskit.circuit._utils import _compute_control_matrix
+from qiskit.circuit.library.standard_gates import U3Gate
 from qiskit.extensions.quantum_initializer import isometry
 from qiskit.quantum_info.operators.predicates import matrix_equal
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
@@ -108,7 +109,7 @@ class UnitaryGate(Gate):
             q = QuantumRegister(1, "q")
             qc = QuantumCircuit(q, name=self.name)
             theta, phi, lam = _DECOMPOSER1Q.angles(self.to_matrix())
-            qc.u3(theta, phi, lam, q[0])
+            qc._append(U3Gate(theta, phi, lam), [q[0]], [])
             self.definition = qc
         elif self.num_qubits == 2:
             self.definition = two_qubit_cnot_decompose(self.to_matrix())

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -91,7 +91,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     if not isinstance(gate.definition, QuantumCircuit):
         raise QiskitError('{0} instruction definition is {1}; expected QuantumCircuit'.format(
             gate.name, type(gate.definition)))
-    for instr, qregs, cregs in gate.definition.data:
+    for instr, qregs, cregs in gate.definition:
         if cregs:
             raise QiskitError(
                 'Cannot apply Instruction with classical registers: {}'.format(

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -592,7 +592,7 @@ class DensityMatrix(QuantumState):
         if not isinstance(other.definition, QuantumCircuit):
             raise QiskitError('{0} instruction definition is {1}; expected QuantumCircuit'.format(
                 other.name, type(other.definition)))
-        for instr, qregs, cregs in other.definition.data:
+        for instr, qregs, cregs in other.definition:
             if cregs:
                 raise QiskitError(
                     'Cannot apply instruction with classical registers: {}'.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -677,7 +677,7 @@ class Statevector(QuantumState):
         if not isinstance(obj.definition, QuantumCircuit):
             raise QiskitError('{0} instruction definition is {1}; expected QuantumCircuit'.format(
                 obj.name, type(obj.definition)))
-        for instr, qregs, cregs in obj.definition.data:
+        for instr, qregs, cregs in obj.definition:
             if cregs:
                 raise QiskitError(
                     'Cannot apply instruction with classical registers: {}'.format(


### PR DESCRIPTION


### Summary

Resolves #4668.

### Details and comments

```
$ asv continuous --python 3.6 --no-only-changed --bench 'time_unroll|time_circuit_to_instruction' master 4668-Performance-regression-in-unolling-and-circuit_to_instruction
...
       before           after         ratio
     [80dcb846]       [2c43a177]
     <master>         <4668-Performance-regression-in-unrolling-and-circuit_to_instruction>
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(14, 8192)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(20, 2048)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(20, 8192)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(32, 2048)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(32, 8192)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(53, 2048)
              n/a              n/a      n/a  converters.ConverterBenchmarks.time_circuit_to_instruction(53, 8192)
       4.11±0.07s        3.60±0.2s    ~0.88  passes.PassBenchmarks.time_unroll_3q_or_more(14, 1024)
        6.71±0.1s       5.81±0.05s    ~0.87  passes.PassBenchmarks.time_unroll_3q_or_more(20, 1024)
       1.02±0.03s         862±60ms    ~0.84  passes.PassBenchmarks.time_unroll_3q_or_more(5, 1024)
       6.97±0.07s       5.75±0.04s    ~0.83  passes.PassBenchmarks.time_unroller(14, 1024)
-      1.94±0.07s       1.60±0.08s     0.82  passes.PassBenchmarks.time_unroller(5, 1024)
          13.6±2s       9.08±0.07s    ~0.67  passes.PassBenchmarks.time_unroller(20, 1024)
-        300±10μs         175±30μs     0.58  converters.ConverterBenchmarks.time_circuit_to_instruction(1, 8)
-         173±6ms        94.7±10ms     0.55  converters.ConverterBenchmarks.time_circuit_to_instruction(1, 8192)
-        538±80μs         272±30μs     0.51  converters.ConverterBenchmarks.time_circuit_to_instruction(2, 8)
-      3.00±0.2ms       1.52±0.3ms     0.51  converters.ConverterBenchmarks.time_circuit_to_instruction(1, 128)
-      4.77±0.1ms       2.29±0.1ms     0.48  converters.ConverterBenchmarks.time_circuit_to_instruction(2, 128)
-        792±20ms         360±40ms     0.45  converters.ConverterBenchmarks.time_circuit_to_instruction(5, 8192)
-        203±20ms        92.0±20ms     0.45  converters.ConverterBenchmarks.time_circuit_to_instruction(5, 2048)
-        49.1±2ms       22.2±0.7ms     0.45  converters.ConverterBenchmarks.time_circuit_to_instruction(1, 2048)
-       85.0±20ms         37.3±3ms     0.44  converters.ConverterBenchmarks.time_circuit_to_instruction(2, 2048)
       1.38±0.01s         587±20ms    ~0.43  converters.ConverterBenchmarks.time_circuit_to_instruction(8, 8192)
-      1.71±0.1ms         719±60μs     0.42  converters.ConverterBenchmarks.time_circuit_to_instruction(8, 8)
-        352±20ms          142±5ms     0.40  converters.ConverterBenchmarks.time_circuit_to_instruction(2, 8192)
-        13.4±1ms       5.34±0.7ms     0.40  converters.ConverterBenchmarks.time_circuit_to_instruction(5, 128)
-      1.27±0.2ms         493±50μs     0.39  converters.ConverterBenchmarks.time_circuit_to_instruction(5, 8)
-      21.0±0.6ms       7.42±0.8ms     0.35  converters.ConverterBenchmarks.time_circuit_to_instruction(8, 128)
-        367±20ms          127±7ms     0.35  converters.ConverterBenchmarks.time_circuit_to_instruction(8, 2048)
-      6.04±0.2ms       1.77±0.3ms     0.29  converters.ConverterBenchmarks.time_circuit_to_instruction(20, 8)
-        45.5±3ms       13.0±0.8ms     0.29  converters.ConverterBenchmarks.time_circuit_to_instruction(14, 128)
-        719±30ms          198±6ms     0.28  converters.ConverterBenchmarks.time_circuit_to_instruction(14, 2048)
-       86.5±10ms         23.6±6ms     0.27  converters.ConverterBenchmarks.time_circuit_to_instruction(20, 128)
-      3.86±0.2ms         969±30μs     0.25  converters.ConverterBenchmarks.time_circuit_to_instruction(14, 8)
-      13.2±0.8ms         2.54±1ms     0.19  converters.ConverterBenchmarks.time_circuit_to_instruction(32, 8)
-         180±8ms         29.1±4ms     0.16  converters.ConverterBenchmarks.time_circuit_to_instruction(32, 128)
-        395±20ms         46.8±3ms     0.12  converters.ConverterBenchmarks.time_circuit_to_instruction(53, 128)
-        35.1±2ms       3.20±0.3ms     0.09  converters.ConverterBenchmarks.time_circuit_to_instruction(53, 8)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

