### PR TITLE
Latex drawer prioritizes instruction label over name

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -385,8 +385,12 @@ class QCircuitImage:
                         'ccx', 'cx', 'cz', 'cu1', 'cu3', 'crz',
                         'cswap']:
                     qarglist = op.qargs
-                    name = generate_latex_label(
-                        op.op.base_gate.name.upper()).replace(" ", "\\,")
+                    if op.op.label:
+                        name = generate_latex_label(
+                            op.op.base_gate.label.upper()).replace(" ", "\\,")
+                    else:
+                        name = generate_latex_label(
+                            op.op.base_gate.name.upper()).replace(" ", "\\,")
                     pos_array = []
                     num_ctrl_qubits = op.op.num_ctrl_qubits
                     num_qargs = len(qarglist) - num_ctrl_qubits
@@ -475,7 +479,10 @@ class QCircuitImage:
 
                 elif op.name not in ['measure', 'barrier', 'snapshot', 'load',
                                      'save', 'noise']:
-                    nm = generate_latex_label(op.name).replace(" ", "\\,")
+                    if op.name != 'reset' and op.op.label:
+                        nm = generate_latex_label(op.op.label).replace(" ", "\\,")
+                    else:
+                        nm = generate_latex_label(op.name).replace(" ", "\\,")
                     qarglist = op.qargs
 
                     if len(qarglist) == 1:
@@ -587,8 +594,8 @@ class QCircuitImage:
                                     self.parse_params(op.op.params[0]))
                             elif nm == "reset":
                                 self._latex[pos_1][column] = (
-                                    "\\push{\\rule{.6em}{0em}\\ket{0}\\"
-                                    "rule{.2em}{0em}} \\qw")
+                                    "\\push{\\ket{0}}"
+                                    "\\qw")
                             else:
                                 self._latex[pos_1][column] = ("\\gate{%s}" % nm)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #3765 and #5605 .

### Details and comments

The latex drawer now prioritizes the label of the instruction over the name of the instruction. For instance the circuit in #3765 is now drawn as,

![Corrected Image](https://user-images.githubusercontent.com/51048173/104631601-7a463e00-56c2-11eb-8887-59c377d86715.png)

Also, the excess white spaces before and after the reset gates have been removed.

![Image white space removed](https://user-images.githubusercontent.com/51048173/104631606-7d412e80-56c2-11eb-8eef-d253aba66bff.png)

