### PR TITLE
PulseQobjInstruction: show frequency in str/repr

### DIFF
--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -176,8 +176,8 @@ class PulseQobjInstruction:
 
     def __repr__(self):
         out = "PulseQobjInstruction(name='%s', t0=%s" % (self.name, self.t0)
-        for attr in ['ch', 'conditional', 'val', 'phase', 'duration',
-                     'qubits', 'memory_slot', 'register_slot',
+        for attr in ['ch', 'conditional', 'val', 'phase', 'frequency',
+                     'duration', 'qubits', 'memory_slot', 'register_slot',
                      'label', 'type', 'pulse_shape', 'parameters']:
             attr_val = getattr(self, attr, None)
             if attr_val is not None:
@@ -191,8 +191,8 @@ class PulseQobjInstruction:
     def __str__(self):
         out = "Instruction: %s\n" % self.name
         out += "\t\tt0: %s\n" % self.t0
-        for attr in ['ch', 'conditional', 'val', 'phase', 'duration',
-                     'qubits', 'memory_slot', 'register_slot',
+        for attr in ['ch', 'conditional', 'val', 'phase', 'frequency',
+                     'duration', 'qubits', 'memory_slot', 'register_slot',
                      'label', 'type', 'pulse_shape', 'parameters']:
             if hasattr(self, attr):
                 out += '\t\t%s: %s\n' % (attr, getattr(self, attr))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The frequency would not show up in the str(PulseQobjInstruction) or
repr(PulseQobjInstruction) views of a PulseQobjInstruction. This commit
should remedy that bug.

e.g.
``PulseQobjInstruction(name='setf', t0=0, ch="d0")`` -> ``PulseQobjInstruction(name='setf', t0=0, ch="d0", frequency="4.5")``

### Details and comments

I can add a release note if it's a big enough fix (don't know if people rely on the string representation of a PulseQobjInstruction for any reason...). Or add a test if desired.
A different fix implementation is factoring out the list of attributes into a class variable, to prevent this mistake in the future.
One **other semi-bug**: values have different quotes than the names (i.e. ``name='instr_name', ch="d0"``). Not sure which quote you want to use, but happy to add a small commit to fix that.