### PR TITLE
Restore using aqua from release for tutorials job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
-# TODO in L591 change git+https://github.com/Qiskit/qiskit-aqua back to "qiskit-aqua"
-# after the joint release of Terra 0.16 and Aqua 0.8
-
 trigger:
   branches:
     include:
@@ -588,7 +585,7 @@ stages:
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" git+https://github.com/Qiskit/qiskit-aqua "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz pandoc
             pip check


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit reverts a change made during #5083 to use aqua from master
for the tutorials job. This was done to workaround an aqua bug with
a non-u1/u2/u3 basis that was occuring with the 0.7.x release of aqua.
We typically use the released versions of the libraries in these jobs to
catch potentially breaking changes for the biggest users of the terra
api (the other qiskit elements). This restores this coverage by
switching back to using the aqua release for the job.

### Details and comments


