### PR TITLE
Fix global phase for qobj assembly

### DIFF
--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -113,9 +113,6 @@ def _assemble_circuit(
             # measurement result may be needed for a conditional gate.
             if instruction.name == "measure" and is_conditional_experiment:
                 instruction.register = clbit_indices
-        if op_context[0].definition is not None and op_context[0].definition.global_phase:
-            # pylint:  disable=no-member
-            header.global_phase += float(op_context[0].definition.global_phase)
 
         # To convert to a qobj-style conditional, insert a bfunc prior
         # to the conditional instruction to map the creg ?= val condition

--- a/releasenotes/notes/fix_global_phase_in_assembled_circuit-8836260c7962c247.yaml
+++ b/releasenotes/notes/fix_global_phase_in_assembled_circuit-8836260c7962c247.yaml
@@ -1,3 +1,0 @@
-fixes:
-  - |
-    Fixes bug where gates whose definition had a global phase would incorrectly be added together during assembly. This would be using the phase from the unrolled circuit when it was needed (during assembly).

--- a/releasenotes/notes/fix_global_phase_in_assembled_circuit-8836260c7962c247.yaml
+++ b/releasenotes/notes/fix_global_phase_in_assembled_circuit-8836260c7962c247.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixes bug where gates whose definition had a global phase would incorrectly be added together during assembly. This would be using the phase from the unrolled circuit when it was needed (during assembly).

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -413,6 +413,7 @@ class TestCircuitAssembler(QiskitTestCase):
     def test_circuit_global_phase_gate_definitions(self):
         """Test circuit with global phase on gate definitions."""
         class TestGate(Gate):
+            """dummy gate"""
             def __init__(self):
                 super().__init__('test_gate', 1, [])
 

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -410,6 +410,27 @@ class TestCircuitAssembler(QiskitTestCase):
         self.assertEqual(getattr(qobj.experiments[0].header, 'global_phase'),
                          .3 * np.pi)
 
+    def test_circuit_global_phase_gate_definitions(self):
+        """Test circuit with global phase on gate definitions."""
+        class TestGate(Gate):
+            def __init__(self):
+                super().__init__('test_gate', 1, [])
+
+            def _define(self):
+                circ_def = QuantumCircuit(1)
+                circ_def.x(0)
+                circ_def.global_phase = np.pi
+                self._definition = circ_def
+
+        gate = TestGate()
+        circ = QuantumCircuit(1)
+        circ.append(gate, [0])
+        qobj = assemble([circ])
+        self.assertEqual(getattr(qobj.experiments[0].header, 'global_phase'), 0)
+        circ.global_phase = np.pi / 2
+        qobj = assemble([circ])
+        self.assertEqual(getattr(qobj.experiments[0].header, 'global_phase'), np.pi/2)
+
     def test_pulse_gates_single_circ(self):
         """Test that we can add calibrations to circuits."""
         theta = Parameter('theta')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes bug where extra global_phase from unrolled gates was added during circuit assembly which didn't need unrolling.


### Details and comments


