### PR TITLE
Restrict qiskit.util to actual deprecated functions

### DIFF
--- a/qiskit/util.py
+++ b/qiskit/util.py
@@ -15,4 +15,12 @@
 """Common utilities for Qiskit."""
 
 # Deprecated: for backwards compatibility to be removed in a future release
-from qiskit.utils import *
+from qiskit.utils.deprecation import deprecate_arguments
+from qiskit.utils.deprecation import deprecate_function
+from qiskit.utils.multiprocessing import is_main_process
+from qiskit.utils.multiprocessing import local_hardware_info
+from qiskit.utils.units import apply_prefix
+
+
+__all__ = ['deprecate_arguments', 'deprecate_function', 'is_main_process',
+           'local_hardware_info', 'apply_prefix']


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5420 the `qiskit.util` module was migrated to `qiskit/utils` to be
consistent with imported code from qiskit-aqua in #5422. However, the
backwards compat shim added in that PR has a couple of issues, mainly
around re-exporting the entirety of `qiskit.utils` which occasionally
causes import cycles and is larger than what functions used to exist in
`qiskit.util` and should be deprecated. This commit fixes this by changing
the deprecation shim in `qiskit.util` to only re-export the functions that
previously existed in `qiskit.util` for backwards compatibility during the
deprecation period.

### Details and comments