### PR TITLE
Correct global phase of TwoQubitBasisDecomposer output.

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -442,6 +442,14 @@ class TwoQubitBasisDecomposer():
         return_circuit.compose(decomposition_euler[2*best_nbasis], [q[0]], inplace=True)
         return_circuit.compose(decomposition_euler[2*best_nbasis+1], [q[1]], inplace=True)
 
+        return_operator = Operator(return_circuit).data
+        for idx, elt in np.ndenumerate(return_operator):
+            if abs(elt) > 1e-8:
+                global_phase = np.angle(target[idx]) - np.angle(return_operator[idx])
+                break
+
+        return_circuit.global_phase += global_phase
+
         return return_circuit
 
     def num_basis_gates(self, unitary):

--- a/releasenotes/notes/two-qubit-basis-decomposer-correct-global-phase-58424ddbdf62061f.yaml
+++ b/releasenotes/notes/two-qubit-basis-decomposer-correct-global-phase-58424ddbdf62061f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The ``TwoQubitBasisDecomposer`` had in some cases, not been preserving
+    the global phase of the input circuit. This has been corrected.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -123,13 +123,9 @@ class CheckDecompositions(QiskitTestCase):
     def check_exact_decomposition(self, target_unitary, decomposer, tolerance=1.e-7):
         """Check exact decomposition for a particular target"""
         decomp_circuit = decomposer(target_unitary)
-        result = execute(decomp_circuit, UnitarySimulatorPy()).result()
+        result = execute(decomp_circuit, UnitarySimulatorPy(), optimization_level=0).result()
         decomp_unitary = result.get_unitary()
-        target_unitary *= la.det(target_unitary) ** (-0.25)
-        decomp_unitary *= la.det(decomp_unitary) ** (-0.25)
-        maxdists = [np.max(np.abs(target_unitary + phase * decomp_unitary))
-                    for phase in [1, 1j, -1, -1j]]
-        maxdist = np.min(maxdists)
+        maxdist = np.max(np.abs(target_unitary - decomp_unitary))
         self.assertTrue(np.abs(maxdist) < tolerance,
                         "Unitary {}: Worst distance {}".format(target_unitary, maxdist))
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Correct the global phase of circuits synthesized by the `TwoQubitBasisDecomposer` by simulating the output unitary and applying any needed phase offset. 

on hold for #5474 . 

### Details and comments

Calculating the phase from the input unitary and basis gate unitary should also be possible (and faster), but likely needs correct global phase from #5474. Calculating the phase offset from the operator is also correct but is ~5-10% slower. 
