### PR TITLE
Fixed issue 4526 by adding InitializeGate

### DIFF
--- a/qiskit/extensions/__init__.py
+++ b/qiskit/extensions/__init__.py
@@ -47,7 +47,7 @@ Initialization
 from qiskit.circuit.library.standard_gates import *
 from qiskit.circuit.barrier import Barrier
 
-from .quantum_initializer.initializer import Initialize
+from .quantum_initializer.initializer import Initialize, InitializeGate
 from .unitary import UnitaryGate
 from .hamiltonian_gate import HamiltonianGate
 from .simulator import Snapshot

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -198,7 +198,7 @@ class TestGateEquivalenceEqual(QiskitTestCase):
         exclude = {'ControlledGate', 'DiagonalGate', 'UCGate', 'MCGupDiag',
                    'MCU1Gate', 'UnitaryGate', 'HamiltonianGate', 'MCPhaseGate',
                    'UCPauliRotGate', 'SingleQubitUnitary', 'MCXGate',
-                   'VariadicZeroParamGate', 'ClassicalFunction'}
+                   'VariadicZeroParamGate', 'ClassicalFunction', 'InitializeGate'}
         cls._gate_classes = []
         for aclass in class_list:
             if aclass.__name__ not in exclude:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4526 

### Details and comments

`Initialize` is implemented as an `Instruction` object instead of `Gate` because it uses reset instruction which is not unitary. This fix modifies `Initialize` passing an additional named parameter `reset` to its constructor whose default value is `True`. You can expect the behavior of `Initialize` to be the same if you don't specify the `reset` parameter. 

However, instantiating `Initialize` with `reset=False` lets us define the `InitializeGate` gate. We can now create the controlled version of `Initialize` using `InitializeGate(desired_vector).control(how_many_controlled_qubits)`.

Here an example usage:

```
from qiskit import * 
from qiskit.extensions.quantum_initializer.initializer import InitializeGate
import math

circuit = QuantumCircuit(2)
circuit.x(0)
wanted_state = [1 / math.sqrt(2), 1 / math.sqrt(2)]
circuit.append(InitializeGate(wanted_state).control(1), [0, 1])

result = execute(circuit, backend=Aer.get_backend('statevector_simulator'), shots=1).result()
print(result.get_statevector())
```

The introduction of `InitializeGate` and its controlled version may help with the implementation of quantum distance-based classifier like the one you find in [[Schuld, Fingerhuth, Petruccione, 2018]](https://arxiv.org/abs/1703.10793).