### PR TITLE
Add cache for custom definitions in UnrollCustomDefinitions

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -94,6 +94,8 @@ class ControlledGate(Gate):
         self.definition = copy.deepcopy(definition)
         self._ctrl_state = None
         self.ctrl_state = ctrl_state
+        self._hash = hash((self.num_ctrl_qubits, self.ctrl_state,
+                           self.base_gate, self.num_qubits, self.num_clbits))
 
     @property
     def definition(self) -> List:
@@ -221,6 +223,9 @@ class ControlledGate(Gate):
                 self.num_qubits == other.num_qubits and
                 self.num_clbits == other.num_clbits and
                 self.definition == other.definition)
+
+    def __hash__(self):
+        return self._hash
 
     def inverse(self) -> 'ControlledGate':
         """Invert this gate by calling inverse on the base gate."""

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -85,6 +85,7 @@ class Instruction:
 
         self._duration = duration
         self._unit = unit
+        self._hash = hash((self.name, self.num_qubits, self.num_clbits))
 
     def __eq__(self, other):
         """Two instructions are the same if they have the same name,
@@ -128,6 +129,9 @@ class Instruction:
             return False
 
         return True
+
+    def __hash__(self):
+        return self._hash
 
     def _define(self):
         """Populates self.definition with a decomposition of this gate."""

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -72,6 +72,10 @@ class UnitaryGate(Gate):
         self._qasm_def_written = False
         # Store instruction params
         super().__init__('unitary', num_qubits, [data], label=label)
+        self._hash = hash(id(self))
+
+    def __hash__(self):
+        return self._hash
 
     def __eq__(self, other):
         if not isinstance(other, UnitaryGate):

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -34,6 +34,7 @@ class UnrollCustomDefinitions(TransformationPass):
         super().__init__()
         self._equiv_lib = equivalence_library
         self._basis_gates = basis_gates
+        self._definition_cache = {}
 
     def run(self, dag):
         """Run the UnrollCustomDefinitions pass on `dag`.
@@ -87,7 +88,11 @@ class UnrollCustomDefinitions(TransformationPass):
                                   "Instruction %s not found in equivalence library "
                                   "and no rule found to expand." %
                                   (str(self._basis_gates), node.op.name))
-            decomposition = circuit_to_dag(node.op.definition)
+            if node.op not in self._definition_cache:
+                self._definition_cache[node.op] = circuit_to_dag(
+                    node.op.definition)
+
+            decomposition = self._definition_cache[node.op]
             unrolled_dag = UnrollCustomDefinitions(self._equiv_lib,
                                                    self._basis_gates).run(
                                                        decomposition)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a cache for generating DAGCircuit objects from circuit
definitions. Previously, in the pass it would loop over all the custom
gate definitions and run the converter on each instance everytime, even
if there were multiple instances of the same custom gate. While the
circuit_to_dag conversion is typically very fast, especially for the
normally small circuits used for custom gate definitions, the time
spent on conversion can add up over lots of gates. By caching the
conversion we only run it once per instance of a gate.


### Details and comments