### PR TITLE
Remove IBMQ provider from docs CI job

### DIFF
--- a/qiskit/tools/jupyter/job_watcher.py
+++ b/qiskit/tools/jupyter/job_watcher.py
@@ -176,5 +176,6 @@ class JobWatcherMagic(Magics):
         _JOB_WATCHER.stop_viewer()
 
 
-# The Jupyter job watcher instance
-_JOB_WATCHER = JobWatcher()
+if HAS_IBMQ:
+    # The Jupyter job watcher instance
+    _JOB_WATCHER = JobWatcher()

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,8 @@ basepython = python3
 setenv =
   {[testenv]setenv}
   QISKIT_DOCS=TRUE
+  QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
   -r{toxinidir}/requirements-dev.txt
-  qiskit-aer
-  qiskit-ibmq-provider
 commands =
   sphinx-build -W -b html -j auto docs/ docs/_build/html {posargs}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

A recent urllib3 release is breaking compatibility with requests which
is blocking CI in the docs job. However, requests is only ever used by
the IBMQ provider which we install in the docs job because of one
jupyter widget and to avoid a packaging warning (which would also be
fatal to the sphinx build). This commit attempts to fix the current ci
failure by removing the qiskit-ibmq-provider package from the CI job and
fixing or suppressing the warnings/failures related to packaging.

### Details and comments