### PR TITLE
Update the qobj schema to support pulse gate calibrations.

### DIFF
--- a/qiskit/qobj/qasm_qobj.py
+++ b/qiskit/qobj/qasm_qobj.py
@@ -368,7 +368,34 @@ class QasmQobjExperimentHeader(QobjDictField):
 
 class QasmQobjExperimentConfig(QobjDictField):
     """Configuration for a single QASM experiment in the qobj."""
-    pass
+
+    def __init__(self, calibrations=None, **kwargs):
+        """
+        Args:
+            calibrations (QasmQobjCalibrations): Information required for
+                                                 Pulse gates.
+            kwargs: Additional free form key value fields to add to the
+                configuration.
+        """
+        if calibrations:
+            self.calibrations = calibrations
+
+        if kwargs:
+            self.__dict__.update(kwargs)
+
+
+class QasmQobjCalibrations(QobjDictField):
+    """"""
+
+    def __init__(self, gates, pulse_library):
+        """
+        Args:
+            gates (list): A list of dictionaries which specify a gate by name, qubits,
+                          and params, and contains the Pulse instructions to implement it.
+            pulse_library (list): List of :class:`PulseLibraryItem`.
+        """
+        self.gates = gates
+        self.pulse_library = pulse_library
 
 
 class QobjHeader(QobjDictField):
@@ -405,7 +432,7 @@ class QasmQobj:
         self.experiments = experiments or []
         self.qobj_id = qobj_id
         self.type = 'QASM'
-        self.schema_version = '1.2.0'
+        self.schema_version = '1.3.0'
 
     def __repr__(self):
         experiments_str = [repr(x) for x in self.experiments]

--- a/qiskit/schemas/qobj_schema.json
+++ b/qiskit/schemas/qobj_schema.json
@@ -847,6 +847,41 @@
             },
             "type": "array"
         },
+        "calibration_entry": {
+            "description": "The instruction description of each calibrated gate.",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "Gate name",
+                    "type": "string"
+                },
+                "qubits": {
+                    "items": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "minItems": 1,
+                    "type": "array"
+                },
+                "params": {
+                    "description": "Gate parameters",
+                    "type": "array"
+                },
+                "instructions": {
+                    "description": "Pulse instructions implementing the given gate.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/qobjinstructions"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "qubits",
+                "params",
+                "instructions"
+            ]
+        },
         "qobjexp": {
             "description": "Quantum experiment",
             "properties": {
@@ -866,6 +901,22 @@
                         "init_qubits": {
                             "description": "Whether to initialize the qubits in the ground state before each shot.",
                             "type": "boolean"
+                        },
+                        "calibrations": {
+                            "description": "User-specified pulse-level calibrations for operations utilized in this experiment.",
+                            "type": "object",
+                            "properties": {
+                                "gates": {
+                                    "$ref": "#/definitions/calibration_entry"
+                                },
+                                "pulse_library": {
+                                    "description": "Pulses for gate calibrations.",
+                                        "items": {
+                                            "$ref": "#/definitions/pulse_library"
+                                        },
+                                    "type": "array"
+                                }
+                            }
                         }
                     },
                     "title": "Experiment level configuration",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Begin Pulse Gates feature by updating the schema.
Example:
```
// job: QasmQobj
// job.experiments[0].config.calibrations
{
  'gates: [
    {"name": "rxtheta", "qubits": [0], "params": [3.14], "instructions": [openpulse_instructions]}
    {"name": "rxtheta", "qubits": [0], "params": [1.57], "instructions": [openpulse_instructions]}
    {"name": "rxtheta", "qubits": [1], "params": [1.57], "instructions": [openpulse_instructions]}
  ],
  'pulse_library': [
    // same as pulse lib for PulseQobj
  ]
}
```
The `'gates'` information must be sufficient to match against an instruction, for instance: `QasmQobjInstruction(name='rxtheta', params=[1.57], qubits=[1])` matches the last entry.

### Details and comments
- [ ] TODO: parameters

