### PR TITLE
Collect Blocks pass: Allow blocks of consecutive gates to be collected, allowing user to specify max number of qubits involved in a block

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -780,14 +780,14 @@ class DAGCircuit:
         """
         raise NotImplementedError()
 
-    def topological_op_nodes(self):
+    def topological_op_nodes(self, key_func=None):
         """
         Yield op nodes in topological order.
 
         Returns:
             generator(DAGNode): op node in topological order
         """
-        return (nd for nd in self.topological_nodes() if nd.type == 'op')
+        return (nd for nd in self.topological_nodes(key_func) if nd.type == 'op')
 
     def substitute_node_with_dag(self, node, input_dag, wires=None):
         """Replace one node with dag.

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -780,14 +780,14 @@ class DAGCircuit:
         """
         raise NotImplementedError()
 
-    def topological_op_nodes(self, key_func=None):
+    def topological_op_nodes(self, key=None):
         """
         Yield op nodes in topological order.
 
         Returns:
             generator(DAGNode): op node in topological order
         """
-        return (nd for nd in self.topological_nodes(key_func) if nd.type == 'op')
+        return (nd for nd in self.topological_nodes(key) if nd.type == 'op')
 
     def substitute_node_with_dag(self, node, input_dag, wires=None):
         """Replace one node with dag.

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -783,6 +783,7 @@ class DAGCircuit:
     def topological_op_nodes(self, key=None):
         """
         Yield op nodes in topological order.
+        Allowed to pass in specific key to break ties in top order
 
         Returns:
             generator(DAGNode): op node in topological order

--- a/qiskit/dagcircuit/networkx_dagcircuit.py
+++ b/qiskit/dagcircuit/networkx_dagcircuit.py
@@ -100,7 +100,7 @@ class NetworkxDAGCircuit(DAGCircuit):
             slf, oth,
             node_match=lambda x, y: DAGNode.semantic_eq(x['node'], y['node']))
 
-    def topological_nodes(self):
+    def topological_nodes(self, key=None):
         """
         Yield nodes in topological order.
 
@@ -109,7 +109,11 @@ class NetworkxDAGCircuit(DAGCircuit):
         """
         def _key(x):
             return str(self._id_to_node[x].qargs)
-
+        if key is not None:
+            return (self._id_to_node[idx]
+                for idx in nx.lexicographical_topological_sort(
+                    self._multi_graph,
+                    key=key))
         return (self._id_to_node[idx]
                 for idx in nx.lexicographical_topological_sort(
                     self._multi_graph,

--- a/qiskit/dagcircuit/retworkx_dagcircuit.py
+++ b/qiskit/dagcircuit/retworkx_dagcircuit.py
@@ -99,7 +99,7 @@ class RetworkxDAGCircuit(DAGCircuit):
             slf, oth,
             DAGNode.semantic_eq)
 
-    def topological_nodes(self):
+    def topological_nodes(self, key_func=None):
         """
         Yield nodes in topological order.
 
@@ -109,6 +109,10 @@ class RetworkxDAGCircuit(DAGCircuit):
         def _key(x):
             return x.sort_key
 
+        if key_func is not None:
+            return iter(rx.lexicographical_topological_sort(
+                self._multi_graph,
+                key=key_func))
         return iter(rx.lexicographical_topological_sort(
             self._multi_graph,
             key=_key))

--- a/qiskit/dagcircuit/retworkx_dagcircuit.py
+++ b/qiskit/dagcircuit/retworkx_dagcircuit.py
@@ -99,7 +99,7 @@ class RetworkxDAGCircuit(DAGCircuit):
             slf, oth,
             DAGNode.semantic_eq)
 
