### PR TITLE
Make stream capturing test class opportunistic

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -82,8 +82,85 @@ def gather_details(source_dict, target_dict):
         target_dict[name] = _copy_content(content_object)
 
 
-class QiskitTestCase(unittest.TestCase):
+class BaseQiskitTestCase(unittest.TestCase):
+    """Common extra functionality on top of unittest."""
+    @staticmethod
+    def _get_resource_path(filename, path=Path.TEST):
+        """Get the absolute path to a resource.
+
+        Args:
+            filename (string): filename or relative path to the resource.
+            path (Path): path used as relative to the filename.
+        Returns:
+            str: the absolute path to the resource.
+        """
+        return os.path.normpath(os.path.join(path.value, filename))
+
+    def assertNoLogs(self, logger=None, level=None):
+        """Assert that no message is sent to the specified logger and level.
+
+        Context manager to test that no message is sent to the specified
+        logger and level (the opposite of TestCase.assertLogs()).
+        """
+        return _AssertNoLogsContext(self, logger, level)
+
+    def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
+                              places=None, default_value=0):
+        """Assert two dictionaries with numeric values are almost equal.
+
+        Fail if the two dictionaries are unequal as determined by
+        comparing that the difference between values with the same key are
+        not greater than delta (default 1e-8), or that difference rounded
+        to the given number of decimal places is not zero. If a key in one
+        dictionary is not in the other the default_value keyword argument
+        will be used for the missing value (default 0). If the two objects
+        compare equal then they will automatically compare almost equal.
+
+        Args:
+            dict1 (dict): a dictionary.
+            dict2 (dict): a dictionary.
+            delta (number): threshold for comparison (defaults to 1e-8).
+            msg (str): return a custom message on failure.
+            places (int): number of decimal places for comparison.
+            default_value (number): default value for missing keys.
+
+        Raises:
+            TypeError: if the arguments are not valid (both `delta` and
+                `places` are specified).
+            AssertionError: if the dictionaries are not almost equal.
+        """
+
+        error_msg = dicts_almost_equal(dict1, dict2, delta, places, default_value)
+
+        if error_msg:
+            msg = self._formatMessage(msg, error_msg)
+            raise self.failureException(msg)
+
+
+class BasicQiskitTestCase(BaseQiskitTestCase):
     """Helper class that contains common functionality."""
+
+    @classmethod
+    def setUpClass(cls):
+        # Determines if the TestCase is using IBMQ credentials.
+        cls.using_ibmq_credentials = False
+
+        # Set logging to file and stdout if the LOG_LEVEL envar is set.
+        cls.log = logging.getLogger(cls.__name__)
+        if os.getenv('LOG_LEVEL'):
+            filename = '%s.log' % os.path.splitext(inspect.getfile(cls))[0]
+            setup_test_logging(cls.log, os.getenv('LOG_LEVEL'), filename)
+
+    def tearDown(self):
+        # Reset the default providers, as in practice they acts as a singleton
+        # due to importing the instances from the top-level qiskit namespace.
+        from qiskit.providers.basicaer import BasicAer
+
+        BasicAer._backends = BasicAer._verify_backends()
+
+
+class FullQiskitTestCase(BaseQiskitTestCase):
+    """Helper class that contains common functionality that captures streams."""
 
     run_tests_with = RunTest
 
@@ -91,8 +168,8 @@ class QiskitTestCase(unittest.TestCase):
         """Construct a TestCase."""
         if not HAS_FIXTURES:
             raise ImportError(
-                "Test runner requirements are missing, install "
-                "requirements-dev.txt and run tests again.")
+                "Test runner requirements testtools and fixtures are missing. "
+                "Install them with 'pip install testtools fixtures'")
         super(QiskitTestCase, self).__init__(*args, **kwargs)
         self.__RunTest = self.run_tests_with
         self._reset()
@@ -338,58 +415,6 @@ class QiskitTestCase(unittest.TestCase):
         cls.using_ibmq_credentials = False
         cls.log = logging.getLogger(cls.__name__)
 
