### PR TITLE
Remove DeprecationWarning of np.int, np.bool, np.complex

### DIFF
--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -131,7 +131,7 @@ class Register:
             CircuitError: if the `key` is not an integer.
             QiskitIndexError: if the `key` is not in the range `(0, self.size)`.
         """
-        if not isinstance(key, (int, np.int, np.int32, np.int64, slice, list)):
+        if not isinstance(key, (int, np.int32, np.int64, slice, list)):
             raise CircuitError("expected integer or slice index into register")
         if isinstance(key, slice):
             return self._bits[key]

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -220,7 +220,7 @@ class PauliOp(PrimitiveOp):
                 corrected_z_bits = self.primitive.z[::-1]  # type: ignore
 
                 for bstr, v in front.primitive.items():
-                    bitstr = np.asarray(list(bstr)).astype(int).astype(bool)
+                    bitstr = np.fromiter(bstr, dtype=int).astype(bool)
                     new_b_str = np.logical_xor(bitstr, corrected_x_bits)
                     new_str = ''.join(map(str, 1 * new_b_str))
                     z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits))

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -220,7 +220,7 @@ class PauliOp(PrimitiveOp):
                 corrected_z_bits = self.primitive.z[::-1]  # type: ignore
 
                 for bstr, v in front.primitive.items():
-                    bitstr = np.asarray(list(bstr)).astype(np.int).astype(np.bool)
+                    bitstr = np.asarray(list(bstr)).astype(int).astype(bool)
                     new_b_str = np.logical_xor(bitstr, corrected_x_bits)
                     new_str = ''.join(map(str, 1 * new_b_str))
                     z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits))

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -298,7 +298,7 @@ class PauliSumOp(PrimitiveOp):
                 corrected_z_bits = self.primitive.table.Z
                 coeffs = self.primitive.coeffs
                 for bstr, v in front.primitive.items():
-                    bitstr = np.fromiter(bstr, dtype=np.int).astype(np.bool)
+                    bitstr = np.fromiter(bstr, dtype=int).astype(bool)
                     new_b_str = np.logical_xor(bitstr, corrected_x_bits)
                     new_str = ["".join([str(b) for b in bs]) for bs in new_b_str.astype(int)]
                     z_factor = np.product(1 - 2 * np.logical_and(bitstr, corrected_z_bits), axis=1)

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -404,7 +404,7 @@ def _tp_condition(channel):
         if not isinstance(channel, Choi):
             channel = Choi(channel)
         choi = channel.data
-        dims = tuple(np.sqrt(choi.shape).astype(np.int))
+        dims = tuple(np.sqrt(choi.shape).astype(int))
         shape = dims + dims
         tr_choi = np.trace(np.reshape(choi, shape), axis1=1, axis2=3)
     else:

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -60,8 +60,8 @@ def pauli_group(number_of_qubits, case='weight'):
         elif case == 'tensor':
             # the Pauli set is in tensor order II IX IY IZ XI ...
             for k in range(4 ** number_of_qubits):
-                z = np.zeros(number_of_qubits, dtype=np.bool)
-                x = np.zeros(number_of_qubits, dtype=np.bool)
+                z = np.zeros(number_of_qubits, dtype=bool)
+                x = np.zeros(number_of_qubits, dtype=bool)
                 # looping over all the qubits
                 for j in range(number_of_qubits):
                     # making the Pauli for each j fill it in from the

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -312,19 +312,19 @@ class BasePauli(BaseOperator):
     @staticmethod
     def _from_array(z, x, phase=0):
         """Convert array data to BasePauli data."""
-        if isinstance(z, np.ndarray) and z.dtype == np.bool:
+        if isinstance(z, np.ndarray) and z.dtype == bool:
             base_z = z
         else:
-            base_z = np.asarray(z, dtype=np.bool)
+            base_z = np.asarray(z, dtype=bool)
         if base_z.ndim == 1:
             base_z = base_z.reshape((1, base_z.size))
         elif base_z.ndim != 2:
             raise QiskitError("Invalid Pauli z vector shape.")
 
-        if isinstance(x, np.ndarray) and x.dtype == np.bool:
+        if isinstance(x, np.ndarray) and x.dtype == bool:
             base_x = x
         else:
-            base_x = np.asarray(x, dtype=np.bool)
+            base_x = np.asarray(x, dtype=bool)
         if base_x.ndim == 1:
             base_x = base_x.reshape((1, base_x.size))
         elif base_x.ndim != 2:
@@ -335,7 +335,7 @@ class BasePauli(BaseOperator):
 
         # Convert group phase convention to internal ZX-phase convertion.
         base_phase = np.mod(np.sum(np.logical_and(base_x, base_z),
-                                   axis=1, dtype=np.int) + phase, 4)
+                                   axis=1, dtype=int) + phase, 4)
         return base_z, base_x, base_phase
 
     @staticmethod

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -118,7 +118,7 @@ class Clifford(BaseOperator):
             if not data.num_qubits or not data.is_unitary():
                 raise QiskitError("Can only initalize from N-qubit identity ScalarOp.")
             self._table = StabilizerTable(
-                np.eye(2 * data.num_qubits, dtype=np.bool))
+                np.eye(2 * data.num_qubits, dtype=bool))
 
         # Initialize from a QuantumCircuit or Instruction object
         elif isinstance(data, (QuantumCircuit, Instruction)):
@@ -436,7 +436,7 @@ class Clifford(BaseOperator):
             raise QiskitError('Label contains invalid characters.')
         # Initialize an identity matrix and apply each gate
         num_qubits = len(label)
-        op = Clifford(np.eye(2 * num_qubits, dtype=np.bool))
+        op = Clifford(np.eye(2 * num_qubits, dtype=bool))
         for qubit, char in enumerate(reversed(label)):
             _append_circuit(op, label_gates[char], qargs=[qubit])
         return op
@@ -456,10 +456,10 @@ class Clifford(BaseOperator):
         if mat.shape != (2 * dim, 2 * dim):
             return False
 
-        one = np.eye(dim, dtype=np.int)
-        zero = np.zeros((dim, dim), dtype=np.int)
+        one = np.eye(dim, dtype=int)
+        zero = np.zeros((dim, dim), dtype=int)
         seye = np.block([[zero, one], [one, zero]])
-        arr = mat.astype(np.int)
+        arr = mat.astype(int)
         return np.array_equal(np.mod(arr.T.dot(seye).dot(arr), 2), seye)
 
     @staticmethod
@@ -487,7 +487,7 @@ class Clifford(BaseOperator):
         if method in ['C', 'T']:
             # Apply conjugate
             ret.table.phase ^= np.mod(np.sum(
-                ret.table.X & ret.table.Z, axis=1), 2).astype(np.bool)
+                ret.table.X & ret.table.Z, axis=1), 2).astype(bool)
         return ret
 
     def _tensor_product(self, other, reverse=False):
@@ -528,7 +528,7 @@ class Clifford(BaseOperator):
             return clifford
 
         padded = Clifford(StabilizerTable(
-            np.eye(2 * self.num_qubits, dtype=np.bool)), validate=False)
+            np.eye(2 * self.num_qubits, dtype=bool)), validate=False)
 
         inds = list(qargs) + [self.num_qubits + i for i in qargs]
 
@@ -567,7 +567,7 @@ class Clifford(BaseOperator):
         phase = np.mod(array2.dot(phase1) + phase2, 2)
 
         # Correcting for phase due to Pauli multiplication
-        ifacts = np.zeros(2 * num_qubits, dtype=np.int)
+        ifacts = np.zeros(2 * num_qubits, dtype=int)
 
         for k in range(2 * num_qubits):
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -290,7 +290,7 @@ class Pauli(BasePauli):
     def __getitem__(self, qubits):
         """Return the unsigned Pauli group Pauli for subset of qubits."""
         # Set group phase to 0 so returned Pauli is always +1 coeff
-        if isinstance(qubits, (int, np.int)):
+        if isinstance(qubits, int):
             qubits = [qubits]
         return Pauli((self.z[qubits], self.x[qubits]))
 
@@ -316,7 +316,7 @@ class Pauli(BasePauli):
             QiskitError: if ind is out of bounds for the array size or
                          number of qubits.
         """
