### PR TITLE
Clarify the CONTRIBUTING.md section on stream capture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,13 +282,20 @@ C:\..\> python -m unittest test/python/circuit/test_circuit_operations.py
 
 ##### STDOUT/STDERR and logging capture
 
-When running tests in parallel either via tox, the makefile, or in CI we set
-the env variable `QISKIT_TEST_CAPTURE_STREAMS` which will capture any text
-written to stdout, stderr, and log messages and add them as attachments to
-the tests run so output can be associated with the test case it originated
-from. However, if you run tests outside of these mechanisms by default the
-streams are not captured. To enable stream capture just set the
-`QISKIT_TEST_CAPTURE_STREAMS` env variable to `1`.
+When running tests in parallel using `stestr` either via tox, the Makefile
+(`make test_ci`), or in CI we set the env variable
+`QISKIT_TEST_CAPTURE_STREAMS` which will capture any text written to stdout,
+stderr, and log messages and add them as attachments to the tests run so
+output can be associated with the test case it originated from. However, if
+you run tests with `stestr` outside of these mechanisms by default the streams
+are not captured. To enable stream capture just set the
+`QISKIT_TEST_CAPTURE_STREAMS` env variable to `1`. If this environment
+variable is set outside of running with `stestr` the streams (STDOUT, STDERR,
+and logging) will still be captured but **not** displayed in the test runners
+output. If you are using the stdlib unittest runner a similar result can be
+accomplished by using the
+[`--buffer`](https://docs.python.org/3/library/unittest.html#command-line-options)
+option (e.g. `python -m unittest discover --buffer ./test/python`).
 
 ##### Test Skip Options
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit expands on the stream capture section of the CONTRIBUTING.md
guide. The existing section was a bit confusing because it makes the
QISKIT_TEST_CAPTURE_STREAMS environment variable sound general but it
only works with stestr (or a similar test runner built on the same
stack). This clarifies that it only has the desired effect with stestr
and if you're using the stdlib runner this is the equivalent of running
--buffer.

### Details and comments