### PR TITLE
Allow float pulse duration

### DIFF
--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -15,13 +15,11 @@ to the device.
 """
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Optional, TypeVar
-from warnings import warn
 
 import numpy as np
 
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.exceptions import PulseError
-
 
 TNum = TypeVar('TNum', int, float, np.integer, np.float)
 

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -23,7 +23,7 @@ from qiskit.circuit.parameterexpression import ParameterExpression, ParameterVal
 from qiskit.pulse.exceptions import PulseError
 
 
-T_num = TypeVar('T_num', int, float, np.integer, np.float)
+TNum = TypeVar('TNum', int, float, np.integer, np.float)
 
 
 class Pulse(ABC):
@@ -92,13 +92,19 @@ class Pulse(ABC):
         raise NotImplementedError
 
 
-def to_integer(duration: T_num):
+def to_integer(duration: TNum) -> int:
     """A helper function to cast float duration data type into integer.
 
     The number after decimal point is rounded.
 
     Args:
         duration: Duration of waveform.
+
+    Returns:
+        Duration casted into python integer.
+
+    Raises:
+        PulseError: When negative duration is given.
     """
     if isinstance(duration, (float, np.float)):
         if not duration.is_integer():

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -20,6 +20,8 @@ from warnings import warn
 import numpy as np
 
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.pulse.exceptions import PulseError
+
 
 T_num = TypeVar('T_num', int, float, np.integer, np.float)
 
@@ -105,5 +107,8 @@ def to_integer(duration: T_num):
             warn('Pulse duration should be integer. Input value {raw:f} is rounded to {round:d}.'
                  ''.format(raw=_raw_duration, round=int(duration)),
                  SyntaxWarning)
+
+    if duration < 0:
+        raise PulseError('Pulse duration must be greater than zero.')
 
     return int(duration)

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -104,15 +104,11 @@ def to_integer(duration: TNum) -> int:
         Duration casted into python integer.
 
     Raises:
-        PulseError: When negative duration is given.
+        PulseError: When negative of non-integer duration is given.
     """
     if isinstance(duration, (float, np.float)):
         if not duration.is_integer():
-            _raw_duration = duration
-            duration = np.round(duration)
-            warn('Pulse duration should be integer. Input value {raw:f} is rounded to {round:d}.'
-                 ''.format(raw=_raw_duration, round=int(duration)),
-                 SyntaxWarning)
+            raise PulseError('Pulse duration must be integer representing system cycle time.')
 
     if duration < 0:
         raise PulseError('Pulse duration must be greater than zero.')

--- a/qiskit/pulse/library/samplers/decorators.py
+++ b/qiskit/pulse/library/samplers/decorators.py
@@ -127,15 +127,15 @@ still seeing the signature for the continuous pulse function and all of its argu
 """
 
 import functools
-from typing import Callable
-import textwrap
 import pydoc
+import textwrap
+from typing import Callable
 
 import numpy as np
 
-from ...exceptions import PulseError
-from ..waveform import Waveform
+from qiskit.pulse.library.pulse import to_integer
 from . import strategies
+from ..waveform import Waveform
 
 
 def functional_pulse(func: Callable) -> Callable:
@@ -150,12 +150,9 @@ def functional_pulse(func: Callable) -> Callable:
     @functools.wraps(func)
     def to_pulse(duration, *args, name=None, **kwargs):
         """Return Waveform."""
-        if isinstance(duration, (int, np.integer)) and duration > 0:
-            samples = func(duration, *args, **kwargs)
-            samples = np.asarray(samples, dtype=np.complex128)
-            return Waveform(samples=samples, name=name)
-        raise PulseError('The first argument must be an integer value representing duration.')
-
+        samples = func(to_integer(duration), *args, **kwargs)
+        samples = np.asarray(samples, dtype=np.complex128)
+        return Waveform(samples=samples, name=name)
     return to_pulse
 
 

--- a/qiskit/pulse/library/samplers/strategies.py
+++ b/qiskit/pulse/library/samplers/strategies.py
@@ -32,8 +32,6 @@ from typing import Callable
 
 import numpy as np
 
-from qiskit.pulse.library.pulse import to_integer
-
 
 def left_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> np.ndarray:
     """Left sample a continuous function.
