### PR TITLE
ParameterExpression.__eq__ takes bounded expr == value

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -375,7 +375,20 @@ class ParameterExpression:
         return self
 
     def __eq__(self, other):
+        """Check if this parameter expression is equal to another parameter expression
+           or a fixed value (only if this is a bound expression).
+        Args:
+            other (ParameterExpression or a number):
+                Parameter expression or numeric constant used for comparison
+        Returns:
+            Boolean result of the comparison
+        """
         from sympy import srepr
-        return (isinstance(other, ParameterExpression)
-                and self.parameters == other.parameters
-                and srepr(self._symbol_expr) == srepr(other._symbol_expr))
+        if isinstance(other, ParameterExpression):
+            return (self.parameters == other.parameters
+                    and srepr(self._symbol_expr) == srepr(other._symbol_expr))
+        elif isinstance(other, numbers.Number):
+            return (len(self.parameters) == 0
+                    and complex(self._symbol_expr) == other)
+        else:
+            return False

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -390,5 +390,4 @@ class ParameterExpression:
         elif isinstance(other, numbers.Number):
             return (len(self.parameters) == 0
                     and complex(self._symbol_expr) == other)
-        else:
-            return False
+        return False

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -381,7 +381,7 @@ class ParameterExpression:
             other (ParameterExpression or a number):
                 Parameter expression or numeric constant used for comparison
         Returns:
-            Boolean result of the comparison
+            bool: result of the comparison
         """
         from sympy import srepr
         if isinstance(other, ParameterExpression):

--- a/releasenotes/notes/parameterexpression-eq-compares-bounded-expr-to-val-ba7588cac6e53b5d.yaml
+++ b/releasenotes/notes/parameterexpression-eq-compares-bounded-expr-to-val-ba7588cac6e53b5d.yaml
@@ -1,0 +1,21 @@
+---
+features:
+  - |
+    The :meth:`~qiskit.circuit.ParameterExpression.__eq__` method of class
+    :class:`~qiskit.circuit.ParameterExpression` previously only allowed 
+    comparison between between two instances of ParameterExpression. With 
+    this update it is possible to compare a fully bounded parameter 
+    expression to a numeric constant.
+
+    .. jupyter-execute::
+
+        from qiskit.circuit import Parameter
+  
+        x = Parameter("x")
+        y = x + 2
+
+        y = y.assign(x, -1)
+
+        if (y == 1):
+            print("y == 1")
+

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -947,6 +947,14 @@ class TestParameterExpressions(QiskitTestCase):
 
     supported_operations = [add, sub, mul, truediv]
 
+    def test_compare_to_value_when_bound(self):
+        """Verify expression can be compared to a fixed value
+        when fully bound."""
+
+        x = Parameter('x')
+        bound_expr = x.bind({x: 2.3})
+        self.assertEqual(bound_expr, 2.3)
+
     def test_cast_to_float_when_bound(self):
         """Verify expression can be cast to a float when fully bound."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This is a code update in response to issue [#5423](https://github.com/Qiskit/qiskit-terra/issues/5423)

The current implementation of __eq__ method of ParameterExpression class only allows comparison between two parameter expressions.

With this update it should be possible to compare a bounded parameter expression with a fixed value.

### Details and comments

If the argument passed to `__eq__` is a number:
(1) Check that self has no unbound parameters i.e. self.parameters == 0
(2) Check that the value of the sympy expression is equal to the argument

Added a test called `test_compare_to_value_when_bound` in test/python/circuit/test_parameters.py to check that the comparison with a fixed value works

