### PR TITLE
Change unitary used for test_qasm_2q_unitary

### DIFF
--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -250,7 +250,7 @@ class TestUnitaryCircuit(QiskitTestCase):
         qr = QuantumRegister(2, 'q0')
         cr = ClassicalRegister(1, 'c0')
         qc = QuantumCircuit(qr, cr)
-        matrix = numpy.eye(4)
+        matrix = random_unitary(4, seed=4242)
         unitary_gate = UnitaryGate(matrix, label="custom_gate")
 
         qc.x(qr[0])
@@ -263,8 +263,17 @@ class TestUnitaryCircuit(QiskitTestCase):
                         "creg c0[1];\n" \
                         "x q0[0];\n" \
                         "gate custom_gate p0,p1 {\n" \
-                        "\tu3(0,0,0) p0;\n" \
-                        "\tu3(0,0,0) p1;\n" \
+                        "\tu3(2.3357379,-1.8518069,-0.7971604) p0;\n" \
+                        "\tu3(1.4450577,-4.0364661,1.5603609) p1;\n" \
+                        "\tcx p0,p1;\n" \
+                        "\tu3(1.0586145,-3*pi/2,pi/2) p0;\n" \
+                        "\tu3(pi/2,-pi,-2.766067) p1;\n" \
+                        "\tcx p0,p1;\n" \
+                        "\tu3(0.71687194,-pi,-pi/2) p0;\n" \
+                        "\tu3(pi/2,0,-3*pi/2) p1;\n" \
+                        "\tcx p0,p1;\n" \
+                        "\tu3(2.9456177,0.68371166,1.9683595) p0;\n" \
+                        "\tu3(0.71790899,-4.6089877,1.2400911) p1;\n" \
                         "}\n" \
                         "custom_gate q0[0],q0[1];\n" \
                         "custom_gate q0[1],q0[0];\n"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the unitary used to construct the gate for qasm
generation in test_qasm_2q_unitary away from using the identity matrix
and instead a randomly generated matrix. The identity matrix is more
likely to have issues with fp precision stemming from near zero values
in the decomposition. Since this test isn't about verifying a
reproducible decomposition and is instead about generating qasm
correctly this commit changes the matrix used to one that is likely to
be more reliable across different systems.

### Details and comments

Fixes #4856 