@@ -44,8 +42,6 @@ def left_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> n
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
-    duration = to_integer(duration)
-
     times = np.arange(duration)
     return continuous_pulse(times, *args, **kwargs)
 
@@ -59,8 +55,6 @@ def right_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> 
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
-    duration = to_integer(duration)
-
     times = np.arange(1, duration+1)
     return continuous_pulse(times, *args, **kwargs)
 
@@ -74,7 +68,5 @@ def midpoint_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) 
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
-    duration = to_integer(duration)
-
     times = np.arange(1/2, duration + 1/2)
     return continuous_pulse(times, *args, **kwargs)

--- a/qiskit/pulse/library/samplers/strategies.py
+++ b/qiskit/pulse/library/samplers/strategies.py
@@ -32,6 +32,8 @@ from typing import Callable
 
 import numpy as np
 
+from qiskit.pulse.library.pulse import to_integer
+
 
 def left_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> np.ndarray:
     """Left sample a continuous function.
@@ -42,6 +44,8 @@ def left_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> n
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
+    duration = to_integer(duration)
+
     times = np.arange(duration)
     return continuous_pulse(times, *args, **kwargs)
 
@@ -55,6 +59,8 @@ def right_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) -> 
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
+    duration = to_integer(duration)
+
     times = np.arange(1, duration+1)
     return continuous_pulse(times, *args, **kwargs)
 
@@ -68,5 +74,7 @@ def midpoint_sample(continuous_pulse: Callable, duration: int, *args, **kwargs) 
         *args: Continuous pulse function args.
         **kwargs: Continuous pulse function kwargs.
     """
+    duration = to_integer(duration)
+
     times = np.arange(1/2, duration + 1/2)
     return continuous_pulse(times, *args, **kwargs)

--- a/releasenotes/notes/allow-float-pulse-duration-6a41be25a4e0f05b.yaml
+++ b/releasenotes/notes/allow-float-pulse-duration-6a41be25a4e0f05b.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Allow float data type for pulse duration. Number after decimal point is rounded and
+    the input value is internally cast into Python integer.
+    SyntaxWarning is raised when a non-integer value is specified as duration.

--- a/releasenotes/notes/allow-float-pulse-duration-6a41be25a4e0f05b.yaml
+++ b/releasenotes/notes/allow-float-pulse-duration-6a41be25a4e0f05b.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
   - |
-    Allow float data type for pulse duration. Number after decimal point is rounded and
-    the input value is internally cast into Python integer.
-    SyntaxWarning is raised when a non-integer value is specified as duration.
+    Allow float data type for pulse duration. If there is nonzero number after decimal point
+    the pulse initialization raises a ``PulseError``, otherwise the float type duration is
+    converted into Python integer.

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -223,6 +223,16 @@ class TestParametricPulses(QiskitTestCase):
             self.assertEqual(const.get_waveform().samples[0], 0.1 + 0.4j)
             self.assertEqual(len(const.get_waveform().samples), 150)
 
+    def test_float_duration(self):
+        """Test constructing parametric pulse with float type duration."""
+        duration = 160.001
+        ref_duration = 160
+
+        with self.assertWarns(SyntaxWarning):
+            gaus_float = Gaussian(duration=duration, amp=0.7, sigma=40)
+        gaus_int = Gaussian(duration=ref_duration, amp=0.7, sigma=40)
+
+        self.assertEqual(gaus_float, gaus_int)
 
 # pylint: disable=invalid-name,unexpected-keyword-arg
 

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -223,16 +223,18 @@ class TestParametricPulses(QiskitTestCase):
             self.assertEqual(const.get_waveform().samples[0], 0.1 + 0.4j)
             self.assertEqual(len(const.get_waveform().samples), 150)
 
-    def test_float_duration(self):
+    def test_non_integer_float_duration(self):
         """Test constructing parametric pulse with float type duration."""
         duration = 160.001
-        ref_duration = 160
+        with self.assertRaises(PulseError):
+            Gaussian(duration=duration, amp=0.7, sigma=40)
 
