### PR TITLE
Fix timeline drawer measurement visualization

### DIFF
--- a/qiskit/visualization/timeline/core.py
+++ b/qiskit/visualization/timeline/core.py
@@ -264,18 +264,19 @@ class DrawerCanvas:
             new_data = deepcopy(data)
             new_data.xvals = self._bind_coordinate(data.xvals)
             new_data.yvals = self._bind_coordinate(data.yvals)
-            if data.data_type == str(types.LineType.GATE_LINK.value):
-                temp_gate_links[data_key] = new_data
-            else:
-                temp_data[data_key] = new_data
+            # add data if it is visible
+            if self._check_data_visible(new_data):
+                if data.data_type == str(types.LineType.GATE_LINK.value):
+                    temp_gate_links[data_key] = new_data
+                else:
+                    temp_data[data_key] = new_data
 
         # update horizontal offset of gate links
         temp_data.update(self._check_link_overlap(temp_gate_links))
 
         # push valid data
         for data_key, data in temp_data.items():
-            if self._check_data_visible(data):
-                self._output_dataset[data_key] = data
+            self._output_dataset[data_key] = data
 
     def _check_data_visible(self, data: drawings.ElementaryData) -> bool:
         """A helper function to check if the data is visible.
@@ -300,7 +301,7 @@ class DrawerCanvas:
 
         def _associated_bit_check(_data):
             """If all associated bits are not shown."""
-            if all([bit not in self.assigned_coordinates for bit in _data.bits]):
+            if any([bit not in self.assigned_coordinates for bit in _data.bits]):
                 return False
             return True
 
@@ -377,7 +378,8 @@ class DrawerCanvas:
 
         This method dynamically shifts horizontal position of links if they are overlapped.
         """
-        allowed_overlap = self.formatter['margin.link_interval_dt']
+        duration = self.time_range[1] - self.time_range[0]
+        allowed_overlap = self.formatter['margin.link_interval_percent'] * duration
 
         # return y coordinates
         def y_coords(link: drawings.GateLinkData):

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -360,7 +360,7 @@ def draw(program: circuit.QuantumCircuit,
     # TODO fix this
     if temp_style['formatter.control.show_clbits']:
         import warnings
-        warnings.warn('Start time of measure instruction on Clbits is not correctly parsed. '
+        warnings.warn('Start time of the measure instruction on Clbits is not correctly parsed. '
                       'See Qiskit/qiskit-terra/#5361 for discussion.')
 
     # create empty canvas and load program

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -112,10 +112,10 @@ def draw(program: circuit.QuantumCircuit,
             the right limit of the horizontal axis. The value is in units of percentage of
             the whole program duration. If the duration is 100 and the value of 0.5 is set,
             this keeps right margin of 5 (default `0.02`).
-        formatter.margin.link_interval_dt: Allowed overlap of gate links.
+        formatter.margin.link_interval_percent: Allowed overlap of gate links.
             If multiple gate links are drawing within this range, links are horizontally
-            shifted not to overlap with each other. This value is in units of
-            the system cycle time dt (default `20`).
+            shifted not to overlap with each other. The value is in units of percentage of
+            the whole program duration (default `0.01`).
         formatter.time_bucket.edge_dt: The length of round edge of gate boxes. Gate boxes are
             smoothly faded in and out from the zero line. This value is in units of
             the system cycle time dt (default `10`).
@@ -355,6 +355,13 @@ def draw(program: circuit.QuantumCircuit,
 
     if show_delays is not None:
         temp_style['formatter.control.show_delays'] = show_delays
+
+    # currently clbits starts at t = 0.
+    # TODO fix this
+    if temp_style['formatter.control.show_clbits']:
+        import warnings
+        warnings.warn('Start time of measure instruction on Clbits is not correctly parsed. '
+                      'See Qiskit/qiskit-terra/#5361 for discussion.')
 
     # create empty canvas and load program
     canvas = core.DrawerCanvas(stylesheet=temp_style)

--- a/qiskit/visualization/timeline/plotters/matplotlib.py
+++ b/qiskit/visualization/timeline/plotters/matplotlib.py
@@ -86,8 +86,8 @@ class MplPlotter(BasePlotter):
         """Output drawings stored in canvas object."""
 
         for _, data in self.canvas.collections:
-            xvals = data.xvals
-            yvals = data.yvals
+            xvals = np.asarray(data.xvals, dtype=float)
+            yvals = np.asarray(data.yvals, dtype=float)
             offsets = [self.canvas.assigned_coordinates[bit] for bit in data.bits]
 
             if isinstance(data, drawings.BoxData):

--- a/qiskit/visualization/timeline/stylesheet.py
+++ b/qiskit/visualization/timeline/stylesheet.py
@@ -45,7 +45,7 @@ from qiskit.visualization.timeline import generators, layouts
 
 class QiskitTimelineStyle(dict):
     """Stylesheet for pulse drawer."""
-    _deprecated_keys = {}
+    _deprecated_keys = {'link_interval_dt': 'link_interval_percent'}
 
     def __init__(self):
         super().__init__()
@@ -199,7 +199,7 @@ def default_style() -> Dict[str, Any]:
         'formatter.margin.bottom': 0.5,
         'formatter.margin.left_percent': 0.02,
         'formatter.margin.right_percent': 0.02,
-        'formatter.margin.link_interval_dt': 20,
+        'formatter.margin.link_interval_percent': 0.01,
         'formatter.margin.minimum_duration': 50,
         'formatter.time_bucket.edge_dt': 10,
         'formatter.color.background': '#FFFFFF',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #5361 


### Details and comments
Fix bit link visualization. Currently the drawer tries to visualize the bit link between qreg and creg even though the creg is disabled. This causes an error because the coordinate of the creg is not initialized. In this PR, visible check is moved to correct place so that the link is also disabled. Unittests are also updated.

Box position bug of cregs is not fixed with this PR.