### PR TITLE
Fix random crashes on TextProgressBar

### DIFF
--- a/qiskit/tools/events/progressbar.py
+++ b/qiskit/tools/events/progressbar.py
@@ -153,6 +153,10 @@ class TextProgressBar(BaseProgressBar):
                                   (pbar, 0, '/', self.iter, ''))
 
     def update(self, n):
+        # Don't update if we are not initialized or
+        # the update iteration number is greater than the total iterations set on start.
+        if not self.touched or n > self.iter:
+            return
         filled_length = int(round(50 * n / self.iter))
         pbar = '█' * filled_length + '-' * (50 - filled_length)
         time_left = self.time_remaining_est(n)

--- a/qiskit/tools/events/pubsub.py
+++ b/qiskit/tools/events/pubsub.py
@@ -52,7 +52,7 @@ class _Broker:
             """Overrides the default implementation"""
             if isinstance(other, self.__class__):
                 return self.event == other.event and \
-                       self.callback.__name__ == other.callback.__name__
+                       id(self.callback) == id(other.callback)  # Allow 1:N subscribers
             return False
 
     def subscribe(self, event, callback):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5012.

### Details and comments

It allows more than one subscriber per event, so that bad subscribers
don't block good subscribers from getting events. It does this by changing
the internal _Subscriber class to determine equality based on the callback
function object id, instead of just by name.

To prevent errors described in #5012, it avoids running the progress bar update if it
has not been initialized yet (i.e. start() has not run yet). It also
skips update when it doesn't make sense (e.g. step iteration is greater than
the set total number of iterations on start).

This is sensitive to object ids in order to work, so as long as the callbacks
are dynamically defined functions, this will work.