### PR TITLE
QuantumCircuit.extend updates cached bits

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -539,9 +539,11 @@ class QuantumCircuit:
         for element in rhs.qregs:
             if element not in self.qregs:
                 self.qregs.append(element)
+                self._qubits += element[:]
         for element in rhs.cregs:
             if element not in self.cregs:
                 self.cregs.append(element)
+                self._clbits += element[:]
 
         # Copy the circuit data if rhs and self are the same, otherwise the data of rhs is
         # appended to both self and rhs resulting in an infinite loop

--- a/releasenotes/notes/extend-updates-cached-qubits-2dbafe010bd5a946.yaml
+++ b/releasenotes/notes/extend-updates-cached-qubits-2dbafe010bd5a946.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Extending circuits with differing registers updated the ``qregs`` and 
+    ``cregs`` properties accordingly, but not the ``qubits`` and ``clbits`` 
+    lists. As these are no longer generated from the registers but are cached
+    lists, this lead to a discrepancy of registers and bits. This has been 
+    fixed and the ``extend`` method explicitly updates the cached bit lists.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -135,7 +135,7 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(counts, target)
 
     def test_extend_circuit_fail(self):
-        """Test extending a circuits fails if registers incompatible.
+        """Test extending a circuit fails if registers incompatible.
 
         If two circuits have same name register of different size or type
         it should raise a CircuitError.
@@ -149,6 +149,15 @@ class TestCircuitOperations(QiskitTestCase):
 
         self.assertRaises(CircuitError, qc1.__iadd__, qc2)
         self.assertRaises(CircuitError, qc1.__iadd__, qcr3)
+
+    def test_extend_circuit_adds_qubits(self):
+        """Test extending a circuits with differing registers adds the qubits."""
+        qr = QuantumRegister(1, "q")
+        qc = QuantumCircuit(qr)
+        empty = QuantumCircuit()
+        empty.extend(qc)
+
+        self.assertListEqual(empty.qubits, qr[:])
 
     def test_measure_args_type_cohesion(self):
         """Test for proper args types for measure function.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5038.

### Details and comments

Extending circuits with differing registers didn't updates the cached list of qubits. 
