### PR TITLE
fixed issue 4170 by updating pi_check function

### DIFF
--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -47,7 +47,42 @@ def pi_check(inpt, eps=1e-6, output='text', ndigits=5):
         try:
             return pi_check(float(inpt), eps=eps, output=output, ndigits=ndigits)
         except (ValueError, TypeError):
-            return str(inpt)
+            # string expression of the Parameter expression
+            string_p = str(inpt)
+
+            # modified expression of the Parameter expression
+            new_str = ''
+
+            # creating the new string by replacing all special characters
+            for tup in enumerate(string_p):
+                if tup[1] in ['+', '-', '*', '/', '(', ')']:
+                    new_str = new_str + ' ' + tup[1] + ' '
+                else:
+                    new_str = new_str + tup[1]
+
+            # splitting the new string and filtering it for unwanted symbols
+            elements = new_str.split(' ')
+            elements = list(filter((' ').__ne__, elements))
+            new_arr = []
+
+            # replacing the value of pi by its symbol
+            for item in elements:
+                try:
+                    val = float(item)
+                    if 'pi' in pi_check(val):
+                        new_arr.append(pi_check(val))
+                    elif 'pi' in pi_check(1/val):
+                        new_arr.append('(1/(' + pi_check(1/val) + '))')
+                    else:
+                        new_arr.append(pi_check(val))
+                except (ValueError, TypeError):
+                    new_arr.append(item)
+
+            # joining the elements together
+            separator = ''
+            output_string = separator.join(new_arr)
+            return output_string
+
     elif isinstance(inpt, str):
         return inpt
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fixed  #4170 


### Details and comments
The pi_check function while evaluating parametric expressions that have 'pi' concatenated to some other Parameters using arithmetic operations, didn't report the value of pi or any of its multiples as 'pi' but rather with its numeric value. I changed the pi_check function to fix this issue. 

eg.- 
Earlier somehing like (pi - x)*((3pi/2) - 2*y) would be reported as '(3.1415 - x)*(4.712 - 2*y)' however now it is reported as intended, that is (pi - x)*((3pi/2) - 2*y)