-    def topological_nodes(self, key_func=None):
+    def topological_nodes(self, key=None):
         """
         Yield nodes in topological order.
 
@@ -109,10 +109,10 @@ class RetworkxDAGCircuit(DAGCircuit):
         def _key(x):
             return x.sort_key
 
-        if key_func is not None:
+        if key is not None:
             return iter(rx.lexicographical_topological_sort(
                 self._multi_graph,
-                key=key_func))
+                key=key))
         return iter(rx.lexicographical_topological_sort(
             self._multi_graph,
             key=_key))

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -130,6 +130,7 @@ from .basis import BasisTranslator
 # optimization
 from .optimization import Optimize1qGates
 from .optimization import Collect2qBlocks
+from .optimization import CollectMultiQBlocks
 from .optimization import ConsolidateBlocks
 from .optimization import CommutationAnalysis
 from .optimization import CommutativeCancellation

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -36,10 +36,9 @@ class Unroll3qOrMore(TransformationPass):
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:
-           
                 if rule == []:  # empty node
-                        dag.remove_op_node(node)
-                        continue
+                    dag.remove_op_node(node)
+                    continue
                 raise QiskitError("Cannot unroll all 3q or more gates. "
                                   "No rule to expand instruction %s." %
                                   node.op.name)

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -36,6 +36,10 @@ class Unroll3qOrMore(TransformationPass):
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition
             if not rule:
+           
+                if rule == []:  # empty node
+                        dag.remove_op_node(node)
+                        continue
                 raise QiskitError("Cannot unroll all 3q or more gates. "
                                   "No rule to expand instruction %s." %
                                   node.op.name)

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -16,6 +16,7 @@
 
 from .optimize_1q_gates import Optimize1qGates
 from .collect_2q_blocks import Collect2qBlocks
+from .collect_multiqubit_blocks import CollectMultiQBlocks
 from .consolidate_blocks import ConsolidateBlocks
 from .commutation_analysis import CommutationAnalysis
 from .commutative_cancellation import CommutativeCancellation

--- a/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Collect sequences of uninterrupted gates acting on 2 qubits."""
+
+from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.circuit import Gate
+
+
+class CollectMultiQBlocks(AnalysisPass):
+    """Collect sequences of uninterrupted gates acting on 2 qubits.
+
+    Traverse the DAG and find blocks of gates that act consecutively on
+    groups of qubits. Write the blocks to propert_set as a list of blocks
+    of the form:
+        [[g0, g1, g2], [g4, g5]]
+
+    """
+
+    def __init__(self, max_block_size=2):
+        super().__init__()
+        self.parent = {} # parent array for the union
+        self.bit_groups = {} # current groups of bits stored at top of trees
+        self.gate_groups = {} # current gate lists for the groups
+        self.max_block_size = max_block_size
+
+    def find_set(self, index):
+        """ DSU function for finding root of set of items """
+
+        if index not in self.parent:
+            self.parent[index] = index
+            self.bit_groups[index] = [index]
+            self.gate_groups[index] = []
+        if self.parent[index] == index:
+            return index
+        self.parent[index] = self.find_set(self.parent[index])
+        return self.parent[index]
+
+    def union_set(self, set1, set2):
+        """ DSU function for unioning two sets together
+        Merges smaller set into larger set
+        """
+
+        set1 = self.find_set(set1)
+        set2 = self.find_set(set2)
+        if set1 == set2:
+            return
+        if len(self.gate_groups[set1]) < len(self.gate_groups[set2]):
+            set1, set2 = set2, set1
+        self.parent[set2] = set1
+        for gate in self.gate_groups[set2]:
+            self.gate_groups[set1].append(gate)
+        for bit in self.bit_groups[set2]:
+            self.bit_groups[set1].append(bit)
+        self.gate_groups[set2].clear()
+        self.bit_groups[set2].clear()
+
+    def run(self, dag):
+        """Run the Collect2qBlocks pass on `dag`.
+
+        The blocks contain "op" nodes in topological sort order
+        such that all gates in a block act on the same pair of
+        qubits and are adjacent in the circuit. the blocks are built
+        by examining predecessors and successors of "cx" gates in
+        the circuit. u1, u2, u3, cx, id gates will be included.
+
+        After the execution, ``property_set['block_list']`` is set to
+        a list of tuples of "op"a node labels.
+        """
+
+        block_list = []
+
+        def collect_key(x):
+            # special key function for topological ordering
+            if x.type != "op":
+                return "c"
+            if isinstance(x.op, Gate):
+                if x.op.is_parameterized():
+                    return "b"
+                print(x.op.name, "a" + chr(ord('a') + len(x.qargs)))
+                return "a" + chr(ord('a') + len(x.qargs))
+            return "c"
+
+        op_nodes = dag.topological_op_nodes(key_func=collect_key)
+
+        for nd in op_nodes:
+            print("processing:", nd.op.name)
+            can_process = True
+            makes_too_big = False
+
+            # check if the node is a gate and if it is parameterized
+            if nd.condition is not None:
+                can_process = False
+            if nd.op.is_parameterized():
+                can_process = False
+            if not isinstance(nd.op, Gate):
+                can_process = False
+
+            cur_qu = set(nd.qargs)
+            cur_qubits = set()
+            for v in cur_qu:
+                cur_qubits.add(v.index)
+
+            if can_process:
+                # if the gate is valid, check if grouping up the bits
+                # in the gate would fit within our desired max size
+                c_tops = set()
+                for bit in cur_qubits:
+                    c_tops.add(self.find_set(bit))
+                tot_size = 0
+                for group in c_tops:
+                    tot_size += len(self.bit_groups[group])
+                if tot_size > self.max_block_size:
+                    makes_too_big = True
+
+            if not can_process:
+                # resolve the case where we cannot process this node
+                for bit in cur_qubits:
+                    # create a gate out of me
+                    bit = self.find_set(bit)
+                    if len(self.gate_groups[bit]) == 0:
+                        continue
+                    block_list.append(self.gate_groups[bit][:])
+                    cur_set = set(self.bit_groups[bit])
+                    for v in cur_set:
+                        # reset this bit
+                        self.parent[v] = v
+                        self.bit_groups[v] = [v]
+                        self.gate_groups[v] = []
+
+            if makes_too_big:
+                # adding in all of the new qubits would make the group too big
+                # we must block off sub portions of the groups until the new
+                # group would no longer be too big
+                savings = {}
+                groups_seen = set()
+                tot_size = 0
+                for bit in cur_qubits:
+                    top = self.find_set(bit)
+                    if top in groups_seen:
+                        savings[top] = savings[top] - 1
+                    else:
+                        groups_seen.add(top)
+                        savings[top] = len(self.bit_groups[top]) - 1
+                        tot_size += len(self.bit_groups[top])
+                slist = []
+                for item in groups_seen:
+                    slist.append((savings[item], item))
+                slist.sort(reverse=True)
+                savings_need = tot_size - self.max_block_size
+                for item in slist:
+                    # remove groups until the size created would be acceptable
+                    # start with blocking out the group that would decrease
+                    # the new size the most
+                    if savings_need > 0:
+                        savings_need = savings_need - item[0]
+                        if len(self.gate_groups[item[1]]) >= 1:
+                            block_list.append(self.gate_groups[item[1]][:])
+                        cur_set = set(self.bit_groups[item[1]])
+                        for v in cur_set:
+                            self.parent[v] = v
+                            self.bit_groups[v] = [v]
+                            self.gate_groups[v] = []
+
+            if can_process:
+                # if the operation is a gate, either skip it if it is too large
+                # or group up all of the qubits involved in the gate
+                if len(cur_qubits) > self.max_block_size:
+                    continue # unable to be part of a group
+                prev = -1
+                for bit in cur_qubits:
+                    if prev != -1:
+                        self.union_set(prev, bit)
+                    prev = bit
+                self.gate_groups[self.find_set(prev)].append(nd)
+        # need to add in all groups that exist at the end!!!!
+        for index in self.parent:
+            if self.parent[index] == index and len(self.gate_groups[index]) != 0:
+                block_list.append(self.gate_groups[index][:])
+
+        print('HEEEEEEERE ')
+        for clist in block_list:
+            print('list', end=" ")
+            for val in clist:
+                print(val.name, end=" ")
+            print()
+
+        self.property_set['block_list'] = block_list
+
+        return dag

