### PR TITLE
User API: support pulse gate calibrations

### DIFF
--- a/qiskit/circuit/exceptions.py
+++ b/qiskit/circuit/exceptions.py
@@ -21,3 +21,8 @@ class CircuitError(QiskitError):
     """Base class for errors raised while processing a circuit."""
 
     pass
+
+class CalibrationError(QiskitError):
+    """Base class for errors raised during waveform level calibrations."""
+
+    pass

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -22,7 +22,6 @@ import numbers
 import multiprocessing as mp
 from collections import OrderedDict, defaultdict
 import numpy as np
-from typing import Union, List, Tuple
 from qiskit.exceptions import QiskitError
 from qiskit.util import is_main_process
 from qiskit.util import deprecate_arguments


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR implements stage 2 after PR #4761 

We introduce a new circuit method `add_calibrations`.

### Details and comments

```
def add_calibrations(self,
                     gate: Union[Gate, str],
                     qubits: Union[int, Tuple[int]],
                     params: List[Union[float, Parameter]],
                     schedule: Schedule) -> None:
        self._calibrations[gate.name][tuple(qubits)][tuple(params)] = schedule
```

### TODO

- [ ] Fix this: Currently, it works for custom gates but not on the standard gates because `gate.name` errors for standard gates.

