### PR TITLE
Fix bug: execute valid circuits built with delays

### DIFF
--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -21,7 +21,6 @@ Executing Experiments (:mod:`qiskit.execute`)
 """
 import logging
 from time import time
-from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile, assemble, schedule
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -249,14 +249,6 @@ def execute(experiments, backend,
                                     initial_layout=initial_layout)
         experiments = pass_manager.run(experiments)
     else:
-        if 'delay' not in backend.configuration().basis_gates and _any_delay_in(experiments):
-            if schedule_circuit and backend.configuration().open_pulse:
-                pass  # the delay will be handled in the Pulse schedule
-            else:
-                raise QiskitError("Backend {} does not support delay instruction. "
-                                  "Use 'schedule_circuit=True' for pulse-enabled backends."
-                                  .format(backend.name()))
-
         # transpiling the circuits using given transpile options
         experiments = transpile(experiments,
                                 basis_gates=basis_gates,

--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -324,22 +324,3 @@ def _check_conflicting_argument(**kargs):
     if conflicting_args:
         raise QiskitError("The parameters pass_manager conflicts with the following "
                           "parameter(s): {}.".format(', '.join(conflicting_args)))
-
-
-def _any_delay_in(circuits):
-    """Check if the circuits have any delay instruction.
-
-    Args:
-        circuits (QuantumCircuit or list[QuantumCircuit]): Circuits to be checked
-
-    Returns:
-        bool: True if there is any delay in either of the circuit, otherwise False.
-    """
-    if isinstance(circuits, QuantumCircuit):
-        circuits = [circuits]
-    has_delay = False
-    for qc in circuits:
-        if 'delay' in qc.count_ops():
-            has_delay = True
-            break
-    return has_delay

--- a/releasenotes/notes/bugfix-delays-are-supported-d294bc1cb478d149.yaml
+++ b/releasenotes/notes/bugfix-delays-are-supported-d294bc1cb478d149.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue where an error was thrown in execute for valid circuits
+    built with delays.

--- a/test/python/circuit/test_scheduled_circuit.py
+++ b/test/python/circuit/test_scheduled_circuit.py
@@ -108,13 +108,12 @@ class TestScheduledCircuit(QiskitTestCase):
         with self.assertRaises(QiskitError):
             transpile(qc, self.backend_without_dt, scheduling_method='alap')
 
-    def test_cannot_execute_delay_circuit_when_schedule_circuit_off(self):
+    def test_can_execute_delay_circuit_when_schedule_circuit_off(self):
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.delay(500, 1)
         qc.cx(0, 1)
-        with self.assertRaises(QiskitError):
-            execute(qc, backend=self.backend_with_dt, schedule_circuit=False)
+        execute(qc, backend=self.backend_with_dt, schedule_circuit=False)
 
     def test_transpile_single_delay_circuit(self):
         qc = QuantumCircuit(1)


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This no longer errors.

```
qc = QuantumCircuit(2, 2)
qc.delay(10, [0])
tqc = transpile(qc, backend)
execute(tqc, backend)
```

### Details and comments


