### PR TITLE
Remove deprecated methods/parameters from algorithms and opflow

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -14,6 +14,7 @@
 
 from typing import Optional, Union, Dict, List, Callable
 import logging
+import warnings
 import operator
 import math
 import numpy as np
@@ -24,8 +25,9 @@ from qiskit.providers import Backend
 from qiskit.providers import BaseBackend
 from qiskit.quantum_info import Statevector
 
-from qiskit.utils import QuantumInstance, algorithm_globals
+from qiskit.utils import name_args, QuantumInstance, algorithm_globals
 from qiskit.quantum_info import partial_trace
+from qiskit.utils.validation import validate_min, validate_in_set
 from ..algorithm_result import AlgorithmResult
 from ..exceptions import AlgorithmError
 
@@ -107,6 +109,15 @@ class Grover:
 
     """
 
+    @name_args([
+        ('oracle', ),
+        ('state_preparation', {bool: 'incremental'}),
+        ('iterations', ),
+        ('post_processing', {float: 'lam'}),
+        ('grover_operator', {list: 'rotation_counts'}),
+        ('quantum_instance', {str: 'mct_mode'}),
+        ('incremental', {(Backend, BaseBackend, QuantumInstance): 'quantum_instance'})
+    ], skip=1)  # skip the argument 'self'
     def __init__(self,
                  oracle: Union[QuantumCircuit, Statevector],
                  good_state: Optional[Union[Callable[[str], bool],
@@ -116,8 +127,14 @@ class Grover:
                  sample_from_iterations: bool = False,
                  post_processing: Callable[[List[int]], List[int]] = None,
                  grover_operator: Optional[QuantumCircuit] = None,
-                 quantum_instance: Optional[Union[QuantumInstance, Backend, BaseBackend]] = None
+                 quantum_instance: Optional[Union[QuantumInstance, Backend, BaseBackend]] = None,
+                 incremental: bool = False,
+                 num_iterations: Optional[int] = None,
+                 lam: Optional[float] = None,
+                 rotation_counts: Optional[List[int]] = None,
+                 mct_mode: Optional[str] = None,
                  ) -> None:
+        # pylint: disable=line-too-long
         r"""
         Args:
             oracle: The oracle to flip the phase of good states, :math:`\mathcal{S}_f`.
@@ -144,6 +161,29 @@ class Grover:
                 If None, the operator is constructed automatically using the
                 :class:`~qiskit.circuit.library.GroverOperator` from the circuit library.
             quantum_instance: A Quantum Instance or Backend to run the circuits.