-        if isinstance(qubits, (int, np.int)):
+        if isinstance(qubits, int):
             qubits = [qubits]
         if max(qubits) > self.num_qubits - 1:
             raise QiskitError(
@@ -346,9 +346,9 @@ class Pauli(BasePauli):
 
         # Initialize empty operator
         ret_qubits = self.num_qubits + value.num_qubits
-        ret = Pauli((np.zeros(ret_qubits, dtype=np.bool),
-                     np.zeros(ret_qubits, dtype=np.bool)))
-        if isinstance(qubits, (int, np.int)):
+        ret = Pauli((np.zeros(ret_qubits, dtype=bool),
+                     np.zeros(ret_qubits, dtype=bool)))
+        if isinstance(qubits, int):
             if value.num_qubits == 1:
                 qubits = [qubits]
             else:
@@ -618,9 +618,9 @@ class Pauli(BasePauli):
 
         # Convert to Symplectic representation
         num_qubits = len(pauli)
-        base_z = np.zeros((1, num_qubits), dtype=np.bool)
-        base_x = np.zeros((1, num_qubits), dtype=np.bool)
-        base_phase = np.array([phase], dtype=np.int)
+        base_z = np.zeros((1, num_qubits), dtype=bool)
+        base_x = np.zeros((1, num_qubits), dtype=bool)
+        base_phase = np.array([phase], dtype=int)
         for i, char in enumerate(pauli):
             if char == 'X':
                 base_x[0, num_qubits - 1 - i] = True
@@ -637,8 +637,8 @@ class Pauli(BasePauli):
         """Convert a ScalarOp to BasePauli data."""
         if op.num_qubits is None:
             raise QiskitError('{} is not an N-qubit identity'.format(op))
-        base_z = np.zeros((1, op.num_qubits), dtype=np.bool)
-        base_x = np.zeros((1, op.num_qubits), dtype=np.bool)
+        base_z = np.zeros((1, op.num_qubits), dtype=bool)
+        base_x = np.zeros((1, op.num_qubits), dtype=bool)
         base_phase = np.mod(
             cls._phase_from_complex(op.coeff) +
             np.sum(np.logical_and(base_z, base_x), axis=1), 4)
@@ -676,9 +676,9 @@ class Pauli(BasePauli):
 
         # Initialize identity Pauli
         ret = Pauli(
-            BasePauli(np.zeros((1, instr.num_qubits), dtype=np.bool),
-                      np.zeros((1, instr.num_qubits), dtype=np.bool),
-                      np.zeros(1, dtype=np.int)))
+            BasePauli(np.zeros((1, instr.num_qubits), dtype=bool),
+                      np.zeros((1, instr.num_qubits), dtype=bool),
+                      np.zeros(1, dtype=int)))
 
         # Add circuit global phase if specified
         if instr.global_phase:
@@ -726,7 +726,7 @@ class Pauli(BasePauli):
     def _make_np_bool(arr):
         if not isinstance(arr, (list, np.ndarray, tuple)):
             arr = [arr]
-        arr = np.asarray(arr).astype(np.bool)
+        arr = np.asarray(arr).astype(bool)
         return arr
 
     @staticmethod
@@ -1007,8 +1007,8 @@ class Pauli(BasePauli):
             Pauli: single qubit pauli
         """
         tmp = Pauli(pauli_label)
-        ret = Pauli((np.zeros(num_qubits, dtype=np.bool),
-                     np.zeros(num_qubits, dtype=np.bool)))
+        ret = Pauli((np.zeros(num_qubits, dtype=bool),
+                     np.zeros(num_qubits, dtype=bool)))
         ret.x[index] = tmp.x[0]
         ret.z[index] = tmp.z[0]
         ret.phase = tmp.phase

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -137,7 +137,7 @@ class PauliTable(BaseOperator):
             can share the same underlying array.
         """
         if isinstance(data, (np.ndarray, list)):
-            self._array = np.asarray(data, dtype=np.bool)
+            self._array = np.asarray(data, dtype=bool)
         elif isinstance(data, str):
             # If input is a single Pauli string we convert to table
             self._array = PauliTable._from_label(data)
@@ -151,7 +151,7 @@ class PauliTable(BaseOperator):
             if data.num_qubits is None:
                 raise QiskitError(
                     '{} is not an N-qubit identity'.format(data))
