### PR TITLE
Fix mybinder tests

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -3,11 +3,7 @@
 # See https://mybinder.readthedocs.io/en/latest/config_files.html?#postbuild-run-code-after-installing-the-environment
 
 # Dependencies
-# - matplotlib: for MPL drawer
-# - pylatexenc: for MPL drawer
-# - pillow: for image comparison
-# - appmode: jupyter extension for executing the notebook
-pip install matplotlib pylatexenc pillow appmode
+pip install -r requirements-binder.txt
 
 # Activation of appmode extension
 jupyter nbextension     enable --py --sys-prefix appmode

--- a/requirements-binder.txt
+++ b/requirements-binder.txt
@@ -1,0 +1,6 @@
+matplotlib>=2.1
+pillow>=4.2.1
+fixtures>=3.0.0
+testtools>=2.2.0
+pylatexenc>=1.4
+appmode


### PR DESCRIPTION
After #5071, mybinder tests fail because lack of `fixtures` and `testtools`. I created `requirements-binder.txt` because the list of dependencies for the mybinder tests are getting longer.