### PR TITLE
Simplify adding params to paramvect

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2049,10 +2049,10 @@ class QuantumCircuit:
             the_values = value_dict[the_param_key]
             # if param_name is set then parse value dict
             if param_name and isinstance(the_values, np.ndarray):
-                for i, _ in enumerate(the_values):
+                for i, the_value in enumerate(the_values):
                     for key in self.parameters:
                         if key.name == '{}[{}]'.format(param_name, i):
-                            parsed_value_dict[key] = the_values[i]
+                            parsed_value_dict[key] = the_value
             # otherwise just copy the item
             else:
                 parsed_value_dict[the_param_key] = the_values

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2049,7 +2049,7 @@ class QuantumCircuit:
             the_values = value_dict[the_param_key]
             # if param_name is set then parse value dict
             if param_name and isinstance(the_values, np.ndarray):
-                for i in range(len(the_values)):
+                for i, _ in enumerate(the_values):
                     for key in self.parameters:
                         if key.name == '{}[{}]'.format(param_name, i):
                             parsed_value_dict[key] = the_values[i]

--- a/releasenotes/notes/Easier-vector-params-assignment-a1bf5ed83f048d06.yaml
+++ b/releasenotes/notes/Easier-vector-params-assignment-a1bf5ed83f048d06.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    It is now easier to assign parameters using ParameterVectors.
+    There is no need to enumerate all paramenters in the value dict
+    Values can be assigned to the Parameter vector either using the
+    key value pairs: ``ParameterVector, numpyarray`` in the value dict or
+    ``'paramenter vector name', numparray``. Refer to 
+    `#5557 <https://github.com/Qiskit/qiskit-terra/issues/5557>` for more
+    details.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -543,7 +543,7 @@ class TestParameters(QiskitTestCase):
         p_idx = 0
         for inst, _, _ in qc_bind.data:
             if inst.name != 'cx':
-                self.assertEqual(inst.params[0],  paramvalues[p_idx])
+                self.assertEqual(inst.params[0], paramvalues[p_idx])
                 p_idx += 1
 
     def test_bind_paramvect_w_str_array_keyvalue(self):
@@ -555,7 +555,7 @@ class TestParameters(QiskitTestCase):
         p_idx = 0
         for inst, _, _ in qc_bind.data:
             if inst.name != 'cx':
-                self.assertEqual(inst.params[0],  paramvalues[p_idx])
+                self.assertEqual(inst.params[0], paramvalues[p_idx])
                 p_idx += 1
 
     def test_compile_vector(self):

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -534,6 +534,30 @@ class TestParameters(QiskitTestCase):
                     if hasattr(gate_tuple[0], 'params') and gate_tuple[0].params:
                         self.assertIn(float(gate_tuple[0].params[0]), theta_vals)
 
+    def test_bind_paramvect_w_paramvect_array_keyvalue(self):
+        """Test binding a parameter vector passing a ParamVector and an array"""
+        num_qubits = 4
+        paramvalues = numpy.random.random(16)
+        qc = circlib.EfficientSU2(num_qubits, reps=1, parameter_prefix='th')
+        qc_bind = qc.bind_parameters({ParameterVector('th', 16): paramvalues})
+        p_idx = 0
+        for inst, _, _ in qc_bind.data:
+            if inst.name != 'cx':
+                self.assertEqual(inst.params[0],  paramvalues[p_idx])
+                p_idx += 1
+
+    def test_bind_paramvect_w_str_array_keyvalue(self):
+        """Test binding a parameter vector passing a string and an array"""
+        num_qubits = 4
+        paramvalues = numpy.random.random(16)
+        qc = circlib.EfficientSU2(num_qubits, reps=1, parameter_prefix='th')
+        qc_bind = qc.bind_parameters({'th': paramvalues})
+        p_idx = 0
+        for inst, _, _ in qc_bind.data:
+            if inst.name != 'cx':
+                self.assertEqual(inst.params[0],  paramvalues[p_idx])
+                p_idx += 1
+
     def test_compile_vector(self):
         """Test compiling a circuit with an unbound ParameterVector"""
         qc = QuantumCircuit(4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #5557

Manages different ways to bind Paramvects
### Details and comments

Added a value_dict parsing loop to expand paramvects using the array in the value before assigning paramaters.
