### PR TITLE
Fix bug when multiplying SparsePauliOp by np.int64

### DIFF
--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -99,6 +99,9 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
         elif input_dims is not None and output_dims is not None:
             self._set_dims(input_dims, output_dims)
 
+    # Set higher priority than Numpy array and matrix classes
+    __array_priority__ = 20
+
     def __call__(self, qargs):
         """Return a clone with qargs set"""
         if isinstance(qargs, int):
@@ -636,10 +639,3 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
 
     def __neg__(self):
         return self._multiply(-1)
-
-    def __array_ufunc__(self, ufunc, method, *args, **kwargs):
-        # Dispatch numpy multiply ufunc to multiple
-        if (ufunc == np.multiply and method == '__call__') and not kwargs:
-            value = args[0] if isinstance(args[1], type(self)) else args[1]
-            return self._multiply(value)
-        return NotImplemented

--- a/qiskit/quantum_info/operators/base_operator.py
+++ b/qiskit/quantum_info/operators/base_operator.py
@@ -636,3 +636,10 @@ class BaseOperator(metaclass=AbstractTolerancesMeta):
 
     def __neg__(self):
         return self._multiply(-1)
+
+    def __array_ufunc__(self, ufunc, method, *args, **kwargs):
+        # Dispatch numpy multiply ufunc to multiple
+        if (ufunc == np.multiply and method == '__call__') and not kwargs:
+            value = args[0] if isinstance(args[1], type(self)) else args[1]
+            return self._multiply(value)
+        return NotImplemented

--- a/releasenotes/notes/fix-op-ufunc-multiple-d1c59b236024f483.yaml
+++ b/releasenotes/notes/fix-op-ufunc-multiple-d1c59b236024f483.yaml
@@ -3,3 +3,4 @@ fixes:
   - |
     Fixes bug in :class:`~qiskit.quantum_info.SparsePauliOp` where multiplying
     by a certain non Python builtin Numpy scalar types returned incorrect values.
+    Fixes `#5408 <https://github.com/Qiskit/qiskit-terra/issues/5408>`__

--- a/releasenotes/notes/fix-op-ufunc-multiple-d1c59b236024f483.yaml
+++ b/releasenotes/notes/fix-op-ufunc-multiple-d1c59b236024f483.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes bug in :class:`~qiskit.quantum_info.SparsePauliOp` where multiplying
+    by a certain non Python builtin Numpy scalar types returned incorrect values.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -328,7 +328,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         value = (spp_op1 - spp_op2(qargs)).to_operator()
         self.assertEqual(value, target)
 
-    @combine(num_qubits=[1, 2, 3], value=[0, 1, 1j, -3+4.4j])
+    @combine(num_qubits=[1, 2, 3], value=[0, 1, 1j, -3+4.4j, np.int64(2)])
     def test_mul(self, num_qubits, value):
         """Test * method for {num_qubits} qubits and value {value}."""
         spp_op = random_unitary(2 ** num_qubits, seed=self.RNG)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5408

### Details and comments

Fix is to add dispatch mechanism for numpy ufuncs to BaseOperator which maps `np.multiply` to the `BaseOperator._multiply` method.

