### PR TITLE
Move scipy.stats imports to runtime

### DIFF
--- a/qiskit/circuit/library/probability_distributions/lognormal.py
+++ b/qiskit/circuit/library/probability_distributions/lognormal.py
@@ -14,7 +14,6 @@
 
 from typing import Tuple, List, Union, Optional
 import numpy as np
-from scipy.stats import multivariate_normal
 from qiskit.circuit import QuantumCircuit
 from .normal import _check_bounds_valid, _check_dimensions_match
 
@@ -133,6 +132,8 @@ class LogNormalDistribution(QuantumCircuit):
 
         # compute the normalized, truncated probabilities
         probabilities = []
+        from scipy.stats import multivariate_normal
+
         for x_i in x:
             # pylint: disable=line-too-long
             # map probabilities from normal to log-normal reference:

--- a/qiskit/circuit/library/probability_distributions/normal.py
+++ b/qiskit/circuit/library/probability_distributions/normal.py
@@ -14,7 +14,6 @@
 
 from typing import Tuple, Union, List, Optional
 import numpy as np
-from scipy.stats import multivariate_normal
 from qiskit.circuit import QuantumCircuit
 
 
@@ -177,6 +176,8 @@ class NormalDistribution(QuantumCircuit):
                                      for i, bound in enumerate(bounds)], indexing='ij')
             # flatten into a list of points
             x = list(zip(*[grid.flatten() for grid in meshgrid]))
+
+        from scipy.stats import multivariate_normal
 
         # compute the normalized, truncated probabilities
         probabilities = multivariate_normal.pdf(x, mu, sigma)

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -16,7 +16,6 @@ Methods to create random operators.
 
 import numpy as np
 from numpy.random import default_rng
-from scipy import stats
 
 from qiskit.quantum_info.operators import Operator, Stinespring
 from qiskit.exceptions import QiskitError
@@ -50,6 +49,7 @@ def random_unitary(dims, seed=None):
         random_state = default_rng(seed)
 
     dim = np.product(dims)
+    from scipy import stats
     mat = stats.unitary_group.rvs(dim, random_state=random_state)
     return Operator(mat, input_dims=dims, output_dims=dims)
 
@@ -79,6 +79,7 @@ def random_hermitian(dims, traceless=False, seed=None):
 
     # Total dimension
     dim = np.product(dims)
+    from scipy import stats
 
     if traceless:
         mat = np.zeros((dim, dim), dtype=complex)
@@ -141,6 +142,7 @@ def random_quantum_channel(input_dims=None,
         rank = d_in * d_out
     if rank < 1:
         raise QiskitError("Rank {} must be greater than 0.".format(rank))
+    from scipy import stats
 
     # Generate a random unitary matrix
     unitary = stats.unitary_group.rvs(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The scipy.stats submodule is a relatively slow import and takes up
roughly 12% of our total import time. This is disproportionately large
compared to its use in the random operator generator functions and
probability distribution circuit library classes which are not critical to
any of the core functionality or performance
critical. This commit shifts the module level import to be a runtime
import to avoid this import cost, while this does add runtime overhead
(and an initial cost on the first execution) that is worth the tradeoff
to remove it from the default import path.

### Details and comments

Related #5100