### PR TITLE
Fix C4XGate QASM definition.

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -662,7 +662,7 @@ class C4XGate(ControlledGate):
         {
             h e; cu1(-pi/2) d,e; h e;
             c3x a,b,c,d;
-            h d; cu1(pi/4) d,e; h d;
+            h e; cu1(pi/4) d,e; h e;
             c3x a,b,c,d;
             c3sqrtx a,b,c,e;
         }

--- a/qiskit/qasm/libs/qelib1.inc
+++ b/qiskit/qasm/libs/qelib1.inc
@@ -242,7 +242,7 @@ gate c4x a,b,c,d,e
 {
     h e; cu1(-pi/2) d,e; h e;
     c3x a,b,c,d;
-    h d; cu1(pi/4) d,e; h d;
+    h e; cu1(pi/2) d,e; h e;
     c3x a,b,c,d;
     c3sqrtx a,b,c,e;
 }

--- a/releasenotes/notes/c4xgate-fix-inconsistent-qasm-def-b979edcc93a591d7.yaml
+++ b/releasenotes/notes/c4xgate-fix-inconsistent-qasm-def-b979edcc93a591d7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The QASM definition of 'c4x' in qelib1.inc has been corrected to match
+    the standard library definition for C4XGate.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QASM definition of `C4XGate` doesn't currently match `C4XGate._define`.

qelib1
```
// 4-controlled X gate
gate c4x a,b,c,d,e
{
    h e; cu1(-pi/2) d,e; h e;
    c3x a,b,c,d;
    h d; cu1(pi/4) d,e; h d;
    c3x a,b,c,d;
    c3sqrtx a,b,c,e;
}
```
`_define`:
```
        from qiskit.circuit.quantumcircuit import QuantumCircuit
        from .u1 import CU1Gate
        q = QuantumRegister(5, name='q')
        qc = QuantumCircuit(q, name=self.name)
        rules = [
            (HGate(), [q[4]], []),
            (CU1Gate(-numpy.pi / 2), [q[3], q[4]], []),
            (HGate(), [q[4]], []),
            (C3XGate(), [q[0], q[1], q[2], q[3]], []),
            (HGate(), [q[4]], []),
            (CU1Gate(numpy.pi / 2), [q[3], q[4]], []),
            (HGate(), [q[4]], []),
            (C3XGate(), [q[0], q[1], q[2], q[3]], []),
            (C3XGate(numpy.pi / 8), [q[0], q[1], q[2], q[4]], []),
        ]
        for instr, qargs, cargs in rules:
            qc._append(instr, qargs, cargs)
```

which leaves some inconsistent behavior.

```
import qiskit as qk
from qiskit.quantum_info import Operator
from qiskit.quantum_info.operators.predicates import is_identity_matrix

is_identity_matrix(
    Operator(qk.QuantumCircuit.from_qasm_str("""
OPENQASM 2.0;
include "qelib1.inc";
qreg q[5];
c4x q[0],q[1],q[2],q[3],q[4];
c4x q[0],q[1],q[2],q[3],q[4];
""")).data, ignore_phase=True)
```

is `False` and

```
qc = qk.QuantumCircuit(5)
qc.append(C4XGate(), range(5))
qc.append(C4XGate(), range(5))

is_identity_matrix(
    Operator(qc).data, ignore_phase=True)
```
is `True`.

This PR updates the QASM definition to match `_define`. 

### Details and comments


