### PR TITLE
Restore approx 0 rounding to decomp0 method

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -382,7 +382,7 @@ class TwoQubitBasisDecomposer():
                 4]
 
     @staticmethod
-    def decomp0(target):
+    def decomp0(target, eps=1e-15):
         """Decompose target ~Ud(x, y, z) with 0 uses of the basis gate.
         Result Ur has trace:
         :math:`|Tr(Ur.Utarget^dag)| = 4|(cos(x)cos(y)cos(z)+ j sin(x)sin(y)sin(z)|`,
@@ -390,7 +390,10 @@ class TwoQubitBasisDecomposer():
 
         U0l = target.K1l.dot(target.K2l)
         U0r = target.K1r.dot(target.K2r)
-
+        U0l.real[abs(U0l.real) < eps] = 0.0
+        U0l.imag[abs(U0l.imag) < eps] = 0.0
+        U0r.real[abs(U0r.real) < eps] = 0.0
+        U0r.imag[abs(U0r.imag) < eps] = 0.0
         return U0r, U0l
 
     def decomp1(self, target):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #4656 we added rounding to the output of the decomp0 method to handle
a case where differing FP precision on windows environments was causing
an expected result in running two_qubit_cnot_decompose on np.eye(4)
with numpy 1.19.x installed leading to a hard failure in the qasm tests.
This seemed to reliably unblock testing and make unit tests work
reliably. However, that original fix from #4656 was superseded by #4835
which was a fix for a more general issue with the reproducibility of the
decompositions and reverted. Since #4835 has merged we've been seeing an
uptick in the failure rate on the same unitary qasm test that #4656
fixed, so the change in #4835 was not actually sufficient for the
windows case. This commit restores the fix from #4656 to unblock CI and
fix the reproducability of the decompositions across systems.

### Details and comments

Fixes #4856
