### PR TITLE
Circuit.compose updates the ParameterTable

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -586,6 +586,9 @@ class QuantumCircuit:
             dest = self.copy()
 
         if not isinstance(other, QuantumCircuit):
+            if isinstance(other, Instruction):
+                dest._update_parameter_table(other)
+
             if front:
                 dest.data.insert(0, (other, qubits, clbits))
             else:
@@ -641,6 +644,9 @@ class QuantumCircuit:
             dest._data = mapped_instrs + dest._data
         else:
             dest._data += mapped_instrs
+
+        for instr, _, _ in mapped_instrs:
+            dest._update_parameter_table(instr)
 
         if inplace:
             return None

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -586,9 +586,6 @@ class QuantumCircuit:
             dest = self.copy()
 
         if not isinstance(other, QuantumCircuit):
-            if isinstance(other, Instruction):
-                dest._update_parameter_table(other)
-
             if front:
                 dest.data.insert(0, (other, qubits, clbits))
             else:

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Parameter
 from qiskit.circuit.library import HGate, RZGate, CXGate, CCXGate
 from qiskit.test import QiskitTestCase
 
@@ -489,6 +489,29 @@ class TestCircuitCompose(QiskitTestCase):
         expected.cx(0, 1)
 
         self.assertEqual(output, expected)
+
+    def test_compose_adds_parameters(self):
+        """Test the composed circuit contains all parameters."""
+        a, b = Parameter('a'), Parameter('b')
+
+        qc_a = QuantumCircuit(1)
+        qc_a.rx(a, 0)
+
+        qc_b = QuantumCircuit(1)
+        qc_b.rx(b, 0)
+
+        with self.subTest('compose with other circuit out-of-place'):
+            qc_1 = qc_a.compose(qc_b)
+            self.assertEqual(qc_1.parameters, {a, b})
+
+        with self.subTest('compose with other instruction out-of-place'):
+            instr_b = qc_b.to_instruction()
+            qc_2 = qc_a.compose(instr_b, [0])
+            self.assertEqual(qc_2.parameters, {a, b})
+
+        with self.subTest('compose with other circuit in-place'):
+            qc_a.compose(qc_b, inplace=True)
+            self.assertEqual(qc_a.parameters, {a, b})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes a bug where the parameters of the added object were not added to the new parameter table. Thereby also fixes the Aqua CI, which is currently failing due to this.

### Details and comments

```python
p = ParameterVector('p', 10)
qc1 = QuantumCircuit(1)
qc1.rx(p[0], 0)
qc2 = QuantumCircuit(1)
qc2.rx(p[1], 0)
qc3 = qc1.compose(qc2)
qc3.parameters  # before: {Parameter(p[0])}, now: {Parameter(p[0]), Parameter(p[1])}
```

