### PR TITLE
Fix rendering of "pi" in the U3 documentation

### DIFF
--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -51,7 +51,7 @@ class U3Gate(Gate):
 
     .. math::
 
-        U3(\theta, -\frac{\pi}{2}, \frac{pi}{2}) = RX(\theta)
+        U3(\theta, -\frac{\pi}{2}, \frac{\pi}{2}) = RX(\theta)
 
     .. math::
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixed issue #5210 
(Originally addressed here https://github.com/Qiskit/qiskit/issues/1055)

### Details and comments
An instance of pi is not defined correctly in the code under the examples section of the U3Gate documentation

![image](https://user-images.githubusercontent.com/59269494/95696861-d05e9d80-0c0a-11eb-9d56-c3c468675e43.png)

The problem can be found here under the examples section:
https://qiskit.org/documentation/stubs/qiskit.circuit.library.U3Gate.html

This pull request adds the missing backslash in front of "pi" in the lambda input variable of the example

Example of the results from the changes in the code:

![image](https://user-images.githubusercontent.com/59269494/95696925-026fff80-0c0b-11eb-9a93-0bd318b24fc3.png)