### PR TITLE
Fixed #4791: Explicity checked for several int types

### DIFF
--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -19,7 +19,7 @@ Base register reference object.
 """
 import re
 import itertools
-import numbers
+import numpy as np
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -118,7 +118,7 @@ class Register:
             CircuitError: if the `key` is not an integer.
             QiskitIndexError: if the `key` is not in the range `(0, self.size)`.
         """
-        if not isinstance(key, (numbers.Integral, slice, list)):
+        if not isinstance(key, (int, np.int, np.int32, np.int64, slice, list)):
             raise CircuitError("expected integer or slice index into register")
         if isinstance(key, slice):
             return self._bits[key]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #4791 


### Details and comments

#4591 has caused a significant performance regression in circuit construction time because numbers.Integral adds significant overhead
So, I have resolved this by explicitly checking for several types to reduce overhead


