### PR TITLE
Get probabilities and marginal counts directly from Counts object

### DIFF
--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -14,9 +14,9 @@
 
 import re
 
-from qiskit.result import postprocess
 from qiskit import exceptions
-
+from qiskit.result.utils import marginal_counts
+from .result import postprocess
 
 # NOTE: A dict subclass should not overload any dunder methods like __getitem__
 # this can cause unexpected behavior and issues as the cPython dict
@@ -179,3 +179,34 @@ class Counts(dict):
                 int_key = int(bitstring.replace(" ", ""), 2)
                 out_dict[int_key] = value
             return out_dict
+
+    def as_probabilities(self):
+        """Return counts dict as probabilities.
+
+        Returns:
+            dict: A dictionary probabilities in place of counts
+        """
+        shots = sum(self.values())
+        out_dict = {}
+        for key, val in self.items():
+            out_dict[key] = val / shots
+        return out_dict
+
+    def marginal_counts(self, indices=None, inplace=False):
+        """
+        Marginalize counts over some indices of interest.
+
+        Args:
+            indices (list(int) or None): The bit positions of interest
+                to marginalize over. If ``None`` (default), do not marginalize at all.
+
+            inplace (bool): Default: False. Operates on the original Result
+                argument if True, leading to loss of original Job Result.
+                It has no effect if ``result`` is a dict.
+
+        Returns:
+            Result or dict[str, int]: A dictionary with the observed counts,
+            marginalized to only account for frequency of observations
+            of bits of interest.
+        """
+        return marginal_counts(self, indices, inplace)

--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -18,6 +18,7 @@ from qiskit import exceptions
 from qiskit.result.utils import marginal_counts
 from .result import postprocess
 
+
 # NOTE: A dict subclass should not overload any dunder methods like __getitem__
 # this can cause unexpected behavior and issues as the cPython dict
 # implementation has many standard methods in C for performance and the dunder

--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -205,7 +205,7 @@ class Counts(dict):
                 It has no effect if ``result`` is a dict.
 
         Returns:
-            Result or dict[str, int]: A dictionary with the observed counts,
+            dict[str, int]: A dictionary with the observed counts,
             marginalized to only account for frequency of observations
             of bits of interest.
         """

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -18,7 +18,6 @@ import warnings
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.pulse.schedule import Schedule
 from qiskit.exceptions import QiskitError
-from qiskit.quantum_info.states import statevector
 from qiskit.result.models import ExperimentResult
 from qiskit.result import postprocess
 from qiskit.result.counts import Counts
@@ -253,6 +252,7 @@ class Result:
         Raises:
             QiskitError: if there are no counts for the experiment.
         """
+        from qiskit.quantum_info.states import statevector
         if experiment is None:
             exp_keys = range(len(self.results))
         else:

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -17,7 +17,6 @@ from re import match
 from copy import deepcopy
 
 from qiskit.exceptions import QiskitError
-from qiskit.result.result import Result
 from qiskit.result.postprocess import _bin_to_hex
 
 
@@ -41,6 +40,7 @@ def marginal_counts(result, indices=None, inplace=False):
     Raises:
         QiskitError: in case of invalid indices to marginalize over.
     """
+    from qiskit.result.result import Result
     if isinstance(result, Result):
         if not inplace:
             result = deepcopy(result)

--- a/releasenotes/notes/counts_methods-3b34ea3b6922311b.yaml
+++ b/releasenotes/notes/counts_methods-3b34ea3b6922311b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added `counts.as_probabilities()` and `counts.marginal_counts()` methods that
+    converts integer counts to probabilities and extracts marginal_counts, respectively.

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -286,3 +286,10 @@ class TestCounts(unittest.TestCase):
         counts_obj = counts.Counts(raw_counts)
         result = counts_obj.hex_outcomes()
         self.assertEqual(expected, result)
+
+    def test_as_probabilities(self):
+        raw_counts = {'00': 1024, '11': 3072}
+        counts_obj = counts.Counts(raw_counts)
+        expected = {'00': 0.25, '11': 0.75}
+        expected_counts = counts.Counts(expected)
+        self.assertEqual(counts_obj, expected_counts)

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -290,6 +290,5 @@ class TestCounts(unittest.TestCase):
     def test_as_probabilities(self):
         raw_counts = {'00': 1024, '11': 3072}
         counts_obj = counts.Counts(raw_counts)
-        expected = {'00': 0.25, '11': 0.75}
-        expected_counts = counts.Counts(expected)
-        self.assertEqual(counts_obj, expected_counts)
+        expected_counts = {'00': 0.25, '11': 0.75}
+        self.assertEqual(counts_obj.as_probabilities(), expected_counts)


### PR DESCRIPTION
Adds the ability to get probabilities and marginal counts directly from the `Counts` object.