### PR TITLE
[WIP] Implementing functionality to add gates mid circuit

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -82,8 +82,10 @@ class Bit:
 
     def __repr__(self):
         """Return the official string representing the bit."""
-        return "%s(%s, %s, %s)" % (self.__class__.__name__, 
-            self._register, self._index, self._instruction_index)
+        return "%s(%s, %s, %s)" % (self.__class__.__name__,
+                                   self._register,
+                                   self._index,
+                                   self._instruction_index)
 
     def __hash__(self):
         return self._hash

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -21,7 +21,7 @@ from qiskit.circuit.exceptions import CircuitError
 class Bit:
     """Implement a generic bit."""
 
-    __slots__ = {'_register', '_index', '_instruction_index', '_hash'}
+    __slots__ = {'_register', '_index', '_hash'}
 
     def __init__(self, register, index):
         """Create a new generic bit.
@@ -41,11 +41,10 @@ class Bit:
 
         self._register = register
         self._index = index
-        self._instruction_index = ()
         self._update_hash()
 
     def _update_hash(self):
-        self._hash = hash((self._register, self._index, self._instruction_index))
+        self._hash = hash((self._register, self._index))
 
     @property
     def register(self):
@@ -69,23 +68,9 @@ class Bit:
         self._index = value
         self._update_hash()
 
-    @property
-    def instruction_index(self):
-        """Get bit's instruction_index."""
-        return self._instruction_index
-
-    @instruction_index.setter
-    def instruction_index(self, value):
-        """Set bit's instruction_index."""
-        self._instruction_index = value
-        self._update_hash()
-
     def __repr__(self):
         """Return the official string representing the bit."""
-        return "%s(%s, %s, %s)" % (self.__class__.__name__,
-                                   self._register,
-                                   self._index,
-                                   self._instruction_index)
+        return "%s(%s, %s)" % (self.__class__.__name__, self._register, self._index)
 
     def __hash__(self):
         return self._hash

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -21,7 +21,7 @@ from qiskit.circuit.exceptions import CircuitError
 class Bit:
     """Implement a generic bit."""
 
-    __slots__ = {'_register', '_index', '_hash'}
+    __slots__ = {'_register', '_index', '_instruction_index', '_hash'}
 
     def __init__(self, register, index):
         """Create a new generic bit.
@@ -41,10 +41,11 @@ class Bit:
 
         self._register = register
         self._index = index
+        self._instruction_index = ()
         self._update_hash()
 
     def _update_hash(self):
-        self._hash = hash((self._register, self._index))
+        self._hash = hash((self._register, self._index, self._instruction_index))
 
     @property
     def register(self):
@@ -68,9 +69,21 @@ class Bit:
         self._index = value
         self._update_hash()
 
+    @property
+    def instruction_index(self):
+        """Get bit's instruction_index."""
+        return self._instruction_index
+
+    @instruction_index.setter
+    def instruction_index(self, value):
+        """Set bit's instruction_index."""
+        self._instruction_index = value
+        self._update_hash()
+
     def __repr__(self):
         """Return the official string representing the bit."""
-        return "%s(%s, %s)" % (self.__class__.__name__, self._register, self._index)
+        return "%s(%s, %s, %s)" % (self.__class__.__name__, 
+            self._register, self._index, self._instruction_index)
 
     def __hash__(self):
         return self._hash

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -97,7 +97,7 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().qasm(formatted, filename)
 
-    def append(self, instruction, qargs=None, cargs=None, i=None):
+    def append(self, instruction, qargs=None, cargs=None, index=None):
         if self._data is None:
             self._build()
         return super().append(instruction, qargs, cargs)

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -97,7 +97,7 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().qasm(formatted, filename)
 
-    def append(self, instruction, qargs=None, cargs=None):
+    def append(self, instruction, qargs=None, cargs=None, i=None):
         if self._data is None:
             self._build()
         return super().append(instruction, qargs, cargs)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -837,8 +837,8 @@ class QuantumCircuit:
                             if qubit_list[1][n] == qubit_in_instruct:
                                 shifter_instructions[n].append(instruct)
                                 qubit_flags[n] = True
-                    if not any(qubit_flags): # move instruction not affecting qubits
-                        shifter_instructions[low_index].append(instruct) # low_index is arbitary
+                    if not any(qubit_flags):   # move instruction not affecting qubits
+                        shifter_instructions[low_index].append(instruct)   # low_index is arbitary
                 else:
                     raise CircuitError("Unable to place gate at index"
                                        " as multibit gate is in between")
@@ -851,7 +851,6 @@ class QuantumCircuit:
                     for m in range(len(instructions.qargs[qubit_list[0]+1])):
                         if instructions.qargs[qubit_list[0]+1][m] == inst_to_move[1][n]:
                             index_list[m] += 1
