### PR TITLE
Exploit symmetry in Hessian/QFI evaluations

### DIFF
--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -94,7 +94,7 @@ class LinCombFull(CircuitQFI):
         # Get the circuits needed to compute〈∂iψ|∂jψ〉
         for i, param_i in enumerate(params):  # loop over parameters
             qfi_ops = []
-            for j, param_j in enumerate(params):
+            for j, param_j in enumerate(params[i:]):
                 # Get the gates of the quantum state which are parameterized by param_i
                 qfi_op = []
                 param_gates_i = state_qc._parameter_table[param_i]
@@ -167,7 +167,7 @@ class LinCombFull(CircuitQFI):
 
             qfi_operators.append(ListOp(qfi_ops))
         # Return the full QFI
-        return ListOp(qfi_operators)
+        return ListOp(qfi_operators, combo_fn=_triu_to_dense)
 
     @staticmethod
     def trim_circuit(circuit: QuantumCircuit,
@@ -200,3 +200,15 @@ class LinCombFull(CircuitQFI):
                 return trimmed_circuit
 
         raise OpflowError('The reference gate is not in the given quantum circuit.')
+
+
+def _triu_to_dense(triu):
+    dim = len(triu)
+    matrix = np.empty((dim, dim))
+    for i in range(dim):
+        for j in range(dim - i):
+            matrix[i, i + j] = triu[i][j]
+            if j != 0:
+                matrix[i + j, i] = triu[i][j]
+
+    return matrix

--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -159,7 +159,7 @@ class LinCombFull(CircuitQFI):
                 def phase_fix_combo_fn(x):
                     return 4 * (-0.5) * (x[0] * np.conjugate(x[1]) + x[1] * np.conjugate(x[0]))
 
-                phase_fix = ListOp([phase_fix_states[i], phase_fix_states[j]],
+                phase_fix = ListOp([phase_fix_states[i], phase_fix_states[i + j]],
                                    combo_fn=phase_fix_combo_fn)
                 # Add the phase fix quantities to the entries of the QFI
                 # Get 4 * Re[〈∂kψ|∂lψ〉−〈∂kψ|ψ〉〈ψ|∂lψ〉]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5631.

### Details and comments

Reduces the nested list ops to only contain the upper triangular elements and add a combo functions to convert the upper triangular elements into a dense matrix.

Todo:
- [ ] same thing for the hessians
