### PR TITLE
Fix U2Gate decomposition in QuantumCircuit.u2 deprecation message.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2405,7 +2405,7 @@ class QuantumCircuit:
                         'qubit gate QuantumCircuit.u instead: u2(φ,λ) = '
                         'u(π/2, φ, λ). Alternatively, you can decompose it in'
                         'terms of QuantumCircuit.p and QuantumCircuit.sx: '
-                        'u2(φ,λ) = p(π/2+φ) sx p(π/2+λ) (1 pulse on hardware).')
+                        'u2(φ,λ) = p(π/2+φ) sx p(λ-π/2) (1 pulse on hardware).')
     def u2(self, phi, lam, qubit):  # pylint: disable=invalid-name
         """Apply :class:`~qiskit.circuit.library.U2Gate`."""
         from .library.standard_gates.u2 import U2Gate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As pointed out by Aleksey Zhuravlev on the Qiskit slack, the deprecation message for `QuantumCircuit.u2` gives an incorrect decomposition of the U2Gate in terms of phase + sx. This PR updates it to `u2(φ,λ) = p(π/2+φ) sx p(λ-π/2)`, which is consistent with the definition in the OpenQASM spec.

### Details and comments


