### PR TITLE
The lookahead_swap pass is global_phase aware

### DIFF
--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -16,7 +16,6 @@ import logging
 from copy import deepcopy
 
 from qiskit.circuit.quantumregister import QuantumRegister
-from qiskit.dagcircuit import DAGCircuit
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -125,7 +125,7 @@ class LookaheadSwap(TransformationPass):
             mapped_gates.extend(gates_mapped)
 
         # Preserve input DAG's name, regs, wire_map, etc. but replace the graph.
-        mapped_dag = _copy_circuit_metadata(dag, self.coupling_map)
+        mapped_dag = dag._copy_circuit_metadata()
 
         for node in mapped_gates:
             mapped_dag.apply_operation_back(op=node.op, qargs=node.qargs, cargs=node.cargs)
@@ -294,22 +294,6 @@ def _score_step(step):
     # Each added swap will add 3 ops to gates_mapped, so subtract 3.
     return len([g for g in step['gates_mapped']
                 if len(g.qargs) == 2]) - 3 * len(step['swaps_added'])
-
-
-def _copy_circuit_metadata(source_dag, coupling_map):
-    """Return a copy of source_dag with metadata but empty.
-
-    Generate only a single qreg in the output DAG, matching the size of the
-    coupling_map.
-    """
-    target_dag = source_dag._copy_circuit_metadata()
-
-    len_not_allocated_qubits = len(coupling_map.physical_qubits) - len(target_dag.qubits)
-    if len_not_allocated_qubits:
-        device_qreg = QuantumRegister(len_not_allocated_qubits, 'q')
-        target_dag.add_qreg(device_qreg)
-
-    return target_dag
 
 
 def _transform_gate_for_layout(gate, layout):

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -303,14 +303,12 @@ def _copy_circuit_metadata(source_dag, coupling_map):
     Generate only a single qreg in the output DAG, matching the size of the
     coupling_map.
     """
-    target_dag = DAGCircuit()
-    target_dag.name = source_dag.name
+    target_dag = source_dag._copy_circuit_metadata()
 
-    for creg in source_dag.cregs.values():
-        target_dag.add_creg(creg)
-
-    device_qreg = QuantumRegister(len(coupling_map.physical_qubits), 'q')
-    target_dag.add_qreg(device_qreg)
+    len_not_allocated_qubits = len(coupling_map.physical_qubits) - len(target_dag.qubits)
+    if len_not_allocated_qubits:
+        device_qreg = QuantumRegister(len_not_allocated_qubits, 'q')
+        target_dag.add_qreg(device_qreg)
 
     return target_dag
 

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -13,6 +13,7 @@
 """Test the LookaheadSwap pass"""
 
 import unittest
+from numpy import pi
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.passes import LookaheadSwap
 from qiskit.transpiler import CouplingMap
@@ -232,6 +233,23 @@ class TestLookaheadSwap(QiskitTestCase):
 
         self.assertIsInstance(out, DAGCircuit)
 
+    def test_global_phase_preservation(self):
+        """Test that LookaheadSwap preserves global phase
+        """
+
+        qr = QuantumRegister(3, 'q')
+        circuit = QuantumCircuit(qr)
+        circuit.global_phase = pi / 3
+        circuit.cx(qr[0], qr[2])
+        dag_circuit = circuit_to_dag(circuit)
+
+        coupling_map = CouplingMap([[0, 1], [1, 2]])
+
+        mapped_dag = LookaheadSwap(coupling_map).run(dag_circuit)
+
+        self.assertEqual(mapped_dag.global_phase, circuit.global_phase)
+        self.assertEqual(mapped_dag.count_ops().get('swap', 0),
+                         dag_circuit.count_ops().get('swap', 0) + 1)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_lookahead_swap.py
+++ b/test/python/transpiler/test_lookahead_swap.py
@@ -251,5 +251,6 @@ class TestLookaheadSwap(QiskitTestCase):
         self.assertEqual(mapped_dag.count_ops().get('swap', 0),
                          dag_circuit.count_ops().get('swap', 0) + 1)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In #4915, the passes were extended with global phase awareness. The `lookahead` pass was coping the dag without the global phase. This PR fixes that. 