### PR TITLE
Parallelize swap trials in stochastic swap

### DIFF
--- a/qiskit/transpiler/passes/routing/cython/stochastic_swap/utils.pyx
+++ b/qiskit/transpiler/passes/routing/cython/stochastic_swap/utils.pyx
@@ -161,6 +161,34 @@ cdef class NLayout:
                 out[qreg[idx]] = self.logic_to_phys[main_idx]
                 main_idx += 1
         return out
+
+    def __getstate__(self):
+        logic_to_phys_list = []
+        for x in range(self.l2p_len):
+            logic_to_phys_list.append(self.logic_to_phys[x])
+        phys_to_logic_list = []
+        for x in range(self.l2p_len):
+            phys_to_logic_list.append(self.phys_to_logic[x])
+        return {'num_logical': self.l2p_len, 'num_physical': self.p2l_len,
+                'logic_to_phys': logic_to_phys_list,
+                'phys_to_logic': phys_to_logic_list}
+
+    def __setstate__(self, state):
+        self.l2p_len = state['num_logical']
+        self.p2l_len = state['num_physical']
+        self.logic_to_phys = <unsigned int *>calloc(self.l2p_len,
+                                                    sizeof(unsigned int))
+        for index, x in enumerate(state['logic_to_phys']):
+            self.logic_to_phys[index] = x
+        self.phys_to_logic = <unsigned int *>calloc(self.p2l_len,
+                                                    sizeof(unsigned int))
+
+        for index, x in enumerate(state['phys_to_logic']):
+            self.phys_to_logic[index] = x
+
+    def __reduce__(self):
+        return (self.__class__, (self.l2p_len, self.p2l_len),
+                self.__getstate__())
     
     
 cpdef NLayout nlayout_from_layout(object layout, object qregs, 

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -14,9 +14,13 @@
 
 """Map a DAGCircuit onto a `coupling_map` adding swap gates."""
 
+from collections import OrderedDict
+import itertools
+import tempfile
 from logging import getLogger
 from math import inf
-from collections import OrderedDict
+import os
+
 import numpy as np
 
 from qiskit.circuit.quantumregister import QuantumRegister
@@ -34,6 +38,35 @@ from .cython.stochastic_swap.swap_trial import swap_trial
 
 
 logger = getLogger(__name__)
+
+def _swap_trial(trial, num_qubits, int_layout, int_qubit_subset,
+                int_gates, cdist2, cdist, edges, scale, seed, best_path):
+    if os.path.isfile(best_path):
+        return
+    rng = np.random.default_rng(seed + trial)
+    logger.info("layer_permutation: trial %s", trial)
+    # This is one Trial --------------------------------------
+    dist, optim_edges, trial_layout, depth_step = swap_trial(
+        num_qubits, int_layout, int_qubit_subset, int_gates, cdist2,
+        cdist, edges, scale, rng)
+
+    logger.debug("layer_permutation: final distance for this trial = %s", dist)
+    # Break out of trial loop if we found a depth 1 circuit
+    # since we can't improve it further
+    if depth_step == 1:
+        with open(best_path, 'w') as fd:
+            fd.write(str(trial))
+    return dist, optim_edges, trial_layout, depth_step
+
+
+def _parallel_swap_trials(trials, num_qubits, int_layout, int_qubit_subset,
+                         int_gates, cdist2, cdist, edges, scale, seed,
+                         best_path):
+    results = parallel_map(_swap_trial, range(trials),
+                           (num_qubits, int_layout, int_qubit_subset,
+                            int_gates, cdist2, cdist, edges, scale, seed,
+                            best_path))
+    return results
 
 
 class StochasticSwap(TransformationPass):
@@ -69,7 +102,6 @@ class StochasticSwap(TransformationPass):
         self.trials = trials
         self.seed = seed
         self.qregs = None
-        self.rng = None
         self.trivial_layout = None
 
     def run(self, dag):
@@ -98,32 +130,10 @@ class StochasticSwap(TransformationPass):
         self.qregs = dag.qregs
         if self.seed is None:
             self.seed = np.random.randint(0, np.iinfo(np.int32).max)
-        self.rng = np.random.default_rng(self.seed)
         logger.debug("StochasticSwap default_rng seeded with seed=%s", self.seed)
 
         new_dag = self._mapper(dag, self.coupling_map, trials=self.trials)
         return new_dag
-
-    def _swap_trial(self, trial, num_qubits, int_layout, int_qubit_subset,
-                    int_gates, cdist2, cdist, edges, scale, rng):
-        if self.ideal_depth_found:
-            return
-        logger.info("layer_permutation: trial %s", trial)
-        # This is one Trial --------------------------------------
-        dist, optim_edges, trial_layout, depth_step = swap_trial(
-            num_qubits, int_layout, int_qubit_subset, int_gates, cdist2,
-            cdist, edges, scale, rng)
-
-        logger.debug("layer_permutation: final distance for this trial = %s", dist)
-        # Break out of trial loop if we found a depth 1 circuit
-        # since we can't improve it further
-        if depth_step == 1:
-            self.best_edges = optim_edges
-            self.best_layout = trial_layout
-            self.best_depth = 1
-            self.ideal_depth_found = True
-        return dist, optim_edges, trial_layout, depth_step
-
 
     def _layer_permutation(self, layer_partition, layout, qubit_subset,
                            coupling, trials):
@@ -192,11 +202,10 @@ class StochasticSwap(TransformationPass):
 
         # Begin loop over trials of randomized algorithm
         num_qubits = len(layout)
-        self.best_depth = inf  # initialize best depth
-        self.best_edges = None  # best edges found
-        self.best_circuit = None  # initialize best swap circuit
-        self.best_layout = None  # initialize best final layout
-        self.ideal_depth_found = False
+        best_depth = inf  # initialize best depth
+        best_edges = None  # best edges found
+        best_circuit = None  # initialize best swap circuit
+        best_layout = None  # initialize best final layout
 
         cdist2 = coupling._dist_matrix**2
         # Scaling matrix
@@ -213,36 +222,44 @@ class StochasticSwap(TransformationPass):
 
         edges = np.asarray(coupling.get_edges(), dtype=np.int32).ravel()
         cdist = coupling._dist_matrix
-
-        results = parallel_map(self._swap_trial, range(trials),
-                               (num_qubits, int_layout, int_qubit_subset,
-                                int_gates, cdist2, cdist, edges, scale,
-                                self.rng))
-        if not self.ideal_depth_found:
+        best_path = os.path.join(tempfile.gettempdir(),
+                                 'stochastic_swap+%s' % os.getpid())
+        results = _parallel_swap_trials(trials, num_qubits, int_layout,
+                                        int_qubit_subset, int_gates, cdist2,
+                                        cdist, edges, scale, self.seed,
+                                        best_path)
+        if os.path.isfile(best_path):
+            filtered_results = filter(None, results)
+            ideal_result = [x for x in filtered_results if x[3] == 1][0]
+            best_edges = ideal_result[1]
+            best_layout = ideal_result[2]
+            best_depth = 1
+            os.remove(best_path)
+        else:
             for dist, optim_edges, trial_layout, depth_step in results:
-                if dist == len(gates) and depth_step < self.best_depth:
+                if dist == len(gates) and depth_step < best_depth:
                     logger.debug("layer_permutation: got circuit with improved depth %s",
                                  depth_step)
-                    self.best_edges = optim_edges
-                    self.best_layout = trial_layout
-                    self.best_depth = min(self.best_depth, depth_step)
+                    best_edges = optim_edges
+                    best_layout = trial_layout
+                    best_depth = min(best_depth, depth_step)
         # If we have no best circuit for this layer, all of the
         # trials have failed
-        if self.best_layout is None:
+        if best_layout is None:
             logger.debug("layer_permutation: failed!")
             return False, None, None, None
 
-        edges = self.best_edges.edges()
-        for idx in range(self.best_edges.size//2):
+        edges = best_edges.edges()
+        for idx in range(best_edges.size//2):
             swap_src = self.trivial_layout[edges[2*idx]]
             swap_tgt = self.trivial_layout[edges[2*idx+1]]
             trial_circuit.apply_operation_back(SwapGate(), [swap_src, swap_tgt], [])
-        self.best_circuit = trial_circuit
+        best_circuit = trial_circuit
 
         # Otherwise, we return our result for this layer
         logger.debug("layer_permutation: success!")
-        best_lay = self.best_layout.to_layout(qregs)
-        return True, self.best_circuit, self.best_depth, best_lay
+        best_lay = best_layout.to_layout(qregs)
+        return True, best_circuit, best_depth, best_lay
 
     def _layer_update(self, i, best_layout, best_depth,
                       best_circuit, layer_list):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the use of parallel_map to parallelize the execution of
individual swap trials as a part of stochastic_swap transpiler pass. The
individual trials are independent and can be run in parallel without any
issues.

As part of this pickling support is added for the NLayout
Cython class which is a parameter used in the swap trial method. Without
this the parallel workers would not be able to send or recieve these
objects since pickling is used to pass data between processes.

An alternative approach to explore in the future is to leverage cython's
builtin parallel and openmp support to use multiple threads (without the
GIL) to avoid the serialization overhead and have more efficient
parallelization. This will require a refactor of the cython code though
because to effectively leverage parallel cython we'll need to minimize
the creation of new python objects (ie run in nogil mode).

### Details and comments

Fixes #1743