### PR TITLE
Improve init efficiency of BaseOperator for N-qubit operators

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -96,7 +96,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         # Set dimension attributes
         if num_qubits:
             self._set_qubit_dims(num_qubits)
-        else:
+        elif input_dims is not None and output_dims is not None:
             self._set_dims(input_dims, output_dims)
 
     def __call__(self, qargs):
@@ -132,10 +132,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
     @property
     def dim(self):
         """Return tuple (input_shape, output_shape)."""
-        if self.num_qubits:
-            dim = 2 ** self.num_qubits
-            return dim, dim
-        return np.product(self._input_dims), np.product(self._output_dims)
+        return self._input_dim, self._output_dim
 
     @property
     def num_qubits(self):
@@ -541,9 +538,8 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
                 input_dims = other.input_dims()
             else:
                 input_dims = list(self.input_dims())
-                new_dims = other.input_dims()
-                for i, qubit in enumerate(qargs):
-                    input_dims[qubit] = new_dims[i]
+                for qubit, dim in zip(qargs, other.input_dims()):
+                    input_dims[qubit] = dim
         else:
             if other.input_dims() != self.output_dims(qargs):
                 raise QiskitError(
@@ -555,9 +551,8 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
                 output_dims = other.output_dims()
             else:
                 output_dims = list(self.output_dims())
-                new_dims = other.output_dims()
-                for i, qubit in enumerate(qargs):
-                    output_dims[qubit] = new_dims[i]
+                for qubit, dim in zip(qargs, other.output_dims()):
+                    output_dims[qubit] = dim
         return input_dims, output_dims
 
     def _validate_add_dims(self, other, qargs=None):

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -72,18 +72,32 @@ class AbstractTolerancesMeta(TolerancesMeta, ABCMeta):
 class BaseOperator(metaclass=AbstractTolerancesMeta):
     """Abstract linear operator base class."""
 
-    def __init__(self, input_dims, output_dims):
+    def __init__(self, input_dims=None, output_dims=None, num_qubits=None):
         """Initialize an operator object."""
-        # Dimension attributes
+        # qargs for composition, set with __call__
+        self._qargs = None
+
+        # Number of qubit subsystems if N-qubit operator.
+        # None if operator is not an N-qubit operator
+        self._num_qubits = None
+
+        # General dimension operators
         # Note that the tuples of input and output dims are ordered
         # from least-significant to most-significant subsystems
-        self._qargs = None        # qargs for composition, set with __call__
+        # These may be None for N-qubit operators
         self._input_dims = None   # tuple of input dimensions of each subsystem
         self._output_dims = None  # tuple of output dimensions of each subsystem
-        self._input_dim = None    # combined input dimension of all subsystems
-        self._output_dim = None   # combined output dimension of all subsystems
-        self._num_qubits = None   # number of qubit subsystems if N-qubit operator
-        self._set_dims(input_dims, output_dims)
+
+        # The number of input and output subsystems
+        # This is either the number of qubits, or length of the input/output dims
+        self._num_input = 0
+        self._num_output = 0
+
+        # Set dimension attributes
+        if num_qubits:
+            self._set_qubit_dims(num_qubits)
+        else:
+            self._set_dims(input_dims, output_dims)
 
     def __call__(self, qargs):
         """Return a clone with qargs set"""
@@ -92,11 +106,12 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         n_qargs = len(qargs)
         # We don't know if qargs will be applied to input our output
         # dimensions so we just check it matches one of them.
-        if n_qargs not in (len(self._input_dims), len(self._output_dims)):
+        if n_qargs != self._num_qubits and n_qargs not in (
+                self._num_input, self._num_output):
             raise QiskitError(
                 "Length of qargs ({}) does not match number of input ({})"
                 " or output ({}) subsystems.".format(
-                    n_qargs, len(self._input_dims), len(self._output_dims)))
+                    n_qargs, self._num_input, self._num_output))
         # Make a shallow copy
         ret = copy.copy(self)
         ret._qargs = qargs
@@ -105,6 +120,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
     def __eq__(self, other):
         """Check types and subsystem dimensions are equal"""
         return (isinstance(other, self.__class__) and
+                self._num_qubits == other._num_qubits and
                 self._input_dims == other._input_dims and
                 self._output_dims == other._output_dims)
 
@@ -116,12 +132,29 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
     @property
     def dim(self):
         """Return tuple (input_shape, output_shape)."""
-        return self._input_dim, self._output_dim
+        if self.num_qubits:
+            dim = 2 ** self.num_qubits
+            return dim, dim
+        return np.product(self._input_dims), np.product(self._output_dims)
 
     @property
     def num_qubits(self):
         """Return the number of qubits if a N-qubit operator or None otherwise."""
         return self._num_qubits