--- a/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_multiqubit_blocks.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Collect sequences of uninterrupted gates acting on 2 qubits."""
+"""Collect sequences of uninterrupted gates acting on a number of qubits."""
 
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.circuit import Gate
@@ -27,15 +27,26 @@ class CollectMultiQBlocks(AnalysisPass):
     groups of qubits. Write the blocks to propert_set as a list of blocks
     of the form:
         [[g0, g1, g2], [g4, g5]]
-    Blocks are reported in a valid topological order. Some gates may not be present
-    in any block (e.g. if the number of operands is greater than max_block_size)
+    Blocks are reported in a valid topological order. Further, the gates
+    within each block are also reported in topological order
+    Some gates may not be present in any block (e.g. if the number
+    of operands is greater than max_block_size)
+
+    A Disjont Set Union data structure (DSU) is used to maintain blocks as
+    gates are processed. This data structure points each qubit to a set at all
+    times and the sets correspond to current blocks. These change over time
+    and the data structure allows these changes to be done quickly.
     """
 
     def __init__(self, max_block_size=2):
         super().__init__()
         self.parent = {} # parent array for the union
+
+        # the dicts belowed are keyed by a qubit signifying the root of a
+        #    set in the DSU data structure
         self.bit_groups = {} # current groups of bits stored at top of trees
         self.gate_groups = {} # current gate lists for the groups
