### PR TITLE
Add support for parameters to the pulse builder

### DIFF
--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -275,7 +275,7 @@ class _PulseBuilder():
         """Initialize the builder context.
 
         .. note::
-            At some point we may consider incorpating the builder into
+            At some point we may consider incorporating the builder into
             the :class:`~qiskit.pulse.Schedule` class. However, the risk of
             this is tying the user interface to the intermediate
             representation. For now we avoid this at the cost of some code
@@ -946,7 +946,7 @@ def align_func(duration: int,
 
     Pulse instructions within this context are scheduled at the location specified by
     arbitrary callback function `position` that takes integer index and returns
-    the associated fractional location witin [0, 1].
+    the associated fractional location within [0, 1].
     Delay instruction is automatically inserted in between pulses.
 
     This context may be convenient to write a schedule of arbitrary dynamical decoupling
@@ -1148,7 +1148,7 @@ def circuit_scheduler_settings(**settings) -> ContextManager[None]:
 
 
 @contextmanager
-def phase_offset(phase: float,
+def phase_offset(phase: Union[float, circuit.ParameterExpression],
                  *channels: chans.PulseChannel
                  ) -> ContextManager[None]:
     """Shift the phase of input channels on entry into context and undo on exit.
@@ -1186,7 +1186,7 @@ def phase_offset(phase: float,
 
 
 @contextmanager
-def frequency_offset(frequency: float,
+def frequency_offset(frequency: Union[float, circuit.ParameterExpression],
                      *channels: chans.PulseChannel,
                      compensate_phase: bool = False
                      ) -> ContextManager[None]:
@@ -1210,7 +1210,7 @@ def frequency_offset(frequency: float,
 
         with pulse.build(backend) as pulse_prog:
             # Shift frequency by 1GHz.
-            # Undo accumulated phase in the shifted freqeuncy frame
+            # Undo accumulated phase in the shifted frequency frame
             # when exiting the context.
             with pulse.frequency_offset(1e9, d0, compensate_phase=True):
                 pulse.play(pulse.Constant(10, 1.0), d0)
@@ -1436,7 +1436,7 @@ def acquire(duration: int,
             'Register of type: "{}" is not supported'.format(type(register)))
 
 
-def set_frequency(frequency: float,
+def set_frequency(frequency: Union[float, circuit.ParameterExpression],
                   channel: chans.PulseChannel):
     """Set the ``frequency`` of a pulse ``channel``.
 
@@ -1458,7 +1458,7 @@ def set_frequency(frequency: float,
     append_instruction(instructions.SetFrequency(frequency, channel))
 
 
-def shift_frequency(frequency: float,
+def shift_frequency(frequency: Union[float, circuit.ParameterExpression],
                     channel: chans.PulseChannel):
     """Shift the ``frequency`` of a pulse ``channel``.
 
@@ -1481,7 +1481,7 @@ def shift_frequency(frequency: float,
     append_instruction(instructions.ShiftFrequency(frequency, channel))
 
 
-def set_phase(phase: float,
+def set_phase(phase: Union[float, circuit.ParameterExpression],
               channel: chans.PulseChannel):
     """Set the ``phase`` of a pulse ``channel``.
 
@@ -1506,7 +1506,7 @@ def set_phase(phase: float,
     append_instruction(instructions.SetPhase(phase, channel))
 
 
-def shift_phase(phase: float,
+def shift_phase(phase: Union[float, circuit.ParameterExpression],
                 channel: chans.PulseChannel):
     """Shift the ``phase`` of a pulse ``channel``.
 
@@ -1697,7 +1697,7 @@ def barrier(*channels_or_qubits: Union[chans.Channel, int]):
         assert barrier_pulse_prog == aligned_pulse_prog
 
     The barrier allows the pulse compiler to take care of more advanced
-    scheduling aligment operations across channels. For example
+    scheduling alignment operations across channels. For example
     in the case where we are calling an outside circuit or schedule and
     want to align a pulse at the end of one call:
 
@@ -1782,7 +1782,7 @@ def measure(qubits: Union[List[int], int],
     Args:
         qubits: Physical qubit to measure.
         registers: Register to store result in. If not selected the current
-            behaviour is to return the :class:`MemorySlot` with the same
+            behavior is to return the :class:`MemorySlot` with the same
             index as ``qubit``. This register will be returned.
     Returns:
         The ``register`` the qubit measurement result will be stored in.
@@ -1968,7 +1968,7 @@ def cx(control: int, target: int):
     call_gate(gates.CXGate(), (control, target))
 
 
-def u1(theta: float, qubit: int):
+def u1(theta: Union[float, circuit.ParameterExpression], qubit: int):
     """Call a :class:`~qiskit.circuit.library.standard_gates.U1Gate` on the
     input physical qubit.
 
@@ -1995,7 +1995,9 @@ def u1(theta: float, qubit: int):
     call_gate(gates.U1Gate(theta), qubit)
 
 
-def u2(phi: float, lam: float, qubit: int):
+def u2(phi: Union[float, circuit.ParameterExpression],
+       lam: Union[float, circuit.ParameterExpression],
+       qubit: int):
     """Call a :class:`~qiskit.circuit.library.standard_gates.U2Gate` on the
     input physical qubit.
 
@@ -2022,7 +2024,10 @@ def u2(phi: float, lam: float, qubit: int):
     call_gate(gates.U2Gate(phi, lam), qubit)
 
 
-def u3(theta: float, phi: float, lam: float, qubit: int):
+def u3(theta: Union[float, circuit.ParameterExpression],
+       phi: Union[float, circuit.ParameterExpression],
+       lam: Union[float, circuit.ParameterExpression],
+       qubit: int):
     """Call a :class:`~qiskit.circuit.library.standard_gates.U3Gate` on the
     input physical qubit.
 

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -56,7 +56,7 @@ def measure(qubits: List[int],
     except AttributeError:
         raise exceptions.PulseError(
             'inst_map or meas_map, and backend cannot be None simultaneously')
-    if isinstance(meas_map, List):
+    if isinstance(meas_map, list):
         meas_map = utils.format_meas_map(meas_map)
 
     measure_groups = set()

--- a/qiskit/pulse/parser.py
+++ b/qiskit/pulse/parser.py
@@ -320,4 +320,3 @@ def _match_Num_or_Parameter(node: ast.AST) -> bool:
           isinstance(node.value, circuit.ParameterExpression)):
         return True
     return False
-    

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -251,6 +251,23 @@ class TestContexts(TestBuilder):
 
         self.assertEqual(schedule, reference)
 
+    def test_phase_offset_parameter(self):
+        """Test the phase offset context with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            with pulse.phase_offset(param, d0):
+                pulse.delay(10, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.ShiftPhase(param, d0)
+        reference += instructions.Delay(10, d0)
+        reference += instructions.ShiftPhase(-param, d0)
+
+        self.assertEqual(schedule, reference)
+
     def test_frequency_offset(self):
         """Test the frequency offset context."""
         d0 = pulse.DriveChannel(0)
@@ -260,9 +277,26 @@ class TestContexts(TestBuilder):
                 pulse.delay(10, d0)
 
         reference = pulse.Schedule()
-        reference += instructions.ShiftFrequency(1e9, d0)  # pylint: disable=no-member
+        reference += instructions.ShiftFrequency(1e9, d0)
         reference += instructions.Delay(10, d0)
-        reference += instructions.ShiftFrequency(-1e9, d0)  # pylint: disable=no-member
+        reference += instructions.ShiftFrequency(-1e9, d0)
+
+        self.assertEqual(schedule, reference)
+
+    def test_frequency_offset_parameter(self):
+        """Test the frequency offset context with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            with pulse.frequency_offset(param, d0):
+                pulse.delay(10, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.ShiftFrequency(param, d0)
+        reference += instructions.Delay(10, d0)
+        reference += instructions.ShiftFrequency(-param, d0)
 
         self.assertEqual(schedule, reference)
 
@@ -276,11 +310,11 @@ class TestContexts(TestBuilder):
                 pulse.delay(10, d0)
 
         reference = pulse.Schedule()
-        reference += instructions.ShiftFrequency(1e9, d0)  # pylint: disable=no-member
+        reference += instructions.ShiftFrequency(1e9, d0)
         reference += instructions.Delay(10, d0)
         reference += instructions.ShiftPhase(
             -(1e9*10*self.configuration.dt % (2*np.pi)), d0)
-        reference += instructions.ShiftFrequency(-1e9, d0)  # pylint: disable=no-member
+        reference += instructions.ShiftFrequency(-1e9, d0)
         self.assertEqual(schedule, reference)
 
 
@@ -415,7 +449,21 @@ class TestInstructions(TestBuilder):
 
         self.assertEqual(schedule, reference)
 
-    def test_shift_frequency(self):  # pylint: disable=no-member
+    def test_set_frequency_parameter(self):
+        """Test set frequency instruction with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            pulse.set_frequency(param, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.SetFrequency(param, d0)
+
+        self.assertEqual(schedule, reference)
+
+    def test_shift_frequency(self):
         """Test shift frequency instruction."""
         d0 = pulse.DriveChannel(0)
 
@@ -423,11 +471,25 @@ class TestInstructions(TestBuilder):
             pulse.shift_frequency(0.1e9, d0)
 
         reference = pulse.Schedule()
-        reference += instructions.ShiftFrequency(0.1e9, d0)  # pylint: disable=no-member
+        reference += instructions.ShiftFrequency(0.1e9, d0)
 
         self.assertEqual(schedule, reference)
 
-    def test_set_phase(self):  # pylint: disable=no-member
+    def test_shift_frequency_parameter(self):
+        """Test shift frequency instruction with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            pulse.shift_frequency(param, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.ShiftFrequency(param, d0)
+
+        self.assertEqual(schedule, reference)
+
+    def test_set_phase(self):
         """Test set phase instruction."""
         d0 = pulse.DriveChannel(0)
 
@@ -435,7 +497,21 @@ class TestInstructions(TestBuilder):
             pulse.set_phase(3.14, d0)
 
         reference = pulse.Schedule()
-        reference += instructions.SetPhase(3.14, d0)  # pylint: disable=no-member
+        reference += instructions.SetPhase(3.14, d0)
+
+        self.assertEqual(schedule, reference)
+
+    def test_set_phase_parameter(self):
+        """Test set phase instruction with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            pulse.set_phase(param, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.SetPhase(param, d0)
 
         self.assertEqual(schedule, reference)
 
@@ -448,6 +524,20 @@ class TestInstructions(TestBuilder):
 
         reference = pulse.Schedule()
         reference += instructions.ShiftPhase(3.14, d0)
+
+        self.assertEqual(schedule, reference)
+
+    def test_shift_phase_parameter(self):
+        """Test shift phase instruction with parameter."""
+        d0 = pulse.DriveChannel(0)
+
+        param = circuit.Parameter('param')
+
+        with pulse.build() as schedule:
+            pulse.shift_phase(param, d0)
+
+        reference = pulse.Schedule()
+        reference += instructions.ShiftPhase(param, d0)
 
         self.assertEqual(schedule, reference)
 
@@ -790,6 +880,19 @@ class TestGates(TestBuilder):
 
         self.assertEqual(schedule, reference)
 
+    def test_u1_parameter(self):
+        """Test u1 gate with parameter."""
+        param = circuit.Parameter('param')
+
+        with pulse.build(self.backend) as schedule:
+            pulse.u1(param, 0)
+
+        reference_qc = circuit.QuantumCircuit(1)
+        reference_qc.append(circuit.library.U1Gate(param), [0])
+        reference = compiler.schedule(reference_qc, self.backend)
+
+        self.assertEqual(schedule, reference)
+
     def test_u2(self):
         """Test u2 gate."""
         with pulse.build(self.backend) as schedule:
@@ -801,10 +904,39 @@ class TestGates(TestBuilder):
 
         self.assertEqual(schedule, reference)
 
+    def test_u2_parameter(self):
+        """Test u2 gate with parameter."""
+        param1 = circuit.Parameter('param1')
+        param2 = circuit.Parameter('param2')
+
+        with pulse.build(self.backend) as schedule:
+            pulse.u2(param1, param2, 0)
+
+        reference_qc = circuit.QuantumCircuit(1)
+        reference_qc.append(circuit.library.U2Gate(param1, param2), [0])
+        reference = compiler.schedule(reference_qc, self.backend)
+
+        self.assertEqual(schedule, reference)
+
     def test_u3(self):
         """Test u3 gate."""
         with pulse.build(self.backend) as schedule:
             pulse.u3(np.pi, 0, np.pi/2, 0)
+
+        reference_qc = circuit.QuantumCircuit(1)
+        reference_qc.append(circuit.library.U3Gate(np.pi, 0, np.pi/2), [0])
+        reference = compiler.schedule(reference_qc, self.backend)
+
+        self.assertEqual(schedule, reference)
+
+    def test_u3_parameter(self):
+        """Test u3 gate with parameter."""
+        param1 = circuit.Parameter('param1')
+        param2 = circuit.Parameter('param2')
+        param3 = circuit.Parameter('param3')
+
+        with pulse.build(self.backend) as schedule:
+            pulse.u3(param1, param2, param3, 0)
 
         reference_qc = circuit.QuantumCircuit(1)
         reference_qc.append(circuit.library.U3Gate(np.pi, 0, np.pi/2), [0])
@@ -825,7 +957,7 @@ class TestGates(TestBuilder):
         self.assertEqual(schedule, reference)
 
     def test_lazy_evaluation_with_transpiler(self):
-        """Test that the two cx gates are optimizied away by the transpiler."""
+        """Test that the two cx gates are optimized away by the transpiler."""
         with pulse.build(self.backend) as schedule:
             pulse.cx(0, 1)
             pulse.cx(0, 1)
@@ -858,7 +990,7 @@ class TestGates(TestBuilder):
                 pulse.x(0)
 
     def test_call_circuit_with_cregs(self):
-        """Test calling of circuit wiht classical registers."""
+        """Test calling of circuit with classical registers."""
 
         qc = circuit.QuantumCircuit(2, 2)
         qc.h(0)

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -181,20 +181,20 @@ class TestInstructionScheduleMap(QiskitTestCase):
         sched = inst_map.get('inst_seq', 0, 1, 2, p3_expr)
         self.assertEqual(sched.instructions[0][-1].phase, 1)
         self.assertEqual(sched.instructions[1][-1].phase, 2)
-        self.assertEqual(sched.instructions[2][-1].phase, 3)
+        self.assertEqual(sched.instructions[2][-1].phase, p3_expr)
 
         sched = inst_map.get('inst_seq', 0, P1=1, P2=2, P3=p3_expr)
         self.assertEqual(sched.instructions[0][-1].phase, 1)
         self.assertEqual(sched.instructions[1][-1].phase, 2)
-        self.assertEqual(sched.instructions[2][-1].phase, 3)
+        self.assertEqual(sched.instructions[2][-1].phase, p3_expr)
 
         sched = inst_map.get('inst_seq', 0, 1, 2, P3=p3_expr)
         self.assertEqual(sched.instructions[0][-1].phase, 1)
         self.assertEqual(sched.instructions[1][-1].phase, 2)
-        self.assertEqual(sched.instructions[2][-1].phase, 3)
+        self.assertEqual(sched.instructions[2][-1].phase, p3_expr)
 
     def test_schedule_generator(self):
-        """Test schedule generator functionalty."""
+        """Test schedule generator functionality."""
 
         dur_val = 10
         amp = 1.0
@@ -214,7 +214,7 @@ class TestInstructionScheduleMap(QiskitTestCase):
         self.assertEqual(inst_map.get_parameters('f', (0,)), ('dur',))
 
     def test_schedule_generator_supports_parameter_expressions(self):
-        """Test expression-based schedule generator functionalty."""
+        """Test expression-based schedule generator functionality."""
 
         t_param = Parameter('t')
         amp = 1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR adds support for parameters to the pulse builder. This includes tests and type-hints.


### Details and comments
It was necessary to slightly modify the pulse math parser to support parameter expressions in circuits in the pulse scheduler.

