### PR TITLE
Once parameters are binded, convert them to native for instruction.param

### DIFF
--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -110,7 +110,7 @@ class PhaseGate(Gate):
 
     def to_matrix(self):
         """Return a numpy.array for the Phase gate."""
-        lam = float(self.params[0])
+        lam = self.params[0]
         return numpy.array([[1, 0], [0, numpy.exp(1j * lam)]], dtype=complex)
 
 
@@ -200,7 +200,7 @@ class CPhaseGate(ControlledGate):
 
     def to_matrix(self):
         """Return a numpy.array for the CPhase gate."""
-        eith = numpy.exp(1j * float(self.params[0]))
+        eith = numpy.exp(1j * self.params[0])
         if self.ctrl_state:
             return numpy.array([[1, 0, 0, 0],
                                 [0, 1, 0, 0],

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -73,7 +73,8 @@ class RGate(Gate):
 
     def to_matrix(self):
         """Return a numpy.array for the R gate."""
-        theta, phi = float(self.params[0]), float(self.params[1])
+        theta = self.params[0]
+        phi = self.params[1]
         cos = math.cos(theta / 2)
         sin = math.sin(theta / 2)
         exp_m = numpy.exp(-1j * phi)

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -190,7 +190,7 @@ class CRXGate(ControlledGate):
 
     def to_matrix(self):
         """Return a numpy.array for the CRX gate."""
-        half_theta = float(self.params[0]) / 2
+        half_theta = self.params[0] / 2
         cos = numpy.cos(half_theta)
         isin = 1j * numpy.sin(half_theta)
         if self.ctrl_state:

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -99,7 +99,7 @@ class RXXGate(Gate):
     def to_matrix(self):
         """Return a Numpy.array for the RXX gate."""
         import numpy
-        theta2 = float(self.params[0]) / 2
+        theta2 = self.params[0] / 2
         cos = numpy.cos(theta2)
         isin = 1j * numpy.sin(theta2)
         return numpy.array([

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -185,7 +185,7 @@ class CRYGate(ControlledGate):
 
     def to_matrix(self):
         """Return a numpy.array for the CRY gate."""
-        half_theta = float(self.params[0]) / 2
+        half_theta = self.params[0] / 2
         cos = numpy.cos(half_theta)
         sin = numpy.sin(half_theta)
         if self.ctrl_state:

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -100,7 +100,7 @@ class RYYGate(Gate):
 
     def to_matrix(self):
         """Return a numpy.array for the RYY gate."""
-        theta = float(self.params[0])
+        theta = self.params[0]
         cos = np.cos(theta / 2)
         isin = 1j * np.sin(theta / 2)
         return np.array([

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -102,7 +102,7 @@ class RZGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the RZ gate."""
         import numpy as np
-        ilam2 = 0.5j * float(self.params[0])
+        ilam2 = 0.5j * self.params[0]
         return np.array([[np.exp(-ilam2), 0],
                          [0, np.exp(ilam2)]], dtype=complex)
 
@@ -203,7 +203,7 @@ class CRZGate(ControlledGate):
     def to_matrix(self):
         """Return a numpy.array for the CRZ gate."""
         import numpy
-        arg = 1j * float(self.params[0]) / 2
+        arg = 1j * self.params[0] / 2
         if self.ctrl_state:
             return numpy.array([[1, 0, 0, 0],
                                 [0, numpy.exp(-arg), 0, 0],

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -145,7 +145,7 @@ class RZXGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the RZX gate."""
         import numpy
-        half_theta = float(self.params[0]) / 2
+        half_theta = self.params[0] / 2
         cos = numpy.cos(half_theta)
         isin = 1j * numpy.sin(half_theta)
         return numpy.array([[cos, 0, -isin, 0],

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -109,7 +109,7 @@ class RZZGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the RZZ gate."""
         import numpy
-        itheta2 = 1j * float(self.params[0]) / 2
+        itheta2 = 1j * self.params[0] / 2
         return numpy.array([[numpy.exp(-itheta2), 0, 0, 0],
                             [0, numpy.exp(itheta2), 0, 0],
                             [0, 0, numpy.exp(itheta2), 0],

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -98,7 +98,9 @@ class UGate(Gate):
 
     def to_matrix(self):
         """Return a numpy.array for the U gate."""
-        theta, phi, lam = [float(param) for param in self.params]
+        theta = self.params[0]
+        phi = self.params[1]
+        lam = self.params[2]
         return numpy.array([
             [
                 numpy.cos(theta / 2),
@@ -209,7 +211,11 @@ class CUGate(ControlledGate):
 
     def to_matrix(self):
         """Return a numpy.array for the CU gate."""
-        theta, phi, lam, gamma = [float(param) for param in self.params]
+        theta = self.params[0]
+        phi = self.params[1]
+        lam = self.params[2]
+        gamma = self.params[3]
+
         cos = numpy.cos(theta / 2)
         sin = numpy.sin(theta / 2)
         a = numpy.exp(1j * gamma) * cos

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -117,7 +117,7 @@ class U1Gate(Gate):
 
     def to_matrix(self):
         """Return a numpy.array for the U1 gate."""
-        lam = float(self.params[0])
+        lam = self.params[0]
         return numpy.array([[1, 0], [0, numpy.exp(1j * lam)]], dtype=complex)
 
 
@@ -212,7 +212,7 @@ class CU1Gate(ControlledGate):
     def to_matrix(self):
         """Return a numpy.array for the CU1 gate."""
 
-        eith = numpy.exp(1j * float(self.params[0]))
+        eith = numpy.exp(1j * self.params[0])
         if self.ctrl_state:
             return numpy.array([[1, 0, 0, 0],
                                 [0, 1, 0, 0],

--- a/qiskit/circuit/library/standard_gates/u2.py
+++ b/qiskit/circuit/library/standard_gates/u2.py
@@ -83,7 +83,6 @@ class U2Gate(Gate):
         """Return a Numpy.array for the U2 gate."""
         isqrt2 = 1 / numpy.sqrt(2)
         phi, lam = self.params
-        phi, lam = float(phi), float(lam)
         return numpy.array([
             [
                 isqrt2,

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -90,7 +90,6 @@ class U3Gate(Gate):
     def to_matrix(self):
         """Return a Numpy.array for the U3 gate."""
         theta, phi, lam = self.params
-        theta, phi, lam = float(theta), float(phi), float(lam)
         cos = numpy.cos(theta / 2)
         sin = numpy.sin(theta / 2)
         return numpy.array([
@@ -202,7 +201,6 @@ class CU3Gate(ControlledGate):
     def to_matrix(self):
         """Return a numpy.array for the CU3 gate."""
         theta, phi, lam = self.params
-        theta, phi, lam = float(theta), float(phi), float(lam)
         cos = numpy.cos(theta / 2)
         sin = numpy.sin(theta / 2)
         if self.ctrl_state:

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -264,7 +264,7 @@ class ParameterExpression():
             raise TypeError('ParameterExpression with unbound parameters ({}) '
                             'cannot converted to native.'.format(self.parameters))
         if self._symbol_expr.is_Float or self._symbol_expr.is_Rational:
-            return float(self)
+            return float(self._symbol_expr)
         if self._symbol_expr.is_Integer:
-            return int(self)
+            return int(self._symbol_expr)
         return NotImplemented

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -244,10 +244,7 @@ class ParameterExpression():
         return str(self._symbol_expr)
 
     def __float__(self):
-        if self.parameters:
-            raise TypeError('ParameterExpression with unbound parameters ({}) '
-                            'cannot be cast to a float.'.format(self.parameters))
-        return float(self._symbol_expr)
+        return float(self.to_native())
 
     def __copy__(self):
         return self
@@ -262,6 +259,10 @@ class ParameterExpression():
                 and srepr(self._symbol_expr) == srepr(other._symbol_expr))
 
     def to_native(self):
+        """Converts the ParameterExpression to a native type (int or float)."""
+        if self.parameters:
+            raise TypeError('ParameterExpression with unbound parameters ({}) '
+                            'cannot converted to native.'.format(self.parameters))
         if self._symbol_expr.is_Float or self._symbol_expr.is_Rational:
             return float(self)
         if self._symbol_expr.is_Integer:

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -260,3 +260,10 @@ class ParameterExpression():
         return (isinstance(other, ParameterExpression)
                 and self.parameters == other.parameters
                 and srepr(self._symbol_expr) == srepr(other._symbol_expr))
+
+    def to_native(self):
+        if self._symbol_expr.is_Float or self._symbol_expr.is_Rational:
+            return float(self)
+        if self._symbol_expr.is_Integer:
+            return int(self)
+        return NotImplemented

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1872,7 +1872,8 @@ class QuantumCircuit:
     def _bind_parameter(self, parameter, value):
         """Assigns a parameter value to matching instructions in-place."""
         for (instr, param_index) in self._parameter_table[parameter]:
-            instr.params[param_index] = instr.params[param_index].bind({parameter: value})
+            param = instr.params[param_index].bind({parameter: value})
+            instr.params[param_index] = param if param.parameters else param.to_native()
 
             # For instructions which have already been defined (e.g. composite
             # instructions), search the definition for instances of the

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -248,7 +248,7 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0][0].params[0], ParameterExpression))
+                self.assertTrue(isinstance(fbqc.data[0][0].params[0], float))
                 self.assertEqual(float(fbqc.data[0][0].params[0]), 3)
 
     def test_expression_partial_binding_zero(self):
@@ -274,7 +274,7 @@ class TestParameters(QiskitTestCase):
                 fbqc = getattr(pqc, assign_fun)({phi: 1})
 
                 self.assertEqual(fbqc.parameters, set())
-                self.assertTrue(isinstance(fbqc.data[0][0].params[0], ParameterExpression))
+                self.assertTrue(isinstance(fbqc.data[0][0].params[0], float))
                 self.assertEqual(float(fbqc.data[0][0].params[0]), 0)
 
     def test_raise_if_assigning_params_not_in_circuit(self):
@@ -497,7 +497,7 @@ class TestParameters(QiskitTestCase):
         self.assertEqual(len(qobj.experiments), 1)
         self.assertEqual(len(qobj.experiments[0].instructions), 4)
         self.assertTrue(all(len(inst.params) == 1
-                            and isinstance(inst.params[0], ParameterExpression)
+                            and isinstance(inst.params[0], float)
                             and float(inst.params[0]) == 1
                             for inst in qobj.experiments[0].instructions))
 


### PR DESCRIPTION
Once a parameter does not have free variables, it can be converted to a native type. This allows to consider this parameter as any other parameter.