### PR TITLE
[WIP] Added plot_state_pixel to State Visualizations

### DIFF
--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -32,6 +32,7 @@ Counts and State Visualizations
    plot_state_hinton
    plot_state_paulivec
    plot_state_qsphere
+   plot_state_pixel
 
 Device Visualizations
 =====================
@@ -104,7 +105,8 @@ from qiskit.visualization.state_visualization import (plot_state_hinton,
                                                       plot_bloch_multivector,
                                                       plot_state_city,
                                                       plot_state_paulivec,
-                                                      plot_state_qsphere)
+                                                      plot_state_qsphere,
+                                                      plot_state_pixel)
 from qiskit.visualization.transition_visualization import visualize_transition
 
 from .circuit_visualization import circuit_drawer, qx_color_scheme


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

I'd like to add a new state visualization to Terra, which visualizes the quantum state as a graph of pixels. The hue of each pixel represents the phase, and the intensity represents the magnitude/probability. I showed an example of this visualization for the GroverOptimizer tutorial [here](https://github.com/Qiskit/qiskit-tutorials/blob/master/tutorials/optimization/4_grover_optimizer.ipynb), but now I'm trying to format it similar to the other state visualizations in Terra. I'd like some help/feedback to achieve the best fit.

### Details and comments

1. Currently I don't take a DensityMatrix, as it's not clear to me how to easily convert that into a Statevector object (which is what I need). Could I get some help on that?
2. I borrow the color wheel from plot_state_qsphere (and separate that functionality as its own utility), but I can create my own if this creates an issue.
3. I'm trying to keep the layout options of the graph relatively flexible, but I'm looking for feedback on what the best defaults are for the Optional parameters.

