### PR TITLE
Fix performance regression in CSPLayout pass

### DIFF
--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -106,7 +106,7 @@ class CSPLayout(AnalysisPass):
         for gate in dag.two_qubit_ops():
             cxs.add((qubits.index(gate.qargs[0]),
                      qubits.index(gate.qargs[1])))
-        edges = self.coupling_map.get_edges()
+        edges = set(self.coupling_map.get_edges())
 
         if self.time_limit is None and self.call_limit is None:
             solver = RecursiveBacktrackingSolver()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5183 the inner graph object of the CouplingMap object was switched
to retworkx. While generally faster there are a few different edge cases
where retworkx performance can be worse than networkx. Namely, any place
where large lists are returned, for example lists of all nodes or edges
in a graph. In those cases the conversion from the Rust objects to the
Python objects can cumulatively be expensive. To avoid this conversion
overhead in every case retworkx has custom return types that are python
sequences but defer type conversion to `__getitem__`, meaning that the
return is fast but complete traversal can be slow, especially when done
multiple times. In such cases it's easier to cast the sequence to a
Python object such as a set or a list so the conversion is only done
once. However, in the CSPLayout pass the edges list returned from
retworkx was searched multiple times as part of the constraint function
which resulted in a large performance regression. This commit fixes this
by casting the local edges to a set(). This has 2 advantages, first it
avoids the multiple traversals of the graph which removes the conversion
overhead. The second advantage is that by using a set the lookups are
constant time instead of iterating over the full list every time. This
results in a performance improvement over the performance prior to #5183
and the introduction of the regression.

### Details and comments