### PR TITLE
Add user config file options to control parallel execution

### DIFF
--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -119,7 +119,7 @@ def parallel_map(  # pylint: disable=dangerous-default-value
 
     # Run in parallel if not Win and not in parallel already
     if num_processes > 1 and os.getenv('QISKIT_IN_PARALLEL') == 'FALSE' \
-            and CONFIG.get('parallel_enabled', user_config.parallel_default):
+            and CONFIG.get('parallel_enabled', user_config.PARALLEL_DEFAULT):
         os.environ['QISKIT_IN_PARALLEL'] = 'TRUE'
         try:
             results = []

--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -49,18 +49,23 @@ from the multiprocessing library.
 """
 
 import os
-import platform
 from concurrent.futures import ProcessPoolExecutor
 from qiskit.exceptions import QiskitError
 from qiskit.util import local_hardware_info
 from qiskit.tools.events.pubsub import Publisher
+from qiskit import user_config
+
+CONFIG = user_config.get_config()
 
 # Set parallel flag
 if os.getenv('QISKIT_IN_PARALLEL') is None:
     os.environ['QISKIT_IN_PARALLEL'] = 'FALSE'
 
 # Number of local physical cpus
-CPU_COUNT = local_hardware_info()['cpus']
+if 'num_processes' in CONFIG:
+    CPU_COUNT = CONFIG['num_processes']
+else:
+    CPU_COUNT = local_hardware_info()['cpus']
 
 
 def _task_wrapper(param):
@@ -113,8 +118,8 @@ def parallel_map(  # pylint: disable=dangerous-default-value
         Publisher().publish("terra.parallel.done", nfinished[0])
 
     # Run in parallel if not Win and not in parallel already
-    if platform.system() != 'Windows' and num_processes > 1 \
-       and os.getenv('QISKIT_IN_PARALLEL') == 'FALSE':
+    if num_processes > 1 and os.getenv('QISKIT_IN_PARALLEL') == 'FALSE' \
+            and CONFIG.get('parallel_enabled', user_config.parallel_default):
         os.environ['QISKIT_IN_PARALLEL'] = 'TRUE'
         try:
             results = []

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -14,12 +14,23 @@
 
 import configparser
 import os
+import sys
 from warnings import warn
 
 from qiskit import exceptions
 
 DEFAULT_FILENAME = os.path.join(os.path.expanduser("~"),
                                 '.qiskit', 'settings.conf')
+
+
+parallel_env_var = os.getenv('QISKIT_PARALLEL', None)
+if parallel_env_var is not None:
+    parallel_default = parallel_env_var.lower() == 'true'
+else:
+    if sys.platform in {'darwin', 'win32'}:
+        parallel_default = False
+    else:
+        parallel_default = True
 
 
 class UserConfig:
@@ -33,6 +44,8 @@ class UserConfig:
     circuit_mpl_style_path = ~/.qiskit:<default location>
     transpile_optimization_level = 1
     suppress_packaging_warnings = False
+    parallel = False
+    num_processes = 4
 
     """
     def __init__(self, filename=None):
@@ -111,6 +124,21 @@ class UserConfig:
             if package_warnings:
                 self.settings['suppress_packaging_warnings'] = package_warnings
 
+            # Parse parallel
+            parallel_enabled = self.config_parser.getboolean(
+                'default', 'parallel', fallback=parallel_default)
+            self.settings['parallel_enabled'] = parallel_enabled
+
+            # Parse num_processes
+            num_processes = self.config_parser.getint(
+                'default', 'num_processes', fallback=-1)
+            if not num_processes == -1:
+                if num_processes <= 0:
+                    raise exceptions.QiskitUserConfigError(
+                        "%s is not a valid number of processes. Must be "
+                        "greater than 0")
+                self.settings['num_processes'] = num_processes
+
 
 def get_config():
     """Read the config file from the default location or env var
@@ -124,7 +152,7 @@ def get_config():
     """
     filename = os.getenv('QISKIT_SETTINGS', DEFAULT_FILENAME)
     if not os.path.isfile(filename):
-        return {}
+        return {'parallel_enabled': parallel_default}
     user_config = UserConfig(filename)
     user_config.read_config_file()
     return user_config.settings

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -22,15 +22,13 @@ from qiskit import exceptions
 DEFAULT_FILENAME = os.path.join(os.path.expanduser("~"),
                                 '.qiskit', 'settings.conf')
 
-
-parallel_env_var = os.getenv('QISKIT_PARALLEL', None)
-if parallel_env_var is not None:
-    parallel_default = parallel_env_var.lower() == 'true'
+if os.getenv('QISKIT_PARALLEL', None) is not None:
+    PARALLEL_DEFAULT = os.getenv('QISKIT_PARALLEL', None).lower() == 'true'
 else:
     if sys.platform in {'darwin', 'win32'}:
-        parallel_default = False
+        PARALLEL_DEFAULT = False
     else:
-        parallel_default = True
+        PARALLEL_DEFAULT = True
 
 
 class UserConfig:
@@ -126,7 +124,7 @@ class UserConfig:
 
             # Parse parallel
             parallel_enabled = self.config_parser.getboolean(
-                'default', 'parallel', fallback=parallel_default)
+                'default', 'parallel', fallback=PARALLEL_DEFAULT)
             self.settings['parallel_enabled'] = parallel_enabled
 
             # Parse num_processes
