### PR TITLE
Add unroll step to level2 passmanager optimization loop

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -206,7 +206,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         pm2.append(_direction_check)
         pm2.append(_direction, condition=_direction_condition)
     pm2.append(_reset)
-    pm2.append(_depth_check + _opt, do_while=_opt_control)
+    pm2.append(_depth_check + _opt + _unroll, do_while=_opt_control)
     if scheduling_method:
         pm2.append(_scheduling)
 

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -14,6 +14,8 @@
 from test import combine
 from ddt import ddt, data
 
+import numpy as np
+
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 from qiskit.circuit import Qubit
 from qiskit.compiler import transpile, assemble
@@ -84,6 +86,23 @@ class TestPresetPassManager(QiskitTestCase):
         circuit.reset(q[0])
         result = transpile(circuit, basis_gates=None, optimization_level=0)
         self.assertEqual(result, circuit)
+
+    def test_level2_respects_basis(self):
+        """Test that level2 with commutative cancellation respects basis"""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.h(1)
+        qc.cp(np.pi/8,0,1)
+        qc.cp(np.pi/4,0,2)
+        result = transpile(qc, basis_gates=['id', 'rz', 'sx', 'x', 'cx'],
+                           optimization_level=2)
+
+        dag = circuit_to_dag(result)
+        op_nodes = [node.name for node in dag.topological_op_nodes()]
+        # Assert no u1 or rx gates from commutative cancellation end up in
+        # end up in the output since they're not in the target basis gates
+        self.assertNotIn('u1', op_nodes)
+        self.assertNotIn('u1', op_nodes)
 
 
 @ddt

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -92,8 +92,8 @@ class TestPresetPassManager(QiskitTestCase):
         qc = QuantumCircuit(3)
         qc.h(0)
         qc.h(1)
-        qc.cp(np.pi/8,0,1)
-        qc.cp(np.pi/4,0,2)
+        qc.cp(np.pi / 8, 0, 1)
+        qc.cp(np.pi / 4, 0, 2)
         result = transpile(qc, basis_gates=['id', 'rz', 'sx', 'x', 'cx'],
                            optimization_level=2)
 
@@ -102,7 +102,7 @@ class TestPresetPassManager(QiskitTestCase):
         # Assert no u1 or rx gates from commutative cancellation end up in
         # end up in the output since they're not in the target basis gates
         self.assertNotIn('u1', op_nodes)
-        self.assertNotIn('u1', op_nodes)
+        self.assertNotIn('rx', op_nodes)
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the basis translation step to the level 2 preset
passmanager's optimization loop. The level 2 optimization loop runs the
commutative cancellation pass which use Rx and U1 gates as part of it's
optimization step which may not be in the target basis gates. This can
result in a gate outside of the target basis ended up in the output. To
avoid this in a general manner we need to rely on the basis translation
step because we can't write a pass to do the simplified rotation in a
manner compatible with any basis (especially since the target basis
could be using custom gates).

### Details and comments

Fixes #5644
