### PR TITLE
monospaced_output magic for a nicer print(circuit)

### DIFF
--- a/qiskit/tools/jupyter/__init__.py
+++ b/qiskit/tools/jupyter/__init__.py
@@ -88,6 +88,14 @@ Qiskit copyright
     import qiskit.tools.jupyter
     %qiskit_copyright
 
+Monospaced output
+=================
+
+.. jupyter-execute::
+
+    import qiskit.tools.jupyter
+    %monospaced_output
+
 """
 import warnings
 
@@ -98,6 +106,7 @@ from .jupyter_magics import (ProgressBarMagic, StatusMagic)
 from .progressbar import HTMLProgressBar
 from .version_table import VersionTable
 from .copyright import Copyright
+from .monospace import MonospacedOutput
 from .job_watcher import JobWatcher, JobWatcherMagic
 
 if HAS_MATPLOTLIB:
@@ -115,6 +124,7 @@ _IP = get_ipython()
 if _IP is not None:
     _IP.register_magics(ProgressBarMagic)
     _IP.register_magics(VersionTable)
+    _IP.register_magics(MonospacedOutput)
     _IP.register_magics(Copyright)
     _IP.register_magics(JobWatcherMagic)
     if HAS_MATPLOTLIB:

--- a/qiskit/tools/jupyter/monospace.py
+++ b/qiskit/tools/jupyter/monospace.py
@@ -1,0 +1,31 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=unused-argument
+
+"""A Jupyter magic to choose a real monospaced fonts, if available."""
+
+from IPython.display import HTML, display               # pylint: disable=import-error
+from IPython.core.magic import (line_magic,             # pylint: disable=import-error
+                                Magics, magics_class)
+
+
+@magics_class
+class MonospacedOutput(Magics):
+    """A class for setting "Courier New" for output code.
+    """
+    @line_magic
+    def monospaced_output(self, line='', cell=None):
+        """A Jupyter magic function to set "Courier New" for output code.
+        """
+        html = '''<style type='text/css'>
+        code, kbd, pre, samp {font-family: Courier New,monospace;line-height: 1.1;}</style>'''
+        display(HTML(html))

--- a/releasenotes/notes/monospaced_magic-4716fbc6aec82f5f.yaml
+++ b/releasenotes/notes/monospaced_magic-4716fbc6aec82f5f.yaml
@@ -6,6 +6,8 @@ features:
     text circuit drawings that are better aligned.
 
     .. code-block:: python
+
       import qiskit.tools.jupyter
       %monospaced_output
+
     .. code-block::

--- a/releasenotes/notes/monospaced_magic-4716fbc6aec82f5f.yaml
+++ b/releasenotes/notes/monospaced_magic-4716fbc6aec82f5f.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    The new jupyter magic :meth:`~qiskit.tools.jupyter.monospace.MonospacedOutput.monospaced_output`
+    allows to the Jupyter notebook output font to "Courier New", when possible. This fonts returns
+    text circuit drawings that are better aligned.
+
+    .. code-block:: python
+      import qiskit.tools.jupyter
+      %monospaced_output
+    .. code-block::


### PR DESCRIPTION
Printing circuit in Jupyter notebooks is relatively common use case. For example, printing circuits in a loop. When `print(circuit)`, the `TextDrawing._repr_html_` method is not called (this happens only when Jupyter shows `circuit.draw('text')`. This creates an ugly output when `print(circuit)`.
<img width="540" alt="Screen Shot 2020-09-04 at 2 51 05 PM" src="https://user-images.githubusercontent.com/766693/92276777-a9040a80-eebf-11ea-8d10-8fbcf41baa49.png">

This PR adds the magic `%monospaced_output`, solving the issue:
<img width="535" alt="Screen Shot 2020-09-04 at 2 52 04 PM" src="https://user-images.githubusercontent.com/766693/92276898-e1a3e400-eebf-11ea-8bfa-83173efdbc4c.png">
