### PR TITLE
Tune performance of optimize_1q_decomposition

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -827,6 +827,9 @@ class DAGCircuit:
         return full_pred_map, full_succ_map
 
     def __eq__(self, other):
+        # Try to convert to float, but in case of unbound ParameterExpressions
+        # a TypeError will be raise, fallback to normal equality in those
+        # cases
         try:
             self_phase = float(self.global_phase)
             other_phase = float(other.global_phase)

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -26,6 +26,7 @@ import itertools
 import warnings
 import math
 
+import numpy as np
 import retworkx as rx
 
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
@@ -826,10 +827,15 @@ class DAGCircuit:
         return full_pred_map, full_succ_map
 
     def __eq__(self, other):
-        if (
-                self.global_phase != other.global_phase
-                or self.calibrations != other.calibrations
-        ):
+        try:
+            self_phase = float(self.global_phase)
+            other_phase = float(other.global_phase)
+            if not np.isclose(self_phase, other_phase):
+                return False
+        except TypeError:
+            if self.global_phase != other.global_phase:
+                return False
+        if self.calibrations != other.calibrations:
             return False
 
         return rx.is_isomorphic_node_match(self._multi_graph,

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -488,6 +488,9 @@ class Operator(BaseOperator, TolerancesMixin):
     def _init_instruction(cls, instruction):
         """Convert a QuantumCircuit or Instruction to an Operator."""
         # Initialize an identity operator of the correct size of the circuit
+        if hasattr(instruction, '__array__'):
+            return Operator(np.array(instruction, dtype=complex))
+
         dimension = 2 ** instruction.num_qubits
         op = Operator(np.eye(dimension))
         # Convert circuit to an instruction

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -75,7 +75,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
             for decomposer in self.basis:
                 new_circs.append(decomposer(operator))
             if new_circs:
-                new_circ = min(new_circs, key=lambda circ: len(circ))
+                new_circ = min(new_circs, key=len)
                 if len(run) > len(new_circ):
                     new_dag = circuit_to_dag(new_circ)
                     dag.substitute_node_with_dag(run[0], new_dag)

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -57,13 +57,14 @@ class Optimize1qGatesDecomposition(TransformationPass):
             LOG.info("Skipping pass because no basis is set")
             return dag
         runs = dag.collect_1q_runs()
+        identity_matrix = np.eye(2)
         for run in runs:
             # Don't try to optimize a single 1q gate
             if len(run) <= 1:
                 params = run[0].op.params
                 # Remove single identity gates
                 if len(params) > 0 and np.array_equal(run[0].op.to_matrix(),
-                                                      np.eye(2)):
+                                                      identity_matrix):
                     dag.remove_op_node(run[0])
                 continue
 

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -69,16 +69,9 @@ class Optimize1qGatesDecomposition(TransformationPass):
                 continue
 
             new_circs = []
-            if hasattr(run[0].op, '__array__'):
-                operator = Operator(np.array(run[0].op, dtype=complex))
-            else:
-                operator = Operator(run[0].op)
+            operator = Operator(run[0].op)
             for gate in run[1:]:
-                if hasattr(gate.op, '__array__'):
-                    operator = operator.compose(
-                        np.array(gate.op, dtype=complex))
-                else:
-                    operator = operator.compose(gate.op)
+                operator = operator.compose(gate.op)
             for decomposer in self.basis:
                 new_circs.append(decomposer(operator))
             if new_circs:

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -74,8 +74,8 @@ class Optimize1qGatesDecomposition(TransformationPass):
             for decomposer in self.basis:
                 new_circs.append(decomposer(operator))
             if new_circs:
-                new_circ = min(new_circs, key=lambda circ: circ.depth())
-                if len(run) > new_circ.depth():
+                new_circ = min(new_circs, key=lambda circ: len(circ))
+                if len(run) > len(new_circ):
                     new_dag = circuit_to_dag(new_circ)
                     dag.substitute_node_with_dag(run[0], new_dag)
                     # Delete the other nodes in the run

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -16,7 +16,6 @@ import logging
 
 import numpy as np
 
-from qiskit.circuit import QuantumCircuit, QuantumRegister
 from qiskit.quantum_info import Operator
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.quantum_info.synthesis import one_qubit_decompose

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -997,7 +997,8 @@ class TestTranspile(QiskitTestCase):
         expected.sx(0)
         expected.p(np.pi, 0)
 
-        self.assertEqual(out, expected)
+        error_message = "Output circuit:\n%s\nExpected circuit:\n%s" %(str(out), str(expected))
+        self.assertEqual(out, expected, error_message)
 
     @data(0, 1, 2, 3)
     def test_transpile_preserves_circuit_metadata(self, optimization_level):

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -997,7 +997,8 @@ class TestTranspile(QiskitTestCase):
         expected.sx(0)
         expected.p(np.pi, 0)
 
-        error_message = "Output circuit:\n%s\nExpected circuit:\n%s" %(str(out), str(expected))
+        error_message = "\nOutput circuit:\n%s\nExpected circuit:\n%s" % (
+            str(out), str(expected))
         self.assertEqual(out, expected, error_message)
 
     @data(0, 1, 2, 3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit tunes the performance of the optimize_1q_decomposition pass.
Previously, the bottleneck of the pass was in creating the operator to
decompose because we were creating an unecessary circuit and then having
the Operator class convert that to a matrix which involved running
to_instruction() and lots of copying. Instead this commit switches the
pass to just go straight to an array or operator (if __array__ isn't
defined) for each gate and compose that directly onto the operator.
Doing this ends up being faster than using a circuit as an
intermediate class.

### Details and comments


