### PR TITLE
Corrected u2 decomposition and added examples

### DIFF
--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -26,7 +26,7 @@ class U2Gate(Gate):
     Implemented using one X90 pulse on IBM Quantum systems:
 
     .. math::
-        U2(\phi, \lambda) = RZ(\phi+\pi/2).RX(\frac{\pi}{2}).RZ(\lambda-\pi/2)
+        U2(\phi, \lambda) = RZ(\phi+\pi/2).RX(\frac{\pi}{2}).RZ(\lambda)
 
     **Circuit symbol:**
 
@@ -51,7 +51,8 @@ class U2Gate(Gate):
     .. math::
 
         U2(0, \pi) = H
-
+        U2(0, 0) = RY(\pi/2)
+        U2(-\pi/2,\pi/2) = RX(\pi/2)
     .. seealso::
 
         :class:`~qiskit.circuit.library.standard_gates.U3Gate`:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Corrects decomposition of U2 and X90 and virtual Z's assuming the matrix representation is correct. 
Fixes #4752 


