### PR TITLE
Fix hasattr in Backend.set_options

### DIFF
--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -112,7 +112,7 @@ class BackendV1(Backend, ABC):
                 options
         """
         for field in fields:
-            if not hasattr(field, self._options):
+            if not hasattr(self._options, field):
                 raise AttributeError(
                     "Options field %s is not valid for this "
                     "backend" % field)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes a typo in `Backend.set_options()` where `field` is the first argument when it should be the second. 


### Details and comments


