### PR TITLE
Allow arbitrary data attributes in ``ExperimentResultData``

### DIFF
--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -63,16 +63,8 @@ class ExperimentResultData:
 
     def __repr__(self):
         string_list = []
-        if hasattr(self, 'counts'):
-            string_list.append("counts=%s" % self.counts)
-        if hasattr(self, 'snapshots'):
-            string_list.append("snapshots=%s" % self.snapshots)
-        if hasattr(self, 'memory'):
-            string_list.append("memory=%s" % self.memory)
-        if hasattr(self, 'statevector'):
-            string_list.append("statevector=%s" % self.statevector)
-        if hasattr(self, 'unitary'):
-            string_list.append("unitary=%s" % self.statevector)
+        for field in self._data_attributes:
+            string_list.append(f"{field}={getattr(self, field)}")
         out = "ExperimentResultData(%s)" % ', '.join(string_list)
         return out
 

--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -22,14 +22,41 @@ from qiskit.exceptions import QiskitError
 class ExperimentResultData:
     """Class representing experiment result data"""
 
-    def __init__(self, **kwargs):
+    def __init__(self, counts=None, snapshots=None, memory=None,
+                 statevector=None, unitary=None, **kwargs):
         """Initialize an ExperimentalResult Data class
 
         Args:
-            kwargs (any): experiment result data key-value pairs.
+            counts (dict): A dictionary where the keys are the result in
+                hexadecimal as string of the format "0xff" and the value
+                is the number of counts for that result
+            snapshots (dict): A dictionary where the key is the snapshot
+                slot and the value is a dictionary of the snapshots for
+                that slot.
+            memory (list): A list of results per shot if the run had
+                memory enabled
+            statevector (list or numpy.array): A list or numpy array of the
+                statevector result
+            unitary (list or numpy.array): A list or numpy arrray of the
+                unitary result
+            kwargs (any): additional data key-value pairs.
         """
         self._data_attributes = []
-
+        if counts is not None:
+            self._data_attributes.append('counts')
+            self.counts = counts
+        if snapshots is not None:
+            self._data_attributes.append('snapshots')
+            self.snapshots = snapshots
+        if memory is not None:
+            self._data_attributes.append('memory')
+            self.memory = memory
+        if statevector is not None:
+            self._data_attributes.append('statevector')
+            self.statevector = statevector
+        if unitary is not None:
+            self._data_attributes.append('unitary')
+            self.unitary = unitary
         for key, value in kwargs.items():
             setattr(self, key, value)
             self._data_attributes.append(key)
@@ -97,7 +124,8 @@ class ExperimentResult:
             shots(int or tuple): if an integer the number of shots or if a
                 tuple the starting and ending shot for this data
             success (bool): True if the experiment was successful
-            data (ExperimentResultData): The data for the experiment's result
+            data (ExperimentResultData): The data for the experiment's
+                result
             meas_level (int): Measurement result level
             status (str): The status of the experiment
             seed (int): The seed used for simulation (if run on a simulator)

--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -22,35 +22,17 @@ from qiskit.exceptions import QiskitError
 class ExperimentResultData:
     """Class representing experiment result data"""
 
-    def __init__(self, counts=None, snapshots=None, memory=None,
-                 statevector=None, unitary=None):
+    def __init__(self, **kwargs):
         """Initialize an ExperimentalResult Data class
 
         Args:
-            counts (dict): A dictionary where the keys are the result in
-                hexadecimal as string of the format "0xff" and the value
-                is the number of counts for that result
-            snapshots (dict): A dictionary where the key is the snapshot
-                slot and the value is a dictionary of the snapshots for
-                that slot.
-            memory (list): A list of results per shot if the run had
-                memory enabled
-            statevector (list or numpy.array): A list or numpy array of the
-                statevector result
-            unitary (list or numpy.array): A list or numpy arrray of the
-                unitary result
+            kwargs (any): experiment result data key-value pairs.
         """
+        self._data_attributes = []
 
-        if counts is not None:
-            self.counts = counts
-        if snapshots is not None:
-            self.snapshots = snapshots
-        if memory is not None:
-            self.memory = memory
-        if statevector is not None:
-            self.statevector = statevector
-        if unitary is not None:
-            self.unitary = unitary
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+            self._data_attributes.append(key)
 
     def __repr__(self):
         string_list = []
@@ -74,10 +56,8 @@ class ExperimentResultData:
             dict: The dictionary form of the ExperimentResultData
         """
         out_dict = {}
-        for field in ['counts', 'snapshots', 'memory', 'statevector',
-                      'unitary']:
-            if hasattr(self, field):
-                out_dict[field] = getattr(self, field)
+        for field in self._data_attributes:
+            out_dict[field] = getattr(self, field)
         return out_dict
 
     @classmethod
@@ -117,8 +97,7 @@ class ExperimentResult:
             shots(int or tuple): if an integer the number of shots or if a
                 tuple the starting and ending shot for this data
             success (bool): True if the experiment was successful
-            data (ExperimentResultData): The data for the experiment's
-                result
+            data (ExperimentResultData): The data for the experiment's result
             meas_level (int): Measurement result level
             status (str): The status of the experiment
             seed (int): The seed used for simulation (if run on a simulator)

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -402,6 +402,15 @@ class TestResultOperations(QiskitTestCase):
         self.assertEqual(unitary.dtype, np.complex_)
         np.testing.assert_almost_equal(unitary, processed_unitary)
 
+    def test_additional_result_data(self):
+        """Test construction of ExperimentResult with additional data"""
+        target_probs = {"0x0": 0.5, "0x1": 0.5}
+        data = models.ExperimentResultData(probabilities=target_probs)
+        exp_result = models.ExperimentResult(shots=1, success=True, data=data)
+        result = Result(results=[exp_result], **self.base_result_args)
+        result_probs = result.data(0)['probabilities']
+        self.assertEqual(result_probs, target_probs)
+
 
 class TestResultOperationsFailed(QiskitTestCase):
     """Result operations methods."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Allows arbitrary data attributes in the `ExperimentResultData` class letting it function more like the dict container it is exposed to users as via the `Result.data` method.

### Details and comments

This (or something like this) will be needed if the future to allow Aer to add different data types to the result data container (such as probabilities and expectation values).

The existence of this class at all seems rather superfluous since it is always converted to a dict via the various `Result` methods like `data` `get_statevector` `get_unitary`. It could easily just be replaced by a plain dictionary in the `ExperimentResult` and `Result` classes and methods. I think it is only still here as a leftover from the Marshmallow classes.