-            self._array = np.zeros((1, 2 * data.num_qubits), dtype=np.bool)
+            self._array = np.zeros((1, 2 * data.num_qubits), dtype=bool)
         else:
             raise QiskitError("Invalid input data for PauliTable.")
 
@@ -242,7 +242,7 @@ class PauliTable(BaseOperator):
         """Return a view of the PauliTable."""
         # Returns a view of specified rows of the PauliTable
         # This supports all slicing operations the underlying array supports.
-        if isinstance(key, (int, np.int)):
+        if isinstance(key, int):
             key = [key]
         return PauliTable(self._array[key])
 
@@ -659,7 +659,7 @@ class PauliTable(BaseOperator):
 
         # Pad other with identity and then add
         padded = PauliTable(
-            np.zeros((1, 2 * self.num_qubits), dtype=np.bool))
+            np.zeros((1, 2 * self.num_qubits), dtype=bool))
         padded = padded.compose(other, qargs=qargs)
         return PauliTable(np.vstack((self._array, padded._array)))
 
@@ -821,7 +821,7 @@ class PauliTable(BaseOperator):
             raise QiskitError("Input Pauli list is empty.")
         # Get size from first Pauli
         first = cls._from_label(labels[0])
-        array = np.zeros((n_paulis, len(first)), dtype=np.bool)
+        array = np.zeros((n_paulis, len(first)), dtype=bool)
         array[0] = first
         for i in range(1, n_paulis):
             array[i] = cls._from_label(labels[i])
@@ -911,7 +911,7 @@ class PauliTable(BaseOperator):
         # array where first index is the Pauli row, and second two
         # indices are the matrix indices
         dim = 2 ** self.num_qubits
-        ret = np.zeros((self.size, dim, dim), dtype=np.complex)
+        ret = np.zeros((self.size, dim, dim), dtype=complex)
         for i in range(self.size):
             ret[i] = self._to_matrix(self._array[i])
         return ret
@@ -924,7 +924,7 @@ class PauliTable(BaseOperator):
             # stabilizer strings
             label = label[1:]
         num_qubits = len(label)
-        symp = np.zeros(2 * num_qubits, dtype=np.bool)
+        symp = np.zeros(2 * num_qubits, dtype=bool)
         xs = symp[0:num_qubits]
         zs = symp[num_qubits:2*num_qubits]
         for i, char in enumerate(label):
@@ -943,7 +943,7 @@ class PauliTable(BaseOperator):
         # Cast in symplectic representation
         # This should avoid a copy if the pauli is already a row
         # in the symplectic table
-        symp = np.asarray(pauli, dtype=np.bool)
+        symp = np.asarray(pauli, dtype=bool)
         num_qubits = symp.size // 2
         x = symp[0:num_qubits]
         z = symp[num_qubits:2*num_qubits]
@@ -981,7 +981,7 @@ class PauliTable(BaseOperator):
             i = (i & 0x33333333) + ((i >> 2) & 0x33333333)
             return (((i + (i >> 4) & 0xF0F0F0F) * 0x1010101) & 0xffffffff) >> 24
 
-        symp = np.asarray(pauli, dtype=np.bool)
+        symp = np.asarray(pauli, dtype=bool)
         num_qubits = symp.size // 2
         x = symp[0:num_qubits]
         z = symp[num_qubits:2*num_qubits]

--- a/qiskit/quantum_info/operators/symplectic/pauli_utils.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_utils.py
@@ -32,7 +32,7 @@ def pauli_basis(num_qubits, weight=False):
                                     [True, False],
                                     [True, True],
                                     [False, True]],
-                                   dtype=np.bool))
+                                   dtype=bool))
     if num_qubits == 1:
         return pauli_1q
     pauli = pauli_1q

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -42,8 +42,8 @@ def random_pauli(num_qubits, group_phase=False, seed=None):
         rng = seed
     else:
         rng = default_rng(seed)
-    z = rng.integers(2, size=num_qubits, dtype=np.bool)
-    x = rng.integers(2, size=num_qubits, dtype=np.bool)
+    z = rng.integers(2, size=num_qubits, dtype=bool)
+    x = rng.integers(2, size=num_qubits, dtype=bool)
     phase = rng.integers(4) if group_phase else 0
     pauli = Pauli((z, x, phase))
     return pauli
@@ -68,7 +68,7 @@ def random_pauli_table(num_qubits, size=1, seed=None):
     else:
         rng = default_rng(seed)
 
-    table = rng.integers(2, size=(size, 2 * num_qubits)).astype(np.bool)
+    table = rng.integers(2, size=(size, 2 * num_qubits)).astype(bool)
     return PauliTable(table)
 
 
@@ -91,8 +91,8 @@ def random_stabilizer_table(num_qubits, size=1, seed=None):
     else:
         rng = default_rng(seed)
 
-    table = rng.integers(2, size=(size, 2 * num_qubits)).astype(np.bool)
-    phase = rng.integers(2, size=size).astype(np.bool)
+    table = rng.integers(2, size=(size, 2 * num_qubits)).astype(bool)
+    phase = rng.integers(2, size=size).astype(bool)
     return StabilizerTable(table, phase)
 
 
@@ -159,10 +159,10 @@ def random_clifford(num_qubits, seed=None):
     table[lhs_inds, :] = table[rhs_inds, :]
 
     # Apply table
-    table = np.mod(np.matmul(table1, table), 2).astype(np.bool)
+    table = np.mod(np.matmul(table1, table), 2).astype(bool)
 
     # Generate random phases
-    phase = rng.integers(2, size=2 * num_qubits).astype(np.bool)
+    phase = rng.integers(2, size=2 * num_qubits).astype(bool)
     return Clifford(StabilizerTable(table, phase))
 
 
@@ -173,7 +173,7 @@ def _sample_qmallows(n, rng=None):
         rng = np.random.default_rng()
 
     # Hadmard layer
-    had = np.zeros(n, dtype=np.bool)
+    had = np.zeros(n, dtype=bool)
 
     # Permutation layer
     perm = np.zeros(n, dtype=int)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -58,7 +58,7 @@ class SparsePauliOp(BaseOperator, TolerancesMixin):
         else:
             table = PauliTable(data)
             if coeffs is None:
