### PR TITLE
Convert delays to instructions when assembling

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -198,10 +198,6 @@ def _assemble_instructions(
             acquire_instruction_map[(time, instruction.duration)].append(instruction)
             continue
 
-        if isinstance(instruction, (instructions.Delay, instructions.Directive)):
-            # delay instructions are ignored as timing is explicit within qobj
-            continue
-
         qobj_instructions.append(instruction_converter(time, instruction))
 
     if acquire_instruction_map:

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -342,12 +342,12 @@ class InstructionToQobjConverter:
         return self._qobj_model(**command_dict)
 
     @bind_instruction(instructions.Delay)
-    def convert_shift_phase(self, shift, instruction):
-        """Return converted `ShiftPhase`.
+    def convert_delay(self, shift, instruction):
+        """Return converted `Delay`.
 
         Args:
             shift(int): Offset time.
-            instruction (ShiftPhase): Shift phase instruction.
+            instruction (Delay): Delay instruction.
         Returns:
             dict: Dictionary of required parameters.
         """

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -341,6 +341,24 @@ class InstructionToQobjConverter:
         }
         return self._qobj_model(**command_dict)
 
+    @bind_instruction(instructions.Delay)
+    def convert_shift_phase(self, shift, instruction):
+        """Return converted `ShiftPhase`.
+
+        Args:
+            shift(int): Offset time.
+            instruction (ShiftPhase): Shift phase instruction.
+        Returns:
+            dict: Dictionary of required parameters.
+        """
+        command_dict = {
+            'name': 'delay',
+            't0': shift + instruction.start_time,
+            'ch': instruction.channel.name,
+            'duration': instruction.duration
+        }
+        return self._qobj_model(**command_dict)
+
     @bind_instruction(instructions.Play)
     def convert_play(self, shift, instruction):
         """Return the converted `Play`.

--- a/releasenotes/notes/bugfix-assemble-delay-32a96b59bb84badd.yaml
+++ b/releasenotes/notes/bugfix-assemble-delay-32a96b59bb84badd.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Pulse :py:class:`~qiskit.pulse.instructions.Delay` is now explicitly
+    assembled as qobj instructions.
+
+    Previously, we could ignore delays rather than assembling them. Now, with
+    pulse gates, there are times that we want to schedule ONLY a delay, and not
+    including the delay itself would remove the delay.

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -844,19 +844,6 @@ class TestPulseAssembler(QiskitTestCase):
         # two user pulses and one measurement pulse should be contained
         self.assertEqual(len(qobj.config.pulse_library), 3)
 
-    def test_assemble_with_delay(self):
-        """Test that delay instruction is ignored in assembly."""
-        orig_schedule = self.schedule
-        delay_schedule = orig_schedule + pulse.Delay(10, self.backend_config.drive(0))
-
-        orig_qobj = assemble(orig_schedule, self.backend)
-        validate_qobj_against_schema(orig_qobj)
-        delay_qobj = assemble(delay_schedule, self.backend)
-        validate_qobj_against_schema(delay_qobj)
-
-        self.assertEqual(orig_qobj.experiments[0].to_dict(),
-                         delay_qobj.experiments[0].to_dict())
-
     def test_assemble_schedule_enum(self):
         """Test assembling a schedule with enum input values to assemble."""
         qobj = assemble(self.schedule,

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -552,11 +552,12 @@ class TestCircuitAssembler(QiskitTestCase):
         """Test that a single delay gate is translated to an instruction."""
         circ = QuantumCircuit(2)
         circ.append(Gate('test', 1, []), [0])
-        circ.add_calibration('test', [0], pulse.Delay(160, DriveChannel(0)))
+        test_sched = pulse.Delay(64, DriveChannel(0)) + pulse.Delay(160, DriveChannel(0))
+        circ.add_calibration('test', [0], test_sched)
         qobj = assemble(circ, FakeOpenPulse2Q())
-        self.assertEqual(len(qobj.config.calibrations.gates[0].instructions), 1)
-        self.assertEqual(qobj.config.calibrations.gates[0].instructions[0].to_dict(),
-                         {"name": "delay", "t0": 0, "ch": "d0", "duration": 160})
+        self.assertEqual(len(qobj.config.calibrations.gates[0].instructions), 2)
+        self.assertEqual(qobj.config.calibrations.gates[0].instructions[1].to_dict(),
+                         {"name": "delay", "t0": 64, "ch": "d0", "duration": 160})
 
 
 class TestPulseAssembler(QiskitTestCase):

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -844,6 +844,16 @@ class TestPulseAssembler(QiskitTestCase):
         # two user pulses and one measurement pulse should be contained
         self.assertEqual(len(qobj.config.pulse_library), 3)
 
+    def test_assemble_with_delay(self):
+        """Test that delay instruction is ignored in assembly."""
+        delay_schedule = pulse.Delay(10, self.backend_config.drive(0))
+        delay_schedule += self.schedule
+        delay_qobj = assemble(delay_schedule, self.backend)
+
+        validate_qobj_against_schema(delay_qobj)
+        self.assertEqual(delay_qobj.experiments[0].instructions[0].name, "delay")
+        self.assertEqual(delay_qobj.experiments[0].instructions[0].duration, 10)
+
     def test_assemble_schedule_enum(self):
         """Test assembling a schedule with enum input values to assemble."""
         qobj = assemble(self.schedule,

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -548,6 +548,16 @@ class TestCircuitAssembler(QiskitTestCase):
         self.assertEqual(len(qobj.experiments[0].config.calibrations.gates), 1)
         self.assertFalse(hasattr(qobj.experiments[1].config, 'calibrations'))
 
+    def test_pulse_gates_delay_only(self):
+        """Test that a single delay gate is translated to an instruction."""
+        circ = QuantumCircuit(2)
+        circ.append(Gate('test', 1, []), [0])
+        circ.add_calibration('test', [0], pulse.Delay(160, DriveChannel(0)))
+        qobj = assemble(circ, FakeOpenPulse2Q())
+        self.assertEqual(len(qobj.config.calibrations.gates[0].instructions), 1)
+        self.assertEqual(qobj.config.calibrations.gates[0].instructions[0].to_dict(),
+                         {"name": "delay", "t0": 0, "ch": "d0", "duration": 160})
+
 
 class TestPulseAssembler(QiskitTestCase):
     """Tests for assembling schedules to qobj."""

--- a/test/python/compiler/test_disassembler.py
+++ b/test/python/compiler/test_disassembler.py
@@ -251,7 +251,7 @@ class TestPulseScheduleDisassembler(QiskitTestCase):
         self.assertEqual(run_config_out.qubit_lo_freq, self.backend.defaults().qubit_freq_est)
         self.assertEqual(run_config_out.rep_time, 99)
         self.assertEqual(len(scheds), 1)
-        self.assertEqual(scheds[0], sched.exclude(instruction_types=[pulse.Delay]))
+        self.assertEqual(scheds[0], sched)
 
     def test_disassemble_multiple_schedules(self):
         """Test disassembling multiple schedules, all should have the same config.
@@ -290,8 +290,8 @@ class TestPulseScheduleDisassembler(QiskitTestCase):
         self.assertEqual(run_config_out.shots, 2000)
         self.assertEqual(run_config_out.memory, False)
         self.assertEqual(len(scheds), 2)
-        self.assertEqual(scheds[0], sched0.exclude(instruction_types=[pulse.Delay]))
-        self.assertEqual(scheds[1], sched1.exclude(instruction_types=[pulse.Delay]))
+        self.assertEqual(scheds[0], sched0)
+        self.assertEqual(scheds[1], sched1)
 
     def test_disassemble_parametric_pulses(self):
         """Test disassembling multiple schedules all should have the same config.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously, we could ignore delays rather than assembling them. Now, with pulse gates, there are times that we want to schedule ONLY a delay, and not including the delay itself would remove the delay!

### Details and comments
Example:
```
qc = QuantumCircuit(1, 1)
qc.x(0)
qc.append(Gate('example', 1, []), [0])
qc.measure(0, 0)
qc.add_calibration('example', [0], pulse.Delay(1600, pulse.DriveChannel(0)))
```
