### PR TITLE
instruction_durations overwrites backend durations, does not extend them

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -640,7 +640,8 @@ def _parse_instruction_durations(backend, inst_durations, dt, num_circuits):
             backend_durations = InstructionDurations()
         durations = backend_durations.update(inst_durations, dt)
     else:
-        durations = InstructionDurations(inst_durations, dt or inst_durations.dt)
+        durations = InstructionDurations(inst_durations,
+                dt or getattr(inst_durations, 'dt', None))
 
     if not isinstance(durations, list):
         durations = [durations] * num_circuits

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -638,10 +638,10 @@ def _parse_instruction_durations(backend, inst_durations, dt, num_circuits):
             backend_durations = InstructionDurations.from_backend(backend)
         except AttributeError:
             backend_durations = InstructionDurations()
-        durations = backend_durations.update(inst_durations, dt)
+        durations = backend_durations.update(None, dt)
     else:
         durations = InstructionDurations(inst_durations,
-                dt or getattr(inst_durations, 'dt', None))
+                                         dt or getattr(inst_durations, 'dt', None))
 
     if not isinstance(durations, list):
         durations = [durations] * num_circuits

--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -29,7 +29,7 @@ from qiskit.tools.parallel import parallel_map
 from qiskit.transpiler import Layout, CouplingMap, PropertySet, PassManager
 from qiskit.transpiler.basepasses import BasePass
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.transpiler.instruction_durations import InstructionDurationsType
+from qiskit.transpiler.instruction_durations import InstructionDurations, InstructionDurationsType
 from qiskit.transpiler.passes import ApplyLayout
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import (level_0_pass_manager,
@@ -132,8 +132,8 @@ def transpile(circuits: Union[QuantumCircuit, List[QuantumCircuit]],
             in the ground state when possible. (alias: ``'alap'``)
             If ``None``, no scheduling will be done.
         instruction_durations: Durations of instructions.
-            The gate lengths defined in ``backend.properties`` are used as default and
-            they are updated (overwritten) if this ``instruction_durations`` is specified.
+            The gate lengths defined in ``backend.properties`` are used as default.
+            They are overwritten if this ``instruction_durations`` is specified.
             The format of ``instruction_durations`` must be as follows.
             The `instruction_durations` must be given as a list of tuples
             [(instruction_name, qubits, duration, unit), ...].
@@ -427,7 +427,7 @@ def _parse_transpile_args(circuits, backend,
     routing_method = _parse_routing_method(routing_method, num_circuits)
     translation_method = _parse_translation_method(translation_method, num_circuits)
     durations = _parse_instruction_durations(backend, instruction_durations, dt,
-                                             scheduling_method, num_circuits)
+                                             num_circuits)
     scheduling_method = _parse_scheduling_method(scheduling_method, num_circuits)
     seed_transpiler = _parse_seed_transpiler(seed_transpiler, num_circuits)
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
@@ -631,14 +631,16 @@ def _parse_scheduling_method(scheduling_method, num_circuits):
     return scheduling_method
 
 
-def _parse_instruction_durations(backend, inst_durations, dt, scheduling_method, num_circuits):
+def _parse_instruction_durations(backend, inst_durations, dt, num_circuits):
     durations = None
-    if scheduling_method is not None:
-        from qiskit.transpiler.instruction_durations import InstructionDurations
-        if backend:
-            durations = InstructionDurations.from_backend(backend).update(inst_durations, dt)
-        else:
-            durations = InstructionDurations(inst_durations, dt)
+    if inst_durations is None and backend:
+        try:
+            backend_durations = InstructionDurations.from_backend(backend)
+        except AttributeError:
+            backend_durations = InstructionDurations()
+        durations = backend_durations.update(inst_durations, dt)
+    else:
+        durations = InstructionDurations(inst_durations, dt or inst_durations.dt)
 
     if not isinstance(durations, list):
         durations = [durations] * num_circuits

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -390,6 +390,14 @@ Layout and Topology
    Layout
    CouplingMap
 
+Scheduling
+----------
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   InstructionDurations
+
 Fenced Objects
 --------------
 
@@ -418,3 +426,4 @@ from .fencedobjs import FencedDAGCircuit, FencedPropertySet
 from .basepasses import AnalysisPass, TransformationPass
 from .coupling import CouplingMap
 from .layout import Layout
+from .instruction_durations import InstructionDurations

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -82,9 +82,6 @@ class InstructionDurations:
         # TODO: backend.properties() should tell us durations of measurements
         # TODO: Remove the following lines after that
         try:
-            dtm = backend.configuration().dtm
-            if dtm != dt:
-                raise TranspilerError("dtm != dt case is not supported.")
             inst_map = backend.defaults().instruction_schedule_map
             all_qubits = tuple(range(backend.configuration().num_qubits))
             meas_duration = inst_map.get('measure', all_qubits).duration

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -38,6 +38,21 @@ class InstructionDurations:
         if instruction_durations:
             self.update(instruction_durations)
 
+    def __str__(self):
+        """Return a string representation of all stored durations."""
+        string = ""
+        for k, v in self.duration_by_name.items():
+            string += k
+            string += ': '
+            string += str(v[0]) + ' ' + v[1]
+            string += '\n'
+        for k, v in self.duration_by_name_qubits.items():
+            string += k[0] + str(k[1])
+            string += ': '
+            string += str(v[0]) + ' ' + v[1]
+            string += '\n'
+        return string
+
     @classmethod
     def from_backend(cls, backend: BaseBackend):
         """Construct an :class:`InstructionDurations` object from the backend.

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -215,7 +215,7 @@ class TestScheduledCircuit(QiskitTestCase):
                               )
         self.assertEqual(scheduled.duration, 1300)
 
-    def test_unit_seconds_for_users_who_uses_durations_given_by_backend(self):
+    def test_unit_seconds_when_using_backend_durations(self):
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.delay(500*self.dt, 1, 's')
@@ -228,17 +228,11 @@ class TestScheduledCircuit(QiskitTestCase):
         self.assertEqual(scheduled.duration, 1908)
 
         # update durations
+        durations = InstructionDurations.from_backend(self.backend_with_dt)
+        durations.update([('cx', [0, 1], 1000*self.dt, 's')])
         scheduled = transpile(qc,
                               backend=self.backend_with_dt,
                               scheduling_method='alap',
-                              instruction_durations=[('cx', [0, 1], 1000*self.dt, 's')]
-                              )
-        self.assertEqual(scheduled.duration, 1500)
-
-        my_own_durations = InstructionDurations([('cx', [0, 1], 1000*self.dt, 's')])
-        scheduled = transpile(qc,
-                              backend=self.backend_with_dt,  # unit='s'
-                              scheduling_method='alap',
-                              instruction_durations=my_own_durations
+                              instruction_durations=durations
                               )
         self.assertEqual(scheduled.duration, 1500)


### PR DESCRIPTION
like all other args in transpile(), supplying your own arg should overwrite the one that is read from backend.

plus a couple other enhancements to the InstructionDuration object, like a print option.