### PR TITLE
redress global_phase in controlled UnitaryGate

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -149,9 +149,7 @@ class UnitaryGate(Gate):
             raise ExtensionError('controlled unitary generation failed')
         phase = numpy.angle(diag[0])
         if phase:
-            qreg = cunitary.definition.qregs[0]
-            cunitary.definition.u3(numpy.pi, phase, phase - numpy.pi, qreg[0])
-            cunitary.definition.u3(numpy.pi, 0, numpy.pi, qreg[0])
+            cunitary.definition.global_phase = phase
         cunitary.base_gate = self.copy()
         cunitary.base_gate.label = self.label
         return cunitary

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -87,6 +87,7 @@ class UnitarySynthesis(TransformationPass):
             Output dag with UnitaryGates synthesized to target basis.
         """
 
+        import ipdb;ipdb.set_trace()
         euler_basis = _choose_euler_basis(self._basis_gates)
         kak_gate = _choose_kak_gate(self._basis_gates)
 

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -634,7 +634,7 @@ class TestControlledGate(QiskitTestCase):
         cop_mat = _compute_control_matrix(base_mat, num_ctrl_qubits)
         self.assertTrue(matrix_equal(cop_mat, test_op.data, ignore_phase=True))
 
-    @combine(num_ctrl_qubits=[1, 2, 3], ctrl_state=[None])
+    @combine(num_ctrl_qubits=[1, 2, 3], ctrl_state=[0, None])
     def test_open_controlled_unitary_z(self, num_ctrl_qubits, ctrl_state):
         """Test that UnitaryGate with control returns params."""
         umat = np.array([[1, 0], [0, -1]])
@@ -643,6 +643,17 @@ class TestControlledGate(QiskitTestCase):
         ref_mat = _compute_control_matrix(umat, num_ctrl_qubits, ctrl_state=ctrl_state)
         self.assertEqual(Operator(cugate), Operator(ref_mat))
 
+    def test_controlled_controlled_unitary(self):
+        """Test that global phase in iso decomposition of unitary is handled."""
+        umat = np.array([[1, 0], [0, -1]])
+        ugate = UnitaryGate(umat)
+        cugate = ugate.control()
+        ccugate = cugate.control()
+        ccugate2 = ugate.control(2)
+        ref_mat = _compute_control_matrix(umat, 2)
+        self.assertTrue(Operator(ccugate2).equiv(Operator(ref_mat)))
+        self.assertTrue(Operator(ccugate).equiv(Operator(ccugate2)))        
+        
     @data(1, 2, 3)
     def test_open_controlled_unitary_matrix(self, num_ctrl_qubits):
         """test open controlled unitary matrix"""

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -652,8 +652,8 @@ class TestControlledGate(QiskitTestCase):
         ccugate2 = ugate.control(2)
         ref_mat = _compute_control_matrix(umat, 2)
         self.assertTrue(Operator(ccugate2).equiv(Operator(ref_mat)))
-        self.assertTrue(Operator(ccugate).equiv(Operator(ccugate2)))        
-        
+        self.assertTrue(Operator(ccugate).equiv(Operator(ccugate2)))
+
     @data(1, 2, 3)
     def test_open_controlled_unitary_matrix(self, num_ctrl_qubits):
         """test open controlled unitary matrix"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This is a follow-up to a PR #4565 to simplify handling of global_phase in controlled UnitaryGate similar to the rest of the PR.


### Details and comments


