### PR TITLE
Switch RNG used in two qubit decomposer

### DIFF
--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -47,7 +47,8 @@ def _assemble_circuit(circuit):
                                   clbit_labels=clbit_labels,
                                   memory_slots=memory_slots,
                                   creg_sizes=creg_sizes,
-                                  name=circuit.name)
+                                  name=circuit.name,
+                                  global_phase=circuit.global_phase)
     # TODO: why do we need n_qubits and memory_slots in both the header and the config
     config = QasmQobjExperimentConfig(n_qubits=num_qubits, memory_slots=memory_slots)
 

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -167,9 +167,7 @@ class TwoQubitWeylDecomposition:
         # P ∈ SO(4), D is diagonal with unit-magnitude elements.
         # D, P = la.eig(M2)  # this can fail for certain kinds of degeneracy
         for i in range(100):  # FIXME: this randomized algorithm is horrendous
-            seed_seq = np.random.SeedSequence(i)
-            generator = np.random.MT19937(seed_seq)
-            state = np.random.default_rng(generator)
+            state = np.random.Generator(np.random.MT19937(i))
             M2real = state.normal()*M2.real + state.normal()*M2.imag
             _, P = la.eigh(M2real)
             D = P.T.dot(M2).dot(P).diagonal()

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -167,7 +167,9 @@ class TwoQubitWeylDecomposition:
         # P ∈ SO(4), D is diagonal with unit-magnitude elements.
         # D, P = la.eig(M2)  # this can fail for certain kinds of degeneracy
         for i in range(100):  # FIXME: this randomized algorithm is horrendous
-            state = np.random.default_rng(i)
+            seed_seq = np.random.SeedSequence(i)
+            generator = np.random.MT19937(seed_seq)
+            state = np.random.default_rng(generator)
             M2real = state.normal()*M2.real + state.normal()*M2.imag
             _, P = la.eigh(M2real)
             D = P.T.dot(M2).dot(P).diagonal()

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -167,7 +167,7 @@ class TwoQubitWeylDecomposition:
         # P ∈ SO(4), D is diagonal with unit-magnitude elements.
         # D, P = la.eig(M2)  # this can fail for certain kinds of degeneracy
         for i in range(100):  # FIXME: this randomized algorithm is horrendous
-            state = np.random.Generator(np.random.MT19937(i))
+            state = np.random.Generator(np.random.MT19937(2**33 + i))
             M2real = state.normal()*M2.real + state.normal()*M2.imag
             _, P = la.eigh(M2real)
             D = P.T.dot(M2).dot(P).diagonal()

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -342,6 +342,19 @@ class TestCircuitAssembler(QiskitTestCase):
         qobj = assemble(self.circ, init_qubits=False)
         self.assertEqual(qobj.config.init_qubits, False)
 
+    def test_circuit_with_global_phase(self):
+        """Test that global phase for a circuit is handled correctly."""
+        circ = QuantumCircuit(2)
+        circ.h(0)
+        circ.cx(0, 1)
+        circ.measure_all()
+        circ.global_phase = .3 * np.pi
+        qobj = assemble([circ, self.circ])
+        self.assertEqual(getattr(qobj.experiments[1].header, 'global_phase'),
+                         0)
+        self.assertEqual(getattr(qobj.experiments[0].header, 'global_phase'),
+                         .3 * np.pi)
+
 
 class TestPulseAssembler(QiskitTestCase):
     """Tests for assembling schedules to qobj."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the RNG algorithm used in the
TwoQubitWeylDecomposition class from the default PCG64 to MT19937. The
MT19937 algorithm was the old algorithm we used in the class when
numpy's deprecated RandomState was being used. We've been seeing issues
where the decomposition with a fixed input varies which is unexpected
since there is a fixed seed for the RNG. The MT19937 is called out in
the documentation as having a guaranteed output for a fixed seed [1]
which should hopefully fix this issue.

### Details and comments

[1] https://numpy.org/doc/stable/reference/random/bit_generators/mt19937.html
