### PR TITLE
Fix dag_drawer() that raises file access error on Windows.

### DIFF
--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -173,6 +173,6 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color', category=None):
             tmp_path = os.path.join(tmpdirname, 'dag.png')
             dot.write_png(tmp_path)
             image = Image.open(tmp_path)
-            os.remove(tmp_path)
             image.show()
+            os.remove(tmp_path)
             return None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes dag_drawer visualization as mentioned in the issue #4793.

### Details and comments
A temporary files is deleted after the image is shown.