### PR TITLE
Add per-qubit duration in a scheduled circuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2438,7 +2438,7 @@ class QuantumCircuit:
         """
         from .delay import Delay
         if self.duration is None:
-            raise CircuitError("bit_start_time is defined only for scheduled circuit.")
+            raise CircuitError("qubit_start_time is defined only for scheduled circuit.")
 
         qubits = [self.qubits[q] if isinstance(q, int) else q for q in qubits]
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2401,7 +2401,7 @@ class QuantumCircuit:
         """
         from .delay import Delay
         if self.duration is None:
-            raise CircuitError("bit_start_time is defined only for scheduled circuit.")
+            raise CircuitError("qubit_start_time is defined only for scheduled circuit.")
 
         qubits = [self.qubits[q] if isinstance(q, int) else q for q in qubits]
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -36,6 +36,7 @@ from .instructionset import InstructionSet
 from .register import Register
 from .bit import Bit
 from .quantumcircuitdata import QuantumCircuitData
+from .delay import Delay
 
 try:
     import pygments
@@ -2007,7 +2008,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if arguments have bad format.
         """
-        from .delay import Delay
         qubits = []
         if qarg is None:  # -> apply delays to all qubits
             for q in self.qubits:
@@ -2399,7 +2399,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if ``self`` is a not-yet scheduled circuit.
         """
-        from .delay import Delay
         if self.duration is None:
             raise CircuitError("qubit_start_time is defined only for scheduled circuit.")
 
@@ -2436,7 +2435,6 @@ class QuantumCircuit:
         Raises:
             CircuitError: if ``self`` is a not-yet scheduled circuit.
         """
-        from .delay import Delay
         if self.duration is None:
             raise CircuitError("qubit_start_time is defined only for scheduled circuit.")
 

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -243,39 +243,36 @@ class TestScheduledCircuit(QiskitTestCase):
                               )
         self.assertEqual(scheduled.duration, 1500)
 
-    def test_per_bit_durations(self):
+    def test_per_qubit_durations(self):
         """See: https://github.com/Qiskit/qiskit-terra/issues/5109"""
         qc = QuantumCircuit(3)
         qc.h(0)
         qc.delay(500, 1)
         qc.cx(0, 1)
         qc.h(1)
-        scheduled = transpile(qc,
-                              scheduling_method='alap',
-                              instruction_durations=[('h', None, 200), ('cx', [0, 1], 700)])
-        self.assertEqual(scheduled.bit_start_time(0), 300)
-        self.assertEqual(scheduled.bit_stop_time(0), 1200)
-        self.assertEqual(scheduled.bit_start_time(1), 500)
-        self.assertEqual(scheduled.bit_stop_time(1), 1400)
-        self.assertEqual(scheduled.bit_start_time(2), 0)
-        self.assertEqual(scheduled.bit_stop_time(2), 0)
-        self.assertEqual(scheduled.bit_start_time(0, 1), 300)
-        self.assertEqual(scheduled.bit_stop_time(0, 1), 1400)
+        sc = transpile(qc,
+                       scheduling_method='alap',
+                       instruction_durations=[('h', None, 200), ('cx', [0, 1], 700)])
+        self.assertEqual(sc.qubit_start_time(0), 300)
+        self.assertEqual(sc.qubit_stop_time(0), 1200)
+        self.assertEqual(sc.qubit_start_time(1), 500)
+        self.assertEqual(sc.qubit_stop_time(1), 1400)
+        self.assertEqual(sc.qubit_start_time(2), 0)
+        self.assertEqual(sc.qubit_stop_time(2), 0)
+        self.assertEqual(sc.qubit_start_time(0, 1), 300)
+        self.assertEqual(sc.qubit_stop_time(0, 1), 1400)
 
         qc.measure_all()
-        scheduled = transpile(qc,
-                              scheduling_method='alap',
-                              instruction_durations=[('h', None, 200), ('cx', [0, 1], 700),
-                                                     ('measure', None, 1000)])
-        q = scheduled.qubits
-        self.assertEqual(scheduled.bit_start_time(q[0]), 300)
-        self.assertEqual(scheduled.bit_stop_time(q[0]), 2400)
-        self.assertEqual(scheduled.bit_start_time(q[1]), 500)
-        self.assertEqual(scheduled.bit_stop_time(q[1]), 2400)
-        self.assertEqual(scheduled.bit_start_time(q[2]), 1400)
-        self.assertEqual(scheduled.bit_stop_time(q[2]), 2400)
-        self.assertEqual(scheduled.bit_start_time(*q), 300)
-        self.assertEqual(scheduled.bit_stop_time(*q), 2400)
-        c = scheduled.clbits
-        self.assertEqual(scheduled.bit_start_time(c[0]), 1400)
-        self.assertEqual(scheduled.bit_stop_time(c[0]), 2400)
+        sc = transpile(qc,
+                       scheduling_method='alap',
+                       instruction_durations=[('h', None, 200), ('cx', [0, 1], 700),
+                                              ('measure', None, 1000)])
+        q = sc.qubits
+        self.assertEqual(sc.qubit_start_time(q[0]), 300)
+        self.assertEqual(sc.qubit_stop_time(q[0]), 2400)
+        self.assertEqual(sc.qubit_start_time(q[1]), 500)
+        self.assertEqual(sc.qubit_stop_time(q[1]), 2400)
+        self.assertEqual(sc.qubit_start_time(q[2]), 1400)
+        self.assertEqual(sc.qubit_stop_time(q[2]), 2400)
+        self.assertEqual(sc.qubit_start_time(*q), 300)
+        self.assertEqual(sc.qubit_stop_time(*q), 2400)

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -276,3 +276,6 @@ class TestScheduledCircuit(QiskitTestCase):
         self.assertEqual(scheduled.bit_stop_time(q[2]), 2400)
         self.assertEqual(scheduled.bit_start_time(*q), 300)
         self.assertEqual(scheduled.bit_stop_time(*q), 2400)
+        c = scheduled.clbits
+        self.assertEqual(scheduled.bit_start_time(c[0]), 1400)
+        self.assertEqual(scheduled.bit_stop_time(c[0]), 2400)


### PR DESCRIPTION
### Summary
Fix #5109 

### Details and comments
Add functions to inquire the `start_time` and `stop_time` of each qubit in a circuit that has been scheduled.

- `qubit_start_time`: the start time of the first instruction, excluding delays, over the supplied qubits.
- `qubit_stop_time`: the stop time of the last instruction, excluding delays, over the supplied qubits.
- `qubit_duration`: `qubit_stop_time - qubit_start_time`, which is the same spec as the future spec of `pulse.Schedule.ch_duration` after #4848. 