+
         self.max_block_size = max_block_size # maximum block size
 
     def find_set(self, index):
@@ -74,16 +85,17 @@ class CollectMultiQBlocks(AnalysisPass):
         self.bit_groups[set2].clear()
 
     def run(self, dag):
-        """Run the Collect2qBlocks pass on `dag`.
+        """Run the CollectMultiQBlocks pass on `dag`.
 
         The blocks contain "op" nodes in topological sort order
-        such that all gates in a block act on the same pair of
-        qubits and are adjacent in the circuit. the blocks are built
-        by examining predecessors and successors of "cx" gates in
-        the circuit. u1, u2, u3, cx, id gates will be included.
+        such that all gates in a block act on the same set of
+        qubits and are adjacent in the circuit.
+
+        The blocks are built by examining predecessors and successors of
+        "cx" gates in the circuit. u1, u2, u3, cx, id gates will be included.
 
         After the execution, ``property_set['block_list']`` is set to
-        a list of tuples of "op"a node labels.
+        a list of tuples of ``DAGNode`` objects
         """
 
         self.parent = {} #reset all variables on run
@@ -160,19 +172,17 @@ class CollectMultiQBlocks(AnalysisPass):
                 # we must block off sub portions of the groups until the new
                 # group would no longer be too big
                 savings = {}
-                groups_seen = set()
                 tot_size = 0
                 for bit in cur_qubits:
                     top = self.find_set(bit)
-                    if top in groups_seen:
+                    if top in savings.keys():
                         savings[top] = savings[top] - 1
                     else:
-                        groups_seen.add(top)
                         savings[top] = len(self.bit_groups[top]) - 1
                         tot_size += len(self.bit_groups[top])
                 slist = []
-                for item in groups_seen:
-                    slist.append((savings[item], item))
+                for item, value in savings.items():
+                    slist.append((value, item))
                 slist.sort(reverse=True)
                 savings_need = tot_size - self.max_block_size
                 for item in slist:
@@ -195,6 +205,10 @@ class CollectMultiQBlocks(AnalysisPass):
                 # if the operation is a gate, either skip it if it is too large
                 # or group up all of the qubits involved in the gate
                 if len(cur_qubits) > self.max_block_size:
+                    # gates acting on more qubits than max_block_size cannot
+                    #   be a part of any block and thus we skip them here.
+                    # we have already finalized the blocks involving the gate's
+                    #   qubits in the above makes_too_big block
                     continue # unable to be part of a group
                 prev = -1
                 for bit in cur_qubits:

--- a/releasenotes/notes/large_gate_bugfix-cbf0b6f1dcfbd5dd.yaml
+++ b/releasenotes/notes/large_gate_bugfix-cbf0b6f1dcfbd5dd.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed issue where some gates with three or more qubits would fail to compile
+    in certain instances. Refer to 
+    `#4577 <https://github.com/Qiskit/qiskit-terra/issues/4577` for more detail.
+
+

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Tests for the Collect2qBlocks transpiler pass.
+"""
+
+import unittest
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+from qiskit.converters import circuit_to_dag
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes import CollectMultiQBlocks
+from qiskit.test import QiskitTestCase
+
+
+class TestCollect2qBlocks(QiskitTestCase):
+    """
+    Tests to verify that blocks of 2q interactions are found correctly.
+    """
+
+    def test_blocks_in_topological_order(self):
+        """the pass returns blocks in correct topological order
+                                                     ______
+         q0:--[u1]-------.----      q0:-------------|      |--
+                         |                 ______   |  U2  |
+         q1:--[u2]--(+)-(+)---   =  q1:---|      |--|______|--
+                     |                    |  U1  |
+         q2:---------.--------      q2:---|______|------------
+        """
+        qr = QuantumRegister(3, "qr")
+        qc = QuantumCircuit(qr)
+        qc.u1(0.5, qr[0])
+        qc.u2(0.2, 0.6, qr[1])
+        qc.cx(qr[2], qr[1])
+        qc.cx(qr[0], qr[1])
+        dag = circuit_to_dag(qc)
+
+        topo_ops = list(dag.topological_op_nodes())
+        block_1 = [topo_ops[1], topo_ops[2]]
+        block_2 = [topo_ops[0], topo_ops[3]]
+
+        pass_ = CollectMultiQBlocks()
+        pass_.run(dag)
+        self.assertTrue(pass_.property_set['block_list'], [block_1, block_2])
+
+    def test_block_interrupted_by_gate(self):
+        """Test that blocks interrupted by a gate that can't be added
+        to the block can be collected correctly
+
+        This was raised in #2775 where a measure in the middle of a block
+        stopped the block collection from working properly. This was because
+        the pass didn't expect to have measures in the middle of the circuit.
+
+        blocks : [['cx', 'id', 'id', 'id'], ['id', 'cx']]
+
+                ┌───┐┌───┐┌─┐     ┌───┐┌───┐
+        q_0: |0>┤ X ├┤ I ├┤M├─────┤ I ├┤ X ├
+                └─┬─┘├───┤└╥┘┌───┐└───┘└─┬─┘
+        q_1: |0>──■──┤ I ├─╫─┤ I ├───────■──
+                     └───┘ ║ └───┘
+         c_0: 0 ═══════════╩════════════════
+
+        """
+        qc = QuantumCircuit(2, 1)
+        qc.cx(1, 0)
+        qc.i(0)
+        qc.i(1)
+        qc.measure(0, 0)
+        qc.i(0)
+        qc.i(1)
+        qc.cx(1, 0)
+
+        dag = circuit_to_dag(qc)
+        pass_ = CollectMultiQBlocks()
+        pass_.run(dag)
+
+        # list from Collect2QBlocks of nodes that it should have put into blocks
+        good_names = ['cx', 'u1', 'u2', 'u3', 'id']
+        dag_nodes = [node for node in dag.topological_op_nodes() if node.name in good_names]
+
+        # we have to convert them to sets as the ordering can be different
+        # but equivalent between python 3.5 and 3.7
+        # there is no implied topology in a block, so this isn't an issue
+        dag_nodes = [set(dag_nodes[:4]), set(dag_nodes[4:])]
+        pass_nodes = [set(bl) for bl in pass_.property_set['block_list']]
+
+        self.assertEqual(dag_nodes, pass_nodes)
+
+    def test_block_with_classical_register(self):
+        """Test that only blocks that share quantum wires are added to the block.
+        It was the case that gates which shared a classical wire could be added to
+        the same block, despite not sharing the same qubits. This was fixed in #2956.
+
+                                    ┌─────────────────────┐
+        q_0: |0>────────────────────┤ U2(0.25*pi,0.25*pi) ├
+                     ┌─────────────┐└──────────┬──────────┘
+        q_1: |0>──■──┤ U1(0.25*pi) ├───────────┼───────────
+                ┌─┴─┐└──────┬──────┘           │
+        q_2: |0>┤ X ├───────┼──────────────────┼───────────
+                └───┘    ┌──┴──┐            ┌──┴──┐
+        c0_0: 0 ═════════╡ = 0 ╞════════════╡ = 0 ╞════════
+                         └─────┘            └─────┘
+
+        Previously the blocks collected were : [['cx', 'u1', 'u2']]
+        This is now corrected to : [['cx', 'u1']]
+        """
+
+        qasmstr = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c0[1];
+
+        cx q[1],q[2];
+        if(c0==0) u1(0.25*pi) q[1];
+        if(c0==0) u2(0.25*pi, 0.25*pi) q[0];
+        """
+        qc = QuantumCircuit.from_qasm_str(qasmstr)
+
+        pass_manager = PassManager()
+        pass_manager.append(CollectMultiQBlocks())
+
+        pass_manager.run(qc)
+
+        self.assertEqual([['cx']],
+                         [[n.name for n in block]
+                          for block in pass_manager.property_set['block_list']])
+
+    def test_do_not_merge_conditioned_gates(self):
+        """Validate that classically conditioned gates are never considered for
+        inclusion in a block. Note that there are cases where gates conditioned
+        on the same (register, value) pair could be correctly merged, but this is
+        not yet implemented.
+
+                 ┌─────────┐┌─────────┐┌─────────┐      ┌───┐
+        qr_0: |0>┤ U1(0.1) ├┤ U1(0.2) ├┤ U1(0.3) ├──■───┤ X ├────■───
+                 └─────────┘└────┬────┘└────┬────┘┌─┴─┐ └─┬─┘  ┌─┴─┐
+        qr_1: |0>────────────────┼──────────┼─────┤ X ├───■────┤ X ├─
+                                 │          │     └───┘   │    └─┬─┘
+        qr_2: |0>────────────────┼──────────┼─────────────┼──────┼───
+                              ┌──┴──┐    ┌──┴──┐       ┌──┴──┐┌──┴──┐
+         cr_0: 0 ═════════════╡     ╞════╡     ╞═══════╡     ╞╡     ╞
+                              │ = 0 │    │ = 0 │       │ = 0 ││ = 1 │
+         cr_1: 0 ═════════════╡     ╞════╡     ╞═══════╡     ╞╡     ╞
+                              └─────┘    └─────┘       └─────┘└─────┘
+
+        Previously the blocks collected were : [['u1', 'u1', 'u1', 'cx', 'cx', 'cx']]
+        This is now corrected to : [['cx']]
+        """
+        # ref: https://github.com/Qiskit/qiskit-terra/issues/3215
+
+        qr = QuantumRegister(3, 'qr')
+        cr = ClassicalRegister(2, 'cr')
+
+        qc = QuantumCircuit(qr, cr)
+        qc.u1(0.1, 0)
+        qc.u1(0.2, 0).c_if(cr, 0)
+        qc.u1(0.3, 0).c_if(cr, 0)
+        qc.cx(0, 1)
+        qc.cx(1, 0).c_if(cr, 0)
+        qc.cx(0, 1).c_if(cr, 1)
+
+        pass_manager = PassManager()
+        pass_manager.append(CollectMultiQBlocks())
+
+        pass_manager.run(qc)
+        for block in pass_manager.property_set['block_list']:
+            self.assertTrue(len(block) <= 1)
+
+    def test_do_not_go_across_barrier(self):
+        """Validate that blocks are not collected across barriers
+                   ░      
+        q_0: ──■───░───■──
+             ┌─┴─┐ ░ ┌─┴─┐
+        q_1: ┤ X ├─░─┤ X ├
+             └───┘ ░ └───┘
+        q_2: ──────░──────
+                   ░  
+        """
+        qr = QuantumRegister(3, 'qr')
+        qc = QuantumCircuit(qr)
+        qc.cx(0,1)
+        qc.barrier()
+        qc.cx(0,1)
+
+        pass_manager = PassManager()
+        pass_manager.append(CollectMultiQBlocks())
+
+        pass_manager.run(qc)
+        for block in pass_manager.property_set['block_list']:
+            self.assertTrue(len(block) <= 1)
+
+    def test_optimal_blocking(self):
+        """ Test that blocks are created optimally in at least the two quibit case.
+        Here, if the topological ordering of nodes is wrong then we might create
+        an extra block
+        qr_0: ────────────■────■───────
+                   ┌───┐┌─┴─┐┌─┴─┐┌───┐
+        qr_1: ──■──┤ H ├┤ X ├┤ X ├┤ H ├
+              ┌─┴─┐├───┤└───┘└───┘└───┘
+        qr_2: ┤ X ├┤ X ├───────────────
+              └───┘└───┘ 
+        """
+        qr = QuantumRegister(3, 'qr')
+        qc = QuantumCircuit(qr)
+        qc.cx(1,2)
+        qc.h(1)
+        qc.cx(0,1)
+        qc.cx(0,1)
+        qc.h(1)
+        qc.x(2)
+
+        pass_manager = PassManager()
+        pass_manager.append(CollectMultiQBlocks())
+
+        pass_manager.run(qc)
+        self.assertTrue(len(pass_manager.property_set['block_list']) == 2)
+
+    def test_ignore_measurement(self):
+        """ Test that doing a measurement on one qubit will not prevent
+        gates from being added to the block that do not act on the qubit
+        that was measured
+                       ┌─┐    
+        q_0: ──■───────┤M├──────────
+             ┌─┴─┐     └╥┘     ┌───┐
+        q_1: ┤ X ├──■───╫───■──┤ X ├
+             └───┘┌─┴─┐ ║ ┌─┴─┐├───┤
+        q_2: ─────┤ X ├─╫─┤ X ├┤ H ├
+                  └───┘ ║ └───┘└───┘
+        c_0: ═══════════╩═══════════
+        """
+        qc = QuantumCircuit(3, 1)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.measure(0, 0)
+        qc.cx(1, 2)
+        qc.x(1)
+        qc.h(2)
+
+        pass_manager= PassManager()
+        pass_manager.append(CollectMultiQBlocks(max_block_size=3))
+
+        pass_manager.run(qc)
+        self.assertTrue(len(pass_manager.property_set['block_list']) == 1)
+
+    def test_larger_blocks(self):
+        """ Test that a max block size of 4 is still being processed 
+        reasonably. 
+        q_0: ──■──────────────■───────
+             ┌─┴─┐            │       
+        q_1: ┤ X ├──■─────────■───────
+             └───┘┌─┴─┐     ┌─┴─┐     
+        q_2: ─────┤ X ├──■──┤ X ├─────
+                  └───┘┌─┴─┐└───┘     
+        q_3: ──────────┤ X ├──■────■──
+                       └───┘┌─┴─┐┌─┴─┐
+        q_4: ───────────────┤ X ├┤ X ├
+                            └───┘└───┘
+        """
+        qc = QuantumCircuit(5)
+        qc.cx(0,1)
+        qc.cx(1,2)
+        qc.cx(2,3)
+        qc.cx(3,4)
+        qc.ccx(0,1,2)
+        qc.cx(3,4)
+
+        pass_manager= PassManager()
+        pass_manager.append(CollectMultiQBlocks(max_block_size=4))
+
+        pass_manager.run(qc)
+        self.assertTrue(len(pass_manager.property_set['block_list']) <= 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -21,7 +21,7 @@ import unittest
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler import PassManager
-from qiskit.transpiler.passes import AlternateCollect
+from qiskit.transpiler.passes import CollectMultiQBlocks
 from qiskit.test import QiskitTestCase
 
 
@@ -51,7 +51,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         block_1 = [topo_ops[1], topo_ops[2]]
         block_2 = [topo_ops[0], topo_ops[3]]
 
-        pass_ = AlternateCollect()
+        pass_ = CollectMultiQBlocks()
         pass_.run(dag)
         self.assertTrue(pass_.property_set['block_list'], [block_1, block_2])
 
@@ -83,7 +83,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(1, 0)
 
         dag = circuit_to_dag(qc)
-        pass_ = AlternateCollect()
+        pass_ = CollectMultiQBlocks()
         pass_.run(dag)
 
         # list from Collect2QBlocks of nodes that it should have put into blocks
@@ -130,7 +130,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc = QuantumCircuit.from_qasm_str(qasmstr)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect())
+        pass_manager.append(CollectMultiQBlocks())
 
         pass_manager.run(qc)
 
@@ -175,7 +175,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(0, 1).c_if(cr, 1)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect())
+        pass_manager.append(CollectMultiQBlocks())
 
         pass_manager.run(qc)
         for block in pass_manager.property_set['block_list']:
@@ -198,7 +198,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(0, 1)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect())
+        pass_manager.append(CollectMultiQBlocks())
 
         pass_manager.run(qc)
         for block in pass_manager.property_set['block_list']:
@@ -227,7 +227,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.x(2)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect())
+        pass_manager.append(CollectMultiQBlocks())
 
         pass_manager.run(qc)
         self.assertTrue(len(pass_manager.property_set['block_list']) == 2)
@@ -254,7 +254,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.h(2)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect(max_block_size=3))
+        pass_manager.append(CollectMultiQBlocks(max_block_size=3))
 
         pass_manager.run(qc)
         self.assertTrue(len(pass_manager.property_set['block_list']) == 1)
@@ -283,7 +283,7 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.cx(3, 4)
 
         pass_manager = PassManager()
-        pass_manager.append(AlternateCollect(max_block_size=4))
+        pass_manager.append(CollectMultiQBlocks(max_block_size=4))
 
         pass_manager.run(qc)
 

--- a/test/python/transpiler/test_collect_multiq_blocks.py
+++ b/test/python/transpiler/test_collect_multiq_blocks.py
@@ -277,12 +277,6 @@ class TestCollect2qBlocks(QiskitTestCase):
         qc.ccx(0,1,2)
         qc.cx(3,4)
 
-        pass_manager= PassManager()
-        pass_manager.append(CollectMultiQBlocks(max_block_size=4))
-
-        pass_manager.run(qc)
-        self.assertTrue(len(pass_manager.property_set['block_list']) <= 2)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -20,8 +20,8 @@ from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeLondon
 from qiskit.extensions import UnitaryGate
+
 
 class TestUnroll3qOrMore(QiskitTestCase):
     """Tests the Unroll3qOrMore pass, for unrolling all
