### PR TITLE
Explicity set encoding of release notes via reno config

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -1,0 +1,2 @@
+---
+encoding: utf8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,7 @@ cython>=0.27.1
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
-reno>=3.1.0
+reno>=3.2.0
 Sphinx>=1.8.3,<3.1.0
 sphinx-rtd-theme>=0.4.0
 sphinx-tabs>=1.1.11


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent reno release 3.2.0 included a new feature [1] for setting the
character encoding that reno uses for all it's files. [2] This commit
sets this option in the reno config file to make the release note files
explicitly utf8. This is important (especially for windows users)
because we have literal inlines of the text drawer in some release notes
which use utf8 characters. This should avoid issues for users who's
system encoding is not compatible with the text drawer output in the
release notes.

### Details and comments

[1] https://opendev.org/openstack/reno/commit/984bcba17e4e0b46763f42015d09680e5c5d5a04
[2] https://docs.openstack.org/reno/latest/user/usage.html#configuring-reno
