### PR TITLE
result.py: fix documentation for get_counts()

### DIFF
--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -237,7 +237,7 @@ class Result:
 
         Args:
             experiment (str or QuantumCircuit or Schedule or int or None): the index of the
-                experiment, as specified by ``get_data()``.
+                experiment, as specified by ``data([experiment])``.
 
         Returns:
             dict[str:int] or list[dict[str:int]]: a dictionary or a list of


### PR DESCRIPTION
Replace ``get_data()`` with ``data()`` as  the former was superseded by the latter as of Terra 0.7.