### PR TITLE
Don't try and run ConsolidateBlocks without a KAK basis

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -60,7 +60,10 @@ class ConsolidateBlocks(TransformationPass):
             self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
         elif basis_gates is not None:
             kak_basis_gate = unitary_synthesis._choose_kak_gate(basis_gates)
-            self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
+            if kak_basis_gate is not None:
+                self.decomposer = TwoQubitBasisDecomposer(kak_basis_gate)
+            else:
+                self.decomposer = None
         else:
             self.decomposer = TwoQubitBasisDecomposer(CXGate())
 

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -310,6 +310,15 @@ class TestConsolidateBlocks(QiskitTestCase):
 
         self.assertEqual(qc, qc1)
 
+    def test_no_kak_in_basis(self):
+        """Test that pass just returns the input dag without a KAK gate."""
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        dag = circuit_to_dag(qc)
+        consolidate_blocks_pass = ConsolidateBlocks(basis_gates=['u3'])
+        res = consolidate_blocks_pass.run(dag)
+        self.assertEqual(res, dag)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an edge condition in the consolidate blocks when a
basis gate was set but it doesn't contain a KAK gate that can be used
for decomposition. In this case we don't have a method to decompose the
any 2q blocks and the pass can't run. While the machinery in the pass's
run() method existed to skip any analysis if there isn't a decomposer
set we weren't doing this in this case. Instead we'd instantiate a
TwoQubitBasisDecomposer object without a KAK basis set. This fixes this
by just setting decomposer to None in these cases so that when
consolidate blocks is run on a dag it becomes a no-op.

### Details and comments

Fixes #4826
