### PR TITLE
Fixes MCPhaseGate definition

### DIFF
--- a/qiskit/circuit/library/standard_gates/p.py
+++ b/qiskit/circuit/library/standard_gates/p.py
@@ -258,9 +258,9 @@ class MCPhaseGate(ControlledGate):
         else:
             from .u3 import _gray_code_chain
             scaled_lam = self.params[0] / (2 ** (self.num_ctrl_qubits - 1))
-            bottom_gate = PhaseGate(scaled_lam)
+            bottom_gate = CPhaseGate(scaled_lam)
             definition = _gray_code_chain(q, self.num_ctrl_qubits, bottom_gate)
-            qc.data = definition
+            qc._data = definition
         self.definition = qc
 
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):


### PR DESCRIPTION
### Summary
Fixes an issue with MCPhaseGate definition.

### Details and comments
When defining a many-controlled PhaseGate with more that 1 control, PhaseGates are used to implement two-qubit rotations.  However PhaseGate is defined as one qubit gate. This was causing an issue when creating operator from MCPhaseGate.

```
Operator(MCPhaseGate(pi,2))
# causes error: 'The amount of qubit/clbit arguments does not match the gate expectation.'
```
This PR uses CPhaseGate instead. 

MCPhaseGate(pi,2) definition before this PR
```
                 ┌───┐┌───────────┐┌───┐┌──────────┐
q_0: ────────────┤ X ├┤0          ├┤ X ├┤0         ├
     ┌──────────┐└─┬─┘│           │└─┬─┘│          │
q_1: ┤0         ├──■──┤  P(-pi/2) ├──■──┤  P(pi/2) ├
     │  P(pi/2) │     │           │     │          │
q_2: ┤1         ├─────┤1          ├─────┤1         ├
     └──────────┘     └───────────┘     └──────────┘
```

MCPhaseGate(pi,2) definition before this PR
```
                ┌───┐            ┌───┐           
q_0: ───────────┤ X ├─────■──────┤ X ├─────■─────
                └─┬─┘     │      └─┬─┘     │     
q_1: ─────■───────■───────┼────────■───────┼─────
     ┌────┴────┐     ┌────┴─────┐     ┌────┴────┐
q_2: ┤ P(pi/2) ├─────┤ P(-pi/2) ├─────┤ P(pi/2) ├
     └─────────┘     └──────────┘     └─────────┘
```
