### PR TITLE
Allow ParameterExpressions to be cast to ints

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -249,6 +249,12 @@ class ParameterExpression():
                             'cannot be cast to a float.'.format(self.parameters))
         return float(self._symbol_expr)
 
+    def __int__(self):
+        if self.parameters:
+            raise TypeError('ParameterExpression with unbound parameters ({}) '
+                            'cannot be cast to an int.'.format(self.parameters))
+        return int(self._symbol_expr)
+
     def __copy__(self):
         return self
 


### PR DESCRIPTION
- Resolves #4978

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Allows `ParameterExpression`s to be cast to ints

### Details and comments

Adds cast operator for `int`s. Any truncation will occur only after evaluation of the expression (which must be fully bound in order to cast).

