### PR TITLE
Skip classical function compiler tests if tweedledum unavailable.

### DIFF
--- a/test/python/classical_function_compiler/test_classical_function.py
+++ b/test/python/classical_function_compiler/test_classical_function.py
@@ -11,10 +11,12 @@
 # that they have been altered from the originals.
 
 """Tests ClassicalFunction as a gate."""
+import unittest
 
 from qiskit.test import QiskitTestCase
 
 from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.circuit.classicalfunction.classicalfunction import HAS_TWEEDLEDUM
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import XGate
@@ -25,6 +27,7 @@ from . import examples
 class TestOracleDecomposition(QiskitTestCase):
     """Tests ClassicalFunction.decomposition."""
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_grover_oracle(self):
         """ grover_oracle.decomposition"""
         oracle = compile_classical_function(examples.grover_oracle)

--- a/test/python/classical_function_compiler/test_parse.py
+++ b/test/python/classical_function_compiler/test_parse.py
@@ -24,7 +24,6 @@ from . import bad_examples as examples
 class TestParseFail(QiskitTestCase):
     """Tests bad_examples with the classicalfunction parser."""
 
-    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def assertExceptionMessage(self, context, message):
         """Asserts the message of an exception context"""
         self.assertTrue(message in context.exception.args[0])

--- a/test/python/classical_function_compiler/test_parse.py
+++ b/test/python/classical_function_compiler/test_parse.py
@@ -11,9 +11,12 @@
 # that they have been altered from the originals.
 
 """Tests the classicalfunction parser."""
+import unittest
 
 from qiskit.circuit.classicalfunction import ClassicalFunctionParseError
 from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.circuit.classicalfunction.classicalfunction import HAS_TWEEDLEDUM
+
 from qiskit.test import QiskitTestCase
 from . import bad_examples as examples
 
