### PR TITLE
Inverse of MCX gates to include ancillae

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -267,7 +267,20 @@ class Instruction:
         """
         if self.definition is None:
             raise CircuitError("inverse() not implemented for %s." % self.name)
-        inverse_gate = self.copy(name=self.name + '_dg')
+
+        from qiskit.circuit import QuantumCircuit, Gate  # pylint: disable=cyclic-import
+        if self.num_clbits:
+            inverse_gate = Instruction(name=self.name + '_dg',
+                                       num_qubits=self.num_qubits,
+                                       num_clbits=self.num_clbits,
+                                       params=self.params.copy())
+
+        else:
+            inverse_gate = Gate(name=self.name + '_dg',
+                                num_qubits=self.num_qubits,
+                                params=self.params.copy())
+
+        inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs)
         inverse_gate.definition._data = [(inst.inverse(), qargs, cargs)
                                          for inst, qargs, cargs in reversed(self._definition)]
 

--- a/qiskit/circuit/library/standard_gates/sx.py
+++ b/qiskit/circuit/library/standard_gates/sx.py
@@ -76,6 +76,10 @@ class SXGate(Gate):
         qc.data = rules
         self.definition = qc
 
+    def inverse(self):
+        """Return inverse SX gate (i.e. SXdg)."""
+        return SXdgGate()
+
     def control(self, num_ctrl_qubits=1, label=None, ctrl_state=None):
         """Return a (multi-)controlled-SX gate.
 
@@ -149,6 +153,10 @@ class SXdgGate(Gate):
         ]
         qc.data = rules
         self.definition = qc
+
+    def inverse(self):
+        """Return inverse SXdg gate (i.e. SX)."""
+        return SXGate()
 
     def to_matrix(self):
         """Return a numpy.array for the SXdg gate."""

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -519,7 +519,7 @@ class C3XGate(ControlledGate):
 
     def inverse(self):
         """Invert this gate. The C3X is its own inverse."""
-        return C3XGate(angle=self._angle, ctrl_state=self.ctrl_state)
+        return C3XGate(angle=-self._angle, ctrl_state=self.ctrl_state)
 
     # This matrix is only correct if the angle is pi/4
     # def to_matrix(self):

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -752,6 +752,10 @@ class MCXGate(ControlledGate):
                          num_ctrl_qubits=num_ctrl_qubits, label=label, ctrl_state=ctrl_state)
         self.base_gate = XGate()
 
