### PR TITLE
Build BlueprintCircuit before inverse and compose

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -100,6 +100,16 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().append(instruction, qargs, cargs)
 
+    def compose(self, other, qubits=None, clbits=None, front=False, inplace=False):
+        if self._data is None:
+            self._build()
+        return super().compose(other, qubits, clbits, front, inplace)
+
+    def inverse(self):
+        if self._data is None:
+            self._build()
+        return super().inverse()
+
     def __len__(self):
         return len(self.data)
 

--- a/releasenotes/notes/build-blueprintcircuit-before-inverse-8ef85f6389588fe0.yaml
+++ b/releasenotes/notes/build-blueprintcircuit-before-inverse-8ef85f6389588fe0.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     Calling inverse or compose on a ``BlueprintCircuit`` could fail
-    if ``_data`` was not yet popualted. This has been fixed by asserting
+    if ``_data`` was not yet populated. This has been fixed by asserting
     a call on ``_build`` method.

--- a/releasenotes/notes/build-blueprintcircuit-before-inverse-8ef85f6389588fe0.yaml
+++ b/releasenotes/notes/build-blueprintcircuit-before-inverse-8ef85f6389588fe0.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Calling inverse or compose on a ``BlueprintCircuit`` could fail
+    if ``_data`` was not yet popualted. This has been fixed by asserting
+    a call on ``_build`` method.

--- a/test/python/circuit/library/test_blueprintcircuit.py
+++ b/test/python/circuit/library/test_blueprintcircuit.py
@@ -116,5 +116,6 @@ class TestBlueprintCircuit(QiskitTestCase):
 
         self.assertEqual(reference, circuit)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/circuit/library/test_blueprintcircuit.py
+++ b/test/python/circuit/library/test_blueprintcircuit.py
@@ -15,7 +15,7 @@
 import unittest
 
 from qiskit.test.base import QiskitTestCase
-from qiskit.circuit import QuantumRegister, Parameter
+from qiskit.circuit import QuantumRegister, Parameter, QuantumCircuit
 from qiskit.circuit.library import BlueprintCircuit
 
 
@@ -90,7 +90,7 @@ class TestBlueprintCircuit(QiskitTestCase):
                 self.assertGreater(len(circuit._data), 0)
 
         methods = ['qasm', 'count_ops', 'num_connected_components', 'num_nonlocal_gates',
-                   'depth', '__len__', 'copy']
+                   'depth', '__len__', 'copy', 'inverse']
         for method in methods:
             with self.subTest(method=method):
                 circuit = MockBlueprint(3)
@@ -102,6 +102,19 @@ class TestBlueprintCircuit(QiskitTestCase):
             _ = circuit[2]
             self.assertGreater(len(circuit._data), 0)
 
+    def test_compose_works(self):
+        """Test that the circuit is constructed when compose is called."""
+        qc = QuantumCircuit(3)
+        qc.x([0, 1, 2])
+        circuit = MockBlueprint(3)
+        circuit.compose(qc, inplace=True)
+
+        reference = QuantumCircuit(3)
+        reference.rx(list(circuit.parameters)[0], 0)
+        reference.h([0, 1, 2])
+        reference.x([0, 1, 2])
+
+        self.assertEqual(reference, circuit)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Assert a call on `_build` method of a `BlueprintCircuit` if `inverse` or `compose` is called in order to populate internal `_data` field.


### Details and comments
Previously, as reported on #5140, the following would fail since `_data` is still `None`.
```python
var_form = EfficientSU2(2, entanglement="linear")
var_form.inverse()
---
raises TypeError
---
qc = QuantumCircuit(2)
qc.h([0, 1])

var_form.compose(qc, inplace=True)
---
raises TypeError
---
```
As with other attributes, before internal data of the circuit is accessed on `inverse` and `compose` functions, the `_build` method is called.


