### PR TITLE
Transition Visualization: defer matplotlib import

### DIFF
--- a/qiskit/visualization/transition_visualization.py
+++ b/qiskit/visualization/transition_visualization.py
@@ -17,17 +17,6 @@ import sys
 from math import sin, cos, acos, sqrt
 import numpy as np
 
-try:
-    import matplotlib
-    from matplotlib import pyplot as plt
-    from matplotlib import animation
-    from mpl_toolkits.mplot3d import Axes3D
-    from qiskit.visualization.bloch import Bloch
-    from qiskit.visualization.exceptions import VisualizationError
-    HAS_MATPLOTLIB = True
-except ImportError:
-    HAS_MATPLOTLIB = False
-
 
 def _normalize(v, tolerance=0.00001):
     """Makes sure magnitude of the vector is 1 with given tolerance"""
@@ -168,11 +157,22 @@ def visualize_transition(circuit,
     except ImportError:
         has_ipython = False
 
+    try:
+        import matplotlib
+        from matplotlib import pyplot as plt
+        from matplotlib import animation
+        from mpl_toolkits.mplot3d import Axes3D
+        from qiskit.visualization.bloch import Bloch
+        from qiskit.visualization.exceptions import VisualizationError
+        has_matplotlib = True
+    except ImportError:
+        has_matplotlib = False
+
     jupyter = False
     if ('ipykernel' in sys.modules) and ('spyder' not in sys.modules):
         jupyter = True
 
-    if not HAS_MATPLOTLIB:
+    if not has_matplotlib:
         raise ImportError("Must have Matplotlib installed.")
     if not has_ipython and jupyter is True:
         raise ImportError("Must have IPython installed.")


### PR DESCRIPTION
### Summary

As laid out in https://github.com/Qiskit/qiskit-terra/issues/5100,
``qiskit.visualization.transition_visualization`` is on the critical
path for any ``qiskit`` import. This means that the imports in this file
will always be imported. Profiling of import time showed that
``matplotlib.animation`` was a slow import, and so should be deferred
from the critical path.

### Details and comments

Ref #5100 

Moved after ``HAS_MATPLOTLIB`` check to be reasonably sure that matplotlib & the animation module is installed.
