### PR TITLE
Change collect_1q_runs return for performance

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1393,8 +1393,7 @@ class DAGCircuit:
                 and isinstance(node.op, Gate) \
                 and hasattr(node.op, '__array__')
 
-        group_list = rx.collect_runs(self._multi_graph, filter_fn)
-        return set(tuple(x) for x in group_list)
+        return rx.collect_runs(self._multi_graph, filter_fn)
 
     def nodes_on_wire(self, wire, only_ops=False):
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently the return type from collect_1q_runs is being converted from
the 'list(list(DAGNode))' which is returned by retworkx.collect_runs()
to be 'set(tuple(DAGNode))' so that it is consistent with the return
type from collect_runs(). However, this ends up adding significant
overhead to the collect_1q_runs method and ends up being the bottleneck.
We spend more time running the set expression to convert from the list
than we do in rx.collect_runs() (mainly the filter function). Since
collect_1q_runs hasn't been included in a release yet we can change the
return type without breaking users and avoid this extra overhead. This
commit does that and removes the set comprehension and just returns the
nested list directly from retworkx.collect_runs().

### Details and comments