### PR TITLE
Remove rx.is_directed_acyclic_graph() from DAGCircuit.depth()

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -710,10 +710,10 @@ class DAGCircuit:
         Raises:
             DAGCircuitError: if not a directed acyclic graph
         """
-        if not rx.is_directed_acyclic_graph(self._multi_graph):
+        try:
+            depth = rx.dag_longest_path_length(self._multi_graph) - 1
+        except rx.DAGHasCycle:
             raise DAGCircuitError("not a DAG")
-
-        depth = rx.dag_longest_path_length(self._multi_graph) - 1
         return depth if depth >= 0 else 0
 
     def width(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commits removes the `rx.is_directed_acyclic_graph()` call from the
`DAGCircuit.depth()` method. This call was unnecessary as the
`rx.dag_longest_path_length()` method will internally raise an exception
if the input graph has a cycle. Additionally, for very large circuits
the `rx.is_directed_acyclic_graph()` can segfault. To reduce the overhead
of the `depth()` method and to avoid the potential bug this unnecessary
call is removed.

### Details and comments

Fixes #5502