### PR TITLE
Fix codeowners matching rule for utils

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # Qiskit folders (also their corresponding tests)
 algorithms/           @Qiskit/terra-core @manoelmarques @woodsp-ibm
 opflow/               @Qiskit/terra-core @manoelmarques @woodsp-ibm
-utils/                @Qiskit/terra-core @manoelmarques @woodsp-ibm
+qiskit/utils/         @Qiskit/terra-core @manoelmarques @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00 @chriseclectic
 quantum_info/         @Qiskit/terra-core @chriseclectic
 pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli @taalexander @lcapelluto


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The utils/ codeowners rule was intended to match the qiskit/utils
directory which contains a lot of code migrated from aqua. However, the
the rule was overly broad and matching any utils directory for example
qiskit/transpiler/passes/utils. This commit restricts the rule to
explicitly match qiskit/utils only which was the intent.

### Details and comments


