### PR TITLE
Avoid module level sympy import again

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -18,7 +18,6 @@ import numbers
 import operator
 
 import numpy
-import sympy
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -30,7 +29,7 @@ class ParameterExpression:
 
     __slots__ = ['_parameter_symbols', '_parameters', '_symbol_expr', '_names']
 
-    def __init__(self, symbol_map: Dict, expr: sympy.Expr):
+    def __init__(self, symbol_map: Dict, expr):
         """Create a new ParameterExpression.
 
         Not intended to be called directly, but to be instantiated via operations
@@ -39,7 +38,7 @@ class ParameterExpression:
         Args:
             symbol_map: Mapping of Parameter instances to the sympy.Symbol
                         serving as their placeholder in expr.
-            expr: Expression of sympy.Symbols.
+            expr (sympy.Expr): Expression of sympy.Symbols.
         """
         self._parameter_symbols = symbol_map
         self._parameters = set(self._parameter_symbols)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Just as in #4385 and #3156 we should not be importing sympy at the
module level. Sympy is a very heavy dependency and is slow to import
(and slow to run too). Adding a sympy import to the module level makes
imports significantly slower. This commit reverts the top level import
of sympy, which was only added for type hints, to fix the import
performance regression.

### Details and comments