### PR TITLE
Use evd driver for eigh in TwoQubitWeylDecomposition

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -169,7 +169,7 @@ class TwoQubitWeylDecomposition:
         for i in range(100):  # FIXME: this randomized algorithm is horrendous
             state = np.random.default_rng(i)
             M2real = state.normal()*M2.real + state.normal()*M2.imag
-            _, P = np.linalg.eigh(M2real)
+            _, P = la.eigh(M2real, driver='evd')
             D = P.T.dot(M2).dot(P).diagonal()
             if np.allclose(P.dot(np.diag(D)).dot(P.T), M2, rtol=1.0e-13, atol=1.0e-13):
                 break

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -169,7 +169,7 @@ class TwoQubitWeylDecomposition:
         for i in range(100):  # FIXME: this randomized algorithm is horrendous
             state = np.random.default_rng(i)
             M2real = state.normal()*M2.real + state.normal()*M2.imag
-            _, P = la.eigh(M2real)
+            _, P = np.linalg.eigh(M2real)
             D = P.T.dot(M2).dot(P).diagonal()
             if np.allclose(P.dot(np.diag(D)).dot(P.T), M2, rtol=1.0e-13, atol=1.0e-13):
                 break

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -351,44 +351,6 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
                         a = Ud(aaa, aaa, ccc)
                         self.check_two_qubit_weyl_decomposition(k1 @ a @ k2)
 
-    def test_random_unitary_fp_precision_error(self):
-        """Assert there are no fp precision sign flips."""
-        gate = CXGate()
-        self.check_two_qubit_weyl_decomposition(Operator(gate).data)
-        decomp = TwoQubitWeylDecomposition(Operator(gate).data)
-        expected_k1r = np.array([[-0.5 + 0.5j, -0.5 + 0.5j],
-                                 [0.5 + 0.5j, -0.5 - 0.5j]])
-        expected_k2l = np.array([[0.0 + 0.0j, -1.0 + 0.0j],
-                                 [1.0 + 0.0j, 0.0 + 0.0j]])
-        sqrt_2 = 1 / np.sqrt(2)
-        expected_k2r = np.array([[complex(0, sqrt_2), complex(0, sqrt_2)],
-                                 [complex(0, sqrt_2), complex(0, -sqrt_2)]])
-        expected_k1l = np.array([[complex(0, sqrt_2), complex(-sqrt_2, 0)],
-                                 [complex(sqrt_2, 0), complex(0, -sqrt_2)]])
-        np.allclose(decomp.K1r, expected_k1r)
-        np.allclose(decomp.K2r, expected_k2r)
-        np.allclose(decomp.K2l, expected_k2l)
-        np.allclose(decomp.K1l, expected_k1l)
-        # Assert approx 0s are not negative
-        # K2l
-        self.assertGreaterEqual(decomp.K2l[0][0].real, 0)
-        self.assertGreaterEqual(decomp.K2l[0][0].imag, 0)
-        self.assertGreaterEqual(decomp.K2l[0][1].imag, 0)
-        self.assertGreaterEqual(decomp.K2l[1][0].imag, 0)
-        self.assertGreaterEqual(decomp.K2l[1][1].real, 0)
-        self.assertGreaterEqual(decomp.K2l[1][1].imag, 0)
-        # K2r
-        self.assertGreaterEqual(decomp.K2r[0][0].real, 0)
-        self.assertGreaterEqual(decomp.K2r[0][1].real, 0)
-        self.assertGreaterEqual(decomp.K2r[1][0].real, 0)
-        self.assertGreaterEqual(decomp.K2r[1][1].real, 0)
-        # k1l
-        self.assertGreaterEqual(decomp.K2r[0][0].real, 0)
-        self.assertGreaterEqual(decomp.K2r[0][1].imag, 0)
-        self.assertGreaterEqual(decomp.K2r[1][0].imag, 0)
-        self.assertGreaterEqual(decomp.K2r[1][1].real, 0)
-
-
 @ddt
 class TestTwoQubitDecomposeExact(CheckDecompositions):
     """Test TwoQubitBasisDecomposer() for exact decompositions

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -351,6 +351,7 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
                         a = Ud(aaa, aaa, ccc)
                         self.check_two_qubit_weyl_decomposition(k1 @ a @ k2)
 
+
 @ddt
 class TestTwoQubitDecomposeExact(CheckDecompositions):
     """Test TwoQubitBasisDecomposer() for exact decompositions


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The hermitian optimized eigen solver function in scipy has shown
to possibly produce varied results in different environments. For
example, the matrix returned by the `eigh()` call in the
`TwoQubitWeylDecomposition` class's `__init__` method when called for
a CXGate:
```python
TwoQubitWeylDecomposition(Operator(CXGate()))
```
was observed to be
```
[[ 0.70710678  0.         -0.70710678  0.        ]
 [ 0.         -0.70710678  0.          0.70710678]
 [ 0.          0.70710678  0.          0.70710678]
 [ 0.70710678  0.          0.70710678  0.        ]]
```
on one system/environment but
```
[[ 0.70710678  0.         -0.70710678  0.        ]
 [ 0.          0.70710678  0.          0.70710678]
 [ 0.         -0.70710678  0.          0.70710678]
 [ 0.70710678  0.          0.70710678  0.        ]]
```
on a different environment. This difference was resulting in
inconsistent decompositions being generated and made reproducing results
from the transpiler difficult. In testing the numpy equivalent
function [2] has proven to be more reliable across different
environments. It turns out that this was because the LAPACK driver
used by the numpy routine was `evd` while the default driver for scipy
was `ev`. Switching the scipy driver to use `evd` too fixes this issue. This
commit switches the `eigh()` usage in the `TwoQubitWeylDecomposition`
class to explicilty set the driver to `evd instead of the default `ev`,
this should fix the inconsistent decompositions we were seeing between
environments.

### Details and comments


[1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.eigh.html
[2] https://numpy.org/doc/stable/reference/generated/numpy.linalg.eigh.html