### PR TITLE
Improve the circuit latex (source) drawer testing

### DIFF
--- a/test/python/visualization/references/test_4597.tex
+++ b/test/python/visualization/references/test_4597.tex
@@ -1,7 +1,7 @@
 % \documentclass[preview]{standalone}
 % If the image is too large to fit on this documentclass use
 \documentclass[draft]{beamer}
-% img_width = 3, img_depth = 3
+% img_width = 4, img_depth = 4
 \usepackage[size=custom,height=10,width=10,scale=0.7]{beamerposter}
 % instead and customize the height and width (in cm) to fit.
 % Large images may run out of memory quickly.
@@ -14,12 +14,12 @@
 % Comment out the above line if using the beamer documentclass.
 \begin{document}
 
-{\small Global Phase: $\frac{\pi}{2}$}
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \gate{H} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \qw & \gate{X} & \qw & \qw\\
+	 	\lstick{c:} & {/_{_{3}}} \cw & \control \cw \cwx[-1] & \cw & \cw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_deep.tex
+++ b/test/python/visualization/references/test_deep.tex
@@ -1,0 +1,23 @@
+% \documentclass[preview]{standalone}
+% If the image is too large to fit on this documentclass use
+\documentclass[draft]{beamer}
+% img_width = 1, img_depth = 102
+\usepackage[size=custom,height=10,width=159,scale=0.7]{beamerposter}
+% instead and customize the height and width (in cm) to fit.
+% Large images may run out of memory quickly.
+% To fix this use the LuaLaTeX compiler, which dynamically
+% allocates memory.
+\usepackage[braket, qm]{qcircuit}
+\usepackage{amsmath}
+\pdfmapfile{+sansmathaccent.map}
+% \usepackage[landscape]{geometry}
+% Comment out the above line if using the beamer documentclass.
+\begin{document}
+
+\begin{equation*}
+    \Qcircuit @C=1.0em @R=0.0em @!R {
+	 	\lstick{ {q}_{0} :  } & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \gate{H} & \qw & \qw\\
+	 }
+\end{equation*}
+
+\end{document}

--- a/test/python/visualization/references/test_empty.tex
+++ b/test/python/visualization/references/test_empty.tex
@@ -1,7 +1,7 @@
 % \documentclass[preview]{standalone}
 % If the image is too large to fit on this documentclass use
 \documentclass[draft]{beamer}
-% img_width = 3, img_depth = 3
+% img_width = 1, img_depth = 2
 \usepackage[size=custom,height=10,width=10,scale=0.7]{beamerposter}
 % instead and customize the height and width (in cm) to fit.
 % Large images may run out of memory quickly.
@@ -14,12 +14,9 @@
 % Comment out the above line if using the beamer documentclass.
 \begin{document}
 
-{\small Global Phase: $\frac{\pi}{2}$}
 \begin{equation*}
-    \Qcircuit @C=1.0em @R=0.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \gate{H} & \qw & \qw\\
+    \Qcircuit @C=1.0em @R=1.0em @!R {
+	 	\lstick{ {q}_{0} :  } & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_huge.tex
+++ b/test/python/visualization/references/test_huge.tex
@@ -1,0 +1,62 @@
+% \documentclass[preview]{standalone}
+% If the image is too large to fit on this documentclass use
+\documentclass[draft]{beamer}
+% img_width = 40, img_depth = 42
+\usepackage[size=custom,height=60,width=69,scale=0.7]{beamerposter}
+% instead and customize the height and width (in cm) to fit.
+% Large images may run out of memory quickly.
+% To fix this use the LuaLaTeX compiler, which dynamically
+% allocates memory.
+\usepackage[braket, qm]{qcircuit}
+\usepackage{amsmath}
+\pdfmapfile{+sansmathaccent.map}
+% \usepackage[landscape]{geometry}
+% Comment out the above line if using the beamer documentclass.
+\begin{document}
+
+\begin{equation*}
+    \Qcircuit @C=1.0em @R=0.0em @!R {
+	 	\lstick{ {q}_{0} :  } & \gate{H} & \ctrl{39} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \gate{H} & \qw & \ctrl{38} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \gate{H} & \qw & \qw & \ctrl{37} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \gate{H} & \qw & \qw & \qw & \ctrl{36} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \gate{H} & \qw & \qw & \qw & \qw & \ctrl{35} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{5} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \ctrl{34} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{6} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{33} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{7} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{32} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{8} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{31} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{9} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{30} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{10} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{29} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{11} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{28} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{12} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{27} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{13} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{26} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{14} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{25} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{15} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{24} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{16} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{23} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{17} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{22} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{18} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{21} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{19} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{20} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{20} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{19} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{21} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{18} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{22} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{17} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{23} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{16} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{24} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{15} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{25} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{14} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{26} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{13} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{27} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{12} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{28} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{11} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{29} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{10} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{30} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{9} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{31} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{8} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{32} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{7} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{33} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{6} & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{34} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{5} & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{35} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{4} & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{36} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{3} & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{37} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{2} & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{38} :  } & \gate{H} & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \ctrl{1} & \qw & \qw\\
+	 	\lstick{ {q}_{39} :  } & \qw & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \targ & \qw & \qw\\
+	 }
+\end{equation*}
+
+\end{document}

