### PR TITLE
Disable pylint rule causing failure with fastjsonschema 2.15.0

### DIFF
--- a/qiskit/qobj/utils.py
+++ b/qiskit/qobj/utils.py
@@ -59,5 +59,5 @@ def validate_qobj_against_schema(qobj):
         qobj.to_dict(validate=True)
     except JsonSchemaException as err:
         msg = ("Qobj validation failed. Specifically path: %s failed to fulfil"
-               " %s" % (err.path, err.definition))  #  pylint: disable=no-member
+               " %s" % (err.path, err.definition))  # pylint: disable=no-member
         raise SchemaValidationError(msg)

--- a/qiskit/qobj/utils.py
+++ b/qiskit/qobj/utils.py
@@ -59,5 +59,5 @@ def validate_qobj_against_schema(qobj):
         qobj.to_dict(validate=True)
     except JsonSchemaException as err:
         msg = ("Qobj validation failed. Specifically path: %s failed to fulfil"
-               " %s" % (err.path, err.definition))
+               " %s" % (err.path, err.definition))  #  pylint: disable=no-member
         raise SchemaValidationError(msg)


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

On Feb. 1, 2021 fastjsonschema 2.15.0 was released that made some
changes to the exception API. [1][2] These changed the inheritance tree
used for the exception classes so that `JsonSchemaException` (which is
the class qiskit is catching) was changed to be a base class instead of
the class raised by validation errors. A new class
`JsonSchemaValueException` a subclass of that now base class is now raised
by validation errors. The attributes used to wrap that exception and
raise a custom exception are now defined in `JsonSchemaValueException`
and not `JsonSchemaException`. This is causing pylint to fail because
the attributes are not defined in the base class. But in practice this
will not raise an error as `JsonSchemaValueException` will always be
raised even if we only `isinstance` check its base class. To still support
old versions of fastjsonschema we shouldn't change that `isinstance` check
so this commit just disables the rules. Especially since the qobj
jsonschema validation is deprecated and will be removed in a future
release as long as the code works pylint's pedantry isn't as important.

### Details and comments

[1] https://github.com/horejsek/python-fastjsonschema/commit/64a635e6826d5e34e2ad0e1bb5c3abe25aac07b0
[2] https://github.com/horejsek/python-fastjsonschema/blob/master/CHANGELOG.txt#L6-L8

