### PR TITLE
QuantumCircuit cache bits

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -41,6 +41,7 @@ class BlueprintCircuit(QuantumCircuit, ABC):
         self._data = None
         self._qregs = []
         self._cregs = []
+        self._qubits = []
 
     @abstractmethod
     def _check_configuration(self, raise_on_failure: bool = True) -> bool:
@@ -82,6 +83,7 @@ class BlueprintCircuit(QuantumCircuit, ABC):
     def qregs(self, qregs):
         """Set the quantum registers associated with the circuit."""
         self._qregs = qregs
+        self._qubits = [qbit for qreg in qregs for qbit in qreg]
         self._invalidate()
 
     @property

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -163,6 +163,8 @@ class QuantumCircuit:
         # This is a map of registers bound to this circuit, by name.
         self.qregs = []
         self.cregs = []
+        self._qubits = []
+        self._clbits = []
         self.add_register(*regs)
 
         # Parameter table tracks instructions with variable parameters.
@@ -607,21 +609,21 @@ class QuantumCircuit:
         """
         Returns a list of quantum bits in the order that the registers were added.
         """
-        return [qbit for qreg in self.qregs for qbit in qreg]
+        return self._qubits
 
     @property
     def clbits(self):
         """
         Returns a list of classical bits in the order that the registers were added.
         """
-        return [cbit for creg in self.cregs for cbit in creg]
+        return self._clbits
 
     @property
     def ancillas(self):
         """
         Returns a list of quantum bits in the order that the registers were added.
         """
-        return [qbit for qreg in self.qregs for qbit in qreg if isinstance(qbit, AncillaQubit)]
+        return [qbit for qbit in self._qubits if isinstance(qbit, AncillaQubit)]
 
     def __add__(self, rhs):
         """Overload + to implement self.combine."""
@@ -824,8 +826,10 @@ class QuantumCircuit:
                                    % register.name)
             if isinstance(register, QuantumRegister):
                 self.qregs.append(register)
+                self._qubits.extend(register)
             elif isinstance(register, ClassicalRegister):
                 self.cregs.append(register)
+                self._clbits.extend(register)
             else:
                 raise CircuitError("expected a register")
 
@@ -1480,6 +1484,8 @@ class QuantumCircuit:
         # copy registers correctly, in copy.copy they are only copied via reference
         cpy.qregs = self.qregs.copy()
         cpy.cregs = self.cregs.copy()
+        cpy._qubits = self._qubits.copy()
+        cpy._clbits = self._clbits.copy()
 
         instr_instances = {id(instr): instr
                            for instr, _, __ in self._data}

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -30,7 +30,7 @@ from qiskit.circuit.gate import Gate
 from qiskit.qasm.qasm import Qasm
 from qiskit.circuit.exceptions import CircuitError
 from .parameterexpression import ParameterExpression
-from .quantumregister import QuantumRegister, Qubit, AncillaQubit
+from .quantumregister import QuantumRegister, Qubit, AncillaRegister
 from .classicalregister import ClassicalRegister, Clbit
 from .parametertable import ParameterTable
 from .parametervector import ParameterVector
@@ -165,6 +165,7 @@ class QuantumCircuit:
         self.cregs = []
         self._qubits = []
         self._clbits = []
+        self._ancillas = []
         self.add_register(*regs)
 
         # Parameter table tracks instructions with variable parameters.
@@ -623,7 +624,7 @@ class QuantumCircuit:
         """
         Returns a list of ancilla bits in the order that the registers were added.
         """
-        return [qbit for qbit in self._qubits if isinstance(qbit, AncillaQubit)]
+        return self._ancillas
 
     def __add__(self, rhs):
         """Overload + to implement self.combine."""
@@ -824,6 +825,10 @@ class QuantumCircuit:
             if register.name in [reg.name for reg in self.qregs + self.cregs]:
                 raise CircuitError("register name \"%s\" already exists"
                                    % register.name)
+
+            if isinstance(register, AncillaRegister):
+                self._ancillas.extend(register)
+
             if isinstance(register, QuantumRegister):
                 self.qregs.append(register)
                 self._qubits.extend(register)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -621,7 +621,7 @@ class QuantumCircuit:
     @property
     def ancillas(self):
         """
-        Returns a list of quantum bits in the order that the registers were added.
+        Returns a list of ancilla bits in the order that the registers were added.
         """
         return [qbit for qbit in self._qubits if isinstance(qbit, AncillaQubit)]
 

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -130,8 +130,8 @@ class Register:
             return self._bits[key]
 
     def __iter__(self):
