### PR TITLE
Passmanager.remove(index)

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -109,7 +109,7 @@ class PassManager:
             flow_controller_conditions: control flow plugins.
 
         Raises:
-            TranspilerError: if a pass in passes is not a proper pass.
+            TranspilerError: if the index is not found.
 
         See Also:
             ``RunningPassManager.add_flow_controller()`` for more information about the control

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -127,6 +127,17 @@ class PassManager:
         except IndexError:
             raise TranspilerError('Index to replace %s does not exists' % index)
 
+    def remove(self, index: int) -> None:
+        """Removes a particular pass in the scheduler.
+
+        Args:
+            index: Pass index to replace, based on the position in passes().
+        """
+        try:
+            del self._pass_sets[index]
+        except IndexError:
+            raise TranspilerError('Index to replace %s does not exists' % index)
+
     def __setitem__(self, index, item):
         self.replace(index, item)
 
@@ -161,7 +172,6 @@ class PassManager:
     def _normalize_passes(passes: Union[BasePass, List[BasePass]]) -> List[BasePass]:
         if isinstance(passes, BasePass):
             passes = [passes]
-
         for pass_ in passes:
             if not isinstance(pass_, BasePass):
                 raise TranspilerError('%s is not a pass instance' % pass_.__class__)

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -109,7 +109,7 @@ class PassManager:
             flow_controller_conditions: control flow plugins.
 
         Raises:
-            TranspilerError: if the index is not found.
+            TranspilerError: if a pass in passes is not a proper pass or index not found.
 
         See Also:
             ``RunningPassManager.add_flow_controller()`` for more information about the control
@@ -132,6 +132,9 @@ class PassManager:
 
         Args:
             index: Pass index to replace, based on the position in passes().
+
+        Raises:
+            TranspilerError: if the index is not found.
         """
         try:
             del self._pass_sets[index]

--- a/releasenotes/notes/passmanager_remove-c8f8c0b44ce89756.yaml
+++ b/releasenotes/notes/passmanager_remove-c8f8c0b44ce89756.yaml
@@ -1,0 +1,35 @@
+---
+features:
+  - |
+    The new method :meth:`~qiskit.transpiler.passmanager.PassManager.remove`
+    allows to remove a pass in a `PassManager` instance. It works with indexes, like
+    :meth:`~qiskit.transpiler.passmanager.PassManager.replace`. For example, let's 
+    remove the `RemoveResetInZeroState` pass from the pass manager used at
+    optimization level 1:
+
+    .. code-block:: python
+
+      from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
+      from qiskit.transpiler.passmanager_config import PassManagerConfig
+      
+      pm = level_1_pass_manager(PassManagerConfig())
+      pm.draw()
+
+    .. code-block::
+
+      [0] FlowLinear: UnrollCustomDefinitions, BasisTranslator
+      [1] FlowLinear: RemoveResetInZeroState
+      [2] DoWhile: Depth, FixedPoint, Optimize1qGates, CXCancellation
+
+    The stage `[1]` with `RemoveResetInZeroState` can be removed like this:
+
+    .. code-block:: python
+
+      pass_manager.remove(1)
+      pass_manager.draw()
+
+    .. code-block::
+
+      [0] FlowLinear: UnrollCustomDefinitions, BasisTranslator
+      [1] DoWhile: Depth, FixedPoint, Optimize1qGates, CXCancellation
+    

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -695,8 +695,8 @@ class TestPassManagerReuse(SchedulerTestCase):
         self.assertScheduler(self.circuit, self.passmanager, expected)
 
 
-class TestPassManagerReplace(SchedulerTestCase):
-    """Test PassManager.replace"""
+class TestPassManagerChanges(SchedulerTestCase):
+    """Test PassManager manipulation with changes"""
 
     def setUp(self):
         self.passmanager = PassManager()
@@ -719,6 +719,28 @@ class TestPassManagerReplace(SchedulerTestCase):
         self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
 
         self.passmanager.replace(1, PassC_TP_RA_PA())
+
+        expected = ['run transformation pass PassA_TP_NR_NP',
+                    'run transformation pass PassC_TP_RA_PA']
+        self.assertScheduler(self.circuit, self.passmanager, expected)
+
+    def test_remove0(self):
+        """ Test passmanager.remove(0, ...)."""
+        self.passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
+        self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
+
+        self.passmanager.remove(0)
+
+        expected = ['run transformation pass PassA_TP_NR_NP',
+                    'run transformation pass PassB_TP_RA_PA']
+        self.assertScheduler(self.circuit, self.passmanager, expected)
+
+    def test_remove1(self):
+        """ Test passmanager.remove(1, ...)."""
+        self.passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
+        self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
+
+        self.passmanager.remove(1)
 
         expected = ['run transformation pass PassA_TP_NR_NP',
                     'run transformation pass PassC_TP_RA_PA']

--- a/test/python/transpiler/test_pass_scheduler.py
+++ b/test/python/transpiler/test_pass_scheduler.py
@@ -725,7 +725,7 @@ class TestPassManagerChanges(SchedulerTestCase):
         self.assertScheduler(self.circuit, self.passmanager, expected)
 
     def test_remove0(self):
-        """ Test passmanager.remove(0, ...)."""
+        """ Test passmanager.remove(0)."""
         self.passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
         self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
 
@@ -736,7 +736,7 @@ class TestPassManagerChanges(SchedulerTestCase):
         self.assertScheduler(self.circuit, self.passmanager, expected)
 
     def test_remove1(self):
-        """ Test passmanager.remove(1, ...)."""
+        """ Test passmanager.remove(1)."""
         self.passmanager.append(PassC_TP_RA_PA())  # Request: PassA / Preserves: PassA
         self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
 
@@ -744,6 +744,16 @@ class TestPassManagerChanges(SchedulerTestCase):
 
         expected = ['run transformation pass PassA_TP_NR_NP',
                     'run transformation pass PassC_TP_RA_PA']
+        self.assertScheduler(self.circuit, self.passmanager, expected)
+
+    def test_remove_minus_1(self):
+        """ Test passmanager.remove(-1)."""
+        self.passmanager.append(PassA_TP_NR_NP())
+        self.passmanager.append(PassB_TP_RA_PA())  # Request: PassA / Preserves: PassA
+
+        self.passmanager.remove(-1)
+
+        expected = ['run transformation pass PassA_TP_NR_NP']
         self.assertScheduler(self.circuit, self.passmanager, expected)
 
     def test_setitem(self):


### PR DESCRIPTION
Fixes #5023

```python
from qiskit.transpiler.passmanager_config import PassManagerConfig
from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
pm = level_1_pass_manager(PassManagerConfig())
pm.draw()
```

![image](https://user-images.githubusercontent.com/766693/92147979-dd0cfc00-ede9-11ea-9532-f3455a49901c.png)
```python
pm.remove(1)
pm.draw()
```

![image](https://user-images.githubusercontent.com/766693/92147993-e4340a00-ede9-11ea-917e-cdb3fd2aea47.png)
