### PR TITLE
Fix WeightedPauliOperator.multiply

### DIFF
--- a/qiskit/opflow/legacy/weighted_pauli_operator.py
+++ b/qiskit/opflow/legacy/weighted_pauli_operator.py
@@ -285,7 +285,8 @@ class WeightedPauliOperator(LegacyBaseOperator):
         for existed_weight, existed_pauli in self.paulis:
             for weight, pauli in other.paulis:
                 new_pauli = existed_pauli * pauli
-                new_weight = existed_weight * weight
+                new_weight = existed_weight * weight * (1j ** new_pauli.phase)
+                new_pauli = new_pauli[:]
                 pauli_term = [new_weight, new_pauli]
                 ret_op += WeightedPauliOperator(paulis=[pauli_term])
         return ret_op

--- a/test/python/opflow/legacy/test_weighted_pauli_operator.py
+++ b/test/python/opflow/legacy/test_weighted_pauli_operator.py
@@ -107,14 +107,14 @@ class TestWeightedPauliOperator(QiskitOpflowTestCase):
         new_op = op_a * op_b
 
         self.assertEqual(1, len(new_op.paulis))
-        self.assertEqual(0.25, new_op.paulis[0][0])
-        self.assertEqual('-ZZYY', new_op.paulis[0][1].to_label())
+        self.assertEqual(-0.25, new_op.paulis[0][0])
+        self.assertEqual('ZZYY', new_op.paulis[0][1].to_label())
 
         new_op = -2j * new_op
-        self.assertEqual(-0.5j, new_op.paulis[0][0])
+        self.assertEqual(0.5j, new_op.paulis[0][0])
 
         new_op = new_op * 0.3j
-        self.assertEqual(0.15, new_op.paulis[0][0])
+        self.assertEqual(-0.15, new_op.paulis[0][0])
 
     def test_iadd(self):
         """ iadd test """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fix `WeightedPauliOperator.multiply` to be consistent with Aqua's implementation.

### Details and comments

- Move the phase information of Pauli to coefficient.
- Revert the unit test `test_multiplication` of `weighted_pauli_operator.py` modified by #5520 as follows. https://github.com/Qiskit/qiskit-terra/blob/ff7a4e463ef7488060bfd8134723b51d18ee7584/test/python/opflow/legacy/test_weighted_pauli_operator.py#L97-L117