### PR TITLE
coupling_map argument should not change when SabreSwap is run   

### DIFF
--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -118,7 +118,11 @@ class SabreSwap(TransformationPass):
         """
 
         super().__init__()
+
+        # Assume bidirectional couplings, fixing gate direction is easy later.
         self.coupling_map = coupling_map if coupling_map.is_symmetric else deepcopy(coupling_map)
+        self.coupling_map.make_symmetric()
+
         self.heuristic = heuristic
         self.seed = seed
         self.applied_gates = None
@@ -145,9 +149,6 @@ class SabreSwap(TransformationPass):
 
         # Preserve input DAG's name, regs, wire_map, etc. but replace the graph.
         mapped_dag = dag._copy_circuit_metadata()
-
-        # Assume bidirectional couplings, fixing gate direction is easy later.
-        self.coupling_map.make_symmetric()
 
         canonical_register = dag.qregs['q']
         current_layout = Layout.generate_trivial_layout(canonical_register)

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -120,8 +120,11 @@ class SabreSwap(TransformationPass):
         super().__init__()
 
         # Assume bidirectional couplings, fixing gate direction is easy later.
-        self.coupling_map = coupling_map if coupling_map.is_symmetric else deepcopy(coupling_map)
-        self.coupling_map.make_symmetric()
+        if coupling_map.is_symmetric:
+            self.coupling_map = coupling_map
+        else:
+            self.coupling_map = deepcopy(coupling_map)
+            self.coupling_map.make_symmetric()
 
         self.heuristic = heuristic
         self.seed = seed

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -118,7 +118,7 @@ class SabreSwap(TransformationPass):
         """
 
         super().__init__()
-        self.coupling_map = deepcopy(coupling_map)
+        self.coupling_map = coupling_map if coupling_map.is_symmetric else deepcopy(coupling_map)
         self.heuristic = heuristic
         self.seed = seed
         self.applied_gates = None

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -13,7 +13,7 @@
 """Routing via SWAP insertion using the SABRE method from Li et al."""
 
 import logging
-from copy import copy
+from copy import copy, deepcopy
 from itertools import cycle
 import numpy as np
 
@@ -118,7 +118,7 @@ class SabreSwap(TransformationPass):
         """
 
         super().__init__()
-        self.coupling_map = coupling_map
+        self.coupling_map = deepcopy(coupling_map)
         self.heuristic = heuristic
         self.seed = seed
         self.applied_gates = None

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -84,6 +84,16 @@ class TestSabreSwap(QiskitTestCase):
 
         self.assertEqual(new_qc.num_nonlocal_gates(), 7)
 
+    def test_do_not_change_cm(self):
+        """Coupling map should not change.
+        See https://github.com/Qiskit/qiskit-terra/issues/5675"""
+        coupling = CouplingMap([[1, 0], [2, 0], [2, 1], [3, 2], [3, 4], [4, 2]])
+
+        passmanager = PassManager(SabreSwap(coupling))
+        _ = passmanager.run(QuantumCircuit(1))
+        print(set(coupling.get_edges()))
+        self.assertEqual(set([(1, 0), (2, 0), (2, 1), (3, 2), (3, 4), (4, 2)]), set(coupling.get_edges()))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -87,12 +87,13 @@ class TestSabreSwap(QiskitTestCase):
     def test_do_not_change_cm(self):
         """Coupling map should not change.
         See https://github.com/Qiskit/qiskit-terra/issues/5675"""
-        coupling = CouplingMap([[1, 0], [2, 0], [2, 1], [3, 2], [3, 4], [4, 2]])
+        cm_edges = [(1, 0), (2, 0), (2, 1), (3, 2), (3, 4), (4, 2)]
+        coupling = CouplingMap(cm_edges)
 
         passmanager = PassManager(SabreSwap(coupling))
         _ = passmanager.run(QuantumCircuit(1))
 
-        self.assertEqual(set([(1, 0), (2, 0), (2, 1), (3, 2), (3, 4), (4, 2)]), set(coupling.get_edges()))
+        self.assertEqual(set(cm_edges), set(coupling.get_edges()))
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -91,7 +91,7 @@ class TestSabreSwap(QiskitTestCase):
 
         passmanager = PassManager(SabreSwap(coupling))
         _ = passmanager.run(QuantumCircuit(1))
-        print(set(coupling.get_edges()))
+
         self.assertEqual(set([(1, 0), (2, 0), (2, 1), (3, 2), (3, 4), (4, 2)]), set(coupling.get_edges()))
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

Fixes #5675 

### Summary

SabreSwap does `make_symmetric` on `coupling_map`, changing the parameter in place. This PR makes a copy if the coupling map is not symmetric.

