### PR TITLE
Use jupyter execute instead of >>> in QuantumCircuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -711,19 +711,15 @@ class QuantumCircuit:
 
         Examples:
 
-            >>> from qiskit import QuantumCircuit
-            >>> top = QuantumCircuit(1)
-            >>> top.x(0);
-            >>> bottom = QuantumCircuit(2)
-            >>> bottom.cry(0.2, 0, 1);
-            >>> bottom.tensor(top).draw()
-                    ┌───┐
-            q_0: ───┤ X ├───
-                    └───┘
-            q_1: ─────■─────
-                 ┌────┴────┐
-            q_2: ┤ RY(0.2) ├
-                 └─────────┘
+            .. jupyter-execute::
+
+                from qiskit import QuantumCircuit
+                top = QuantumCircuit(1)
+                top.x(0);
+                bottom = QuantumCircuit(2)
+                bottom.cry(0.2, 0, 1);
+                tensored = bottom.tensor(top)
+                print(tensored.draw())
 
         Returns:
             QuantumCircuit: The tensored circuit (returns None if inplace==True).


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Unblocks Qiskit/qiskit-aqua#1404.

Example code using `>>>` in the docstring is being run by Aqua CI since it has objects deriving from the QuantumCircuit. This sometimes leads to errors since this code is not tested in Terra. Using the jupyter-execute block resolves this issue.

### Details 

In this particular case, Aqua's Sphinx build complains about a missing character encoding and about return values which are not displayed in the code snippet.