@@ -152,7 +150,7 @@ def get_config():
     """
     filename = os.getenv('QISKIT_SETTINGS', DEFAULT_FILENAME)
     if not os.path.isfile(filename):
-        return {'parallel_enabled': parallel_default}
+        return {'parallel_enabled': PARALLEL_DEFAULT}
     user_config = UserConfig(filename)
     user_config.read_config_file()
     return user_config.settings

--- a/releasenotes/notes/paralle-config-options-97c1ad44ab76e052.yaml
+++ b/releasenotes/notes/paralle-config-options-97c1ad44ab76e052.yaml
@@ -1,0 +1,23 @@
+---
+features:
+  - |
+    The user config file has 2 new configuration options, ``num_processes`` and
+    ``parallel``, which are used to control the default behavior of
+    :func:`~qiskit.tools.parallel_map`. The ``parallel`` option is a boolean
+    that is used to dictate whether :func:`~qiskit.tools.parallel_map` will
+    run in multiple processes or not. If it set to ``False`` calls to
+    :func:`~qiskit.tools.parallel_map` will be executed serially, while setting
+    it to ``True`` will enable parallel execution. The ``num_processes`` option
+    takes an integer which sets how many CPUs to use when executing in parallel.
+    By default it will use the number of CPU cores on a system.
+upgrade:
+  - |
+    By default on macOS :func:`~qiskit.tools.parallel_map` will no longer run
+    in multiple processes. This is a change from previous releases where the
+    default behavior was that :func:`~qiskit.tools.parallel_map` would launch
+    multiple processes. This change was made because with newer versions of
+    macOS (especially with Python 3.8) multiprocessing is either unreliable
+    or adds significant overhead because of the change in Python 3.8 to launch
+    new processes with ``spawn`` instead of ``fork``. To re-enable parallel
+    execution on macOS you can use the user config file ``parallel` option or
+    set the environment variable ``QISKIT_PARALLEL`` to ``True``.

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -28,7 +28,8 @@ class TestUserConfig(QiskitTestCase):
     def test_empty_file_read(self):
         config = user_config.UserConfig(self.file_path)
         config.read_config_file()
-        self.assertEqual({}, config.settings)
+        self.assertEqual({},
+                         config.settings)
 
     def test_invalid_suppress_packaging_warnings(self):
         test_config = """
