### PR TITLE
Handle type mismatch on bit and register __eq__

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -76,4 +76,7 @@ class Bit:
         return self._hash
 
     def __eq__(self, other):
-        return self._repr == other._repr
+        try:
+            return self._repr == other._repr
+        except AttributeError:
+            return False

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -150,7 +150,10 @@ class Register:
         Returns:
             bool: `self` and `other` are equal.
         """
-        return self._repr == other._repr
+        try:
+            return self._repr == other._repr
+        except AttributeError:
+            return False
 
     def __hash__(self):
         """Make object hashable, based on the name and size to hash."""

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -84,3 +84,9 @@ class TestBitClass(QiskitTestCase):
         test_bit.index = 2
         new_hash = hash(test_bit)
         self.assertNotEqual(orig_hash, new_hash)
+
+    def test_bit_eq_invalid_type_comparison(self):
+        orig_reg = mock.MagicMock()
+        orig_reg.size = 3
+        test_bit = bit.Bit(orig_reg, 0)
+        self.assertNotEqual(test_bit, 3.14)

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -33,6 +33,12 @@ class TestCircuitRegisters(QiskitTestCase):
         self.assertEqual(qr1.size, 10)
         self.assertEqual(type(qr1), QuantumRegister)
 
+    def test_qregs_eq_invalid_type(self):
+        """Test getting quantum registers from circuit.
+        """
+        qr1 = QuantumRegister(10, "q")
+        self.assertNotEqual(qr1, 3.14)
+
     def test_cregs(self):
         """Test getting classical registers from circuit.
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5272 the `__eq__` method was changed to use a single string comparison
away from a nested attribute comparison for performance reasons. This
had the unexpected side effect that when comparing a register or a bit
object against an object of another type an `AttributeError` would be
raised because the private `_repr` attribute doesn't exist outside of
those classes. This leads to unexpected failures when running with aqua
because they were comparing a register to a string. This commit
addresses this by catching the attribute error and returning false
because objects of different types are not equal.

### Details and comments