### PR TITLE
Avoid module level sympy yet another time

### DIFF
--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -15,7 +15,6 @@ import functools
 from typing import List, Dict, Union
 
 import numpy as np
-from sympy import srepr
 
 from qiskit.circuit.parameterexpression import ParameterExpression
 
@@ -56,6 +55,8 @@ def format_parameter_value(operand: Union[ParameterExpression]
     # however this error can be ignored in practice though we need to be careful for unittests.
     # i.e. "pi=3.141592653589793" will be evaluated as "3.14159265358979"
     # no DAC that recognizes the resolution of 1e-15 but they are AlmostEqual in tests.
+    from sympy import srepr
+
     math_expr = srepr(operand)
     try:
         # value is assigned


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Just as has been demonstrated many times in the past we should not be
importing sympy at the module level. In #5358 another import was added
and was immediately flagged as an import speed regression [1]. Sympy is
a very heavy dependency and is slow to import (and slow to run too).
Adding a sympy import to the module level makes and is honestly a
dependency we should be reluctant to add anywhere because it becomes
the primary bottleneck whenever it is used. This commit removes the top
level sympy import and moves to be a runtime import in the single method
that uses sympy. Just as it was done in #5416, #5149, #4385, and #3156
before.

### Details and comments

Fixes #5575

[1] https://qiskit.github.io/qiskit/#import.QiskitImport.time_qiskit_import?commits=300e9507
