### PR TITLE
Add handling for no stdout encoding to text drawer

### DIFF
--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -543,7 +543,13 @@ class TextDrawing():
         if vertical_compression not in ['high', 'medium', 'low']:
             raise ValueError("Vertical compression can only be 'high', 'medium', or 'low'")
         self.vertical_compression = vertical_compression
-        self.encoding = encoding if encoding else sys.stdout.encoding
+        if encoding:
+            self.encoding = encoding
+        else:
+            if sys.stdout.encoding:
+                self.encoding = sys.stdout.encoding
+            else:
+                self.encoding = 'utf8'
 
     def __str__(self):
         return self.single_string()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There are times when the sys.stdout encoding may be None. Namely if the
sys.stdout object is replaced with a buffer like io.StringIO. This is a
common pattern in testing and is also how the stdlib unittest's --buffer
flag works. However, by default io.StringIO the encoding attribute is
set to None. In this case the text drawer attempts to explicitly encode
a string to bytes with a None encoding which will result in an error. To
address this case this commit adds handling for when sys.stdout.encoding
is None and in those cases it sets a fallback default to utf8 which is
the default character encoding for python3 strings.

### Details and comments