-                coeffs = np.ones(table.size, dtype=np.complex)
+                coeffs = np.ones(table.size, dtype=complex)
         # Initialize PauliTable
         self._table = table
 
@@ -128,7 +128,7 @@ class SparsePauliOp(BaseOperator, TolerancesMixin):
         """Return a view of the SparsePauliOp."""
         # Returns a view of specified rows of the PauliTable
         # This supports all slicing operations the underlying array supports.
-        if isinstance(key, (int, np.int)):
+        if isinstance(key, int):
             key = [key]
         return SparsePauliOp(self.table[key], self.coeffs[key])
 
@@ -355,7 +355,7 @@ class SparsePauliOp(BaseOperator, TolerancesMixin):
         if other == 0:
             # Check edge case that we deleted all Paulis
             # In this case we return an identity Pauli with a zero coefficient
-            table = np.zeros((1, 2 * self.num_qubits), dtype=np.bool)
+            table = np.zeros((1, 2 * self.num_qubits), dtype=bool)
             coeffs = np.array([0j])
             return SparsePauliOp(table, coeffs)
         # Otherwise we just update the phases
@@ -385,7 +385,7 @@ class SparsePauliOp(BaseOperator, TolerancesMixin):
 
         table, indexes = np.unique(self.table.array,
                                    return_inverse=True, axis=0)
-        coeffs = np.zeros(len(table), dtype=np.complex)
+        coeffs = np.zeros(len(table), dtype=complex)
         for i, val in zip(indexes, self.coeffs):
             coeffs[i] += val
         # Delete zero coefficient rows
@@ -397,7 +397,7 @@ class SparsePauliOp(BaseOperator, TolerancesMixin):
         # Check edge case that we deleted all Paulis
         # In this case we return an identity Pauli with a zero coefficient
         if coeffs.size == 0:
-            table = np.zeros((1, 2*self.num_qubits), dtype=np.bool)
+            table = np.zeros((1, 2*self.num_qubits), dtype=bool)
             coeffs = np.array([0j])
         return SparsePauliOp(table, coeffs)
 

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -196,11 +196,11 @@ class StabilizerTable(PauliTable):
 
         # Initialize the phase vector
         if phase is None or phase is False:
-            self._phase = np.zeros(self.size, dtype=np.bool)
+            self._phase = np.zeros(self.size, dtype=bool)
         elif phase is True:
-            self._phase = np.ones(self.size, dtype=np.bool)
+            self._phase = np.ones(self.size, dtype=bool)
         else:
-            self._phase = np.asarray(phase, dtype=np.bool)
+            self._phase = np.asarray(phase, dtype=bool)
             if self._phase.shape != (self.size, ):
                 raise QiskitError("Phase vector is incorrect shape.")
 
@@ -604,7 +604,7 @@ class StabilizerTable(PauliTable):
             minus = (x1 & z2 & (x2 | z1)) | (~x1 & x2 & z1 & ~z2)
         else:
             minus = (x2 & z1 & (x1 | z2)) | (~x2 & x1 & z2 & ~z1)
-        phase_shift = np.array(np.sum(minus, axis=1) % 2, dtype=np.bool)
+        phase_shift = np.array(np.sum(minus, axis=1) % 2, dtype=bool)
         phase = phase_shift ^ phase1 ^ phase2
         return StabilizerTable(pauli, phase)
 
