### PR TITLE
Fix #4984: Added warning when PassManager instance is rerun.

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -210,7 +210,7 @@ class PassManager:
 
         Returns:
             The transformed circuit(s).
-        """   
+        """
         # Checking if the same PassManager instance being used.
         if self._reuse_flag:
             warnings.warn("Reusing a PassManager instance might lead to unexpected results.")

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -63,6 +63,9 @@ class PassManager:
         self.max_iteration = max_iteration
         self.property_set = None
 
+        # A flag to raise warning whenever a PassManager instance is used more than once.
+        self._reuse_flag = False
+
     def append(
             self,
             passes: Union[BasePass, List[BasePass]],
@@ -207,7 +210,12 @@ class PassManager:
 
         Returns:
             The transformed circuit(s).
-        """
+        """   
+        # Checking if the same PassManager instance being used.
+        if self._reuse_flag:
+            warnings.warn("Reusing a PassManager instance might lead to unexpected results.")
+        self._reuse_flag = True
+
         if isinstance(circuits, QuantumCircuit):
             return self._run_single_circuit(circuits, output_name, callback)
         elif len(circuits) == 1:

--- a/releasenotes/notes/warning_pm_reuse-b882317f2ea1e095.yaml
+++ b/releasenotes/notes/warning_pm_reuse-b882317f2ea1e095.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The :class:`~qiskit.transpiler.passmanager.PassManager` instances might result in unexpected results when they are reused.
+    The :meth:`~qiskit.transpiler.passmanager.PassManager.run` now triggers a warning if it is called more than once.

--- a/releasenotes/notes/warning_pm_reuse-b882317f2ea1e095.yaml
+++ b/releasenotes/notes/warning_pm_reuse-b882317f2ea1e095.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+other:
   - |
     The :class:`~qiskit.transpiler.passmanager.PassManager` instances might result in unexpected results when they are reused.
     The :meth:`~qiskit.transpiler.passmanager.PassManager.run` now triggers a warning if it is called more than once.

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -12,6 +12,8 @@
 
 """Tests PassManager.run()"""
 
+import warnings
+
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import CXGate
 from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
@@ -111,3 +113,41 @@ class TestPassManagerRun(QiskitTestCase):
             for gate, qargs, _ in new_circuit.data:
                 if isinstance(gate, CXGate):
                     self.assertIn([x.index for x in qargs], coupling_map)
+
+    def test_passmanager_rerun(self):
+        """Test if warning is raised or not after rerunning PassManager instance
+        """
+
+        with warnings.catch_warnings(record=True) as w:
+
+            qr = QuantumRegister(4, 'qr')
+            circuit1 = QuantumCircuit(qr)
+            circuit1.h(qr[0])
+            circuit1.cx(qr[0], qr[1])
+            circuit1.cx(qr[1], qr[2])
+            circuit1.cx(qr[2], qr[3])
+
+            circuit2 = QuantumCircuit(qr)
+            circuit2.cx(qr[1], qr[2])
+            circuit2.cx(qr[0], qr[1])
+            circuit2.cx(qr[2], qr[3])
+
+            coupling_map = FakeMelbourne().configuration().coupling_map
+            basis_gates = FakeMelbourne().configuration().basis_gates
+            initial_layout = [None, qr[0], qr[1], qr[2], None, qr[3]]
+
+            pass_manager = level_1_pass_manager(PassManagerConfig(
+                basis_gates=basis_gates,
+                coupling_map=CouplingMap(coupling_map),
+                initial_layout=Layout.from_qubit_list(initial_layout),
+                seed_transpiler=42))
+
+            circuits = [circuit1, circuit2]
+
+            for circuit in circuits:
+                pass_manager.run(circuit)
+
+            self.assertEqual(len(w), 1)
+            self.assertEqual(
+                str(w[-1].message),
+                "Reusing a PassManager instance might lead to unexpected results.")

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -117,7 +117,6 @@ class TestPassManagerRun(QiskitTestCase):
     def test_passmanager_rerun(self):
         """Test if warning is raised or not after rerunning PassManager instance
         """
-
         qr = QuantumRegister(4, 'qr')
         circuit1 = QuantumCircuit(qr)
         circuit1.h(qr[0])
@@ -140,9 +139,7 @@ class TestPassManagerRun(QiskitTestCase):
             initial_layout=Layout.from_qubit_list(initial_layout),
             seed_transpiler=42))
 
-        circuits = [circuit1, circuit2]
-
+        pass_manager.run(circuit1)
         with self.assertWarns(UserWarning, msg="Reusing a PassManager instance might lead to"
                                                " unexpected results."):
-            for circuit in circuits:
-                pass_manager.run(circuit)
+            pass_manager.run(circuit2)

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -12,8 +12,6 @@
 
 """Tests PassManager.run()"""
 
-import warnings
-
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import CXGate
 from qiskit.transpiler.preset_passmanagers import level_1_pass_manager


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4984

Due to the last failed attempt in submitting a successful PR. I made a new branch and hence added the feature as @1ucian0 suggests in #4984. I have also added the test cases in the `test_passmanager_run.py` file

### Details and comments


