### PR TITLE
Add more informative error if shots argument is of wrong type

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -139,6 +139,9 @@ class QuantumCircuit:
     def __init__(self, *regs, name=None):
         if any([not isinstance(reg, (QuantumRegister, ClassicalRegister)) for reg in regs]):
             try:
+                if any([isinstance(reg, float) for reg in regs]):
+                    warnings.warn("Float type argument passed as register. Casting to int.")
+
                 regs = tuple(int(reg) for reg in regs)
             except Exception:
                 raise CircuitError("Circuit args must be Registers or be castable to an int" +

--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -225,7 +225,7 @@ def _parse_common_args(backend, qobj_id, qobj_header, shots,
             'Number of shots specified: %s exceeds max_shots property of the '
             'backend: %s.' % (shots, max_shots))
     elif not isinstance(shots, int):
-        raise TypeError('shots must be of type int')
+        raise TypeError('The attribute \'shots\' must be of type int')
 
     # create run configuration and populate
     run_config_dict = dict(shots=shots,

--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -220,10 +220,12 @@ def _parse_common_args(backend, qobj_id, qobj_header, shots,
             shots = min(1024, max_shots)
         else:
             shots = 1024
-    elif max_shots and max_shots < shots:
+    elif isinstance(shots, int) and max_shots and max_shots < shots:
         raise QiskitError(
             'Number of shots specified: %s exceeds max_shots property of the '
             'backend: %s.' % (shots, max_shots))
+    elif not isinstance(shots, int):
+        raise TypeError('shots must be of type int')
 
     # create run configuration and populate
     run_config_dict = dict(shots=shots,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

fixes issue #4878 

### Details and comments

provides an informative error message to make the 'shots' argument in execute function of type 'int'. 