+
+    @property
+    def _input_dim(self):
+        """Return the total input dimension."""
+        if self.num_qubits:
+            return 2 ** self.num_qubits
+        return np.product(self._input_dims)
+
+    @property
+    def _output_dim(self):
+        """Return the total input dimension."""
+        if self.num_qubits:
+            return 2 ** self.num_qubits
+        return np.product(self._output_dims)
 
     @property
     def atol(self):
@@ -155,7 +188,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
                       DeprecationWarning)
         cls.rtol = value
 
-    def reshape(self, input_dims=None, output_dims=None):
+    def reshape(self, input_dims=None, output_dims=None, num_qubits=None):
         """Return a shallow copy with reshaped input and output subsystem dimensions.
 
         Arg:
@@ -165,6 +198,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
             output_dims (None or tuple): new subsystem output dimensions.
                 If None the original output dims will be preserved
                 [Default: None].
+            num_qubits (None or int): reshape to an N-qubit operator [Default: None].
 
         Returns:
             BaseOperator: returns self with reshaped input and output dimensions.
@@ -173,31 +207,57 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
             QiskitError: if combined size of all subsystem input dimension or
                          subsystem output dimensions is not constant.
         """
-        clone = copy.copy(self)
+        # Trivial case
+        if num_qubits:
+            if self.num_qubits == num_qubits:
+                return self
+            dim = 2 * (2 ** num_qubits, )
+            if self.dim != dim:
+                raise QiskitError(
+                    "Reshaped num_qubits ({}) are incompatible with combined"
+                    " input and output dimensions dimension ({}).".format(
+                        num_qubits, self.dim))
+            clone = copy.copy(self)
+            clone._set_qubit_dims(num_qubits)
+            return clone
+
         if output_dims is None and input_dims is None:
             return clone
+
+        input_dim, output_dim = self.dim
         if input_dims is not None:
-            if np.product(input_dims) != self._input_dim:
+            if np.product(input_dims) != input_dim:
                 raise QiskitError(
                     "Reshaped input_dims ({}) are incompatible with combined"
-                    " input dimension ({}).".format(input_dims, self._input_dim))
-            clone._input_dims = tuple(input_dims)
+                    " input dimension ({}).".format(input_dims, input_dim))
+        else:
+            input_dims = self.input_dims()
         if output_dims is not None:
-            if np.product(output_dims) != self._output_dim:
+            if np.product(output_dims) != output_dim:
                 raise QiskitError(
                     "Reshaped output_dims ({}) are incompatible with combined"
-                    " output dimension ({}).".format(output_dims, self._output_dim))
-            clone._output_dims = tuple(output_dims)
+                    " output dimension ({}).".format(output_dims, output_dim))
+        else:
+            output_dim = self.output_dims()
+        # Set new dimensions
+        clone = copy.copy(self)
+        clone._set_dims(input_dims, output_dims)
         return clone
 
     def input_dims(self, qargs=None):
         """Return tuple of input dimension for specified subsystems."""
+        if self._num_qubits:
+            num = self._num_qubits if qargs is None else len(qargs)
+            return num * (2, )
         if qargs is None:
             return self._input_dims
         return tuple(self._input_dims[i] for i in qargs)
 
     def output_dims(self, qargs=None):
         """Return tuple of output dimension for specified subsystems."""
+        if self._num_qubits:
+            num = self._num_qubits if qargs is None else len(qargs)
+            return num * (2, )
         if qargs is None:
             return self._output_dims
         return tuple(self._output_dims[i] for i in qargs)
@@ -312,8 +372,8 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         # this method should be overridden in that class.
         if not isinstance(n, (int, np.integer)) or n < 1:
             raise QiskitError("Can only power with positive integer powers.")
-        if self._input_dim != self._output_dim:
-            raise QiskitError("Can only power with input_dim = output_dim.")
+        if self._input_dims != self._output_dims:
+            raise QiskitError("Can only power with input_dims = output_dims.")
         ret = self.copy()
         for _ in range(1, n):
             ret = ret.compose(self)
@@ -403,88 +463,101 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
             "{} does not support scalar multiplication".format(type(self)))
 
     @classmethod