+    def inverse(self):
+        """Invert this gate. The MCX is its own inverse."""
+        return MCXGate(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
+
     @staticmethod
     def get_num_ancilla_qubits(num_ctrl_qubits, mode='noancilla'):
         """Get the number of required ancilla qubits without instantiating the class.
@@ -811,6 +815,10 @@ class MCXGrayCode(MCXGate):
     def __init__(self, num_ctrl_qubits, label=None, ctrl_state=None):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name='mcx_gray')
 
+    def inverse(self):
+        """Invert this gate. The MCX is its own inverse."""
+        return MCXGrayCode(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
+
     def _define(self):
         """Define the MCX gate using the Gray code."""
         # pylint: disable=cyclic-import
@@ -839,6 +847,10 @@ class MCXRecursive(MCXGate):
     def get_num_ancilla_qubits(num_ctrl_qubits, mode='recursion'):
         """Get the number of required ancilla qubits."""
         return MCXGate.get_num_ancilla_qubits(num_ctrl_qubits, mode)
+
+    def inverse(self):
+        """Invert this gate. The MCX is its own inverse."""
+        return MCXRecursive(num_ctrl_qubits=self.num_ctrl_qubits, ctrl_state=self.ctrl_state)
 
     def _define(self):
         """Define the MCX gate using recursion."""
@@ -895,6 +907,12 @@ class MCXVChain(MCXGate):
     def __init__(self, num_ctrl_qubits, dirty_ancillas=False, label=None, ctrl_state=None):
         super().__init__(num_ctrl_qubits, label=label, ctrl_state=ctrl_state, _name='mcx_vchain')
         self._dirty_ancillas = dirty_ancillas
+
+    def inverse(self):
+        """Invert this gate. The MCX is its own inverse."""
+        return MCXVChain(num_ctrl_qubits=self.num_ctrl_qubits,
+                         dirty_ancillas=self._dirty_ancillas,
+                         ctrl_state=self.ctrl_state)
 
     @staticmethod
     def get_num_ancilla_qubits(num_ctrl_qubits, mode='v-chain'):

--- a/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
+++ b/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
@@ -12,3 +12,8 @@ fixes:
     For ``C3XGate`` with a non-zero ``angle``, inverting the gate via
     ``C3XGate.inverse()`` had previously generated an incorrect inverse gate.
     This has been corrected.
+  - |
+    The ``MCXGate`` modes have been updated to return a gate of the same mode
+    when calling ``.inverse()``. This resolves an issue where in some cases,
+    transpiling a circuit containing the inverse of an ``MCXVChain`` gate would
+    raise an error.

--- a/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
+++ b/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
@@ -8,3 +8,7 @@ fixes:
     ``Instruction.inverse()``, when not overridden by a subclass, would in some
     cases return a ``Gate`` instance with an incorrect ``to_matrix`` method. The
     instances of incorrect ``to_matrix`` methods have been removed.
+  - |
+    For ``C3XGate`` with a non-zero ``angle``, inverting the gate via
+    ``C3XGate.inverse()`` had previously generated an incorrect inverse gate.
+    This has been corrected.

--- a/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
+++ b/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
@@ -4,3 +4,7 @@ fixes:
     ``SXGate().inverse()`` had previously returned an 'sx_dg' gate with a correct
     ``definition`` but incorrect ``to_matrix``. This has been updated such that
     ``SXGate().inverse()`` returns an ``SXdgGate()`` and vice versa.
+  - |
+    ``Instruction.inverse()``, when not overridden by a subclass, would in some
+    cases return a ``Gate`` instance with an incorrect ``to_matrix`` method. The
+    instances of incorrect ``to_matrix`` methods have been removed.

--- a/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
+++ b/releasenotes/notes/4953-Inverse-of-MCX-gates-generated-without-qubits-for-ancillae-d8858552eb2cd3f9.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    ``SXGate().inverse()`` had previously returned an 'sx_dg' gate with a correct
+    ``definition`` but incorrect ``to_matrix``. This has been updated such that
+    ``SXGate().inverse()`` returns an ``SXdgGate()`` and vice versa.

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -120,7 +120,6 @@ class TestGateDefinitions(QiskitTestCase):
 @ddt
 class TestStandardGates(QiskitTestCase):
     """Standard Extension Test."""
-
     @unpack
     @data(
         *inspect.getmembers(
@@ -151,6 +150,42 @@ class TestStandardGates(QiskitTestCase):
 
         if gate.definition is not None:
             self.assertEqual(gate.definition.parameters, set(param_vector))
+
+    @unpack
+    @data(
+        *inspect.getmembers(
+            standard_gates,
+            predicate=lambda value: (inspect.isclass(value)
+                                     and issubclass(value, Gate)))
+    )
+    def test_inverse(self, class_name, gate_class):
+        """Verify self-inverse pair yield identity for all standard gates."""
+
+        free_params = _get_free_params(gate_class)
+        n_params = len(free_params)
+        float_vector = [0.1 + 0.1*i for i in range(n_params)]
+
+        if class_name in ('MCPhaseGate', 'MCU1Gate'):
+            float_vector = float_vector[:-1]
+            gate = gate_class(*float_vector, num_ctrl_qubits=2)
+        elif class_name in ('MCXGate', 'MCXGrayCode', 'MCXRecursive', 'MCXVChain'):
+            num_ctrl_qubits = 3
+            float_vector = float_vector[:-1]
+            gate = gate_class(num_ctrl_qubits, *float_vector)
+        elif class_name == 'MSGate':
+            num_qubits = 3
+            float_vector = float_vector[:-1]
+            gate = gate_class(num_qubits, *float_vector)
+        else:
+            gate = gate_class(*float_vector)
+
+        from qiskit.quantum_info.operators.predicates import is_identity_matrix
+
+        self.assertTrue(is_identity_matrix(Operator(gate).dot(gate.inverse()).data))
+
+        if gate.definition is not None:
+            self.assertTrue(is_identity_matrix(Operator(gate).dot(gate.definition.inverse()).data))
+            self.assertTrue(is_identity_matrix(Operator(gate).dot(gate.inverse().definition).data))
 
 
 class TestGateEquivalenceEqual(QiskitTestCase):


### PR DESCRIPTION

### Summary

Resolves #4953 by adding `inverse` methods to the `MCXGate` modes which return gates of the same mode.

### Details and comments

Also, fixes some small related bugs that came up during testing:
- `SXGate().inverse()` to return `SXdgGate()` and vice versa.
- `Instruction.inverse` to no longer return modified copy of input gate.
  This is necessary for gates which do not have a defined `inverse` method and are not self-adjoint (e.g. DCX, iSwap), because the returned gate would have an updated `definition`, but still incorrectly retain properties of the original gate (namely `to_matrix`).
- Fix `C3XGate.inverse` to negate angle if non-zero.




