### PR TITLE
[WIP] Pauli measure instruction

### DIFF
--- a/qiskit/circuit/library/generalized_measurement/__init__.py
+++ b/qiskit/circuit/library/generalized_measurement/__init__.py
@@ -1,0 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""The circuit library module on generalized measurements."""
+
+from .pauli_measure import PauliMeasure

--- a/qiskit/circuit/library/generalized_measurement/pauli_measure.py
+++ b/qiskit/circuit/library/generalized_measurement/pauli_measure.py
@@ -1,0 +1,94 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Quantum measurement in the Pauli basis.
+"""
+from typing import List
+from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.exceptions import CircuitError
+
+
+class PauliMeasure(Instruction):
+    """Quantum measurement in the Pauli basis."""
+
+    def __init__(self, params: List):
+        """Create new Pauli measurement instruction."""
+        super().__init__("measure", 1, 1, params)
+
+    def broadcast_arguments(self, qargs, cargs):
+        qarg = qargs[0]
+        carg = cargs[0]
+
+        if len(carg) == len(qarg):
+            for qarg, carg in zip(qarg, carg):
+                yield [qarg], [carg]
+        elif len(qarg) == 1 and carg:
+            for each_carg in carg:
+                yield qarg, [each_carg]
+        else:
+            raise CircuitError('register size error')
+
+    def _define(self):
+        """Decompose to 1-qubit measurements in the computational basis"""
+        # pylint: disable=cyclic-import
+        from qiskit import QuantumCircuit
+
+        pauli_string = self.params[0]
+        nqubits = len(pauli_string)
+        qc = QuantumCircuit(nqubits, nqubits,
+                            name='pauli_measure_' + pauli_string)
+        
+        for i, p enumerate(reversed(pauli_string)):
+            if p == 'I':
+                continue
+            if p == 'X':
+                qc.h(i)
+            if p == 'Y':
+                qc.s(i)
+                qc.z(i)
+                qc.h(i)
+            qc.measure(i, i)
+                
+        self.definition = qc
+
+     def validate_parameter(self, parameter):
+        if isinstance(parameter, str):
+            if all([c in ["I", "X", "Y", "Z"] for c in parameter]):
+                return parameter
+            else:
+                raise CircuitError("Parameter string {0} should contain only "
+                                   "'I', 'X', 'Y', 'Z' characters")
+        else:
+            raise CircuitError("Parameter {0} should be a string of "
+                               "'I', 'X', 'Y', 'Z' characters")
+        
+
+def pauli_measure(self, qubit, cbit, params):
+    """Measure quantum bit into classical bit (tuples).
+
+    Args:
+        qubit (QuantumRegister|list|tuple): quantum register
+        cbit (ClassicalRegister|list|tuple): classical register
+
+    Returns:
+        qiskit.Instruction: the attached measure instruction.
+
+    Raises:
+        CircuitError: if qubit is not in this circuit or bad format;
+            if cbit is not in this circuit or not creg.
+    """
+    return self.append(PauliMeasure(), [qubit], [cbit])
+
+
+QuantumCircuit.pauli_measure = pauli_measure


### PR DESCRIPTION
In the spirit of the recently added Pauli gate instruction (#5153), I want to add a Pauli measurement instruction. For example,
```
circ.pauli_measure([0, 3], [0, 1], 'ZX')
```
will measure qubit 0 in the X basis and qubit 3 in the standard basis. Such a measurement, when provided as a single instruction, can be optimized in the Aer simulator.

I'm aware that, with #5153, there has been a discussion about the drawback in adding a new instruction to the already long list of instructions, as opposed to adding a circuit to the circuit library, and other alternatives. There is a decision, for now, to nevertheless add a new instruction, because currently the alternatives do not support assembling to qobj. This discussion applies here too.

This work-in-progress PR shows what I've done so far. In order to be able to continue, I would like some guidance. Someone to review the incomplete code and approve that it makes sense, and to answer several questions:
1. Are there any parts of the code that need to know that the circuit contains a measurement operation? Any requirement for example to update the transpiler about it?
2. How to test the code?
3. Should it really be a new instruction, or just add usage to the currently unused parameters of the existing measurement instruction?
4. If a new instruction: in the PR, I wrote a new class `PauliMeasure`, which inherits directly from `Instruction`. Maybe it would be better to inherit from `Measure`, or to make `Measure` and `PauliMeasure` inherit from the same intermediate class.
5. Location of the new file `pauli_measure.py`.
6. I'm not sure about the correctness of `_define` - if the quantum and classical registers and their indices are handled correctly.