### PR TITLE
enable Operator() of circuits with delay instruction

### DIFF
--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -59,6 +59,15 @@ class Delay(Instruction):
         return np.array([[1, 0],
                          [0, 1]], dtype=dtype)
 
+    def to_matrix(self) -> np.ndarray:
+        """Return a Numpy.array for the unitary matrix. This has been
+        added to enable simulation without making delay a full Gate type.
+
+        Returns:
+            np.ndarray: matrix representation.
+        """
+        return self.__array__(dtype=complex)
+
     def __repr__(self):
         """Return the official string representing the delay."""
         return "%s(duration=%s[unit=%s])" % \

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -112,6 +112,19 @@ class TestDelay(QiskitTestCase):
         self.assertEqual(delay.duration, 10)
         self.assertIsInstance(delay.duration, np.integer)
 
+    def test_operator_delay(self):
+        """Test Operator(delay)."""
+        from qiskit.circuit import QuantumCircuit
+        from qiskit.quantum_info import Operator
+        circ = QuantumCircuit(1)
+        circ.delay(10)
+        op_delay = Operator(circ)
+
+        expected = QuantumCircuit(1)
+        expected.i(0)
+        op_identity = Operator(expected)
+        self.assertEqual(op_delay, op_identity)
+
 
 class TestSetFrequency(QiskitTestCase):
     """Set frequency tests."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This enables `Operator()` of circuits containing `delay` instructions. Previously, this would raise an error.

fixes #5697 

### Details and comments
Adds a `to_matrix` method to delay instruction to point to its alreadly existing `__array__` method.

