### PR TITLE
Convert run_kwargs  keys to list in execute()

### DIFF
--- a/qiskit/execute.py
+++ b/qiskit/execute.py
@@ -319,10 +319,9 @@ def execute(experiments, backend,
             'memory_slot_size': memory_slot_size,
             'rep_time': rep_time,
             'rep_delay': rep_delay,
-            'parameter_binds': parameter_binds,
             'init_qubits': init_qubits,
         }
-        for key in run_kwargs:
+        for key in list(run_kwargs.keys()):
             if not hasattr(backend.options, key):
                 if run_kwargs[key] is not None:
                     logger.info("%s backend doesn't support option %s so not "
@@ -339,6 +338,7 @@ def execute(experiments, backend,
             elif key == 'memory_slot_size' and run_kwargs[key] is None:
                 run_kwargs[key] = 100
 
+        run_kwargs['parameter_binds'] = parameter_binds
         run_kwargs.update(run_config)
         job = backend.run(experiments, **run_kwargs)
         end_time = time()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR makes 2 changes:
1. the current code in `execute()` iterates over `run_kwargs` and may delete its entries. The deletion, however, would raise a `RuntimeError: dictionary changed size during iteration` error. This PR converts the dictionary keys to a list to avoid the iterator being changed while looping. 
2. `parameter_binds` is not really a backend option, so this PR handles it separately to avoid removing it when it's not in backend options.


### Details and comments


