### PR TITLE
Fixed issue 4697 by updating append method

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -27,6 +27,7 @@ from qiskit.util import is_main_process
 from qiskit.util import deprecate_arguments
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.gate import Gate
+from qiskit.circuit.parameter import Parameter
 from qiskit.qasm.qasm import Qasm
 from qiskit.circuit.exceptions import CircuitError
 from .parameterexpression import ParameterExpression
@@ -781,7 +782,16 @@ class QuantumCircuit:
             CircuitError: if object passed is a subclass of Instruction
             CircuitError: if object passed is neither subclass nor an instance of Instruction
         """
-        # Convert input to instruction
+        # make copy of parameterized gate instance if (possibly) used in another circuit
+        is_gate = isinstance(instruction, Gate)
+        is_referenced = sys.getrefcount(instruction) > 4
+        if is_gate and is_referenced:
+            is_parameter = any([isinstance(param, Parameter) for param in instruction.params])
+            param_items = self._parameter_table.items()
+            if is_parameter:
+                if not any([(instruction == item[1][0][0]) for item in param_items]):
+                    instruction = copy.deepcopy(instruction)
+
         if not isinstance(instruction, Instruction) and not hasattr(instruction, 'to_instruction'):
             if issubclass(instruction, Instruction):
                 raise CircuitError('Object is a subclass of Instruction, please add () to '

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -782,7 +782,7 @@ class QuantumCircuit:
             CircuitError: if object passed is a subclass of Instruction
             CircuitError: if object passed is neither subclass nor an instance of Instruction
         """
-        # make copy of parameterized gate instance if (possibly) used in another circuit
+        # make copy of parameterized gate instance if used in another circuit
         is_gate = isinstance(instruction, Gate)
         is_referenced = sys.getrefcount(instruction) > 4
         if is_gate and is_referenced:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -792,6 +792,7 @@ class QuantumCircuit:
                 if not any([(instruction == item[1][0][0]) for item in param_items]):
                     instruction = copy.deepcopy(instruction)
 
+        # convert input to instruction
         if not isinstance(instruction, Instruction) and not hasattr(instruction, 'to_instruction'):
             if issubclass(instruction, Instruction):
                 raise CircuitError('Object is a subclass of Instruction, please add () to '


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4697 

### Details and comments

It was found that when using the same parameterized gate instance in multiple circuits and changing its mapping using `assign_parameter(..., inplace=True)`, the parameter mapping would change for all circuits using the same gate instance. If we know that the `append()` method is to be used to add the same instance to multiple circuits, then copies of the parameterized gate (Instruction) instance will have to be created appropriately so that when the mapping is changed for a parameter in one circuit, the instances in the other circuits will remain unaffected. The minimal possible reference count of a parameterized gate object before being appended to a circuit was found to be 4. So, if the amount of references to this gate instance exceeds 4 and is not found in the current circuit parameter table, then we know there may be another circuit that uses the same instance. Only when this occurs, a deepcopy is made.

