### PR TITLE
added a quick_simulate function

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -79,7 +79,7 @@ except ImportError:
 # with other modules that check for IBMQ (tools)
 from qiskit.execute import execute  # noqa
 from qiskit.compiler import transpile, assemble, schedule  # noqa
-from qiskit.providers.quick_simulate import quick_simulate
+from qiskit.providers.quick_simulate import quick_simulate  # noqa
 
 from .version import __version__  # noqa
 from .version import _get_qiskit_versions  # noqa

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -79,6 +79,7 @@ except ImportError:
 # with other modules that check for IBMQ (tools)
 from qiskit.execute import execute  # noqa
 from qiskit.compiler import transpile, assemble, schedule  # noqa
+from qiskit.providers.quick_simulate import quick_simulate
 
 from .version import __version__  # noqa
 from .version import _get_qiskit_versions  # noqa

--- a/qiskit/providers/quick_simulate.py
+++ b/qiskit/providers/quick_simulate.py
@@ -1,3 +1,17 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 """
 =============================================
 Quickly simulating circuits (:mod:`qiskit.providers.quick_simulate`)
@@ -8,58 +22,66 @@ Quickly simulating circuits (:mod:`qiskit.providers.quick_simulate`)
 
 
 from qiskit.providers.basicaer import BasicAer
-from qiskit.circuit import QuantumCircuit, ClassicalRegister, QuantumRegister
-from qiskit.execute import execute 
+from qiskit.circuit import QuantumCircuit, QuantumRegister
+from qiskit.execute import execute
 from qiskit.exceptions import QiskitError
 
 
 def quick_simulate(circuit, shots=1024, x="0", verbose=False):
-	"""simulates circuit with given input
+    """simulates circuit with given input
 
-	Args:
-	    circuit (QuantumCircuit): Circuit to be simulated. Currently no more than registers supported
-	    shots (int, optional): number of shots to simulate. Default 1024
-	    x (str, optional): input string. eg "1011" would apply an X gate to the first, third and fourth qubits. Default "0"
-	    verbose (bool, optional): prints extra output
+    Args:
+        circuit (QuantumCircuit): Circuit to simulate. Currently no more than 2 registers supported
+        shots (int, optional): number of shots to simulate. Default 1024
+        x (str, optional): input string eg "11" would apply an X gate to first 2 qubits. Default "0"
+        verbose (bool, optional): prints extra output
 
-	Returns:
-	    dict[str:int]: results.get_counts()
-	"""
-	names = []
-	regs = []
-	for q in circuit.qubits:
-		name = q.register.name
-		size = len(q.register)
-		if name not in names:
-			names.append(name)
-			regs.append(size)
+    Returns:
+        dict[str:int]: results.get_counts()
 