@@ -79,7 +80,8 @@ class TestUserConfig(QiskitTestCase):
             file.flush()
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
-            self.assertEqual({'circuit_drawer': 'latex'},
+            self.assertEqual({'circuit_drawer': 'latex',
+                              'parallel_enabled': True},
                              config.settings)
 
     def test_optimization_level_valid(self):
@@ -93,8 +95,10 @@ class TestUserConfig(QiskitTestCase):
             file.flush()
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
-            self.assertEqual({'transpile_optimization_level': 1},
-                             config.settings)
+            self.assertEqual(
+                {'transpile_optimization_level': 1,
+                 'parallel_enabled': user_config.parallel_default},
+                config.settings)
 
     def test_valid_suppress_packaging_warnings_false(self):
         test_config = """
@@ -107,8 +111,9 @@ class TestUserConfig(QiskitTestCase):
             file.flush()
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
-            self.assertEqual({},
-                             config.settings)
+            self.assertEqual(
+                {'parallel_enabled': user_config.parallel_default},
+                config.settings)
 
     def test_valid_suppress_packaging_warnings_true(self):
         test_config = """
@@ -121,8 +126,54 @@ class TestUserConfig(QiskitTestCase):
             file.flush()
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
-            self.assertEqual({'suppress_packaging_warnings': True},
-                             config.settings)
+            self.assertEqual(
+                    {'parallel_enabled': user_config.parallel_default,
+                     'suppress_packaging_warnings': True},
+                    config.settings)
+
+    def test_invalid_num_processes(self):
+        test_config = """
+        [default]
+        num_processes = -256
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, 'w') as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            self.assertRaises(exceptions.QiskitUserConfigError,
+                              config.read_config_file)
+
+    def test_valid_num_processes(self):
+        test_config = """
+        [default]
+        num_processes = 31
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, 'w') as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            config.read_config_file()
+            self.assertEqual(
+                {'parallel_enabled': user_config.parallel_default,
+                 'num_processes': 31},
+                config.settings)
+
+    def test_valid_parallel(self):
+        test_config = """
+        [default]
+        parallel = False
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, 'w') as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            config.read_config_file()
+            self.assertEqual(
+                {'parallel_enabled': False},
+                config.settings)
 
     def test_all_options_valid(self):
         test_config = """
@@ -132,6 +183,8 @@ class TestUserConfig(QiskitTestCase):
         circuit_mpl_style_path = ~:~/.qiskit
         transpile_optimization_level = 3
         suppress_packaging_warnings = true
+        parallel = false
+        num_processes = 15
         """
         self.addCleanup(os.remove, self.file_path)
         with open(self.file_path, 'w') as file:
@@ -143,5 +196,7 @@ class TestUserConfig(QiskitTestCase):
                               'circuit_mpl_style': 'default',
                               'circuit_mpl_style_path': ['~', '~/.qiskit'],
                               'transpile_optimization_level': 3,
+                              'num_processes': 15,
+                              'parallel_enabled': False,
                               'suppress_packaging_warnings': True},
                              config.settings)

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -81,7 +81,7 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual({'circuit_drawer': 'latex',
-                              'parallel_enabled': True},
+                              'parallel_enabled': user_config.parallel_default},
                              config.settings)
 
     def test_optimization_level_valid(self):
@@ -127,9 +127,9 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual(
-                    {'parallel_enabled': user_config.parallel_default,
-                     'suppress_packaging_warnings': True},
-                    config.settings)
+                {'parallel_enabled': user_config.parallel_default,
+                 'suppress_packaging_warnings': True},
+                config.settings)
 
     def test_invalid_num_processes(self):
         test_config = """

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -81,7 +81,7 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual({'circuit_drawer': 'latex',
-                              'parallel_enabled': user_config.parallel_default},
+                              'parallel_enabled': user_config.PARALLEL_DEFAULT},
                              config.settings)
 
     def test_optimization_level_valid(self):
@@ -97,7 +97,7 @@ class TestUserConfig(QiskitTestCase):
             config.read_config_file()
             self.assertEqual(
                 {'transpile_optimization_level': 1,
-                 'parallel_enabled': user_config.parallel_default},
+                 'parallel_enabled': user_config.PARALLEL_DEFAULT},
                 config.settings)
 
     def test_valid_suppress_packaging_warnings_false(self):
@@ -112,7 +112,7 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual(
-                {'parallel_enabled': user_config.parallel_default},
+                {'parallel_enabled': user_config.PARALLEL_DEFAULT},
                 config.settings)
 
     def test_valid_suppress_packaging_warnings_true(self):
@@ -127,7 +127,7 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual(
-                {'parallel_enabled': user_config.parallel_default,
+                {'parallel_enabled': user_config.PARALLEL_DEFAULT,
                  'suppress_packaging_warnings': True},
                 config.settings)
 
@@ -156,7 +156,7 @@ class TestUserConfig(QiskitTestCase):
             config = user_config.UserConfig(self.file_path)
             config.read_config_file()
             self.assertEqual(
-                {'parallel_enabled': user_config.parallel_default,
+                {'parallel_enabled': user_config.PARALLEL_DEFAULT,
                  'num_processes': 31},
                 config.settings)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds new options to the user config file, 'parallel' and
'num_processes' which when set will override the default behavior of
terra's parallel_map function (which is used internally by transpile()
and assemble()). Along with these new options the default behavior on
macOS is changed to disable parallel execution by default.

### Details and comments

Fixes #5323