-        for bit in range(self._size):
-            yield self[bit]
+        for idx in range(self._size):
+            yield self._bits[idx]
 
     def __eq__(self, other):
         """Two Registers are the same if they are of the same type


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Analogous to #4535 , caches `qubits` and `clbits` properties of `QuantumCircuit.` This avoids the cost of the list comprehension from `qc.qubits` in `qbit_argument_conversion` which can be considerable when making many calls to `QuantumCircuit.append`.

Also, updates `Register.__iter__` to avoid the type checks in `Register.__getitem__`.

### Details and comments

ex: Adding 1024 mcx gates on a 53 qubit circuit:

* master @ 80dcb846 : 
![image](https://user-images.githubusercontent.com/2241698/87989819-bb151f80-cab0-11ea-96f3-186a6a7f536f.png)

* After `Register.__iter__` avoiding type checks in `Register.__getitem__`:
![image](https://user-images.githubusercontent.com/2241698/87989874-d08a4980-cab0-11ea-911e-3cff0c075bc7.png)

* With caching QuantumCircuit.qubits:

![image](https://user-images.githubusercontent.com/2241698/87989900-e26bec80-cab0-11ea-87b3-adb2ebda3c40.png)

* Building with `_append`:
![image](https://user-images.githubusercontent.com/2241698/87989926-ebf55480-cab0-11ea-9322-a48e3226f919.png)

```
$ asv continuous --python 3.6 --no-only-changed --bench 'circuit_construction|time_build_ripple_adder' master quantumcircuit-cache-bits

...

       before           after         ratio
     [80dcb846]       [996e18fe]
     <master>         <quantumcircuit-cache-bits>
          277±9μs        538±200μs    ~1.94  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 8)
      2.32±0.04ms       2.68±0.7ms    ~1.16  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 128)
         665±30μs        750±100μs    ~1.13  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 128)
          175±4ms         196±10ms    ~1.12  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 32768)
       10.8±0.2ms       11.9±0.5ms    ~1.11  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 2048)
         228±10μs         248±70μs     1.09  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 8)
       44.0±0.9ms         47.3±2ms     1.08  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 8192)
          145±3μs          154±7μs     1.07  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 8)
          188±9ms          201±9ms     1.07  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 32768)
         190±10ms         202±20ms     1.06  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 32768)
         645±30μs        679±100μs     1.05  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 128)
          802±7ms         842±50ms     1.05  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 131072)
          192±8ms          201±7ms     1.05  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 32768)
         739±40μs         767±20μs     1.04  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 128)
         802±40μs         831±40μs     1.04  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 128)
         725±20μs         751±30μs     1.04  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 128)
       56.4±0.9μs         58.3±1μs     1.03  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 8)
          744±9μs         768±20μs     1.03  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 128)
         784±20ms         808±20ms     1.03  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 131072)
         866±50μs         891±40μs     1.03  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 128)
       44.6±0.3ms         45.7±3ms     1.03  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 8192)
        819±100μs         838±30μs     1.02  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 128)
         669±20μs         682±20μs     1.02  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 128)
       11.1±0.4ms       11.3±0.3ms     1.02  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 2048)
       11.0±0.5ms       11.1±0.2ms     1.01  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 2048)
       11.4±0.5ms       11.5±0.5ms     1.01  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 2048)
         783±30ms         788±30ms     1.01  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 131072)
         745±40ms         750±30ms     1.01  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 131072)
         753±30ms         757±30ms     1.01  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 131072)
       45.5±0.6ms         45.7±2ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 8192)
          188±7ms          189±6ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 32768)
         58.1±5μs       58.3±0.9μs     1.00  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 8)
          184±7ms          184±3ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 32768)
       11.4±0.8ms       11.4±0.1ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 2048)
          187±4ms          186±5ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 32768)
          184±9ms          184±7ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 32768)
         760±40ms         757±20ms     1.00  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 131072)
         745±10ms         741±20ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 131072)
       45.5±0.8ms       45.2±0.8ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 8192)
       49.5±0.9μs         49.2±2μs     0.99  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 8)
       53.0±0.8μs         52.7±2μs     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 8)
         45.7±1ms         45.3±1ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 8192)
       87.6±0.4μs         86.8±2μs     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(8, 8)
         55.4±2μs         54.8±1μs     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 8)
         819±20ms         810±40ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 131072)
       3.06±0.2ms       3.03±0.8ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 128)
         742±20ms         732±30ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 131072)
         44.9±1μs         44.3±2μs     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 8)
       10.4±0.5ms       10.2±0.5ms     0.99  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 2048)
          214±5μs          210±3μs     0.98  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 8)
         47.0±4ms       45.9±0.9ms     0.98  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 8192)
         620±40ms         606±30ms     0.98  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 32768)
       11.3±0.7ms      11.0±0.07ms     0.98  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 2048)
          170±8ms          165±6ms     0.98  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 32768)
       11.6±0.9ms       11.3±0.2ms     0.98  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 2048)
         693±20ms         671±20ms     0.97  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 131072)
         40.9±2ms         39.6±1ms     0.97  circuit_construction.CircuitConstructionBench.time_circuit_extend(1, 8192)
          194±2ms          187±5ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 32768)
         47.3±5ms         45.6±1ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 8192)
          149±7ms          144±6ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 8192)
         838±20ms         804±20ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_copy(14, 131072)
       10.9±0.9ms       10.4±0.2ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 2048)
       11.8±0.4ms       11.3±0.4ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 2048)
       36.7±0.4ms         35.1±2ms     0.96  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 2048)
         752±20μs         716±10μs     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 128)
         826±30ms         787±20ms     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 131072)
          198±4ms          188±6ms     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 32768)
       46.5±0.9ms       44.2±0.9ms     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(5, 8192)
         777±70μs         738±10μs     0.95  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 128)
        93.4±10μs         88.5±1μs     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 8)
         716±60μs         678±10μs     0.95  circuit_construction.CircuitConstructionBench.time_circuit_extend(2, 128)
       11.0±0.2ms       10.4±0.1ms     0.95  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 2048)
         222±10μs          209±3μs     0.94  circuit_construction.CircuitConstructionBench.time_circuit_copy(20, 8)
         46.3±3ms       43.5±0.5ms     0.94  circuit_construction.CircuitConstructionBench.time_circuit_copy(8, 8192)
       11.2±0.9ms       10.5±0.3ms     0.94  circuit_construction.CircuitConstructionBench.time_circuit_copy(2, 2048)
         197±10ms          184±4ms     0.93  circuit_construction.CircuitConstructionBench.time_circuit_copy(1, 32768)
         163±20μs          149±5μs     0.91  circuit_construction.CircuitConstructionBench.time_circuit_extend(14, 8)
         49.7±3ms         45.0±1ms    ~0.91  circuit_construction.CircuitConstructionBench.time_circuit_extend(20, 8192)
       2.51±0.04s       2.27±0.09s    ~0.90  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 131072)
         50.5±6ms         45.0±2ms    ~0.89  circuit_construction.CircuitConstructionBench.time_circuit_extend(5, 8192)
       45.5±0.8ms         40.6±1ms    ~0.89  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 2048)
       3.63±0.1ms       3.12±0.3ms    ~0.86  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 128)
       3.23±0.05s        2.77±0.1s    ~0.86  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 131072)
         193±20μs         166±10μs    ~0.86  circuit_construction.CircuitConstructionBench.time_circuit_construction(1, 8)
         765±20ms         654±30ms    ~0.85  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 32768)
-         192±5ms          158±4ms     0.82  circuit_construction.CircuitConstructionBench.time_circuit_construction(2, 8192)
-         224±7ms          177±4ms     0.79  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 8192)
-        57.7±1ms         45.4±3ms     0.79  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 2048)
-        986±50ms         709±60ms     0.72  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 32768)
-         491±9μs         337±20μs     0.69  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 8)
       4.14±0.01s        2.84±0.2s    ~0.69  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 131072)
-         251±2ms          169±9ms     0.67  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 8192)
        4.05±0.1s       2.71±0.05s    ~0.67  circuit_construction.CircuitConstructionBench.time_circuit_construction(5, 131072)
-      1.05±0.01s         696±10ms     0.66  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 32768)
-     4.23±0.07ms       2.70±0.2ms     0.64  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 128)
-        64.5±1ms         40.8±3ms     0.63  circuit_construction.CircuitConstructionBench.time_circuit_construction(8, 2048)
-        76.0±1ms         44.0±3ms     0.58  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 2048)
       5.05±0.04s        2.79±0.1s    ~0.55  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 131072)
-     5.03±0.04ms      2.74±0.06ms     0.55  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 128)
-     1.08±0.03ms         575±10μs     0.53  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 8)
-        92.5±3ms        48.7±10ms     0.53  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 2048)
-      1.31±0.04s         680±30ms     0.52  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 32768)
-         318±9ms          164±3ms     0.52  circuit_construction.CircuitConstructionBench.time_circuit_construction(14, 8192)
-      1.47±0.03s         713±80ms     0.49  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 32768)
-     1.72±0.04ms         829±30μs     0.48  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 8)
-         374±9ms         180±10ms     0.48  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 8192)
-      7.52±0.5ms       3.50±0.8ms     0.47  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 128)
        6.23±0.1s       2.70±0.02s    ~0.43  circuit_construction.CircuitConstructionBench.time_circuit_construction(20, 131072)
-      7.43±0.3ms       3.13±0.1ms     0.42  ripple_adder.RippleAdderConstruction.time_build_ripple_adder(10)
-         108±2ms       15.2±0.1ms     0.14  ripple_adder.RippleAdderConstruction.time_build_ripple_adder(50)
-        380±20ms       31.0±0.9ms     0.08  ripple_adder.RippleAdderConstruction.time_build_ripple_adder(100)
-      1.44±0.07s         61.9±2ms     0.04  ripple_adder.RippleAdderConstruction.time_build_ripple_adder(200)
        8.98±0.3s        156±0.7ms    ~0.02  ripple_adder.RippleAdderConstruction.time_build_ripple_adder(500)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