@@ -21,28 +24,33 @@ from . import bad_examples as examples
 class TestParseFail(QiskitTestCase):
     """Tests bad_examples with the classicalfunction parser."""
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def assertExceptionMessage(self, context, message):
         """Asserts the message of an exception context"""
         self.assertTrue(message in context.exception.args[0])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_id_bad_return(self):
         """Trying to parse examples.id_bad_return raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
             compile_classical_function(examples.id_bad_return)
         self.assertExceptionMessage(context, 'return type error')
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_id_no_type_arg(self):
         """Trying to parse examples.id_no_type_arg raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
             compile_classical_function(examples.id_no_type_arg)
         self.assertExceptionMessage(context, 'argument type is needed')
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_id_no_type_return(self):
         """Trying to parse examples.id_no_type_return raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:
             compile_classical_function(examples.id_no_type_return)
         self.assertExceptionMessage(context, 'return type is needed')
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_out_of_scope(self):
         """Trying to parse examples.out_of_scope raises ClassicalFunctionParseError"""
         with self.assertRaises(ClassicalFunctionParseError) as context:

--- a/test/python/classical_function_compiler/test_simulate.py
+++ b/test/python/classical_function_compiler/test_simulate.py
@@ -11,9 +11,11 @@
 # that they have been altered from the originals.
 
 """Tests LogicNetwork.simulate method."""
+import unittest
 
 from ddt import ddt, data
 from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.circuit.classicalfunction.classicalfunction import HAS_TWEEDLEDUM
 from qiskit.test import QiskitTestCase
 from .utils import get_truthtable_from_function, example_list
 
@@ -22,6 +24,7 @@ from .utils import get_truthtable_from_function, example_list
 class TestSimulate(QiskitTestCase):
     """Tests LogicNetwork.simulate method"""
     @data(*example_list())
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_(self, a_callable):
         """Tests LogicSimulate.simulate() on all the examples"""
         network = compile_classical_function(a_callable)

--- a/test/python/classical_function_compiler/test_synthesis.py
+++ b/test/python/classical_function_compiler/test_synthesis.py
@@ -11,10 +11,12 @@
 # that they have been altered from the originals.
 
 """Tests classicalfunction compiler synthesis."""
+import unittest
 
 from qiskit.test import QiskitTestCase
 
 from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.circuit.classicalfunction.classicalfunction import HAS_TWEEDLEDUM
 
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library.standard_gates import XGate
@@ -25,6 +27,7 @@ from . import examples
 class TestSynthesis(QiskitTestCase):
     """Tests ClassicalFunction.synth method."""
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_grover_oracle(self):
         """Synthesis of grover_oracle example"""
         oracle = compile_classical_function(examples.grover_oracle)
@@ -36,6 +39,7 @@ class TestSynthesis(QiskitTestCase):
         self.assertEqual(quantum_circuit.name, 'grover_oracle')
         self.assertEqual(quantum_circuit, expected)
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_grover_oracle_arg_regs(self):
         """Synthesis of grover_oracle example with arg_regs"""
         oracle = compile_classical_function(examples.grover_oracle)

--- a/test/python/classical_function_compiler/test_typecheck.py
+++ b/test/python/classical_function_compiler/test_typecheck.py
@@ -11,28 +11,34 @@
 # that they have been altered from the originals.
 
 """Tests classicalfunction compiler type checker."""
+import unittest
 
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.classicalfunction import ClassicalFunctionCompilerTypeError
 from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.circuit.classicalfunction.classicalfunction import HAS_TWEEDLEDUM
+
 from . import examples, bad_examples
 
 
 class TestTypeCheck(QiskitTestCase):
     """Tests classicalfunction compiler type checker (good examples)."""
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_id(self):
         """Tests examples.identity type checking"""
         network = compile_classical_function(examples.identity)
         self.assertEqual(network.args, ['a'])
         self.assertEqual(network.types, [{'Int1': 'type', 'a': 'Int1', 'return': 'Int1'}])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_bool_not(self):
         """Tests examples.bool_not type checking"""
         network = compile_classical_function(examples.bool_not)
         self.assertEqual(network.args, ['a'])
         self.assertEqual(network.types, [{'Int1': 'type', 'a': 'Int1', 'return': 'Int1'}])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_id_assign(self):
         """Tests examples.id_assing type checking"""
         network = compile_classical_function(examples.id_assing)
@@ -40,6 +46,7 @@ class TestTypeCheck(QiskitTestCase):
         self.assertEqual(network.types, [{'Int1': 'type', 'a': 'Int1',
                                           'b': 'Int1', 'return': 'Int1'}])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_bit_and(self):
         """Tests examples.bit_and type checking"""
         network = compile_classical_function(examples.bit_and)
@@ -47,6 +54,7 @@ class TestTypeCheck(QiskitTestCase):
         self.assertEqual(network.types, [{'Int1': 'type', 'a': 'Int1',
                                           'b': 'Int1', 'return': 'Int1'}])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_bit_or(self):
         """Tests examples.bit_or type checking"""
         network = compile_classical_function(examples.bit_or)
@@ -54,6 +62,7 @@ class TestTypeCheck(QiskitTestCase):
         self.assertEqual(network.types, [{'Int1': 'type', 'a': 'Int1',
                                           'b': 'Int1', 'return': 'Int1'}])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_bool_or(self):
         """Tests examples.bool_or type checking"""
         network = compile_classical_function(examples.bool_or)
@@ -69,6 +78,7 @@ class TestTypeCheckFail(QiskitTestCase):
         """Asserts the message of an exception context"""
         self.assertTrue(message in context.exception.args[0])
 
+    @unittest.skipUnless(HAS_TWEEDLEDUM, 'tweedledum not available')
     def test_bit_not(self):
         """Int1wise not does not work on bit (aka bool)
           ~True   # -2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In environments without tweedledum installed, skip rather than fail the classical function compiler tests.

### Details and comments


