### PR TITLE
Flipped qft circuit to respect qiskit's qubit index convention

### DIFF
--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -252,12 +252,12 @@ class QFT(BlueprintCircuit):
         """Construct the circuit representing the desired state vector."""
         super()._build()
 
-        for j in range(self.num_qubits):
+        for j in reversed(range(self.num_qubits)):
             self.h(j)
-            num_entanglements = max(0, self.num_qubits - max(self.approximation_degree, j))
-            for k in range(j + 1, j + num_entanglements):
-                lam = np.pi / (2 ** (k - j))
-                self.cu1(lam, j, k)
+            num_entanglements = max(0, min(self.num_qubits - 1 - self._approximation_degree, j))
+            for k in reversed(range(j - num_entanglements, j)):
+                lam = np.pi / (2 ** (j - k))
+                self.cp(lam, k, j)
 
             if self.insert_barriers:
                 self.barrier()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes the implementation of the quantum Fourier transform in the circuit library. 


### Details and comments
The original QFT code attempted to implement the standard QFT circuit as in the following circuit diagram (layer of swap gates at the end not shown):
![qft](https://user-images.githubusercontent.com/58646822/96043746-709c0880-0e3d-11eb-814a-46055db73ff3.png)

There were 2 issues:
1. The control and target qubits of the controlled rotations were switched. This is clear because the control qubit of the controlled rotations had a Hadamard gate applied before the controlled rotations, which is incorrect.
2. To implement this circuit in qiskit, the diagram needs to be flipped due to qiskit's convention of storing less significant digits of a binary integer in lower index qubits (i.e. the top of a circuit diagram). So first a Hadamard on the nth qubit needs to be applied, then controlled rotations of the nth qubit, and so on, followed by swap gates.

In this pull request, I've fixed these issues by implementing a flipped version of the above circuit diagram. I also changed controlled u1 gates to controlled phase gates, since u1 gates are being deprecated.

This is my first pull request on GitHub, so any feedback will be greatly appreciated. Thanks!