--- a/test/python/visualization/references/test_normal.tex
+++ b/test/python/visualization/references/test_normal.tex
@@ -1,7 +1,7 @@
 % \documentclass[preview]{standalone}
 % If the image is too large to fit on this documentclass use
 \documentclass[draft]{beamer}
-% img_width = 3, img_depth = 3
+% img_width = 5, img_depth = 3
 \usepackage[size=custom,height=10,width=10,scale=0.7]{beamerposter}
 % instead and customize the height and width (in cm) to fit.
 % Large images may run out of memory quickly.
@@ -14,12 +14,13 @@
 % Comment out the above line if using the beamer documentclass.
 \begin{document}
 
-{\small Global Phase: $\frac{\pi}{2}$}
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.0em @!R {
 	 	\lstick{ {q}_{0} :  } & \gate{H} & \qw & \qw\\
 	 	\lstick{ {q}_{1} :  } & \gate{H} & \qw & \qw\\
 	 	\lstick{ {q}_{2} :  } & \gate{H} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \gate{H} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \gate{H} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_teleport.tex
+++ b/test/python/visualization/references/test_teleport.tex
@@ -1,0 +1,26 @@
+% \documentclass[preview]{standalone}
+% If the image is too large to fit on this documentclass use
+\documentclass[draft]{beamer}
+% img_width = 4, img_depth = 10
+\usepackage[size=custom,height=10,width=25,scale=0.7]{beamerposter}
+% instead and customize the height and width (in cm) to fit.
+% Large images may run out of memory quickly.
+% To fix this use the LuaLaTeX compiler, which dynamically
+% allocates memory.
+\usepackage[braket, qm]{qcircuit}
+\usepackage{amsmath}
+\pdfmapfile{+sansmathaccent.map}
+% \usepackage[landscape]{geometry}
+% Comment out the above line if using the beamer documentclass.
+\begin{document}
+
+\begin{equation*}
+    \Qcircuit @C=1.0em @R=0.0em @!R {
+	 	\lstick{ {q}_{0} :  } & \gate{U_3(0.3,0.2,0.1)} & \qw \barrier[0em]{2} & \qw & \ctrl{1} & \gate{H} & \meter & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \gate{H} & \ctrl{1} & \qw & \targ & \meter & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \qw & \targ & \qw & \gate{Z} & \qw & \qw & \gate{X} & \meter & \qw & \qw\\
+	 	\lstick{c:} & {/_{_{3}}} \cw & \cw & \cw & \control \cw \cwx[-1] & \dstick{1} \cw \cwx[-2] & \dstick{0} \cw \cwx[-3] & \control \cw \cwx[-1] & \dstick{2} \cw \cwx[-1] & \cw & \cw\\
+	 }
+\end{equation*}
+
+\end{document}

--- a/test/python/visualization/references/test_tiny.tex
+++ b/test/python/visualization/references/test_tiny.tex
@@ -1,7 +1,7 @@
 % \documentclass[preview]{standalone}
 % If the image is too large to fit on this documentclass use
 \documentclass[draft]{beamer}
-% img_width = 3, img_depth = 3
+% img_width = 1, img_depth = 3
 \usepackage[size=custom,height=10,width=10,scale=0.7]{beamerposter}
 % instead and customize the height and width (in cm) to fit.
 % Large images may run out of memory quickly.
@@ -14,12 +14,9 @@
 % Comment out the above line if using the beamer documentclass.
 \begin{document}
 
-{\small Global Phase: $\frac{\pi}{2}$}
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.0em @!R {
 	 	\lstick{ {q}_{0} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \gate{H} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \gate{H} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -12,36 +12,15 @@
 
 """Tests for visualization of circuit with Latex drawer."""
 
-import os
 import unittest
-from filecmp import cmp as cmpfile
-from shutil import copyfile
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.visualization import circuit_drawer
-from qiskit.test import QiskitTestCase
-
-def path_to_reference(filename):
-    return os.path.join(_this_directory(), 'references', filename)
+from .visualization import QiskitVisualizationTestCase
 
 
-def _this_directory():
-    return os.path.dirname(os.path.abspath(__file__))
-
-
-class TestLatexSourceGenerator(QiskitTestCase):
+class TestLatexSourceGenerator(QiskitVisualizationTestCase):
     """Qiskit latex source generator tests."""
-
-    def assertEqualToReference(self, result):
-        reference = path_to_reference(os.path.basename(result))
-        if not os.path.exists(result):
-            raise self.failureException('Result file was not generated.')
-        if not os.path.exists(reference):
-            copyfile(result, reference)
-        if cmpfile(reference, result):
-            os.remove(result)
-        else:
-            raise self.failureException('Result and reference do not match.')
 
     def test_empty_circuit(self):
         """Test draw an empty circuit"""

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -1,0 +1,156 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+# pylint: disable=anomalous-backslash-in-string
+
+"""Tests for visualization tools."""
+
+import os
+import logging
+import unittest
+
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit import Qubit, Clbit
+from qiskit.visualization import utils
+from qiskit.visualization import circuit_drawer
+from qiskit.test import QiskitTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestLatexSourceGenerator(QiskitTestCase):
+    """Qiskit latex source generator tests."""
+
+    def test_empty_circuit(self):
+        """Test draw an empty circuit"""
+        filename = self._get_resource_path('test_tiny.tex')
+        qc = QuantumCircuit(1)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_tiny_circuit(self):
+        """Test draw tiny circuit."""
+        filename = self._get_resource_path('test_tiny.tex')
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_normal_circuit(self):
+        """Test draw normal size circuit."""
+        filename = self._get_resource_path('test_normal.tex')
+        qc = QuantumCircuit(5)
+        for qubit in range(5):
+            qc.h(qubit)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_4597(self):
+        """Test cregbundle and conditional gates.
+        See: https://github.com/Qiskit/qiskit-terra/pull/4597 """
+        filename = self._get_resource_path('test_4597.tex')
+        qr = QuantumRegister(3, 'q')
+        cr = ClassicalRegister(3, 'c')
+        qc = QuantumCircuit(qr, cr)
+        qc.x(qr[2]).c_if(cr, 2)
+        qc.draw(output='latex_source', cregbundle=True)
+
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_deep_circuit(self):
+        """Test draw deep circuit."""
+        filename = self._get_resource_path('test_deep.tex')
+        qc = QuantumCircuit(1)
+        for _ in range(100):
+            qc.h(0)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_huge_circuit(self):
+        """Test draw huge circuit."""
+        filename = self._get_resource_path('test_huge.tex')
+        qc = QuantumCircuit(40)
+        for qubit in range(39):
+            qc.h(qubit)
+            qc.cx(qubit, 39)
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_teleport(self):
+        """Test draw teleport circuit."""
+        filename = self._get_resource_path('test_teleport.tex')
+        qr = QuantumRegister(3, 'q')
+        cr = ClassicalRegister(3, 'c')
+        qc = QuantumCircuit(qr, cr)
+        # Prepare an initial state
+        qc.u3(0.3, 0.2, 0.1, qr[0])
+        # Prepare a Bell pair
+        qc.h(qr[1])
+        qc.cx(qr[1], qr[2])
+        # Barrier following state preparation
+        qc.barrier(qr)
+        # Measure in the Bell basis
+        qc.cx(qr[0], qr[1])
+        qc.h(qr[0])
+        qc.measure(qr[0], cr[0])
+        qc.measure(qr[1], cr[1])
+        # Apply a correction
+        qc.z(qr[2]).c_if(cr, 1)
+        qc.x(qr[2]).c_if(cr, 2)
+        qc.measure(qr[2], cr[2])
+        try:
+            circuit_drawer(qc, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def test_global_phase(self):
+        """Test circuit with global phase"""
+        filename = self._get_resource_path('test_global_phase.tex')
+        circuit = QuantumCircuit(3, global_phase=1.57079632679)
+        circuit.h(range(3))
+        try:
+            circuit_drawer(circuit, filename=filename, output='latex_source')
+            self.assertNotEqual(os.path.exists(filename), False)
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -10,48 +10,56 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=anomalous-backslash-in-string
-
-"""Tests for visualization tools."""
+"""Tests for visualization of circuit with Latex drawer."""
 
 import os
-import logging
 import unittest
+from filecmp import cmp as cmpfile
+from shutil import copyfile
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit import Qubit, Clbit
-from qiskit.visualization import utils
 from qiskit.visualization import circuit_drawer
 from qiskit.test import QiskitTestCase
 
-logger = logging.getLogger(__name__)
+def path_to_reference(filename):
+    return os.path.join(_this_directory(), 'references', filename)
+
+
+def _this_directory():
+    return os.path.dirname(os.path.abspath(__file__))
 
 
 class TestLatexSourceGenerator(QiskitTestCase):
     """Qiskit latex source generator tests."""
 
+    def assertEqualToReference(self, result):
+        reference = path_to_reference(os.path.basename(result))
+        if not os.path.exists(result):
+            raise self.failureException('Result file was not generated.')
+        if not os.path.exists(reference):
+            copyfile(result, reference)
+        if cmpfile(reference, result):
+            os.remove(result)
+        else:
+            raise self.failureException('Result and reference do not match.')
+
     def test_empty_circuit(self):
         """Test draw an empty circuit"""
-        filename = self._get_resource_path('test_tiny.tex')
+        filename = self._get_resource_path('test_empty.tex')
         qc = QuantumCircuit(1)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_tiny_circuit(self):
         """Test draw tiny circuit."""
         filename = self._get_resource_path('test_tiny.tex')
         qc = QuantumCircuit(1)
         qc.h(0)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_normal_circuit(self):
         """Test draw normal size circuit."""
@@ -59,12 +67,10 @@ class TestLatexSourceGenerator(QiskitTestCase):
         qc = QuantumCircuit(5)
         for qubit in range(5):
             qc.h(qubit)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_4597(self):
         """Test cregbundle and conditional gates.
@@ -76,12 +82,9 @@ class TestLatexSourceGenerator(QiskitTestCase):
         qc.x(qr[2]).c_if(cr, 2)
         qc.draw(output='latex_source', cregbundle=True)
 
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_deep_circuit(self):
         """Test draw deep circuit."""
@@ -89,12 +92,10 @@ class TestLatexSourceGenerator(QiskitTestCase):
         qc = QuantumCircuit(1)
         for _ in range(100):
             qc.h(0)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_huge_circuit(self):
         """Test draw huge circuit."""
@@ -103,12 +104,10 @@ class TestLatexSourceGenerator(QiskitTestCase):
         for qubit in range(39):
             qc.h(qubit)
             qc.cx(qubit, 39)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_teleport(self):
         """Test draw teleport circuit."""
@@ -132,24 +131,20 @@ class TestLatexSourceGenerator(QiskitTestCase):
         qc.z(qr[2]).c_if(cr, 1)
         qc.x(qr[2]).c_if(cr, 2)
         qc.measure(qr[2], cr[2])
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(qc, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
     def test_global_phase(self):
         """Test circuit with global phase"""
         filename = self._get_resource_path('test_global_phase.tex')
         circuit = QuantumCircuit(3, global_phase=1.57079632679)
         circuit.h(range(3))
-        try:
-            circuit_drawer(circuit, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
+
+        circuit_drawer(circuit, filename=filename, output='latex_source')
+
+        self.assertEqualToReference(filename)
 
 
 if __name__ == '__main__':

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -10,21 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=anomalous-backslash-in-string
-
 """Tests for visualization tools."""
 
-import os
-import logging
 import unittest
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Qubit, Clbit
 from qiskit.visualization import utils
-from qiskit.visualization import circuit_drawer
 from qiskit.test import QiskitTestCase
-
-logger = logging.getLogger(__name__)
 
 
 class TestVisualizationUtils(QiskitTestCase):

--- a/test/python/visualization/test_utils.py
+++ b/test/python/visualization/test_utils.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017.
+# (C) Copyright IBM 2020.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -25,131 +25,6 @@ from qiskit.visualization import circuit_drawer
 from qiskit.test import QiskitTestCase
 
 logger = logging.getLogger(__name__)
-
-
-class TestLatexSourceGenerator(QiskitTestCase):
-    """Qiskit latex source generator tests."""
-
-    def test_empty_circuit(self):
-        """Test draw an empty circuit"""
-        filename = self._get_resource_path('test_tiny.tex')
-        qc = QuantumCircuit(1)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_tiny_circuit(self):
-        """Test draw tiny circuit."""
-        filename = self._get_resource_path('test_tiny.tex')
-        qc = QuantumCircuit(1)
-        qc.h(0)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_normal_circuit(self):
-        """Test draw normal size circuit."""
-        filename = self._get_resource_path('test_normal.tex')
-        qc = QuantumCircuit(5)
-        for qubit in range(5):
-            qc.h(qubit)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_4597(self):
-        """Test cregbundle and conditional gates.
-        See: https://github.com/Qiskit/qiskit-terra/pull/4597 """
-        filename = self._get_resource_path('test_4597.tex')
-        qr = QuantumRegister(3, 'q')
-        cr = ClassicalRegister(3, 'c')
-        qc = QuantumCircuit(qr, cr)
-        qc.x(qr[2]).c_if(cr, 2)
-        qc.draw(output='latex_source', cregbundle=True)
-
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_deep_circuit(self):
-        """Test draw deep circuit."""
-        filename = self._get_resource_path('test_deep.tex')
-        qc = QuantumCircuit(1)
-        for _ in range(100):
-            qc.h(0)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_huge_circuit(self):
-        """Test draw huge circuit."""
-        filename = self._get_resource_path('test_huge.tex')
-        qc = QuantumCircuit(40)
-        for qubit in range(39):
-            qc.h(qubit)
-            qc.cx(qubit, 39)
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_teleport(self):
-        """Test draw teleport circuit."""
-        filename = self._get_resource_path('test_teleport.tex')
-        qr = QuantumRegister(3, 'q')
-        cr = ClassicalRegister(3, 'c')
-        qc = QuantumCircuit(qr, cr)
-        # Prepare an initial state
-        qc.u3(0.3, 0.2, 0.1, qr[0])
-        # Prepare a Bell pair
-        qc.h(qr[1])
-        qc.cx(qr[1], qr[2])
-        # Barrier following state preparation
-        qc.barrier(qr)
-        # Measure in the Bell basis
-        qc.cx(qr[0], qr[1])
-        qc.h(qr[0])
-        qc.measure(qr[0], cr[0])
-        qc.measure(qr[1], cr[1])
-        # Apply a correction
-        qc.z(qr[2]).c_if(cr, 1)
-        qc.x(qr[2]).c_if(cr, 2)
-        qc.measure(qr[2], cr[2])
-        try:
-            circuit_drawer(qc, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
-
-    def test_global_phase(self):
-        """Test circuit with global phase"""
-        filename = self._get_resource_path('test_global_phase.tex')
-        circuit = QuantumCircuit(3, global_phase=1.57079632679)
-        circuit.h(range(3))
-        try:
-            circuit_drawer(circuit, filename=filename, output='latex_source')
-            self.assertNotEqual(os.path.exists(filename), False)
-        finally:
-            if os.path.exists(filename):
-                os.remove(filename)
 
 
 class TestVisualizationUtils(QiskitTestCase):
@@ -249,15 +124,15 @@ class TestVisualizationUtils(QiskitTestCase):
 
     def test_get_layered_instructions_left_justification_simple(self):
         """ Test _get_layered_instructions left justification simple since #2802
-q_0: |0>───────■──
-        ┌───┐  │
-q_1: |0>┤ H ├──┼──
-        ├───┤  │
-q_2: |0>┤ H ├──┼──
-        └───┘┌─┴─┐
-q_3: |0>─────┤ X ├
-             └───┘
-"""
+        q_0: |0>───────■──
+                ┌───┐  │
+        q_1: |0>┤ H ├──┼──
+                ├───┤  │
+        q_2: |0>┤ H ├──┼──
+                └───┘┌─┴─┐
+        q_3: |0>─────┤ X ├
+                     └───┘
+        """
         qc = QuantumCircuit(4)
         qc.h(1)
         qc.h(2)
@@ -277,15 +152,15 @@ q_3: |0>─────┤ X ├
 
     def test_get_layered_instructions_right_justification_simple(self):
         """ Test _get_layered_instructions right justification simple since #2802
-q_0: |0>──■───────
-          │  ┌───┐
-q_1: |0>──┼──┤ H ├
-          │  ├───┤
-q_2: |0>──┼──┤ H ├
-        ┌─┴─┐└───┘
-q_3: |0>┤ X ├─────
-        └───┘
-"""
+        q_0: |0>──■───────
+                  │  ┌───┐
+        q_1: |0>──┼──┤ H ├
+                  │  ├───┤
+        q_2: |0>──┼──┤ H ├
+                ┌─┴─┐└───┘
+        q_3: |0>┤ X ├─────
+                └───┘
+        """
         qc = QuantumCircuit(4)
         qc.h(1)
         qc.h(2)
@@ -306,18 +181,18 @@ q_3: |0>┤ X ├─────
     def test_get_layered_instructions_left_justification_less_simple(self):
         """ Test _get_layered_instructions left justification
         less simple example since #2802
-        ┌────────────┐┌───┐┌────────────┐              ┌─┐┌────────────┐┌───┐┌────────────┐
-q_0: |0>┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├──────────────┤M├┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├
-        ├────────────┤└─┬─┘├────────────┤┌────────────┐└╥┘└────────────┘└─┬─┘├────────────┤
-q_1: |0>┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├┤ U2(0,pi/1) ├─╫─────────────────■──┤ U2(0,pi/1) ├
-        └────────────┘     └────────────┘└────────────┘ ║                    └────────────┘
-q_2: |0>────────────────────────────────────────────────╫──────────────────────────────────
-                                                        ║
-q_3: |0>────────────────────────────────────────────────╫──────────────────────────────────
-                                                        ║
-q_4: |0>────────────────────────────────────────────────╫──────────────────────────────────
-                                                        ║
-c1_0: 0 ════════════════════════════════════════════════╩══════════════════════════════════
+                ┌────────────┐┌───┐┌────────────┐              ┌─┐┌────────────┐┌───┐┌────────────┐
+        q_0: |0>┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├──────────────┤M├┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├
+                ├────────────┤└─┬─┘├────────────┤┌────────────┐└╥┘└────────────┘└─┬─┘├────────────┤
+        q_1: |0>┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├┤ U2(0,pi/1) ├─╫─────────────────■──┤ U2(0,pi/1) ├
+                └────────────┘     └────────────┘└────────────┘ ║                    └────────────┘
+        q_2: |0>────────────────────────────────────────────────╫──────────────────────────────────
+                                                                ║
+        q_3: |0>────────────────────────────────────────────────╫──────────────────────────────────
+                                                                ║
+        q_4: |0>────────────────────────────────────────────────╫──────────────────────────────────
+                                                                ║
+        c1_0: 0 ════════════════════════════════════════════════╩══════════════════════════════════
         """
         qasm = """
         OPENQASM 2.0;
@@ -364,18 +239,18 @@ c1_0: 0 ════════════════════════
     def test_get_layered_instructions_right_justification_less_simple(self):
         """ Test _get_layered_instructions right justification
         less simple example since #2802
-        ┌────────────┐┌───┐┌────────────┐┌─┐┌────────────┐┌───┐┌────────────┐
-q_0: |0>┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├┤M├┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├
-        ├────────────┤└─┬─┘├────────────┤└╥┘├────────────┤└─┬─┘├────────────┤
-q_1: |0>┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├─╫─┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├
-        └────────────┘     └────────────┘ ║ └────────────┘     └────────────┘
-q_2: |0>──────────────────────────────────╫──────────────────────────────────
-                                          ║
-q_3: |0>──────────────────────────────────╫──────────────────────────────────
-                                          ║
-q_4: |0>──────────────────────────────────╫──────────────────────────────────
-                                          ║
-c1_0: 0 ══════════════════════════════════╩══════════════════════════════════
+                ┌────────────┐┌───┐┌────────────┐┌─┐┌────────────┐┌───┐┌────────────┐
+        q_0: |0>┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├┤M├┤ U2(0,pi/1) ├┤ X ├┤ U2(0,pi/1) ├
+                ├────────────┤└─┬─┘├────────────┤└╥┘├────────────┤└─┬─┘├────────────┤
+        q_1: |0>┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├─╫─┤ U2(0,pi/1) ├──■──┤ U2(0,pi/1) ├
+                └────────────┘     └────────────┘ ║ └────────────┘     └────────────┘
+        q_2: |0>──────────────────────────────────╫──────────────────────────────────
+                                                  ║
+        q_3: |0>──────────────────────────────────╫──────────────────────────────────
+                                                  ║
+        q_4: |0>──────────────────────────────────╫──────────────────────────────────
+                                                  ║
+        c1_0: 0 ══════════════════════════════════╩══════════════════════════════════
         """
         qasm = """
         OPENQASM 2.0;

--- a/test/python/visualization/visualization.py
+++ b/test/python/visualization/visualization.py
@@ -17,9 +17,9 @@ Useful for refactoring purposes."""
 
 import os
 import unittest
-import matplotlib
 from filecmp import cmp as cmpfile
 from shutil import copyfile
+import matplotlib
 
 from qiskit.test import QiskitTestCase
 

--- a/test/python/visualization/visualization.py
+++ b/test/python/visualization/visualization.py
@@ -18,6 +18,8 @@ Useful for refactoring purposes."""
 import os
 import unittest
 import matplotlib
+from filecmp import cmp as cmpfile
+from shutil import copyfile
 
 from qiskit.test import QiskitTestCase
 
@@ -42,6 +44,17 @@ class QiskitVisualizationTestCase(QiskitTestCase):
         with open(current, encoding=encoding) as cur, \
                 open(expected, encoding=encoding) as exp:
             self.assertEqual(cur.read(), exp.read())
+
+    def assertEqualToReference(self, result):
+        reference = path_to_diagram_reference(os.path.basename(result))
+        if not os.path.exists(result):
+            raise self.failureException('Result file was not generated.')
+        if not os.path.exists(reference):
+            copyfile(result, reference)
+        if cmpfile(reference, result):
+            os.remove(result)
+        else:
+            raise self.failureException('Result and reference do not match.')
 
     def assertImagesAreEqual(self, current, expected, diff_tolerance=0.001):
         """Checks if both images are similar enough to be considered equal.


### PR DESCRIPTION
Fixes #1186

I split the `test_visualization.py` into `test_circuit_latex.py` and `test_utils.py`. In `test_circuit_latex.py`, I created the references for the latex source and the equality check.