-
 
     def _append(self, instruction, qargs, cargs):
         """Append an instruction to the end of the circuit, modifying
@@ -1983,7 +1982,8 @@ class QuantumCircuit:
 
     @deprecate_arguments({'ctl': 'control_qubit', 'tgt': 'target_qubit'})
     def ch(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
-           *, label=None, ctrl_state=None, ctl=None, tgt=None, index=None):  # pylint: disable=unused-argument
+           *, label=None, ctrl_state=None, ctl=None,
+           tgt=None, index=None):  # pylint: disable=unused-argument
         """Apply :class:`~qiskit.circuit.library.CHGate`."""
         from .library.standard_gates.h import CHGate
         return self.append(CHGate(label=label, ctrl_state=ctrl_state),

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -809,6 +809,7 @@ class QuantumCircuit:
     def _indexer(self, instructions, index_list):
         # TODO: docs for this helper function
         # TODO: make helper functions and clean up variable names
+        # TODO: throw exception when qubit gate width does not match index width
         for qubit_list in enumerate(instructions.qargs):
             qubit_gate_counts = [-1] * len(qubit_list[1])
             instruction_counts = [-1] * len(qubit_list[1])
@@ -1982,8 +1983,8 @@ class QuantumCircuit:
 
     @deprecate_arguments({'ctl': 'control_qubit', 'tgt': 'target_qubit'})
     def ch(self, control_qubit, target_qubit,  # pylint: disable=invalid-name
-           *, label=None, ctrl_state=None, ctl=None,
-           tgt=None, index=None):  # pylint: disable=unused-argument
+           *, label=None, ctrl_state=None,   # pylint: disable=unused-argument
+           ctl=None, tgt=None, index=None):  # pylint: disable=unused-argument
         """Apply :class:`~qiskit.circuit.library.CHGate`."""
         from .library.standard_gates.h import CHGate
         return self.append(CHGate(label=label, ctrl_state=ctrl_state),

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -800,7 +800,7 @@ class QuantumCircuit:
         for (qarg, carg) in instruction.broadcast_arguments(expanded_qargs, expanded_cargs):
             instructions.add(self._append(instruction, qarg, carg), qarg, carg)
         if index is not None and len(instructions.qargs) == 1 and len(instructions.qargs[0]) == 1:
-            #Todo: raise error if index is not None and len of qargs>1 or qargs[0]
+            # Todo: raise error if index is not None and len of qargs>1 or qargs[0]
             qubit_gate_count = -1
             instruction_count = -1
             qubit_to_find = instructions.qargs[0][0]
@@ -2117,7 +2117,8 @@ class QuantumCircuit:
         return self.append(TdgGate(), [qubit], [], index)
 
     @deprecate_arguments({'q': 'qubit'})
-    def u1(self, theta, qubit, *, q=None, index=None):  # pylint: disable=invalid-name,unused-argument
+    def u1(self, theta, qubit, *,
+           q=None, index=None):  # pylint: disable=invalid-name,unused-argument
         """Apply :class:`~qiskit.circuit.library.U1Gate`."""
         from .library.standard_gates.u1 import U1Gate
         return self.append(U1Gate(theta), [qubit], [], index)
@@ -2138,13 +2139,15 @@ class QuantumCircuit:
         return self.append(MCU1Gate(lam, num_ctrl_qubits), control_qubits[:] + [target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
-    def u2(self, phi, lam, qubit, *, q=None, index=None):  # pylint: disable=invalid-name,unused-argument
+    def u2(self, phi, lam, qubit, *,
+           q=None, index=None):  # pylint: disable=invalid-name,unused-argument
         """Apply :class:`~qiskit.circuit.library.U2Gate`."""
         from .library.standard_gates.u2 import U2Gate
         return self.append(U2Gate(phi, lam), [qubit], [], index)
 
     @deprecate_arguments({'q': 'qubit'})
-    def u3(self, theta, phi, lam, qubit, *, q=None, index=None):  # pylint: disable=invalid-name,unused-argument
+    def u3(self, theta, phi, lam, qubit, *,
+           q=None, index=None):  # pylint: disable=invalid-name,unused-argument
         """Apply :class:`~qiskit.circuit.library.U3Gate`."""
         from .library.standard_gates.u3 import U3Gate
         return self.append(U3Gate(theta, phi, lam), [qubit], [], index)
@@ -2159,7 +2162,8 @@ class QuantumCircuit:
                            [control_qubit, target_qubit], [])
 
     @deprecate_arguments({'q': 'qubit'})
-    def x(self, qubit, *, label=None, ctrl_state=None, q=None, index=None):  # pylint: disable=unused-argument
+    def x(self, qubit, *,
+          label=None, ctrl_state=None, q=None, index=None):  # pylint: disable=unused-argument
         """Apply :class:`~qiskit.circuit.library.XGate`."""
         from .library.standard_gates.x import XGate
         return self.append(XGate(label=label), [qubit], [], index)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -765,7 +765,7 @@ class QuantumCircuit:
         """
         return QuantumCircuit._bit_argument_conversion(clbit_representation, self.clbits)
 
