### PR TITLE
Remove packaging dependency

### DIFF
--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -52,12 +52,10 @@ __all__ = ['Bloch']
 
 import os
 import numpy as np
-import matplotlib as mpl
 from matplotlib import get_backend
 import matplotlib.pyplot as plt  # pylint: disable=import-error
 from matplotlib.patches import FancyArrowPatch  # pylint: disable=import-error
 from mpl_toolkits.mplot3d import (Axes3D, proj3d)  # pylint: disable=import-error
-from packaging import version
 
 
 class Arrow3D(FancyArrowPatch):
@@ -415,7 +413,9 @@ class Bloch():
             self.axes.set_ylim3d(-0.7, 0.7)
             self.axes.set_zlim3d(-0.7, 0.7)
 
-        if version.parse(mpl.__version__) >= version.parse('3.3.0'):
+        # Force aspect ratio
+        # MPL 3.2 or previous do not have set_box_aspect
+        if hasattr(self.axes, 'set_box_aspect'):
             self.axes.set_box_aspect((1, 1, 1))
 
         self.axes.grid(False)

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -27,7 +27,6 @@ from qiskit.util import deprecate_arguments
 from .matplotlib import HAS_MATPLOTLIB
 
 if HAS_MATPLOTLIB:
-    import matplotlib as mpl
     from matplotlib import get_backend
     from matplotlib import pyplot as plt
     from matplotlib.patches import FancyArrowPatch
@@ -41,7 +40,6 @@ if HAS_MATPLOTLIB:
     from qiskit.visualization.bloch import Bloch
     from qiskit.visualization.utils import _bloch_multivector_data, _paulivec_data
     from qiskit.circuit.tools.pi_check import pi_check
-    from packaging import version
 
 
 if HAS_MATPLOTLIB:
@@ -714,7 +712,9 @@ def plot_state_qsphere(state, figsize=None, ax=None, show_state_labels=True,
     ax.axes.grid(False)
     ax.view_init(elev=5, azim=275)
 
-    if version.parse(mpl.__version__) >= version.parse('3.3.0'):
+    # Force aspect ratio
+    # MPL 3.2 or previous do not have set_box_aspect
+    if hasattr(ax.axes, 'set_box_aspect'):
         ax.axes.set_box_aspect((1, 1, 1))
 
     # start the plotting


### PR DESCRIPTION
I accidentally introduced a dependency to `packaging` when merging #4893 (which was detected via #5108). When tested, I assumed `packaging` was installed as part of one of our requirements. Well... no. So, this PR removes the dependency via checking if matplotlib has the aspect ratio method available. In this way, instead of comparing the versions, it sets the right ratio when possible. 