### PR TITLE
Fix release note about the classical function compiler

### DIFF
--- a/releasenotes/notes/0.16/classical_funciton_compliation-c5d75e0aaf04c8f1.yaml
+++ b/releasenotes/notes/0.16/classical_funciton_compliation-c5d75e0aaf04c8f1.yaml
@@ -38,7 +38,13 @@ features:
 
       circuit = QuantumCircuit(5)
       circuit.append(grover_oracle, range(5))
-      quantum_circuit.draw()
+      circuit.draw()
 
-    The feature requires ``tweedledum``, a library for synthesizing quantum
-    circuits, that can be installed via pip with ``pip install tweedledum``.
+    The ``GROVER_ORACLE`` gate is synthesized when its decomposition is required.
+
+    .. jupyter-execute::
+
+      circuit.decompose().draw()
+
+      The feature requires ``tweedledum``, a library for synthesizing quantum
+      circuits, that can be installed via pip with ``pip install tweedledum``.

--- a/releasenotes/notes/0.16/classical_funciton_compliation-c5d75e0aaf04c8f1.yaml
+++ b/releasenotes/notes/0.16/classical_funciton_compliation-c5d75e0aaf04c8f1.yaml
@@ -46,5 +46,5 @@ features:
 
       circuit.decompose().draw()
 
-      The feature requires ``tweedledum``, a library for synthesizing quantum
-      circuits, that can be installed via pip with ``pip install tweedledum``.
+    The feature requires ``tweedledum``, a library for synthesizing quantum
+    circuits, that can be installed via pip with ``pip install tweedledum``.


### PR DESCRIPTION
There is a typo in the release note for 0.16, when classical function compiler is explained.

Related to https://github.com/Qiskit/qiskit/pull/1071