### PR TITLE
Remove stray print from test_backendconfiguration

### DIFF
--- a/test/python/providers/test_backendconfiguration.py
+++ b/test/python/providers/test_backendconfiguration.py
@@ -156,7 +156,4 @@ class TestBackendConfiguration(QiskitTestCase):
     def test_deepcopy(self):
         """Ensure that a deepcopy succeeds and results in an identical object."""
         copy_config = copy.deepcopy(self.config)
-        print(copy_config.to_dict())
-        print("Original:")
-        print(self.config.to_dict())
         self.assertEqual(copy_config, self.config)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #4711 a regression test was added to validate the bugfix being added
in that PR. However, a stray debug print from development slipped in and
has stuck around since that merged. This commit removes the stray print
to remove it from our test output since it serves no purpose.

### Details and comments