-    def append(self, instruction, qargs=None, cargs=None, i=None):
+    def append(self, instruction, qargs=None, cargs=None, index=None):
         """Append one or more instructions to the end of the circuit, modifying
         the circuit in place. Expands qargs and cargs.
 
@@ -773,7 +773,7 @@ class QuantumCircuit:
             instruction (qiskit.circuit.Instruction): Instruction instance to append
             qargs (list(argument)): qubits to attach instruction to
             cargs (list(argument)): clbits to attach instruction to
-            i (int): Index number for gate position on bit (zero-based)
+            index (int): Index number for gate's position on bit (zero-based)
 
         Returns:
             qiskit.circuit.Instruction: a handle to the instruction that was just added
@@ -798,10 +798,27 @@ class QuantumCircuit:
 
         instructions = InstructionSet()
         for (qarg, carg) in instruction.broadcast_arguments(expanded_qargs, expanded_cargs):
-            instructions.add(self._append(instruction, qarg, carg, i), qarg, carg)
+            instructions.add(self._append(instruction, qarg, carg), qarg, carg)
+        if index is not None:
+            qubit_gate_count = -1
+            instruction_count = -1
+            qubit_to_find = instructions.qargs[0][0]
+            for inst in self._data:
+                if index != qubit_gate_count:
+                    instruction_count += 1
+                    for qubit_in_instruct in inst[1]:
+                        if qubit_in_instruct == qubit_to_find:
+                            qubit_gate_count += 1
+                else:
+                    break
+            if index == qubit_gate_count:
+                lhs_data = self._data[0:instruction_count]
+                rhs_data = self._data[instruction_count:-1]
+                self._data = lhs_data + [self._data[-1]] + rhs_data
+
         return instructions
 
-    def _append(self, instruction, qargs, cargs, i=None):
+    def _append(self, instruction, qargs, cargs):
         """Append an instruction to the end of the circuit, modifying
         the circuit in place.
 
@@ -809,7 +826,6 @@ class QuantumCircuit:
             instruction (Instruction or Operator): Instruction instance to append
             qargs (list(tuple)): qubits to attach instruction to
             cargs (list(tuple)): clbits to attach instruction to
-            i (int): Index number for gate position on bit (zero-based)
 
         Returns:
             Instruction: a handle to the instruction that was just added
@@ -828,16 +844,7 @@ class QuantumCircuit:
 
         # add the instruction onto the given wires
         instruction_context = instruction, qargs, cargs
-        if i is not None and i < len(qargs[0].instruction_index):
-            lhs_data = self._data[0:qargs[0].instruction_index[i]]
-            lhs_index_list = qargs[0].instruction_index[0:i]
-            rhs_data = self._data[qargs[0].instruction_index[i]:]
-            rhs_index_list = qargs[0].instruction_index[i:]
-            self._data = lhs_data + [instruction_context] + rhs_data
-            qargs[0].instruction_index = rhs_index_list + (len(lhs_data),) + lhs_index_list
-        else:
-            qargs[0].instruction_index = qargs[0].instruction_index + (len(self._data),)
-            self._data.append(instruction_context)
+        self._data.append(instruction_context)
 
         self._update_parameter_table(instruction)
 
@@ -1934,10 +1941,10 @@ class QuantumCircuit:
         return self.append(Barrier(len(qubits)), qubits, [])
 
     @deprecate_arguments({'q': 'qubit'})
-    def h(self, qubit, *, q=None, i=None):  # pylint: disable=invalid-name,unused-argument
+    def h(self, qubit, *, q=None, index=None):  # pylint: disable=invalid-name,unused-argument
         """Apply :class:`~qiskit.circuit.library.HGate`."""
         from .library.standard_gates.h import HGate
-        return self.append(HGate(), [qubit], [], i)
+        return self.append(HGate(), [qubit], [], index)
 
     @deprecate_arguments({'ctl': 'control_qubit', 'tgt': 'target_qubit'})
     def ch(self, control_qubit, target_qubit,  # pylint: disable=invalid-name


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [✓] I have updated the documentation accordingly.
- [✓] I have read the CONTRIBUTING document.
-->

### Summary
This is part of an implementation for an idea to add gates mid circuit, for issue #4736 (more explained in my comment https://github.com/Qiskit/qiskit-terra/issues/4736#issuecomment-663993070 ).

h, i, rx-z, s, sdg, t, tdg, u1-3, x-z, ch, crz, swap, cx, cz,  ccx gate implementations are working at this point. 

### Details and comments

~~As of now, three tests when `make test` is run fail:
test_qasm_text
test_from_ast_to_dag
test_lookahead_swap_maps_measurements~~

~~This is due to the added attribute~~

**Update (after commit https://github.com/Qiskit/qiskit-terra/pull/4809/commits/fe97a578a0eb7f88215a8acac3feba710d17202d):**
Explained in https://github.com/Qiskit/qiskit-terra/issues/4736#issuecomment-664518347