### PR TITLE
_ipython_display_ in QuantumCircuit allows nice output when circuits are the last stmt in  jupyter notebooks

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1221,6 +1221,10 @@ class QuantumCircuit:
         else:
             return string_temp
 
+    def _repr_html_(self):
+        return self.draw('mpl')._repr_html_()
+
+
     def draw(self, output=None, scale=None, filename=None, style=None,
              interactive=False, plot_barriers=True,
              reverse_bits=False, justify=None, vertical_compression='medium', idle_wires=True,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1221,9 +1221,13 @@ class QuantumCircuit:
         else:
             return string_temp
 
-    def _repr_html_(self):
-        return self.draw('mpl')._repr_html_()
-
+    def _ipython_display_(self):
+        from IPython.display import display
+        from qiskit.visualization import HAS_MATPLOTLIB
+        if HAS_MATPLOTLIB:
+            display(self.draw('mpl'))
+        else:
+            display(self.draw('text'))
 
     def draw(self, output=None, scale=None, filename=None, style=None,
              interactive=False, plot_barriers=True,


### PR DESCRIPTION
By extending `QuantumCircuit` with `_ipython_display_` "drawing" circuits in jupyter notebooks is even more direct. 

<img width="530" alt="Screenshot 2021-01-27 at 10 44 03" src="https://user-images.githubusercontent.com/766693/105973826-7e446980-608d-11eb-9c30-18190189c6d0.png">

Before, `qc.draw('mpl')` needs to be used. This PR chooses `'mpl'` drawer if matplotlib is installed, `'text'` otherwise.