### PR TITLE
Move pycodestyle max-line-length to tox.ini

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint:
 	python tools/find_optional_imports.py
 
 style:
-	pycodestyle --max-line-length=100 qiskit test
+	pycodestyle qiskit test
 
 # Use the -s (starting directory) flag for "unittest discover" is necessary,
 # otherwise the QuantumCircuit header will be modified during the discovery.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -236,7 +236,7 @@ stages:
         - bash: |
             set -e
             source test-job/bin/activate
-            pycodestyle --max-line-length=100 qiskit test
+            pycodestyle qiskit test
             pylint -rn qiskit test
             tools/verify_headers.py qiskit test
             python tools/find_optional_imports.py

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ commands =
 [testenv:lint]
 basepython = python3
 commands =
-  pycodestyle --max-line-length=100 qiskit test
+  pycodestyle qiskit test
   pylint -rn qiskit test
   {toxinidir}/tools/verify_headers.py qiskit test
   {toxinidir}/tools/find_optional_imports.py
@@ -49,5 +49,7 @@ commands =
   sphinx-build -W -b html -j auto docs/ docs/_build/html {posargs}
 
 [pycodestyle]
+max-line-length = 100
 # default ignores + E741 because of opflow global variable I
+# codebase does currently comply with: E133, E242, E704, W505
 ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505, E741


### PR DESCRIPTION
Move pycodestyle max-line-length to tox.ini

Keeps it all consistent in one place, and makes it so that people don't have to configure their editor to use the non-default commandline option, if they are using pycodestyle for live linting in their editor.