-    def _automatic_dims(cls, dims, size):
-        """Check if input dimension corresponds to qubit subsystems."""
-        if dims is None:
-            dims = size
-        elif np.product(dims) != size:
-            raise QiskitError("dimensions do not match size.")
-        if isinstance(dims, (int, np.integer)):
-            num_qubits = int(np.log2(dims))
-            if 2 ** num_qubits == size:
-                return num_qubits * (2,)
-            return (dims,)
-        return tuple(dims)
+    def _automatic_dims(cls, input_dims, input_size, output_dims=None, output_size=None):
+        """Check if dimension corresponds to qubit subsystems."""
+        if input_dims is None:
+            input_dims = input_size
+        elif np.product(input_dims) != input_size:
+            raise QiskitError("Input dimensions do not match size.")
+        din_int = isinstance(input_dims, (int, np.integer))
+
+        if output_size is None:
+            output_size = input_size
+            output_dims = input_dims
+        elif output_dims is None:
+            output_dims = output_size
+        elif np.product(output_dims) != output_size:
+            raise QiskitError("Output dimensions do not match size.")
+        dout_int = isinstance(output_dims, (int, np.integer))
+
+        # Check if N-qubit
+        if (input_size == output_size and din_int and dout_int):
+            num_qubits = int(np.log2(input_dims))
+            if 2 ** num_qubits == input_size:
+                return None, None, num_qubits
+
+        # General dims
+        input_dims = (input_dims, ) if din_int else tuple(input_dims)
+        output_dims = (output_dims, ) if dout_int else tuple(output_dims)
+        return input_dims, output_dims, None
+
+    def _set_qubit_dims(self, num_qubits):
+        """Set dimension attributes"""
+        self._num_qubits = int(num_qubits)
+        self._num_input = self._num_qubits
+        self._num_output = self._num_qubits
+        self._input_dims = None
+        self._output_dims = None
 
     def _set_dims(self, input_dims, output_dims):
         """Set dimension attributes"""
         # Shape lists the dimension of each subsystem starting from
         # least significant through to most significant.
-        self._input_dims = tuple(input_dims)
-        self._output_dims = tuple(output_dims)
-        # The total input and output dimensions are given by the product
-        # of all subsystem dimension in the input_dims/output_dims.
-        self._input_dim = np.product(input_dims)
-        self._output_dim = np.product(output_dims)
-        # Check if an N-qubit operator
-        if (self._input_dims == self._output_dims and
-                set(self._input_dims) == {2}):
-            # If so set the number of qubits
-            self._num_qubits = len(self._input_dims)
+        if (input_dims == output_dims and set(input_dims) == {2}):
+            self._set_qubit_dims(len(input_dims))
         else:
-            # Otherwise set the number of qubits to None
+            self._input_dims = tuple(input_dims)
+            self._output_dims = tuple(output_dims)
+            self._num_input = len(self._input_dims)
+            self._num_output = len(self._output_dims)
             self._num_qubits = None
 
     def _get_compose_dims(self, other, qargs, front):
-        """Check dimensions are compatible for composition.
+        """Check subsystems are compatible for composition."""
+        # Check if both qubit operators
+        if self.num_qubits and other.num_qubits:
+            if qargs and other.num_qubits != len(qargs):
+                raise QiskitError(
+                    "Other operator number of qubits does not match the "
+                    "number of qargs ({} != {})".format(
+                        other.num_qubits, len(qargs)))
+            elif qargs is None and self.num_qubits != other.num_qubits:
+                raise QiskitError(
+                    "Other operator number of qubits does not match the "
+                    "current operator ({} != {})".format(
+                        other.num_qubits, self.num_qubits))
+            dims = [2] * self.num_qubits
+            return dims, dims
 
-        Args:
-            other (BaseOperator): another operator object.
-            qargs (None or list): compose qargs kwarg value.
-            front (bool): compose front kwarg value.
-
-        Returns:
-            tuple: the tuple (input_dims, output_dims) for the composed
-                   operator.
-        Raises:
-            QiskitError: if operator dimensions are invalid for compose.
-        """
+        # General case
         if front:
-            output_dims = self._output_dims
+            if other.output_dims() != self.input_dims(qargs):
+                raise QiskitError(
+                    "Other operator output dimensions ({}) does not"
+                    " match current input dimensions ({}).".format(
+                        other.output_dims(qargs), self.input_dims()))
+            output_dims = self.output_dims()
             if qargs is None:
-                if other._output_dim != self._input_dim:
-                    raise QiskitError(
-                        "Other operator combined output dimension ({}) does not"
-                        " match current combined input dimension ({}).".format(
-                            other._output_dim, self._input_dim))
-                input_dims = other._input_dims
+                input_dims = other.input_dims()
             else:
