### PR TITLE
Leverage retworkx generators for all cmap constructors

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -274,13 +274,14 @@ class CouplingMap:
     def from_full(cls, num_qubits, bidirectional=True):
         """Return a fully connected coupling map on n qubits."""
         cmap = cls(description='full')
-        edge_list = []
-        for i in range(num_qubits):
-            for j in range(i):
-                edge_list.append((j, i))
-                if bidirectional:
-                    edge_list.append((i, j))
-        cmap.graph.extend_from_edge_list(edge_list)
+        if bidirectional:
+            cmap.graph = rx.generators.directed_mesh_graph(num_qubits)
+        else:
+            edge_list = []
+            for i in range(num_qubits):
+                for j in range(i):
+                    edge_list.append((j, i))
+            cmap.graph.extend_from_edge_list(edge_list)
         return cmap
 
     @classmethod
@@ -303,25 +304,8 @@ class CouplingMap:
     def from_grid(cls, num_rows, num_columns, bidirectional=True):
         """Return qubits connected on a grid of num_rows x num_columns."""
         cmap = cls(description='grid')
-        edge_list = []
-        for i in range(num_rows):
-            for j in range(num_columns):
-                node = i * num_columns + j
-
-                up = (node-num_columns) if i > 0 else None  # pylint: disable=invalid-name
-                down = (node+num_columns) if i < num_rows-1 else None
-                left = (node-1) if j > 0 else None
-                right = (node+1) if j < num_columns-1 else None
-
-                if up is not None and bidirectional:
-                    edge_list.append((node, up))
-                if left is not None and bidirectional:
-                    edge_list.append((node, left))
-                if down is not None:
-                    edge_list.append((node, down))
-                if right is not None:
-                    edge_list.append((node, right))
-        cmap.graph.extend_from_edge_list(edge_list)
+        cmap.graph = rx.generators.directed_grid_graph(
+            num_rows, num_columns, bidirectional=bidirectional)
         return cmap
 
     def largest_connected_component(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5183 we switched the internal graph datastructures used for the
CouplingMap to be based on retworkx instead of networkx. That PR was
written against the 0.6.0 retworkx release and for the from_grid()
and from_full() constructors python had to be used since retworkx
was missing functions to generate graphs of those types. However, in the
recent 0.7.x retworkx release 2 new generators directed_grid_graph() [1]
and directed_mesh_graph() [2] were added. This commit switches the
implementation of from_grid() and from_full() to use these generators,
which significantly speeds up (and reduces the memory overhead) of the
constructor methods.

The only constructor which still relies on a Python loop is the
from_full() method when bidirection=False. This is because retworkx
doesn't offer a constructor that will build a graph like that. If in
a future release a generator is added we can remove that for loop too.

### Details and comments

[1] https://retworkx.readthedocs.io/en/stable/stubs/retworkx.generators.directed_grid_graph.html
[2] https://retworkx.readthedocs.io/en/stable/stubs/retworkx.generators.directed_mesh_graph.html