### PR TITLE
Update slow optional import list to include additional packages

### DIFF
--- a/tools/find_optional_imports.py
+++ b/tools/find_optional_imports.py
@@ -15,14 +15,12 @@ import os
 import subprocess
 import sys
 
-os.environ['QISKIT_SUPPRESS_PACKAGING_WARNINGS'] = 'Y'
-
-import qiskit
-
 
 def main():
     optional_imports = ['networkx', 'sympy', 'pydot', 'ipywidgets',
-                        'scipy.stats']
+                        'scipy.stats', 'matplotlib', 'qiskit.providers.aer',
+                        'qiskit.providers.ibmq', 'qiskit.ignis',
+                        'qiskit.aqua']
 
     modules_imported = []
     for mod in optional_imports:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5582 we added a script that is used to ensure we don't import
slow optional dependencies in the default 'import qiskit' path. Since
that PR merged we've managed to remove a few more packages from the
default import path (see #5619, #5485, and #5620) which we should add
the same checks to to ensure we don't regress and accidently start
importing them again in the default path. This commit adds all these
packages to the list of imports not allowed as part of 'import qiskit'.

### Details and comments


