### PR TITLE
Pin appnope in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 docplex==2.15.194
+appnope==0.1.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The appnope 0.1.1 release from this morning is the only package change
between a working and failing CI job. This commit explicitly pins it in
the constraints file (since we don't directly require it) to ensure we
get a known working version to try and unblock CI.


### Details and comments