### PR TITLE
Fix bug in quantum channel subtraction

### DIFF
--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -137,6 +137,16 @@ class QuantumChannel(BaseOperator):
         ret._data = self._data + other._data
         return ret
 
+    def __sub__(self, other):
+        # Override for sub so that other is converted before being negated
+        # which can lead to problems if other is not already a quantum channel
+        if not isinstance(other, QuantumChannel):
+            qargs = getattr(other, 'qargs', None)
+            other = self.__class__(other)
+            if qargs is not None:
+                other.qargs = qargs
+        return self._add(-other)
+
     def _multiply(self, other):
         """Return the QuantumChannel other * self.
 

--- a/releasenotes/notes/fix-quantum_channel_sub-4a31394a7a1237d4.yaml
+++ b/releasenotes/notes/fix-quantum_channel_sub-4a31394a7a1237d4.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes a bug in subtraction for quantum channels :math:`A - B` where :math:`B`
+    was an :class:`~qiskit.quantum_info.Operator` object. Negation was being
+    applied to the matrix in the Operator representation which is not equivalent
+    to negation in the quantum channel representation.

--- a/test/python/quantum_info/operators/channel/test_linearops.py
+++ b/test/python/quantum_info/operators/channel/test_linearops.py
@@ -46,9 +46,9 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
-            targ = SuperOp(sop1 + sop2)
+            target = SuperOp(sop1 + sop2)
             channel = SuperOp(rep(SuperOp(sop1))._add(rep(SuperOp(sop2))))
-            self.assertEqual(channel, targ)
+            self.assertEqual(channel, target)
 
     def _compare_subtract_to_superop(self, rep, dim, samples, unitary=False):
         """Test channel subtraction is equivalent to SuperOp"""
@@ -61,9 +61,22 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
                 sop2 = self.rand_matrix(dim * dim, dim * dim)
-            targ = SuperOp(sop1 - sop2)
+            target = SuperOp(sop1 - sop2)
             channel = SuperOp(rep(SuperOp(sop1))._add(rep(-SuperOp(sop2))))
-            self.assertEqual(channel, targ)
+            self.assertEqual(channel, target)
+
+    def _compare_subtract_operator_to_superop(self, rep, dim, samples, unitary=False):
+        """Test channel addition is equivalent to SuperOp"""
+        for _ in range(samples):
+            if unitary:
+                mat1 = self.rand_matrix(dim, dim)
+                sop1 = np.kron(np.conj(mat1), mat1)
+            else:
+                sop1 = self.rand_matrix(dim * dim, dim * dim)
+            mat2 = self.rand_matrix(dim, dim)
+            target = SuperOp(sop1) - SuperOp(Operator(mat2))
+            channel = SuperOp(rep(SuperOp(sop1)) - Operator(mat2))
+            self.assertEqual(channel, target)
 
     def _compare_multiply_to_superop(self, rep, dim, samples, unitary=False):
         """Test channel scalar multiplication is equivalent to SuperOp"""
@@ -74,9 +87,9 @@ class TestEquivalence(ChannelTestCase):
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
             val = 0.7
-            targ = SuperOp(val * sop1)
+            target = SuperOp(val * sop1)
             channel = SuperOp(rep(SuperOp(sop1))._multiply(val))
-            self.assertEqual(channel, targ)
+            self.assertEqual(channel, target)
 
     def _compare_negate_to_superop(self, rep, dim, samples, unitary=False):
         """Test negative channel is equivalent to SuperOp"""
@@ -86,9 +99,9 @@ class TestEquivalence(ChannelTestCase):
                 sop1 = np.kron(np.conj(mat1), mat1)
             else:
                 sop1 = self.rand_matrix(dim * dim, dim * dim)
-            targ = SuperOp(-1 * sop1)
+            target = SuperOp(-1 * sop1)
             channel = SuperOp(-rep(SuperOp(sop1)))
-            self.assertEqual(channel, targ)
+            self.assertEqual(channel, target)
 
     def _check_add_other_reps(self, chan):
         """Check addition works for other representations"""
@@ -143,6 +156,26 @@ class TestEquivalence(ChannelTestCase):
     def test_ptm_subtract(self):
         """Test subtraction of PTM matrices is correct."""
         self._compare_subtract_to_superop(PTM, 4, 10)
+
+    def test_choi_subtract_operator(self):
+        """Test subtraction of Operator from Choi is correct."""
+        self._compare_subtract_operator_to_superop(Choi, 4, 10)
+
+    def test_kraus_subtract_operator(self):
+        """Test subtraction of Operator from Kraus is correct."""
+        self._compare_subtract_operator_to_superop(Kraus, 4, 10)
+
+    def test_stinespring_subtract_operator(self):
+        """Test subtraction of Operator from Stinespring is correct."""
+        self._compare_subtract_operator_to_superop(Stinespring, 4, 10)
+
+    def test_chi_subtract_operator(self):
+        """Test subtraction of Operator from Chi is correct."""
+        self._compare_subtract_operator_to_superop(Chi, 4, 10)
+
+    def test_ptm_subtract_operator(self):
+        """Test subtraction of Operator from PTM is correct."""
+        self._compare_subtract_operator_to_superop(PTM, 4, 10)
 
     def test_choi_multiply(self):
         """Test scalar multiplication of Choi matrices is correct."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* Fixes bug when subtracting an operator object from a quantum channel object
* Fixes warning in `diamond_norm` from deprecated usage of CVXPY

### Details and comments


