### PR TITLE
Made the 'qubits' argument optional in initialize()

### DIFF
--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -270,15 +270,7 @@ class Initialize(Instruction):
 def initialize(self, params, qubits=None):
     """Apply initialize to circuit."""
     if qubits is None:
-        init = Initialize(params)
-        n_qubits = init.num_qubits
-        total_qubits = self.num_qubits
-        for qbt in range(0, total_qubits, n_qubits):
-            qubits = []
-            for q in range(qbt, qbt + n_qubits):
-                qubits.append(q)
-            self.append(Initialize(params), qubits)
-        return self
+        qubits = self.qubits
     elif not isinstance(qubits, list):
         qubits = [qubits]
     return self.append(Initialize(params), qubits)

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -267,9 +267,19 @@ class Initialize(Instruction):
                                "{1}".format(type(parameter), self.name))
 
 
-def initialize(self, params, qubits):
+def initialize(self, params, qubits=None):
     """Apply initialize to circuit."""
-    if not isinstance(qubits, list):
+    if qubits is None:
+        init = Initialize(params)
+        n_qubits = init.num_qubits
+        total_qubits = self.num_qubits
+        for qbt in range(0, total_qubits, n_qubits):
+            qubits = []
+            for q in range(qbt, qbt + n_qubits):
+                qubits.append(q)
+            self.append(Initialize(params), qubits)
+        return self
+    elif not isinstance(qubits, list):
         qubits = [qubits]
     return self.append(Initialize(params), qubits)
 

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -104,6 +104,19 @@ class TestInitialize(QiskitTestCase):
             fidelity, self._desired_fidelity,
             "Initializer has low fidelity {:.2g}.".format(fidelity))
 
+    def test_initialize_with_no_qubits_argument(self):
+        """Initializing all qubits with the desired state if qubits argument is not provided"""
+        desired_vector = [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)]
+        qc = QuantumCircuit(2)
+        qc.initialize(desired_vector)
+        job = execute(qc, BasicAer.get_backend('statevector_simulator'))
+        result = job.result()
+        statevector = result.get_statevector()
+        fidelity = state_fidelity(statevector, desired_vector)
+        self.assertGreater(
+            fidelity, self._desired_fidelity,
+            "Initializer has low fidelity {:.2g}.".format(fidelity))
+
     def test_initialize_one_by_one(self):
         """Initializing qubits individually into product state same as initializing the pair."""
         qubit_0_state = [1, 0]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4908 

### Details and comments

I made the 'qubits' argument optional in initialize() function in initializer.py. If no 'qubits' argument is provided then all the qubits will be initialized with the desired vector. I also added a test for this in test_initializer.py by the name
test_initialize_with_no_qubits_argument(). I have also performed tests like make style, make lint and make test to ensure that I have not broken anything in the project code.
