### PR TITLE
classical_function decorator to handle parsing indented define.

### DIFF
--- a/qiskit/circuit/classicalfunction/__init__.py
+++ b/qiskit/circuit/classicalfunction/__init__.py
@@ -112,6 +112,7 @@ def classical_function(func):
         method).
     """
     import inspect
+    from textwrap import dedent
 
-    source = inspect.getsource(func).strip()
+    source = dedent(inspect.getsource(func))
     return ClassicalFunction(source, name=func.__name__)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

```
import qiskit as qk
from qiskit.circuit import classical_function, Int1

def build_qc():
    qc = qk.QuantumCircuit(2)
    @classical_function
    def cfunc(a: Int1) -> Int1:
        return not a
    qc.append(cfunc, [0,1])
    return qc

build_qc().draw()
```

had raised

```
Traceback (most recent call last):

  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/lib/python3.6/site-packages/IPython/core/interactiveshell.py", line 3343, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  File "<ipython-input-1-640b2be56591>", line 12, in <module>
    build_qc().draw()

  File "<ipython-input-1-640b2be56591>", line 7, in build_qc
    def cfunc(a: Int1) -> Int1:

  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/circuit/classicalfunction/__init__.py", line 119, in classical_function
    return ClassicalFunction(source, name=func.__name__)

  File "/Users/kevin.krsulichibm.com/q/qiskit-terra/qiskit/circuit/classicalfunction/classicalfunction.py", line 49, in __init__
    self._ast = ast.parse(source)

  File "/Users/kevin.krsulichibm.com/.pyenv/versions/3.6.10/lib/python3.6/ast.py", line 35, in parse
    return compile(source, filename, mode, PyCF_ONLY_AST)

  File "<unknown>", line 2
    def cfunc(a: Int1) -> Int1:
    ^
IndentationError: unexpected indent
```


### Details and comments


