### PR TITLE
Fix global phase handling in circuit.repeat

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -437,8 +437,7 @@ class QuantumCircuit:
             QuantumCircuit: A circuit containing ``reps`` repetitions of this circuit.
         """
         repeated_circ = QuantumCircuit(*self.qregs, *self.cregs,
-                                       name=self.name + '**{}'.format(reps),
-                                       global_phase=reps * self.global_phase)
+                                       name=self.name + '**{}'.format(reps))
 
         # benefit of appending instructions: decomposing shows the subparts, i.e. the power
         # is actually `reps` times this circuit, and it is currently much faster than `compose`.

--- a/releasenotes/notes/fix-global-phase-upon-repeat-f742f4c0201fea97.yaml
+++ b/releasenotes/notes/fix-global-phase-upon-repeat-f742f4c0201fea97.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix the global phase of the output of ``circuit.repeat``. If a circuit with global
+    phase is appended to another circuit, the global phase is currently not propagated.
+    The simulators rely on this, since the phase otherwise gets applied multiple times.
+    This sets the global phase of ``circuit.repeat`` to 0 instead of multiplying the existing
+    phase times the number of repetitions.

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -14,6 +14,7 @@
 """Test Qiskit's QuantumCircuit class."""
 
 from ddt import ddt, data
+import numpy as np
 from qiskit import BasicAer
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import execute
@@ -21,6 +22,7 @@ from qiskit.circuit import Gate, Instruction, Parameter
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.library.standard_gates import SGate
+from qiskit.quantum_info import Operator
 
 
 @ddt
@@ -402,6 +404,14 @@ class TestCircuitOperations(QiskitTestCase):
                 ref.append(inst, ref.qubits, ref.clbits)
             rep = qc.repeat(3)
             self.assertEqual(rep, ref)
+
+    @data(0, 1, 4)
+    def test_repeat_global_phase(self, num):
+        """Test the global phase is properly handled upon repeat."""
+        phase = 0.123
+        qc = QuantumCircuit(1, global_phase=phase)
+        expected = np.exp(1j * phase * num) * np.identity(2)
+        np.testing.assert_array_almost_equal(Operator(qc).data, expected)
 
     def test_power(self):
         """Test taking the circuit to a power works."""

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -411,7 +411,7 @@ class TestCircuitOperations(QiskitTestCase):
         phase = 0.123
         qc = QuantumCircuit(1, global_phase=phase)
         expected = np.exp(1j * phase * num) * np.identity(2)
-        np.testing.assert_array_almost_equal(Operator(qc).data, expected)
+        np.testing.assert_array_almost_equal(Operator(qc.repeat(num)).data, expected)
 
     def test_power(self):
         """Test taking the circuit to a power works."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5586.

### Details and comments

Fix the global phase of the output of ``circuit.repeat``. If a circuit with global
phase is appended to another circuit, the global phase is currently not propagated.
The simulators rely on this, since the phase otherwise gets applied multiple times.
This sets the global phase of ``circuit.repeat`` to 0 instead of multiplying the existing
phase times the number of repetitions.
