### PR TITLE
Fix display of backend name in Result.__repr__

### DIFF
--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -62,7 +62,7 @@ class Result:
     def __repr__(self):
         out = ("Result(backend_name='%s', backend_version='%s', qobj_id='%s', "
                "job_id='%s', success=%s, results=%s" % (
-                   self.backend_version,
+                   self.backend_name,
                    self.backend_version, self.qobj_id, self.job_id, self.success,
                    self.results))
         if hasattr(self, 'date'):

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -77,7 +77,7 @@ class TestResultOperations(QiskitTestCase):
         exp_result = models.ExperimentResult(shots=14, success=True, meas_level=2,
                                              data=data, header=exp_result_header)
         result = Result(results=[exp_result], **self.base_result_args)
-        expected = ("Result(backend_name='1.0.0', backend_version='1.0.0', "
+        expected = ("Result(backend_name='test_backend', backend_version='1.0.0', "
                     "qobj_id='id-123', job_id='job-123', success=True, "
                     "results=[ExperimentResult(shots=14, success=True, "
                     "meas_level=2, data=ExperimentResultData(counts={'0x0': 4,"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixed #5283 , changed ` backend_version ` to ` backend_name ` in `Result.__repr__ `


### Details and comments
changed ` backend_version ` to ` backend_name ` in `Result.__repr__ `
