### PR TITLE
Remove coding: utf-8 per PEP 3120

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ env:
 # Ignoring generated ones with .py extension.
 lint:
 	pylint -rn qiskit test
-	tools/verify_headers.py qiskit test
+	tools/verify_headers.py qiskit test tools
 	pylint -rn --disable='C0103, C0114, W0621' examples/python/*.py
 
 style:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018.

--- a/examples/python/circuit_draw.py
+++ b/examples/python/circuit_draw.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/commutation_relation.py
+++ b/examples/python/commutation_relation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/ghz.py
+++ b/examples/python/ghz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/ibmq/ghz.py
+++ b/examples/python/ibmq/ghz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/ibmq/hello_quantum.py
+++ b/examples/python/ibmq/hello_quantum.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/ibmq/qft.py
+++ b/examples/python/ibmq/qft.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/ibmq/using_qiskit_terra_level_0.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_0.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/ibmq/using_qiskit_terra_level_1.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/ibmq/using_qiskit_terra_level_2.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/initialize.py
+++ b/examples/python/initialize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/load_qasm.py
+++ b/examples/python/load_qasm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/examples/python/qft.py
+++ b/examples/python/qft.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/rippleadd.py
+++ b/examples/python/rippleadd.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/stochastic_swap.py
+++ b/examples/python/stochastic_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/examples/python/teleport.py
+++ b/examples/python/teleport.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/examples/python/using_qiskit_terra_level_0.py
+++ b/examples/python/using_qiskit_terra_level_0.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/assembler/__init__.py
+++ b/qiskit/assembler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/assembler/disassemble.py
+++ b/qiskit/assembler/disassemble.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/assembler/run_config.py
+++ b/qiskit/assembler/run_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/barrier.py
+++ b/qiskit/circuit/barrier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/equivalence_library.py
+++ b/qiskit/circuit/equivalence_library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/exceptions.py
+++ b/qiskit/circuit/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/instructionset.py
+++ b/qiskit/circuit/instructionset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/__init__.py
+++ b/qiskit/circuit/library/arithmetic/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/linear_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/linear_pauli_rotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_linear_pauli_rotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/arithmetic/weighted_adder.py
+++ b/qiskit/circuit/library/arithmetic/weighted_adder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/basis_change/__init__.py
+++ b/qiskit/circuit/library/basis_change/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/boolean_logic/__init__.py
+++ b/qiskit/circuit/library/boolean_logic/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/boolean_logic/inner_product.py
+++ b/qiskit/circuit/library/boolean_logic/inner_product.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/boolean_logic/quantum_and.py
+++ b/qiskit/circuit/library/boolean_logic/quantum_and.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/boolean_logic/quantum_or.py
+++ b/qiskit/circuit/library/boolean_logic/quantum_or.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/boolean_logic/quantum_xor.py
+++ b/qiskit/circuit/library/boolean_logic/quantum_xor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/data_preparation/__init__.py
+++ b/qiskit/circuit/library/data_preparation/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/data_preparation/z_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/z_feature_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/fourier_checking.py
+++ b/qiskit/circuit/library/fourier_checking.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/generalized_gates/diagonal.py
+++ b/qiskit/circuit/library/generalized_gates/diagonal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/generalized_gates/gms.py
+++ b/qiskit/circuit/library/generalized_gates/gms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/generalized_gates/permutation.py
+++ b/qiskit/circuit/library/generalized_gates/permutation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/graph_state.py
+++ b/qiskit/circuit/library/graph_state.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/hidden_linear_function.py
+++ b/qiskit/circuit/library/hidden_linear_function.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/iqp.py
+++ b/qiskit/circuit/library/iqp.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/__init__.py
+++ b/qiskit/circuit/library/n_local/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/efficient_su2.py
+++ b/qiskit/circuit/library/n_local/efficient_su2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/real_amplitudes.py
+++ b/qiskit/circuit/library/n_local/real_amplitudes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/boolean_logical_gates.py
+++ b/qiskit/circuit/library/standard_gates/boolean_logical_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/dcx.py
+++ b/qiskit/circuit/library/standard_gates/dcx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/i.py
+++ b/qiskit/circuit/library/standard_gates/i.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/ms.py
+++ b/qiskit/circuit/library/standard_gates/ms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2018, 2019.

--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/s.py
+++ b/qiskit/circuit/library/standard_gates/s.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/t.py
+++ b/qiskit/circuit/library/standard_gates/t.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/y.py
+++ b/qiskit/circuit/library/standard_gates/y.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/library/standard_gates/z.py
+++ b/qiskit/circuit/library/standard_gates/z.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/random/__init__.py
+++ b/qiskit/circuit/random/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/reset.py
+++ b/qiskit/circuit/reset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/circuit/tools/__init__.py
+++ b/qiskit/circuit/tools/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/compiler/__init__.py
+++ b/qiskit/compiler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/compiler/assemble.py
+++ b/qiskit/compiler/assemble.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/compiler/schedule.py
+++ b/qiskit/compiler/schedule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/converters/__init__.py
+++ b/qiskit/converters/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/converters/ast_to_dag.py
+++ b/qiskit/converters/ast_to_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/converters/circuit_to_dagdependency.py
+++ b/qiskit/converters/circuit_to_dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/converters/dag_to_dagdependency.py
+++ b/qiskit/converters/dag_to_dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/converters/dagdependency_to_circuit.py
+++ b/qiskit/converters/dagdependency_to_circuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/converters/dagdependency_to_dag.py
+++ b/qiskit/converters/dagdependency_to_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/dagcircuit/__init__.py
+++ b/qiskit/dagcircuit/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/dagcircuit/dagdepnode.py
+++ b/qiskit/dagcircuit/dagdepnode.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/dagcircuit/exceptions.py
+++ b/qiskit/dagcircuit/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/exceptions.py
+++ b/qiskit/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/extensions/__init__.py
+++ b/qiskit/extensions/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/exceptions.py
+++ b/qiskit/extensions/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/quantum_initializer/__init__.py
+++ b/qiskit/extensions/quantum_initializer/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/extensions/quantum_initializer/diag.py
+++ b/qiskit/extensions/quantum_initializer/diag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/diagonal.py
+++ b/qiskit/extensions/quantum_initializer/diagonal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
+++ b/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
+++ b/qiskit/extensions/quantum_initializer/uc_pauli_rot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucg.py
+++ b/qiskit/extensions/quantum_initializer/ucg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucrot.py
+++ b/qiskit/extensions/quantum_initializer/ucrot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucrx.py
+++ b/qiskit/extensions/quantum_initializer/ucrx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucry.py
+++ b/qiskit/extensions/quantum_initializer/ucry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucrz.py
+++ b/qiskit/extensions/quantum_initializer/ucrz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucx.py
+++ b/qiskit/extensions/quantum_initializer/ucx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucy.py
+++ b/qiskit/extensions/quantum_initializer/ucy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/quantum_initializer/ucz.py
+++ b/qiskit/extensions/quantum_initializer/ucz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/extensions/simulator/__init__.py
+++ b/qiskit/extensions/simulator/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/__init__.py
+++ b/qiskit/extensions/standard/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/barrier.py
+++ b/qiskit/extensions/standard/barrier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/boolean_logical_gates.py
+++ b/qiskit/extensions/standard/boolean_logical_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/ccx.py
+++ b/qiskit/extensions/standard/ccx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/ch.py
+++ b/qiskit/extensions/standard/ch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/crx.py
+++ b/qiskit/extensions/standard/crx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cry.py
+++ b/qiskit/extensions/standard/cry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/crz.py
+++ b/qiskit/extensions/standard/crz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cswap.py
+++ b/qiskit/extensions/standard/cswap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cu1.py
+++ b/qiskit/extensions/standard/cu1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cu3.py
+++ b/qiskit/extensions/standard/cu3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cx.py
+++ b/qiskit/extensions/standard/cx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cy.py
+++ b/qiskit/extensions/standard/cy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/cz.py
+++ b/qiskit/extensions/standard/cz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/dcx.py
+++ b/qiskit/extensions/standard/dcx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/equivalence_library.py
+++ b/qiskit/extensions/standard/equivalence_library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/h.py
+++ b/qiskit/extensions/standard/h.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/i.py
+++ b/qiskit/extensions/standard/i.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/iden.py
+++ b/qiskit/extensions/standard/iden.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/extensions/standard/iswap.py
+++ b/qiskit/extensions/standard/iswap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/ms.py
+++ b/qiskit/extensions/standard/ms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/multi_control_rotation_gates.py
+++ b/qiskit/extensions/standard/multi_control_rotation_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/r.py
+++ b/qiskit/extensions/standard/r.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/rx.py
+++ b/qiskit/extensions/standard/rx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/rxx.py
+++ b/qiskit/extensions/standard/rxx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/ry.py
+++ b/qiskit/extensions/standard/ry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/ryy.py
+++ b/qiskit/extensions/standard/ryy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/rz.py
+++ b/qiskit/extensions/standard/rz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/rzx.py
+++ b/qiskit/extensions/standard/rzx.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/rzz.py
+++ b/qiskit/extensions/standard/rzz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/s.py
+++ b/qiskit/extensions/standard/s.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/swap.py
+++ b/qiskit/extensions/standard/swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/t.py
+++ b/qiskit/extensions/standard/t.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/u1.py
+++ b/qiskit/extensions/standard/u1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/u2.py
+++ b/qiskit/extensions/standard/u2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/u3.py
+++ b/qiskit/extensions/standard/u3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/x.py
+++ b/qiskit/extensions/standard/x.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/y.py
+++ b/qiskit/extensions/standard/y.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/standard/z.py
+++ b/qiskit/extensions/standard/z.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basebackend.py
+++ b/qiskit/providers/basebackend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basejob.py
+++ b/qiskit/providers/basejob.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/baseprovider.py
+++ b/qiskit/providers/baseprovider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/basicaer/__init__.py
+++ b/qiskit/providers/basicaer/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/basicaer/basicaerjob.py
+++ b/qiskit/providers/basicaer/basicaerjob.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/basicaerprovider.py
+++ b/qiskit/providers/basicaer/basicaerprovider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/basicaertools.py
+++ b/qiskit/providers/basicaer/basicaertools.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/exceptions.py
+++ b/qiskit/providers/basicaer/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/exceptions.py
+++ b/qiskit/providers/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/jobstatus.py
+++ b/qiskit/providers/jobstatus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/providers/models/__init__.py
+++ b/qiskit/providers/models/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/models/backendstatus.py
+++ b/qiskit/providers/models/backendstatus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/providers/models/jobstatus.py
+++ b/qiskit/providers/models/jobstatus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/providers/providerutils.py
+++ b/qiskit/providers/providerutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/configuration.py
+++ b/qiskit/pulse/configuration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/exceptions.py
+++ b/qiskit/pulse/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/instruction_schedule_map.py
+++ b/qiskit/pulse/instruction_schedule_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/instructions/__init__.py
+++ b/qiskit/pulse/instructions/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/acquire.py
+++ b/qiskit/pulse/instructions/acquire.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/delay.py
+++ b/qiskit/pulse/instructions/delay.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/directives.py
+++ b/qiskit/pulse/instructions/directives.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/frequency.py
+++ b/qiskit/pulse/instructions/frequency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/instructions/phase.py
+++ b/qiskit/pulse/instructions/phase.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/play.py
+++ b/qiskit/pulse/instructions/play.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/instructions/snapshot.py
+++ b/qiskit/pulse/instructions/snapshot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/interfaces.py
+++ b/qiskit/pulse/interfaces.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/__init__.py
+++ b/qiskit/pulse/library/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/continuous.py
+++ b/qiskit/pulse/library/continuous.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/discrete.py
+++ b/qiskit/pulse/library/discrete.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/library/sample_pulse.py
+++ b/qiskit/pulse/library/sample_pulse.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/library/samplers/__init__.py
+++ b/qiskit/pulse/library/samplers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/samplers/decorators.py
+++ b/qiskit/pulse/library/samplers/decorators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/samplers/strategies.py
+++ b/qiskit/pulse/library/samplers/strategies.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/pulse/parser.py
+++ b/qiskit/pulse/parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/pulse_lib/__init__.py
+++ b/qiskit/pulse/pulse_lib/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/pulse_lib/samplers/__init__.py
+++ b/qiskit/pulse/pulse_lib/samplers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/pulse/reschedule.py
+++ b/qiskit/pulse/reschedule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/transforms.py
+++ b/qiskit/pulse/transforms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/qasm/__init__.py
+++ b/qiskit/qasm/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/exceptions.py
+++ b/qiskit/qasm/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/__init__.py
+++ b/qiskit/qasm/node/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/barrier.py
+++ b/qiskit/qasm/node/barrier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/binaryop.py
+++ b/qiskit/qasm/node/binaryop.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/binaryoperator.py
+++ b/qiskit/qasm/node/binaryoperator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/cnot.py
+++ b/qiskit/qasm/node/cnot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/creg.py
+++ b/qiskit/qasm/node/creg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/customunitary.py
+++ b/qiskit/qasm/node/customunitary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/expressionlist.py
+++ b/qiskit/qasm/node/expressionlist.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/external.py
+++ b/qiskit/qasm/node/external.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/format.py
+++ b/qiskit/qasm/node/format.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/gate.py
+++ b/qiskit/qasm/node/gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/gatebody.py
+++ b/qiskit/qasm/node/gatebody.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/id.py
+++ b/qiskit/qasm/node/id.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/idlist.py
+++ b/qiskit/qasm/node/idlist.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/if_.py
+++ b/qiskit/qasm/node/if_.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/indexedid.py
+++ b/qiskit/qasm/node/indexedid.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/intnode.py
+++ b/qiskit/qasm/node/intnode.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/measure.py
+++ b/qiskit/qasm/node/measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/node.py
+++ b/qiskit/qasm/node/node.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/nodeexception.py
+++ b/qiskit/qasm/node/nodeexception.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/opaque.py
+++ b/qiskit/qasm/node/opaque.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/prefix.py
+++ b/qiskit/qasm/node/prefix.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/primarylist.py
+++ b/qiskit/qasm/node/primarylist.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/program.py
+++ b/qiskit/qasm/node/program.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/qreg.py
+++ b/qiskit/qasm/node/qreg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/real.py
+++ b/qiskit/qasm/node/real.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/reset.py
+++ b/qiskit/qasm/node/reset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/unaryoperator.py
+++ b/qiskit/qasm/node/unaryoperator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/node/universalunitary.py
+++ b/qiskit/qasm/node/universalunitary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/pygments/__init__.py
+++ b/qiskit/qasm/pygments/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/qasm/pygments/lexer.py
+++ b/qiskit/qasm/pygments/lexer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/qasm/qasm.py
+++ b/qiskit/qasm/qasm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/qasmlexer.py
+++ b/qiskit/qasm/qasmlexer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qasm/qasmparser.py
+++ b/qiskit/qasm/qasmparser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/qobj/__init__.py
+++ b/qiskit/qobj/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/qobj/converters/__init__.py
+++ b/qiskit/qobj/converters/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/qobj/converters/lo_config.py
+++ b/qiskit/qobj/converters/lo_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/qobj/qasm_qobj.py
+++ b/qiskit/qobj/qasm_qobj.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/qobj/utils.py
+++ b/qiskit/qobj/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/analysis/__init__.py
+++ b/qiskit/quantum_info/analysis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/quantum_info/analysis/average.py
+++ b/qiskit/quantum_info/analysis/average.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/quantum_info/analysis/distance.py
+++ b/qiskit/quantum_info/analysis/distance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/analysis/make_observable.py
+++ b/qiskit/quantum_info/analysis/make_observable.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/quantum_info/operators/__init__.py
+++ b/qiskit/quantum_info/operators/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/__init__.py
+++ b/qiskit/quantum_info/operators/channel/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/custom_iterator.py
+++ b/qiskit/quantum_info/operators/custom_iterator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/operators/predicates.py
+++ b/qiskit/quantum_info/operators/predicates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/operators/quaternion.py
+++ b/qiskit/quantum_info/operators/quaternion.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/quantum_info/operators/symplectic/__init__.py
+++ b/qiskit/quantum_info/operators/symplectic/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/symplectic/pauli_utils.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/random.py
+++ b/qiskit/quantum_info/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/random.py
+++ b/qiskit/quantum_info/states/random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/quantum_info/synthesis/__init__.py
+++ b/qiskit/quantum_info/synthesis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/qiskit/quantum_info/synthesis/ion_decompose.py
+++ b/qiskit/quantum_info/synthesis/ion_decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/synthesis/local_invariance.py
+++ b/qiskit/quantum_info/synthesis/local_invariance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/quantum_info/synthesis/weyl.py
+++ b/qiskit/quantum_info/synthesis/weyl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/result/__init__.py
+++ b/qiskit/result/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/result/exceptions.py
+++ b/qiskit/result/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/scheduler/__init__.py
+++ b/qiskit/scheduler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/scheduler/config.py
+++ b/qiskit/scheduler/config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/scheduler/methods/__init__.py
+++ b/qiskit/scheduler/methods/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/scheduler/methods/basic.py
+++ b/qiskit/scheduler/methods/basic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/scheduler/schedule_circuit.py
+++ b/qiskit/scheduler/schedule_circuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/scheduler/utils.py
+++ b/qiskit/scheduler/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/__init__.py
+++ b/qiskit/test/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/test/decorators.py
+++ b/qiskit/test/decorators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/test/ibmq_mock.py
+++ b/qiskit/test/ibmq_mock.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/__init__.py
+++ b/qiskit/test/mock/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/__init__.py
+++ b/qiskit/test/mock/backends/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/almaden/__init__.py
+++ b/qiskit/test/mock/backends/almaden/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/almaden/fake_almaden.py
+++ b/qiskit/test/mock/backends/almaden/fake_almaden.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/armonk/__init__.py
+++ b/qiskit/test/mock/backends/armonk/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/armonk/fake_armonk.py
+++ b/qiskit/test/mock/backends/armonk/fake_armonk.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/athens/__init__.py
+++ b/qiskit/test/mock/backends/athens/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/athens/fake_athens.py
+++ b/qiskit/test/mock/backends/athens/fake_athens.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/boeblingen/__init__.py
+++ b/qiskit/test/mock/backends/boeblingen/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/boeblingen/fake_boeblingen.py
+++ b/qiskit/test/mock/backends/boeblingen/fake_boeblingen.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/bogota/__init__.py
+++ b/qiskit/test/mock/backends/bogota/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/bogota/fake_bogota.py
+++ b/qiskit/test/mock/backends/bogota/fake_bogota.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/burlington/__init__.py
+++ b/qiskit/test/mock/backends/burlington/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/burlington/fake_burlington.py
+++ b/qiskit/test/mock/backends/burlington/fake_burlington.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/cambridge/__init__.py
+++ b/qiskit/test/mock/backends/cambridge/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/cambridge/fake_cambridge.py
+++ b/qiskit/test/mock/backends/cambridge/fake_cambridge.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/essex/__init__.py
+++ b/qiskit/test/mock/backends/essex/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/essex/fake_essex.py
+++ b/qiskit/test/mock/backends/essex/fake_essex.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/johannesburg/__init__.py
+++ b/qiskit/test/mock/backends/johannesburg/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/johannesburg/fake_johannesburg.py
+++ b/qiskit/test/mock/backends/johannesburg/fake_johannesburg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/london/__init__.py
+++ b/qiskit/test/mock/backends/london/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/london/fake_london.py
+++ b/qiskit/test/mock/backends/london/fake_london.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/melbourne/__init__.py
+++ b/qiskit/test/mock/backends/melbourne/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/melbourne/fake_melbourne.py
+++ b/qiskit/test/mock/backends/melbourne/fake_melbourne.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/montreal/__init__.py
+++ b/qiskit/test/mock/backends/montreal/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/montreal/fake_montreal.py
+++ b/qiskit/test/mock/backends/montreal/fake_montreal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/ourense/__init__.py
+++ b/qiskit/test/mock/backends/ourense/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/ourense/fake_ourense.py
+++ b/qiskit/test/mock/backends/ourense/fake_ourense.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/paris/__init__.py
+++ b/qiskit/test/mock/backends/paris/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/paris/fake_paris.py
+++ b/qiskit/test/mock/backends/paris/fake_paris.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/poughkeepsie/__init__.py
+++ b/qiskit/test/mock/backends/poughkeepsie/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/poughkeepsie/fake_poughkeepsie.py
+++ b/qiskit/test/mock/backends/poughkeepsie/fake_poughkeepsie.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/rochester/__init__.py
+++ b/qiskit/test/mock/backends/rochester/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/rochester/fake_rochester.py
+++ b/qiskit/test/mock/backends/rochester/fake_rochester.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/rome/__init__.py
+++ b/qiskit/test/mock/backends/rome/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/rome/fake_rome.py
+++ b/qiskit/test/mock/backends/rome/fake_rome.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/rueschlikon/__init__.py
+++ b/qiskit/test/mock/backends/rueschlikon/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/rueschlikon/fake_rueschlikon.py
+++ b/qiskit/test/mock/backends/rueschlikon/fake_rueschlikon.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/singapore/__init__.py
+++ b/qiskit/test/mock/backends/singapore/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/singapore/fake_singapore.py
+++ b/qiskit/test/mock/backends/singapore/fake_singapore.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/tenerife/__init__.py
+++ b/qiskit/test/mock/backends/tenerife/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/tenerife/fake_tenerife.py
+++ b/qiskit/test/mock/backends/tenerife/fake_tenerife.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/tokyo/__init__.py
+++ b/qiskit/test/mock/backends/tokyo/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/tokyo/fake_tokyo.py
+++ b/qiskit/test/mock/backends/tokyo/fake_tokyo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/toronto/__init__.py
+++ b/qiskit/test/mock/backends/toronto/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/toronto/fake_toronto.py
+++ b/qiskit/test/mock/backends/toronto/fake_toronto.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/backends/valencia/__init__.py
+++ b/qiskit/test/mock/backends/valencia/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/valencia/fake_valencia.py
+++ b/qiskit/test/mock/backends/valencia/fake_valencia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/vigo/__init__.py
+++ b/qiskit/test/mock/backends/vigo/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/vigo/fake_vigo.py
+++ b/qiskit/test/mock/backends/vigo/fake_vigo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/yorktown/__init__.py
+++ b/qiskit/test/mock/backends/yorktown/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/backends/yorktown/fake_yorktown.py
+++ b/qiskit/test/mock/backends/yorktown/fake_yorktown.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_1q.py
+++ b/qiskit/test/mock/fake_1q.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_job.py
+++ b/qiskit/test/mock/fake_job.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_openpulse_2q.py
+++ b/qiskit/test/mock/fake_openpulse_2q.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_openpulse_3q.py
+++ b/qiskit/test/mock/fake_openpulse_3q.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_provider.py
+++ b/qiskit/test/mock/fake_provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_qasm_simulator.py
+++ b/qiskit/test/mock/fake_qasm_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/fake_qobj.py
+++ b/qiskit/test/mock/fake_qobj.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/test/mock/utils/__init__.py
+++ b/qiskit/test/mock/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/mock/utils/configurable_backend.py
+++ b/qiskit/test/mock/utils/configurable_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/providers/__init__.py
+++ b/qiskit/test/providers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/test/providers/backend.py
+++ b/qiskit/test/providers/backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/test/providers/provider.py
+++ b/qiskit/test/providers/provider.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/test/testing_options.py
+++ b/qiskit/test/testing_options.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/test/utils.py
+++ b/qiskit/test/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/__init__.py
+++ b/qiskit/tools/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/events/__init__.py
+++ b/qiskit/tools/events/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/events/progressbar.py
+++ b/qiskit/tools/events/progressbar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/events/pubsub.py
+++ b/qiskit/tools/events/pubsub.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/__init__.py
+++ b/qiskit/tools/jupyter/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/backend_overview.py
+++ b/qiskit/tools/jupyter/backend_overview.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/copyright.py
+++ b/qiskit/tools/jupyter/copyright.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/job_watcher.py
+++ b/qiskit/tools/jupyter/job_watcher.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/job_widgets.py
+++ b/qiskit/tools/jupyter/job_widgets.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/progressbar.py
+++ b/qiskit/tools/jupyter/progressbar.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/jupyter/version_table.py
+++ b/qiskit/tools/jupyter/version_table.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/tools/jupyter/watcher_monitor.py
+++ b/qiskit/tools/jupyter/watcher_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/tools/monitor/__init__.py
+++ b/qiskit/tools/monitor/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/monitor/job_monitor.py
+++ b/qiskit/tools/monitor/job_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/monitor/overview.py
+++ b/qiskit/tools/monitor/overview.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/tools/visualization.py
+++ b/qiskit/tools/visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/exceptions.py
+++ b/qiskit/transpiler/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/fencedobjs.py
+++ b/qiskit/transpiler/fencedobjs.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/analysis/__init__.py
+++ b/qiskit/transpiler/passes/analysis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/analysis/count_ops.py
+++ b/qiskit/transpiler/passes/analysis/count_ops.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/count_ops_longest_path.py
+++ b/qiskit/transpiler/passes/analysis/count_ops_longest_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/dag_longest_path.py
+++ b/qiskit/transpiler/passes/analysis/dag_longest_path.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/depth.py
+++ b/qiskit/transpiler/passes/analysis/depth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/num_qubits.py
+++ b/qiskit/transpiler/passes/analysis/num_qubits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/num_tensor_factors.py
+++ b/qiskit/transpiler/passes/analysis/num_tensor_factors.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/resource_estimation.py
+++ b/qiskit/transpiler/passes/analysis/resource_estimation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/size.py
+++ b/qiskit/transpiler/passes/analysis/size.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/analysis/width.py
+++ b/qiskit/transpiler/passes/analysis/width.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/basis/__init__.py
+++ b/qiskit/transpiler/passes/basis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/basis/decompose.py
+++ b/qiskit/transpiler/passes/basis/decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
+++ b/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/layout/__init__.py
+++ b/qiskit/transpiler/passes/layout/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/layout/apply_layout.py
+++ b/qiskit/transpiler/passes/layout/apply_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
+++ b/qiskit/transpiler/passes/layout/enlarge_with_ancilla.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
+++ b/qiskit/transpiler/passes/layout/full_ancilla_allocation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/layout/set_layout.py
+++ b/qiskit/transpiler/passes/layout/set_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019

--- a/qiskit/transpiler/passes/layout/trivial_layout.py
+++ b/qiskit/transpiler/passes/layout/trivial_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/_gate_extension.py
+++ b/qiskit/transpiler/passes/optimization/_gate_extension.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_2q_blocks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/commutation_analysis.py
+++ b/qiskit/transpiler/passes/optimization/commutation_analysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/cx_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/cx_cancellation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/remove_diagonal_gates_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/remove_diagonal_gates_before_measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/optimization/remove_reset_in_zero_state.py
+++ b/qiskit/transpiler/passes/optimization/remove_reset_in_zero_state.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/routing/__init__.py
+++ b/qiskit/transpiler/passes/routing/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/algorithms/__init__.py
+++ b/qiskit/transpiler/passes/routing/algorithms/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
+++ b/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/routing/algorithms/types.py
+++ b/qiskit/transpiler/passes/routing/algorithms/types.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/routing/algorithms/util.py
+++ b/qiskit/transpiler/passes/routing/algorithms/util.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/routing/basic_swap.py
+++ b/qiskit/transpiler/passes/routing/basic_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/cython/__init__.py
+++ b/qiskit/transpiler/passes/routing/cython/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/cython/stochastic_swap/__init__.py
+++ b/qiskit/transpiler/passes/routing/cython/stochastic_swap/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/cython/stochastic_swap/swap_trial.pyx
+++ b/qiskit/transpiler/passes/routing/cython/stochastic_swap/swap_trial.pyx
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #!python
 #cython: language_level = 3
 #distutils: language = c++

--- a/qiskit/transpiler/passes/routing/cython/stochastic_swap/utils.pyx
+++ b/qiskit/transpiler/passes/routing/cython/stochastic_swap/utils.pyx
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #!python
 #cython: language_level = 3
 #distutils: language = c++

--- a/qiskit/transpiler/passes/routing/layout_transformation.py
+++ b/qiskit/transpiler/passes/routing/layout_transformation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/synthesis/__init__.py
+++ b/qiskit/transpiler/passes/synthesis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/passes/utils/__init__.py
+++ b/qiskit/transpiler/passes/utils/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/check_cx_direction.py
+++ b/qiskit/transpiler/passes/utils/check_cx_direction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/cx_direction.py
+++ b/qiskit/transpiler/passes/utils/cx_direction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/dag_fixed_point.py
+++ b/qiskit/transpiler/passes/utils/dag_fixed_point.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/utils/fixed_point.py
+++ b/qiskit/transpiler/passes/utils/fixed_point.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passes/utils/remove_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/remove_final_measurements.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/propertyset.py
+++ b/qiskit/transpiler/propertyset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/runningpassmanager.py
+++ b/qiskit/transpiler/runningpassmanager.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/transpiler/synthesis/__init__.py
+++ b/qiskit/transpiler/synthesis/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/synthesis/graysynth.py
+++ b/qiskit/transpiler/synthesis/graysynth.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/util.py
+++ b/qiskit/util.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/validation/__init__.py
+++ b/qiskit/validation/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/validation/jsonschema/__init__.py
+++ b/qiskit/validation/jsonschema/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/qiskit/validation/jsonschema/exceptions.py
+++ b/qiskit/validation/jsonschema/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/validation/jsonschema/schema_validation.py
+++ b/qiskit/validation/jsonschema/schema_validation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018, 2020.

--- a/qiskit/visualization/exceptions.py
+++ b/qiskit/visualization/exceptions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/__init__.py
+++ b/qiskit/visualization/interactive/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_blochsphere.py
+++ b/qiskit/visualization/interactive/iplot_blochsphere.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_cities.py
+++ b/qiskit/visualization/interactive/iplot_cities.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_hinton.py
+++ b/qiskit/visualization/interactive/iplot_hinton.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_histogram.py
+++ b/qiskit/visualization/interactive/iplot_histogram.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_paulivec.py
+++ b/qiskit/visualization/interactive/iplot_paulivec.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/interactive/iplot_qsphere.py
+++ b/qiskit/visualization/interactive/iplot_qsphere.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/pulse/__init__.py
+++ b/qiskit/visualization/pulse/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/pulse/interpolation.py
+++ b/qiskit/visualization/pulse/interpolation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/pulse/qcstyle.py
+++ b/qiskit/visualization/pulse/qcstyle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/pulse_v2/__init__.py
+++ b/qiskit/visualization/pulse_v2/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/drawing_objects.py
+++ b/qiskit/visualization/pulse_v2/drawing_objects.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/events.py
+++ b/qiskit/visualization/pulse_v2/events.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators.py
+++ b/qiskit/visualization/pulse_v2/generators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/style/__init__.py
+++ b/qiskit/visualization/pulse_v2/style/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/style/library.py
+++ b/qiskit/visualization/pulse_v2/style/library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/style/stylesheet.py
+++ b/qiskit/visualization/pulse_v2/style/stylesheet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/types.py
+++ b/qiskit/visualization/pulse_v2/types.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_visualization.py
+++ b/qiskit/visualization/pulse_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/qcstyle.py
+++ b/qiskit/visualization/qcstyle.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/transition_visualization.py
+++ b/qiskit/visualization/transition_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/ipynb/mpl/test_circuit_matplotlib_drawer.py
+++ b/test/ipynb/mpl/test_circuit_matplotlib_drawer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/ipynb/results.py
+++ b/test/ipynb/results.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/__init__.py
+++ b/test/python/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/basicaer/__init__.py
+++ b/test/python/basicaer/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_basicaer_backends.py
+++ b/test/python/basicaer/test_basicaer_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_basicaer_integration.py
+++ b/test/python/basicaer/test_basicaer_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_basicaer_qobj_headers.py
+++ b/test/python/basicaer/test_basicaer_qobj_headers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_multi_registers_convention.py
+++ b/test/python/basicaer/test_multi_registers_convention.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/circuit/__init__.py
+++ b/test/python/circuit/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/gate_utils.py
+++ b/test/python/circuit/gate_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/circuit/test_circuit_data.py
+++ b/test/python/circuit/test_circuit_data.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/circuit/test_circuit_multi_registers.py
+++ b/test/python/circuit/test_circuit_multi_registers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_circuit_properties.py
+++ b/test/python/circuit/test_circuit_properties.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_diagonal_gate.py
+++ b/test/python/circuit/test_diagonal_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_equivalence.py
+++ b/test/python/circuit/test_equivalence.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_gate_power.py
+++ b/test/python/circuit/test_gate_power.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_hamiltonian_gate.py
+++ b/test/python/circuit/test_hamiltonian_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/circuit/test_identifiers_circuits.py
+++ b/test/python/circuit/test_identifiers_circuits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/circuit/test_instruction_repeat.py
+++ b/test/python/circuit/test_instruction_repeat.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/circuit/test_isometry.py
+++ b/test/python/circuit/test_isometry.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_library.py
+++ b/test/python/circuit/test_library.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/circuit/test_random_circuit.py
+++ b/test/python/circuit/test_random_circuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/circuit/test_registerless_circuit.py
+++ b/test/python/circuit/test_registerless_circuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/circuit/test_squ.py
+++ b/test/python/circuit/test_squ.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_tools.py
+++ b/test/python/circuit/test_tools.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/circuit/test_uc.py
+++ b/test/python/circuit/test_uc.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_ucx_y_z.py
+++ b/test/python/circuit/test_ucx_y_z.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/compiler/__init__.py
+++ b/test/python/compiler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/compiler/test_disassembler.py
+++ b/test/python/compiler/test_disassembler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/converters/__init__.py
+++ b/test/python/converters/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/converters/test_ast_to_dag.py
+++ b/test/python/converters/test_ast_to_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/converters/test_circuit_to_dag.py
+++ b/test/python/converters/test_circuit_to_dag.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/converters/test_circuit_to_dagdependency.py
+++ b/test/python/converters/test_circuit_to_dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/converters/test_circuit_to_gate.py
+++ b/test/python/converters/test_circuit_to_gate.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/converters/test_dag_to_dagdependency.py
+++ b/test/python/converters/test_dag_to_dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/dagcircuit/__init__.py
+++ b/test/python/dagcircuit/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/dagcircuit/test_compose.py
+++ b/test/python/dagcircuit/test_compose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/dagcircuit/test_dagdependency.py
+++ b/test/python/dagcircuit/test_dagdependency.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/mock/__init__.py
+++ b/test/python/mock/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/mock/test_configurable_backend.py
+++ b/test/python/mock/test_configurable_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/mock/test_fake_backends.py
+++ b/test/python/mock/test_fake_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/providers/__init__.py
+++ b/test/python/providers/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/providers/faulty_backends.py
+++ b/test/python/providers/faulty_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/providers/test_backendconfiguration.py
+++ b/test/python/providers/test_backendconfiguration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/providers/test_backendproperties.py
+++ b/test/python/providers/test_backendproperties.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/providers/test_base_backend.py
+++ b/test/python/providers/test_base_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/providers/test_faulty_backend.py
+++ b/test/python/providers/test_faulty_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/providers/test_jobmethods.py
+++ b/test/python/providers/test_jobmethods.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/providers/test_pulse_defaults.py
+++ b/test/python/providers/test_pulse_defaults.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/pulse/__init__.py
+++ b/test/python/pulse/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/pulse/test_channels.py
+++ b/test/python/pulse/test_channels.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_continuous_pulses.py
+++ b/test/python/pulse/test_continuous_pulses.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_discrete_pulses.py
+++ b/test/python/pulse/test_discrete_pulses.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_experiment_configurations.py
+++ b/test/python/pulse/test_experiment_configurations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/pulse/test_macros.py
+++ b/test/python/pulse/test_macros.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/pulse/test_parser.py
+++ b/test/python/pulse/test_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/pulse/test_samplers.py
+++ b/test/python/pulse/test_samplers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/pulse/test_transforms.py
+++ b/test/python/pulse/test_transforms.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/qobj/__init__.py
+++ b/test/python/qobj/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/qobj/test_qobj.py
+++ b/test/python/qobj/test_qobj.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/qobj/test_qobj_identifiers.py
+++ b/test/python/qobj/test_qobj_identifiers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/quantum_info/__init__.py
+++ b/test/python/quantum_info/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/quantum_info/operators/__init__.py
+++ b/test/python/quantum_info/operators/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/quantum_info/operators/channel/__init__.py
+++ b/test/python/quantum_info/operators/channel/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/channel_test_case.py
+++ b/test/python/quantum_info/operators/channel/channel_test_case.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_adjoint.py
+++ b/test/python/quantum_info/operators/channel/test_adjoint.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_choi.py
+++ b/test/python/quantum_info/operators/channel/test_choi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_evolve.py
+++ b/test/python/quantum_info/operators/channel/test_evolve.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_kraus.py
+++ b/test/python/quantum_info/operators/channel/test_kraus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_linearops.py
+++ b/test/python/quantum_info/operators/channel/test_linearops.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_ptm.py
+++ b/test/python/quantum_info/operators/channel/test_ptm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_stinespring.py
+++ b/test/python/quantum_info/operators/channel/test_stinespring.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_tensor_compose.py
+++ b/test/python/quantum_info/operators/channel/test_tensor_compose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/channel/test_transformations.py
+++ b/test/python/quantum_info/operators/channel/test_transformations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/symplectic/__init__.py
+++ b/test/python/quantum_info/operators/symplectic/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/symplectic/test_pauli_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_table.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/symplectic/test_pauli_utils.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/test_measures.py
+++ b/test/python/quantum_info/operators/test_measures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/operators/test_random.py
+++ b/test/python/quantum_info/operators/test_random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/operators/test_scalar_op.py
+++ b/test/python/quantum_info/operators/test_scalar_op.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/states/__init__.py
+++ b/test/python/quantum_info/states/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020

--- a/test/python/quantum_info/states/test_random.py
+++ b/test/python/quantum_info/states/test_random.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/quantum_info/test_analyzation.py
+++ b/test/python/quantum_info/test_analyzation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/quantum_info/test_local_invariance.py
+++ b/test/python/quantum_info/test_local_invariance.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/test_pauli.py
+++ b/test/python/quantum_info/test_pauli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/quantum_info/test_quaternions.py
+++ b/test/python/quantum_info/test_quaternions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/quantum_info/test_weyl.py
+++ b/test/python/quantum_info/test_weyl.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/result/__init__.py
+++ b/test/python/result/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/scheduler/__init__.py
+++ b/test/python/scheduler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/scheduler/test_basic_scheduler.py
+++ b/test/python/scheduler/test_basic_scheduler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/test_examples.py
+++ b/test/python/test_examples.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/test_schemas.py
+++ b/test/python/test_schemas.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/test_util.py
+++ b/test/python/test_util.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/__init__.py
+++ b/test/python/tools/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/jupyter/__init__.py
+++ b/test/python/tools/jupyter/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/jupyter/test_notebooks.py
+++ b/test/python/tools/jupyter/test_notebooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/monitor/__init__.py
+++ b/test/python/tools/monitor/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/monitor/test_backend_monitor.py
+++ b/test/python/tools/monitor/test_backend_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/monitor/test_job_monitor.py
+++ b/test/python/tools/monitor/test_job_monitor.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/tools/test_parallel.py
+++ b/test/python/tools/test_parallel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/tools/test_pubsub.py
+++ b/test/python/tools/test_pubsub.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/transpiler/__init__.py
+++ b/test/python/transpiler/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/_dummy_passes.py
+++ b/test/python/transpiler/_dummy_passes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_1q.py
+++ b/test/python/transpiler/test_1q.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/transpiler/test_adjacent_barriers.py
+++ b/test/python/transpiler/test_adjacent_barriers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_apply_layout.py
+++ b/test/python/transpiler/test_apply_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/transpiler/test_barrier_before_final_measurements.py
+++ b/test/python/transpiler/test_barrier_before_final_measurements.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_basic_swap.py
+++ b/test/python/transpiler/test_basic_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_basis_translator.py
+++ b/test/python/transpiler/test_basis_translator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/transpiler/test_check_cx_direction.py
+++ b/test/python/transpiler/test_check_cx_direction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_check_map.py
+++ b/test/python/transpiler/test_check_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_collect_2q_blocks.py
+++ b/test/python/transpiler/test_collect_2q_blocks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_commutation_analysis.py
+++ b/test/python/transpiler/test_commutation_analysis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_count_ops_longest_path_pass.py
+++ b/test/python/transpiler/test_count_ops_longest_path_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_count_ops_pass.py
+++ b/test/python/transpiler/test_count_ops_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_coupling.py
+++ b/test/python/transpiler/test_coupling.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
+++ b/test/python/transpiler/test_crosstalk_adaptive_scheduler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_cx_direction.py
+++ b/test/python/transpiler/test_cx_direction.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_dag_fixed_point_pass.py
+++ b/test/python/transpiler/test_dag_fixed_point_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_dag_longest_path_pass.py
+++ b/test/python/transpiler/test_dag_longest_path_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_decompose.py
+++ b/test/python/transpiler/test_decompose.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_dense_layout.py
+++ b/test/python/transpiler/test_dense_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_depth_pass.py
+++ b/test/python/transpiler/test_depth_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_enlarge_with_ancilla_pass.py
+++ b/test/python/transpiler/test_enlarge_with_ancilla_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_faulty_backend.py
+++ b/test/python/transpiler/test_faulty_backend.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/transpiler/test_fixed_point_pass.py
+++ b/test/python/transpiler/test_fixed_point_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_full_ancilla_allocation.py
+++ b/test/python/transpiler/test_full_ancilla_allocation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_generic_pass.py
+++ b/test/python/transpiler/test_generic_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_hoare_opt.py
+++ b/test/python/transpiler/test_hoare_opt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_kak_over_optimization.py
+++ b/test/python/transpiler/test_kak_over_optimization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_layout_score.py
+++ b/test/python/transpiler/test_layout_score.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/transpiler/test_layout_transformation.py
+++ b/test/python/transpiler/test_layout_transformation.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_naming_transpiled_circuits.py
+++ b/test/python/transpiler/test_naming_transpiled_circuits.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/transpiler/test_noise_adaptive_layout.py
+++ b/test/python/transpiler/test_noise_adaptive_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_passmanager.py
+++ b/test/python/transpiler/test_passmanager.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_property_set.py
+++ b/test/python/transpiler/test_property_set.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
+++ b/test/python/transpiler/test_remove_diagonal_gates_before_measure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_remove_reset_in_zero_state.py
+++ b/test/python/transpiler/test_remove_reset_in_zero_state.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_resource_estimation_pass.py
+++ b/test/python/transpiler/test_resource_estimation_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/transpiler/test_size_pass.py
+++ b/test/python/transpiler/test_size_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_synthesis.py
+++ b/test/python/transpiler/test_synthesis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_tensor_factor_pass.py
+++ b/test/python/transpiler/test_tensor_factor_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_token_swapper.py
+++ b/test/python/transpiler/test_token_swapper.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_trivial_layout.py
+++ b/test/python/transpiler/test_trivial_layout.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_unroll_custom_definitions.py
+++ b/test/python/transpiler/test_unroll_custom_definitions.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/python/transpiler/test_unroller.py
+++ b/test/python/transpiler/test_unroller.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/transpiler/test_width_pass.py
+++ b/test/python/transpiler/test_width_pass.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/visualization/__init__.py
+++ b/test/python/visualization/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/visualization/pulse_v2/__init__.py
+++ b/test/python/visualization/pulse_v2/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/pulse_v2/test_drawing_objects.py
+++ b/test/python/visualization/pulse_v2/test_drawing_objects.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/pulse_v2/test_framework.py
+++ b/test/python/visualization/pulse_v2/test_framework.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/pulse_v2/test_generators.py
+++ b/test/python/visualization/pulse_v2/test_generators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/visualization/test_circuit_visualization_output.py
+++ b/test/python/visualization/test_circuit_visualization_output.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/visualization/test_dag_drawer.py
+++ b/test/python/visualization/test_dag_drawer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/visualization/test_pulse_visualization_output.py
+++ b/test/python/visualization/test_pulse_visualization_output.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/python/visualization/test_visualization.py
+++ b/test/python/visualization/test_visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/python/visualization/visualization.py
+++ b/test/python/visualization/visualization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2019.

--- a/test/randomized/__init__.py
+++ b/test/randomized/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017.

--- a/test/randomized/test_clifford.py
+++ b/test/randomized/test_clifford.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/tools/report_ci_failure.py
+++ b/tools/report_ci_failure.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/tools/subunit_to_junit.py
+++ b/tools/subunit_to_junit.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/tools/update_fake_backends.py
+++ b/tools/update_fake_backends.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020
@@ -28,15 +26,13 @@ def discover_files(code_paths):
             for directory in os.walk(path):
                 dir_path = directory[0]
                 for subfile in directory[2]:
-                    if subfile.endswith('.py'):
+                    if subfile.endswith('.py') or subfile.endswith('.pyx'):
                         out_paths.append(os.path.join(dir_path, subfile))
     return out_paths
 
 
 def validate_header(file_path):
-    header = """# -*- coding: utf-8 -*-
-
-# This code is part of Qiskit.
+    header = """# This code is part of Qiskit.
 #
 """
     apache_text = """#
@@ -56,16 +52,16 @@ def validate_header(file_path):
         count += 1
         if count > 5:
             return (file_path, False, "Header not found in first 5 lines")
-        if line == "# -*- coding: utf-8 -*-\n":
+        if line == "# This code is part of Qiskit.\n":
             start = index
             break
-    if ''.join(lines[start:start + 4]) != header:
+    if ''.join(lines[start:start + 2]) != header:
         return (file_path, False,
                 "Header up to copyright line does not match: %s" % header)
-    if not lines[start + 4].startswith("# (C) Copyright IBM"):
+    if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
         return (file_path, False,
                 "Header copyright line not found")
-    if ''.join(lines[start + 5:start + 13]) != apache_text:
+    if ''.join(lines[start + 3:start + 11]) != apache_text:
         return (file_path, False,
                 "Header apache text string doesn't match:\n %s" % apache_text)
     return (file_path, True, None)


### PR DESCRIPTION
utf-8 has been the default since PEP 3120.
https://www.python.org/dev/peps/pep-3120/

Non trivial edits are to Makefile and verify_headers.py