### PR TITLE
Propagate Pauli phase when evaluating PauliOp

### DIFF
--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -228,7 +228,8 @@ class PauliOp(PrimitiveOp):
                     y_factor = np.product(np.sqrt(1 - 2 * np.logical_and(corrected_x_bits,
                                                                          corrected_z_bits) + 0j))
                     new_dict[new_str] = (v * z_factor * y_factor) + new_dict.get(new_str, 0)
-                    new_front = StateFn(new_dict, coeff=self.coeff * front.coeff)
+                    new_front = StateFn(new_dict, coeff=self.coeff * front.coeff *
+                                        (-1j) ** self.primitive.phase)
 
             elif isinstance(front, StateFn) and front.is_measurement:
                 raise ValueError('Operator composed with a measurement is undefined.')

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -228,6 +228,11 @@ class PauliOp(PrimitiveOp):
                     y_factor = np.product(np.sqrt(1 - 2 * np.logical_and(corrected_x_bits,
                                                                          corrected_z_bits) + 0j))
                     new_dict[new_str] = (v * z_factor * y_factor) + new_dict.get(new_str, 0)
+                    # The coefficient consists of:
+                    #   1. the coefficient of *this* PauliOp (self)
+                    #   2. the coefficient of the evaluated DictStateFn (front)
+                    #   3. AND acquires the phase of the internal primitive. This is necessary to
+                    #      ensure that (X @ Z) and (-iY) return the same result.
                     new_front = StateFn(new_dict, coeff=self.coeff * front.coeff *
                                         (-1j) ** self.primitive.phase)
 

--- a/releasenotes/notes/bugfix-propagate-pauli-phase-in-pauliop-eval-b7fa0d14b1e3b61a.yaml
+++ b/releasenotes/notes/bugfix-propagate-pauli-phase-in-pauliop-eval-b7fa0d14b1e3b61a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The phase of the primitive inside a `PauliOp` did not get propagated upon
+    evaluation. This caused `(Z @ X).eval('0')` and `(X @ Z).eval('0')` to be
+    indistinguishable from each other and, therefore, not match with `(1j * Y)`
+    and `(-1j * Y)`, respectively. Propagation of the phase during the `eval()`
+    method fixes this bug.

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -63,6 +63,8 @@ class TestOpConstruction(QiskitOpflowTestCase):
         """ Test eval of ComposedOp """
         self.assertAlmostEqual(Minus.eval('1'), -.5 ** .5)
 
+    def test_xz_compose_phase(self):
+        """ Test phase composition """
         self.assertEqual((-1j * Y).eval('0').eval('0'), 0)
         self.assertEqual((-1j * Y).eval('0').eval('1'), 1)
         self.assertEqual((-1j * Y).eval('1').eval('0'), -1)

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -63,6 +63,23 @@ class TestOpConstruction(QiskitOpflowTestCase):
         """ Test eval of ComposedOp """
         self.assertAlmostEqual(Minus.eval('1'), -.5 ** .5)
 
+        self.assertEqual((-1j * Y).eval('0').eval('0'), 0)
+        self.assertEqual((-1j * Y).eval('0').eval('1'), 1)
+        self.assertEqual((-1j * Y).eval('1').eval('0'), -1)
+        self.assertEqual((-1j * Y).eval('1').eval('1'), 0)
+        self.assertEqual((X @ Z).eval('0').eval('0'), 0)
+        self.assertEqual((X @ Z).eval('0').eval('1'), 1)
+        self.assertEqual((X @ Z).eval('1').eval('0'), -1)
+        self.assertEqual((X @ Z).eval('1').eval('1'), 0)
+        self.assertEqual((1j * Y).eval('0').eval('0'), 0)
+        self.assertEqual((1j * Y).eval('0').eval('1'), -1)
+        self.assertEqual((1j * Y).eval('1').eval('0'), 1)
+        self.assertEqual((1j * Y).eval('1').eval('1'), 0)
+        self.assertEqual((Z @ X).eval('0').eval('0'), 0)
+        self.assertEqual((Z @ X).eval('0').eval('1'), -1)
+        self.assertEqual((Z @ X).eval('1').eval('0'), 1)
+        self.assertEqual((Z @ X).eval('1').eval('1'), 0)
+
     def test_evals(self):
         """ evals test """
         # pylint: disable=no-member


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Propagate the phase of the internal primitive when evaluating a `PauliOp`.

### Details and comments

The phase of the Pauli needs to be propagated into the result coefficient when evaluating a `PauliOp`.
Otherwise, the following two codes would return identical results:
```
    (X @ Z).eval('0')
    (Z @ X).eval('0')
```
This is obviously not intentional and this PR fixes the behavior.
Rather, the above codes should return different results and, on top of that, should be equal to the following:
```
    (X @ Z).eval('0') == (-1j * Y).eval('0')
    (Z @ X).eval('0') == (1j * Y).eval('0')
```
(Note, that `(+/-1j * Y)` was already working before.)

Unittests have been added to assert this behavior.

