### PR TITLE
Add global phase to qobj in assembly

### DIFF
--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -47,7 +47,8 @@ def _assemble_circuit(circuit):
                                   clbit_labels=clbit_labels,
                                   memory_slots=memory_slots,
                                   creg_sizes=creg_sizes,
-                                  name=circuit.name)
+                                  name=circuit.name,
+                                  global_phase=circuit.global_phase)
     # TODO: why do we need n_qubits and memory_slots in both the header and the config
     config = QasmQobjExperimentConfig(n_qubits=num_qubits, memory_slots=memory_slots)
 

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -342,6 +342,19 @@ class TestCircuitAssembler(QiskitTestCase):
         qobj = assemble(self.circ, init_qubits=False)
         self.assertEqual(qobj.config.init_qubits, False)
 
+    def test_circuit_with_global_phase(self):
+        """Test that global phase for a circuit is handled correctly."""
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.cx(0, 1)
+        circ.measure_all
+        circ.global_phase = .3 * np.pi
+        qobj = assemble([circ, self.circ])
+        self.assertEqual(getattr(qobj.experiments[1].header, 'global_phase'),
+                         0)
+        self.assertEqual(getattr(qobj.experiments[0].header, 'global_phase'),
+                         .3 * np.pi)
+
 
 class TestPulseAssembler(QiskitTestCase):
     """Tests for assembling schedules to qobj."""

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -347,7 +347,7 @@ class TestCircuitAssembler(QiskitTestCase):
         circ = QuantumCircuit(2)
         circ.h(0)
         circ.cx(0, 1)
-        circ.measure_all
+        circ.measure_all()
         circ.global_phase = .3 * np.pi
         qobj = assemble([circ, self.circ])
         self.assertEqual(getattr(qobj.experiments[1].header, 'global_phase'),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the global phase circuit property to the experiment
headers in the assembled qobj. Currently we do not pass the global phase
to backends so simulators can not take it into account. The experiment
header is used since it's a free form field for properties of the
circuit that a backend can use if they want, but there are no
requirements on it. With this in place it should enable #4805 and
Qiskit/qiskit-aer#847 to be fixed.

### Details and comments

Related to #4805