-                if other._output_dims != self.input_dims(qargs):
-                    raise QiskitError(
-                        "Other operator output dimensions ({}) does not"
-                        " match current subsystem input dimensions ({}).".format(
-                            other._output_dims, self.input_dims(qargs)))
-                input_dims = list(self._input_dims)
+                input_dims = list(self.input_dims())
+                new_dims = other.input_dims()
                 for i, qubit in enumerate(qargs):
-                    input_dims[qubit] = other._input_dims[i]
+                    input_dims[qubit] = new_dims[i]
         else:
-            input_dims = self._input_dims
+            if other.input_dims() != self.output_dims(qargs):
+                raise QiskitError(
+                    "Other operator input dimensions ({}) does not"
+                    " match current output dimensions ({}).".format(
+                        other.output_dims(qargs), self.input_dims()))
+            input_dims = self.input_dims()
             if qargs is None:
-                if self._output_dim != other._input_dim:
-                    raise QiskitError(
-                        "Other operator combined input dimension ({}) does not"
-                        " match current combined output dimension ({}).".format(
-                            other._input_dim, self._output_dim))
-                output_dims = other._output_dims
+                output_dims = other.output_dims()
             else:
-                if self.output_dims(qargs) != other._input_dims:
-                    raise QiskitError(
-                        "Other operator input dimensions ({}) does not"
-                        " match current subsystem output dimension ({}).".format(
-                            other._input_dims, self.output_dims(qargs)))
-                output_dims = list(self._output_dims)
+                output_dims = list(self.output_dims())
+                new_dims = other.output_dims()
                 for i, qubit in enumerate(qargs):
-                    output_dims[qubit] = other._output_dims[i]
+                    output_dims[qubit] = new_dims[i]
         return input_dims, output_dims
 
     def _validate_add_dims(self, other, qargs=None):
@@ -497,6 +570,30 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         Raises:
             QiskitError: if operators have incompatibile dimensions for addition.
         """
+        if self.num_qubits and other.num_qubits:
+            self._validate_qubit_add_dims(other, qargs=qargs)
+        else:
+            self._validate_qudit_add_dims(other, qargs=qargs)
+
+    def _validate_qubit_add_dims(self, other, qargs=None):
+        """Check qubit operator dimensions are compatible for addition."""
+        if qargs is None:
+            # For adding without qargs we only require that operators have
+            # the same total dimensions rather than each subsystem dimension
+            # matching.
+            if self.num_qubits != other.num_qubits:
+                raise QiskitError(
+                    "Cannot add operators with different numbers of qubits"
+                    " ({} != {}).".format(self.num_qubits, other.num_qubits))
+        else:
+            if len(qargs) != other.num_qubits:
+                raise QiskitError(
+                    "Cannot add operators on subsystems with different"
+                    " number of qubits ({} != {}).".format(
+                        len(qargs), other.num_qubits))
+
+    def _validate_qudit_add_dims(self, other, qargs=None):
+        """Check general operatior dimensions are compatible for addition."""
         if qargs is None:
             # For adding without qargs we only require that operators have
             # the same total dimensions rather than each subsystem dimension
@@ -508,16 +605,16 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         else:
             # If adding on subsystems the operators must have equal
             # shape on subsystems
-            if (self._input_dims != self._output_dims or
-                    other._input_dims != other._output_dims):
+            if (self.input_dims() != self.output_dims() or
+                    other.input_dims() != other.output_dims()):
                 raise QiskitError(
                     "Cannot add operators on subsystems for non-square"
                     " operator.")
-            if self.input_dims(qargs) != other._input_dims:
+            if self.input_dims(qargs) != other.input_dims():
                 raise QiskitError(
                     "Cannot add operators on subsystems with different"
                     " dimensions ({} != {}).".format(
-                        self.input_dims(qargs), other._input_dims))
+                        self.input_dims(qargs), other.input_dims()))
 
     # Overloads
     def __matmul__(self, other):

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -188,7 +188,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
     def reshape(self, input_dims=None, output_dims=None, num_qubits=None):
         """Return a shallow copy with reshaped input and output subsystem dimensions.
 
-        Arg:
+        Args:
             input_dims (None or tuple): new subsystem input dimensions.
                 If None the original input dims will be preserved [Default: None].
             output_dims (None or tuple): new subsystem output dimensions.

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -190,11 +190,9 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
 
         Arg:
             input_dims (None or tuple): new subsystem input dimensions.
-                If None the original input dims will be preserved
-                [Default: None].
+                If None the original input dims will be preserved [Default: None].
             output_dims (None or tuple): new subsystem output dimensions.
