### PR TITLE
Removing deprecated n_qubits and numberofqubits (warnings in 0.13)

### DIFF
--- a/qiskit/circuit/library/standard_gates/ms.py
+++ b/qiskit/circuit/library/standard_gates/ms.py
@@ -12,7 +12,6 @@
 
 """Global Mølmer–Sørensen gate."""
 
-from qiskit.util import deprecate_arguments
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.quantumregister import QuantumRegister
 
@@ -27,9 +26,7 @@ class MSGate(Gate):
     and is thus reduced to the RXXGate.
     """
 
-    @deprecate_arguments({'n_qubits': 'num_qubits'})
-    def __init__(self, num_qubits, theta, *, n_qubits=None,  # pylint:disable=unused-argument
-                 label=None):
+    def __init__(self, num_qubits, theta, label=None):
         """Create new MS gate."""
         super().__init__('ms', num_qubits, [theta], label=label)
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1418,15 +1418,6 @@ class QuantumCircuit:
         return len(self.ancillas)
 
     @property
-    def n_qubits(self):
-        """Deprecated, use ``num_qubits`` instead. Return number of qubits."""
-        warnings.warn('The QuantumCircuit.n_qubits method is deprecated as of 0.13.0, and '
-                      'will be removed no earlier than 3 months after that release date. '
-                      'You should use the QuantumCircuit.num_qubits method instead.',
-                      DeprecationWarning, stacklevel=2)
-        return self.num_qubits
-
-    @property
     def num_clbits(self):
         """Return number of classical bits."""
         return sum(len(reg) for reg in self.cregs)

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -23,13 +23,10 @@ from qiskit.circuit.library.standard_gates import (IGate, U1Gate, U2Gate, U3Gate
                                                    CU3Gate, SwapGate, RZZGate,
                                                    CCXGate, CSwapGate)
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.util import deprecate_arguments
 
 
-@deprecate_arguments({'n_qubits': 'num_qubits'})
 def random_circuit(num_qubits, depth, max_operands=3, measure=False,
-                   conditional=False, reset=False, seed=None,
-                   *, n_qubits=None):  # pylint:disable=unused-argument
+                   conditional=False, reset=False, seed=None):
     """Generate random circuit of arbitrary size and form.
 
     This function will generate a random circuit by randomly selecting gates
@@ -50,7 +47,6 @@ def random_circuit(num_qubits, depth, max_operands=3, measure=False,
         conditional (bool): if True, insert middle measurements and conditionals
         reset (bool): if True, insert middle resets
         seed (int): sets random seed (optional)
-        n_qubits (int): deprecated, use num_qubits instead
 
     Returns:
         QuantumCircuit: constructed circuit

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -18,8 +18,6 @@ Tools for working with Pauli Operators.
 A simple pauli class and some tools.
 """
 
-import warnings
-
 import numpy as np
 from scipy import sparse
 
@@ -259,15 +257,6 @@ class Pauli:
     def num_qubits(self):
         """Number of qubits."""
         return len(self)
-
-    @property
-    def numberofqubits(self):
-        """Deprecated, use ``num_qubits`` instead. Number of qubits."""
-        warnings.warn('The Pauli.numberofqubits method is deprecated as of 0.13.0, and '
-                      'will be removed no earlier than 3 months after that release date. '
-                      'You should use the Pauli.num_qubits method instead.',
-                      DeprecationWarning, stacklevel=2)
-        return self.num_qubits
 
     def to_label(self):
         """Present the pauli labels in I, X, Y, Z format.

--- a/releasenotes/notes/3927-0d94adeac9299540.yaml
+++ b/releasenotes/notes/3927-0d94adeac9299540.yaml
@@ -1,0 +1,16 @@
+---
+deprecations:
+  - |
+    In 0.13, the process to deprecate``n_qubits`` and ``numberofqubits`` parameters from some methods and functions started.
+    See https://github.com/Qiskit/qiskit-terra/pull/3927 . The
+    deprecation warning now was removed and the paremeters are not available anymore. 
+    The objects affected by this change are listed below.
+
+    class                  | old method      | new method
+    -----------------------+-----------------+--------------------------------
+    QuantumCircuit         | n_qubits        | num_qubits
+    Pauli                  | numberofqubits  | num_qubits
+    function               | old argument   | new argument
+    -----------------------+----------------+-------------
+    random_circuit         | n_qubits       | num_qubits
+    MSGate.__init__        | n_qubit        | num_qubits

--- a/test/python/circuit/test_extensions_standard.py
+++ b/test/python/circuit/test_extensions_standard.py
@@ -1344,20 +1344,12 @@ class TestStandardMethods(QiskitTestCase):
     def test_to_matrix(self):
         """test gates implementing to_matrix generate matrix which matches
         definition."""
-        from qiskit.circuit.library.standard_gates.ms import MSGate
-
         params = [0.1 * (i + 1) for i in range(10)]
         gate_class_list = Gate.__subclasses__() + ControlledGate.__subclasses__()
         simulator = BasicAer.get_backend('unitary_simulator')
         for gate_class in gate_class_list:
             sig = signature(gate_class)
-            if gate_class == MSGate:
-                # due to the signature (num_qubits, theta, *, n_qubits=Noe) the signature detects
-                # 3 arguments but really its only 2. This if can be removed once the deprecated
-                # n_qubits argument is no longer supported.
-                free_params = 2
-            else:
-                free_params = len(set(sig.parameters) - {'label'})
+            free_params = len(set(sig.parameters) - {'label'})
             try:
                 gate = gate_class(*params[0:free_params])
             except (CircuitError, QiskitError, AttributeError):


### PR DESCRIPTION
In #3927, some deprecation warnings were inserted for parameters `n_qubits` and `numberofqubits`. The warnings were released with 0.13 (Apr, 2020). This PR removes those warnings.

