### PR TITLE
Fix incorrect durations in scheduled circuit

### DIFF
--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -70,12 +70,14 @@ class ALAPSchedule(TransformationPass):
             start_time = max(qubit_time_available[q] for q in node.qargs)
             pad_with_delays(node.qargs, until=start_time, unit=time_unit)
 
-            new_node = new_dag.apply_operation_front(node.op, node.qargs, node.cargs,
-                                                     node.condition)
             duration = self.durations.get(node.op, node.qargs, unit=time_unit)
+
             # set duration for each instruction (tricky but necessary)
-            new_node.op.duration = duration
-            new_node.op.unit = time_unit
+            new_op = node.op.copy()  # need different op instance to store duration
+            new_op.duration = duration
+            new_op.unit = time_unit
+
+            new_dag.apply_operation_front(new_op, node.qargs, node.cargs, node.condition)
 
             stop_time = start_time + duration
             # update time table

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -70,11 +70,14 @@ class ASAPSchedule(TransformationPass):
             start_time = max(qubit_time_available[q] for q in node.qargs)
             pad_with_delays(node.qargs, until=start_time, unit=time_unit)
 
-            new_node = new_dag.apply_operation_back(node.op, node.qargs, node.cargs, node.condition)
             duration = self.durations.get(node.op, node.qargs, unit=time_unit)
+
             # set duration for each instruction (tricky but necessary)
-            new_node.op.duration = duration
-            new_node.op.unit = time_unit
+            new_op = node.op.copy()  # need different op instance to store duration
+            new_op.duration = duration
+            new_op.unit = time_unit
+
+            new_dag.apply_operation_back(new_op, node.qargs, node.cargs, node.condition)
 
             stop_time = start_time + duration
             # update time table


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #5771 

### Details and comments
Within scheduling passes, `Instruction` object is used to store duration. However, instructions in scheduled circuit was not always guaranteed to have different objects, and failed to report correct durations occasionally. This PR fix the bug by ensuring all instruction objects in scheduled circuit are different.