-                If None the original output dims will be preserved
-                [Default: None].
+                If None the original output dims will be preserved [Default: None].
             num_qubits (None or int): reshape to an N-qubit operator [Default: None].
 
         Returns:
@@ -518,7 +516,7 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
                     "Other operator number of qubits does not match the "
                     "number of qargs ({} != {})".format(
                         other.num_qubits, len(qargs)))
-            elif qargs is None and self.num_qubits != other.num_qubits:
+            if qargs is None and self.num_qubits != other.num_qubits:
                 raise QiskitError(
                     "Other operator number of qubits does not match the "
                     "current operator ({} != {})".format(

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -116,12 +116,9 @@ class Chi(QuantumChannel):
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
         num_qubits = int(np.log2(input_dim))
-        if 2**num_qubits != input_dim:
+        if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Chi matrix.")
-        # Check and format input and output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__(chi_mat, input_dims, output_dims, 'Chi')
+        super().__init__(chi_mat, None, None, num_qubits, 'Chi')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/choi.py
+++ b/qiskit/quantum_info/operators/channel/choi.py
@@ -123,9 +123,9 @@ class Choi(QuantumChannel):
             if output_dims is None:
                 output_dims = data.output_dims()
         # Check and format input and output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__(choi_mat, input_dims, output_dims, 'Choi')
+        input_dims, output_dims, num_qubits = self._automatic_dims(
+            input_dims, input_dim, output_dims, output_dim)
+        super().__init__(choi_mat, input_dims, output_dims, num_qubits, 'Choi')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -159,16 +159,16 @@ class Kraus(QuantumChannel):
 
         output_dim, input_dim = kraus[0][0].shape
         # Check and format input and output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
+        input_dims, output_dims, num_qubits = self._automatic_dims(
+            input_dims, input_dim, output_dims, output_dim)
         # Initialize either single or general Kraus
         if kraus[1] is None or np.allclose(kraus[0], kraus[1]):
             # Standard Kraus map
             super().__init__((kraus[0], None), input_dims,
-                             output_dims, 'Kraus')
+                             output_dims, num_qubits, 'Kraus')
         else:
             # General (non-CPTP) Kraus map
-            super().__init__(kraus, input_dims, output_dims, 'Kraus')
+            super().__init__(kraus, input_dims, output_dims, num_qubits, 'Kraus')
 
     @property
     def data(self):

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -120,12 +120,9 @@ class PTM(QuantumChannel):
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
         num_qubits = int(np.log2(input_dim))
-        if 2**num_qubits != input_dim:
+        if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
-        # Check and format input and output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__(ptm, input_dims, output_dims, 'PTM')
+        super().__init__(ptm, None, None, num_qubits, 'PTM')
 
     @property
     def _bipartite_shape(self):

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -34,6 +34,7 @@ class QuantumChannel(BaseOperator):
     """Quantum channel representation base class."""
 
     def __init__(self, data, input_dims=None, output_dims=None,
+                 num_qubits=None,
                  channel_rep=None):
         """Initialize a quantum channel Superoperator operator.
 
@@ -43,6 +44,8 @@ class QuantumChannel(BaseOperator):
                                 [Default: None]
             output_dims (tuple): the output subsystem dimensions.
                                  [Default: None]
+            num_qubits (int): the number of qubits if N-qubit channel.
+                              [Default: None]                     
             channel_rep (str): quantum channel representation name string.
 
         Raises:
@@ -54,7 +57,9 @@ class QuantumChannel(BaseOperator):
                 channel_rep.__class__))
         self._channel_rep = channel_rep
         self._data = data
-        super().__init__(input_dims, output_dims)
+        super().__init__(input_dims=input_dims,
+                         output_dims=output_dims,
+                         num_qubits=num_qubits)
 
     def __repr__(self):
         prefix = '{}('.format(self._channel_rep)
@@ -62,7 +67,7 @@ class QuantumChannel(BaseOperator):
         return '{}{},\n{}input_dims={}, output_dims={})'.format(
             prefix, np.array2string(
                 np.asarray(self.data), separator=', ', prefix=prefix),
-            pad, self._input_dims, self._output_dims)
+            pad, self.input_dims(), self.output_dims())
 
     def __eq__(self, other):
         """Test if two QuantumChannels are equal."""

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -45,7 +45,7 @@ class QuantumChannel(BaseOperator):
             output_dims (tuple): the output subsystem dimensions.
                                  [Default: None]
             num_qubits (int): the number of qubits if N-qubit channel.
-                              [Default: None]                     
+                              [Default: None]
             channel_rep (str): quantum channel representation name string.
 
         Raises:

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -129,20 +129,22 @@ class Stinespring(QuantumChannel):
                 output_dims = data.output_dims()
 
         # Check and format input and output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
+        input_dims, output_dims, num_qubits = self._automatic_dims(
+            input_dims, input_dim, output_dims, output_dim)
         # Initialize either single or general Stinespring
         if stine[1] is None or (stine[1] == stine[0]).all():
             # Standard Stinespring map
             super().__init__((stine[0], None),
                              input_dims=input_dims,
                              output_dims=output_dims,
+                             num_qubits=num_qubits,
                              channel_rep='Stinespring')
         else:
             # General (non-CPTP) Stinespring map
             super().__init__(stine,
                              input_dims=input_dims,
                              output_dims=output_dims,
+                             num_qubits=num_qubits,
                              channel_rep='Stinespring')
 
     @property

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -111,9 +111,9 @@ class SuperOp(QuantumChannel):
                 output_dims = data.output_dims()
         # Finally we format and validate the channel input and
         # output dimensions
-        input_dims = self._automatic_dims(input_dims, input_dim)
-        output_dims = self._automatic_dims(output_dims, output_dim)
-        super().__init__(super_mat, input_dims, output_dims, 'SuperOp')
+        input_dims, output_dims, num_qubits = self._automatic_dims(
+            input_dims, input_dim, output_dims, output_dim)
+        super().__init__(super_mat, input_dims, output_dims, num_qubits, 'SuperOp')
 
     @property
     def _shape(self):
@@ -181,11 +181,11 @@ class SuperOp(QuantumChannel):
 
         # Compute tensor contraction indices from qargs
         if front:
-            num_indices = len(self._input_dims)
-            shift = 2 * len(self._output_dims)
+            num_indices = self._num_input
+            shift = 2 * self._num_output
             right_mul = True
         else:
-            num_indices = len(self._output_dims)
+            num_indices = self._num_output
             shift = 0
             right_mul = False
 
@@ -328,8 +328,9 @@ class SuperOp(QuantumChannel):
         tensor = Operator._einsum_matmul(tensor, mat, indices)
         # Replace evolved dimensions
         new_dims = list(state.dims())
+        output_dims = self.output_dims()
         for i, qubit in enumerate(qargs):
-            new_dims[qubit] = self._output_dims[i]
+            new_dims[qubit] = output_dims[i]
         new_dim = np.product(new_dims)
         # reshape tensor to density matrix
         tensor = np.reshape(tensor, (new_dim, new_dim))

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -89,9 +89,9 @@ class Operator(BaseOperator):
             data = data.to_operator()
             self._data = data.data
             if input_dims is None:
-                input_dims = data._input_dims
+                input_dims = data.input_dims()
             if output_dims is None:
-                output_dims = data._output_dims
+                output_dims = data.output_dims()
         elif hasattr(data, 'to_matrix'):
             # If no 'to_operator' attribute exists we next look for a
             # 'to_matrix' attribute to a matrix that will be cast into
@@ -101,9 +101,7 @@ class Operator(BaseOperator):
             raise QiskitError("Invalid input data format for Operator")
         # Determine input and output dimensions
         dout, din = self._data.shape
-        output_dims = self._automatic_dims(output_dims, dout)
-        input_dims = self._automatic_dims(input_dims, din)
-        super().__init__(input_dims, output_dims)
+        super().__init__(*self._automatic_dims(input_dims, din, output_dims, dout))
 
     def __repr__(self):
         prefix = 'Operator('
@@ -111,7 +109,7 @@ class Operator(BaseOperator):
         return '{}{},\n{}input_dims={}, output_dims={})'.format(
             prefix, np.array2string(
                 self.data, separator=', ', prefix=prefix),
-            pad, self._input_dims, self._output_dims)
+            pad, self.input_dims(), self.output_dims())
 
     def __eq__(self, other):
         """Test if two Operators are equal."""
@@ -213,7 +211,7 @@ class Operator(BaseOperator):
         ret = copy.copy(self)
         ret._data = np.transpose(self._data)
         # Swap input and output dimensions
-        ret._set_dims(self._output_dims, self._input_dims)
+        ret._set_dims(self.output_dims(), self.input_dims())
         return ret
 
     def compose(self, other, qargs=None, front=False):
@@ -261,11 +259,11 @@ class Operator(BaseOperator):
 
         # Compose with other on subsystem
         if front:
-            num_indices = len(self._input_dims)
-            shift = len(self._output_dims)
+            num_indices = self._num_input
+            shift = self._num_output
             right_mul = True
         else:
-            num_indices = len(self._output_dims)
+            num_indices = self._num_output
             shift = 0
             right_mul = False
 

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -32,7 +32,7 @@ class ScalarOp(BaseOperator):
     :meth:`tensor`, :meth:`expand` methods.
     """
 
-    def __init__(self, dims, coeff=1):
+    def __init__(self, dims=None, coeff=1):
         """Initialize an operator object.
 
         Args:
@@ -46,12 +46,11 @@ class ScalarOp(BaseOperator):
         if not isinstance(coeff, Number):
             QiskitError("coeff {} must be a number.".format(coeff))
         self._coeff = coeff
-        input_dims = self._automatic_dims(dims, np.product(dims))
-        super().__init__(input_dims, input_dims)
+        super().__init__(*self._automatic_dims(dims, np.product(dims)))
 
     def __repr__(self):
         return 'ScalarOp({}, coeff={})'.format(
-            self._input_dims, self.coeff)
+            self.input_dims(), self.coeff)
 
     @property
     def coeff(self):
@@ -85,8 +84,8 @@ class ScalarOp(BaseOperator):
     def to_operator(self):
         """Convert to an Operator object."""
         return Operator(self.to_matrix(),
-                        input_dims=self._input_dims,
-                        output_dims=self._output_dims)
+                        input_dims=self.input_dims(),
+                        output_dims=self.output_dims())
 
     def tensor(self, other):
         """Return the tensor product operator self ⊗ other.
@@ -102,7 +101,7 @@ class ScalarOp(BaseOperator):
             other = Operator(other)
         if isinstance(other, ScalarOp):
             coeff = self.coeff * other.coeff
-            dims = other._input_dims + self._input_dims
+            dims = other.input_dims() + self.input_dims()
             return ScalarOp(dims, coeff=coeff)
         return other.expand(self)
 
@@ -120,7 +119,7 @@ class ScalarOp(BaseOperator):
             other = Operator(other)
         if isinstance(other, ScalarOp):
             coeff = self.coeff * other.coeff
-            dims = self._input_dims + other._input_dims
+            dims = self.input_dims() + other.input_dims()
             return ScalarOp(dims, coeff=coeff)
         return other.tensor(self)
 
@@ -226,6 +225,10 @@ class ScalarOp(BaseOperator):
 
         self._validate_add_dims(other, qargs)
 
+        # Next if we are adding two ScalarOps we return a ScalarOp
+        if isinstance(other, ScalarOp):
+            return ScalarOp(self.input_dims(), coeff=self.coeff+other.coeff)
+
         # If qargs are specified we have to pad the other BaseOperator
         # with identities on remaining subsystems. We do this by
         # composing it with an identity ScalarOp.
@@ -236,16 +239,12 @@ class ScalarOp(BaseOperator):
         # subsystem dimensions are equal to the current operator for the
         # case where total dimensions agree but subsystem dimensions differ.
         if self.coeff == 0:
-            return other.reshape(self._input_dims, self._output_dims)
-
-        # Next if we are adding two ScalarOps we return a ScalarOp
-        if isinstance(other, ScalarOp):
-            return ScalarOp(self._input_dims, coeff=self.coeff+other.coeff)
+            return other.reshape(self.input_dims(), self.output_dims())
 
         # Finally if we are adding another BaseOperator subclass
         # we use that subclasses `_add` method and reshape the
         # final dimensions.
-        return other.reshape(self._input_dims, self._output_dims)._add(self)
+        return other.reshape(self.input_dims(), self.output_dims())._add(self)
 
     def _multiply(self, other):
         """Return the ScalarOp other * self.
@@ -279,4 +278,4 @@ class ScalarOp(BaseOperator):
         """
         if qargs is None:
             return other
-        return ScalarOp(current._input_dims).compose(other, qargs=qargs)
+        return ScalarOp(current.input_dims()).compose(other, qargs=qargs)

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -131,8 +131,7 @@ class Clifford(BaseOperator):
                     ' symplectic matrix.')
 
         # Initialize BaseOperator
