### PR TITLE
Fix/5015 QuantumCircuit __eq__ should always return a Bool

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -220,6 +220,9 @@ class QuantumCircuit:
         return str(self.draw(output='text'))
 
     def __eq__(self, other):
+        if not isinstance(other, QuantumCircuit):
+            return False
+
         # TODO: remove the DAG from this function
         from qiskit.converters import circuit_to_dag
         return circuit_to_dag(self) == circuit_to_dag(other)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -619,6 +619,7 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertFalse(qc1 == qc2)
 
+
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""
 

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -587,6 +587,37 @@ class TestCircuitOperations(QiskitTestCase):
         expected.global_phase = -0.5
         self.assertEqual(qc.inverse(), expected)
 
+    def test_compare_two_equal_circuits(self):
+        """Test to compare that 2 circuits are equal.
+        """
+        qc1 = QuantumCircuit(2, 2)
+        qc1.h(0)
+
+        qc2 = QuantumCircuit(2, 2)
+        qc2.h(0)
+
+        self.assertTrue(qc1 == qc2)
+
+    def test_compare_two_different_circuits(self):
+        """Test to compare that 2 circuits are different.
+        """
+        qc1 = QuantumCircuit(2, 2)
+        qc1.h(0)
+
+        qc2 = QuantumCircuit(2, 2)
+        qc2.x(0)
+
+        self.assertFalse(qc1 == qc2)
+
+    def test_compare_a_circuit_with_none(self):
+        """Test to compare that a circuit is different to None.
+        """
+        qc1 = QuantumCircuit(2, 2)
+        qc1.h(0)
+
+        qc2 = None
+
+        self.assertFalse(qc1 == qc2)
 
 class TestCircuitBuilding(QiskitTestCase):
     """QuantumCircuit tests."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #5015 

### Details and comments
Checks that `other` parameter in `__eq__` is a `QuantumCircuit`. That way, if `None`, an empty `Instance` traitlet or anything different to a `QuantumCircuit` is provided it will return `False`.

