### PR TITLE
Quadratic form on binary variables circuit

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -194,6 +194,7 @@ from .arithmetic import (
     PolynomialPauliRotations,
     IntegerComparator,
     WeightedAdder,
+    QuadraticForm,
 )
 from .n_local import (
     NLocal,

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -128,6 +128,14 @@ Comparators
 
    IntegerComparator
 
+Functions on binary variables
++++++++++++++++++++++++++++++
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   QuadraticForm
+
 Particular Quantum Circuits
 ===========================
 

--- a/qiskit/circuit/library/arithmetic/__init__.py
+++ b/qiskit/circuit/library/arithmetic/__init__.py
@@ -20,3 +20,4 @@ from .linear_pauli_rotations import LinearPauliRotations
 from .piecewise_linear_pauli_rotations import PiecewiseLinearPauliRotations
 from .polynomial_pauli_rotations import PolynomialPauliRotations
 from .weighted_adder import WeightedAdder
+from .quadratic_form import QuadraticForm

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Quadratic form."""
+
+from typing import Union, Optional, List
+
+import numpy as np
+
+from qiskit.circuit import QuantumCircuit, QuantumRegister, ParameterExpression
+from qiskit.circuit.library import QFT
+
+
+class QuadraticForm(QuantumCircuit):
+    """Converts an optimization problem (QUBO) to a negative value oracle.
+
+    In addition, a state preparation operator is generated from the coefficients and constant of a
+    QUBO, which can be used to encode the function into a quantum state. In conjunction, this oracle
+    and operator can be used to flag the negative values of a QUBO encoded in a quantum state.
+
+    The construction of the oracle is discussed in [1].
+
+    References:
+        [1]: Gilliam et al., Grover Adaptive Search for Constrained Polynomial Binary Optimization.
+            arxiv:1912.04088.
+    """
+
+    def __init__(self,
+                 num_value_qubits: int,
+                 quadratic: Optional[Union[np.ndarray,
+                                           List[List[Union[float, ParameterExpression]]]]] = None,
+                 linear: Optional[Union[np.ndarray,
+                                        List[Union[float, ParameterExpression]]]] = None,
+                 offset: Optional[Union[float, ParameterExpression]] = None) -> None:
+        """ """
+        # check inputs match
+        if quadratic is not None and linear is not None:
+            if len(quadratic) != len(linear):
+                raise ValueError('Mismatching sizes of quadratic and linear.')
+            num_key = len(linear)
+        elif quadratic is None and linear is not None:
+            num_key = len(linear)
+        elif quadratic is not None and linear is None:
+            num_key = len(quadratic)
+        else:  # both None
+            num_key = 1
+
+        qr_key = QuantumRegister(num_key)
+        qr_value = QuantumRegister(num_value_qubits)
+        super().__init__(qr_key, qr_value, name='q(x)')
+
+        scaling = np.pi * 2 ** (1 - num_value_qubits)
+
+        # constant coefficient
+        if offset is not None:
+            for i in range(num_value_qubits):
+                self.u1(scaling * 2 ** i * offset, qr_value[i])
+
+        if linear is not None:
+            for j in range(num_key):
+                value = linear[j]
+                if value != 0:
+                    for i in range(num_value_qubits):
+                        self.cu1(scaling * 2 ** i * value, qr_key[j], qr_value[i])
+
+        if quadratic is not None:
+            for j in range(num_key):
+                for k in range(j + 1, num_key):
+                    value = quadratic[j][k]
+                    if value != 0:
+                        for i in range(num_value_qubits):
+                            self.mcu1(scaling * 2 ** i * value, [qr_key[j], qr_key[k]], qr_value[i])
+
+        # Add IQFT. Adding swaps at the end of the IQFT, not the beginning.
+        iqft = QFT(num_value_qubits, do_swaps=False).inverse()
+        self.append(iqft, qr_value)
+
+        for i in range(num_value_qubits // 2):
+            self.swap(qr_value[i], qr_value[-(i + 1)])

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -19,7 +19,7 @@ from typing import Union, Optional, List
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ParameterExpression
-from qiskit.circuit.library import QFT
+from ..basis_change import QFT
 
 
 class QuadraticForm(QuantumCircuit):

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -39,6 +39,12 @@ class QuadraticForm(QuantumCircuit):
 
         |x\rangle_n |0\rangle_m \mapsto |x\rangle_n |Q(x) \mod 2\rangle_m
 
+    The implementation of this circuit is discussed in [1], Fig. 6.
+
+    References:
+        [1]: Gilliam et al., Grover Adaptive Search for Constrained Polynomial Binary Optimization.
+             `arXiv:1912.04088 <https://arxiv.org/pdf/1912.04088.pdf>`_
+
     """
 
     def __init__(self,

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -12,7 +12,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Quadratic form."""
+"""A circuit implementing a quadratic form on binary variables."""
 
 from typing import Union, Optional, List
 
@@ -23,17 +23,22 @@ from qiskit.circuit.library import QFT
 
 
 class QuadraticForm(QuantumCircuit):
-    """Converts an optimization problem (QUBO) to a negative value oracle.
+    r"""Implements a quadratic form on binary variables encoded in qubit registers.
 
-    In addition, a state preparation operator is generated from the coefficients and constant of a
-    QUBO, which can be used to encode the function into a quantum state. In conjunction, this oracle
-    and operator can be used to flag the negative values of a QUBO encoded in a quantum state.
+    A quadratic form on binary variables is a quadratic function :math:`Q` acting on a binary
+    variable of :math:`n` bits, :math:`x = x_0 ... x_{n-1}`. For a matrix :math:`A`, a vector
+    :math:`b` and a scalar :math:`c` the function can be written as
 
-    The construction of the oracle is discussed in [1].
+    .. math::
 
-    References:
-        [1]: Gilliam et al., Grover Adaptive Search for Constrained Polynomial Binary Optimization.
-            arxiv:1912.04088.
+        Q(x) = x^T A x + x^T b + c
+
+    Provided with :math:`m` qubits to encode the value, this circuit computes :math:`Q(x) \mod 2^m`.
+
+    .. math::
+
+        |x\rangle_n |0\rangle_m \mapsto |x\rangle_n |Q(x) \mod 2\rangle_m
+
     """
 
     def __init__(self,
@@ -43,7 +48,17 @@ class QuadraticForm(QuantumCircuit):
                  linear: Optional[Union[np.ndarray,
                                         List[Union[float, ParameterExpression]]]] = None,
                  offset: Optional[Union[float, ParameterExpression]] = None) -> None:
-        """ """
+        r"""
+        Args:
+            num_value_qubits: The number of qubits to encode the result. Called :math:`m` in
+                the class documentation.
+            quadratic: A matrix containing the quadratic coefficients, :math:`A`.
+            linear: An array containing the linear coefficients, :math:`b`.
+            offset: A constant offset, :math:`c`.
+
+        Raises:
+            ValueError: If ``linear`` and ``quadratic`` have mismatching sizes.
+        """
         # check inputs match
         if quadratic is not None and linear is not None:
             if len(quadratic) != len(linear):
@@ -58,26 +73,27 @@ class QuadraticForm(QuantumCircuit):
 
         qr_key = QuantumRegister(num_key)
         qr_value = QuantumRegister(num_value_qubits)
-        super().__init__(qr_key, qr_value, name='q(x)')
+        super().__init__(qr_key, qr_value, name='Q(x)')
 
         scaling = np.pi * 2 ** (1 - num_value_qubits)
 
         # constant coefficient
-        if offset is not None:
+        if offset is not None and offset != 0:
             for i in range(num_value_qubits):
                 self.u1(scaling * 2 ** i * offset, qr_value[i])
 
-        if linear is not None:
-            for j in range(num_key):
-                value = linear[j]
-                if value != 0:
-                    for i in range(num_value_qubits):
-                        self.cu1(scaling * 2 ** i * value, qr_key[j], qr_value[i])
+        # linear part
+        for j in range(num_key):
+            value = linear[j] if linear is not None else 0
+            value += quadratic[j][j] if quadratic is not None else 0
+            if value != 0:
+                for i in range(num_value_qubits):
+                    self.cu1(scaling * 2 ** i * value, qr_key[j], qr_value[i])
 
         if quadratic is not None:
             for j in range(num_key):
                 for k in range(j + 1, num_key):
-                    value = quadratic[j][k]
+                    value = quadratic[j][k] + quadratic[k][j]
                     if value != 0:
                         for i in range(num_value_qubits):
                             self.mcu1(scaling * 2 ** i * value, [qr_key[j], qr_key[k]], qr_value[i])

--- a/releasenotes/notes/quadratic-form-circuit-f0ddb1694960cbc1.yaml
+++ b/releasenotes/notes/quadratic-form-circuit-f0ddb1694960cbc1.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Added a circuit implementing a quadratic form on binary variables.
+    The circuit implements the operation 
+    :math:`|x\rangle |0\rangle \mapsto |x\rangle |Q(x) \mod 2^m\rangle` 
+    for the quadratic form :math:`Q` and :math:`m` output qubits.
+    The quadratic form is specified using a matrix for the quadratic 
+    terms, a vector for the linear terms and a constant offset.

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -1923,7 +1923,7 @@ class TestQuadraticForm(QiskitTestCase):
 
     def assertQuadraticFormIsCorrect(self, m, quadratic, linear, offset, circuit):
         """Assert ``circuit`` implements the quadratic form correctly."""
-        def f(x):
+        def q_form(x):
             x = np.array([int(val) for val in x])
             return int(x.T.dot(quadratic).dot(x) + x.T.dot(linear) + offset)
 
@@ -1931,7 +1931,7 @@ class TestQuadraticForm(QiskitTestCase):
         ref = np.zeros(2 ** (n + m), dtype=complex)
         for x in range(2 ** n):
             x_bin = bin(x)[2:].zfill(n)[::-1]
-            index = x_bin + bin(f(x_bin) % 2 ** m)[2:].zfill(m)[::-1]
+            index = x_bin + bin(q_form(x_bin) % 2 ** m)[2:].zfill(m)[::-1]
             index = int(index[::-1], 2)
             ref[index] = 1 / np.sqrt(2 ** n)
 
@@ -1987,11 +1987,11 @@ class TestQuadraticForm(QiskitTestCase):
 
     def test_quadratic_form_parameterized(self):
         """Test the quadratic form circuit with parameters."""
-        p = ParameterVector('p', 7)
+        theta = ParameterVector('th', 7)
 
-        p_quadratic = [[p[0], p[1]], [p[2], p[3]]]
-        p_linear = [p[4], p[5]]
-        p_offset = p[6]
+        p_quadratic = [[theta[0], theta[1]], [theta[2], theta[3]]]
+        p_linear = [theta[4], theta[5]]
+        p_offset = theta[6]
 
         quadratic = np.array([[2, 1], [-1, -2]])
         linear = np.array([2, 0])

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -1999,7 +1999,7 @@ class TestQuadraticForm(QiskitTestCase):
         m = 2
 
         circuit = QuadraticForm(m, p_quadratic, p_linear, p_offset)
-        param_dict = dict(zip(p, [*quadratic[0]] + [*quadratic[1]] + [*linear] + [offset]))
+        param_dict = dict(zip(theta, [*quadratic[0]] + [*quadratic[1]] + [*linear] + [offset]))
         circuit.assign_parameters(param_dict, inplace=True)
 
         self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -31,7 +31,8 @@ from qiskit.circuit.library import (BlueprintCircuit, Permutation, QuantumVolume
                                     WeightedAdder, Diagonal, NLocal, TwoLocal, RealAmplitudes,
                                     EfficientSU2, ExcitationPreserving, PauliFeatureMap,
                                     ZFeatureMap, ZZFeatureMap, MCMT, MCMTVChain, GMS,
-                                    HiddenLinearFunction, GraphState, PhaseEstimation)
+                                    HiddenLinearFunction, GraphState, PhaseEstimation,
+                                    QuadraticForm)
 from qiskit.circuit.random.utils import random_circuit
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 from qiskit.exceptions import QiskitError
@@ -1915,6 +1916,93 @@ class TestPhaseEstimation(QiskitTestCase):
             iqft = QFT(3, approximation_degree=2, do_swaps=False).inverse()
             pec = PhaseEstimation(3, unitary, iqft=iqft)
             self.assertEqual(pec.data[-1][0].definition, iqft)
+
+
+class TestQuadraticForm(QiskitTestCase):
+    """Test the QuadraticForm circuit."""
+
+    def assertQuadraticFormIsCorrect(self, m, quadratic, linear, offset, circuit):
+        """Assert ``circuit`` implements the quadratic form correctly."""
+        def f(x):
+            x = np.array([int(val) for val in x])
+            return int(x.T.dot(quadratic).dot(x) + x.T.dot(linear) + offset)
+
+        n = len(quadratic)  # number of value qubits
+        ref = np.zeros(2 ** (n + m), dtype=complex)
+        for x in range(2 ** n):
+            x_bin = bin(x)[2:].zfill(n)[::-1]
+            index = x_bin + bin(f(x_bin) % 2 ** m)[2:].zfill(m)[::-1]
+            index = int(index[::-1], 2)
+            ref[index] = 1 / np.sqrt(2 ** n)
+
+        actual = QuantumCircuit(circuit.num_qubits)
+        actual.h(actual.qubits)
+        actual.compose(circuit, inplace=True)
+        self.assertTrue(Statevector.from_instruction(actual).equiv(ref))
+
+    def test_quadratic_form(self):
+        """Test the quadratic form circuit."""
+
+        with self.subTest('empty'):
+            m = 1
+            circuit = QuadraticForm(m)
+            self.assertQuadraticFormIsCorrect(m, [[0]], [0], 0, circuit)
+
+        with self.subTest('1d case'):
+            quadratic = np.array([[1]])
+            linear = np.array([2])
+            offset = -1
+            m = 2
+
+            circuit = QuadraticForm(m, quadratic, linear, offset)
+
+            self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)
+
+        with self.subTest('missing quadratic'):
+            quadratic = np.zeros((3, 3))
+            linear = np.array([2, 0, 1])
+            offset = -1
+            m = 2
+
+            circuit = QuadraticForm(m, None, linear, offset)
+            self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)
+
+        with self.subTest('missing linear'):
+            quadratic = np.array([[1, 2, 3], [3, 1, 2], [2, 3, 1]])
+            linear = np.zeros(3)
+            offset = -1
+            m = 2
+
+            circuit = QuadraticForm(m, quadratic, None, offset)
+            self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)
+
+        with self.subTest('missing offset'):
+            quadratic = np.array([[2, 1], [-1, -2]])
+            linear = np.array([2, 0])
+            offset = 0
+            m = 2
+
+            circuit = QuadraticForm(m, quadratic, linear)
+            self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)
+
+    def test_quadratic_form_parameterized(self):
+        """Test the quadratic form circuit with parameters."""
+        p = ParameterVector('p', 7)
+
+        p_quadratic = [[p[0], p[1]], [p[2], p[3]]]
+        p_linear = [p[4], p[5]]
+        p_offset = p[6]
+
+        quadratic = np.array([[2, 1], [-1, -2]])
+        linear = np.array([2, 0])
+        offset = 0
+        m = 2
+
+        circuit = QuadraticForm(m, p_quadratic, p_linear, p_offset)
+        param_dict = dict(zip(p, [*quadratic[0]] + [*quadratic[1]] + [*linear] + [offset]))
+        circuit.assign_parameters(param_dict, inplace=True)
+
+        self.assertQuadraticFormIsCorrect(m, quadratic, linear, offset, circuit)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add a circuit implementing a quadratic form on binary variables.

### Details and comments

Uses a circuit from https://arxiv.org/pdf/1912.04088.pdf and works similar to the QFT-based adder. Used to construct the input states for the Grover applications in the `GroverOptimizer` algorithm.

Co-authored-by: Austin Gilliam <austin.gilliam777@gmail.com>