-        dims = self._table.num_qubits * (2,)
-        super().__init__(dims, dims)
+        super().__init__(num_qubits=self._table.num_qubits)
 
     def __repr__(self):
         return 'Clifford({})'.format(repr(self.table))

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -163,8 +163,8 @@ class PauliTable(BaseOperator):
 
         # Set size properties
         self._num_paulis = self._array.shape[0]
-        dims = (self._array.shape[1] // 2) * (2, )
-        super().__init__(dims, dims)
+        num_qubits = self._array.shape[1] // 2
+        super().__init__(num_qubits=num_qubits)
 
     def __repr__(self):
         """Display representation."""

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -68,7 +68,7 @@ class SparsePauliOp(BaseOperator):
                               " of Paulis {} != {}".format(self._coeffs.shape,
                                                            self._table.size))
         # Initialize BaseOperator
-        super().__init__(self._table._input_dims, self._table._output_dims)
+        super().__init__(num_qubits=self._table.num_qubits)
 
     def __repr__(self):
         prefix = 'SparsePauliOp('

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -523,13 +523,13 @@ class DensityMatrix(QuantumState):
         """Evolve density matrix by an operator"""
         if qargs is None:
             # Evolution on full matrix
-            if self._dim != other._input_dim:
+            if self._dim != other.dim[0]:
                 raise QiskitError(
                     "Operator input dimension is not equal to density matrix dimension."
                 )
             op_mat = other.data
             mat = np.dot(op_mat, self.data).dot(op_mat.T.conj())
