### PR TITLE
Fix latex circuit drawer handling of circuits without gates

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -299,7 +299,8 @@ class QCircuitImage:
         columns = 2
 
         # add extra column if needed
-        if self.cregbundle and (self.ops[0][0].name == "measure" or self.ops[0][0].condition):
+        if self.cregbundle and (self.ops and self.ops[0] and
+                                (self.ops[0][0].name == "measure" or self.ops[0][0].condition)):
             columns += 1
 
         # all gates take up 1 column except from those with labels (ie cu1)
@@ -382,7 +383,8 @@ class QCircuitImage:
 
         column = 1
         # Leave a column to display number of classical registers if needed
-        if self.cregbundle and (self.ops[0][0].name == "measure" or self.ops[0][0].condition):
+        if self.cregbundle and (self.ops and self.ops[0] and
+                                (self.ops[0][0].name == "measure" or self.ops[0][0].condition)):
             column += 1
         for layer in self.ops:
             num_cols_used = 1

--- a/test/python/visualization/test_visualization.py
+++ b/test/python/visualization/test_visualization.py
@@ -31,7 +31,7 @@ class TestLatexSourceGenerator(QiskitTestCase):
     """Qiskit latex source generator tests."""
 
     def test_empty_circuit(self):
-        """Test draw an empty circuit (edge case)."""
+        """Test draw an empty circuit"""
         filename = self._get_resource_path('test_tiny.tex')
         qc = QuantumCircuit(1)
         try:

--- a/test/python/visualization/test_visualization.py
+++ b/test/python/visualization/test_visualization.py
@@ -30,6 +30,17 @@ logger = logging.getLogger(__name__)
 class TestLatexSourceGenerator(QiskitTestCase):
     """Qiskit latex source generator tests."""
 
+    def test_empty_circuit(self):
+        """Test draw an empty circuit (edge case)."""
+        filename = self._get_resource_path('test_tiny.tex')
+        qc = QuantumCircuit(1)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
     def test_tiny_circuit(self):
         """Test draw tiny circuit."""
         filename = self._get_resource_path('test_tiny.tex')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5025 by checking that `self.ops` list is not empty, before checking its first element.

### Details and comments

The issue seems to be that `self.ops` is empty, but its first element is checked in `if self.cregbundle and self.ops[0][0].name == "measure"`
https://github.com/Qiskit/qiskit-terra/blob/master/qiskit/visualization/latex.py#L302

Now, if I have understood correctly, `self.ops` is the list of layers in the circuit.
I noticed that in text.py this list is handled differently (called `instructions` there, but still, if I'm not mistaken...), so my guess is that it's OK for `self.ops` to be empty, and it's fine just checking it before accessing its first element.

**Question**: how come test_visualization.py (TestLatexSourceGenerator) wasn't failing earlier? There are tests about latex conversion...
**Answered**:  this fails only on empty circuits, adding a single gate is enough to avoid the error. 
In the tests, all circuits are non-empty: I added a test for an empty circuit, and verified it was failing before the change, and not anymore afterwards.
(Note: I ran style, lint and tests locally - there are 9 test failing, but they all seem unrelated to this issue).
