### PR TITLE
Add missing __init__.py to template_circuits

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
+            pip install -c constraints.txt .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz

--- a/qiskit/circuit/library/template_circuits/__init__.py
+++ b/qiskit/circuit/library/template_circuits/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a missing `__init__.py` file to
`qiskit/circuits/library/template_circuits`, without this `__init__.py` the
template_circuits directory is not a valid python package. This means
it's `qiskit.circuit.library.template_circuits` is not a valid python
path, which means tooling that relies on this in python like unittest
discovery or critically in this case `setuptools.find_packages()` would
not see this package and it would be excluded. This results in
ModuleNotFoundErrors when installing the package. However, in the case
where an editable install was used this wouldn't cause a hard error
because the editable install is just a symlink to the source repo and
since the module was only accessed via relative imports it would be
found. Adding the missing `__init__.py` will fix this issue in the
scenarios it was broken.

At the same time to catch issues like this in the future the pip install
-e is removed from one of the CI jobs to ensure we install the package
instead of just symlinking. This will catch issues with missing packages
since we have setuptools copy the files from the package at install
time, so if we're missing an `__init__.py` this will fail tests since it's
not in the installed copy.

### Details and comments

Fixes #5058
