### PR TITLE
add delay as a builtin instruction

### DIFF
--- a/qiskit/compiler/transpile.py
+++ b/qiskit/compiler/transpile.py
@@ -323,13 +323,6 @@ def _transpile_circuit(circuit_config_tuple: Tuple[QuantumCircuit, Dict]) -> Qua
     else:
         raise TranspilerError("optimization_level can range from 0 to 3.")
 
-    if pass_manager_config.scheduling_method is not None:
-        if pass_manager_config.basis_gates:
-            if 'delay' not in pass_manager_config.basis_gates:
-                pass_manager_config.basis_gates.append('delay')
-        else:
-            pass_manager_config.basis_gates = ['delay']
-
     result = pass_manager.run(circuit, callback=transpile_config['callback'],
                               output_name=transpile_config['output_name'])
 

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -82,7 +82,7 @@ class BasisTranslator(TransformationPass):
             return dag
 
         # Names of instructions assumed to supported by any backend.
-        basic_instrs = ['measure', 'reset', 'barrier', 'snapshot']
+        basic_instrs = ['measure', 'reset', 'barrier', 'snapshot', 'delay']
 
         target_basis = set(self._target_basis).union(basic_instrs)
 

--- a/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
+++ b/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
@@ -68,7 +68,7 @@ class MSBasisDecomposer(TransformationPass):
         cnot_decomposition = cnot_rxx_decompose()
 
         for node in dag.op_nodes():
-            basic_insts = ['measure', 'reset', 'barrier', 'snapshot']
+            basic_insts = ['measure', 'reset', 'barrier', 'snapshot', 'delay']
             if node.name in basic_insts:
                 # TODO: this is legacy behavior. basic_insts should be removed and these
                 #  instructions should be part of the device-reported basis. Currently, no

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -52,7 +52,7 @@ class UnrollCustomDefinitions(TransformationPass):
         if self._basis_gates is None:
             return dag
 
-        basic_insts = {'measure', 'reset', 'barrier', 'snapshot'}
+        basic_insts = {'measure', 'reset', 'barrier', 'snapshot', 'delay'}
         device_insts = basic_insts | set(self._basis_gates)
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -52,7 +52,7 @@ class Unroller(TransformationPass):
             return dag
         # Walk through the DAG and expand each non-basis node
         for node in dag.op_nodes():
-            basic_insts = ['measure', 'reset', 'barrier', 'snapshot']
+            basic_insts = ['measure', 'reset', 'barrier', 'snapshot', 'delay']
             if node.name in basic_insts:
                 # TODO: this is legacy behavior.Basis_insts should be removed that these
                 #  instructions should be part of the device-reported basis. Currently, no

--- a/qiskit/transpiler/passes/optimization/commutation_analysis.py
+++ b/qiskit/transpiler/passes/optimization/commutation_analysis.py
@@ -95,7 +95,7 @@ def _commute(node1, node2, cache):
     if node1.type != "op" or node2.type != "op":
         return False
 
-    if any([nd.name in {"barrier", "snapshot", "measure", "reset", "copy"}
+    if any([nd.name in {"barrier", "snapshot", "measure", "reset", "copy", "delay"}
             for nd in [node1, node2]]):
         return False
 


### PR DESCRIPTION
delay, like measure, reset, etc. is a fundamental instruction that cannot be re-written as another instruction. So this commit teaches the compiler to not attempt to unroll or translate it. With this I also remove a previous hack that patched delay onto basis gates.