### PR TITLE
Remove deprecated DAGNode dict constructor argument

### DIFF
--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -32,38 +32,18 @@ class DAGNode:
     def __init__(self, type=None, op=None, name=None, qargs=None, cargs=None,
                  condition=None, wire=None, nid=-1):
         """Create a node """
-        if isinstance(type, dict):
-            warnings.warn("Using data_dict as a a parameter to create a "
-                          "DAGNode object is deprecated. Instead pass each "
-                          "field in the dictionary as a kwarg",
-                          DeprecationWarning, stacklevel=2)
-            data_dict = type
-            self.type = data_dict.get('type')
-            self._op = data_dict.get('op')
-            self.name = data_dict.get('name')
-            self._qargs = data_dict.get('qargs')
-            self.cargs = data_dict.get('cargs')
-            if data_dict.get('condition'):
-                warnings.warn("Use of condition arg is deprecated, set condition in instruction",
-                              DeprecationWarning)
-            if self._op:
-                self._op.condition = (data_dict.get('condition') if self._op.condition is None
-                                      else self._op.condition)
-            self.condition = self._op.condition if self._op is not None else None
-            self._wire = data_dict.get('wire')
-        else:
-            self.type = type
-            self._op = op
-            self.name = name
-            self._qargs = qargs if qargs is not None else []
-            self.cargs = cargs if cargs is not None else []
-            if condition:
-                warnings.warn("Use of condition arg is deprecated, set condition in instruction.",
-                              DeprecationWarning)
-            if self._op:
-                self._op.condition = condition if self._op.condition is None else self._op.condition
-            self.condition = self._op.condition if self._op is not None else None
-            self._wire = wire
+        self.type = type
+        self._op = op
+        self.name = name
+        self._qargs = qargs if qargs is not None else []
+        self.cargs = cargs if cargs is not None else []
+        if condition:
+            warnings.warn("Use of condition arg is deprecated, set condition in instruction.",
+                          DeprecationWarning)
+        if self._op:
+            self._op.condition = condition if self._op.condition is None else self._op.condition
+        self.condition = self._op.condition if self._op is not None else None
+        self._wire = wire
         self._node_id = nid
         self.sort_key = str(self._qargs)
 

--- a/qiskit/dagcircuit/releasenotes/notes/remove-dagnode-dict-32fa35479c0a8331.yaml
+++ b/qiskit/dagcircuit/releasenotes/notes/remove-dagnode-dict-32fa35479c0a8331.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The previously deprecated support for passing in a dictionary as the
+    first positional argument to :class:`~qiskit.dagcircuit.DAGNode` constructor
+    has been removed. This argument was deprecated in the 0.13.0 release. To
+    create a :class:`~qiskit.dagcircuit.DAGNode` object now you should directly
+    pass the attributes as kwargs on the constructor.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the deprecated DAGNode dict constructor positional
argument support. Passing in a dictionary as the first positional arg
has been deprecated since the 0.13.0 release on April 9th, 2020 so per
the deprecation policy [1] it has been sufficient time to remove the
deprecated feature now.

### Details and comments

[1] https://qiskit.org/documentation/contributing_to_qiskit.html#deprecation-policy
