### PR TITLE
Paul Feature_map update with rotation factor (alpha)

### DIFF
--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -118,7 +118,7 @@ class PauliFeatureMap(NLocal):
         Args:
             feature_dimension: Number of qubits in the circuit.
             reps: The number of repeated circuits.
-            alpha: The rotational velocity factor
+            alpha: The Pauli rotation factor
             entanglement: Specifies the entanglement structure. Refer to
                 :class:`~qiskit.circuit.library.NLocal` for detail.
             paulis: A list of strings for to-be-used paulis. If None are provided, ``['Z', 'ZZ']``

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -106,6 +106,7 @@ class PauliFeatureMap(NLocal):
     def __init__(self,
                  feature_dimension: Optional[int] = None,
                  reps: int = 2,
+                 alpha: float = 2.0,
                  entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = 'full',
                  paulis: Optional[List[str]] = None,
                  data_map_func: Optional[Callable[[np.ndarray], float]] = None,
@@ -117,6 +118,7 @@ class PauliFeatureMap(NLocal):
         Args:
             feature_dimension: Number of qubits in the circuit.
             reps: The number of repeated circuits.
+            alpha: The rotational velocity factor
             entanglement: Specifies the entanglement structure. Refer to
                 :class:`~qiskit.circuit.library.NLocal` for detail.
             paulis: A list of strings for to-be-used paulis. If None are provided, ``['Z', 'ZZ']``
@@ -139,6 +141,7 @@ class PauliFeatureMap(NLocal):
 
         self._data_map_func = data_map_func or self_product
         self._paulis = paulis or ['Z', 'ZZ']
+        self._alpha = alpha
 
     # pylint: disable=unused-argument
     def _parameter_generator(self, rep: int, block: int, indices: List[int]
@@ -170,6 +173,25 @@ class PauliFeatureMap(NLocal):
         """
         self._invalidate()
         self._paulis = paulis
+
+    @property
+    def alpha(self) -> float:
+        """The Pauli rotation factor (alpha).
+
+        Returns:
+            The Pauli rotation factor.
+        """
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, alpha: float) -> None:
+        """Set the Pauli rotation factor (alpha).
+
+        Args:
+            alpha: Pauli rotation factor
+        """
+        self._invalidate()
+        self._alpha = alpha
 
     @property
     def entanglement_blocks(self):
@@ -240,7 +262,7 @@ class PauliFeatureMap(NLocal):
 
         basis_change(evo)
         cx_chain(evo)
-        evo.p(2.0 * time, indices[-1])
+        evo.p(self.alpha * time, indices[-1])
         cx_chain(evo, inverse=True)
         basis_change(evo, inverse=True)
         return evo

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -106,8 +106,8 @@ class PauliFeatureMap(NLocal):
     def __init__(self,
                  feature_dimension: Optional[int] = None,
                  reps: int = 2,
-                 alpha: float = 2.0,
                  entanglement: Union[str, List[List[int]], Callable[[int], List[int]]] = 'full',
+                 alpha: float = 2.0,
                  paulis: Optional[List[str]] = None,
                  data_map_func: Optional[Callable[[np.ndarray], float]] = None,
                  parameter_prefix: str = 'x',
@@ -118,9 +118,9 @@ class PauliFeatureMap(NLocal):
         Args:
             feature_dimension: Number of qubits in the circuit.
             reps: The number of repeated circuits.
-            alpha: The Pauli rotation factor
             entanglement: Specifies the entanglement structure. Refer to
                 :class:`~qiskit.circuit.library.NLocal` for detail.
+            alpha: The Pauli rotation factor, multiplicative to the pauli rotations
             paulis: A list of strings for to-be-used paulis. If None are provided, ``['Z', 'ZZ']``
                 will be used.
             data_map_func: A mapping function for data x which can be supplied to override the

--- a/releasenotes/notes/paul_feature_alpha-1fdba69c577c6b4d.yaml
+++ b/releasenotes/notes/paul_feature_alpha-1fdba69c577c6b4d.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Introducing alpha, rotational factor, instead of "hard-coded" 2 to control the rotational speed of Pauli Feature
+    maps.
+    This allows better control of decision boundaries and provide additonal flexiblity handle the input features
+    without explicit scaling input features in the data set.

--- a/releasenotes/notes/paul_feature_alpha-1fdba69c577c6b4d.yaml
+++ b/releasenotes/notes/paul_feature_alpha-1fdba69c577c6b4d.yaml
@@ -1,7 +1,6 @@
 ---
 features:
   - |
-    Introducing alpha, rotational factor, instead of "hard-coded" 2 to control the rotational speed of Pauli Feature
-    maps.
-    This allows better control of decision boundaries and provide additonal flexiblity handle the input features
-    without explicit scaling input features in the data set.
+    Allow modifying the rotational factor :math:`\alpha` in the Pauli feature map, instead of using the hardcoded value of 2.
+    This allows better control of decision boundaries and provide additional flexibility handle the input features
+    without explicit scaling them in the data set.

--- a/test/python/circuit/library/test_pauli_feature_map.py
+++ b/test/python/circuit/library/test_pauli_feature_map.py
@@ -116,6 +116,13 @@ class TestDataPreparation(QiskitTestCase):
 
         self.assertTrue(Operator(encoding).equiv(ref))
 
+    def test_pauli_alpha(self):
+        """Test  Pauli rotation factor (getter, setter)."""
+        encoding = PauliFeatureMap()
+        self.assertEqual(encoding.alpha, 2.0)
+        encoding.alpha = 1.4
+        self.assertEqual(encoding.alpha, 1.4)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Introduce parameter alpha( default=2) instead of hard-coded 2 in the Paul-feature-map.  
This would allow more flexible decision boundary control for QSVM

This work is done with close collaboration with @woodsp-ibm , Stephen Woener, and Jae-Eun Park from IBM

### Details and comments

Original Paul Feature Map has hard-coded value "2" 

Beyond the feature scaling,  the factor allows QSVM to create more classical looking decision boundaries with better analytical performance.  

![image](https://user-images.githubusercontent.com/54322126/96922976-9f8a2e00-147e-11eb-8010-0f12afb92f94.png)