-	if verbose: print(names, regs)
+    Raises:
+        QiskitError: if circuit has more than two registers
+    """
+    names = []
+    regs = []
+    for q in circuit.qubits:
+        name = q.register.name
+        size = len(q.register)
+        if name not in names:
+            names.append(name)
+            regs.append(size)
 
-	#assuming that we only have 2: control + anciallary
-	qra = QuantumRegister(regs[0], name=names[0])
-	if len(regs) > 2:
-		raise QiskitError("Not yet implemented for more than 2 registers")
-	elif len(regs) == 2:
-		qran = QuantumRegister(regs[1], name=names[1])
-		qa = QuantumCircuit(qra,qran)
-	else:
-		qa = QuantumCircuit(qra)
+    if verbose:
+        print(names, regs)
 
-	if len(x) != sum(regs): x += "0" * (sum(regs) - len(x))
-	if verbose: print(x)
-	for bit in range(len(x)):
-		if verbose: print(x[bit], type(x[bit]))
-		if x[bit] != "0":
-			qa.x(bit)
-	qa.barrier()
+    # assuming that we only have 2: control + ancillary
 
-	qa.extend(circuit)
+    qra = QuantumRegister(regs[0], name=names[0])
+    if len(regs) == 1:
+        qa = QuantumCircuit(qra)
+    elif len(regs) == 2:
+        qran = QuantumRegister(regs[1], name=names[1])
+        qa = QuantumCircuit(qra, qran)
+    else:
+        raise QiskitError("Not yet implemented for more than 2 registers")
 
-	if verbose:
-		print(qa)
+    if len(x) != sum(regs):
+        x += "0" * (sum(regs) - len(x))
+    if verbose:
+        print(x)
+    for i, bit in enumerate(x):
+        if verbose:
+            print(bit, type(bit))
+        if bit != "0":
+            qa.x(i)
+    qa.barrier()
 
-	backend = BasicAer.get_backend('qasm_simulator')
-	results = execute(qa, backend=backend, shots=shots).result()
-	answer = results.get_counts()
-	return answer
+    qa.extend(circuit)
+
+    if verbose:
+        print(qa)
+
+    backend = BasicAer.get_backend('qasm_simulator')
+    results = execute(qa, backend=backend, shots=shots).result()
+    answer = results.get_counts()
+    return answer

--- a/qiskit/providers/quick_simulate.py
+++ b/qiskit/providers/quick_simulate.py
@@ -1,0 +1,65 @@
+"""
+=============================================
+Quickly simulating circuits (:mod:`qiskit.providers.quick_simulate`)
+=============================================
+.. currentmodule:: qiskit.providers.quick_simulate
+.. autofunction:: quick_simulate
+"""
+
+
+from qiskit.providers.basicaer import BasicAer
+from qiskit.circuit import QuantumCircuit, ClassicalRegister, QuantumRegister
+from qiskit.execute import execute 
+from qiskit.exceptions import QiskitError
+
+
+def quick_simulate(circuit, shots=1024, x="0", verbose=False):
+	"""simulates circuit with given input
+
+	Args:
+	    circuit (QuantumCircuit): Circuit to be simulated. Currently no more than registers supported
+	    shots (int, optional): number of shots to simulate. Default 1024
+	    x (str, optional): input string. eg "1011" would apply an X gate to the first, third and fourth qubits. Default "0"
+	    verbose (bool, optional): prints extra output
+
+	Returns:
+	    dict[str:int]: results.get_counts()
+	"""
+	names = []
+	regs = []
+	for q in circuit.qubits:
+		name = q.register.name
+		size = len(q.register)
+		if name not in names:
+			names.append(name)
+			regs.append(size)
+
+	if verbose: print(names, regs)
+
+	#assuming that we only have 2: control + anciallary
+	qra = QuantumRegister(regs[0], name=names[0])
+	if len(regs) > 2:
+		raise QiskitError("Not yet implemented for more than 2 registers")
+	elif len(regs) == 2:
+		qran = QuantumRegister(regs[1], name=names[1])
+		qa = QuantumCircuit(qra,qran)
+	else:
+		qa = QuantumCircuit(qra)
+
+	if len(x) != sum(regs): x += "0" * (sum(regs) - len(x))
+	if verbose: print(x)
+	for bit in range(len(x)):
+		if verbose: print(x[bit], type(x[bit]))
+		if x[bit] != "0":
+			qa.x(bit)
+	qa.barrier()
+
+	qa.extend(circuit)
+
+	if verbose:
+		print(qa)
+
+	backend = BasicAer.get_backend('qasm_simulator')
+	results = execute(qa, backend=backend, shots=shots).result()
+	answer = results.get_counts()
+	return answer

--- a/releasenotes/notes/added-quick-simulate-60aac80399788d7d.yaml
+++ b/releasenotes/notes/added-quick-simulate-60aac80399788d7d.yaml
@@ -1,6 +1,4 @@
 ---
-prelude: >
-    A handy function to quickly simulate a given circuit on a given classical input.
 features:
   - |
     Always forgetting the simulation code myself, this introduces a function 'quick_simulate'. For example to test a 1-bit adder,

--- a/releasenotes/notes/added-quick-simulate-60aac80399788d7d.yaml
+++ b/releasenotes/notes/added-quick-simulate-60aac80399788d7d.yaml
@@ -1,0 +1,25 @@
+---
+prelude: >
+    A handy function to quickly simulate a given circuit on a given classical input.
+features:
+  - |
+    Always forgetting the simulation code myself, this introduces a function 'quick_simulate'. For example to test a 1-bit adder,
+    
+    from qiskit import QuantumCircuit, quick_simulate
+    qc = QuantumCircuit(4,2)
+    qc.cx(0,2)
+    qc.cx(1,2)
+    qc.ccx(0,1,3)
+
+    qc.measure(2,0)
+    qc.measure(3,1)
+
+    simulate(qc) #returns {'00': 1024}
+    simulate(qc, x="01") #returns {'01': 1024}
+    etc.
+
+
+issues:
+  - |
+    It can only work on circuits with 1 or 2 registers.
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x] I have added the tests to cover my changes.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the CONTRIBUTING document.
-->

### Summary
A function which can quickly simulate a QuantumCircuit. It can also take an input string to modify the input. For example to test a 1-bit adder:

`from qiskit import QuantumCircuit, quick_simulate
#make adder
qc = QuantumCircuit(4,2)
qc.cx(0,2)
qc.cx(1,2)
qc.ccx(0,1,3)
qc.barrier()
qc.measure(2,0)
qc.measure(3,1)

#get results
quick_simulate(qc) #returns {'00':1024}
quick_simulate(qc, x="10") # returns {'01': 1024}
etc.`


### Details and comments
I wasn't exactly sure where to place the import statement. At the moment it can be imported as 'from qiskit import simulate' but if it would be better placed in the providers directory then line 82 in qiskit/__init__.py can be moved to qiskit/providers/__init__.py
I also just copied and pasted the license agreement without signing anything anywhere, it that OK?

