### PR TITLE
Add `reverse_qargs` method to `Statevector` and `DensityMatrix`

### DIFF
--- a/qiskit/quantum_info/operators/op_shape.py
+++ b/qiskit/quantum_info/operators/op_shape.py
@@ -359,6 +359,15 @@ class OpShape:
                        num_qargs_l=num_qargs_l,
                        num_qargs_r=num_qargs_r)
 
+    def reverse(self):
+        """Reverse order of left and right qargs"""
+        ret = copy.copy(self)
+        if self._dims_r:
+            ret._dims_r = tuple(reversed(self._dims_r))
+        if self._dims_l:
+            ret._dims_l = tuple(reversed(self._dims_l))
+        return ret
+
     def transpose(self):
         """Return the transposed OpShape."""
         ret = copy.copy(self)

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -272,6 +272,27 @@ class DensityMatrix(QuantumState, TolerancesMixin):
             other = Operator(other)
         return self._evolve_operator(other, qargs=qargs)
 
+    def reverse_qargs(self):
+        r"""Return a DensityMatrix with reversed subsystem ordering.
+
+        For a tensor product state this is equivalent to reversing the order
+        of tensor product subsystems. For a density matrix
+        :math:`\rho = \rho_{n-1} \otimes ... \otimes \rho_0`
+        the returned state will be
+        :math:`\rho_0 \otimes ... \otimes \rho_{n-1}`.
+
+        Returns:
+            DensityMatrix: the state with reversed subsystem order.
+        """
+        ret = copy.copy(self)
+        axes = tuple(range(self._op_shape._num_qargs_l - 1, -1, -1))
+        axes = axes + tuple(len(axes) + i for i in axes)
+        ret._data = np.reshape(np.transpose(
+            np.reshape(self.data, self._op_shape.tensor_shape), axes),
+                               self._op_shape.shape)
+        ret._op_shape = self._op_shape.reverse()
+        return ret
+
     def expectation_value(self, oper, qargs=None):
         """Compute the expectation value of an operator.
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -293,6 +293,26 @@ class Statevector(QuantumState, TolerancesMixin):
         return matrix_equal(self.data, other.data, ignore_phase=True,
                             rtol=rtol, atol=atol)
 
+    def reverse_qargs(self):
+        r"""Return a Statevector with reversed subsystem ordering.
+
+        For a tensor product state this is equivalent to reversing the order
+        of tensor product subsystems. For a statevector
+        :math:`|\psi \rangle = |\psi_{n-1} \rangle \otimes ... \otimes |\psi_0 \rangle`
+        the returned statevector will be
+        :math:`|\psi_{0} \rangle \otimes ... \otimes |\psi_{n-1} \rangle`.
+
+        Returns:
+            Statevector: the Statevector with reversed subsystem order.
+        """
+        ret = copy.copy(self)
+        axes = tuple(range(self._op_shape._num_qargs_l - 1, -1, -1))
+        ret._data = np.reshape(np.transpose(
+            np.reshape(self.data, self._op_shape.tensor_shape), axes),
+                               self._op_shape.shape)
+        ret._op_shape = self._op_shape.reverse()
+        return ret
+
     def expectation_value(self, oper, qargs=None):
         """Compute the expectation value of an operator.
 

--- a/releasenotes/notes/state_reverse_qargs-f2f3c9a3e1c3aaa0.yaml
+++ b/releasenotes/notes/state_reverse_qargs-f2f3c9a3e1c3aaa0.yaml
@@ -1,0 +1,22 @@
+---
+features:
+  - |
+    Adds a :meth:`~qiskit.quantum_info.Statevector.reverse_qargs` method to the
+    :class:`qiskit.quantum_info.Statevector` and
+    :class:`qiskit.quantum_info.DensityMatrix` classes. This method reverses
+    the order of subsystems in the states and is equivalent to the
+    :meth:`qiskit.QuantumCircuit.reverse_bits` method for N-qubit states.
+
+    Example:
+
+      .. jupyter-execute::
+
+        from qiskit.circuit.library import QFT
+        from qiskit.quantum_info import Statevector
+        
+        circ = QFT(3)
+  
+        state1 = Statevector.from_instruction(circ)
+        state2 = Statevector.from_instruction(circ.reverse_bits())
+
+        state1.reverse_qargs() == state2

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -22,7 +22,7 @@ from numpy.testing import assert_allclose
 from qiskit.test import QiskitTestCase
 from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
-from qiskit.circuit.library import HGate
+from qiskit.circuit.library import HGate, QFT
 
 from qiskit.quantum_info.random import random_unitary
 from qiskit.quantum_info.states import DensityMatrix, Statevector
@@ -895,6 +895,15 @@ class TestDensityMatrix(QiskitTestCase):
                 op = Operator.from_label(label)
                 expval = rho.expectation_value(op)
                 self.assertAlmostEqual(expval, target)
+
+    def test_reverse_qargs(self):
+        """Test reverse_qargs method"""
+        circ1 = QFT(5)
+        circ2 = circ1.reverse_bits()
+
+        state1 = DensityMatrix.from_instruction(circ1)
+        state2 = DensityMatrix.from_instruction(circ2)
+        self.assertEqual(state1.reverse_qargs(), state2)
 
 
 if __name__ == '__main__':

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -23,7 +23,7 @@ from qiskit.test import QiskitTestCase
 from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
-from qiskit.circuit.library import HGate
+from qiskit.circuit.library import HGate, QFT
 
 from qiskit.quantum_info.random import random_unitary
 from qiskit.quantum_info.states import Statevector
@@ -911,6 +911,15 @@ class TestStatevector(QiskitTestCase):
         expected = np.array([0.96891242-0.24740396j, 0])
         self.assertEqual(float(qc2.global_phase), -1/4)
         self.assertEqual(sv, Statevector(expected))
+
+    def test_reverse_qargs(self):
+        """Test reverse_qargs method"""
+        circ1 = QFT(5)
+        circ2 = circ1.reverse_bits()
+
+        state1 = Statevector.from_instruction(circ1)
+        state2 = Statevector.from_instruction(circ2)
+        self.assertEqual(state1.reverse_qargs(), state2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Implements #4592 for state classes.

### Details and comments

~Depends on #5432~