### PR TITLE
fixed issue 4959 by change text pi with character unicode u03C0

### DIFF
--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -68,7 +68,7 @@ def pi_check(inpt, eps=1e-6, output='text', ndigits=5):
             return '0'
 
         if output in ['text', 'qasm']:
-            pi = 'pi'
+            pi = '\u03C0'
         elif output == 'latex':
             pi = '\\pi'
         elif output == 'mpl':


### PR DESCRIPTION
… correspond to pi

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #4959 

### Details and comments

Circuit drawn using circuit.draw() when output a pi value just present the text. I used Unicode for plotting pi