@@ -681,7 +681,7 @@ class StabilizerTable(PauliTable):
 
         # Pad other with identity and then add
         padded = StabilizerTable(
-            np.zeros((1, 2 * self.num_qubits), dtype=np.bool))
+            np.zeros((1, 2 * self.num_qubits), dtype=bool))
         padded = padded.compose(other, qargs=qargs)
 
         return StabilizerTable(
@@ -705,13 +705,13 @@ class StabilizerTable(PauliTable):
             QiskitError: if other is not in (False, True, 1, -1).
         """
         # Numeric (integer) value case
-        if not isinstance(other, (bool, np.bool)) and other not in [1, -1]:
+        if not isinstance(other, bool) and other not in [1, -1]:
             raise QiskitError(
                 "Can only multiply a Stabilizer value by +1 or -1 phase.")
 
         # We have to be careful we don't cast True <-> +1 when
         # we store -1 phase as boolen True value
-        if (isinstance(other, (bool, np.bool)) and other) or other == -1:
+        if (isinstance(other, bool) and other) or other == -1:
             ret = self.copy()
             ret._phase ^= True
             return ret
@@ -795,8 +795,8 @@ class StabilizerTable(PauliTable):
             raise QiskitError("Input Pauli list is empty.")
         # Get size from first Pauli
         pauli, phase = cls._from_label(labels[0])
-        table = np.zeros((n_paulis, len(pauli)), dtype=np.bool)
-        phases = np.zeros(n_paulis, dtype=np.bool)
+        table = np.zeros((n_paulis, len(pauli)), dtype=bool)
+        phases = np.zeros(n_paulis, dtype=bool)
         table[0], phases[0] = pauli, phase
         for i in range(1, n_paulis):
             table[i], phases[i] = cls._from_label(labels[i])

--- a/qiskit/visualization/pulse_v2/generators/waveform.py
+++ b/qiskit/visualization/pulse_v2/generators/waveform.py
@@ -91,9 +91,9 @@ def gen_filled_waveform_stepwise(data: types.PulseInstruction,
 
         # phase modulation
         if formatter['control.apply_phase_modulation']:
-            ydata = np.asarray(ydata, dtype=np.complex) * np.exp(1j * data.frame.phase)
+            ydata = np.asarray(ydata, dtype=complex) * np.exp(1j * data.frame.phase)
         else:
-            ydata = np.asarray(ydata, dtype=np.complex)
+            ydata = np.asarray(ydata, dtype=complex)
 
         return _draw_shaped_waveform(xdata=xdata,
                                      ydata=ydata,
@@ -267,9 +267,9 @@ def gen_waveform_max_value(data: types.PulseInstruction,
 
     # phase modulation
     if formatter['control.apply_phase_modulation']:
-        ydata = np.asarray(ydata, dtype=np.complex) * np.exp(1j * data.frame.phase)
+        ydata = np.asarray(ydata, dtype=complex) * np.exp(1j * data.frame.phase)
     else:
-        ydata = np.asarray(ydata, dtype=np.complex)
+        ydata = np.asarray(ydata, dtype=complex)
 
     texts = []
 

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -321,7 +321,7 @@ def _bloch_multivector_data(state):
     bloch_data = []
     for i in range(num):
         if num > 1:
-            paulis = PauliTable(np.zeros((3, 2 * (num-1)), dtype=np.bool)).insert(
+            paulis = PauliTable(np.zeros((3, 2 * (num-1)), dtype=bool)).insert(
                 i, pauli_singles, qubit=True)
         else:
             paulis = pauli_singles

--- a/test/python/pulse/test_samplers.py
+++ b/test/python/pulse/test_samplers.py
@@ -41,7 +41,7 @@ class TestSampler(QiskitTestCase):
         b = 0.1
         duration = 2
         left_linear_pulse_fun = samplers.left(linear)
-        reference = np.array([0.1, 0.2], dtype=np.complex)
+        reference = np.array([0.1, 0.2], dtype=complex)
 
         pulse = left_linear_pulse_fun(duration, m=m, b=b)
         self.assertIsInstance(pulse, library.Waveform)
@@ -53,7 +53,7 @@ class TestSampler(QiskitTestCase):
         b = 0.1
         duration = 2
         right_linear_pulse_fun = samplers.right(linear)
-        reference = np.array([0.2, 0.3], dtype=np.complex)
+        reference = np.array([0.2, 0.3], dtype=complex)
 
         pulse = right_linear_pulse_fun(duration, m=m, b=b)
         self.assertIsInstance(pulse, library.Waveform)
@@ -65,7 +65,7 @@ class TestSampler(QiskitTestCase):
         b = 0.1
         duration = 2
         midpoint_linear_pulse_fun = samplers.midpoint(linear)
-        reference = np.array([0.15, 0.25], dtype=np.complex)
+        reference = np.array([0.15, 0.25], dtype=complex)
 
         pulse = midpoint_linear_pulse_fun(duration, m=m, b=b)
         self.assertIsInstance(pulse, library.Waveform)
@@ -87,7 +87,7 @@ class TestSampler(QiskitTestCase):
         m = 0.1
         duration = 2
         left_linear_pulse_fun = samplers.left(linear)
-        reference = np.array([0.1, 0.2], dtype=np.complex)
+        reference = np.array([0.1, 0.2], dtype=complex)
 
         pulse = left_linear_pulse_fun(duration, m=m)
         self.assertIsInstance(pulse, library.Waveform)

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -110,33 +110,33 @@ class TestCliffordGates(QiskitTestCase):
         """Tests for append of 1-qubit gates"""
 
         target_table = {
-            "i": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "id": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "iden": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "x": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "y": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "z": np.array([[[True, False], [False, True]]], dtype=np.bool),
-            "h": np.array([[[False, True], [True, False]]], dtype=np.bool),
-            "s": np.array([[[True, True], [False, True]]], dtype=np.bool),
-            "sdg": np.array([[[True, True], [False, True]]], dtype=np.bool),
-            "sinv": np.array([[[True, True], [False, True]]], dtype=np.bool),
-            "v": np.array([[[True, True], [True, False]]], dtype=np.bool),
-            "w": np.array([[[False, True], [True, True]]], dtype=np.bool),
+            "i": np.array([[[True, False], [False, True]]], dtype=bool),
+            "id": np.array([[[True, False], [False, True]]], dtype=bool),
+            "iden": np.array([[[True, False], [False, True]]], dtype=bool),
+            "x": np.array([[[True, False], [False, True]]], dtype=bool),
+            "y": np.array([[[True, False], [False, True]]], dtype=bool),
+            "z": np.array([[[True, False], [False, True]]], dtype=bool),
+            "h": np.array([[[False, True], [True, False]]], dtype=bool),
+            "s": np.array([[[True, True], [False, True]]], dtype=bool),
+            "sdg": np.array([[[True, True], [False, True]]], dtype=bool),
+            "sinv": np.array([[[True, True], [False, True]]], dtype=bool),
+            "v": np.array([[[True, True], [True, False]]], dtype=bool),
+            "w": np.array([[[False, True], [True, True]]], dtype=bool),
         }
 
         target_phase = {
-            "i": np.array([[False, False]], dtype=np.bool),
-            "id": np.array([[False, False]], dtype=np.bool),
-            "iden": np.array([[False, False]], dtype=np.bool),
-            "x": np.array([[False, True]], dtype=np.bool),
-            "y": np.array([[True, True]], dtype=np.bool),
-            "z": np.array([[True, False]], dtype=np.bool),
-            "h": np.array([[False, False]], dtype=np.bool),
-            "s": np.array([[False, False]], dtype=np.bool),
-            "sdg": np.array([[True, False]], dtype=np.bool),
-            "sinv": np.array([[True, False]], dtype=np.bool),
-            "v": np.array([[False, False]], dtype=np.bool),
-            "w": np.array([[False, False]], dtype=np.bool)
+            "i": np.array([[False, False]], dtype=bool),
+            "id": np.array([[False, False]], dtype=bool),
+            "iden": np.array([[False, False]], dtype=bool),
+            "x": np.array([[False, True]], dtype=bool),
+            "y": np.array([[True, True]], dtype=bool),
+            "z": np.array([[True, False]], dtype=bool),
+            "h": np.array([[False, False]], dtype=bool),
+            "s": np.array([[False, False]], dtype=bool),
+            "sdg": np.array([[True, False]], dtype=bool),
+            "sinv": np.array([[True, False]], dtype=bool),
+            "v": np.array([[False, False]], dtype=bool),
+            "w": np.array([[False, False]], dtype=bool)
         }
 
         target_stabilizer = {

--- a/test/python/quantum_info/operators/symplectic/test_legacy_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_legacy_pauli.py
@@ -33,16 +33,16 @@ class TestPauliAPI(QiskitTestCase):
         self.assertEqual(result.to_label(), 'IY')
 
     def test_ndarray_bool(self):
-        """Test creation from np.bool."""
-        x = np.asarray([1, 0]).astype(np.bool)
-        z = np.asarray([1, 0]).astype(np.bool)
+        """Test creation from bool."""
+        x = np.asarray([1, 0]).astype(bool)
+        z = np.asarray([1, 0]).astype(bool)
         pauli = Pauli(x=x, z=z)
         self.check(pauli)
 
     def test_ndarray_int(self):
-        """Test creation from np.int."""
-        x = np.asarray([2, 0]).astype(np.int)
-        z = np.asarray([2, 0]).astype(np.int)
+        """Test creation from int."""
+        x = np.asarray([2, 0]).astype(int)
+        z = np.asarray([2, 0]).astype(int)
         pauli = Pauli(x=x, z=z)
         self.check(pauli)
 
@@ -68,8 +68,8 @@ class TestPauli(QiskitTestCase):
     def setUp(self):
         """Setup."""
         super().setUp()
-        z = np.asarray([1, 0, 1, 0]).astype(np.bool)
-        x = np.asarray([1, 1, 0, 0]).astype(np.bool)
+        z = np.asarray([1, 0, 1, 0]).astype(bool)
+        x = np.asarray([1, 1, 0, 0]).astype(bool)
         self.ref_p = Pauli(z, x)
         self.ref_label = 'IZXY'
         self.ref_matrix = np.array([[0. + 0.j, 0. + 0.j, 0. + 0.j, 0. - 1.j,
@@ -214,28 +214,28 @@ class TestPauli(QiskitTestCase):
 
     def test_update_z(self):
         """Test update_z method."""
-        updated_z = np.asarray([0, 0, 0, 0]).astype(np.bool)
+        updated_z = np.asarray([0, 0, 0, 0]).astype(bool)
         self.ref_p.update_z(updated_z)
         np.testing.assert_equal(self.ref_p.z, np.asarray([False, False, False, False]))
         self.assertEqual(self.ref_p.to_label(), 'IIXX')
 
     def test_update_z_2(self):
         """Test update_z method, update partial z."""
-        updated_z = np.asarray([0, 1]).astype(np.bool)
+        updated_z = np.asarray([0, 1]).astype(bool)
         self.ref_p.update_z(updated_z, [0, 1])
         np.testing.assert_equal(self.ref_p.z, np.asarray([False, True, True, False]))
         self.assertEqual(self.ref_p.to_label(), 'IZYX')
 
     def test_update_x(self):
         """Test update_x method."""
-        updated_x = np.asarray([0, 1, 0, 1]).astype(np.bool)
+        updated_x = np.asarray([0, 1, 0, 1]).astype(bool)
         self.ref_p.update_x(updated_x)
         np.testing.assert_equal(self.ref_p.x, np.asarray([False, True, False, True]))
         self.assertEqual(self.ref_p.to_label(), 'XZXZ')
 
     def test_update_x_2(self):
         """Test update_x method, update partial x."""
-        updated_x = np.asarray([0, 1]).astype(np.bool)
+        updated_x = np.asarray([0, 1]).astype(bool)
         self.ref_p.update_x(updated_x, [1, 2])
         np.testing.assert_equal(self.ref_p.x, np.asarray([True, False, True, False]))
         self.assertEqual(self.ref_p.to_label(), 'IYIY')

--- a/test/python/quantum_info/operators/symplectic/test_pauli_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_table.py
@@ -83,43 +83,43 @@ class TestPauliTableInit(QiskitTestCase):
         # String initialization
         with self.subTest(msg='str init "I"'):
             value = PauliTable('I')._array
-            target = np.array([[False, False]], dtype=np.bool)
+            target = np.array([[False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "X"'):
             value = PauliTable('X')._array
-            target = np.array([[True, False]], dtype=np.bool)
+            target = np.array([[True, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "Y"'):
             value = PauliTable('Y')._array
-            target = np.array([[True, True]], dtype=np.bool)
+            target = np.array([[True, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "Z"'):
             value = PauliTable('Z')._array
-            target = np.array([[False, True]], dtype=np.bool)
+            target = np.array([[False, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "IX"'):
             value = PauliTable('IX')._array
-            target = np.array([[True, False, False, False]], dtype=np.bool)
+            target = np.array([[True, False, False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "XI"'):
             value = PauliTable('XI')._array
-            target = np.array([[False, True, False, False]], dtype=np.bool)
+            target = np.array([[False, True, False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "YZ"'):
             value = PauliTable('YZ')._array
-            target = np.array([[False, True, True, True]], dtype=np.bool)
+            target = np.array([[False, True, True, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "XIZ"'):
             value = PauliTable('XIZ')._array
             target = np.array([[False, False, True, True, False, False]],
-                              dtype=np.bool)
+                              dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
     def test_table_init(self):
@@ -145,12 +145,12 @@ class TestPauliTableProperties(QiskitTestCase):
 
         with self.subTest(msg='array'):
             pauli = PauliTable('II')
-            array = np.zeros([2, 4], dtype=np.bool)
+            array = np.zeros([2, 4], dtype=bool)
             self.assertTrue(np.all(pauli.array == array))
 
         with self.subTest(msg='set array'):
             pauli = PauliTable('XX')
-            array = np.zeros([1, 4], dtype=np.bool)
+            array = np.zeros([1, 4], dtype=bool)
             pauli.array = array
             self.assertTrue(np.all(pauli.array == array))
 
@@ -168,12 +168,12 @@ class TestPauliTableProperties(QiskitTestCase):
         with self.subTest(msg='X'):
             pauli = PauliTable.from_labels(['XI', 'IZ', 'YY'])
             array = np.array([[False, True], [False, False], [True, True]],
-                             dtype=np.bool)
+                             dtype=bool)
             self.assertTrue(np.all(pauli.X == array))
 
         with self.subTest(msg='set X'):
             pauli = PauliTable.from_labels(['XI', 'IZ'])
-            val = np.array([[False, False], [True, True]], dtype=np.bool)
+            val = np.array([[False, False], [True, True]], dtype=bool)
             pauli.X = val
             self.assertEqual(pauli, PauliTable.from_labels(['II', 'XY']))
 
@@ -182,7 +182,7 @@ class TestPauliTableProperties(QiskitTestCase):
             def set_x():
                 pauli = PauliTable.from_labels(['XI', 'IZ'])
                 val = np.array([[False, False, False], [True, True, True]],
-                               dtype=np.bool)
+                               dtype=bool)
                 pauli.X = val
                 return pauli
 
@@ -193,12 +193,12 @@ class TestPauliTableProperties(QiskitTestCase):
         with self.subTest(msg='Z'):
             pauli = PauliTable.from_labels(['XI', 'IZ', 'YY'])
             array = np.array([[False, False], [True, False], [True, True]],
-                             dtype=np.bool)
+                             dtype=bool)
             self.assertTrue(np.all(pauli.Z == array))
 
         with self.subTest(msg='set Z'):
             pauli = PauliTable.from_labels(['XI', 'IZ'])
-            val = np.array([[False, False], [True, True]], dtype=np.bool)
+            val = np.array([[False, False], [True, True]], dtype=bool)
             pauli.Z = val
             self.assertEqual(pauli, PauliTable.from_labels(['XI', 'ZZ']))
 
@@ -207,7 +207,7 @@ class TestPauliTableProperties(QiskitTestCase):
             def set_z():
                 pauli = PauliTable.from_labels(['XI', 'IZ'])
                 val = np.array([[False, False, False], [True, True, True]],
-                               dtype=np.bool)
+                               dtype=bool)
                 pauli.Z = val
                 return pauli
 
@@ -358,7 +358,7 @@ class TestPauliTableLabels(QiskitTestCase):
                           [False, True],
                           [True, False],
                           [True, True]],
-                         dtype=np.bool)
+                         dtype=bool)
         target = PauliTable(array)
         value = PauliTable.from_labels(labels)
         self.assertEqual(target, value)
@@ -369,7 +369,7 @@ class TestPauliTableLabels(QiskitTestCase):
         array = np.array([[False, False, False, False],
                           [True, True, True, True],
                           [False, True, True, False]],
-                         dtype=np.bool)
+                         dtype=bool)
         target = PauliTable(array)
         value = PauliTable.from_labels(labels)
         self.assertEqual(target, value)
@@ -381,7 +381,7 @@ class TestPauliTableLabels(QiskitTestCase):
                           5 * [True] + 5 * [False],
                           10 * [True],
                           5 * [False] + 5 * [True]],
-                         dtype=np.bool)
+                         dtype=bool)
         target = PauliTable(array)
         value = PauliTable.from_labels(labels)
         self.assertEqual(target, value)
@@ -393,7 +393,7 @@ class TestPauliTableLabels(QiskitTestCase):
                                      [False, True],
                                      [True, False],
                                      [True, True]],
-                                    dtype=np.bool))
+                                    dtype=bool))
         target = ['I', 'Z', 'Z', 'X', 'Y']
         value = pauli.to_labels()
         self.assertEqual(value, target)
@@ -405,7 +405,7 @@ class TestPauliTableLabels(QiskitTestCase):
                                      [False, True],
                                      [True, False],
                                      [True, True]],
-                                    dtype=np.bool))
+                                    dtype=bool))
         target = np.array(['I', 'Z', 'Z', 'X', 'Y'])
         value = pauli.to_labels(array=True)
         self.assertTrue(np.all(value == target))

--- a/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
@@ -86,43 +86,43 @@ class TestStabilizerTableInit(QiskitTestCase):
 
         with self.subTest(msg='str init "I"'):
             value = StabilizerTable('I')._array
-            target = np.array([[False, False]], dtype=np.bool)
+            target = np.array([[False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "X"'):
             value = StabilizerTable('X')._array
-            target = np.array([[True, False]], dtype=np.bool)
+            target = np.array([[True, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "Y"'):
             value = StabilizerTable('Y')._array
-            target = np.array([[True, True]], dtype=np.bool)
+            target = np.array([[True, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "Z"'):
             value = StabilizerTable('Z')._array
-            target = np.array([[False, True]], dtype=np.bool)
+            target = np.array([[False, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "IX"'):
             value = StabilizerTable('IX')._array
-            target = np.array([[True, False, False, False]], dtype=np.bool)
+            target = np.array([[True, False, False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "XI"'):
             value = StabilizerTable('XI')._array
-            target = np.array([[False, True, False, False]], dtype=np.bool)
+            target = np.array([[False, True, False, False]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "YZ"'):
             value = StabilizerTable('YZ')._array
-            target = np.array([[False, True, True, True]], dtype=np.bool)
+            target = np.array([[False, True, True, True]], dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
         with self.subTest(msg='str init "XIZ"'):
             value = StabilizerTable('XIZ')._array
             target = np.array([[False, False, True, True, False, False]],
-                              dtype=np.bool)
+                              dtype=bool)
             self.assertTrue(np.all(np.array(value == target)))
 
     def test_table_init(self):
@@ -148,7 +148,7 @@ class TestStabilizerTableProperties(QiskitTestCase):
 
         with self.subTest(msg='array'):
             stab = StabilizerTable('II')
-            array = np.zeros([2, 4], dtype=np.bool)
+            array = np.zeros([2, 4], dtype=bool)
             self.assertTrue(np.all(stab.array == array))
 
         with self.subTest(msg='set array'):
@@ -166,12 +166,12 @@ class TestStabilizerTableProperties(QiskitTestCase):
         with self.subTest(msg='X'):
             stab = StabilizerTable.from_labels(['XI', 'IZ', 'YY'])
             array = np.array([[False, True], [False, False], [True, True]],
-                             dtype=np.bool)
+                             dtype=bool)
             self.assertTrue(np.all(stab.X == array))
 
         with self.subTest(msg='set X'):
             stab = StabilizerTable.from_labels(['XI', 'IZ'])
-            val = np.array([[False, False], [True, True]], dtype=np.bool)
+            val = np.array([[False, False], [True, True]], dtype=bool)
             stab.X = val
             self.assertEqual(stab, StabilizerTable.from_labels(['II', 'XY']))
 
@@ -180,7 +180,7 @@ class TestStabilizerTableProperties(QiskitTestCase):
             def set_x():
                 stab = StabilizerTable.from_labels(['XI', 'IZ'])
                 val = np.array([[False, False, False], [True, True, True]],
-                               dtype=np.bool)
+                               dtype=bool)
                 stab.X = val
                 return stab
 
@@ -191,12 +191,12 @@ class TestStabilizerTableProperties(QiskitTestCase):
         with self.subTest(msg='Z'):
             stab = StabilizerTable.from_labels(['XI', 'IZ', 'YY'])
             array = np.array([[False, False], [True, False], [True, True]],
-                             dtype=np.bool)
+                             dtype=bool)
             self.assertTrue(np.all(stab.Z == array))
 
         with self.subTest(msg='set Z'):
             stab = StabilizerTable.from_labels(['XI', 'IZ'])
-            val = np.array([[False, False], [True, True]], dtype=np.bool)
+            val = np.array([[False, False], [True, True]], dtype=bool)
             stab.Z = val
             self.assertEqual(stab, StabilizerTable.from_labels(['XI', 'ZZ']))
 
@@ -205,7 +205,7 @@ class TestStabilizerTableProperties(QiskitTestCase):
             def set_z():
                 stab = StabilizerTable.from_labels(['XI', 'IZ'])
                 val = np.array([[False, False, False], [True, True, True]],
-                               dtype=np.bool)
+                               dtype=bool)
                 stab.Z = val
                 return stab
 
@@ -237,20 +237,20 @@ class TestStabilizerTableProperties(QiskitTestCase):
         """Test phase property"""
         with self.subTest(msg='phase'):
             phase = np.array([False, True, True, False])
-            array = np.eye(4, dtype=np.bool)
+            array = np.eye(4, dtype=bool)
             stab = StabilizerTable(array, phase)
             self.assertTrue(np.all(stab.phase == phase))
 
         with self.subTest(msg='set phase'):
             phase = np.array([False, True, True, False])
-            array = np.eye(4, dtype=np.bool)
+            array = np.eye(4, dtype=bool)
             stab = StabilizerTable(array)
             stab.phase = phase
             self.assertTrue(np.all(stab.phase == phase))
 
         with self.subTest(msg='set phase raises'):
             phase = np.array([False, True, False])
-            array = np.eye(4, dtype=np.bool)
+            array = np.eye(4, dtype=bool)
             stab = StabilizerTable(array)
 
             def set_phase_raise():
@@ -263,25 +263,25 @@ class TestStabilizerTableProperties(QiskitTestCase):
         """Test pauli property"""
         with self.subTest(msg='pauli'):
             phase = np.array([False, True, True, False])
-            array = np.eye(4, dtype=np.bool)
+            array = np.eye(4, dtype=bool)
             stab = StabilizerTable(array, phase)
             pauli = PauliTable(array)
             self.assertEqual(stab.pauli, pauli)
 
         with self.subTest(msg='set pauli'):
             phase = np.array([False, True, True, False])
-            array = np.zeros((4, 4), dtype=np.bool)
+            array = np.zeros((4, 4), dtype=bool)
             stab = StabilizerTable(array, phase)
-            pauli = PauliTable(np.eye(4, dtype=np.bool))
+            pauli = PauliTable(np.eye(4, dtype=bool))
             stab.pauli = pauli
             self.assertTrue(np.all(stab.array == pauli.array))
             self.assertTrue(np.all(stab.phase == phase))
 
         with self.subTest(msg='set pauli'):
             phase = np.array([False, True, True, False])
-            array = np.zeros((4, 4), dtype=np.bool)
+            array = np.zeros((4, 4), dtype=bool)
             stab = StabilizerTable(array, phase)
-            pauli = PauliTable(np.eye(4, dtype=np.bool)[1:])
+            pauli = PauliTable(np.eye(4, dtype=bool)[1:])
 
             def set_pauli_raise():
                 """Raise exception"""
@@ -413,8 +413,8 @@ class TestStabilizerTableLabels(QiskitTestCase):
                                          [True, False],
                                          [True, True],
                                          [False, True]],
-                                        dtype=np.bool)])
-        phase = np.array(8 * [False] + 4 * [True], dtype=np.bool)
+                                        dtype=bool)])
+        phase = np.array(8 * [False] + 4 * [True], dtype=bool)
         target = StabilizerTable(array, phase)
         value = StabilizerTable.from_labels(labels)
         self.assertEqual(target, value)
@@ -425,7 +425,7 @@ class TestStabilizerTableLabels(QiskitTestCase):
         array = np.array([[False, False, False, False],
                           [True, True, True, True],
                           [False, True, True, False]],
-                         dtype=np.bool)
+                         dtype=bool)
         phase = np.array([False, True, False])
         target = StabilizerTable(array, phase)
         value = StabilizerTable.from_labels(labels)
@@ -438,7 +438,7 @@ class TestStabilizerTableLabels(QiskitTestCase):
                           5 * [True] + 5 * [False],
                           10 * [True],
                           5 * [False] + 5 * [True]],
-                         dtype=np.bool)
+                         dtype=bool)
         phase = np.array([False, True, False, False])
         target = StabilizerTable(array, phase)
         value = StabilizerTable.from_labels(labels)
@@ -450,8 +450,8 @@ class TestStabilizerTableLabels(QiskitTestCase):
                                          [True, False],
                                          [True, True],
                                          [False, True]],
-                                        dtype=np.bool)])
-        phase = np.array(4 * [False] + 4 * [True], dtype=np.bool)
+                                        dtype=bool)])
+        phase = np.array(4 * [False] + 4 * [True], dtype=bool)
         value = StabilizerTable(array, phase).to_labels()
         target = ['+I', '+X', '+Y', '+Z', '-I', '-X', '-Y', '-Z']
         self.assertEqual(value, target)
@@ -462,8 +462,8 @@ class TestStabilizerTableLabels(QiskitTestCase):
                                          [True, False],
                                          [True, True],
                                          [False, True]],
-                                        dtype=np.bool)])
-        phase = np.array(4 * [False] + 4 * [True], dtype=np.bool)
+                                        dtype=bool)])
+        phase = np.array(4 * [False] + 4 * [True], dtype=bool)
         value = StabilizerTable(array, phase).to_labels(array=True)
         target = np.array(['+I', '+X', '+Y', '+Z',
                            '-I', '-X', '-Y', '-Z'])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Resolves: https://github.com/Qiskit/qiskit-terra/issues/5756

Numpy 1.20.0 deprecates `Using the aliases of builtin types like np.int`.
See the [release note](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).