### PR TITLE
Fix typo in qiskit.optimization import redirect

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -39,7 +39,7 @@ new_meta_path.append(namespace.QiskitElementImport(
 new_meta_path.append(namespace.QiskitElementImport(
     'qiskit_aqua.ml', 'qiskit.ml'))
 new_meta_path.append(namespace.QiskitElementImport(
-    'qiskit_aqua.optimizations', 'qiskit.optimizations'))
+    'qiskit_aqua.optimization', 'qiskit.optimization'))
 new_meta_path.append(namespace.QiskitElementImport(
     'qiskit_ibmq_provider', 'qiskit.providers.ibmq'))
 new_meta_path.append(namespace.QiskitElementImport(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #4767 we added a namespace redirect for qiskit.optimizations to
qiskit_aqua.optimizations, however the module in aqua is named
optimization not optimizations. This commit corrects the oversight to
unblock Qiskit/qiskit-aqua#1127

### Details and comments