-    @staticmethod
-    def _get_resource_path(filename, path=Path.TEST):
-        """Get the absolute path to a resource.
-
-        Args:
-            filename (string): filename or relative path to the resource.
-            path (Path): path used as relative to the filename.
-        Returns:
-            str: the absolute path to the resource.
-        """
-        return os.path.normpath(os.path.join(path.value, filename))
-
-    def assertNoLogs(self, logger=None, level=None):
-        """Assert that no message is sent to the specified logger and level.
-
-        Context manager to test that no message is sent to the specified
-        logger and level (the opposite of TestCase.assertLogs()).
-        """
-        return _AssertNoLogsContext(self, logger, level)
-
-    def assertDictAlmostEqual(self, dict1, dict2, delta=None, msg=None,
-                              places=None, default_value=0):
-        """Assert two dictionaries with numeric values are almost equal.
-
-        Fail if the two dictionaries are unequal as determined by
-        comparing that the difference between values with the same key are
-        not greater than delta (default 1e-8), or that difference rounded
-        to the given number of decimal places is not zero. If a key in one
-        dictionary is not in the other the default_value keyword argument
-        will be used for the missing value (default 0). If the two objects
-        compare equal then they will automatically compare almost equal.
-
-        Args:
-            dict1 (dict): a dictionary.
-            dict2 (dict): a dictionary.
-            delta (number): threshold for comparison (defaults to 1e-8).
-            msg (str): return a custom message on failure.
-            places (int): number of decimal places for comparison.
-            default_value (number): default value for missing keys.
-
-        Raises:
-            TypeError: if the arguments are not valid (both `delta` and
-                `places` are specified).
-            AssertionError: if the dictionaries are not almost equal.
-        """
-
-        error_msg = dicts_almost_equal(dict1, dict2, delta, places, default_value)
-
-        if error_msg:
-            msg = self._formatMessage(msg, error_msg)
-            raise self.failureException(msg)
-
 
 def dicts_almost_equal(dict1, dict2, delta=None, places=None, default_value=0):
     """Test if two dictionaries with numeric values are almost equal.
@@ -450,3 +475,8 @@ def dicts_almost_equal(dict1, dict2, delta=None, places=None, default_value=0):
         return error_msg[:-2] + msg_suffix
     else:
         return ''
+
+if not HAS_FIXTURES and not os.environ.get('QISKIT_TEST_CAPTURE_STREAMS'):
+    QiskitTestCase = BasicQiskitTestCase
+else:
+    QiskitTestCase = FullQiskitTestCase

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -477,6 +477,7 @@ def dicts_almost_equal(dict1, dict2, delta=None, places=None, default_value=0):
     else:
         return ''
 
+
 if not HAS_FIXTURES and not os.environ.get('QISKIT_TEST_CAPTURE_STREAMS'):
     QiskitTestCase = BasicQiskitTestCase
 else:

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -91,6 +91,7 @@ class BaseQiskitTestCase(unittest.TestCase):
         Args:
             filename (string): filename or relative path to the resource.
             path (Path): path used as relative to the filename.
+
         Returns:
             str: the absolute path to the resource.
         """

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -21,6 +21,7 @@ the environment variables for customizing different options), and the
 decorators in the ``decorators`` package.
 """
 
+import inspect
 import itertools
 import logging
 import os
@@ -36,7 +37,7 @@ except ImportError:
     HAS_FIXTURES = False
 
 from .runtest import RunTest, MultipleExceptions
-from .utils import Path, _AssertNoLogsContext
+from .utils import Path, _AssertNoLogsContext, setup_test_logging
 
 
 __unittest = True  # Allows shorter stack trace for .assertDictAlmostEqual
@@ -171,7 +172,7 @@ class FullQiskitTestCase(BaseQiskitTestCase):
             raise ImportError(
                 "Test runner requirements testtools and fixtures are missing. "
                 "Install them with 'pip install testtools fixtures'")
-        super(QiskitTestCase, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__RunTest = self.run_tests_with
         self._reset()
         self.__exception_handlers = []

--- a/qiskit/test/runtest.py
+++ b/qiskit/test/runtest.py
@@ -83,8 +83,8 @@ class RunTest:
         """
         if not HAS_TESTTOOLS:
             raise ImportError(
-                'Test runner requirements are missing, install '
-                'requirements-dev.txt before running tests')
+                "Test runner requirements testtools and fixtures are missing. "
+                "Install them with 'pip install testtools fixtures'")
         self.case = case
         self.handlers = handlers or []
         self.exception_caught = object()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,8 +8,6 @@ pycodestyle
 pydot
 astroid==2.3.3
 pylint==2.4.4
-fixtures>=3.0.0
-testtools>=2.2.0
 stestr>=2.0.0
 PyGithub
 wheel


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5071 we tried to fix an implicit testing requirement dependency we
added in #3982 for capturing output streams from test runs. However,
that change didn't go far enough in making the capture features opt-in.
While it fixed the hard failure it still made the installation of
testtools and fixtures hard requirement for running tests, even if the
stream capturing was never used. For an example of this see #5078. This
commit attempts to remedy this situation by making the stream capturing
opportunistically opt-in. It splits out the common functionality between
the old test class without stream capturing into a new common base
class. Then it adds the stream capturing base class on top of that. The
stream capturing class is only used if testtools and fixtures is
installed and QISKIT_CAPTURE_STREAMS is not set.

### Details and comments