-            return DensityMatrix(mat, dims=other._output_dims)
+            return DensityMatrix(mat, dims=other.output_dims())
         # Otherwise we are applying an operator only to subsystems
         # Check dimensions of subsystems match the operator
         if self.dims(qargs) != other.input_dims():
@@ -551,8 +551,8 @@ class DensityMatrix(QuantumState):
                                          True)
         # Replace evolved dimensions
         new_dims = list(self.dims())
-        for i, qubit in enumerate(qargs):
-            new_dims[qubit] = other._output_dims[i]
+        for qubit, dim in zip(qargs, other.output_dims()):
+            new_dims[qubit] = dim
         new_dim = np.product(new_dims)
         return DensityMatrix(np.reshape(tensor, (new_dim, new_dim)),
                              dims=new_dims)

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -450,7 +450,16 @@ class QuantumState(metaclass=AbstractTolerancesMeta):
     @classmethod
     def _automatic_dims(cls, dims, size):
         """Check if input dimension corresponds to qubit subsystems."""
-        return BaseOperator._automatic_dims(dims, size)
+        if dims is None:
+            dims = size
+        elif np.product(dims) != size:
+            raise QiskitError("dimensions do not match size.")
+        if isinstance(dims, (int, np.integer)):
+            num_qubits = int(np.log2(dims))
+            if 2 ** num_qubits == size:
+                return num_qubits * (2,)
+            return (dims,)
+        return tuple(dims)
 
     def _set_dims(self, dims):
         """Set dimension attribute"""

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -21,7 +21,7 @@ from abc import abstractmethod
 import numpy as np
 
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info.operators.base_operator import BaseOperator, AbstractTolerancesMeta
+from qiskit.quantum_info.operators.base_operator import AbstractTolerancesMeta
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.result.counts import Counts
 

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -66,7 +66,7 @@ class TestChi(ChannelTestCase):
 
     def test_copy(self):
         """Test copy method"""
