### PR TITLE
Fix the matrix representation in the documentation of CHGate

### DIFF
--- a/qiskit/circuit/library/standard_gates/h.py
+++ b/qiskit/circuit/library/standard_gates/h.py
@@ -143,12 +143,11 @@ class CHGate(ControlledGate):
 
             CH\ q_1, q_0 =
                 |0\rangle\langle 0| \otimes I + |1\rangle\langle 1| \otimes H =
-                \frac{1}{\sqrt{2}}
                 \begin{pmatrix}
                     1 & 0 & 0 & 0 \\
                     0 & 1 & 0 & 0 \\
-                    0 & 0 & 1 & 1 \\
-                    0 & 0 & 1 & -1
+                    0 & 0 & \frac{1}{\sqrt{2}} & \frac{1}{\sqrt{2}} \\
+                    0 & 0 & \frac{1}{\sqrt{2}} & -\frac{1}{\sqrt{2}}
                 \end{pmatrix}
     """
     # Define class constants. This saves future allocation time.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes issue number #5207
(Originally addressed here https://github.com/Qiskit/qiskit/issues/1053)

### Details and comments
The note on the documentation page for the CHGate displays an equation where a 1/sqrt(2) is incorrectly factored out the final matrix representation. This pull request fixes the terms in the final matrix representation by removing the 1/sqrt(2) outside the matrix and distributing it correctly to the bottom-right block of the matrix. 

Here is a visual representation of what was changed: 
![image](https://user-images.githubusercontent.com/59269494/95694621-0f87f100-0c01-11eb-9e5f-eef9a0da1c4c.png)


