### PR TITLE
Remove "coding: utf-8" (PEP 3120) and add the verify_header checker

### DIFF
--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/__init__.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_2a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_2a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_2a_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_2a_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_2a_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_2a_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_4a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_4a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_4a_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_4a_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_4a_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_4a_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_4b_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_4b_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_4b_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_4b_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_5a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_5a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_5a_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_5a_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_5a_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_5a_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_5a_4.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_5a_4.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6a_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6a_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6a_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6a_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6a_4.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6a_4.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6b_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6b_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6b_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6b_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_6c_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_6c_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_7a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_7a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_7b_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_7b_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_7c_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_7c_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_7d_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_7d_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_7e_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_7e_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9a_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9a_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_10.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_10.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_11.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_11.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_12.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_12.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_4.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_4.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_5.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_5.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_6.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_6.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_7.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_7.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_8.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_8.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9c_9.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9c_9.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_1.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_1.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_10.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_10.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_2.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_2.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_3.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_3.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_4.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_4.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_5.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_5.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_6.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_6.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_7.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_7.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_8.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_8.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/circuit/library/template_circuits/toffoli/template_9d_9.py
+++ b/qiskit/circuit/library/template_circuits/toffoli/template_9d_9.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/test/runtest.py
+++ b/qiskit/test/runtest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2018.

--- a/qiskit/transpiler/passes/optimization/template_matching/__init__.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_matching/backward_match.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/backward_match.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_matching/forward_match.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/forward_match.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_matching/maximal_matches.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/maximal_matches.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/transpiler/passes/optimization/template_optimization.py
+++ b/qiskit/transpiler/passes/optimization/template_optimization.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/core.py
+++ b/qiskit/visualization/pulse_v2/core.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/device_info.py
+++ b/qiskit/visualization/pulse_v2/device_info.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators/barrier.py
+++ b/qiskit/visualization/pulse_v2/generators/barrier.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators/chart.py
+++ b/qiskit/visualization/pulse_v2/generators/chart.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators/frame.py
+++ b/qiskit/visualization/pulse_v2/generators/frame.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators/snapshot.py
+++ b/qiskit/visualization/pulse_v2/generators/snapshot.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/generators/waveform.py
+++ b/qiskit/visualization/pulse_v2/generators/waveform.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/layouts.py
+++ b/qiskit/visualization/pulse_v2/layouts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/qiskit/visualization/pulse_v2/stylesheet.py
+++ b/qiskit/visualization/pulse_v2/stylesheet.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/transpiler/test_template_matching.py
+++ b/test/python/transpiler/test_template_matching.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/pulse_v2/test_events.py
+++ b/test/python/visualization/pulse_v2/test_events.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/python/visualization/pulse_v2/test_layouts.py
+++ b/test/python/visualization/pulse_v2/test_layouts.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2020.

--- a/test/randomized/test_synthesis.py
+++ b/test/randomized/test_synthesis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # This code is part of Qiskit.
 #
 # (C) Copyright IBM 2017, 2019.

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -55,7 +55,7 @@ def validate_header(file_path):
         count += 1
         if count > 5:
             return file_path, False, "Header not found in first 5 lines"
-        if pep3120.match(line):
+        if count<=2 and pep263.match(line):
             return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
         if line == "# This code is part of Qiskit.\n":
             start = index

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -17,7 +17,8 @@ import os
 import sys
 import re
 
-pep3120 = re.compile("^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+# regex for character encoding from PEP 263
+pep263 = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
 
 def discover_files(code_paths):
     out_paths = []


### PR DESCRIPTION
Some sort of follow up to https://github.com/Qiskit/qiskit-terra/pull/4914 . I extended `tools/verify_headers.py` so the header does not added anymore accidentally.