-        with self.assertWarns(SyntaxWarning):
-            gaus_float = Gaussian(duration=duration, amp=0.7, sigma=40)
-        gaus_int = Gaussian(duration=ref_duration, amp=0.7, sigma=40)
+    def test_integer_float_duration(self):
+        """Test constructing parametric pulse with float type duration."""
+        duration = 160.000
+        # no error
+        Gaussian(duration=duration, amp=0.7, sigma=40)
 
-        self.assertEqual(gaus_float, gaus_int)
 
 # pylint: disable=invalid-name,unexpected-keyword-arg
 

--- a/test/python/pulse/test_samplers.py
+++ b/test/python/pulse/test_samplers.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from qiskit.test import QiskitTestCase
 from qiskit.pulse import library
+from qiskit.pulse.exceptions import PulseError
 import qiskit.pulse.library.samplers as samplers
 
 
@@ -93,7 +94,7 @@ class TestSampler(QiskitTestCase):
         self.assertIsInstance(pulse, library.Waveform)
         np.testing.assert_array_almost_equal(pulse.samples, reference)
 
-    def test_samplers_with_float_duration(self):
+    def test_samplers_with_non_integer_float_duration(self):
         """Test samplers with float type duration."""
         m = 0.1
         b = 0.1
@@ -101,15 +102,36 @@ class TestSampler(QiskitTestCase):
 
         # right sampler
         right_linear_pulse_fun = samplers.right(linear)
-        with self.assertWarns(SyntaxWarning):
+        with self.assertRaises(PulseError):
             right_linear_pulse_fun(duration, m=m, b=b)
 
         # left sampler
         left_linear_pulse_fun = samplers.left(linear)
-        with self.assertWarns(SyntaxWarning):
+        with self.assertRaises(PulseError):
             left_linear_pulse_fun(duration, m=m, b=b)
 
         # midpoint sampler
         midpoint_linear_pulse_fun = samplers.midpoint(linear)
-        with self.assertWarns(SyntaxWarning):
+        with self.assertRaises(PulseError):
             midpoint_linear_pulse_fun(duration, m=m, b=b)
+
+    def test_samplers_with_integer_float_duration(self):
+        """Test samplers with float type duration."""
+        m = 0.1
+        b = 0.1
+        duration = 2.00
+
+        # right sampler
+        right_linear_pulse_fun = samplers.right(linear)
+        # no error
+        right_linear_pulse_fun(duration, m=m, b=b)
+
+        # left sampler
+        left_linear_pulse_fun = samplers.left(linear)
+        # no error
+        left_linear_pulse_fun(duration, m=m, b=b)
+
+        # midpoint sampler
+        midpoint_linear_pulse_fun = samplers.midpoint(linear)
+        # no error
+        midpoint_linear_pulse_fun(duration, m=m, b=b)

--- a/test/python/pulse/test_samplers.py
+++ b/test/python/pulse/test_samplers.py
@@ -92,3 +92,24 @@ class TestSampler(QiskitTestCase):
         pulse = left_linear_pulse_fun(duration, m=m)
         self.assertIsInstance(pulse, library.Waveform)
         np.testing.assert_array_almost_equal(pulse.samples, reference)
+
+    def test_samplers_with_float_duration(self):
+        """Test samplers with float type duration."""
+        m = 0.1
+        b = 0.1
+        duration = 2.01
+
+        # right sampler
+        right_linear_pulse_fun = samplers.right(linear)
+        with self.assertWarns(SyntaxWarning):
+            right_linear_pulse_fun(duration, m=m, b=b)
+
+        # left sampler
+        left_linear_pulse_fun = samplers.left(linear)
+        with self.assertWarns(SyntaxWarning):
+            left_linear_pulse_fun(duration, m=m, b=b)
+
+        # midpoint sampler
+        midpoint_linear_pulse_fun = samplers.midpoint(linear)
+        with self.assertWarns(SyntaxWarning):
+            midpoint_linear_pulse_fun(duration, m=m, b=b)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Pulse duration with float data type is allowed with this PR. Non-integer value is rounded and converted into Python integer.

close #5330 


### Details and comments
SyntaxWarning is raised when non-integer value is specified.
New unittests and reno are added.