### PR TITLE
Avoid module level sympy yet another time

### DIFF
--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -15,8 +15,6 @@ Template matching substitution, given a list of maximal matches it substitutes
 them in circuit and creates a new optimized dag version of the circuit.
 """
 import copy
-import sympy as sym
-from sympy.parsing.sympy_parser import parse_expr
 
 from qiskit.circuit import ParameterExpression
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
@@ -426,6 +424,9 @@ class TemplateSubstitution:
                 the parameters bound. If no binding satisfies the
                 parameter constraints, returns None.
         """
+        import sympy as sym
+        from sympy.parsing.sympy_parser import parse_expr
+
         circuit_params, template_params = [], []
 
         template_dag_dep = copy.deepcopy(self.template_dag_dep)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Just as has been demonstrated many times in the past we should not be
importing sympy at the module level. In #5259 another import was added
and was immediately flagged as an import speed regression [1]. Sympy is
a very heavy dependency and is slow to import (and slow to run too).
Adding a sympy import to the module level makes and is honestly a
dependency we should be reluctant to add anywhere because it becomes
the primary bottleneck whenever it is used. This commit removes the top
level sympy import and moves to be a runtime import in the single method
that uses sympy. Just as it was done in #5149, #4385, and #3156 before.

### Details and comments

[1] https://qiskit.github.io/qiskit/#import.QiskitImport.time_qiskit_import?commits=b5d5a3bb