+            incremental: DEPRECATED, use ``iterations`` instead.
+                Whether to use incremental search mode (True) or not (False).
+                Supplied *num_iterations* is ignored when True and instead the search task will
+                be carried out in successive rounds, using circuits built with incrementally
+                higher number of iterations for the repetition of the amplitude amplification
+                until a target is found or the maximal number :math:`\log N` (:math:`N` being the
+                total number of elements in the set from the oracle used) of iterations is
+                reached. The implementation follows Section 4 of [2].
+            num_iterations: DEPRECATED, use ``iterations`` instead.
+                How many times the marking and reflection phase sub-circuit is
+                repeated to amplify the amplitude(s) of the target(s). Has a minimum value of 1.
+            lam: DEPRECATED, use ``iterations`` instead.
+                For incremental search mode, the maximum number of repetition of amplitude
+                amplification increases by factor lam in every round,
+                :math:`R_{i+1} = lam \times R_{i}`. If this parameter is not set, the default
+                value lam = 1.34 is used, which is proved to be optimal [1].
+            rotation_counts: DEPRECATED, use ``iterations`` instead.
+                For incremental mode, if rotation_counts is defined, parameter *lam*
+                is ignored. rotation_counts is the list of integers that defines the number of
+                repetition of amplitude amplification for each round.
+            mct_mode: DEPRECATED, pass a custom ``grover_operator`` instead.
+                Multi-Control Toffoli mode ('basic' | 'basic-dirty-ancilla' |
+                'advanced' | 'noancilla')
 
         Raises:
             TypeError: If ``init_state`` is of unsupported type or is of type ``InitialState` but
@@ -159,6 +199,11 @@ class Grover:
         if quantum_instance:
             self.quantum_instance = quantum_instance
 
+        _check_deprecated_args(mct_mode, rotation_counts, lam, num_iterations)
+
+        if mct_mode is None:
+            mct_mode = 'noancilla'
+
         self._oracle = oracle
 
         # Construct GroverOperator circuit
@@ -167,10 +212,28 @@ class Grover:
         else:
             # wrap in method to hide the logic of handling deprecated arguments, can be simplified
             # once the deprecated arguments are removed
-            self._grover_operator = _construct_grover_operator(oracle, state_preparation)
+            self._grover_operator = _construct_grover_operator(oracle, state_preparation,
+                                                               mct_mode)
 
         max_iterations = np.ceil(2 ** (len(self._grover_operator.reflection_qubits) / 2))
-        if not isinstance(iterations, list):
+        if incremental:  # TODO remove 3 months after 0.8.0
+            if rotation_counts is not None:
+                iterations = rotation_counts
+                self._sample_from_iterations = False
+            else:
+                if lam is None:
+                    lam = 1.34
+
+                iterations = []
+                self._sample_from_iterations = True
+                power = 1.0
+                while power < max_iterations:
+                    iterations.append(int(power))
+                    power = lam * power
+
+        elif num_iterations is not None:  # TODO remove 3 months after 0.8.0
+            iterations = [num_iterations]
+        elif not isinstance(iterations, list):
             iterations = [iterations]
         # else: already a list
 
@@ -187,8 +250,11 @@ class Grover:
         self._is_good_state = good_state
         self._sample_from_iterations = sample_from_iterations
         self._post_processing = post_processing
+        self._incremental = incremental
+        self._lam = lam
+        self._rotation_counts = rotation_counts
 
-        if isinstance(iterations, list) and len(iterations) > 1:
+        if incremental or (isinstance(iterations, list) and len(iterations) > 1):
             logger.debug('Incremental mode specified, \
                 ignoring "num_iterations" and "num_solutions".')
 
@@ -356,7 +422,7 @@ class Grover:
         return self._grover_operator
 
 
-def _construct_grover_operator(oracle, state_preparation):
+def _construct_grover_operator(oracle, state_preparation, mct_mode):
     # check the type of state_preparation
     if not (isinstance(state_preparation, QuantumCircuit) or state_preparation is None):
         raise TypeError('Unsupported type "{}" of state_preparation'.format(
@@ -369,8 +435,47 @@ def _construct_grover_operator(oracle, state_preparation):
 
     grover_operator = GroverOperator(oracle=oracle,
                                      state_preparation=state_preparation,
-                                     reflection_qubits=reflection_qubits)
+                                     reflection_qubits=reflection_qubits,
+                                     mcx_mode=mct_mode)
     return grover_operator
+
+
+def _check_deprecated_args(mct_mode, rotation_counts, lam, num_iterations):
+    """Check the deprecated args."""
+
+    if mct_mode is not None:
+        validate_in_set('mct_mode', mct_mode,
+                        {'basic', 'basic-dirty-ancilla', 'advanced', 'noancilla'})
+        warnings.warn('The mct_mode argument is deprecated as of 0.8.0, and will be removed no '
+                      'earlier than 3 months after the release date. If you want to use a '
+                      'special MCX mode you should use the GroverOperator in '
+                      'qiskit.circuit.library directly and pass it to the grover_operator '
+                      'keyword argument.', DeprecationWarning, stacklevel=3)
+
+    if rotation_counts is not None:
+        warnings.warn('The rotation_counts argument is deprecated as of 0.8.0, and will be '
+                      'removed no earlier than 3 months after the release date. '
+                      'If you want to use the incremental mode with the rotation_counts '
+                      'argument or you should use the iterations argument instead and pass '
+                      'a list of integers',
+                      DeprecationWarning, stacklevel=3)
+
+    if lam is not None:
+        warnings.warn('The lam argument is deprecated as of 0.8.0, and will be '
+                      'removed no earlier than 3 months after the release date. '
+                      'If you want to use the incremental mode with the lam argument, '
+                      'you should use the iterations argument instead and pass '
+                      'a list of integers calculated with the lam argument.',
+                      DeprecationWarning, stacklevel=3)
+
+    if num_iterations is not None:
+        validate_min('num_iterations', num_iterations, 1)
+        warnings.warn('The num_iterations argument is deprecated as of 0.8.0, and will be '
+                      'removed no earlier than 3 months after the release date. '
+                      'If you want to use the num_iterations argument '
+                      'you should use the iterations argument instead and pass an integer '
+                      'for the number of iterations.',
+                      DeprecationWarning, stacklevel=3)
 
 
 def _check_is_good_state(is_good_state):

--- a/qiskit/algorithms/optimizers/aqgd.py
+++ b/qiskit/algorithms/optimizers/aqgd.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2020.
+# (C) Copyright IBM 2019, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,7 +13,6 @@
 """Analytical Quantum Gradient Descent (AQGD) optimizer."""
 
 import logging
-import warnings
 from typing import Callable, Tuple, List, Dict, Union
 
 import numpy as np
@@ -50,7 +49,6 @@ class AQGD(Optimizer):
                  maxiter: Union[int, List[int]] = 1000,
                  eta: Union[float, List[float]] = 1.0,
                  tol: float = 1e-6,  # this is tol
-                 disp: bool = False,
                  momentum: Union[float, List[float]] = 0.25,
                  param_tol: float = 1e-6,
                  averaging: int = 10) -> None:
@@ -64,7 +62,6 @@ class AQGD(Optimizer):
             tol: Tolerance for change in windowed average of objective values.
                 Convergence occurs when either objective tolerance is met OR parameter
                 tolerance is met.
-            disp: Set to True to display convergence messages.
             momentum: Bias towards the previous gradient momentum in current
                 update. Must be within the bounds: [0,1)
             param_tol: Tolerance for change in norm of parameters.
@@ -93,12 +90,6 @@ class AQGD(Optimizer):
         self._param_tol = param_tol
         self._tol = tol
         self._averaging = averaging
-        if disp:
-            warnings.warn('The disp parameter is deprecated as of '
-                          '0.8.0 and will be removed no sooner than 3 months after the release. '
-                          'The information is now available if you enable INFO level logging.',
-                          DeprecationWarning, stacklevel=2)
-        self._disp = disp
 
         # state
         self._avg_objval = None
@@ -299,9 +290,6 @@ class AQGD(Optimizer):
         converged = False
         for (eta, mom_coeff) in zip(self._eta, self._momenta_coeff):
             logger.info("Epoch: %4d | Stepsize: %6.4f | Momentum: %6.4f", epoch, eta, mom_coeff)
-            if self._disp:
-                print("Epoch: {:4d} | Stepsize: {:6.4f} | Momentum: {:6.4f}"
-                      .format(epoch, eta, mom_coeff))
 
             sum_max_iters = sum(self._maxiter[0:epoch + 1])
             while iter_count < sum_max_iters:
@@ -323,9 +311,6 @@ class AQGD(Optimizer):
 
                 logger.info(" Iter: %4d | Obj: %11.6f | Grad Norm: %f",
                             iter_count, objval, np.linalg.norm(gradient, ord=np.inf))
-                if self._disp:
-                    print(" Iter: {:4d} | Obj: {:11.6f} | Grad Norm: {:f}"
-                          .format(iter_count, objval, np.linalg.norm(gradient, ord=np.inf)))
 
                 # Check for objective convergence
                 converged = self._converged_objective(objval, self._tol, self._averaging)

--- a/qiskit/algorithms/optimizers/gsls.py
+++ b/qiskit/algorithms/optimizers/gsls.py
@@ -12,7 +12,6 @@
 
 """Line search with Gaussian-smoothed samples on a sphere."""
 
-import warnings
 from typing import Dict, Optional, Tuple, List, Callable
 import logging
 import numpy as np
@@ -48,8 +47,7 @@ class GSLS(Optimizer):
                  step_size_multiplier: float = 0.4,
                  armijo_parameter: float = 1.0e-1,
                  min_gradient_norm: float = 1e-8,
-                 max_failed_rejection_sampling: int = 50,
-                 max_iter: Optional[int] = None) -> None:
+                 max_failed_rejection_sampling: int = 50) -> None:
         """
         Args:
             maxiter: Maximum number of iterations.
@@ -67,15 +65,8 @@ class GSLS(Optimizer):
             min_gradient_norm: If the gradient norm is below this threshold, the algorithm stops.
             max_failed_rejection_sampling: Maximum number of attempts to sample points within
                 bounds.
-            max_iter: Deprecated, use maxiter.
         """
         super().__init__()
-        if max_iter is not None:
-            warnings.warn('The max_iter parameter is deprecated as of '
-                          '0.8.0 and will be removed no sooner than 3 months after the release. '
-                          'You should use maxiter instead.',
-                          DeprecationWarning)
-            maxiter = max_iter
         for k, v in list(locals().items()):
             if k in self._OPTIONS:
                 self._options[k] = v

--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -12,8 +12,7 @@
 
 """Simultaneous Perturbation Stochastic Approximation optimizer."""
 
-import warnings
-from typing import Optional, List, Callable
+from typing import List, Callable
 import logging
 
 import numpy as np
@@ -70,8 +69,7 @@ class SPSA(Optimizer):
                  c2: float = 0.602,
                  c3: float = 0.101,
                  c4: float = 0,
-                 skip_calibration: bool = False,
-                 max_trials: Optional[int] = None) -> None:
+                 skip_calibration: bool = False) -> None:
         """
         Args:
             maxiter: Maximum number of iterations to perform.
@@ -84,17 +82,10 @@ class SPSA(Optimizer):
             c3: The gamma in the paper, and it is used to adjust c (c1) at each iteration.
             c4: The parameter used to control a as well.
             skip_calibration: Skip calibration and use provided c(s) as is.
-            max_trials: Deprecated, use maxiter.
         """
         validate_min('save_steps', save_steps, 1)
         validate_min('last_avg', last_avg, 1)
         super().__init__()
-        if max_trials is not None:
-            warnings.warn('The max_trials parameter is deprecated as of '
-                          '0.8.0 and will be removed no sooner than 3 months after the release. '
-                          'You should use maxiter instead.',
-                          DeprecationWarning)
-            maxiter = max_trials
         for k, v in list(locals().items()):
             if k in self._OPTIONS:
                 self._options[k] = v

--- a/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,14 +13,13 @@
 """The module to compute the state gradient with the linear combination method."""
 
 from collections.abc import Iterable
-import warnings
 from copy import deepcopy
 from functools import partial
 from itertools import product
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
-from qiskit.circuit import Gate, Instruction, Qubit
+from qiskit.circuit import Gate, Instruction
 from qiskit.circuit import (QuantumCircuit, QuantumRegister, ParameterVector,
                             ParameterExpression, Parameter)
 from qiskit.circuit.parametertable import ParameterTable
@@ -378,49 +377,6 @@ class LinComb(CircuitGradient):
             return coeffs_gates
 
         raise TypeError('Unrecognized parametrized gate, {}'.format(gate))
-
-    @staticmethod
-    def insert_gate(circuit: QuantumCircuit,
-                    reference_gate: Gate,
-                    gate_to_insert: Instruction,
-                    qubits: Optional[List[Qubit]] = None,
-                    additional_qubits: Optional[Tuple[List[Qubit], List[Qubit]]] = None,
-                    after: bool = False):
-        """Insert a gate into the circuit.
-
-        Args:
-            circuit: The circuit onto which the gate is added.
-            reference_gate: A gate instance before or after which a gate is inserted.
-            gate_to_insert: The gate to be inserted.
-            qubits: The qubits on which the gate is inserted. If None, the qubits of the
-                reference_gate are used.
-            additional_qubits: If qubits is None and the qubits of the reference_gate are
-                used, this can be used to specify additional qubits before (first list in
-                tuple) or after (second list in tuple) the qubits.
-            after: If the gate_to_insert should be inserted after the reference_gate set True.
-
-        Raises:
-            OpflowError: Gate insertion fail
-        """
-        warnings.warn('The LinComb.insert_gate method is deprecated as of Qiskit Terra '
-                      '0.17.0 and will be removed no earlier than 3 months after the release.',
-                      DeprecationWarning, stacklevel=2)
-
-        if isinstance(gate_to_insert, IGate):
-            return
-        else:
-            for i, op in enumerate(circuit.data):
-                if op[0] == reference_gate:
-                    qubits = qubits or op[1]
-                    if additional_qubits:
-                        qubits = additional_qubits[0] + qubits + additional_qubits[1]
-                    if after:
-                        insertion_index = i + 1
-                    else:
-                        insertion_index = i
-                    circuit.data.insert(insertion_index, (gate_to_insert, qubits, []))
-                    return
-            raise OpflowError('Could not insert the controlled gate, something went wrong!')
 
     @staticmethod
     def apply_grad_gate(circuit, gate, param_index, grad_gate, grad_coeff, qr_superpos,

--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020.
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -13,10 +13,8 @@
 """The module for Quantum the Fisher Information."""
 
 from typing import List, Union
-import warnings
 
 import numpy as np
-from qiskit.circuit import Gate
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ParameterVector, ParameterExpression
 from qiskit.utils.arithmetic import triu_to_dense
 
@@ -26,7 +24,6 @@ from ...operator_globals import I, Z, Y
 from ...state_fns.state_fn import StateFn
 from ...state_fns.circuit_state_fn import CircuitStateFn
 from ..circuit_gradients.lin_comb import LinComb
-from ...exceptions import OpflowError
 from .circuit_qfi import CircuitQFI
 
 
@@ -168,35 +165,3 @@ class LinCombFull(CircuitQFI):
             qfi_operators.append(ListOp(qfi_ops))
         # Return the full QFI
         return ListOp(qfi_operators, combo_fn=triu_to_dense)
-
-    @staticmethod
-    def trim_circuit(circuit: QuantumCircuit,
-                     reference_gate: Gate) -> QuantumCircuit:
-        """Trim the given quantum circuit before the reference gate.
-
-        Args:
-            circuit: The circuit to be trimmed.
-            reference_gate: The gate where the circuit is supposed to be trimmed.
-
-        Returns:
-            The trimmed circuit.
-
-        Raises:
-            OpflowError: If the reference gate is not part of the given circuit.
-        """
-        warnings.warn('The LinCombFull.trim_circuit method is deprecated as of Qiskit Terra '
-                      '0.17.0 and will be removed no earlier than 3 months after the release.',
-                      DeprecationWarning, stacklevel=2)
-
-        parameterized_gates = []
-        for _, elements in circuit._parameter_table.items():
-            for element in elements:
-                parameterized_gates.append(element[0])
-
-        for i, op in enumerate(circuit.data):
-            if op[0] == reference_gate:
-                trimmed_circuit = QuantumCircuit(*circuit.qregs)
-                trimmed_circuit.data = circuit.data[:i]
-                return trimmed_circuit
-
-        raise OpflowError('The reference gate is not in the given quantum circuit.')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Algorithms and Opflow are new in Terra so remove any deprecated method or method parameters.

### Details and comments
As requested on issue  #5776, it removes deprecation with the exception of Grover that is handled on PR #5680

