### PR TITLE
Attempt to install latest numpy in all CI jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -623,7 +623,7 @@ stages:
             git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -U-c constraints.txt -e .
+            pip install -U -c constraints.txt -e .
             pip install -U "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "git+https://github.com/Qiskit/qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz pandoc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -399,9 +399,9 @@ stages:
             python -m pip install --upgrade pip setuptools wheel virtualenv
             virtualenv test-job
             source test-job/Scripts/activate
-            pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -u -c constraints.txt -e .
-            pip install -U "z3-solver" -c constraints.txt
+            pip install -r requirements.txt -r requirements-dev.txt -c constraints.txt
+            pip install -c constraints.txt -e .
+            pip install "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,8 +163,8 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt .
-            pip install "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U -c constraints.txt .
+            pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
@@ -229,8 +229,8 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "qiskit-aer" -c constraints.txt
+            pip install -U -c constraints.txt -e .
+            pip install -U "qiskit-aer" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
         - bash: |
@@ -326,8 +326,8 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "qiskit-aer" -c constraints.txt
+            pip install -U -c constraints.txt -e .
+            pip install -U "qiskit-aer" -c constraints.txt
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'
@@ -400,8 +400,8 @@ stages:
             virtualenv test-job
             source test-job/Scripts/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "z3-solver" -c constraints.txt
+            pip install -u -c constraints.txt -e .
+            pip install -U "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'
@@ -479,8 +479,8 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U -c constraints.txt -e .
+            pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
@@ -559,7 +559,7 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
+            pip install -U -c constraints.txt -e .
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'
@@ -623,8 +623,8 @@ stages:
             git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "git+https://github.com/Qiskit/qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+            pip install -U-c constraints.txt -e .
+            pip install -U "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "git+https://github.com/Qiskit/qiskit-ignis" "qiskit-aqua" "pyscf<1.7.4" "matplotlib<3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz pandoc
             pip check
@@ -672,8 +672,8 @@ stages:
             set -e
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -c constraints.txt
-            pip install -c constraints.txt -e .
-            pip install "matplotlib<3.3.0" pylatexenc pillow
+            pip install -U -c constraints.txt -e .
+            pip install -U "matplotlib<3.3.0" pylatexenc pillow
             python setup.py build_ext --inplace
             sudo apt install -y graphviz pandoc
             pip check

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,3 @@
 docplex==2.15.194
 appnope==0.1.0
-numpy>=1.20.0
+numpy>=1.20.0 ; python_version>'3.6'

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 docplex==2.15.194
 appnope==0.1.0
+numpy>=1.20.0

--- a/qiskit/opflow/converters/abelian_grouper.py
+++ b/qiskit/opflow/converters/abelian_grouper.py
@@ -13,7 +13,7 @@
 """AbelianGrouper Class"""
 
 from collections import defaultdict
-from typing import cast, List, Optional, Tuple, Union
+from typing import cast, List, Tuple, Union
 
 import numpy as np
 import retworkx as rx


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since the pulse simulator in the aer 0.7.4 release appears to not be
compatible with numpy releases <1.20.0 (see Qiskit/qiskit-aer#1120) we
need to ensure that we're running jobs that use aer with numpy 1.20.0
too. This commit attempts to ensure we're using the latest numpy release
in all CI jobs to unblock CI while we wait for a fixed aer release.

### Details and comments