### PR TITLE
Fix typo adding non-gates to _collect_1q_runs() output

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1441,10 +1441,11 @@ class DAGCircuit:
                 while len(s) == 1 and \
                         s[0].type == "op" and \
                         len(s[0].qargs) == 1 and \
-                        len(s[0].cargs) == 0 and \
+                        not s[0].cargs and \
                         s[0].condition is None and \
+                        s[0] not in nodes_seen and \
                         not s[0].op.is_parameterized() and \
-                        isinstance(node.op, Gate):
+                        isinstance(s[0].op, Gate):
                     group.append(s[0])
                     nodes_seen.add(s[0])
                     s = self._multi_graph.successors(s[0]._node_id)

--- a/releasenotes/notes/fix-invalid-ops-collect-runs-b9fd2f2e85136834.yaml
+++ b/releasenotes/notes/fix-invalid-ops-collect-runs-b9fd2f2e85136834.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue introduced in 0.16.2 that would cause errors when running
+    :func:`~qiskit.compiler.transpile` on a circuit with a series of 1 qubit
+    gates and a non-gate instruction that only operates on a qubit (e.g.
+    :class:`~qiskit.circuit.Reset`). Fixes
+    `#5736 <https://github.com/Qiskit/qiskit-terra/issues/5736>`__

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -734,6 +734,21 @@ class TestDagNodeSelection(QiskitTestCase):
             else:
                 self.fail('Unknown run encountered')
 
+    def test_dag_no_reset_in_collect_1q_runs(self):
+        """Test a run does not include a reset instruction."""
+        dag = DAGCircuit()
+        qreg = QuantumRegister(1, 'qr')
+        creg = ClassicalRegister(1, 'cr')
+        dag.add_qreg(qreg)
+        dag.add_creg(creg)
+        dag.apply_operation_back(U1Gate(3.14), [qreg[0]])
+        dag.apply_operation_back(HGate(), [qreg[0]])
+        dag.apply_operation_back(Reset(), [qreg[0]])
+        dag.apply_operation_back(Measure(), [qreg[0]], [creg[0]])
+        runs = dag._collect_1q_runs()
+        self.assertEqual([[x.name for x in run] for run in runs],
+                         [['u1', 'h']])
+
     def test_dag_collect_1q_runs_start_with_conditional(self):
         """Test collect 1q runs with a conditional at the start of the run."""
         h_gate = HGate()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a bug introduced in the backport PR #5655. On the
current master branch the bugfix that was being backported relies on a
feature in newer versions of retworkx. Since we can't bump the minimum
retworkx version required on a stable branch that functionality was
rewritten in the dagcircuit class directly. However, that implementation
included a typo which is causing non-gates and atomic instructions to be
included in collected runs which is not correct behavior and causes
errors to be raised. This commit corrects the bug in the backport and
adds a test to ensure the regression is not present.

This is a direct commit to the stable branch and not a backport since
this bug is not present on master and was only introduced through a bad
backport.

### Details and comments

Fixes #5736 