@@ -96,5 +96,3 @@ class TestUnroll3qOrMore(QiskitTestCase):
         after_dag = pass_.run(dag)
         after_circ = dag_to_circuit(after_dag)
         self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
-
-

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -13,14 +13,15 @@
 # that they have been altered from the originals.
 
 """Test the Unroll3qOrMore pass"""
-
+import numpy as np
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
-
+from qiskit.test.mock import FakeLondon
+from qiskit.extensions import UnitaryGate
 
 class TestUnroll3qOrMore(QiskitTestCase):
     """Tests the Unroll3qOrMore pass, for unrolling all
@@ -83,3 +84,17 @@ class TestUnroll3qOrMore(QiskitTestCase):
         after_dag = pass_.run(dag)
         after_circ = dag_to_circuit(after_dag)
         self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
+
+    def test_identity(self):
+        """Test unrolling of identity gate over 3qubits."""
+        qr = QuantumRegister(3, 'qr')
+        circuit = QuantumCircuit(qr)
+        gate = UnitaryGate(np.eye(2 ** 3))
+        circuit.append(gate, range(3))
+        dag = circuit_to_dag(circuit)
+        pass_ = Unroll3qOrMore()
+        after_dag = pass_.run(dag)
+        after_circ = dag_to_circuit(after_dag)
+        self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
+
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The new pass added is called CollectMultiQBlocks. It is run on a dag of operations. It can be passed a single parameter, max_block_size. This parameter specifies the maximum number of qubits that can be acted on in each block it creates. A block consists of gates that are uninterrupted by other gates and thus could be grouped up into a single, large unitary. 

### Details and comments
New pass is to replace Collect2qBlocks. It performs marginally better than collect2qblocks when you set the parameter for max qubits in a block to 2. 

Collecting blocks optimally is NP-hard (if max_block_size is not 2). The current implementation is thus not optimal. The implementation runs very quickly (theoretically and in practice), and the number of blocks it outputs scales about as one would expect. 

The tests for the pass involve all previous tests used for Collect2qBlocks. Other tests that examine cases where max_block_size is greater than 2 were also added. 