-        mat = np.eye(2)
+        mat = np.eye(4)
         with self.subTest("Deep copy"):
             orig = Chi(mat)
             cpy = orig.copy()

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -253,6 +253,20 @@ class TestOperator(OperatorTestCase):
         self.assertEqual(reshaped2.output_dims(), (2, 4))
         self.assertEqual(reshaped2.input_dims(), (4, 2))
 
+    def test_reshape_num_qubits(self):
+        """Test Operator reshape method with num_qubits."""
+        op = Operator(self.rand_matrix(8, 8),
+                      input_dims=(4, 2), output_dims=(2, 4))
+        reshaped = op.reshape(num_qubits=3)
+        self.assertEqual(reshaped.num_qubits, 3)
+        self.assertEqual(reshaped.output_dims(), (2, 2, 2))
+        self.assertEqual(reshaped.input_dims(), (2, 2, 2))
+
+    def test_reshape_raise(self):
+        """Test Operator reshape method with invalid args."""
+        op = Operator(self.rand_matrix(3, 3))
+        self.assertRaises(QiskitError, op.reshape, num_qubits=2)
+
     def test_copy(self):
         """Test Operator copy method"""
         mat = np.eye(2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Updates BaseOperator class to have a more efficient __init__ method for N-qubit operators. This is important for improving the performance of Cliffords and Pauli operators for large numbers of qubits which were spending a large amount of time in the initialization.

### Details and comments

Previously the initialization would construct the two input and output dimension tuples `num_qubits * (2, )`. These aren't needed if the operator is known to be an N-qubit operator,  so now these dimensions are only generated lazily for N-qubit operators when needed (such as composing them with a non-qubit operator or reshaping).

