### PR TITLE
pyupgrade to python 3.6, mostly f-strings

### DIFF
--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -382,7 +382,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         if kind in ["observed_fisher", "observed_information", "oi"]:
             return _fisher_confint(result, alpha, observed=True)
 
-        raise NotImplementedError("CI `{}` is not implemented.".format(kind))
+        raise NotImplementedError(f"CI `{kind}` is not implemented.")
 
 
 class AmplitudeEstimationResult(AmplitudeEstimatorResult):

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -210,7 +210,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
             interval = _fisher_confint(result, alpha, observed=True)
 
         if interval is None:
-            raise NotImplementedError("CI `{}` is not implemented.".format(kind))
+            raise NotImplementedError(f"CI `{kind}` is not implemented.")
 
         if apply_post_processing:
             return tuple(result.post_processing(value) for value in interval)

--- a/qiskit/algorithms/factorizers/shor.py
+++ b/qiskit/algorithms/factorizers/shor.py
@@ -142,7 +142,7 @@ class Shor:
 
     def _controlled_multiple_mod_N(self, num_qubits: int, N: int, a: int) -> Instruction:
         """Implements modular multiplication by a as an instruction."""
-        circuit = QuantumCircuit(num_qubits, name="multiply_by_{}_mod_{}".format(a % N, N))
+        circuit = QuantumCircuit(num_qubits, name=f"multiply_by_{a % N}_mod_{N}")
         down = circuit.qubits[1 : self._n + 1]
         aux = circuit.qubits[self._n + 1 :]
         qubits = [aux[i] for i in reversed(range(self._n + 1))]
@@ -219,7 +219,7 @@ class Shor:
 
         # Create Quantum Circuit
         circuit = QuantumCircuit(
-            self._up_qreg, self._down_qreg, self._aux_qreg, name="Shor(N={}, a={})".format(N, a)
+            self._up_qreg, self._down_qreg, self._aux_qreg, name=f"Shor(N={N}, a={a})"
         )
 
         # Create gates to perform addition/subtraction by N in Fourier Space

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -236,15 +236,15 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     @property
     def setting(self):
         """Prepare the setting of VQE as a string."""
-        ret = "Algorithm: {}\n".format(self.__class__.__name__)
+        ret = f"Algorithm: {self.__class__.__name__}\n"
         params = ""
         for key, value in self.__dict__.items():
             if key[0] == "_":
                 if "initial_point" in key and value is None:
                     params += "-- {}: {}\n".format(key[1:], "Random seed")
                 else:
-                    params += "-- {}: {}\n".format(key[1:], value)
-        ret += "{}".format(params)
+                    params += f"-- {key[1:]}: {value}\n"
+        ret += f"{params}"
         return ret
 
     def print_settings(self):
@@ -258,18 +258,18 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         ret += "==================== Setting of {} ============================\n".format(
             self.__class__.__name__
         )
-        ret += "{}".format(self.setting)
+        ret += f"{self.setting}"
         ret += "===============================================================\n"
         if hasattr(self._ansatz, "setting"):
-            ret += "{}".format(self._ansatz.setting)
+            ret += f"{self._ansatz.setting}"
         elif hasattr(self._ansatz, "print_settings"):
-            ret += "{}".format(self._ansatz.print_settings())
+            ret += f"{self._ansatz.print_settings()}"
         elif isinstance(self._ansatz, QuantumCircuit):
             ret += "ansatz is a custom circuit"
         else:
             ret += "ansatz has not been set"
         ret += "===============================================================\n"
-        ret += "{}".format(self._optimizer.setting)
+        ret += f"{self._optimizer.setting}"
         ret += "===============================================================\n"
         return ret
 

--- a/qiskit/algorithms/optimizers/adam_amsgrad.py
+++ b/qiskit/algorithms/optimizers/adam_amsgrad.py
@@ -156,7 +156,7 @@ class ADAM(Optimizer):
         Args:
             load_dir: The directory containing ``adam_params.csv``.
         """
-        with open(os.path.join(load_dir, "adam_params.csv"), mode="r") as csv_file:
+        with open(os.path.join(load_dir, "adam_params.csv")) as csv_file:
             if self._amsgrad:
                 fieldnames = ["v", "v_eff", "m", "t"]
             else:

--- a/qiskit/algorithms/optimizers/gsls.py
+++ b/qiskit/algorithms/optimizers/gsls.py
@@ -204,13 +204,11 @@ class GSLS(Optimizer):
 
             # Print information
             if self._options["disp"]:
-                print("Iter {:d}".format(iter_count))
-                print("Point {} obj {}".format(x, x_value))
-                print("Gradient {}".format(grad))
-                print(
-                    "Grad norm {} new_x_value {} step_size {}".format(grad_norm, new_x_value, alpha)
-                )
-                print("Direction {}".format(directions))
+                print(f"Iter {iter_count:d}")
+                print(f"Point {x} obj {x_value}")
+                print(f"Gradient {grad}")
+                print(f"Grad norm {grad_norm} new_x_value {new_x_value} step_size {alpha}")
+                print(f"Direction {directions}")
 
             # Test Armijo condition for sufficient decrease
             if new_x_value <= x_value - self._options["armijo_parameter"] * alpha * grad_norm:

--- a/qiskit/algorithms/optimizers/optimizer.py
+++ b/qiskit/algorithms/optimizers/optimizer.py
@@ -139,12 +139,12 @@ class Optimizer(ABC):
     @property
     def setting(self):
         """Return setting"""
-        ret = "Optimizer: {}\n".format(self.__class__.__name__)
+        ret = f"Optimizer: {self.__class__.__name__}\n"
         params = ""
         for key, value in self.__dict__.items():
             if key[0] == "_":
-                params += "-- {}: {}\n".format(key[1:], value)
-        ret += "{}".format(params)
+                params += f"-- {key[1:]}: {value}\n"
+        ret += f"{params}"
         return ret
 
     @abstractmethod
@@ -275,7 +275,7 @@ class Optimizer(ABC):
     def print_options(self):
         """Print algorithm-specific options."""
         for name in sorted(self._options):
-            logger.debug("{:s} = {:s}".format(name, str(self._options[name])))
+            logger.debug("%s = %s", name, str(self._options[name]))
 
     def set_max_evals_grouped(self, limit):
         """Set max evals grouped"""

--- a/qiskit/algorithms/variational_algorithm.py
+++ b/qiskit/algorithms/variational_algorithm.py
@@ -118,7 +118,7 @@ class VariationalAlgorithm:
             self._ansatz_params = None
             self._ansatz = ansatz
         else:
-            raise ValueError('Unsupported type "{}" of ansatz'.format(type(ansatz)))
+            raise ValueError(f'Unsupported type "{type(ansatz)}" of ansatz')
 
     @property
     def optimizer(self) -> Optional[Optimizer]:

--- a/qiskit/assembler/assemble_circuits.py
+++ b/qiskit/assembler/assemble_circuits.py
@@ -57,7 +57,7 @@ def _assemble_circuit(
     """
     if circuit.unit != "dt":
         raise QiskitError(
-            "Unable to assemble circuit with unit '{}', which must be 'dt'.".format(circuit.unit)
+            f"Unable to assemble circuit with unit '{circuit.unit}', which must be 'dt'."
         )
 
     # header data

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -150,7 +150,7 @@ def _assemble_experiments(
             qobj.PulseLibraryItem(name=name, samples=samples)
             for name, samples in user_pulselib.items()
         ],
-        "memory_slots": max([exp.header.memory_slots for exp in experiments]),
+        "memory_slots": max(exp.header.memory_slots for exp in experiments),
     }
 
     return experiments, experiment_config

--- a/qiskit/assembler/disassemble.py
+++ b/qiskit/assembler/disassemble.py
@@ -126,7 +126,7 @@ def _experiments_to_circuits(qobj):
                     _inst = instr_method(*params, *qubits, *clbits)
             elif name == "bfunc":
                 conditional["value"] = int(i.val, 16)
-                full_bit_size = sum([creg_dict[x].size for x in creg_dict])
+                full_bit_size = sum(creg_dict[x].size for x in creg_dict)
                 mask_map = {}
                 raw_map = {}
                 raw = []

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -93,5 +93,5 @@ def _ctrl_state_to_int(ctrl_state, num_ctrl_qubits):
     elif ctrl_state is None:
         ctrl_state_std = 2 ** num_ctrl_qubits - 1
     else:
-        raise CircuitError("invalid control state specification: {}".format(repr(ctrl_state)))
+        raise CircuitError(f"invalid control state specification: {repr(ctrl_state)}")
     return ctrl_state_std

--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -96,7 +96,7 @@ def control(
     q_control = QuantumRegister(num_ctrl_qubits, name="control")
     q_target = QuantumRegister(operation.num_qubits, name="target")
     q_ancillae = None  # TODO: add
-    controlled_circ = QuantumCircuit(q_control, q_target, name="c_{}".format(operation.name))
+    controlled_circ = QuantumCircuit(q_control, q_target, name=f"c_{operation.name}")
     if isinstance(operation, controlledgate.ControlledGate):
         original_ctrl_state = operation.ctrl_state
     global_phase = 0
@@ -205,9 +205,7 @@ def control(
                 controlled_circ.mcx(q_control, q_target[bit_indices[qargs[0]]], q_ancillae)
                 controlled_circ.h(q_target[bit_indices[qargs[0]]])
             else:
-                raise CircuitError(
-                    "gate contains non-controllable instructions: {}".format(gate.name)
-                )
+                raise CircuitError(f"gate contains non-controllable instructions: {gate.name}")
             if gate.definition is not None and gate.definition.global_phase:
                 global_phase += gate.definition.global_phase
     # apply controlled global phase
@@ -232,10 +230,10 @@ def control(
     # is named like "cc<base_gate.name>", else it is named like
     # "c<num_ctrl_qubits><base_name>".
     if new_num_ctrl_qubits > 2:
-        ctrl_substr = "c{:d}".format(new_num_ctrl_qubits)
+        ctrl_substr = f"c{new_num_ctrl_qubits:d}"
     else:
         ctrl_substr = ("{0}" * new_num_ctrl_qubits).format("c")
-    new_name = "{}{}".format(ctrl_substr, base_name)
+    new_name = f"{ctrl_substr}{base_name}"
     cgate = controlledgate.ControlledGate(
         new_name,
         controlled_circ.num_qubits,

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -50,7 +50,7 @@ class Bit:
             self._register = register
             self._index = index
             self._hash = hash((self._register, self._index))
-            self._repr = "%s(%s, %s)" % (self.__class__.__name__, self._register, self._index)
+            self._repr = f"{self.__class__.__name__}({self._register}, {self._index})"
 
     @property
     def register(self):

--- a/qiskit/circuit/classicalfunction/classicalfunction.py
+++ b/qiskit/circuit/classicalfunction/classicalfunction.py
@@ -53,7 +53,7 @@ class ClassicalFunction(ClassicalElement):
         self._truth_table = None
         super().__init__(
             name or "*classicalfunction*",
-            num_qubits=sum([qreg.size for qreg in self.qregs]),
+            num_qubits=sum(qreg.size for qreg in self.qregs),
             params=[],
         )
 

--- a/qiskit/circuit/classicalfunction/utils.py
+++ b/qiskit/circuit/classicalfunction/utils.py
@@ -60,7 +60,7 @@ def _convert_tweedledum_operator(op):
         qubits = op.qubits()
         ctrl_state = ""
         for qubit in qubits[: op.num_controls()]:
-            ctrl_state += "{}".format(int(qubit.polarity() == Qubit.Polarity.positive))
+            ctrl_state += f"{int(qubit.polarity() == Qubit.Polarity.positive)}"
         return base_gate().control(len(ctrl_state), ctrl_state=ctrl_state[::-1])
     return base_gate()
 

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -64,7 +64,7 @@ class Delay(Instruction):
 
     def __repr__(self):
         """Return the official string representing the delay."""
-        return "%s(duration=%s[unit=%s])" % (self.__class__.__name__, self.params[0], self.unit)
+        return f"{self.__class__.__name__}(duration={self.params[0]}[unit={self.unit}])"
 
     def validate_parameter(self, parameter):
         """Delay parameter (i.e. duration) must be int, float or ParameterExpression."""

--- a/qiskit/circuit/duration.py
+++ b/qiskit/circuit/duration.py
@@ -68,7 +68,7 @@ def convert_durations_to_dt(qc: QuantumCircuit, dt_in_sec: float, inplace=True):
             continue
 
         if not inst.unit.endswith("s"):
-            raise CircuitError("Invalid time unit: '{0}'".format(inst.unit))
+            raise CircuitError(f"Invalid time unit: '{inst.unit}'")
 
         duration = inst.duration
         if inst.unit != "s":

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -207,10 +207,10 @@ class EquivalenceLibrary:
             name, num_qubits = key
             equivalences = self._get_equivalences(key)
 
-            basis = frozenset(["{}/{}".format(name, num_qubits)])
+            basis = frozenset([f"{name}/{num_qubits}"])
             for params, decomp in equivalences:
                 decomp_basis = frozenset(
-                    "{}/{}".format(name, num_qubits)
+                    f"{name}/{num_qubits}"
                     for name, num_qubits in {
                         (inst.name, inst.num_qubits) for inst, _, __ in decomp.data
                     }
@@ -224,7 +224,7 @@ class EquivalenceLibrary:
                     )
                     node_map[decomp_basis] = decomp_basis_node
 
-                label = "%s\n%s" % (str(params), str(decomp) if num_qubits <= 5 else "...")
+                label = "{}\n{}".format(str(params), str(decomp) if num_qubits <= 5 else "...")
                 graph.add_edge(
                     node_map[basis],
                     node_map[decomp_basis],

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -56,7 +56,7 @@ class Gate(Instruction):
         if hasattr(self, "__array__"):
             # pylint: disable=no-member
             return self.__array__(dtype=complex)
-        raise CircuitError("to_matrix not defined for this {}".format(type(self)))
+        raise CircuitError(f"to_matrix not defined for this {type(self)}")
 
     def power(self, exponent: float):
         """Creates a unitary gate as `gate^exponent`.
@@ -87,12 +87,10 @@ class Gate(Instruction):
             decomposition_power.append(pow(element, exponent))
         # Then reconstruct the resulting gate.
         unitary_power = unitary @ np.diag(decomposition_power) @ unitary.conj().T
-        return UnitaryGate(unitary_power, label="%s^%s" % (self.name, exponent))
+        return UnitaryGate(unitary_power, label=f"{self.name}^{exponent}")
 
     def _return_repeat(self, exponent: float) -> "Gate":
-        return Gate(
-            name="%s*%s" % (self.name, exponent), num_qubits=self.num_qubits, params=self.params
-        )
+        return Gate(name=f"{self.name}*{exponent}", num_qubits=self.num_qubits, params=self.params)
 
     def assemble(self) -> "Instruction":
         """Assemble a QasmQobjInstruction"""
@@ -178,7 +176,7 @@ class Gate(Instruction):
                 yield [arg0, qarg1[0]], []
         else:
             raise CircuitError(
-                "Not sure how to combine these two-qubit arguments:\n %s\n %s" % (qarg0, qarg1)
+                f"Not sure how to combine these two-qubit arguments:\n {qarg0}\n {qarg1}"
             )
 
     @staticmethod
@@ -250,7 +248,7 @@ class Gate(Instruction):
             if len(parameter.parameters) > 0:
                 return parameter  # expression has free parameters, we cannot validate it
             if not parameter.is_real():
-                msg = "Bound parameter expression is complex in gate {}".format(self.name)
+                msg = f"Bound parameter expression is complex in gate {self.name}"
                 raise CircuitError(msg)
             return parameter  # per default assume parameters must be real when bound
         if isinstance(parameter, (int, float)):
@@ -268,6 +266,4 @@ class Gate(Instruction):
             )
             return parameter
         else:
-            raise CircuitError(
-                "Invalid param type {0} for gate {1}.".format(type(parameter), self.name)
-            )
+            raise CircuitError(f"Invalid param type {type(parameter)} for gate {self.name}.")

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -415,7 +415,7 @@ class Instruction:
         """
         name_param = self.name
         if self.params:
-            name_param = "%s(%s)" % (
+            name_param = "{}({})".format(
                 name_param,
                 ",".join([pi_check(i, ndigits=8, output="qasm") for i in self.params]),
             )
@@ -450,7 +450,7 @@ class Instruction:
 
     def _return_repeat(self, exponent):
         return Instruction(
-            name="%s*%s" % (self.name, exponent),
+            name=f"{self.name}*{exponent}",
             num_qubits=self.num_qubits,
             num_clbits=self.num_clbits,
             params=self.params,

--- a/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/functional_pauli_rotations.py
@@ -66,7 +66,7 @@ class FunctionalPauliRotations(BlueprintCircuit, ABC):
         basis = basis.lower()
         if self._basis is None or basis != self._basis:
             if basis not in ["x", "y", "z"]:
-                raise ValueError("The provided basis must be X, Y or Z, not {}".format(basis))
+                raise ValueError(f"The provided basis must be X, Y or Z, not {basis}")
             self._invalidate()
             self._basis = basis
 

--- a/qiskit/circuit/library/arithmetic/integer_comparator.py
+++ b/qiskit/circuit/library/arithmetic/integer_comparator.py
@@ -153,7 +153,7 @@ class IntegerComparator(BlueprintCircuit):
              The 2's complement of ``self.value``.
         """
         twos_complement = pow(2, self.num_state_qubits) - int(np.ceil(self.value))
-        twos_complement = "{:b}".format(twos_complement).rjust(self.num_state_qubits, "0")
+        twos_complement = f"{twos_complement:b}".rjust(self.num_state_qubits, "0")
         twos_complement = [
             1 if twos_complement[i] == "1" else 0 for i in reversed(range(len(twos_complement)))
         ]

--- a/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
+++ b/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
@@ -192,9 +192,9 @@ def _check_sorted_and_in_range(breakpoints, domain):
 def _check_sizes_match(slope, offset, breakpoints):
     size = len(slope)
     if len(offset) != size:
-        raise ValueError("Size mismatch of slope ({}) and offset ({}).".format(size, len(offset)))
+        raise ValueError(f"Size mismatch of slope ({size}) and offset ({len(offset)}).")
     if breakpoints is not None:
         if len(breakpoints) != size:
             raise ValueError(
-                "Size mismatch of slope ({}) and breakpoints ({}).".format(size, len(breakpoints))
+                f"Size mismatch of slope ({size}) and breakpoints ({len(breakpoints)})."
             )

--- a/qiskit/circuit/library/arithmetic/weighted_adder.py
+++ b/qiskit/circuit/library/arithmetic/weighted_adder.py
@@ -250,7 +250,7 @@ class WeightedAdder(BlueprintCircuit):
             q_state = qr_state[i]
 
             # get bit representation of current weight
-            weight_binary = "{:b}".format(int(weight)).rjust(self.num_sum_qubits, "0")[::-1]
+            weight_binary = f"{int(weight):b}".rjust(self.num_sum_qubits, "0")[::-1]
 
             # loop over bits of current weight and add them to sum and carry registers
             for j, bit in enumerate(weight_binary):

--- a/qiskit/circuit/library/fourier_checking.py
+++ b/qiskit/circuit/library/fourier_checking.py
@@ -82,7 +82,7 @@ class FourierChecking(QuantumCircuit):
                 "{1, -1}."
             )
 
-        super().__init__(num_qubits, name="fc: %s, %s" % (f, g))
+        super().__init__(num_qubits, name=f"fc: {f}, {g}")
 
         self.h(self.qubits)
 

--- a/qiskit/circuit/library/generalized_gates/mcmt.py
+++ b/qiskit/circuit/library/generalized_gates/mcmt.py
@@ -79,7 +79,7 @@ class MCMT(QuantumCircuit):
         super().__init__(num_qubits, name="mcmt")
 
         if label is None:
-            self.label = "{}-{}".format(num_target_qubits, self.gate.name.capitalize())
+            self.label = f"{num_target_qubits}-{self.gate.name.capitalize()}"
         else:
             self.label = label
 
@@ -139,7 +139,7 @@ class MCMT(QuantumCircuit):
             elif isinstance(gate, str):
                 name = gate
             else:
-                raise AttributeError("Invalid gate specified: {}".format(gate))
+                raise AttributeError(f"Invalid gate specified: {gate}")
             base_gate = valid_gates[name]
 
         return base_gate

--- a/qiskit/circuit/library/generalized_gates/pauli.py
+++ b/qiskit/circuit/library/generalized_gates/pauli.py
@@ -47,7 +47,7 @@ class PauliGate(Gate):
 
         gates = {"I": IGate, "X": XGate, "Y": YGate, "Z": ZGate}
         q = QuantumRegister(len(self.params[0]), "q")
-        qc = QuantumCircuit(q, name="{}({})".format(self.name, self.params[0]))
+        qc = QuantumCircuit(q, name=f"{self.name}({self.params[0]})")
 
         rules = [(gates[p](), [q[i]], []) for (i, p) in enumerate(reversed(self.params[0]))]
         qc._data = rules

--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -132,7 +132,7 @@ class ExcitationPreserving(TwoLocal):
         """
         supported_modes = ["iswap", "fsim"]
         if mode not in supported_modes:
-            raise ValueError("Unsupported mode {}, choose one of {}".format(mode, supported_modes))
+            raise ValueError(f"Unsupported mode {mode}, choose one of {supported_modes}")
 
         theta = Parameter("θ")
         swap = QuantumCircuit(2, name="Interaction")

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -205,7 +205,7 @@ class NLocal(BlueprintCircuit):
         except AttributeError:
             pass
 
-        raise TypeError("Adding a {} to an NLocal is not supported.".format(type(layer)))
+        raise TypeError(f"Adding a {type(layer)} to an NLocal is not supported.")
 
     @property
     def rotation_blocks(self) -> List[Instruction]:
@@ -514,12 +514,12 @@ class NLocal(BlueprintCircuit):
         Returns:
             The class name and the attributes/parameters of the instance as ``str``.
         """
-        ret = "NLocal: {}\n".format(self.__class__.__name__)
+        ret = f"NLocal: {self.__class__.__name__}\n"
         params = ""
         for key, value in self.__dict__.items():
             if key[0] == "_":
-                params += "-- {}: {}\n".format(key[1:], value)
-        ret += "{}".format(params)
+                params += f"-- {key[1:]}: {value}\n"
+        ret += f"{params}"
         return ret
 
     @property
@@ -587,7 +587,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is list of something
         if not isinstance(entanglement, (tuple, list)):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
         num_i = len(entanglement)
 
         # entanglement is List[str]
@@ -600,7 +600,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List]
         if not all(isinstance(e, (tuple, list)) for e in entanglement):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
         num_j = len(entanglement[i % num_i])
 
         # entanglement is List[List[str]]
@@ -615,7 +615,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List[List]]
         if not all(isinstance(e2, (tuple, list)) for e in entanglement for e2 in e):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
         # entanglement is List[List[List[int]]]
         if all(isinstance(e3, int) for e in entanglement for e2 in e for e3 in e2):
@@ -623,13 +623,13 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List[List[List]]]
         if not all(isinstance(e3, (tuple, list)) for e in entanglement for e2 in e for e3 in e2):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
         # entanglement is List[List[List[List[int]]]]
         if all(isinstance(e4, int) for e in entanglement for e2 in e for e3 in e2 for e4 in e3):
             return entanglement[i % num_i][j % num_j]
 
-        raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+        raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
     @property
     def initial_state(self) -> Any:
@@ -1070,4 +1070,4 @@ def get_entangler_map(
         return sca
 
     else:
-        raise ValueError("Unsupported entanglement type: {}".format(entanglement))
+        raise ValueError(f"Unsupported entanglement type: {entanglement}")

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -600,7 +600,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List]
         if not all(isinstance(en, (tuple, list)) for en in entanglement):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
         num_j = len(entanglement[i % num_i])
 
         # entanglement is List[List[str]]
@@ -617,7 +617,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List[List]]
         if not all(isinstance(e2, (tuple, list)) for en in entanglement for e2 in en):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
         # entanglement is List[List[List[int]]]
         if all(
@@ -633,7 +633,7 @@ class NLocal(BlueprintCircuit):
 
         # check if entanglement is List[List[List[List]]]
         if not all(isinstance(e3, (tuple, list)) for en in entanglement for e2 in en for e3 in e2):
-            raise ValueError("Invalid value of entanglement: {}".format(entanglement))
+            raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
         # entanglement is List[List[List[List[int]]]]
         if all(

--- a/qiskit/circuit/library/n_local/two_local.py
+++ b/qiskit/circuit/library/n_local/two_local.py
@@ -281,7 +281,7 @@ class TwoLocal(NLocal):
                 if isinstance(gate, layer):
                     instance = gate
             if instance is None:
-                raise ValueError("Unknown layer type`{}`.".format(layer))
+                raise ValueError(f"Unknown layer type`{layer}`.")
             layer = instance
 
         if isinstance(layer, Instruction):
@@ -290,8 +290,7 @@ class TwoLocal(NLocal):
             return circuit
 
         raise TypeError(
-            "Invalid input type {}. ".format(type(layer))
-            + "`layer` must be a type, str or QuantumCircuit."
+            f"Invalid input type {type(layer)}. " + "`layer` must be a type, str or QuantumCircuit."
         )
 
     def get_entangler_map(

--- a/qiskit/circuit/library/probability_distributions/lognormal.py
+++ b/qiskit/circuit/library/probability_distributions/lognormal.py
@@ -137,14 +137,14 @@ class LogNormalDistribution(QuantumCircuit):
             # compute the evaluation points using numpy's meshgrid
             # indexing 'ij' yields the "column-based" indexing
             meshgrid = np.meshgrid(
-                *[
+                *(
                     np.linspace(bound[0], bound[1], num=2 ** num_qubits[i])
                     for i, bound in enumerate(bounds)
-                ],
+                ),
                 indexing="ij",
             )
             # flatten into a list of points
-            x = list(zip(*[grid.flatten() for grid in meshgrid]))
+            x = list(zip(*(grid.flatten() for grid in meshgrid)))
 
         # compute the normalized, truncated probabilities
         probabilities = []

--- a/qiskit/circuit/library/probability_distributions/normal.py
+++ b/qiskit/circuit/library/probability_distributions/normal.py
@@ -184,14 +184,14 @@ class NormalDistribution(QuantumCircuit):
             # compute the evaluation points using numpy's meshgrid
             # indexing 'ij' yields the "column-based" indexing
             meshgrid = np.meshgrid(
-                *[
+                *(
                     np.linspace(bound[0], bound[1], num=2 ** num_qubits[i])
                     for i, bound in enumerate(bounds)
-                ],
+                ),
                 indexing="ij",
             )
             # flatten into a list of points
-            x = list(zip(*[grid.flatten() for grid in meshgrid]))
+            x = list(zip(*(grid.flatten() for grid in meshgrid)))
 
         from scipy.stats import multivariate_normal
 

--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -216,7 +216,7 @@ def mcry(self, theta, q_controls, q_target, q_ancillae=None, mode=None, use_basi
                 use_basis_gates=use_basis_gates,
             )
     else:
-        raise QiskitError("Unrecognized mode for building MCRY circuit: {}.".format(mode))
+        raise QiskitError(f"Unrecognized mode for building MCRY circuit: {mode}.")
 
 
 def mcrz(self, lam, q_controls, q_target, use_basis_gates=False):

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -97,7 +97,7 @@ class UGate(Gate):
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the U gate."""
-        theta, phi, lam = [float(param) for param in self.params]
+        theta, phi, lam = (float(param) for param in self.params)
         return numpy.array(
             [
                 [numpy.cos(theta / 2), -numpy.exp(1j * lam) * numpy.sin(theta / 2)],
@@ -221,7 +221,7 @@ class CUGate(ControlledGate):
 
     def __array__(self, dtype=None):
         """Return a numpy.array for the CU gate."""
-        theta, phi, lam, gamma = [float(param) for param in self.params]
+        theta, phi, lam, gamma = (float(param) for param in self.params)
         cos = numpy.cos(theta / 2)
         sin = numpy.sin(theta / 2)
         a = numpy.exp(1j * gamma) * cos

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -898,7 +898,7 @@ class MCXGate(ControlledGate):
             return int(num_ctrl_qubits > 4)
         if mode[:7] == "v-chain" or mode[:5] == "basic":
             return max(0, num_ctrl_qubits - 2)
-        raise AttributeError("Unsupported mode ({}) specified!".format(mode))
+        raise AttributeError(f"Unsupported mode ({mode}) specified!")
 
     def _define(self):
         """The standard definition used the Gray code implementation."""

--- a/qiskit/circuit/parameter.py
+++ b/qiskit/circuit/parameter.py
@@ -83,7 +83,7 @@ class Parameter(ParameterExpression):
         return self
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self.name)
+        return f"{self.__class__.__name__}({self.name})"
 
     def __eq__(self, other):
         if isinstance(other, Parameter):

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -201,7 +201,7 @@ class ParameterExpression:
         }
         if nan_parameter_values:
             raise CircuitError(
-                "Expression cannot bind non-numeric values ({})".format(nan_parameter_values)
+                f"Expression cannot bind non-numeric values ({nan_parameter_values})"
             )
 
     def _raise_if_parameter_names_conflict(self, inbound_parameters, outbound_parameters=None):
@@ -407,7 +407,7 @@ class ParameterExpression:
             return self._call(_log)
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, str(self))
+        return f"{self.__class__.__name__}({str(self)})"
 
     def __str__(self):
         from sympy import sympify

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -80,7 +80,7 @@ class ParameterTable(MutableMapping):
         return len(self._table)
 
     def __repr__(self):
-        return "ParameterTable({})".format(repr(self._table))
+        return f"ParameterTable({repr(self._table)})"
 
 
 def _deprecated_set_method():

--- a/qiskit/circuit/parametervector.py
+++ b/qiskit/circuit/parametervector.py
@@ -96,7 +96,7 @@ class ParameterVector:
             return self.params[start:stop:step]
 
         if key > self._size:
-            raise IndexError("Index out of range: {} > {}".format(key, self._size))
+            raise IndexError(f"Index out of range: {key} > {self._size}")
         return self.params[key]
 
     def __iter__(self):
@@ -106,10 +106,10 @@ class ParameterVector:
         return self._size
 
     def __str__(self):
-        return "{}, {}".format(self.name, [str(item) for item in self.params[: self._size]])
+        return f"{self.name}, {[str(item) for item in self.params[: self._size]]}"
 
     def __repr__(self):
-        return "{}(name={}, length={})".format(self.__class__.__name__, self.name, len(self))
+        return f"{self.__class__.__name__}(name={self.name}, length={len(self)})"
 
     def resize(self, length):
         """Resize the parameter vector.

--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -638,9 +638,7 @@ def _write_parameter_expression(file_obj, param):
             container.seek(0)
             data = container.read()
         else:
-            raise TypeError(
-                "Invalid expression type in symbol map for %s: %s" % (param, type(value))
-            )
+            raise TypeError(f"Invalid expression type in symbol map for {param}: {type(value)}")
 
         elem_header = struct.pack(PARAM_EXPR_MAP_ELEM_PACK, type_str.encode("utf8"), len(data))
         file_obj.write(elem_header)
@@ -665,7 +663,7 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
         gate_class_name = instruction_tuple[0].name
 
     has_condition = False
-    condition_register = "".encode("utf8")
+    condition_register = b""
     condition_value = 0
     if instruction_tuple[0].condition:
         has_condition = True
@@ -688,14 +686,10 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
     file_obj.write(condition_register)
     # Encode instruciton args
     for qbit in instruction_tuple[1]:
-        instruction_arg_raw = struct.pack(
-            INSTRUCTION_ARG_PACK, "q".encode("utf8"), index_map["q"][qbit]
-        )
+        instruction_arg_raw = struct.pack(INSTRUCTION_ARG_PACK, b"q", index_map["q"][qbit])
         file_obj.write(instruction_arg_raw)
     for clbit in instruction_tuple[2]:
-        instruction_arg_raw = struct.pack(
-            INSTRUCTION_ARG_PACK, "c".encode("utf8"), index_map["c"][clbit]
-        )
+        instruction_arg_raw = struct.pack(INSTRUCTION_ARG_PACK, b"c", index_map["c"][clbit])
         file_obj.write(instruction_arg_raw)
     # Encode instruction params
     for param in instruction_tuple[0].params:
@@ -728,7 +722,7 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
             size = len(data)
         else:
             raise TypeError(
-                "Invalid parameter type %s for gate %s," % (instruction_tuple[0], type(param))
+                f"Invalid parameter type {instruction_tuple[0]} for gate {type(param)},"
             )
         instruction_param_raw = struct.pack(INSTRUCTION_PARAM_PACK, type_key.encode("utf8"), size)
         file_obj.write(instruction_param_raw)
@@ -738,9 +732,9 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
 
 def _write_custom_instruction(file_obj, name, instruction):
     if isinstance(instruction, Gate):
-        type_str = "g".encode("utf8")
+        type_str = b"g"
     else:
-        type_str = "i".encode("utf8")
+        type_str = b"i"
     has_definition = False
     size = 0
     data = None
@@ -818,7 +812,7 @@ def dump(file_obj, circuits):
     version_parts = [int(x) for x in __version__.split(".")[0:3]]
     header = struct.pack(
         FILE_HEADER_PACK,
-        "QISKIT".encode("utf8"),
+        b"QISKIT",
         1,
         version_parts[0],
         version_parts[1],
@@ -854,16 +848,16 @@ def _write_circuit(file_obj, circuit):
     if num_registers > 0:
         for reg in circuit.qregs:
             reg_name = reg.name.encode("utf8")
-            file_obj.write(struct.pack(REGISTER_PACK, "q".encode("utf8"), reg.size, len(reg_name)))
+            file_obj.write(struct.pack(REGISTER_PACK, b"q", reg.size, len(reg_name)))
             file_obj.write(reg_name)
             REGISTER_ARRAY_PACK = "%sI" % reg.size
-            file_obj.write(struct.pack(REGISTER_ARRAY_PACK, *[qubit_indices[bit] for bit in reg]))
+            file_obj.write(struct.pack(REGISTER_ARRAY_PACK, *(qubit_indices[bit] for bit in reg)))
         for reg in circuit.cregs:
             reg_name = reg.name.encode("utf8")
-            file_obj.write(struct.pack(REGISTER_PACK, "c".encode("utf8"), reg.size, len(reg_name)))
+            file_obj.write(struct.pack(REGISTER_PACK, b"c", reg.size, len(reg_name)))
             file_obj.write(reg_name)
             REGISTER_ARRAY_PACK = "%sI" % reg.size
-            file_obj.write(struct.pack(REGISTER_ARRAY_PACK, *[clbit_indices[bit] for bit in reg]))
+            file_obj.write(struct.pack(REGISTER_ARRAY_PACK, *(clbit_indices[bit] for bit in reg)))
     instruction_buffer = io.BytesIO()
     custom_instructions = {}
     index_map = {}

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -470,7 +470,7 @@ class QuantumCircuit:
             QuantumCircuit: A circuit containing ``reps`` repetitions of this circuit.
         """
         repeated_circ = QuantumCircuit(
-            self.qubits, self.clbits, *self.qregs, *self.cregs, name=self.name + "**{}".format(reps)
+            self.qubits, self.clbits, *self.qregs, *self.cregs, name=self.name + f"**{reps}"
         )
 
         # benefit of appending instructions: decomposing shows the subparts, i.e. the power
@@ -555,7 +555,7 @@ class QuantumCircuit:
         controlled_gate = gate.control(num_ctrl_qubits, label, ctrl_state)
         control_qreg = QuantumRegister(num_ctrl_qubits)
         controlled_circ = QuantumCircuit(
-            control_qreg, self.qubits, *self.qregs, name="c_{}".format(self.name)
+            control_qreg, self.qubits, *self.qregs, name=f"c_{self.name}"
         )
         controlled_circ.append(controlled_gate, controlled_circ.qubits)
 
@@ -993,7 +993,7 @@ class QuantumCircuit:
                 ]
             else:
                 raise CircuitError(
-                    "Not able to expand a %s (%s)" % (bit_representation, type(bit_representation))
+                    f"Not able to expand a {bit_representation} ({type(bit_representation)})"
                 )
         except IndexError as ex:
             raise CircuitError("Index out of range.") from ex
@@ -1124,7 +1124,7 @@ class QuantumCircuit:
                     else:
                         if parameter.name in self._parameter_table.get_names():
                             raise CircuitError(
-                                "Name conflict on adding parameter: {}".format(parameter.name)
+                                f"Name conflict on adding parameter: {parameter.name}"
                             )
                         self._parameter_table[parameter] = [(instruction, param_index)]
 
@@ -1310,7 +1310,7 @@ class QuantumCircuit:
             gate_qargs = ",".join(
                 ["q%i" % index for index in [definition_bit_labels[qubit] for qubit in qargs]]
             )
-            composite_circuit_gates += "%s %s; " % (data.qasm(), gate_qargs)
+            composite_circuit_gates += f"{data.qasm()} {gate_qargs}; "
 
         if composite_circuit_gates:
             composite_circuit_gates = composite_circuit_gates.rstrip(" ")
@@ -1412,8 +1412,8 @@ class QuantumCircuit:
         for register in self.cregs:
             string_temp += register.qasm() + "\n"
 
-        qreg_bits = set(bit for reg in self.qregs for bit in reg)
-        creg_bits = set(bit for reg in self.cregs for bit in reg)
+        qreg_bits = {bit for reg in self.qregs for bit in reg}
+        creg_bits = {bit for reg in self.cregs for bit in reg}
         regless_qubits = []
         regless_clbits = []
 
@@ -1445,7 +1445,7 @@ class QuantumCircuit:
             if instruction.name == "measure":
                 qubit = qargs[0]
                 clbit = cargs[0]
-                string_temp += "%s %s -> %s;\n" % (
+                string_temp += "{} {} -> {};\n".format(
                     instruction.qasm(),
                     bit_labels[qubit],
                     bit_labels[clbit],
@@ -1477,19 +1477,19 @@ class QuantumCircuit:
 
                     # Insert composite circuit qasm definition right after header and extension lib
                     string_temp = string_temp.replace(
-                        self.extension_lib, "%s\n%s" % (self.extension_lib, qasm_string)
+                        self.extension_lib, f"{self.extension_lib}\n{qasm_string}"
                     )
 
                     existing_composite_circuits.append(instruction)
                     existing_gate_names.append(instruction.name)
 
                 # Insert qasm representation of the original instruction
-                string_temp += "%s %s;\n" % (
+                string_temp += "{} {};\n".format(
                     instruction.qasm(),
                     ",".join([bit_labels[j] for j in qargs + cargs]),
                 )
             else:
-                string_temp += "%s %s;\n" % (
+                string_temp += "{} {};\n".format(
                     instruction.qasm(),
                     ",".join([bit_labels[j] for j in qargs + cargs]),
                 )
@@ -2829,7 +2829,7 @@ class QuantumCircuit:
         if hasattr(gate, "num_ancilla_qubits") and gate.num_ancilla_qubits > 0:
             required = gate.num_ancilla_qubits
             if ancilla_qubits is None:
-                raise AttributeError("No ancillas provided, but {} are needed!".format(required))
+                raise AttributeError(f"No ancillas provided, but {required} are needed!")
 
             # convert ancilla qubits to a list if they were passed as int or qubit
             if not hasattr(ancilla_qubits, "__len__"):
@@ -2837,9 +2837,7 @@ class QuantumCircuit:
 
             if len(ancilla_qubits) < required:
                 actually = len(ancilla_qubits)
-                raise ValueError(
-                    "At least {} ancillas required, but {} given.".format(required, actually)
-                )
+                raise ValueError(f"At least {required} ancillas required, but {actually} given.")
             # size down if too many ancillas were provided
             ancilla_qubits = ancilla_qubits[:required]
         else:

--- a/qiskit/circuit/tools/pi_check.py
+++ b/qiskit/circuit/tools/pi_check.py
@@ -92,12 +92,12 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
             if abs(abs(val) - abs(round(val))) < eps:
                 val = int(abs(round(val)))
                 if abs(val) == 1:
-                    str_out = "{}{}".format(neg_str, pi)
+                    str_out = f"{neg_str}{pi}"
                 else:
                     if output == "qasm":
-                        str_out = "{}{}*{}".format(neg_str, val, pi)
+                        str_out = f"{neg_str}{val}*{pi}"
                     else:
-                        str_out = "{}{}{}".format(neg_str, val, pi)
+                        str_out = f"{neg_str}{val}{pi}"
                 return str_out
 
         # Second is a check for powers of pi
@@ -107,11 +107,11 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
                 if output == "qasm":
                     str_out = "{:.{}g}".format(single_inpt, ndigits)
                 elif output == "latex":
-                    str_out = "{}{}^{}".format(neg_str, pi, power[0][0] + 2)
+                    str_out = f"{neg_str}{pi}^{power[0][0] + 2}"
                 elif output == "mpl":
-                    str_out = "{}{}$^{}$".format(neg_str, pi, power[0][0] + 2)
+                    str_out = f"{neg_str}{pi}$^{power[0][0] + 2}$"
                 else:
-                    str_out = "{}{}**{}".format(neg_str, pi, power[0][0] + 2)
+                    str_out = f"{neg_str}{pi}**{power[0][0] + 2}"
                 return str_out
 
         # Third is a check for a number larger than MAX_FRAC * pi, not a
@@ -128,7 +128,7 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
             if output == "latex":
                 str_out = "\\frac{%s%s}{%s}" % (neg_str, pi, val)
             else:
-                str_out = "{}{}/{}".format(neg_str, pi, val)
+                str_out = f"{neg_str}{pi}/{val}"
             return str_out
 
         # Fifth check is for fractions where the numer > 1*pi and numer
@@ -141,9 +141,9 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
             if output == "latex":
                 str_out = "\\frac{%s%s%s}{%s}" % (neg_str, numer, pi, denom)
             elif output == "qasm":
-                str_out = "{}{}*{}/{}".format(neg_str, numer, pi, denom)
+                str_out = f"{neg_str}{numer}*{pi}/{denom}"
             else:
-                str_out = "{}{}{}/{}".format(neg_str, numer, pi, denom)
+                str_out = f"{neg_str}{numer}{pi}/{denom}"
             return str_out
 
         # Sixth check is for fractions where the numer > 1 and numer
@@ -158,9 +158,9 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
             if output == "latex":
                 str_out = "\\frac{%s%s}{%s%s}" % (neg_str, numer, denom, pi)
             elif output == "qasm":
-                str_out = "{}{}/({}*{})".format(neg_str, numer, denom, pi)
+                str_out = f"{neg_str}{numer}/({denom}*{pi})"
             else:
-                str_out = "{}{}/{}{}".format(neg_str, numer, denom, pi)
+                str_out = f"{neg_str}{numer}/{denom}{pi}"
             return str_out
 
         # Nothing found
@@ -178,7 +178,7 @@ def pi_check(inpt, eps=1e-6, output="text", ndigits=5):
         # Remove + if imag negative except for latex fractions
         if complex_inpt.imag < 0 and (output != "latex" or "\\frac" not in imag):
             op_str = ""
-        str_out = "{}{}{}{}".format(real, op_str, imag, jstr)
+        str_out = f"{real}{op_str}{imag}{jstr}"
     else:
         str_out = real
     return str_out

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -268,9 +268,7 @@ def _parse_common_args(
         n_qubits = backend_config.n_qubits
         # check for memory flag applied to backend that does not support memory
         if memory and not backend_config.memory:
-            raise QiskitError(
-                "memory not supported by backend {}".format(backend_config.backend_name)
-            )
+            raise QiskitError(f"memory not supported by backend {backend_config.backend_name}")
 
         # try to set defaults for pulse, other leave as None
         if backend_config.open_pulse:
@@ -389,7 +387,7 @@ def _check_lo_freqs(
         for i, freq in enumerate(lo_freq):
             freq_range = lo_range[i]
             if not (isinstance(freq_range, list) and len(freq_range) == 2):
-                raise QiskitError("Each element of {} LO range must be a 2d list.".format(lo_type))
+                raise QiskitError(f"Each element of {lo_type} LO range must be a 2d list.")
             if freq < freq_range[0] or freq > freq_range[1]:
                 raise QiskitError(
                     "Qubit {} {} LO frequency is {}. The range is [{}, {}].".format(

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -306,10 +306,8 @@ def _check_circuits_coupling_map(circuits, transpile_args, backend):
 
         if max_qubits is not None and (num_qubits > max_qubits):
             raise TranspilerError(
-                "Number of qubits ({}) ".format(num_qubits)
-                + "in {} ".format(circuit.name)
-                + "is greater than maximum ({}) ".format(max_qubits)
-                + "in the coupling_map"
+                f"Number of qubits ({num_qubits}) in {circuit.name} "
+                f"is greater than maximum ({max_qubits}) in the coupling_map"
             )
 
 
@@ -635,7 +633,7 @@ def _parse_backend_properties(backend_properties, backend, num_circuits):
                     replacement_gate = Gate.from_dict(gate_dict)
                     gate_dict["qubits"] = [faulty_qubits_map[qubit] for qubit in gate.qubits]
                     args = "_".join([str(qubit) for qubit in gate_dict["qubits"]])
-                    gate_dict["name"] = "%s%s" % (gate_dict["gate"], args)
+                    gate_dict["name"] = "{}{}".format(gate_dict["gate"], args)
                     gates.append(replacement_gate)
 
                 backend_properties.gates = gates

--- a/qiskit/converters/circuit_to_gate.py
+++ b/qiskit/converters/circuit_to_gate.py
@@ -73,7 +73,7 @@ def circuit_to_gate(circuit, parameter_map=None, equivalence_library=None, label
 
     gate = Gate(
         name=circuit.name,
-        num_qubits=sum([qreg.size for qreg in circuit.qregs]),
+        num_qubits=sum(qreg.size for qreg in circuit.qregs),
         params=[*parameter_dict.values()],
         label=label,
     )

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -76,8 +76,8 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
 
     instruction = Instruction(
         name=circuit.name,
-        num_qubits=sum([qreg.size for qreg in circuit.qregs]),
-        num_clbits=sum([creg.size for creg in circuit.cregs]),
+        num_qubits=sum(qreg.size for qreg in circuit.qregs),
+        num_clbits=sum(creg.size for creg in circuit.cregs),
         params=[*parameter_dict.values()],
     )
     instruction.condition = None

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -144,7 +144,7 @@ class DAGCircuit:
                 elif isinstance(node.wire, Clbit):
                     dag.add_clbits([node.wire])
                 else:
-                    raise DAGCircuitError("unknown node wire type: {}".format(node.wire))
+                    raise DAGCircuitError(f"unknown node wire type: {node.wire}")
             elif node.type == "op":
                 dag.apply_operation_back(node.op.copy(), node.qargs, node.cargs)
         return dag
@@ -315,7 +315,7 @@ class DAGCircuit:
             self.output_map[wire] = outp_node
             self._multi_graph.add_edge(inp_node._node_id, outp_node._node_id, wire)
         else:
-            raise DAGCircuitError("duplicate wire %s" % (wire,))
+            raise DAGCircuitError(f"duplicate wire {wire}")
 
     def _check_condition(self, name, condition):
         """Verify that the condition is valid.
@@ -349,7 +349,7 @@ class DAGCircuit:
         # Check for each wire
         for wire in args:
             if wire not in amap:
-                raise DAGCircuitError("(qu)bit %s not found in %s" % (wire, amap))
+                raise DAGCircuitError(f"(qu)bit {wire} not found in {amap}")
 
     def _bits_in_condition(self, cond):
         """Return a list of bits in the given condition.
@@ -556,7 +556,7 @@ class DAGCircuit:
             # Qubits upon being converted to an Instruction. Until this translation is fixed
             # and Instructions have a concept of ancilla qubits, this fix is required.
             if not (isinstance(k, type(v)) or isinstance(v, type(k))):
-                raise DAGCircuitError("inconsistent wire_map at (%s,%s)" % (k, v))
+                raise DAGCircuitError(f"inconsistent wire_map at ({k},{v})")
 
     @staticmethod
     def _map_condition(wire_map, condition, target_cregs):
@@ -1505,7 +1505,7 @@ class DAGCircuit:
             return node.type == "op" and node.name in namelist and node.op.condition is None
 
         group_list = rx.collect_runs(self._multi_graph, filter_fn)
-        return set(tuple(x) for x in group_list)
+        return {tuple(x) for x in group_list}
 
     def collect_1q_runs(self):
         """Return a set of non-conditional runs of 1q "op" nodes."""

--- a/qiskit/exceptions.py
+++ b/qiskit/exceptions.py
@@ -53,11 +53,11 @@ class MissingOptionalLibraryError(QiskitError, ImportError):
             pip_install: pip install command, if any
             msg: Descriptive message, if any
         """
-        message = ["The '{}' library is required to use '{}'.".format(libname, name)]
+        message = [f"The '{libname}' library is required to use '{name}'."]
         if pip_install:
-            message.append("You can install it with '{}'.".format(pip_install))
+            message.append(f"You can install it with '{pip_install}'.")
         if msg:
-            message.append(" {}.".format(msg))
+            message.append(f" {msg}.")
 
         super().__init__(" ".join(message))
         self.message = " ".join(message)

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -123,7 +123,7 @@ class HamiltonianGate(Gate):
             return float(parameter)
         else:
             raise CircuitError(
-                "invalid param type {0} for gate  " "{1}".format(type(parameter), self.name)
+                "invalid param type {} for gate  " "{}".format(type(parameter), self.name)
             )
 
 

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -351,7 +351,7 @@ class Initialize(Instruction):
             if parameter in ["0", "1", "+", "-", "l", "r"]:
                 return parameter
             raise CircuitError(
-                "invalid param label {0} for instruction {1}. Label should be "
+                "invalid param label {} for instruction {}. Label should be "
                 "0, 1, +, -, l, or r ".format(type(parameter), self.name)
             )
 
@@ -362,7 +362,7 @@ class Initialize(Instruction):
             return complex(parameter.item())
         else:
             raise CircuitError(
-                "invalid param type {0} for instruction  " "{1}".format(type(parameter), self.name)
+                "invalid param type {} for instruction  " "{}".format(type(parameter), self.name)
             )
 
 

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -299,7 +299,7 @@ class Isometry(Instruction):
             return parameter
         else:
             raise CircuitError(
-                "invalid param type {0} for gate  " "{1}".format(type(parameter), self.name)
+                "invalid param type {} for gate  " "{}".format(type(parameter), self.name)
             )
 
     def inverse(self):

--- a/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
+++ b/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
@@ -136,5 +136,5 @@ class MCGupDiag(Gate):
             return parameter
         else:
             raise CircuitError(
-                "invalid param type {0} in gate " "{1}".format(type(parameter), self.name)
+                "invalid param type {} in gate " "{}".format(type(parameter), self.name)
             )

--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -160,7 +160,7 @@ class SingleQubitUnitary(Gate):
             return parameter
         else:
             raise CircuitError(
-                "invalid param type {0} in gate " "{1}".format(type(parameter), self.name)
+                "invalid param type {} in gate " "{}".format(type(parameter), self.name)
             )
 
 

--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -287,7 +287,7 @@ class UCGate(Gate):
             return parameter
         else:
             raise CircuitError(
-                "invalid param type {0} in gate " "{1}".format(type(parameter), self.name)
+                "invalid param type {} in gate " "{}".format(type(parameter), self.name)
             )
 
 

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -195,7 +195,7 @@ class UnitaryGate(Gate):
                     reg_to_qasm[reg] = "p" + str(current_reg)
                     current_reg += 1
 
-            curr_gate = "\t%s %s;\n" % (
+            curr_gate = "\t{} {};\n".format(
                 gate[0].qasm(),
                 ",".join([reg_to_qasm[j] for j in gate[1] + gate[2]]),
             )
@@ -223,7 +223,7 @@ class UnitaryGate(Gate):
             return parameter
         else:
             raise CircuitError(
-                "invalid param type {0} in gate " "{1}".format(type(parameter), self.name)
+                "invalid param type {} in gate " "{}".format(type(parameter), self.name)
             )
 
 

--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -392,7 +392,7 @@ class CircuitSampler(ConverterBase):
             param_mappings = {}
             for param in inst_param._parameter_symbols.keys():
                 if param not in input_params:
-                    raise ValueError("unexpected parameter: {0}".format(param))
+                    raise ValueError(f"unexpected parameter: {param}")
                 param_mappings[param] = input_params[param]
             return float(inst_param.bind(param_mappings))
 

--- a/qiskit/opflow/evolutions/evolved_op.py
+++ b/qiskit/opflow/evolutions/evolved_op.py
@@ -110,12 +110,12 @@ class EvolvedOp(PrimitiveOp):
     def __str__(self) -> str:
         prim_str = str(self.primitive)
         if self.coeff == 1.0:
-            return "e^(-i*{})".format(prim_str)
+            return f"e^(-i*{prim_str})"
         else:
-            return "{} * e^(-i*{})".format(self.coeff, prim_str)
+            return f"{self.coeff} * e^(-i*{prim_str})"
 
     def __repr__(self) -> str:
-        return "EvolvedOp({}, coeff={})".format(repr(self.primitive), self.coeff)
+        return f"EvolvedOp({repr(self.primitive)}, coeff={self.coeff})"
 
     def reduce(self) -> "EvolvedOp":
         return EvolvedOp(self.primitive.reduce(), coeff=self.coeff)

--- a/qiskit/opflow/evolutions/trotterizations/trotterization_factory.py
+++ b/qiskit/opflow/evolutions/trotterizations/trotterization_factory.py
@@ -44,4 +44,4 @@ class TrotterizationFactory:
         elif mode == "qdrift":
             return QDrift(reps=reps)
 
-        raise ValueError("Trotter mode {} not supported".format(mode))
+        raise ValueError(f"Trotter mode {mode} not supported")

--- a/qiskit/opflow/expectations/pauli_expectation.py
+++ b/qiskit/opflow/expectations/pauli_expectation.py
@@ -98,10 +98,8 @@ class PauliExpectation(ExpectationBase):
                 measurement = operator.oplist[0]
                 average = measurement.eval(sfdict)
                 variance = sum(
-                    [
-                        (v * (measurement.eval(b) - average)) ** 2
-                        for (b, v) in sfdict.primitive.items()
-                    ]
+                    (v * (measurement.eval(b) - average)) ** 2
+                    for (b, v) in sfdict.primitive.items()
                 )
                 return operator.coeff * variance
 

--- a/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
@@ -440,7 +440,7 @@ class LinComb(CircuitGradient):
                 coeffs_gates.append(c_g)
             return coeffs_gates
 
-        raise TypeError("Unrecognized parameterized gate, {}".format(gate))
+        raise TypeError(f"Unrecognized parameterized gate, {gate}")
 
     @staticmethod
     def apply_grad_gate(

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -470,7 +470,7 @@ class ListOp(OperatorBase):
         if self.abelian:
             main_string = "Abelian" + main_string
         if self.coeff != 1.0:
-            main_string = "{} * ".format(self.coeff) + main_string
+            main_string = f"{self.coeff} * " + main_string
         return main_string
 
     def __repr__(self) -> str:

--- a/qiskit/opflow/list_ops/tensored_op.py
+++ b/qiskit/opflow/list_ops/tensored_op.py
@@ -47,7 +47,7 @@ class TensoredOp(ListOp):
 
     @property
     def num_qubits(self) -> int:
-        return sum([op.num_qubits for op in self.oplist])
+        return sum(op.num_qubits for op in self.oplist)
 
     @property
     def distributive(self) -> bool:

--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -159,8 +159,8 @@ class OperatorBase(StarAlgebraMixin, TensorMixin, ABC):
     @staticmethod
     def _indent(lines: str, indentation: str = INDENTATION) -> str:
         """Indented representation to allow pretty representation of nested operators."""
-        indented_str = indentation + lines.replace("\n", "\n{}".format(indentation))
-        if indented_str.endswith("\n{}".format(indentation)):
+        indented_str = indentation + lines.replace("\n", f"\n{indentation}")
+        if indented_str.endswith(f"\n{indentation}"):
             indented_str = indented_str[: -len(indentation)]
         return indented_str
 

--- a/qiskit/opflow/primitive_ops/circuit_op.py
+++ b/qiskit/opflow/primitive_ops/circuit_op.py
@@ -157,7 +157,7 @@ class CircuitOp(PrimitiveOp):
         if self.coeff == 1.0:
             return prim_str
         else:
-            return "{} * {}".format(self.coeff, prim_str)
+            return f"{self.coeff} * {prim_str}"
 
     def assign_parameters(self, param_dict: dict) -> OperatorBase:
         param_value = self.coeff

--- a/qiskit/opflow/primitive_ops/matrix_op.py
+++ b/qiskit/opflow/primitive_ops/matrix_op.py
@@ -183,7 +183,7 @@ class MatrixOp(PrimitiveOp):
         if self.coeff == 1.0:
             return prim_str
         else:
-            return "{} * {}".format(self.coeff, prim_str)
+            return f"{self.coeff} * {prim_str}"
 
     def eval(
         self,

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -45,9 +45,7 @@ class PauliOp(PrimitiveOp):
             TypeError: invalid parameters.
         """
         if not isinstance(primitive, Pauli):
-            raise TypeError(
-                "PauliOp can only be instantiated with Paulis, not {}".format(type(primitive))
-            )
+            raise TypeError(f"PauliOp can only be instantiated with Paulis, not {type(primitive)}")
         super().__init__(primitive, coeff=coeff)
 
     def primitive_strings(self) -> Set[str]:
@@ -197,7 +195,7 @@ class PauliOp(PrimitiveOp):
         if self.coeff == 1.0:
             return prim_str
         else:
-            return "{} * {}".format(self.coeff, prim_str)
+            return f"{self.coeff} * {prim_str}"
 
     def eval(
         self,

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -97,7 +97,7 @@ class PauliSumOp(PrimitiveOp):
             """Matrix representation iteration and item access."""
 
             def __repr__(self):
-                return "<PauliSumOp_matrix_iterator at {}>".format(hex(id(self)))
+                return f"<PauliSumOp_matrix_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 sumopcoeff = self.obj.coeff * self.obj.primitive.coeffs[key]

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -211,7 +211,7 @@ class PrimitiveOp(OperatorBase):
         raise NotImplementedError
 
     def __repr__(self) -> str:
-        return "{}({}, coeff={})".format(type(self).__name__, repr(self.primitive), self.coeff)
+        return f"{type(self).__name__}({repr(self.primitive)}, coeff={self.coeff})"
 
     def eval(
         self,

--- a/qiskit/opflow/state_fns/cvar_measurement.py
+++ b/qiskit/opflow/state_fns/cvar_measurement.py
@@ -138,7 +138,7 @@ class CVaRMeasurement(OperatorStateFn):
         raise NotImplementedError
 
     def __str__(self) -> str:
-        return "CVaRMeasurement({}) * {}".format(str(self.primitive), self.coeff)
+        return f"CVaRMeasurement({str(self.primitive)}) * {self.coeff}"
 
     def eval(
         self, front: Union[str, dict, np.ndarray, OperatorBase, Statevector] = None

--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -265,7 +265,7 @@ class DictStateFn(StateFn):
             return np.round(
                 cast(
                     float,
-                    sum([v * front.primitive.get(b, 0) for (b, v) in self.primitive.items()])
+                    sum(v * front.primitive.get(b, 0) for (b, v) in self.primitive.items())
                     * self.coeff
                     * front.coeff,
                 ),
@@ -281,7 +281,7 @@ class DictStateFn(StateFn):
             return np.round(
                 cast(
                     float,
-                    sum([v * front.primitive.data[int(b, 2)] for (b, v) in self.primitive.items()])
+                    sum(v * front.primitive.data[int(b, 2)] for (b, v) in self.primitive.items())
                     * self.coeff,
                 ),
                 decimals=EVAL_SIG_DIGITS,

--- a/qiskit/opflow/state_fns/sparse_vector_state_fn.py
+++ b/qiskit/opflow/state_fns/sparse_vector_state_fn.py
@@ -185,10 +185,8 @@ class SparseVectorStateFn(StateFn):
         if isinstance(front, DictStateFn):
             return np.round(
                 sum(
-                    [
-                        v * self.primitive.data[int(b, 2)] * front.coeff
-                        for (b, v) in front.primitive.items()
-                    ]
+                    v * self.primitive.data[int(b, 2)] * front.coeff
+                    for (b, v) in front.primitive.items()
                 )
                 * self.coeff,
                 decimals=EVAL_SIG_DIGITS,

--- a/qiskit/opflow/state_fns/vector_state_fn.py
+++ b/qiskit/opflow/state_fns/vector_state_fn.py
@@ -210,10 +210,8 @@ class VectorStateFn(StateFn):
         if isinstance(front, DictStateFn):
             return np.round(
                 sum(
-                    [
-                        v * self.primitive.data[int(b, 2)] * front.coeff
-                        for (b, v) in front.primitive.items()
-                    ]
+                    v * self.primitive.data[int(b, 2)] * front.coeff
+                    for (b, v) in front.primitive.items()
                 )
                 * self.coeff,
                 decimals=EVAL_SIG_DIGITS,

--- a/qiskit/providers/backend.py
+++ b/qiskit/providers/backend.py
@@ -176,7 +176,7 @@ class BackendV1(Backend, ABC):
 
         [0] https://docs.python.org/3/reference/datamodel.html#object.__repr__
         """
-        return "<{}('{}')>".format(self.__class__.__name__, self.name())
+        return f"<{self.__class__.__name__}('{self.name()}')>"
 
     @property
     def options(self):

--- a/qiskit/providers/basebackend.py
+++ b/qiskit/providers/basebackend.py
@@ -129,4 +129,4 @@ class BaseBackend(ABC):
 
         [0] https://docs.python.org/3/reference/datamodel.html#object.__repr__
         """
-        return "<{}('{}') from {}()>".format(self.__class__.__name__, self.name(), self._provider)
+        return f"<{self.__class__.__name__}('{self.name()}') from {self._provider}()>"

--- a/qiskit/providers/basejob.py
+++ b/qiskit/providers/basejob.py
@@ -100,7 +100,7 @@ class BaseJob(ABC):
         while status not in JOB_FINAL_STATES:
             elapsed_time = time.time() - start_time
             if timeout is not None and elapsed_time >= timeout:
-                raise JobTimeoutError("Timeout while waiting for job {}.".format(self.job_id()))
+                raise JobTimeoutError(f"Timeout while waiting for job {self.job_id()}.")
             if callback:
                 callback(self.job_id(), status, self)
             time.sleep(wait)

--- a/qiskit/providers/basicaer/basicaertools.py
+++ b/qiskit/providers/basicaer/basicaertools.py
@@ -124,7 +124,7 @@ def einsum_vecmul_index(gate_indices, number_of_qubits):
 
     # Combine indices into matrix multiplication string format
     # for numpy.einsum function
-    return "{mat_l}{mat_r}, ".format(mat_l=mat_l, mat_r=mat_r) + "{tens_lin}->{tens_lout}".format(
+    return f"{mat_l}{mat_r}, " + "{tens_lin}->{tens_lout}".format(
         tens_lin=tens_lin, tens_lout=tens_lout
     )
 

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -282,8 +282,7 @@ class QasmSimulatorPy(BackendV1):
         required_dim = 2 ** self._number_of_qubits
         if length != required_dim:
             raise BasicAerError(
-                "initial statevector is incorrect length: "
-                + "{} != {}".format(length, required_dim)
+                f"initial statevector is incorrect length: {length} != {required_dim}"
             )
 
     def _set_options(self, qobj_config=None, backend_options=None):
@@ -306,9 +305,7 @@ class QasmSimulatorPy(BackendV1):
             # Check the initial statevector is normalized
             norm = np.linalg.norm(self._initial_statevector)
             if round(norm, 12) != 1:
-                raise BasicAerError(
-                    "initial statevector is not normalized: " + "norm {} != 1".format(norm)
-                )
+                raise BasicAerError(f"initial statevector is not normalized: norm {norm} != 1")
         # Check for custom chop threshold
         # Replace with custom options
         if "chop_threshold" in backend_options:
@@ -658,9 +655,8 @@ class QasmSimulatorPy(BackendV1):
         max_qubits = self.configuration().n_qubits
         if n_qubits > max_qubits:
             raise BasicAerError(
-                "Number of qubits {} ".format(n_qubits)
-                + "is greater than maximum ({}) ".format(max_qubits)
-                + 'for "{}".'.format(self.name())
+                f"Number of qubits {n_qubits} is greater than maximum ({max_qubits}) "
+                f'for "{self.name()}".'
             )
         for experiment in qobj.experiments:
             name = experiment.header.name

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -104,9 +104,8 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         max_qubits = self.configuration().n_qubits
         if num_qubits > max_qubits:
             raise BasicAerError(
-                "Number of qubits {} ".format(num_qubits)
-                + "is greater than maximum ({}) ".format(max_qubits)
-                + 'for "{}".'.format(self.name())
+                f"Number of qubits {num_qubits} is greater than maximum ({max_qubits}) "
+                f'for "{self.name()}".'
             )
         if qobj.config.shots != 1:
             logger.info('"%s" only supports 1 shot. Setting shots=1.', self.name())

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -150,8 +150,7 @@ class UnitarySimulatorPy(BackendV1):
         required_shape = (2 ** self._number_of_qubits, 2 ** self._number_of_qubits)
         if shape != required_shape:
             raise BasicAerError(
-                "initial unitary is incorrect shape: "
-                + "{} != 2 ** {}".format(shape, required_shape)
+                f"initial unitary is incorrect shape: {shape} != 2 ** {required_shape}"
             )
 
     def _set_options(self, qobj_config=None, backend_options=None):
@@ -375,9 +374,8 @@ class UnitarySimulatorPy(BackendV1):
         max_qubits = self.configuration().n_qubits
         if n_qubits > max_qubits:
             raise BasicAerError(
-                "Number of qubits {} ".format(n_qubits)
-                + "is greater than maximum ({}) ".format(max_qubits)
-                + 'for "{}".'.format(self.name())
+                f"Number of qubits {n_qubits} is greater than maximum ({max_qubits}) "
+                f'for "{self.name()}".'
             )
         if hasattr(qobj.config, "shots") and qobj.config.shots != 1:
             logger.info('"%s" only supports 1 shot. Setting shots=1.', self.name())

--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -112,7 +112,7 @@ class JobV1(Job, ABC):
         while status not in JOB_FINAL_STATES:
             elapsed_time = time.time() - start_time
             if timeout is not None and elapsed_time >= timeout:
-                raise JobTimeoutError("Timeout while waiting for job {}.".format(self.job_id()))
+                raise JobTimeoutError(f"Timeout while waiting for job {self.job_id()}.")
             if callback:
                 callback(self.job_id(), status, self)
             time.sleep(wait)

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -127,7 +127,7 @@ class GateConfig:
         return False
 
     def __repr__(self):
-        out_str = "GateConfig(%s, %s, %s" % (self.name, self.parameters, self.qasm_def)
+        out_str = f"GateConfig({self.name}, {self.parameters}, {self.qasm_def}"
         for i in ["coupling_map", "latency_map", "conditional", "description"]:
             if hasattr(self, i):
                 out_str += ", " + repr(getattr(self, i))
@@ -191,7 +191,7 @@ class UchannelLO:
         return False
 
     def __repr__(self):
-        return "UchannelLO(%s, %s)" % (self.q, self.scale)
+        return f"UchannelLO({self.q}, {self.scale})"
 
 
 class QasmBackendConfiguration:
@@ -802,7 +802,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             Qubit drive channel.
         """
         if not 0 <= qubit < self.n_qubits:
-            raise BackendConfigurationError("Invalid index for {}-qubit system.".format(qubit))
+            raise BackendConfigurationError(f"Invalid index for {qubit}-qubit system.")
         return DriveChannel(qubit)
 
     def measure(self, qubit: int) -> MeasureChannel:
@@ -815,7 +815,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             Qubit measurement stimulus line.
         """
         if not 0 <= qubit < self.n_qubits:
-            raise BackendConfigurationError("Invalid index for {}-qubit system.".format(qubit))
+            raise BackendConfigurationError(f"Invalid index for {qubit}-qubit system.")
         return MeasureChannel(qubit)
 
     def acquire(self, qubit: int) -> AcquireChannel:
@@ -828,7 +828,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             Qubit measurement acquisition line.
         """
         if not 0 <= qubit < self.n_qubits:
-            raise BackendConfigurationError("Invalid index for {}-qubit systems.".format(qubit))
+            raise BackendConfigurationError(f"Invalid index for {qubit}-qubit systems.")
         return AcquireChannel(qubit)
 
     def control(self, qubits: Iterable[int] = None, channel: int = None) -> List[ControlChannel]:

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -80,7 +80,7 @@ class Nduv:
         return False
 
     def __repr__(self):
-        return "Nduv(%s, %s, %s, %s)" % (repr(self.date), self.name, self.unit, self.value)
+        return f"Nduv({repr(self.date)}, {self.name}, {self.unit}, {self.value})"
 
 
 class Gate:
@@ -302,9 +302,7 @@ class BackendProperties:
                 if name:
                     result = result[name]
             elif name:
-                raise BackendPropertyError(
-                    "Provide qubits to get {n} of {g}".format(n=name, g=gate)
-                )
+                raise BackendPropertyError(f"Provide qubits to get {name} of {gate}")
         except KeyError as ex:
             raise BackendPropertyError(f"Could not find the desired property for {gate}") from ex
         return result

--- a/qiskit/providers/models/pulsedefaults.py
+++ b/qiskit/providers/models/pulsedefaults.py
@@ -280,8 +280,8 @@ class PulseDefaults:
     def __str__(self):
         qubit_freqs = [freq / 1e9 for freq in self.qubit_freq_est]
         meas_freqs = [freq / 1e9 for freq in self.meas_freq_est]
-        qfreq = "Qubit Frequencies [GHz]\n{freqs}".format(freqs=qubit_freqs)
-        mfreq = "Measurement Frequencies [GHz]\n{freqs} ".format(freqs=meas_freqs)
+        qfreq = f"Qubit Frequencies [GHz]\n{qubit_freqs}"
+        mfreq = f"Measurement Frequencies [GHz]\n{meas_freqs} "
         return "<{name}({insts}{qfreq}\n{mfreq})>" "".format(
             name=self.__class__.__name__,
             insts=str(self.instruction_schedule_map),

--- a/qiskit/providers/providerutils.py
+++ b/qiskit/providers/providerutils.py
@@ -91,7 +91,7 @@ def resolve_backend_name(name, backends, deprecated, aliased):
         resolved_name = next((b for b in resolved_name if b in available), "")
 
     if resolved_name not in available:
-        raise LookupError("backend '{}' not found.".format(name))
+        raise LookupError(f"backend '{name}' not found.")
 
     if name in deprecated:
         logger.warning("Backend '%s' is deprecated. Use '%s'.", name, resolved_name)

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -1529,9 +1529,7 @@ def acquire(
             instructions.Acquire(duration, qubit_or_channel, reg_slot=register, **metadata)
         )
     else:
-        raise exceptions.PulseError(
-            'Register of type: "{}" is not supported'.format(type(register))
-        )
+        raise exceptions.PulseError(f'Register of type: "{type(register)}" is not supported')
 
 
 def set_frequency(frequency: float, channel: chans.PulseChannel, name: Optional[str] = None):

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -59,7 +59,7 @@ class Channel(metaclass=ABCMeta):
                 "See Channel documentation for more information."
             )
 
-        return super(Channel, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, index: int):
         """Channel class.
@@ -141,10 +141,10 @@ class Channel(metaclass=ABCMeta):
     @property
     def name(self) -> str:
         """Return the shorthand alias for this channel, which is based on its type and index."""
-        return "{}{}".format(self.__class__.prefix, self._index)
+        return f"{self.__class__.prefix}{self._index}"
 
     def __repr__(self):
-        return "{}({})".format(self.__class__.__name__, self._index)
+        return f"{self.__class__.__name__}({self._index})"
 
     def __eq__(self, other: "Channel") -> bool:
         """Return True iff self and other are equal, specifically, iff they have the same type

--- a/qiskit/pulse/configuration.py
+++ b/qiskit/pulse/configuration.py
@@ -38,7 +38,7 @@ class Kernel:
         return "{}({}{})".format(
             self.__class__.__name__,
             "'" + self.name + "', " or "",
-            ", ".join("{}={}".format(str(k), str(v)) for k, v in self.params.items()),
+            ", ".join(f"{str(k)}={str(v)}" for k, v in self.params.items()),
         )
 
 
@@ -61,7 +61,7 @@ class Discriminator:
         return "{}({}{})".format(
             self.__class__.__name__,
             "'" + self.name + "', " or "",
-            ", ".join("{}={}".format(str(k), str(v)) for k, v in self.params.items()),
+            ", ".join(f"{str(k)}={str(v)}" for k, v in self.params.items()),
         )
 
 
@@ -96,7 +96,7 @@ class LoRange:
         return self._ub
 
     def __repr__(self):
-        return "%s(%f, %f)" % (self.__class__.__name__, self._lb, self._ub)
+        return f"{self.__class__.__name__}({self._lb:f}, {self._ub:f})"
 
     def __eq__(self, other):
         """Two LO ranges are the same if they are of the same type, and
@@ -181,7 +181,7 @@ class LoConfig:
         if channel in lo_ranges:
             lo_range = lo_ranges[channel]
             if not lo_range.includes(freq):
-                raise PulseError("Specified LO freq %f is out of range %s" % (freq, lo_range))
+                raise PulseError(f"Specified LO freq {freq:f} is out of range {lo_range}")
 
     def channel_lo(self, channel: Union[DriveChannel, MeasureChannel]) -> float:
         """Return channel lo.

--- a/qiskit/pulse/instruction_schedule_map.py
+++ b/qiskit/pulse/instruction_schedule_map.py
@@ -245,11 +245,11 @@ class InstructionScheduleMap:
         # validation of target qubit
         qubits = _to_tuple(qubits)
         if qubits == ():
-            raise PulseError("Cannot add definition {} with no target qubits.".format(instruction))
+            raise PulseError(f"Cannot add definition {instruction} with no target qubits.")
 
         # generate signature
         if isinstance(schedule, (Schedule, ScheduleBlock)):
-            ordered_names = sorted(list(set(par.name for par in schedule.parameters)))
+            ordered_names = sorted(list({par.name for par in schedule.parameters}))
             if arguments:
                 if set(arguments) != set(ordered_names):
                     raise PulseError(
@@ -370,9 +370,9 @@ class InstructionScheduleMap:
         multi_q_insts = "Multi qubit instructions:\n"
         for qubits, insts in self._qubit_instructions.items():
             if len(qubits) == 1:
-                single_q_insts += "  q{qubit}: {insts}\n".format(qubit=qubits[0], insts=insts)
+                single_q_insts += f"  q{qubits[0]}: {insts}\n"
             else:
-                multi_q_insts += "  {qubits}: {insts}\n".format(qubits=qubits, insts=insts)
+                multi_q_insts += f"  {qubits}: {insts}\n"
         instructions = single_q_insts + multi_q_insts
         return "<{name}({insts})>" "".format(name=self.__class__.__name__, insts=instructions)
 

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -85,7 +85,7 @@ class Instruction(ABC):
 
         for channel in self.channels:
             if not isinstance(channel, Channel):
-                raise PulseError("Expected a channel, got {} instead.".format(channel))
+                raise PulseError(f"Expected a channel, got {channel} instead.")
 
     @property
     def name(self) -> str:
@@ -397,5 +397,5 @@ class Instruction(ABC):
     def __repr__(self) -> str:
         operands = ", ".join(str(op) for op in self.operands)
         return "{}({}{})".format(
-            self.__class__.__name__, operands, ", name='{}'".format(self.name) if self.name else ""
+            self.__class__.__name__, operands, f", name='{self.name}'" if self.name else ""
         )

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -189,7 +189,7 @@ class Gaussian(ParametricPulse):
             self.duration,
             self.amp,
             self.sigma,
-            ", name='{}'".format(self.name) if self.name is not None else "",
+            f", name='{self.name}'" if self.name is not None else "",
         )
 
 
@@ -337,7 +337,7 @@ class GaussianSquare(ParametricPulse):
             self.amp,
             self.sigma,
             self.width,
-            ", name='{}'".format(self.name) if self.name is not None else "",
+            f", name='{self.name}'" if self.name is not None else "",
         )
 
 
@@ -472,7 +472,7 @@ class Drag(ParametricPulse):
             self.amp,
             self.sigma,
             self.beta,
-            ", name='{}'".format(self.name) if self.name is not None else "",
+            f", name='{self.name}'" if self.name is not None else "",
         )
 
 
@@ -529,7 +529,7 @@ class Constant(ParametricPulse):
             self.__class__.__name__,
             self.duration,
             self.amp,
-            ", name='{}'".format(self.name) if self.name is not None else "",
+            f", name='{self.name}'" if self.name is not None else "",
         )
 
 

--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -139,5 +139,5 @@ class Waveform(Pulse):
         return "{}({}{})".format(
             self.__class__.__name__,
             repr(self.samples),
-            ", name='{}'".format(self.name) if self.name is not None else "",
+            f", name='{self.name}'" if self.name is not None else "",
         )

--- a/qiskit/pulse/macros.py
+++ b/qiskit/pulse/macros.py
@@ -51,7 +51,7 @@ def measure(
     Raises:
         PulseError: If both ``inst_map`` or ``meas_map``, and ``backend`` is None.
     """
-    schedule = Schedule(name="Default measurement schedule for qubits {}".format(qubits))
+    schedule = Schedule(name=f"Default measurement schedule for qubits {qubits}")
     try:
         inst_map = inst_map or backend.defaults().instruction_schedule_map
         meas_map = meas_map or backend.configuration().meas_map

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -131,7 +131,7 @@ class Schedule:
         if name is None:
             name = self.prefix + str(next(self.instances_counter))
             if sys.platform != "win32" and not is_main_process():
-                name += "-{}".format(mp.current_process().pid)
+                name += f"-{mp.current_process().pid}"
 
         self._name = name
         self._parameter_manager = ParameterManager()
@@ -604,7 +604,7 @@ class Schedule:
         for channel in schedule.channels:
 
             if channel not in self._timeslots:
-                raise PulseError("The channel {} is not present in the schedule".format(channel))
+                raise PulseError(f"The channel {channel} is not present in the schedule")
 
             channel_timeslots = self._timeslots[channel]
             other_timeslots = _get_timeslots(schedule)
@@ -822,7 +822,7 @@ class Schedule:
         instructions = ", ".join([repr(instr) for instr in self.instructions[:50]])
         if len(self.instructions) > 25:
             instructions += ", ..."
-        return '{}({}, name="{}")'.format(self.__class__.__name__, instructions, name)
+        return f'{self.__class__.__name__}({instructions}, name="{name}")'
 
 
 def _require_schedule_conversion(function: Callable) -> Callable:
@@ -932,7 +932,7 @@ class ScheduleBlock:
         if name is None:
             name = self.prefix + str(next(self.instances_counter))
             if sys.platform != "win32" and not is_main_process():
-                name += "-{}".format(mp.current_process().pid)
+                name += f"-{mp.current_process().pid}"
 
         self._name = name
         self._parameter_manager = ParameterManager()
@@ -1456,7 +1456,7 @@ class ParameterizedSchedule:
             elif isinstance(schedule, Schedule):
                 full_schedules.append(schedule)
             else:
-                raise PulseError("Input type: {} not supported".format(type(schedule)))
+                raise PulseError(f"Input type: {type(schedule)} not supported")
 
         self._parameterized = tuple(parameterized)
         self._schedules = tuple(full_schedules)
@@ -1710,9 +1710,7 @@ def _interval_index(intervals: List[Interval], interval: Interval) -> int:
     index = _locate_interval_index(intervals, interval)
     found_interval = intervals[index]
     if found_interval != interval:
-        raise PulseError(
-            "The interval: {} does not exist in intervals: {}".format(interval, intervals)
-        )
+        raise PulseError(f"The interval: {interval} does not exist in intervals: {intervals}")
     return index
 
 
@@ -1801,6 +1799,6 @@ def _get_timeslots(schedule: ScheduleComponent) -> TimeSlots:
     elif isinstance(schedule, Schedule):
         timeslots = schedule.timeslots
     else:
-        raise PulseError("Invalid schedule type {} is specified.".format(type(schedule)))
+        raise PulseError(f"Invalid schedule type {type(schedule)} is specified.")
 
     return timeslots

--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -254,7 +254,7 @@ class AlignEquispaced(AlignmentKind):
         """
         instruction_duration_validation(self.duration)
 
-        total_duration = sum([child.duration for _, child in schedule.children])
+        total_duration = sum(child.duration for _, child in schedule.children)
         if self.duration < total_duration:
             return schedule
 

--- a/qiskit/qasm/node/format.py
+++ b/qiskit/qasm/node/format.py
@@ -31,7 +31,7 @@ class Format(Node):
 
     def version(self):
         """Return the version."""
-        return "%s.%s" % (self.majorversion, self.minorversion)
+        return f"{self.majorversion}.{self.minorversion}"
 
     def qasm(self, prec=None):
         """Return the corresponding format string."""
@@ -41,4 +41,4 @@ class Format(Node):
                 DeprecationWarning,
                 2,
             )
-        return "%s %s;" % (self.language, self.version())
+        return f"{self.language} {self.version()};"

--- a/qiskit/qasm/node/id.py
+++ b/qiskit/qasm/node/id.py
@@ -77,7 +77,7 @@ class Id(Node):
         if not nested_scope or self.name not in nested_scope[-1]:
             raise NodeException(
                 "Expected local parameter name: ",
-                "name=%s, line=%s, file=%s" % (self.name, self.line, self.file),
+                f"name={self.name}, line={self.line}, file={self.file}",
             )
         return nested_scope[-1][self.name].sym(nested_scope[0:-1])
 
@@ -86,7 +86,7 @@ class Id(Node):
         if not nested_scope or self.name not in nested_scope[-1]:
             raise NodeException(
                 "Expected local parameter name: ",
-                "name=%s, line=%s, file=%s" % (self.name, self.line, self.file),
+                f"name={self.name}, line={self.line}, file={self.file}",
             )
 
         return nested_scope[-1][self.name].real(nested_scope[0:-1])

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -682,7 +682,7 @@ class QobjToInstructionConverter:
                 pulse=instruction.pulse_shape, params=str(sorted_params)
             )
             short_pulse_id = hashlib.md5(base_str.encode("utf-8")).hexdigest()[:4]
-            pulse_name = "{0}_{1}".format(instruction.pulse_shape, short_pulse_id)
+            pulse_name = f"{instruction.pulse_shape}_{short_pulse_id}"
 
         pulse = ParametricPulseShapes[instruction.pulse_shape].value(
             **instruction.parameters, name=pulse_name

--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -201,14 +201,14 @@ class PulseQobjInstruction:
         return out_dict
 
     def __repr__(self):
-        out = 'PulseQobjInstruction(name="%s", t0=%s' % (self.name, self.t0)
+        out = f'PulseQobjInstruction(name="{self.name}", t0={self.t0}'
         for attr in self._COMMON_ATTRS:
             attr_val = getattr(self, attr, None)
             if attr_val is not None:
                 if isinstance(attr_val, str):
-                    out += ', %s="%s"' % (attr, attr_val)
+                    out += f', {attr}="{attr_val}"'
                 else:
-                    out += ", %s=%s" % (attr, attr_val)
+                    out += f", {attr}={attr_val}"
         out += ")"
         return out
 
@@ -217,7 +217,7 @@ class PulseQobjInstruction:
         out += "\t\tt0: %s\n" % self.t0
         for attr in self._COMMON_ATTRS:
             if hasattr(self, attr):
-                out += "\t\t%s: %s\n" % (attr, getattr(self, attr))
+                out += f"\t\t{attr}: {getattr(self, attr)}\n"
         return out
 
     @classmethod
@@ -266,7 +266,7 @@ def _to_complex(value: Union[List[float], complex]) -> complex:
     elif isinstance(value, complex):
         return value
 
-    raise TypeError("{} is not in a valid complex number format.".format(value))
+    raise TypeError(f"{value} is not in a valid complex number format.")
 
 
 class PulseQobjConfig(QobjDictField):
@@ -522,10 +522,10 @@ class PulseLibraryItem:
         return cls(**data)
 
     def __repr__(self):
-        return "PulseLibraryItem(%s, %s)" % (self.name, repr(self.samples))
+        return f"PulseLibraryItem({self.name}, {repr(self.samples)})"
 
     def __str__(self):
-        return "Pulse Library Item:\n\tname: %s\n\tsamples: %s" % (self.name, self.samples)
+        return f"Pulse Library Item:\n\tname: {self.name}\n\tsamples: {self.samples}"
 
     def __eq__(self, other):
         if isinstance(other, PulseLibraryItem):
@@ -576,7 +576,7 @@ class PulseQobj:
     def __repr__(self):
         experiments_str = [repr(x) for x in self.experiments]
         experiments_repr = "[" + ", ".join(experiments_str) + "]"
-        out = "PulseQobj(qobj_id='%s', config=%s, experiments=%s, header=%s)" % (
+        out = "PulseQobj(qobj_id='{}', config={}, experiments={}, header={})".format(
             self.qobj_id,
             repr(self.config),
             experiments_repr,

--- a/qiskit/qobj/qasm_qobj.py
+++ b/qiskit/qobj/qasm_qobj.py
@@ -155,9 +155,9 @@ class QasmQobjInstruction:
             attr_val = getattr(self, attr, None)
             if attr_val is not None:
                 if isinstance(attr_val, str):
-                    out += ', %s="%s"' % (attr, attr_val)
+                    out += f', {attr}="{attr_val}"'
                 else:
-                    out += ", %s=%s" % (attr, attr_val)
+                    out += f", {attr}={attr_val}"
         out += ")"
         return out
 
@@ -177,7 +177,7 @@ class QasmQobjInstruction:
             "snapshot_type",
         ]:
             if hasattr(self, attr):
-                out += "\t\t%s: %s\n" % (attr, getattr(self, attr))
+                out += f"\t\t{attr}: {getattr(self, attr)}\n"
         return out
 
     @classmethod
@@ -222,7 +222,7 @@ class QasmQobjExperiment:
     def __repr__(self):
         instructions_str = [repr(x) for x in self.instructions]
         instructions_repr = "[" + ", ".join(instructions_str) + "]"
-        out = "QasmQobjExperiment(config=%s, header=%s, instructions=%s)" % (
+        out = "QasmQobjExperiment(config={}, header={}, instructions={})".format(
             repr(self.config),
             repr(self.header),
             instructions_repr,
@@ -594,7 +594,7 @@ class QasmQobj:
     def __repr__(self):
         experiments_str = [repr(x) for x in self.experiments]
         experiments_repr = "[" + ", ".join(experiments_str) + "]"
-        out = "QasmQobj(qobj_id='%s', config=%s, experiments=%s, header=%s)" % (
+        out = "QasmQobj(qobj_id='{}', config={}, experiments={}, header={})".format(
             self.qobj_id,
             repr(self.config),
             experiments_repr,

--- a/qiskit/quantum_info/analysis/make_observable.py
+++ b/qiskit/quantum_info/analysis/make_observable.py
@@ -33,7 +33,7 @@ def make_dict_observable(matrix_observable):
     observable = np.array(matrix_observable)
     observable_size = len(observable)
     observable_bits = int(np.ceil(np.log2(observable_size)))
-    binary_formatter = "0{}b".format(observable_bits)
+    binary_formatter = f"0{observable_bits}b"
     if observable.ndim == 2:
         observable = observable.diagonal()
     for state_no in range(observable_size):

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -48,7 +48,7 @@ class QuantumChannel(LinearOp):
         super().__init__(num_qubits=num_qubits, op_shape=op_shape)
 
     def __repr__(self):
-        prefix = "{}(".format(self._channel_rep)
+        prefix = f"{self._channel_rep}("
         pad = len(prefix) * " "
         return "{}{},\n{}input_dims={}, output_dims={})".format(
             prefix,

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -338,7 +338,7 @@ class SuperOp(QuantumChannel):
             # circuit decomposition definition if it exists, otherwise we
             # cannot compose this gate and raise an error.
             if obj.definition is None:
-                raise QiskitError("Cannot apply Instruction: {}".format(obj.name))
+                raise QiskitError(f"Cannot apply Instruction: {obj.name}")
             if not isinstance(obj.definition, QuantumCircuit):
                 raise QiskitError(
                     "{} instruction definition is {}; "
@@ -348,7 +348,7 @@ class SuperOp(QuantumChannel):
             for instr, qregs, cregs in obj.definition.data:
                 if cregs:
                     raise QiskitError(
-                        "Cannot apply instruction with classical registers: {}".format(instr.name)
+                        f"Cannot apply instruction with classical registers: {instr.name}"
                     )
                 # Get the integer position of the flat register
                 if qargs is None:

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -43,7 +43,7 @@ def _transform_rep(input_rep, output_rep, data, input_dim, output_dim):
         return _to_ptm(input_rep, data, input_dim, output_dim)
     if output_rep == "Stinespring":
         return _to_stinespring(input_rep, data, input_dim, output_dim)
-    raise QiskitError("Invalid QuantumChannel {}".format(output_rep))
+    raise QiskitError(f"Invalid QuantumChannel {output_rep}")
 
 
 def _to_choi(rep, data, input_dim, output_dim):
@@ -63,7 +63,7 @@ def _to_choi(rep, data, input_dim, output_dim):
         return _superop_to_choi(data, input_dim, output_dim)
     if rep == "Stinespring":
         return _stinespring_to_choi(data, input_dim, output_dim)
-    raise QiskitError("Invalid QuantumChannel {}".format(rep))
+    raise QiskitError(f"Invalid QuantumChannel {rep}")
 
 
 def _to_superop(rep, data, input_dim, output_dim):
@@ -83,7 +83,7 @@ def _to_superop(rep, data, input_dim, output_dim):
         return _ptm_to_superop(data, input_dim)
     if rep == "Stinespring":
         return _stinespring_to_superop(data, input_dim, output_dim)
-    raise QiskitError("Invalid QuantumChannel {}".format(rep))
+    raise QiskitError(f"Invalid QuantumChannel {rep}")
 
 
 def _to_kraus(rep, data, input_dim, output_dim):
@@ -173,7 +173,7 @@ def _from_operator(rep, data, input_dim, output_dim):
         _check_nqubit_dim(input_dim, output_dim)
         data = _from_operator("SuperOp", data, input_dim, output_dim)
         return _superop_to_ptm(data, input_dim)
-    raise QiskitError("Invalid QuantumChannel {}".format(rep))
+    raise QiskitError(f"Invalid QuantumChannel {rep}")
 
 
 def _kraus_to_operator(data):
@@ -458,8 +458,7 @@ def _check_nqubit_dim(input_dim, output_dim):
     """Return true if dims correspond to an n-qubit channel."""
     if input_dim != output_dim:
         raise QiskitError(
-            "Not an n-qubit channel: input_dim"
-            + " ({}) != output_dim ({})".format(input_dim, output_dim)
+            f"Not an n-qubit channel: input_dim ({input_dim}) != output_dim ({output_dim})"
         )
     num_qubits = int(np.log2(input_dim))
     if 2 ** num_qubits != input_dim:

--- a/qiskit/quantum_info/operators/custom_iterator.py
+++ b/qiskit/quantum_info/operators/custom_iterator.py
@@ -31,7 +31,7 @@ class CustomIterator(ABC):
         pass
 
     def __repr__(self):
-        return "<{}_iterator at {}>".format(type(self.obj), hex(id(self)))
+        return f"<{type(self.obj)}_iterator at {hex(id(self))}>"
 
     def __len__(self):
         return len(self.obj)

--- a/qiskit/quantum_info/operators/dihedral/dihedral_circuits.py
+++ b/qiskit/quantum_info/operators/dihedral/dihedral_circuits.py
@@ -65,7 +65,7 @@ def _append_circuit(elem, circuit, qargs=None):
         return elem
 
     if gate.definition is None:
-        raise QiskitError("Cannot apply Instruction: {}".format(gate.name))
+        raise QiskitError(f"Cannot apply Instruction: {gate.name}")
     if not isinstance(gate.definition, QuantumCircuit):
         raise QiskitError(
             "{} instruction definition is {}; expected QuantumCircuit".format(
@@ -152,6 +152,6 @@ def _append_circuit(elem, circuit, qargs=None):
             pass
 
         else:
-            raise QiskitError("Not a CNOT-Dihedral gate: {}".format(instr.name))
+            raise QiskitError(f"Not a CNOT-Dihedral gate: {instr.name}")
 
     return elem

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -352,7 +352,7 @@ def _cvxpy_check(name):
         raise MissingOptionalLibraryError(
             "CVXPY >= 1.0",
             "diamond_norm",
-            msg="Incompatible CVXPY version {} found.".format(version),
+            msg=f"Incompatible CVXPY version {version} found.",
         )
 
 
@@ -384,7 +384,7 @@ def _input_formatter(obj, fallback_class, func_name, arg_name):
         "SuperOp, Choi) object instead.".format(func_name, arg_name),
         DeprecationWarning,
     )
-    warnings.warn("Treating array input as a {} object".format(fallback_class.__name__))
+    warnings.warn(f"Treating array input as a {fallback_class.__name__} object")
     return fallback_class(obj)
 
 

--- a/qiskit/quantum_info/operators/mixins/tolerances.py
+++ b/qiskit/quantum_info/operators/mixins/tolerances.py
@@ -31,11 +31,9 @@ class TolerancesMeta(ABCMeta):
     def _check_value(cls, value, value_name):
         """Check if value is within valid ranges"""
         if value < 0:
-            raise QiskitError("Invalid {} ({}) must be non-negative.".format(value_name, value))
+            raise QiskitError(f"Invalid {value_name} ({value}) must be non-negative.")
         if value > cls._MAX_TOL:
-            raise QiskitError(
-                "Invalid {} ({}) must be less than {}.".format(value_name, value, cls._MAX_TOL)
-            )
+            raise QiskitError(f"Invalid {value_name} ({value}) must be less than {cls._MAX_TOL}.")
 
     @property
     def atol(cls):

--- a/qiskit/quantum_info/operators/op_shape.py
+++ b/qiskit/quantum_info/operators/op_shape.py
@@ -52,24 +52,24 @@ class OpShape:
 
     def __repr__(self):
         if self._dims_l:
-            left = "dims_l={}".format(self._dims_l)
+            left = f"dims_l={self._dims_l}"
         elif self._num_qargs_l:
-            left = "num_qargs_l={}".format(self._num_qargs_l)
+            left = f"num_qargs_l={self._num_qargs_l}"
         else:
             left = ""
         if self._dims_r:
-            right = "dims_r={}".format(self._dims_r)
+            right = f"dims_r={self._dims_r}"
         elif self._num_qargs_r:
-            right = "num_qargs_r={}".format(self._num_qargs_r)
+            right = f"num_qargs_r={self._num_qargs_r}"
         else:
             right = ""
         if left and right:
-            inner = "{}, {}".format(left, right)
+            inner = f"{left}, {right}"
         elif left:
             inner = left
         else:
             inner = right
-        return "OpShape({})".format(inner)
+        return f"OpShape({inner})"
 
     def __eq__(self, other):
         """Check types and subsystem dimensions are equal"""
@@ -171,9 +171,7 @@ class OpShape:
         ndim = len(shape)
         if ndim > 2:
             if raise_exception:
-                raise QiskitError(
-                    "Input shape is not 1 or 2-dimensional (shape = {})".format(shape)
-                )
+                raise QiskitError(f"Input shape is not 1 or 2-dimensional (shape = {shape})")
             return False
 
         if self._dims_l:

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -489,7 +489,7 @@ class Operator(LinearOp):
             # circuit decomposition definition if it exists, otherwise we
             # cannot compose this gate and raise an error.
             if obj.definition is None:
-                raise QiskitError("Cannot apply Instruction: {}".format(obj.name))
+                raise QiskitError(f"Cannot apply Instruction: {obj.name}")
             if not isinstance(obj.definition, QuantumCircuit):
                 raise QiskitError(
                     'Instruction "{}" '
@@ -514,7 +514,7 @@ class Operator(LinearOp):
             for instr, qregs, cregs in flat_instr:
                 if cregs:
                     raise QiskitError(
-                        "Cannot apply instruction with classical registers: {}".format(instr.name)
+                        f"Cannot apply instruction with classical registers: {instr.name}"
                     )
                 # Get the integer position of the flat register
                 if qargs is None:

--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -138,7 +138,7 @@ def random_quantum_channel(input_dims=None, output_dims=None, rank=None, seed=No
     if rank is None or rank > d_in * d_out:
         rank = d_in * d_out
     if rank < 1:
-        raise QiskitError("Rank {} must be greater than 0.".format(rank))
+        raise QiskitError(f"Rank {rank} must be greater than 0.")
     from scipy import stats
 
     # Generate a random unitary matrix

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -47,7 +47,7 @@ class ScalarOp(LinearOp):
             QiskitError: If the optional coefficient is invalid.
         """
         if not isinstance(coeff, Number):
-            QiskitError("coeff {} must be a number.".format(coeff))
+            QiskitError(f"coeff {coeff} must be a number.")
         self._coeff = coeff
         super().__init__(input_dims=dims, output_dims=dims)
 
@@ -57,7 +57,7 @@ class ScalarOp(LinearOp):
         return self.to_matrix()
 
     def __repr__(self):
-        return "ScalarOp({}, coeff={})".format(self.input_dims(), self.coeff)
+        return f"ScalarOp({self.input_dims()}, coeff={self.coeff})"
 
     @property
     def coeff(self):
@@ -226,7 +226,7 @@ class ScalarOp(LinearOp):
             QiskitError: if other is not a valid complex number.
         """
         if not isinstance(other, Number):
-            raise QiskitError("other ({}) is not a number".format(other))
+            raise QiskitError(f"other ({other}) is not a number")
         ret = self.copy()
         ret._coeff = other * self.coeff
         return ret

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -96,13 +96,11 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         )
         # Validation
         if qargs is None and other.num_qubits != self.num_qubits:
-            raise QiskitError(
-                "other {} must be on the same number of qubits.".format(type(self).__name__)
-            )
+            raise QiskitError(f"other {type(self).__name__} must be on the same number of qubits.")
 
         if qargs and other.num_qubits != len(qargs):
             raise QiskitError(
-                "Number of qubits of the other {} does not match qargs.".format(type(self).__name__)
+                f"Number of qubits of the other {type(self).__name__} does not match qargs."
             )
 
         if other._num_paulis not in [1, self._num_paulis]:
@@ -462,7 +460,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         if isinstance(gate, str):
             # Check if gate is a valid Clifford basis gate string
             if gate not in basis_1q and gate not in basis_2q:
-                raise QiskitError("Invalid Clifford gate name string {}".format(gate))
+                raise QiskitError(f"Invalid Clifford gate name string {gate}")
             name = gate
         else:
             # Assume gate is an Instruction
@@ -470,7 +468,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
 
         # Apply gate if it is a Clifford basis gate
         if name in non_clifford:
-            raise QiskitError("Cannot update Pauli with non-Clifford gate {}".format(name))
+            raise QiskitError(f"Cannot update Pauli with non-Clifford gate {name}")
         if name in basis_1q:
             if len(qargs) != 1:
                 raise QiskitError("Invalid qubits for 1-qubit gate.")
@@ -483,7 +481,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         # If not a Clifford basis gate we try to unroll the gate and
         # raise an exception if unrolling reaches a non-Clifford gate.
         if gate.definition is None:
-            raise QiskitError("Cannot apply Instruction: {}".format(gate.name))
+            raise QiskitError(f"Cannot apply Instruction: {gate.name}")
         if not isinstance(gate.definition, QuantumCircuit):
             raise QiskitError(
                 "{} instruction definition is {}; expected QuantumCircuit".format(
@@ -501,7 +499,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         for instr, qregs, cregs in flat_instr:
             if cregs:
                 raise QiskitError(
-                    "Cannot apply Instruction with classical registers: {}".format(instr.name)
+                    f"Cannot apply Instruction with classical registers: {instr.name}"
                 )
             # Get the integer position of the flat register
             new_qubits = [qargs[bit_indices[tup]] for tup in qregs]

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -138,7 +138,7 @@ class Clifford(BaseOperator, AdjointMixin):
         super().__init__(num_qubits=self._table.num_qubits)
 
     def __repr__(self):
-        return "Clifford({})".format(repr(self.table))
+        return f"Clifford({repr(self.table)})"
 
     def __str__(self):
         return "Clifford: Stabilizer = {}, Destabilizer = {}".format(

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -66,7 +66,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     if isinstance(gate, str):
         # Check if gate is a valid Clifford basis gate string
         if gate not in basis_1q and gate not in basis_2q:
-            raise QiskitError("Invalid Clifford gate name string {}".format(gate))
+            raise QiskitError(f"Invalid Clifford gate name string {gate}")
         name = gate
     else:
         # Assume gate is an Instruction
@@ -74,7 +74,7 @@ def _append_circuit(clifford, circuit, qargs=None):
 
     # Apply gate if it is a Clifford basis gate
     if name in non_clifford:
-        raise QiskitError("Cannot update Clifford with non-Clifford gate {}".format(name))
+        raise QiskitError(f"Cannot update Clifford with non-Clifford gate {name}")
     if name in basis_1q:
         if len(qargs) != 1:
             raise QiskitError("Invalid qubits for 1-qubit gate.")
@@ -89,7 +89,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     # TODO: We could also check u3 params to see if they
     # are a single qubit Clifford gate rather than raise an exception.
     if gate.definition is None:
-        raise QiskitError("Cannot apply Instruction: {}".format(gate.name))
+        raise QiskitError(f"Cannot apply Instruction: {gate.name}")
     if not isinstance(gate.definition, QuantumCircuit):
         raise QiskitError(
             "{} instruction definition is {}; expected QuantumCircuit".format(
@@ -99,9 +99,7 @@ def _append_circuit(clifford, circuit, qargs=None):
     qubit_indices = {bit: idx for idx, bit in enumerate(gate.definition.qubits)}
     for instr, qregs, cregs in gate.definition:
         if cregs:
-            raise QiskitError(
-                "Cannot apply Instruction with classical registers: {}".format(instr.name)
-            )
+            raise QiskitError(f"Cannot apply Instruction with classical registers: {instr.name}")
         # Get the integer position of the flat register
         new_qubits = [qargs[qubit_indices[tup]] for tup in qregs]
         _append_circuit(clifford, instr, new_qubits)

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -196,7 +196,7 @@ class Pauli(BasePauli):
 
     def __repr__(self):
         """Display representation."""
-        return "Pauli('{}')".format(self.__str__())
+        return f"Pauli('{self.__str__()}')"
 
     def __str__(self):
         """Print representation."""
@@ -653,7 +653,7 @@ class Pauli(BasePauli):
     def _from_scalar_op(cls, op):
         """Convert a ScalarOp to BasePauli data."""
         if op.num_qubits is None:
-            raise QiskitError("{} is not an N-qubit identity".format(op))
+            raise QiskitError(f"{op} is not an N-qubit identity")
         base_z = np.zeros((1, op.num_qubits), dtype=bool)
         base_x = np.zeros((1, op.num_qubits), dtype=bool)
         base_phase = np.mod(
@@ -686,7 +686,7 @@ class Pauli(BasePauli):
         if isinstance(instr, Instruction):
             # Convert other instructions to circuit definition
             if instr.definition is None:
-                raise QiskitError("Cannot apply Instruction: {}".format(instr.name))
+                raise QiskitError(f"Cannot apply Instruction: {instr.name}")
             # Convert to circuit
             instr = instr.definition
 
@@ -707,7 +707,7 @@ class Pauli(BasePauli):
         for dinstr, qregs, cregs in instr.data:
             if cregs:
                 raise QiskitError(
-                    "Cannot apply instruction with classical registers: {}".format(dinstr.name)
+                    f"Cannot apply instruction with classical registers: {dinstr.name}"
                 )
             if not isinstance(dinstr, Barrier):
                 next_instr = BasePauli(*cls._from_circuit(dinstr))
@@ -1086,7 +1086,7 @@ def _phase_from_label(label):
     label = label.replace("+", "", 1).replace("1", "", 1).replace("j", "i", 1)
     phases = {"": 0, "-i": 1, "-": 2, "i": 3}
     if label not in phases:
-        raise QiskitError("Invalid Pauli phase label '{}'".format(label))
+        raise QiskitError(f"Invalid Pauli phase label '{label}'")
     return phases.get(label)
 
 

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -150,7 +150,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         elif isinstance(data, ScalarOp):
             # Initialize an N-qubit identity
             if data.num_qubits is None:
-                raise QiskitError("{} is not an N-qubit identity".format(data))
+                raise QiskitError(f"{data} is not an N-qubit identity")
             self._array = np.zeros((1, 2 * data.num_qubits), dtype=bool)
         else:
             raise QiskitError("Invalid input data for PauliTable.")
@@ -173,7 +173,7 @@ class PauliTable(BaseOperator, AdjointMixin):
 
     def __str__(self):
         """String representation."""
-        return "PauliTable: {}".format(self.to_labels())
+        return f"PauliTable: {self.to_labels()}"
 
     def __eq__(self, other):
         """Test if two Pauli tables are equal."""
@@ -686,11 +686,11 @@ class PauliTable(BaseOperator, AdjointMixin):
 
     def conjugate(self):
         """Not implemented."""
-        raise NotImplementedError("{} does not support conjugatge".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support conjugatge")
 
     def transpose(self):
         """Not implemented."""
-        raise NotImplementedError("{} does not support transpose".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support transpose")
 
     # ---------------------------------------------------------------------
     # Utility methods
@@ -878,7 +878,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         Returns:
             list or array: The rows of the PauliTable in label form.
         """
-        ret = np.zeros(self.size, dtype="<U{}".format(self.num_qubits))
+        ret = np.zeros(self.size, dtype=f"<U{self.num_qubits}")
         for i in range(self.size):
             ret[i] = self._to_label(self._array[i])
         if array:
@@ -1051,7 +1051,7 @@ class PauliTable(BaseOperator, AdjointMixin):
             """Label representation iteration and item access."""
 
             def __repr__(self):
-                return "<PauliTable_label_iterator at {}>".format(hex(id(self)))
+                return f"<PauliTable_label_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 return self.obj._to_label(self.obj.array[key])
@@ -1078,7 +1078,7 @@ class PauliTable(BaseOperator, AdjointMixin):
             """Matrix representation iteration and item access."""
 
             def __repr__(self):
-                return "<PauliTable_matrix_iterator at {}>".format(hex(id(self)))
+                return f"<PauliTable_matrix_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 return self.obj._to_matrix(self.obj.array[key], sparse=sparse)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -387,7 +387,7 @@ class SparsePauliOp(LinearOp):
         num_qubits = len(PauliTable._from_label(obj[0][0]))
         size = len(obj)
         coeffs = np.zeros(size, dtype=complex)
-        labels = np.zeros(size, dtype="<U{}".format(num_qubits))
+        labels = np.zeros(size, dtype=f"<U{num_qubits}")
         for i, item in enumerate(obj):
             labels[i] = item[0]
             coeffs[i] = item[1]
@@ -459,7 +459,7 @@ class SparsePauliOp(LinearOp):
             """Label representation iteration and item access."""
 
             def __repr__(self):
-                return "<SparsePauliOp_label_iterator at {}>".format(hex(id(self)))
+                return f"<SparsePauliOp_label_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 coeff = self.obj.coeffs[key]
@@ -488,7 +488,7 @@ class SparsePauliOp(LinearOp):
             """Matrix representation iteration and item access."""
 
             def __repr__(self):
-                return "<SparsePauliOp_matrix_iterator at {}>".format(hex(id(self)))
+                return f"<SparsePauliOp_matrix_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 coeff = self.obj.coeffs[key]

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -205,11 +205,11 @@ class StabilizerTable(PauliTable, AdjointMixin):
                 raise QiskitError("Phase vector is incorrect shape.")
 
     def __repr__(self):
-        return "StabilizerTable(\n{},\nphase={})".format(repr(self._array), repr(self._phase))
+        return f"StabilizerTable(\n{repr(self._array)},\nphase={repr(self._phase)})"
 
     def __str__(self):
         """String representation"""
-        return "StabilizerTable: {}".format(self.to_labels())
+        return f"StabilizerTable: {self.to_labels()}"
 
     def __eq__(self, other):
         """Test if two StabilizerTables are equal"""
@@ -864,7 +864,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
         Returns:
             list or array: The rows of the StabilizerTable in label form.
         """
-        ret = np.zeros(self.size, dtype="<U{}".format(1 + self.num_qubits))
+        ret = np.zeros(self.size, dtype=f"<U{1 + self.num_qubits}")
         for i in range(self.size):
             ret[i] = self._to_label(self._array[i], self._phase[i])
         if array:
@@ -1014,7 +1014,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
             """Label representation iteration and item access."""
 
             def __repr__(self):
-                return "<StabilizerTable_label_iterator at {}>".format(hex(id(self)))
+                return f"<StabilizerTable_label_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 return self.obj._to_label(self.obj.array[key], self.obj.phase[key])
@@ -1041,7 +1041,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
             """Matrix representation iteration and item access."""
 
             def __repr__(self):
-                return "<StabilizerTable_matrix_iterator at {}>".format(hex(id(self)))
+                return f"<StabilizerTable_matrix_iterator at {hex(id(self))}>"
 
             def __getitem__(self, key):
                 return self.obj._to_matrix(self.obj.array[key], self.obj.phase[key], sparse=sparse)

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -396,10 +396,8 @@ class DensityMatrix(QuantumState, TolerancesMixin):
 
         if isinstance(oper, SparsePauliOp):
             return sum(
-                [
-                    coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
-                    for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)
-                ]
+                coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
+                for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)
             )
 
         if not isinstance(oper, Operator):
@@ -718,7 +716,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         # circuit decomposition definition if it exists, otherwise we
         # cannot compose this gate and raise an error.
         if other.definition is None:
-            raise QiskitError("Cannot apply Instruction: {}".format(other.name))
+            raise QiskitError(f"Cannot apply Instruction: {other.name}")
         if not isinstance(other.definition, QuantumCircuit):
             raise QiskitError(
                 "{} instruction definition is {}; expected QuantumCircuit".format(
@@ -729,7 +727,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         for instr, qregs, cregs in other.definition:
             if cregs:
                 raise QiskitError(
-                    "Cannot apply instruction with classical registers: {}".format(instr.name)
+                    f"Cannot apply instruction with classical registers: {instr.name}"
                 )
             # Get the integer position of the flat register
             if qargs is None:

--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -148,7 +148,7 @@ class QuantumState:
         Raises:
             NotImplementedError: if subclass does not support addition.
         """
-        raise NotImplementedError("{} does not support addition".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support addition")
 
     def _multiply(self, other):
         """Return the scalar multipled state other * self.
@@ -163,7 +163,7 @@ class QuantumState:
             NotImplementedError: if subclass does not support scala
                                  multiplication.
         """
-        raise NotImplementedError("{} does not support scalar multiplication".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support scalar multiplication")
 
     @abstractmethod
     def evolve(self, other, qargs=None):
@@ -429,8 +429,7 @@ class QuantumState:
         # Make dict of tuples
         if string_labels:
             return {
-                "{}|{}".format(ket, bra): val
-                for ket, bra, val in zip(kets, bras, vals[inds_row, inds_col])
+                f"{ket}|{bra}": val for ket, bra, val in zip(kets, bras, vals[inds_row, inds_col])
             }
 
         return {

--- a/qiskit/quantum_info/states/random.py
+++ b/qiskit/quantum_info/states/random.py
@@ -83,7 +83,7 @@ def random_density_matrix(dims, rank=None, method="Hilbert-Schmidt", seed=None):
     elif method == "Bures":
         rho = _random_density_bures(dim, rank, seed)
     else:
-        raise QiskitError("Error: unrecognized method {}".format(method))
+        raise QiskitError(f"Error: unrecognized method {method}")
     return DensityMatrix(rho, dims=dims)
 
 

--- a/qiskit/quantum_info/states/stabilizerstate.py
+++ b/qiskit/quantum_info/states/stabilizerstate.py
@@ -82,7 +82,7 @@ class StabilizerState(QuantumState):
         return self._data.stabilizer == other._data.stabilizer
 
     def __repr__(self):
-        return "StabilizerState({})".format(self._data.stabilizer)
+        return f"StabilizerState({self._data.stabilizer})"
 
     @property
     def clifford(self):
@@ -94,10 +94,10 @@ class StabilizerState(QuantumState):
         return self._data.is_unitary()
 
     def _add(self, other):
-        raise NotImplementedError("{} does not support addition".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support addition")
 
     def _multiply(self, other):
-        raise NotImplementedError("{} does not support scalar multiplication".format(type(self)))
+        raise NotImplementedError(f"{type(self)} does not support scalar multiplication")
 
     def trace(self):
         """Return the trace of the stabilizer state as a density matrix,
@@ -347,7 +347,7 @@ class StabilizerState(QuantumState):
         """
         # Resetting all qubits does not require sampling or RNG
         if qargs is None:
-            return StabilizerState(Clifford((np.eye(2 * self.clifford.num_qubits))))
+            return StabilizerState(Clifford(np.eye(2 * self.clifford.num_qubits)))
 
         randbits = self._rng.integers(2, size=len(qargs))
         ret = self.copy()
@@ -497,7 +497,7 @@ class StabilizerState(QuantumState):
         if (newr != 0) & (newr != 2):
             raise QiskitError("Invalid rowsum in measurement calculation.")
 
-        accum_phase = int((newr == 2))
+        accum_phase = int(newr == 2)
         accum_pauli.x ^= row_pauli.x
         accum_pauli.z ^= row_pauli.z
         return accum_pauli, accum_phase

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -422,10 +422,8 @@ class Statevector(QuantumState, TolerancesMixin):
 
         if isinstance(oper, SparsePauliOp):
             return sum(
-                [
-                    coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
-                    for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)
-                ]
+                coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
+                for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)
             )
 
         val = self.evolve(oper, qargs=qargs)
@@ -782,7 +780,7 @@ class Statevector(QuantumState, TolerancesMixin):
         # circuit decomposition definition if it exists, otherwise we
         # cannot compose this gate and raise an error.
         if obj.definition is None:
-            raise QiskitError("Cannot apply Instruction: {}".format(obj.name))
+            raise QiskitError(f"Cannot apply Instruction: {obj.name}")
         if not isinstance(obj.definition, QuantumCircuit):
             raise QiskitError(
                 "{} instruction definition is {}; expected QuantumCircuit".format(
@@ -795,7 +793,7 @@ class Statevector(QuantumState, TolerancesMixin):
         for instr, qregs, cregs in obj.definition:
             if cregs:
                 raise QiskitError(
-                    "Cannot apply instruction with classical registers: {}".format(instr.name)
+                    f"Cannot apply instruction with classical registers: {instr.name}"
                 )
             # Get the integer position of the flat register
             if qargs is None:

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -211,9 +211,9 @@ def _decompose_clifford_1q(pauli, phase):
         circuit.s(0)
 
     # Add circuit name
-    name_destab = "Destabilizer = ['{}{}']".format(destab_phase_label, destab_label)
-    name_stab = "Stabilizer = ['{}{}']".format(stab_phase_label, stab_label)
-    circuit.name = "Clifford: {}, {}".format(name_stab, name_destab)
+    name_destab = f"Destabilizer = ['{destab_phase_label}{destab_label}']"
+    name_stab = f"Stabilizer = ['{stab_phase_label}{stab_label}']"
+    circuit.name = f"Clifford: {name_stab}, {name_destab}"
     return circuit
 
 

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -186,7 +186,7 @@ class OneQubitEulerDecomposer:
             "XYX": (self._params_xyx, self._circuit_xyx),
         }
         if basis not in basis_methods:
-            raise QiskitError("OneQubitEulerDecomposer: unsupported basis {}".format(basis))
+            raise QiskitError(f"OneQubitEulerDecomposer: unsupported basis {basis}")
         self._basis = basis
         self._params, self._circuit = basis_methods[self._basis]
 

--- a/qiskit/result/exceptions.py
+++ b/qiskit/result/exceptions.py
@@ -37,4 +37,4 @@ class ResultError(QiskitError):
         self.code = error["code"]
 
     def __str__(self):
-        return "{}: {}".format(self.code, self.message)
+        return f"{self.code}: {self.message}"

--- a/qiskit/result/models.py
+++ b/qiskit/result/models.py
@@ -157,7 +157,7 @@ class ExperimentResult:
         self._metadata.update(kwargs)
 
     def __repr__(self):
-        out = "ExperimentResult(shots=%s, success=%s, meas_level=%s, data=%s" % (
+        out = "ExperimentResult(shots={}, success={}, meas_level={}, data={}".format(
             self.shots,
             self.success,
             self.meas_level,
@@ -176,7 +176,7 @@ class ExperimentResult:
                 value_str = "'%s'" % self._metadata[key]
             else:
                 value_str = repr(self._metadata[key])
-            out += ", %s=%s" % (key, value_str)
+            out += f", {key}={value_str}"
         out += ")"
         return out
 

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -30,7 +30,7 @@ def _bin_to_hex(bitstring):
 def _pad_zeros(bitstring, memory_slots):
     """If the bitstring is truncated, pad extra zeros to make its
     length equal to memory_slots"""
-    return format(int(bitstring, 2), "0{}b".format(memory_slots))
+    return format(int(bitstring, 2), f"0{memory_slots}b")
 
 
 def _separate_bitstring(bitstring, creg_sizes):

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -94,7 +94,7 @@ class Result:
                 value_str = "'%s'" % self._metadata[key]
             else:
                 value_str = repr(self._metadata[key])
-            out += ", %s=%s" % (key, value_str)
+            out += f", {key}={value_str}"
         out += ")"
         return out
 
@@ -243,7 +243,7 @@ class Result:
             elif meas_level == MeasLevel.RAW:
                 return postprocess.format_level_0_memory(memory)
             else:
-                raise QiskitError("Measurement level {} is not supported".format(meas_level))
+                raise QiskitError(f"Measurement level {meas_level} is not supported")
 
         except KeyError as ex:
             raise QiskitError(
@@ -297,7 +297,7 @@ class Result:
                 vec = postprocess.format_statevector(self.data(key)["statevector"])
                 dict_list.append(statevector.Statevector(vec).probabilities_dict(decimals=15))
             else:
-                raise QiskitError('No counts for experiment "{}"'.format(repr(key)))
+                raise QiskitError(f'No counts for experiment "{repr(key)}"')
 
         # Return first item of dict_list if size is 1
         if len(dict_list) == 1:

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -104,7 +104,7 @@ def _marginalize(counts, indices=None):
         return ret
 
     if not indices or not set(indices).issubset(set(range(num_clbits))):
-        raise QiskitError("indices must be in range [0, {}].".format(num_clbits - 1))
+        raise QiskitError(f"indices must be in range [0, {num_clbits - 1}].")
 
     # Sort the indices to keep in descending order
     # Since bitstrings have qubit-0 as least significant bit

--- a/qiskit/scheduler/sequence.py
+++ b/qiskit/scheduler/sequence.py
@@ -63,7 +63,7 @@ def sequence(scheduled_circuit: QuantumCircuit, schedule_config: ScheduleConfig)
     for circ_pulse_def in circ_pulse_defs:
         active_qubits = [q for q in circ_pulse_def.qubits if q in qubit_time_available]
 
-        start_time = max([qubit_time_available[q] for q in active_qubits], default=0)
+        start_time = max((qubit_time_available[q] for q in active_qubits), default=0)
 
         for q in active_qubits:
             if qubit_time_available[q] != start_time:

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -521,7 +521,7 @@ def dicts_almost_equal(dict1, dict2, delta=None, places=None, default_value=0):
         val1 = dict1.get(key, default_value)
         val2 = dict2.get(key, default_value)
         if not valid_comparison(abs(val1 - val2)):
-            error_msg += "(%s: %s != %s), " % (safe_repr(key), safe_repr(val1), safe_repr(val2))
+            error_msg += f"({safe_repr(key)}: {safe_repr(val1)} != {safe_repr(val2)}), "
 
     if error_msg:
         return error_msg[:-2] + msg_suffix

--- a/qiskit/test/mock/fake_job.py
+++ b/qiskit/test/mock/fake_job.py
@@ -55,7 +55,7 @@ class FakeJob(JobV1):
         elif self._error:
             _status = JobStatus.ERROR
         else:
-            raise Exception("Unexpected state of {}".format(self.__class__.__name__))
+            raise Exception(f"Unexpected state of {self.__class__.__name__}")
         _status_msg = None
         return {"status": _status, "status_msg": _status_msg}
 
@@ -116,7 +116,7 @@ class FakeLegacyJob(BaseJob):
         elif self._error:
             _status = JobStatus.ERROR
         else:
-            raise Exception("Unexpected state of {}".format(self.__class__.__name__))
+            raise Exception(f"Unexpected state of {self.__class__.__name__}")
         _status_msg = None
         return {"status": _status, "status_msg": _status_msg}
 

--- a/qiskit/test/mock/utils/configurable_backend.py
+++ b/qiskit/test/mock/utils/configurable_backend.py
@@ -177,7 +177,7 @@ class ConfigurableFakeBackend(FakeBackend):
                     gates.append(
                         Gate(
                             gate=gate,
-                            name="{}_{}".format(gate, i),
+                            name=f"{gate}_{i}",
                             qubits=[i],
                             parameters=parameters,
                         )
@@ -187,7 +187,7 @@ class ConfigurableFakeBackend(FakeBackend):
                     gates.append(
                         Gate(
                             gate=gate,
-                            name="{gate}{q1}_{q2}".format(gate=gate, q1=qubit1, q2=qubit2),
+                            name=f"{gate}{qubit1}_{qubit2}",
                             qubits=[qubit1, qubit2],
                             parameters=parameters,
                         )
@@ -209,12 +209,8 @@ class ConfigurableFakeBackend(FakeBackend):
     def _build_conf(self) -> PulseBackendConfiguration:
         """Build configuration for backend."""
         h_str = [
-            ",".join(
-                ["_SUM[i,0,{n_qubits}".format(n_qubits=self.n_qubits), "wq{i}/2*(I{i}-Z{i})]"]
-            ),
-            ",".join(
-                ["_SUM[i,0,{n_qubits}".format(n_qubits=self.n_qubits), "omegad{i}*X{i}||D{i}]"]
-            ),
+            ",".join([f"_SUM[i,0,{self.n_qubits}", "wq{i}/2*(I{i}-Z{i})]"]),
+            ",".join([f"_SUM[i,0,{self.n_qubits}", "omegad{i}*X{i}||D{i}]"]),
         ]
         variables = []
         for (qubit1, qubit2) in self.coupling_map:
@@ -223,14 +219,14 @@ class ConfigurableFakeBackend(FakeBackend):
                 "jq{q1}q{q2}*Sm{q1}*Sp{q2}".format(q1=qubit1, q2=qubit2),
             ]
 
-            variables.append(("jq{q1}q{q2}".format(q1=qubit1, q2=qubit2), 0))
+            variables.append((f"jq{qubit1}q{qubit2}", 0))
         for i, (qubit1, qubit2) in enumerate(self.coupling_map):
-            h_str.append("omegad{}*X{}||U{}".format(qubit1, qubit2, i))
+            h_str.append(f"omegad{qubit1}*X{qubit2}||U{i}")
         for i in range(self.n_qubits):
-            variables += [("omegad{}".format(i), 0), ("wq{}".format(i), 0)]
+            variables += [(f"omegad{i}", 0), (f"wq{i}", 0)]
         hamiltonian = {
             "h_str": h_str,
-            "description": "Hamiltonian description for {} qubits backend.".format(self.n_qubits),
+            "description": f"Hamiltonian description for {self.n_qubits} qubits backend.",
             "qub": {i: 2 for i in range(self.n_qubits)},
             "vars": dict(variables),
         }
@@ -297,7 +293,7 @@ class ConfigurableFakeBackend(FakeBackend):
             ).to_dict()
         ]
         measure_command_sequence += [
-            PulseQobjInstruction(name="test_pulse_1", ch="m{}".format(i), t0=0).to_dict()
+            PulseQobjInstruction(name="test_pulse_1", ch=f"m{i}", t0=0).to_dict()
             for i in range(self.n_qubits)
         ]
 
@@ -320,10 +316,10 @@ class ConfigurableFakeBackend(FakeBackend):
                             "qubits": [i],
                             "sequence": [
                                 PulseQobjInstruction(
-                                    name="fc", ch="d{}".format(i), t0=0, phase="-P0"
+                                    name="fc", ch=f"d{i}", t0=0, phase="-P0"
                                 ).to_dict(),
                                 PulseQobjInstruction(
-                                    name="test_pulse_3", ch="d{}".format(i), t0=0
+                                    name="test_pulse_3", ch=f"d{i}", t0=0
                                 ).to_dict(),
                             ],
                         }
@@ -338,16 +334,16 @@ class ConfigurableFakeBackend(FakeBackend):
                         "qubits": [qubit1, qubit2],
                         "sequence": [
                             PulseQobjInstruction(
-                                name="test_pulse_1", ch="d{}".format(qubit1), t0=0
+                                name="test_pulse_1", ch=f"d{qubit1}", t0=0
                             ).to_dict(),
                             PulseQobjInstruction(
-                                name="test_pulse_2", ch="u{}".format(qubit1), t0=10
+                                name="test_pulse_2", ch=f"u{qubit1}", t0=10
                             ).to_dict(),
                             PulseQobjInstruction(
-                                name="test_pulse_1", ch="d{}".format(qubit2), t0=20
+                                name="test_pulse_1", ch=f"d{qubit2}", t0=20
                             ).to_dict(),
                             PulseQobjInstruction(
-                                name="fc", ch="d{}".format(qubit2), t0=20, phase=2.1
+                                name="fc", ch=f"d{qubit2}", t0=20, phase=2.1
                             ).to_dict(),
                         ],
                     }

--- a/qiskit/test/mock/utils/json_decoder.py
+++ b/qiskit/test/mock/utils/json_decoder.py
@@ -83,7 +83,7 @@ def _to_complex(value: Union[List[float], complex]) -> complex:
     elif isinstance(value, complex):
         return value
 
-    raise TypeError("{} is not in a valid complex number format.".format(value))
+    raise TypeError(f"{value} is not in a valid complex number format.")
 
 
 def _decode_pulse_library_item(pulse_library_item: Dict) -> None:

--- a/qiskit/tools/events/progressbar.py
+++ b/qiskit/tools/events/progressbar.py
@@ -153,7 +153,7 @@ class TextProgressBar(BaseProgressBar):
         self.iter = int(iterations)
         self.t_start = time.time()
         pbar = "-" * 50
-        self.output_handler.write("\r|%s| %s%s%s [%s]" % (pbar, 0, "/", self.iter, ""))
+        self.output_handler.write("\r|{}| {}{}{} [{}]".format(pbar, 0, "/", self.iter, ""))
 
     def update(self, n):
         # Don't update if we are not initialized or
@@ -163,7 +163,7 @@ class TextProgressBar(BaseProgressBar):
         filled_length = int(round(50 * n / self.iter))
         pbar = "█" * filled_length + "-" * (50 - filled_length)
         time_left = self.time_remaining_est(n)
-        self.output_handler.write("\r|%s| %s%s%s [%s]" % (pbar, n, "/", self.iter, time_left))
+        self.output_handler.write("\r|{}| {}{}{} [{}]".format(pbar, n, "/", self.iter, time_left))
         if n == self.iter:
             self.output_handler.write("\n")
         self.output_handler.flush()

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -82,7 +82,7 @@ def _backend_monitor(backend):
         raise QiskitError("Input variable is not of type IBMQBackend.")
     title_style = "style='color:#ffffff;background-color:#000000;padding-top: 1%;"
     title_style += "padding-bottom: 1%;padding-left: 1%; margin-top: 0px'"
-    title_html = "<h1 {style}>{name}</h1>".format(style=title_style, name=backend.name())
+    title_html = f"<h1 {title_style}>{backend.name()}</h1>"
 
     details = [config_tab(backend)]
 
@@ -180,7 +180,7 @@ tr:nth-child(even) {background-color: #f6f6f6;}
 
     upper_str += "<tr><th>Property</th><th>Value</th></tr>"
     for key in upper_list:
-        upper_str += "<tr><td><font style='font-weight:bold'>%s</font></td><td>%s</td></tr>" % (
+        upper_str += "<tr><td><font style='font-weight:bold'>{}</font></td><td>{}</td></tr>".format(
             key,
             config_dict[key],
         )
@@ -227,7 +227,7 @@ tr:nth-child(even) {background-color: #f6f6f6;}
     lower_str += "<tr><th></th><th></th></tr>"
     for key in lower_list:
         if key != "name":
-            lower_str += "<tr><td>%s</td><td>%s</td></tr>" % (key, config_dict[key])
+            lower_str += f"<tr><td>{key}</td><td>{config_dict[key]}</td></tr>"
     lower_str += footer
 
     lower_table = widgets.HTMLMath(
@@ -380,7 +380,7 @@ tr:nth-child(even) {background-color: #f6f6f6;};
 
         left_table += "<tr><td><font style='font-weight:bold'>%s</font>"
         left_table += "</td><td>%s</td><td>%s</td></tr>"
-        left_table = left_table % ("{}{}_{}".format(ttype, qubits[0], qubits[1]), ttype, error)
+        left_table = left_table % (f"{ttype}{qubits[0]}_{qubits[1]}", ttype, error)
     left_table += gate_footer
 
     middle_table = gate_html
@@ -393,7 +393,7 @@ tr:nth-child(even) {background-color: #f6f6f6;};
 
         middle_table += "<tr><td><font style='font-weight:bold'>%s</font>"
         middle_table += "</td><td>%s</td><td>%s</td></tr>"
-        middle_table = middle_table % ("{}{}_{}".format(ttype, qubits[0], qubits[1]), ttype, error)
+        middle_table = middle_table % (f"{ttype}{qubits[0]}_{qubits[1]}", ttype, error)
     middle_table += gate_footer
 
     right_table = gate_html
@@ -406,7 +406,7 @@ tr:nth-child(even) {background-color: #f6f6f6;};
 
         right_table += "<tr><td><font style='font-weight:bold'>%s</font>"
         right_table += "</td><td>%s</td><td>%s</td></tr>"
-        right_table = right_table % ("{}{}_{}".format(ttype, qubits[0], qubits[1]), ttype, error)
+        right_table = right_table % (f"{ttype}{qubits[0]}_{qubits[1]}", ttype, error)
     right_table += gate_footer
 
     left_table_widget = widgets.HTML(value=left_table, layout=widgets.Layout(grid_area="left"))
@@ -571,9 +571,9 @@ def plot_job_history(jobs, interval="year"):
     colors = ["#003f5c", "#ffa600", "#374c80", "#ff764a", "#7a5195", "#ef5675", "#bc5090"]
 
     if interval == "year":
-        labels = ["{}-{}".format(str(bins[b].year)[2:], MONTH_NAMES[bins[b].month]) for b in nz_idx]
+        labels = [f"{str(bins[b].year)[2:]}-{MONTH_NAMES[bins[b].month]}" for b in nz_idx]
     else:
-        labels = ["{}-{}".format(MONTH_NAMES[bins[b].month], bins[b].day) for b in nz_idx]
+        labels = [f"{MONTH_NAMES[bins[b].month]}-{bins[b].day}" for b in nz_idx]
     fig, ax = plt.subplots(1, 1, figsize=(5.5, 5.5))
     ax.pie(
         nz_bins[::-1],

--- a/qiskit/tools/jupyter/backend_overview.py
+++ b/qiskit/tools/jupyter/backend_overview.py
@@ -135,9 +135,7 @@ def backend_widget(backend):
     config = backend.configuration().to_dict()
     props = backend.properties().to_dict()
 
-    name = widgets.HTML(
-        value="<h4>{name}</h4>".format(name=backend.name()), layout=widgets.Layout()
-    )
+    name = widgets.HTML(value=f"<h4>{backend.name()}</h4>", layout=widgets.Layout())
 
     num_qubits = config["n_qubits"]
 
@@ -147,12 +145,12 @@ def backend_widget(backend):
             qv_val = config["quantum_volume"]
 
     qubit_count = widgets.HTML(
-        value="<h5><b>{qubits}</b></h5>".format(qubits=num_qubits),
+        value=f"<h5><b>{num_qubits}</b></h5>",
         layout=widgets.Layout(justify_content="center"),
     )
 
     qv_value = widgets.HTML(
-        value="<h5>{qubits}</h5>".format(qubits=qv_val),
+        value=f"<h5>{qv_val}</h5>",
         layout=widgets.Layout(justify_content="center"),
     )
 
@@ -182,10 +180,10 @@ def backend_widget(backend):
     least_busy = widgets.HTML(value="<h5></h5>", layout=widgets.Layout(justify_content="center"))
 
     t1_units = props["qubits"][0][0]["unit"]
-    avg_t1 = round(sum([q[0]["value"] for q in props["qubits"]]) / num_qubits, 1)
-    avg_t2 = round(sum([q[1]["value"] for q in props["qubits"]]) / num_qubits, 1)
+    avg_t1 = round(sum(q[0]["value"] for q in props["qubits"]) / num_qubits, 1)
+    avg_t2 = round(sum(q[1]["value"] for q in props["qubits"]) / num_qubits, 1)
     t12_widget = widgets.HTML(
-        value="<h5>{t1} / {t2} {units}</h5>".format(t1=avg_t1, t2=avg_t2, units=t1_units),
+        value=f"<h5>{avg_t1} / {avg_t2} {t1_units}</h5>",
         layout=widgets.Layout(),
     )
 
@@ -203,9 +201,7 @@ def backend_widget(backend):
                             num_cx += 1
         avg_cx_err = round(sum_cx_err / (num_cx), 4)
 
-    cx_widget = widgets.HTML(
-        value="<h5>{cx_err}</h5>".format(cx_err=avg_cx_err), layout=widgets.Layout()
-    )
+    cx_widget = widgets.HTML(value=f"<h5>{avg_cx_err}</h5>", layout=widgets.Layout())
 
     avg_meas_err = 0
     for qub in props["qubits"]:
@@ -213,9 +209,7 @@ def backend_widget(backend):
             if item["name"] == "readout_error":
                 avg_meas_err += item["value"]
     avg_meas_err = round(avg_meas_err / num_qubits, 4)
-    meas_widget = widgets.HTML(
-        value="<h5>{meas_err}</h5>".format(meas_err=avg_meas_err), layout=widgets.Layout()
-    )
+    meas_widget = widgets.HTML(value=f"<h5>{avg_meas_err}</h5>", layout=widgets.Layout())
 
     out = widgets.VBox(
         [

--- a/qiskit/tools/jupyter/job_watcher.py
+++ b/qiskit/tools/jupyter/job_watcher.py
@@ -81,11 +81,11 @@ class JobWatcher(Subscriber):
             job_wid = self.jobs[ind]
             # update status
             if update_info[1] == "DONE":
-                stat = "<font style='color:#34BC6E'>{}</font>".format(update_info[1])
+                stat = f"<font style='color:#34BC6E'>{update_info[1]}</font>"
             elif update_info[1] == "ERROR":
-                stat = "<font style='color:#DC267F'>{}</font>".format(update_info[1])
+                stat = f"<font style='color:#DC267F'>{update_info[1]}</font>"
             elif update_info[1] == "CANCELLED":
-                stat = "<font style='color:#FFB000'>{}</font>".format(update_info[1])
+                stat = f"<font style='color:#FFB000'>{update_info[1]}</font>"
             else:
                 stat = update_info[1]
             job_wid.children[3].value = stat

--- a/qiskit/tools/jupyter/job_widgets.py
+++ b/qiskit/tools/jupyter/job_widgets.py
@@ -84,17 +84,17 @@ def create_job_widget(watcher, job, backend, status="", queue_pos=None, msg=""):
     """
     job_id = job.job_id()
 
-    id_label = widgets.HTML(value="{}".format(job_id), layout=widgets.Layout(width="190px"))
-    backend_label = widgets.HTML(value="{}".format(backend), layout=widgets.Layout(width="145px"))
-    status_label = widgets.HTML(value="{}".format(status), layout=widgets.Layout(width="95px"))
+    id_label = widgets.HTML(value=f"{job_id}", layout=widgets.Layout(width="190px"))
+    backend_label = widgets.HTML(value=f"{backend}", layout=widgets.Layout(width="145px"))
+    status_label = widgets.HTML(value=f"{status}", layout=widgets.Layout(width="95px"))
     if queue_pos is None:
         queue_pos = "-"
     else:
         queue_pos = str(queue_pos)
-    queue_label = widgets.HTML(value="{}".format(queue_pos), layout=widgets.Layout(width="70px"))
+    queue_label = widgets.HTML(value=f"{queue_pos}", layout=widgets.Layout(width="70px"))
 
     msg_label = widgets.HTML(
-        value="<p style=white-space:nowrap;>{}</p>".format(msg),
+        value=f"<p style=white-space:nowrap;>{msg}</p>",
         layout=widgets.Layout(overflow_x="scroll"),
     )
 

--- a/qiskit/tools/jupyter/jupyter_magics.py
+++ b/qiskit/tools/jupyter/jupyter_magics.py
@@ -142,7 +142,7 @@ class StatusMagic(Magics):
                 idx_str = "[%s]" % idx
             else:
                 idx_str = ""
-            header = "<p style='{style}'>Job Status {id}: %s </p>".format(id=idx_str, style=style)
+            header = f"<p style='{style}'>Job Status {idx_str}: %s </p>"
             status = widgets.HTML(value=header % job_var.status().value)
 
             thread = threading.Thread(

--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -72,11 +72,11 @@ td {
 
 tr:nth-child(even) {background-color: #f6f6f6;}
 </style>"""
-    html += "<tr><th>{}</th><th></tr>".format(circuit.name)
-    html += "<tr><td>Width</td><td>{}</td></tr>".format(circuit.width())
-    html += "<tr><td>Depth</td><td>{}</td></tr>".format(circuit.depth())
-    html += "<tr><td>Total Gates</td><td>{}</td></tr>".format(sum(ops.values()))
-    html += "<tr><td>Non-local Gates</td><td>{}</td></tr>".format(num_nl)
+    html += f"<tr><th>{circuit.name}</th><th></tr>"
+    html += f"<tr><td>Width</td><td>{circuit.width()}</td></tr>"
+    html += f"<tr><td>Depth</td><td>{circuit.depth()}</td></tr>"
+    html += f"<tr><td>Total Gates</td><td>{sum(ops.values())}</td></tr>"
+    html += f"<tr><td>Non-local Gates</td><td>{num_nl}</td></tr>"
     html += "</table>"
 
     out_wid = wid.HTML(html)
@@ -89,7 +89,7 @@ head_style = (
 )
 
 property_label = wid.HTML(
-    "<p style='{}'>Circuit Properties</p>".format(head_style),
+    f"<p style='{head_style}'>Circuit Properties</p>",
     layout=wid.Layout(margin="0px 0px 10px 0px"),
 )
 
@@ -155,7 +155,7 @@ def qasm_widget(circuit: QuantumCircuit) -> wid.VBox:
     )
 
     out_label = wid.HTML(
-        "<p style='{}'>OpenQASM</p>".format(head_style),
+        f"<p style='{head_style}'>OpenQASM</p>",
         layout=wid.Layout(margin="0px 0px 10px 0px"),
     )
 

--- a/qiskit/tools/jupyter/version_table.py
+++ b/qiskit/tools/jupyter/version_table.py
@@ -47,7 +47,7 @@ class VersionTable(Magics):
         packages.append(("IBM Q Provider", qver["qiskit-ibmq-provider"]))
 
         for name, version in packages:
-            html += "<tr><td>%s</td><td>%s</td></tr>" % (name, version)
+            html += f"<tr><td>{name}</td><td>{version}</td></tr>"
 
         html += "<tr><th>System information</th></tr>"
 
@@ -60,7 +60,7 @@ class VersionTable(Magics):
         ]
 
         for name, version in sys_info:
-            html += "<tr><td>%s</td><td>%s</td></tr>" % (name, version)
+            html += f"<tr><td>{name}</td><td>{version}</td></tr>"
 
         html += "<tr><td colspan='2'>%s</td></tr>" % time.strftime("%a %b %d %H:%M:%S %Y %Z")
         html += "</table>"

--- a/qiskit/tools/monitor/job_monitor.py
+++ b/qiskit/tools/monitor/job_monitor.py
@@ -39,7 +39,7 @@ def _text_checker(
     msg_len = len(msg)
 
     if not quiet:
-        print("%s%s: %s" % (line_discipline, "Job Status", msg), end="", file=output)
+        print("{}{}: {}".format(line_discipline, "Job Status", msg), end="", file=output)
     while status.name not in ["DONE", "CANCELLED", "ERROR"]:
         time.sleep(interval)
         status = job.status()
@@ -62,7 +62,7 @@ def _text_checker(
             msg_len = len(msg)
 
         if msg != prev_msg and not quiet:
-            print("%s%s: %s" % (line_discipline, "Job Status", msg), end="", file=output)
+            print("{}{}: {}".format(line_discipline, "Job Status", msg), end="", file=output)
             prev_msg = msg
     if not quiet:
         print("", file=output)

--- a/qiskit/tools/monitor/overview.py
+++ b/qiskit/tools/monitor/overview.py
@@ -155,7 +155,7 @@ def backend_monitor(backend):
             error = format(props.gate_error(gate.gate, qubits), ".5f")
         except QiskitError:
             pass
-        mstr = sep.join(["{}{}_{}".format(ttype, qubits[0], qubits[1]), ttype, str(error)])
+        mstr = sep.join([f"{ttype}{qubits[0]}_{qubits[1]}", ttype, str(error)])
         print(offset + mstr)
 
 
@@ -215,16 +215,16 @@ def backend_overview():
 
             str_list[6] += " " * (max_len - len(str_list[6])) + offset
             str_list[6] += "Avg. T1:      %s" % round(
-                sum([q[0]["value"] for q in props["qubits"]]) / num_qubits, 1
+                sum(q[0]["value"] for q in props["qubits"]) / num_qubits, 1
             )
             str_list[7] += " " * (max_len - len(str_list[7])) + offset
             str_list[7] += "Avg. T2:      %s" % round(
-                sum([q[1]["value"] for q in props["qubits"]]) / num_qubits, 1
+                sum(q[1]["value"] for q in props["qubits"]) / num_qubits, 1
             )
             count += 1
             if count == num_backends:
                 break
-            max_len = max([len(s) for s in str_list])
+            max_len = max(len(s) for s in str_list)
 
         print("\n".join(str_list))
         print("\n" * 2)

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -200,7 +200,7 @@ class CouplingMap:
         )
         if not paths:
             raise CouplingError(
-                "Nodes %s and %s are not connected" % (str(physical_qubit1), str(physical_qubit2))
+                f"Nodes {str(physical_qubit1)} and {str(physical_qubit2)} are not connected"
             )
         return paths[physical_qubit2]
 
@@ -319,7 +319,7 @@ class CouplingMap:
         string = ""
         if self.get_edges():
             string += "["
-            string += ", ".join(["[%s, %s]" % (src, dst) for (src, dst) in self.get_edges()])
+            string += ", ".join([f"[{src}, {dst}]" for (src, dst) in self.get_edges()])
             string += "]"
         return string
 

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -191,7 +191,7 @@ class InstructionDurations:
         elif name in self.duration_by_name:
             duration, unit = self.duration_by_name[name]
         else:
-            raise TranspilerError("No value is found for key={}".format(key))
+            raise TranspilerError(f"No value is found for key={key}")
 
         return self._convert_unit(duration, unit, to_unit)
 
@@ -206,7 +206,7 @@ class InstructionDurations:
 
         if self.dt is None:
             raise TranspilerError(
-                "dt is necessary to convert durations from '{}' to '{}'".format(from_unit, to_unit)
+                f"dt is necessary to convert durations from '{from_unit}' to '{to_unit}'"
             )
         if from_unit == "s" and to_unit == "dt":
             if isinstance(duration, ParameterExpression):
@@ -215,9 +215,7 @@ class InstructionDurations:
         elif from_unit == "dt" and to_unit == "s":
             return duration * self.dt
         else:
-            raise TranspilerError(
-                "Conversion from '{}' to '{}' is not supported".format(from_unit, to_unit)
-            )
+            raise TranspilerError(f"Conversion from '{from_unit}' to '{to_unit}' is not supported")
 
     def units_used(self) -> Set[str]:
         """Get the set of all units used in this instruction durations.

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -41,7 +41,7 @@ class Layout:
         """Representation of a Layout"""
         str_list = []
         for key, val in self._p2v.items():
-            str_list.append("{k}: {v},".format(k=key, v=val))
+            str_list.append(f"{key}: {val},")
         if str_list:
             str_list[-1] = str_list[-1][:-1]
         return "Layout({\n" + "\n".join(str_list) + "\n})"
@@ -102,7 +102,7 @@ class Layout:
             return self._p2v[item]
         if item in self._v2p:
             return self._v2p[item]
-        raise KeyError("The item %s does not exist in the Layout" % (item,))
+        raise KeyError(f"The item {item} does not exist in the Layout")
 
     def __contains__(self, item):
         return item in self._p2v or item in self._v2p

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -175,7 +175,7 @@ class BasisTranslator(TransformationPass):
                 else:
                     dag.substitute_node_with_dag(node, bound_target_dag)
             else:
-                raise TranspilerError("BasisTranslator did not map {}.".format(node.name))
+                raise TranspilerError(f"BasisTranslator did not map {node.name}.")
 
         replace_end_time = time.time()
         logger.info(

--- a/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
+++ b/qiskit/transpiler/passes/basis/ms_basis_decomposer.py
@@ -97,7 +97,7 @@ class MSBasisDecomposer(TransformationPass):
                 replacement_circuit = cnot_decomposition
             else:
                 raise QiskitError(
-                    "Unable to handle instruction (%s, %s)." % (node.op.name, type(node.op))
+                    f"Unable to handle instruction ({node.op.name}, {type(node.op)})."
                 )
 
             replacement_dag = circuit_to_dag(replacement_circuit)

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -61,7 +61,7 @@ class DenseLayout(AnalysisPass):
         Raises:
             TranspilerError: if dag wider than self.coupling_map
         """
-        num_dag_qubits = sum([qreg.size for qreg in dag.qregs.values()])
+        num_dag_qubits = sum(qreg.size for qreg in dag.qregs.values())
         if num_dag_qubits > self.coupling_map.size():
             raise TranspilerError("Number of qubits greater than device.")
 

--- a/qiskit/transpiler/passes/optimization/template_matching/backward_match.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/backward_match.py
@@ -184,7 +184,7 @@ class BackwardMatch:
             if template_blocked[node_id]:
                 template_block.append(node_id)
 
-        matches_template = sorted([match[0] for match in matches])
+        matches_template = sorted(match[0] for match in matches)
 
         successors = self.template_dag_dep.get_node(self.node_id_t).successors
         potential = []

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -201,12 +201,12 @@ class TemplateSubstitution:
         left = []
         right = []
 
-        pred = set([])
+        pred = set()
         for index in template_sublist:
             pred = pred | set(self.template_dag_dep.get_node(index).predecessors)
         pred = list(pred - set(template_sublist))
 
-        succ = set([])
+        succ = set()
         for index in template_sublist:
             succ = succ | set(self.template_dag_dep.get_node(index).successors)
         succ = list(succ - set(template_sublist))

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -287,7 +287,7 @@ def _map_free_gates(layout, gates, coupling_map):
         elif len(qubits) == 1:
             mapped_gate = _transform_gate_for_layout(gate, layout)
             mapped_gates.append(mapped_gate)
-        elif coupling_map.distance(*[layout[q] for q in qubits]) == 1:
+        elif coupling_map.distance(*(layout[q] for q in qubits)) == 1:
             mapped_gate = _transform_gate_for_layout(gate, layout)
             mapped_gates.append(mapped_gate)
         else:
@@ -305,7 +305,7 @@ def _calc_layout_distance(gates, coupling_map, layout, max_gates=None):
         max_gates = 50 + 10 * len(coupling_map.physical_qubits)
 
     return sum(
-        coupling_map.distance(*[layout[q] for q in gate["partition"][0]])
+        coupling_map.distance(*(layout[q] for q in gate["partition"][0]))
         for gate in gates[:max_gates]
         if gate["partition"] and len(gate["partition"][0]) == 2
     )

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -313,10 +313,10 @@ class SabreSwap(TransformationPass):
         if heuristic == "basic":
             if len(front_layer) > 1:
                 return self.coupling_map.distance_matrix[
-                    tuple(zip(*[[layout[q] for q in node.qargs] for node in front_layer]))
+                    tuple(zip(*([layout[q] for q in node.qargs] for node in front_layer)))
                 ].sum()
             elif len(front_layer) == 1:
-                return self.coupling_map.distance(*[layout[q] for q in list(front_layer)[0].qargs])
+                return self.coupling_map.distance(*(layout[q] for q in list(front_layer)[0].qargs))
             else:
                 return 0
 

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -156,7 +156,7 @@ class StochasticSwap(TransformationPass):
         logger.debug("layer_permutation: gates = %s", gates)
 
         # Can we already apply the gates? If so, there is no work to do.
-        dist = sum([coupling.distance(layout[g[0]], layout[g[1]]) for g in gates])
+        dist = sum(coupling.distance(layout[g[0]], layout[g[1]]) for g in gates)
         logger.debug("layer_permutation: distance = %s", dist)
         if dist == len(gates):
             logger.debug("layer_permutation: nothing to do")

--- a/qiskit/transpiler/passes/scheduling/calibration_creators.py
+++ b/qiskit/transpiler/passes/scheduling/calibration_creators.py
@@ -96,7 +96,7 @@ class RZXCalibrationBuilder(CalibrationCreator):
         if not backend.configuration().open_pulse:
             raise QiskitError(
                 "Calibrations can only be added to Pulse-enabled backends, "
-                "but {0} is not enabled with Pulse.".format(backend.name())
+                "but {} is not enabled with Pulse.".format(backend.name())
             )
 
         self._inst_map = backend.defaults().instruction_schedule_map

--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -53,7 +53,7 @@ class CheckMap(AnalysisPass):
             physical_q1 = qubit_indices[gate.qargs[1]]
 
             if self.coupling_map.distance(physical_q0, physical_q1) != 1:
-                self.property_set["check_map_msg"] = "%s(%s, %s) failed" % (
+                self.property_set["check_map_msg"] = "{}({}, {}) failed".format(
                     gate.name,
                     physical_q0,
                     physical_q1,

--- a/qiskit/transpiler/runningpassmanager.py
+++ b/qiskit/transpiler/runningpassmanager.py
@@ -207,7 +207,7 @@ class RunningPassManager:
         return dag
 
     def _log_pass(self, start_time, end_time, name):
-        log_msg = "Pass: %s - %.5f (ms)" % (name, (end_time - start_time) * 1000)
+        log_msg = f"Pass: {name} - {(end_time - start_time) * 1000:.5f} (ms)"
         logger.info(log_msg)
 
     def _update_valid_passes(self, pass_):

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -184,7 +184,7 @@ def set_config(key, value, section=None, file_path=None):
 
     if section in [None, "default"]:
         if key not in valid_config:
-            raise exceptions.QiskitUserConfigError("{} is not a valid user config.".format(key))
+            raise exceptions.QiskitUserConfigError(f"{key} is not a valid user config.")
 
     config = configparser.ConfigParser()
     config.read(filename)
@@ -199,7 +199,7 @@ def set_config(key, value, section=None, file_path=None):
             config.write(cfgfile)
     except OSError as ex:
         raise exceptions.QiskitUserConfigError(
-            "Unable to load the config file {}. Error: '{}'".format(filename, str(ex))
+            f"Unable to load the config file {filename}. Error: '{str(ex)}'"
         )
 
     # validates config

--- a/qiskit/utils/algorithm_globals.py
+++ b/qiskit/utils/algorithm_globals.py
@@ -65,7 +65,7 @@ class QiskitAlgorithmGlobals:
         if num_processes is None:
             num_processes = QiskitAlgorithmGlobals.CPU_COUNT
         elif num_processes < 1:
-            raise QiskitError("Invalid Number of Processes {}.".format(num_processes))
+            raise QiskitError(f"Invalid Number of Processes {num_processes}.")
         elif num_processes > QiskitAlgorithmGlobals.CPU_COUNT:
             raise QiskitError(
                 "Number of Processes {} cannot be greater than cpu count {}.".format(

--- a/qiskit/utils/arithmetic.py
+++ b/qiskit/utils/arithmetic.py
@@ -59,7 +59,7 @@ def is_power(num, return_decomposition=False):
             m = int((a + c) / 2)
 
             if (m ** b) < (num + 1):
-                p = int((m ** b))
+                p = int(m ** b)
             else:
                 p = int(num + 1)
 

--- a/qiskit/utils/circuit_utils.py
+++ b/qiskit/utils/circuit_utils.py
@@ -34,7 +34,7 @@ def summarize_circuits(circuits):
     if not isinstance(circuits, list):
         circuits = [circuits]
     ret = ""
-    ret += "Submitting {} circuits.\n".format(len(circuits))
+    ret += f"Submitting {len(circuits)} circuits.\n"
     ret += "============================================================================\n"
     stats = np.zeros(4)
     for i, circuit in enumerate(circuits):

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -96,9 +96,7 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
     for old_arg, new_arg in kwarg_map.items():
         if old_arg in kwargs:
             if new_arg in kwargs:
-                raise TypeError(
-                    "{} received both {} and {} (deprecated).".format(func_name, new_arg, old_arg)
-                )
+                raise TypeError(f"{func_name} received both {new_arg} and {old_arg} (deprecated).")
 
             warnings.warn(
                 "{} keyword argument {} is deprecated and "

--- a/qiskit/utils/entangler_map.py
+++ b/qiskit/utils/entangler_map.py
@@ -95,21 +95,17 @@ def validate_entangler_map(entangler_map, num_qubits, allow_double_entanglement=
 
     for src_to_targ in entangler_map:
         if not isinstance(src_to_targ, list):
-            raise TypeError("Entangle index list expected but got {}".format(type(src_to_targ)))
+            raise TypeError(f"Entangle index list expected but got {type(src_to_targ)}")
 
     ret_map = []
     ret_map = [[int(src), int(targ)] for src, targ in entangler_map]
 
     for src, targ in ret_map:
         if src < 0 or src >= num_qubits:
-            raise ValueError(
-                "Qubit entangle source value {} invalid for {} qubits".format(src, num_qubits)
-            )
+            raise ValueError(f"Qubit entangle source value {src} invalid for {num_qubits} qubits")
         if targ < 0 or targ >= num_qubits:
-            raise ValueError(
-                "Qubit entangle target value {} invalid for {} qubits".format(targ, num_qubits)
-            )
+            raise ValueError(f"Qubit entangle target value {targ} invalid for {num_qubits} qubits")
         if not allow_double_entanglement and [targ, src] in ret_map:
-            raise ValueError("Qubit {} and {} cross-entangled.".format(src, targ))
+            raise ValueError(f"Qubit {src} and {targ} cross-entangled.")
 
     return ret_map

--- a/qiskit/utils/measurement_error_mitigation.py
+++ b/qiskit/utils/measurement_error_mitigation.py
@@ -147,7 +147,7 @@ def build_measurement_error_mitigation_circuits(
         # TODO support different calibration
         raise QiskitError("Does not support TensoredMeasFitter yet.")
     else:
-        raise QiskitError("Unknown fitter {}".format(fitter_cls))
+        raise QiskitError(f"Unknown fitter {fitter_cls}")
 
     # the provided `qubit_list` would be used as the initial layout to
     # assure the consistent qubit mapping used in the main circuits.
@@ -207,7 +207,7 @@ def build_measurement_error_mitigation_qobj(
         # TODO support different calibration
         raise QiskitError("Does not support TensoredMeasFitter yet.")
     else:
-        raise QiskitError("Unknown fitter {}".format(fitter_cls))
+        raise QiskitError(f"Unknown fitter {fitter_cls}")
 
     # the provided `qubit_list` would be used as the initial layout to
     # assure the consistent qubit mapping used in the main circuits.

--- a/qiskit/utils/name_unnamed_args.py
+++ b/qiskit/utils/name_unnamed_args.py
@@ -50,7 +50,7 @@ def name_args(mapping, skip=0):
                 default_name = replacement[0]
                 if len(replacement) == 1:  # just renaming, no special cases
                     if default_name in kwargs.keys():
-                        raise ValueError("Name collapse on {}".format(default_name))
+                        raise ValueError(f"Name collapse on {default_name}")
                     kwargs[default_name] = arg
                 else:
                     # check if we find a special name
@@ -63,7 +63,7 @@ def name_args(mapping, skip=0):
                         name = default_name
 
                     if name in kwargs.keys():
-                        raise ValueError("Name collapse on {}".format(default_name))
+                        raise ValueError(f"Name collapse on {default_name}")
                     kwargs[name] = arg
 
             return func(*args[:skip], **kwargs)

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -251,7 +251,7 @@ class QuantumInstance:
         """
         from qiskit import __version__ as terra_version
 
-        info = "\nQiskit Terra version: {}\n".format(terra_version)
+        info = f"\nQiskit Terra version: {terra_version}\n"
         info += "Backend: '{} ({})', with following setting:\n{}\n{}\n{}\n{}\n{}\n{}".format(
             self.backend_name,
             self._backend.provider(),
@@ -262,7 +262,7 @@ class QuantumInstance:
             self._backend_options,
             self._noise_config,
         )
-        info += "\nMeasurement mitigation: {}".format(self._meas_error_mitigation_cls)
+        info += f"\nMeasurement mitigation: {self._meas_error_mitigation_cls}"
 
         return info
 
@@ -646,7 +646,7 @@ class QuantumInstance:
                 self._noise_config[k] = v
 
             else:
-                raise ValueError("unknown setting for the key ({}).".format(k))
+                raise ValueError(f"unknown setting for the key ({k}).")
 
     @property
     def time_taken(self) -> float:
@@ -798,7 +798,7 @@ class QuantumInstance:
         """
         shots = self._meas_error_mitigation_shots or self._run_config.shots
         if qubit_index:
-            qubit_index_str = "_".join([str(x) for x in qubit_index]) + "_{}".format(shots)
+            qubit_index_str = "_".join([str(x) for x in qubit_index]) + f"_{shots}"
             fitter, timestamp = self._meas_error_mitigation_fitters.get(qubit_index_str, None)
             if fitter is not None:
                 return fitter.cal_matrix, timestamp

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -554,7 +554,7 @@ class QuantumInstance:
                         cals_result, mit_pattern=state_labels, circlabel=circuit_labels
                     )
                 else:
-                    raise QiskitError("Unknown fitter {}".format(self._meas_error_mitigation_cls))
+                    raise QiskitError(f"Unknown fitter {self._meas_error_mitigation_cls}")
 
                 self._meas_error_mitigation_fitters[qubit_index_str] = (
                     meas_error_mitigation_fitter,

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -374,7 +374,7 @@ def run_qobj(
                 if not res.success:
                     msg += ", " + res.status
                     break
-        raise QiskitError("Circuit execution failed: {}".format(msg))
+        raise QiskitError(f"Circuit execution failed: {msg}")
 
     if not hasattr(result, "time_taken"):
         setattr(result, "time_taken", 0.0)
@@ -590,7 +590,7 @@ def run_circuits(
                 if not res.success:
                     msg += ", " + res.status
                     break
-        raise QiskitError("Circuit execution failed: {}".format(msg))
+        raise QiskitError(f"Circuit execution failed: {msg}")
 
     if not hasattr(result, "time_taken"):
         setattr(result, "time_taken", 0.0)

--- a/qiskit/utils/units.py
+++ b/qiskit/utils/units.py
@@ -37,4 +37,4 @@ def apply_prefix(value: float, unit: str) -> float:
     elif unit[0] in upfactors:
         return value * upfactors[unit[0]]
     else:
-        raise Exception("Could not understand units: {u}".format(u=unit))
+        raise Exception(f"Could not understand units: {unit}")

--- a/qiskit/utils/validation.py
+++ b/qiskit/utils/validation.py
@@ -27,7 +27,7 @@ def validate_in_set(name: str, value: object, values: Set[object]) -> None:
         ValueError: invalid value
     """
     if value not in values:
-        raise ValueError("{} must be one of '{}', was '{}'.".format(name, values, value))
+        raise ValueError(f"{name} must be one of '{values}', was '{value}'.")
 
 
 def validate_min(name: str, value: float, minimum: float) -> None:
@@ -40,7 +40,7 @@ def validate_min(name: str, value: float, minimum: float) -> None:
         ValueError: invalid value
     """
     if value < minimum:
-        raise ValueError("{} must have value >= {}, was {}".format(name, minimum, value))
+        raise ValueError(f"{name} must have value >= {minimum}, was {value}")
 
 
 def validate_min_exclusive(name: str, value: float, minimum: float) -> None:
@@ -53,7 +53,7 @@ def validate_min_exclusive(name: str, value: float, minimum: float) -> None:
         ValueError: invalid value
     """
     if value <= minimum:
-        raise ValueError("{} must have value > {}, was {}".format(name, minimum, value))
+        raise ValueError(f"{name} must have value > {minimum}, was {value}")
 
 
 def validate_max(name: str, value: float, maximum: float) -> None:
@@ -66,7 +66,7 @@ def validate_max(name: str, value: float, maximum: float) -> None:
         ValueError: invalid value
     """
     if value > maximum:
-        raise ValueError("{} must have value <= {}, was {}".format(name, maximum, value))
+        raise ValueError(f"{name} must have value <= {maximum}, was {value}")
 
 
 def validate_max_exclusive(name: str, value: float, maximum: float) -> None:
@@ -79,7 +79,7 @@ def validate_max_exclusive(name: str, value: float, maximum: float) -> None:
         ValueError: invalid value
     """
     if value >= maximum:
-        raise ValueError("{} must have value < {}, was {}".format(name, maximum, value))
+        raise ValueError(f"{name} must have value < {maximum}, was {value}")
 
 
 def validate_range(name: str, value: float, minimum: float, maximum: float) -> None:
@@ -93,9 +93,7 @@ def validate_range(name: str, value: float, minimum: float, maximum: float) -> N
         ValueError: invalid value
     """
     if value < minimum or value > maximum:
-        raise ValueError(
-            "{} must have value >= {} and <= {}, was {}".format(name, minimum, maximum, value)
-        )
+        raise ValueError(f"{name} must have value >= {minimum} and <= {maximum}, was {value}")
 
 
 def validate_range_exclusive(name: str, value: float, minimum: float, maximum: float) -> None:
@@ -109,9 +107,7 @@ def validate_range_exclusive(name: str, value: float, minimum: float, maximum: f
         ValueError: invalid value
     """
     if value <= minimum or value >= maximum:
-        raise ValueError(
-            "{} must have value > {} and < {}, was {}".format(name, minimum, maximum, value)
-        )
+        raise ValueError(f"{name} must have value > {minimum} and < {maximum}, was {value}")
 
 
 def validate_range_exclusive_min(name: str, value: float, minimum: float, maximum: float) -> None:
@@ -125,9 +121,7 @@ def validate_range_exclusive_min(name: str, value: float, minimum: float, maximu
         ValueError: invalid value
     """
     if value <= minimum or value > maximum:
-        raise ValueError(
-            "{} must have value > {} and <= {}, was {}".format(name, minimum, maximum, value)
-        )
+        raise ValueError(f"{name} must have value > {minimum} and <= {maximum}, was {value}")
 
 
 def validate_range_exclusive_max(name: str, value: float, minimum: float, maximum: float) -> None:
@@ -141,6 +135,4 @@ def validate_range_exclusive_max(name: str, value: float, minimum: float, maximu
         ValueError: invalid value
     """
     if value < minimum or value >= maximum:
-        raise ValueError(
-            "{} must have value >= {} and < {}, was {}".format(name, minimum, maximum, value)
-        )
+        raise ValueError(f"{name} must have value >= {minimum} and < {maximum}, was {value}")

--- a/qiskit/validation/jsonschema/schema_validation.py
+++ b/qiskit/validation/jsonschema/schema_validation.py
@@ -219,13 +219,13 @@ def _format_causes(err, level=0):
     def _format_path(path):
         def _format(item):
             if isinstance(item, str):
-                return ".{}".format(item)
+                return f".{item}"
 
-            return "[{}]".format(item)
+            return f"[{item}]"
 
         return "".join(["<root>"] + list(map(_format, path)))
 
-    _print("'{}' failed @ '{}' because of:".format(err.validator, _format_path(err.absolute_path)))
+    _print(f"'{err.validator}' failed @ '{_format_path(err.absolute_path)}' because of:")
 
     if not err.context:
         _print(str(err.message), offset=1)

--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -405,7 +405,7 @@ def _latex_circuit_drawer(
                 [
                     "pdflatex",
                     "-halt-on-error",
-                    "-output-directory={}".format(tmpdirname),
+                    f"-output-directory={tmpdirname}",
                     "{}".format(tmpfilename + ".tex"),
                 ],
                 stdout=subprocess.PIPE,

--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -204,7 +204,7 @@ def plot_histogram(
     # add some text for labels, title, and axes ticks
     ax.set_ylabel("Probabilities", fontsize=14)
     all_vals = np.concatenate(all_pvalues).ravel()
-    ax.set_ylim([0.0, min([1.2, max([1.2 * val for val in all_vals])])])
+    ax.set_ylim([0.0, min([1.2, max(1.2 * val for val in all_vals)])])
     if sort == "desc":
         ax.invert_xaxis()
 

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -125,7 +125,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
 
     else:
         bit_labels = {
-            bit: "%s[%s]" % (reg.name, idx)
+            bit: f"{reg.name}[{idx}]"
             for reg in list(dag.qregs.values()) + list(dag.cregs.values())
             for (idx, bit) in enumerate(reg)
         }

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -372,8 +372,8 @@ def plot_gate_map(
             ax.axis("off")
             return fig
 
-    x_max = max([d[1] for d in grid_data])
-    y_max = max([d[0] for d in grid_data])
+    x_max = max(d[1] for d in grid_data)
+    y_max = max(d[0] for d in grid_data)
     max_dim = max(x_max, y_max)
 
     if figsize is None:
@@ -734,11 +734,11 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True):
         single_cb.locator = tick_locator
         single_cb.update_ticks()
         single_cb.update_ticks()
-        bleft_ax.set_title("H error rate (%) [Avg. = {}]".format(round(avg_1q_err, 3)))
+        bleft_ax.set_title(f"H error rate (%) [Avg. = {round(avg_1q_err, 3)}]")
 
     if cmap is None:
         bleft_ax.axis("off")
-        bleft_ax.set_title("H error rate (%) = {}".format(round(avg_1q_err, 3)))
+        bleft_ax.set_title(f"H error rate (%) = {round(avg_1q_err, 3)}")
 
     if cmap:
         cx_cb = matplotlib.colorbar.ColorbarBase(
@@ -747,7 +747,7 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True):
         tick_locator = ticker.MaxNLocator(nbins=5)
         cx_cb.locator = tick_locator
         cx_cb.update_ticks()
-        bright_ax.set_title("CNOT error rate (%) [Avg. = {}]".format(round(avg_cx_err, 3)))
+        bright_ax.set_title(f"CNOT error rate (%) [Avg. = {round(avg_cx_err, 3)}]")
 
     if num_qubits < 10:
         num_left = num_qubits
@@ -787,7 +787,7 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True):
         spine.set_visible(False)
 
     if show_title:
-        fig.suptitle("{name} Error Map".format(name=backend.name()), fontsize=24, y=0.9)
+        fig.suptitle(f"{backend.name()} Error Map", fontsize=24, y=0.9)
     if get_backend() in ["module://ipykernel.pylab.backend_inline", "nbAgg"]:
         plt.close(fig)
     return fig

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -535,7 +535,7 @@ class QCircuitImage:
         ctrlqargs = wire_list[:num_ctrl_qubits]
         wire_min = min(wireqargs)
         wire_max = max(wireqargs)
-        ctrl_state = "{:b}".format(op.op.ctrl_state).rjust(num_ctrl_qubits, "0")[::-1]
+        ctrl_state = f"{op.op.ctrl_state:b}".rjust(num_ctrl_qubits, "0")[::-1]
 
         # First do single qubit target gates
         if len(wireqargs) == 1:
@@ -584,7 +584,7 @@ class QCircuitImage:
         if isinstance(op.op, RZZGate) or (base_op and isinstance(base_op, RZZGate)):
             ctrl_bit = "1"
         else:
-            ctrl_bit = "{:b}".format(op.op.ctrl_state).rjust(1, "0")[::-1]
+            ctrl_bit = f"{op.op.ctrl_state:b}".rjust(1, "0")[::-1]
 
         control = "\\ctrlo" if ctrl_bit == "0" else "\\ctrl"
         self._latex[wire_next_last][col] = f"{control}" + (
@@ -711,5 +711,5 @@ class QCircuitImage:
     def _truncate_float(self, matchobj, ndigits=4):
         """Truncate long floats."""
         if matchobj.group(0):
-            return "%.{}g".format(ndigits) % float(matchobj.group(0))
+            return f"%.{ndigits}g" % float(matchobj.group(0))
         return ""

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -374,7 +374,7 @@ class MatplotlibDrawer:
                         break
                     except json.JSONDecodeError as e:
                         warn(
-                            "Could not decode JSON in file '{}': {}. ".format(path, str(e))
+                            f"Could not decode JSON in file '{path}': {str(e)}. "
                             + "Will use default style.",
                             UserWarning,
                             2,
@@ -382,7 +382,7 @@ class MatplotlibDrawer:
                         break
                     except (OSError, FileNotFoundError):
                         warn(
-                            "Error loading JSON file '{}'. Will use default style.".format(path),
+                            f"Error loading JSON file '{path}'. Will use default style.",
                             UserWarning,
                             2,
                         )
@@ -519,12 +519,12 @@ class MatplotlibDrawer:
     def _multiqubit_gate(
         self, op, xy, c_xy=None, fc=None, ec=None, gt=None, sc=None, text="", subtext=""
     ):
-        xpos = min([x[0] for x in xy])
-        ypos = min([y[1] for y in xy])
-        ypos_max = max([y[1] for y in xy])
+        xpos = min(x[0] for x in xy)
+        ypos = min(y[1] for y in xy)
+        ypos_max = max(y[1] for y in xy)
         if c_xy:
-            cxpos = min([x[0] for x in c_xy])
-            cypos = min([y[1] for y in c_xy])
+            cxpos = min(x[0] for x in c_xy)
+            cypos = min(y[1] for y in c_xy)
             ypos = min(ypos, cypos)
         fs = self._style["fs"]
         sfs = self._style["sfs"]
@@ -835,7 +835,7 @@ class MatplotlibDrawer:
             top = min(qubits) > min_ctbit
 
         # display the control qubits as open or closed based on ctrl_state
-        cstate = "{:b}".format(ctrl_state).rjust(num_ctrl_qubits, "0")[::-1]
+        cstate = f"{ctrl_state:b}".rjust(num_ctrl_qubits, "0")[::-1]
         for i in range(num_ctrl_qubits):
             fc_open_close = ec if cstate[i] == "1" else self._style["bg"]
             text_top = None
@@ -977,7 +977,7 @@ class MatplotlibDrawer:
 
             if len(self._qubit) > 1:
                 if self._layout is None:
-                    qubit_name = "${{{name}}}_{{{index}}}$".format(name=register.name, index=index)
+                    qubit_name = f"${{{register.name}}}_{{{index}}}$"
                 else:
                     if self._layout[index]:
                         virt_bit = self._layout[index]
@@ -996,9 +996,9 @@ class MatplotlibDrawer:
                                 name=virt_bit, physical=index
                             )
                     else:
-                        qubit_name = "${{{physical}}}$".format(physical=index)
+                        qubit_name = f"${{{index}}}$"
             else:
-                qubit_name = "{name}".format(name=register.name)
+                qubit_name = f"{register.name}"
             qubit_name = _fix_double_script(qubit_name) + initial_qbit
             text_width = self._get_text_width(qubit_name, fs) * 1.15
 
@@ -1025,7 +1025,7 @@ class MatplotlibDrawer:
                 index = self._bit_locations[reg]["index"]
 
                 if self._cregbundle:
-                    clbit_name = "{}".format(register.name)
+                    clbit_name = f"{register.name}"
                     clbit_name = _fix_double_script(clbit_name) + initial_cbit
                     text_width = self._get_text_width(register.name, fs) * 1.15
                     if text_width > longest_reg_name_width:
@@ -1039,7 +1039,7 @@ class MatplotlibDrawer:
                     if not (not nreg or register != self._bit_locations[nreg]["register"]):
                         continue
                 else:
-                    clbit_name = "${}_{{{}}}$".format(register.name, index)
+                    clbit_name = f"${register.name}_{{{index}}}$"
                     clbit_name = _fix_double_script(clbit_name) + initial_cbit
                     text_width = self._get_text_width(register.name, fs) * 1.15
                     if text_width > longest_reg_name_width:
@@ -1316,7 +1316,7 @@ class MatplotlibDrawer:
                     and len(op.op.params) > 0
                     and not any(isinstance(param, np.ndarray) for param in op.op.params)
                 ):
-                    param = "{}".format(self._param_parse(op.op.params))
+                    param = f"{self._param_parse(op.op.params)}"
                 else:
                     param = ""
 
@@ -1332,7 +1332,7 @@ class MatplotlibDrawer:
                             mask |= 1 << index
                     val = op.op.condition[1]
                     # cbit list to consider
-                    fmt_c = "{{:0{}b}}".format(len(c_xy))
+                    fmt_c = f"{{:0{len(c_xy)}b}}"
                     cmask = list(fmt_c.format(mask))[::-1]
                     # value
                     fmt_v = "{{:0{}b}}".format(cmask.count("1"))
@@ -1448,9 +1448,7 @@ class MatplotlibDrawer:
                         stext = "P"
                     else:
                         stext = "ZZ"
-                    self._sidetext(
-                        op, qubit_b, tc=tc, text="{}".format(stext) + " " + "({})".format(param)
-                    )
+                    self._sidetext(op, qubit_b, tc=tc, text=f"{stext} ({param})")
                     self._line(qubit_b, qubit_t, lc=lc)
 
                 # swap gate
@@ -1502,7 +1500,7 @@ class MatplotlibDrawer:
                             gt=gt,
                             sc=sc,
                             text=gate_text,
-                            subtext="{}".format(param),
+                            subtext=f"{param}",
                         )
                     else:
                         self._multiqubit_gate(
@@ -1513,7 +1511,7 @@ class MatplotlibDrawer:
                             gt=gt,
                             sc=sc,
                             text=gate_text,
-                            subtext="{}".format(param),
+                            subtext=f"{param}",
                         )
 
                 # draw multi-qubit gate as final default
@@ -1527,7 +1525,7 @@ class MatplotlibDrawer:
                         gt=gt,
                         sc=sc,
                         text=gate_text,
-                        subtext="{}".format(param),
+                        subtext=f"{param}",
                     )
 
             # adjust the column if there have been barriers encountered, but not plotted

--- a/qiskit/visualization/pass_manager_visualization.py
+++ b/qiskit/visualization/pass_manager_visualization.py
@@ -130,7 +130,7 @@ def pass_manager_drawer(pass_manager, filename=None, style=None, raw=False):
     for index, controller_group in enumerate(passes):
 
         # label is the name of the flow controller parameter
-        label = "[%s] %s" % (index, ", ".join(controller_group["flow_controllers"]))
+        label = "[{}] {}".format(index, ", ".join(controller_group["flow_controllers"]))
 
         # create the subgraph for this controller
         subgraph = pydot.Cluster(

--- a/qiskit/visualization/pulse_v2/core.py
+++ b/qiskit/visualization/pulse_v2/core.py
@@ -586,7 +586,7 @@ class Chart:
         """
         for name, data in self._output_dataset.items():
             # prepare unique name
-            unique_id = "chart{ind:d}_{key}".format(ind=self.index, key=name)
+            unique_id = f"chart{self.index:d}_{name}"
             if self._check_visible(data):
                 yield unique_id, data
 
@@ -853,7 +853,7 @@ class Chart:
                 return self.vmax
             if val == types.AbstractCoordinate.BOTTOM:
                 return self.vmin
-            raise VisualizationError("Coordinate {name} is not supported.".format(name=val))
+            raise VisualizationError(f"Coordinate {val} is not supported.")
 
         try:
             return np.asarray(vals, dtype=float)

--- a/qiskit/visualization/pulse_v2/drawings.py
+++ b/qiskit/visualization/pulse_v2/drawings.py
@@ -114,7 +114,7 @@ class ElementaryData(ABC):
         )
 
     def __repr__(self):
-        return "{}(type={}, key={})".format(self.__class__.__name__, self.data_type, self.data_key)
+        return f"{self.__class__.__name__}(type={self.data_type}, key={self.data_key})"
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.data_key == other.data_key

--- a/qiskit/visualization/pulse_v2/generators/chart.py
+++ b/qiskit/visualization/pulse_v2/generators/chart.py
@@ -140,7 +140,7 @@ def gen_chart_scale(
         "ha": "right",
     }
 
-    scale_val = "x{param}".format(param=types.DynamicString.SCALE)
+    scale_val = f"x{types.DynamicString.SCALE}"
 
     text = drawings.TextData(
         data_type=types.LabelType.CH_INFO,
@@ -186,12 +186,12 @@ def gen_channel_freqs(
             freq = device.get_channel_frequency(chan)
             if not freq:
                 continue
-            sources.append("{chan}: {val:.2f} GHz".format(chan=chan.name.upper(), val=freq / 1e9))
+            sources.append(f"{chan.name.upper()}: {freq / 1e9:.2f} GHz")
         freq_text = ", ".join(sources)
     else:
         freq = device.get_channel_frequency(data.channels[0])
         if freq:
-            freq_text = "{val:.2f} GHz".format(val=freq / 1e9)
+            freq_text = f"{freq / 1e9:.2f} GHz"
         else:
             freq_text = ""
 

--- a/qiskit/visualization/pulse_v2/generators/frame.py
+++ b/qiskit/visualization/pulse_v2/generators/frame.py
@@ -94,8 +94,8 @@ def gen_formatted_phase(
         channels=data.inst[0].channel,
         xvals=[data.t0],
         yvals=[formatter["label_offset.frame_change"]],
-        text="VZ({phase})".format(phase=plain_phase),
-        latex=r"{{\rm VZ}}({phase})".format(phase=latex_phase),
+        text=f"VZ({plain_phase})",
+        latex=fr"{{\rm VZ}}({latex_phase})",
         ignore_scaling=True,
         styles=style,
     )
@@ -142,8 +142,8 @@ def gen_formatted_freq_mhz(
         channels=data.inst[0].channel,
         xvals=[data.t0],
         yvals=[formatter["label_offset.frame_change"]],
-        text="\u0394f = {freq}".format(freq=plain_freq),
-        latex=r"\Delta f = {freq}".format(freq=latex_freq),
+        text=f"\u0394f = {plain_freq}",
+        latex=fr"\Delta f = {latex_freq}",
         ignore_scaling=True,
         styles=style,
     )
@@ -197,8 +197,8 @@ def gen_formatted_frame_values(
             channels=data.inst[0].channel,
             xvals=[data.t0],
             yvals=[formatter["label_offset.frame_change"]],
-            text="VZ({phase})".format(phase=plain_phase),
-            latex=r"{{\rm VZ}}({phase})".format(phase=latex_phase),
+            text=f"VZ({plain_phase})",
+            latex=fr"{{\rm VZ}}({latex_phase})",
             ignore_scaling=True,
             styles=phase_style,
         )
@@ -217,8 +217,8 @@ def gen_formatted_frame_values(
             channels=data.inst[0].channel,
             xvals=[data.t0],
             yvals=[2 * formatter["label_offset.frame_change"]],
-            text="\u0394f = {freq}".format(freq=plain_freq),
-            latex=r"\Delta f = {freq}".format(freq=latex_freq),
+            text=f"\u0394f = {plain_freq}",
+            latex=fr"\Delta f = {latex_freq}",
             ignore_scaling=True,
             styles=freq_style,
         )
@@ -268,7 +268,7 @@ def gen_raw_operand_values_compact(
             base=data.frame.freq / (10 ** int(np.floor(np.log10(abs_freq)))),
             exp=int(np.floor(np.log10(abs_freq))),
         )
-    frame_info = "{phase:.2f}\n{freq}".format(phase=data.frame.phase, freq=freq_sci_notation)
+    frame_info = f"{data.frame.phase:.2f}\n{freq_sci_notation}"
 
     text = drawings.TextData(
         data_type=types.LabelType.FRAME,
@@ -316,16 +316,16 @@ def gen_frame_symbol(
     for inst in data.inst:
         if isinstance(inst, (instructions.SetFrequency, instructions.ShiftFrequency)):
             try:
-                program.append("{}({:.2e} Hz)".format(inst.__class__.__name__, inst.frequency))
+                program.append(f"{inst.__class__.__name__}({inst.frequency:.2e} Hz)")
             except TypeError:
                 # parameter expression
-                program.append("{}({})".format(inst.__class__.__name__, inst.frequency))
+                program.append(f"{inst.__class__.__name__}({inst.frequency})")
         elif isinstance(inst, (instructions.SetPhase, instructions.ShiftPhase)):
             try:
-                program.append("{}({:.2f} rad.)".format(inst.__class__.__name__, inst.phase))
+                program.append(f"{inst.__class__.__name__}({inst.phase:.2f} rad.)")
             except TypeError:
                 # parameter expression
-                program.append("{}({})".format(inst.__class__.__name__, inst.phase))
+                program.append(f"{inst.__class__.__name__}({inst.phase})")
 
     meta = {
         "total phase change": data.frame.phase,
@@ -382,19 +382,19 @@ def _phase_to_text(
     denom = frac.denominator
     if denom > max_denom:
         # denominator is too large
-        latex = r"{val:.2f}".format(val=np.abs(phase))
-        plain = "{val:.2f}".format(val=np.abs(phase))
+        latex = fr"{np.abs(phase):.2f}"
+        plain = f"{np.abs(phase):.2f}"
     else:
         if num == 1:
             if denom == 1:
                 latex = r"\pi"
                 plain = "pi"
             else:
-                latex = r"\pi/{denom:d}".format(denom=denom)
-                plain = "pi/{denom:d}".format(denom=denom)
+                latex = fr"\pi/{denom:d}"
+                plain = f"pi/{denom:d}"
         else:
-            latex = r"{num:d}/{denom:d} \pi".format(num=num, denom=denom)
-            plain = "{num:d}/{denom:d} pi".format(num=num, denom=denom)
+            latex = fr"{num:d}/{denom:d} \pi"
+            plain = f"{num:d}/{denom:d} pi"
 
     if flip:
         sign = "-" if phase > 0 else ""
@@ -431,7 +431,7 @@ def _freq_to_text(formatter: Dict[str, Any], freq: float, unit: str = "MHz") -> 
     except KeyError as ex:
         raise VisualizationError(f"Unit {unit} is not supported.") from ex
 
-    latex = r"{val:.2f}~{{\rm {unit}}}".format(val=value, unit=unit)
-    plain = "{val:.2f} {unit}".format(val=value, unit=unit)
+    latex = fr"{value:.2f}~{{\rm {unit}}}"
+    plain = f"{value:.2f} {unit}"
 
     return plain, latex

--- a/qiskit/visualization/pulse_v2/generators/waveform.py
+++ b/qiskit/visualization/pulse_v2/generators/waveform.py
@@ -186,7 +186,7 @@ def gen_ibmq_latex_waveform_name(
                 angle_val = match_dict["angle"]
                 frac = Fraction(int(int(angle_val) / 2), 180)
                 if frac.numerator == 1:
-                    angle = r"\pi/{denom:d}".format(denom=frac.denominator)
+                    angle = fr"\pi/{frac.denominator:d}"
                 else:
                     angle = r"{num:d}/{denom:d} \pi".format(
                         num=frac.numerator, denom=frac.denominator
@@ -200,12 +200,12 @@ def gen_ibmq_latex_waveform_name(
                 else:
                     frac = Fraction(int(angle_val), 180)
                     if frac.numerator == 1:
-                        angle = r"\pi/{denom:d}".format(denom=frac.denominator)
+                        angle = fr"\pi/{frac.denominator:d}"
                     else:
                         angle = r"{num:d}/{denom:d} \pi".format(
                             num=frac.numerator, denom=frac.denominator
                         )
-            latex_name = r"{}({}{})".format(op_name, sign, angle)
+            latex_name = fr"{op_name}({sign}{angle})"
         else:
             latex_name = None
 
@@ -278,10 +278,10 @@ def gen_waveform_max_value(
     if np.abs(ydata.real[re_maxind]) > 0.01:
         # generator shows only 2 digits after the decimal point.
         if ydata.real[re_maxind] > 0:
-            max_val = "{val:.2f}\n\u25BE".format(val=ydata.real[re_maxind])
+            max_val = f"{ydata.real[re_maxind]:.2f}\n\u25BE"
             re_style = {"va": "bottom"}
         else:
-            max_val = "\u25B4\n{val:.2f}".format(val=ydata.real[re_maxind])
+            max_val = f"\u25B4\n{ydata.real[re_maxind]:.2f}"
             re_style = {"va": "top"}
         re_style.update(style)
         re_text = drawings.TextData(
@@ -299,10 +299,10 @@ def gen_waveform_max_value(
     if np.abs(ydata.imag[im_maxind]) > 0.01:
         # generator shows only 2 digits after the decimal point.
         if ydata.imag[im_maxind] > 0:
-            max_val = "{val:.2f}\n\u25BE".format(val=ydata.imag[im_maxind])
+            max_val = f"{ydata.imag[im_maxind]:.2f}\n\u25BE"
             im_style = {"va": "bottom"}
         else:
-            max_val = "\u25B4\n{val:.2f}".format(val=ydata.imag[im_maxind])
+            max_val = f"\u25B4\n{ydata.imag[im_maxind]:.2f}"
             im_style = {"va": "top"}
         im_style.update(style)
         im_text = drawings.TextData(

--- a/qiskit/visualization/pulse_v2/interface.py
+++ b/qiskit/visualization/pulse_v2/interface.py
@@ -444,6 +444,6 @@ def draw(
         plotter_api = Mpl2DPlotter(canvas=canvas, axis=axis)
         plotter_api.draw()
     else:
-        raise VisualizationError("Plotter API {name} is not supported.".format(name=plotter))
+        raise VisualizationError(f"Plotter API {plotter} is not supported.")
 
     return plotter_api.get_image()

--- a/qiskit/visualization/pulse_v2/layouts.py
+++ b/qiskit/visualization/pulse_v2/layouts.py
@@ -300,7 +300,7 @@ def qubit_index_sort(
     sorted_map = sorted(qubit_channel_map.items(), key=lambda x: x[0])
 
     for qind, chans in sorted_map:
-        yield "Q{index:d}".format(index=qind), chans
+        yield f"Q{qind:d}", chans
 
 
 def time_map_in_ns(
@@ -351,7 +351,7 @@ def time_map_in_ns(
     else:
         label = "System cycle time (dt)"
 
-    formatted_label = ["{val:.0f}".format(val=val) for val in axis_label]
+    formatted_label = [f"{val:.0f}" for val in axis_label]
 
     return types.HorizontalAxis(
         window=(t0_shift, t1_shift),
@@ -371,7 +371,7 @@ def detail_title(
     title_str = list()
 
     # add program name
-    title_str.append("Name: {name}".format(name=program.name))
+    title_str.append(f"Name: {program.name}")
 
     # add program duration
     dt = device.dt * 1e9 if device.dt else 1.0
@@ -383,7 +383,7 @@ def detail_title(
 
     # add device name
     if device.backend_name != "no-backend":
-        title_str.append("Backend: {backend_name}".format(backend_name=device.backend_name))
+        title_str.append(f"Backend: {device.backend_name}")
 
     return ", ".join(title_str)
 

--- a/qiskit/visualization/pulse_v2/plotters/matplotlib.py
+++ b/qiskit/visualization/pulse_v2/plotters/matplotlib.py
@@ -106,11 +106,9 @@ class Mpl2DPlotter(BasePlotter):
                         self.ax.plot(x, y, **data.styles)
                 elif isinstance(data, drawings.TextData):
                     # text object
-                    text = r"${s}$".format(s=data.latex) if data.latex else data.text
+                    text = fr"${data.latex}$" if data.latex else data.text
                     # replace dynamic text
-                    text = text.replace(
-                        types.DynamicString.SCALE, "{val:.1f}".format(val=chart.scale)
-                    )
+                    text = text.replace(types.DynamicString.SCALE, f"{chart.scale:.1f}")
                     self.ax.text(x=x[0], y=y[0], s=text, **data.styles)
                 elif isinstance(data, drawings.BoxData):
                     xy = x[0], y[0]

--- a/qiskit/visualization/pulse_v2/stylesheet.py
+++ b/qiskit/visualization/pulse_v2/stylesheet.py
@@ -52,7 +52,7 @@ class QiskitPulseStyle(dict):
         for key, value in __m.items():
             if key in self._deprecated_keys:
                 warnings.warn(
-                    "%s is deprecated. Use %s instead." % (key, self._deprecated_keys[key]),
+                    f"{key} is deprecated. Use {self._deprecated_keys[key]} instead.",
                     DeprecationWarning,
                 )
                 self.__setitem__(self._deprecated_keys[key], value)

--- a/qiskit/visualization/pulse_v2/types.py
+++ b/qiskit/visualization/pulse_v2/types.py
@@ -23,7 +23,11 @@ import numpy as np
 from qiskit import pulse
 
 
-PhaseFreqTuple = NamedTuple("PhaseFreqTuple", [("phase", float), ("freq", float)])
+class PhaseFreqTuple(NamedTuple):
+    phase: float
+    freq: float
+
+
 PhaseFreqTuple.__doc__ = "Data to represent a set of frequency and phase values."
 PhaseFreqTuple.phase.__doc__ = "Phase value in rad."
 PhaseFreqTuple.freq.__doc__ = "Frequency value in Hz."
@@ -65,36 +69,45 @@ SnapshotInstruction.dt.__doc__ = "System cycle time."
 SnapshotInstruction.inst.__doc__ = "Snapshot instruction."
 
 
-ChartAxis = NamedTuple("ChartAxis", [("name", str), ("channels", List[pulse.channels.Channel])])
+class ChartAxis(NamedTuple):
+    name: str
+    channels: List[pulse.channels.Channel]
+
+
 ChartAxis.__doc__ = "Data to represent an axis information of chart."
 ChartAxis.name.__doc__ = "Name of chart."
 ChartAxis.channels.__doc__ = "Channels associated with chart."
 
 
-ParsedInstruction = NamedTuple(
-    "ParsedInstruction", [("xvals", np.ndarray), ("yvals", np.ndarray), ("meta", Dict[str, Any])]
-)
+class ParsedInstruction(NamedTuple):
+    xvals: np.ndarray
+    yvals: np.ndarray
+    meta: Dict[str, Any]
+
+
 ParsedInstruction.__doc__ = "Data to represent a parsed pulse instruction for object generation."
 ParsedInstruction.xvals.__doc__ = "Numpy array of x axis data."
 ParsedInstruction.yvals.__doc__ = "Numpy array of y axis data."
 ParsedInstruction.meta.__doc__ = "Dictionary containing instruction details."
 
 
-OpaqueShape = NamedTuple("OpaqueShape", [("duration", np.ndarray), ("meta", Dict[str, Any])])
+class OpaqueShape(NamedTuple):
+    duration: np.ndarray
+    meta: Dict[str, Any]
+
+
 OpaqueShape.__doc__ = "Data to represent a pulse instruction with parameterized shape."
 OpaqueShape.duration.__doc__ = "Duration of instruction."
 OpaqueShape.meta.__doc__ = "Dictionary containing instruction details."
 
 
-HorizontalAxis = NamedTuple(
-    "HorizontalAxis",
-    [
-        ("window", Tuple[int, int]),
-        ("axis_map", Dict[float, Union[float, str]]),
-        ("axis_break_pos", List[int]),
-        ("label", str),
-    ],
-)
+class HorizontalAxis(NamedTuple):
+    window: Tuple[int, int]
+    axis_map: Dict[float, Union[float, str]]
+    axis_break_pos: List[int]
+    label: str
+
+
 HorizontalAxis.__doc__ = "Data to represent configuration of horizontal axis."
 HorizontalAxis.window.__doc__ = "Left and right edge of graph."
 HorizontalAxis.axis_map.__doc__ = "Mapping of apparent coordinate system and actual location."

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -640,7 +640,7 @@ def lex_index(n, k, lst):
     if len(lst) != k:
         raise VisualizationError("list should have length k")
     comb = list(map(lambda x: n - 1 - x, lst))
-    dualm = sum([n_choose_k(comb[k - 1 - i], i + 1) for i in range(k)])
+    dualm = sum(n_choose_k(comb[k - 1 - i], i + 1) for i in range(k))
     return int(dualm)
 
 

--- a/qiskit/visualization/text.py
+++ b/qiskit/visualization/text.py
@@ -263,8 +263,8 @@ class BoxOnQuWireTop(MultiBox, BoxOnQuWire):
         self.left_fill = len(self.wire_label)
         self.top_format = "┌─" + "s".center(self.left_fill + 1, "─") + "─┐"
         self.top_format = self.top_format.replace("s", "%s")
-        self.mid_format = "┤{} %s ├".format(self.wire_label)
-        self.bot_format = "│{} %s │".format(self.bot_pad * self.left_fill)
+        self.mid_format = f"┤{self.wire_label} %s ├"
+        self.bot_format = f"│{self.bot_pad * self.left_fill} %s │"
         self.top_connect = top_connect if top_connect else "─"
 
 
@@ -276,8 +276,8 @@ class BoxOnWireMid(MultiBox):
         self.top_pad = self.bot_pad = self.top_connect = self.bot_connect = " "
         self.wire_label = wire_label
         self.left_fill = len(self.wire_label)
-        self.top_format = "│{} %s │".format(self.top_pad * self.left_fill)
-        self.bot_format = "│{} %s │".format(self.bot_pad * self.left_fill)
+        self.top_format = f"│{self.top_pad * self.left_fill} %s │"
+        self.bot_format = f"│{self.bot_pad * self.left_fill} %s │"
         self.top_connect = self.bot_connect = self.mid_content = ""
         self.center_label(input_length, order)
 
@@ -288,9 +288,9 @@ class BoxOnQuWireMid(BoxOnWireMid, BoxOnQuWire):
     def __init__(self, label, input_length, order, wire_label="", control_label=None):
         super().__init__(label, input_length, order, wire_label=wire_label)
         if control_label:
-            self.mid_format = "{}{} %s ├".format(control_label, self.wire_label)
+            self.mid_format = f"{control_label}{self.wire_label} %s ├"
         else:
-            self.mid_format = "┤{} %s ├".format(self.wire_label)
+            self.mid_format = f"┤{self.wire_label} %s ├"
 
 
 class BoxOnQuWireBot(MultiBox, BoxOnQuWire):
@@ -301,8 +301,8 @@ class BoxOnQuWireBot(MultiBox, BoxOnQuWire):
         self.wire_label = wire_label
         self.top_pad = " "
         self.left_fill = len(self.wire_label)
-        self.top_format = "│{} %s │".format(self.top_pad * self.left_fill)
-        self.mid_format = "┤{} %s ├".format(self.wire_label)
+        self.top_format = f"│{self.top_pad * self.left_fill} %s │"
+        self.mid_format = f"┤{self.wire_label} %s ├"
         self.bot_format = "└─" + "s".center(self.left_fill + 1, "─") + "─┘"
         self.bot_format = self.bot_format.replace("s", "%s")
         bot_connect = bot_connect if bot_connect else "─"
@@ -330,7 +330,7 @@ class BoxOnClWireMid(BoxOnWireMid, BoxOnClWire):
 
     def __init__(self, label, input_length, order, wire_label="", **_):
         super().__init__(label, input_length, order, wire_label=wire_label)
-        self.mid_format = "╡{} %s ╞".format(self.wire_label)
+        self.mid_format = f"╡{self.wire_label} %s ╞"
 
 
 class BoxOnClWireBot(MultiBox, BoxOnClWire):
@@ -342,8 +342,8 @@ class BoxOnClWireBot(MultiBox, BoxOnClWire):
         self.left_fill = len(self.wire_label)
         self.top_pad = " "
         self.bot_pad = "─"
-        self.top_format = "│{} %s │".format(self.top_pad * self.left_fill)
-        self.mid_format = "╡{} %s ╞".format(self.wire_label)
+        self.top_format = f"│{self.top_pad * self.left_fill} %s │"
+        self.mid_format = f"╡{self.wire_label} %s ╞"
         self.bot_format = "└─" + "s".center(self.left_fill + 1, "─") + "─┘"
         self.bot_format = self.bot_format.replace("s", "%s")
         bot_connect = bot_connect if bot_connect else "─"
@@ -520,7 +520,7 @@ class InputWire(DrawElement):
         Returns:
             list: The new layer
         """
-        longest = max([len(name) for name in names])
+        longest = max(len(name) for name in names)
         inputs_wires = []
         for name in names:
             inputs_wires.append(InputWire(name.rjust(longest)))
@@ -892,7 +892,7 @@ class TextDrawing:
 
         if params:
             if isinstance(instruction.op, DelayInstruction) and instruction.op.unit:
-                label += "(%s[%s])" % (params[0], instruction.op.unit)
+                label += f"({params[0]}[{instruction.op.unit}])"
             else:
                 label += "(%s)" % ",".join(params)
         return label
@@ -961,7 +961,7 @@ class TextDrawing:
             layer (list): A list of elements.
         """
         instructions = list(filter(lambda x: x is not None, layer))
-        longest = max([instruction.length for instruction in instructions])
+        longest = max(instruction.length for instruction in instructions)
         for instruction in instructions:
             instruction.layer_width = longest
 
@@ -985,13 +985,13 @@ class TextDrawing:
         num_ctrl_qubits = instruction.op.num_ctrl_qubits
         ctrl_qubits = instruction.qargs[:num_ctrl_qubits]
         args_qubits = instruction.qargs[num_ctrl_qubits:]
-        ctrl_state = "{:b}".format(instruction.op.ctrl_state).rjust(num_ctrl_qubits, "0")[::-1]
+        ctrl_state = f"{instruction.op.ctrl_state:b}".rjust(num_ctrl_qubits, "0")[::-1]
 
         in_box = list()
         top_box = list()
         bot_box = list()
 
-        qubit_index = sorted([i for i, x in enumerate(layer.qubits) if x in args_qubits])
+        qubit_index = sorted(i for i, x in enumerate(layer.qubits) if x in args_qubits)
 
         for ctrl_qubit in zip(ctrl_qubits, ctrl_state):
             if min(qubit_index) > layer.qubits.index(ctrl_qubit[0]):
@@ -1009,7 +1009,7 @@ class TextDrawing:
         gates = []
         num_ctrl_qubits = instruction.op.num_ctrl_qubits
         ctrl_qubits = instruction.qargs[:num_ctrl_qubits]
-        cstate = "{:b}".format(instruction.op.ctrl_state).rjust(num_ctrl_qubits, "0")[::-1]
+        cstate = f"{instruction.op.ctrl_state:b}".rjust(num_ctrl_qubits, "0")[::-1]
         for i in range(len(ctrl_qubits)):
             if cstate[i] == "1":
                 gates.append(Bullet(conditional=conditional, label=ctrl_label, bottom=bottom))
@@ -1116,7 +1116,7 @@ class TextDrawing:
                 gates.append(Bullet(conditional=conditional))
             elif base_gate.name in ["u1", "p"]:
                 # cu1
-                connection_label = "%s(%s)" % (
+                connection_label = "{}({})".format(
                     base_gate.name.upper(),
                     TextDrawing.params_for_label(instruction)[0],
                 )
@@ -1276,8 +1276,8 @@ class Layer:
         controlled_edge=None,
     ):
         if qubits is not None and clbits is not None:
-            cbit_index = sorted([i for i, x in enumerate(self.clbits) if x in clbits])
-            qbit_index = sorted([i for i, x in enumerate(self.qubits) if x in qubits])
+            cbit_index = sorted(i for i, x in enumerate(self.clbits) if x in clbits)
+            qbit_index = sorted(i for i, x in enumerate(self.qubits) if x in qubits)
 
             # Further below, indices are used as wire labels. Here, get the length of
             # the longest label, and pad all labels with spaces to this length.
@@ -1326,7 +1326,7 @@ class Layer:
             return cbit_index
         if qubits is None and clbits is not None:
             bits = list(clbits)
-            bit_index = sorted([i for i, x in enumerate(self.clbits) if x in bits])
+            bit_index = sorted(i for i, x in enumerate(self.clbits) if x in bits)
             wire_label_len = len(str(len(bits) - 1))
             bits.sort(key=self.clbits.index)
             qargs = [""] * len(bits)
@@ -1337,7 +1337,7 @@ class Layer:
             OnWireBot = BoxOnClWireBot
         elif clbits is None and qubits is not None:
             bits = list(qubits)
-            bit_index = sorted([i for i, x in enumerate(self.qubits) if x in bits])
+            bit_index = sorted(i for i, x in enumerate(self.qubits) if x in bits)
             wire_label_len = len(str(len(bits) - 1))
             qargs = [
                 str(bits.index(qbit)).ljust(wire_label_len, " ")

--- a/qiskit/visualization/timeline/core.py
+++ b/qiskit/visualization/timeline/core.py
@@ -117,8 +117,7 @@ class DrawerCanvas:
         When the horizontal coordinate contains `AbstractCoordinate`,
         the value is substituted by current time range preference.
         """
-        for name, data in self._output_dataset.items():
-            yield name, data
+        yield from self._output_dataset.items()
 
     @time_range.setter
     def time_range(self, new_range: Tuple[int, int]):
@@ -354,7 +353,7 @@ class DrawerCanvas:
                 return self.vmax
             if val == types.AbstractCoordinate.BOTTOM:
                 return self.vmin
-            raise VisualizationError("Coordinate {name} is not supported.".format(name=val))
+            raise VisualizationError(f"Coordinate {val} is not supported.")
 
         try:
             return np.asarray(vals, dtype=float)

--- a/qiskit/visualization/timeline/drawings.py
+++ b/qiskit/visualization/timeline/drawings.py
@@ -133,7 +133,7 @@ class ElementaryData(ABC):
         )
 
     def __repr__(self):
-        return "{}(type={}, key={})".format(self.__class__.__name__, self.data_type, self.data_key)
+        return f"{self.__class__.__name__}(type={self.data_type}, key={self.data_key})"
 
     def __eq__(self, other):
         return isinstance(other, self.__class__) and self.data_key == other.data_key

--- a/qiskit/visualization/timeline/generators.py
+++ b/qiskit/visualization/timeline/generators.py
@@ -227,37 +227,37 @@ def gen_full_gate_name(
         "ha": "center",
     }
     # find latex representation
-    default_name = r"{{\rm {name}}}".format(name=gate.operand.name)
+    default_name = fr"{{\rm {gate.operand.name}}}"
     latex_name = formatter["latex_symbol.gates"].get(gate.operand.name, default_name)
 
-    label_plain = "{name}".format(name=gate.operand.name)
-    label_latex = r"{name}".format(name=latex_name)
+    label_plain = f"{gate.operand.name}"
+    label_latex = fr"{latex_name}"
 
     # bit index
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         if len(gate.bits) > 1:
             bits_str = ", ".join(map(str, [bit.index for bit in gate.bits]))
-            label_plain += "[{bits}]".format(bits=bits_str)
-            label_latex += "[{bits}]".format(bits=bits_str)
+            label_plain += f"[{bits_str}]"
+            label_latex += f"[{bits_str}]"
 
     # parameter list
     params = []
     for val in gate.operand.params:
         try:
-            params.append("{val:.2f}".format(val=float(val)))
+            params.append(f"{float(val):.2f}")
         except ValueError:
-            params.append("{val}".format(val=val))
+            params.append(f"{val}")
     params_str = ", ".join(params)
 
     if params_str and gate.operand.name != "delay":
-        label_plain += "({params})".format(params=params_str)
-        label_latex += "({params})".format(params=params_str)
+        label_plain += f"({params_str})"
+        label_latex += f"({params_str})"
 
     # duration
     if gate.duration > 0:
-        label_plain += "[{dur}]".format(dur=gate.duration)
-        label_latex += "[{dur}]".format(dur=gate.duration)
+        label_plain += f"[{gate.duration}]"
+        label_latex += f"[{gate.duration}]"
 
     # assign special name to delay for filtering
     if gate.operand.name == "delay":
@@ -313,11 +313,11 @@ def gen_short_gate_name(
         "ha": "center",
     }
     # find latex representation
-    default_name = r"{{\rm {name}}}".format(name=gate.operand.name)
+    default_name = fr"{{\rm {gate.operand.name}}}"
     latex_name = formatter["latex_symbol.gates"].get(gate.operand.name, default_name)
 
-    label_plain = "{name}".format(name=gate.operand.name)
-    label_latex = "{name}".format(name=latex_name)
+    label_plain = f"{gate.operand.name}"
+    label_latex = f"{latex_name}"
 
     # assign special name for delay to filtering
     if gate.operand.name == "delay":
@@ -392,7 +392,7 @@ def gen_bit_name(bit: types.Bits, formatter: Dict[str, Any]) -> List[drawings.Te
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        label_plain = "{name}".format(name=bit.register.name)
+        label_plain = f"{bit.register.name}"
         label_latex = r"{{\rm {register}}}_{{{index}}}".format(
             register=bit.register.prefix, index=bit.index
         )

--- a/qiskit/visualization/timeline/interface.py
+++ b/qiskit/visualization/timeline/interface.py
@@ -404,7 +404,7 @@ def draw(
         plotter_api = MplPlotter(canvas=canvas, axis=axis)
         plotter_api.draw()
     else:
-        raise VisualizationError("Plotter API {name} is not supported.".format(name=plotter))
+        raise VisualizationError(f"Plotter API {plotter} is not supported.")
 
     # save figure
     if filename:

--- a/qiskit/visualization/timeline/layouts.py
+++ b/qiskit/visualization/timeline/layouts.py
@@ -79,7 +79,7 @@ def qreg_creg_ascending(bits: List[types.Bits]) -> List[types.Bits]:
         elif isinstance(bit, circuit.Clbit):
             cregs.append(bit)
         else:
-            VisualizationError("Unknown bit {bit} is provided.".format(bit=bit))
+            VisualizationError(f"Unknown bit {bit} is provided.")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -109,7 +109,7 @@ def qreg_creg_descending(bits: List[types.Bits]) -> List[types.Bits]:
         elif isinstance(bit, circuit.Clbit):
             cregs.append(bit)
         else:
-            VisualizationError("Unknown bit {bit} is provided.".format(bit=bit))
+            VisualizationError(f"Unknown bit {bit} is provided.")
 
     qregs = sorted(qregs, key=lambda x: x.index, reverse=True)
     cregs = sorted(cregs, key=lambda x: x.index, reverse=True)
@@ -138,7 +138,7 @@ def time_map_in_dt(time_window: Tuple[int, int]) -> types.HorizontalAxis:
     # consider time resolution
     label = "System cycle time (dt)"
 
-    formatted_label = ["{val:.0f}".format(val=val) for val in axis_label]
+    formatted_label = [f"{val:.0f}" for val in axis_label]
 
     return types.HorizontalAxis(
         window=(t0, t1), axis_map=dict(zip(axis_loc, formatted_label)), label=label

--- a/qiskit/visualization/timeline/plotters/matplotlib.py
+++ b/qiskit/visualization/timeline/plotters/matplotlib.py
@@ -119,7 +119,7 @@ class MplPlotter(BasePlotter):
             elif isinstance(data, drawings.TextData):
                 # text data
                 if data.latex is not None:
-                    s = r"${latex}$".format(latex=data.latex)
+                    s = fr"${data.latex}$"
                 else:
                     s = data.text
 

--- a/qiskit/visualization/timeline/stylesheet.py
+++ b/qiskit/visualization/timeline/stylesheet.py
@@ -59,7 +59,7 @@ class QiskitTimelineStyle(dict):
         for key, value in __m.items():
             if key in self._deprecated_keys:
                 warnings.warn(
-                    "%s is deprecated. Use %s instead." % (key, self._deprecated_keys[key]),
+                    f"{key} is deprecated. Use {self._deprecated_keys[key]} instead.",
                     DeprecationWarning,
                 )
                 self.__setitem__(self._deprecated_keys[key], value)

--- a/qiskit/visualization/transition_visualization.py
+++ b/qiskit/visualization/transition_visualization.py
@@ -72,10 +72,10 @@ class _Quaternion:
             return self._multiply_with_quaternion(b)
         elif isinstance(b, (list, tuple, np.ndarray)):
             if len(b) != 3:
-                raise Exception("Input vector has invalid length {}".format(len(b)))
+                raise Exception(f"Input vector has invalid length {len(b)}")
             return self._multiply_with_vector(b)
         else:
-            raise Exception("Multiplication with unknown type {}".format(type(b)))
+            raise Exception(f"Multiplication with unknown type {type(b)}")
 
     def _multiply_with_quaternion(self, q_2):
         """Multiplication of quaternion with quaternion"""
@@ -102,7 +102,7 @@ class _Quaternion:
 
     def __repr__(self):
         theta, v = self.get_axisangle()
-        return "(({}; {}, {}, {}))".format(theta, v[0], v[1], v[2])
+        return f"(({theta}; {v[0]}, {v[1]}, {v[2]}))"
 
     def get_axisangle(self):
         """Returns angle and vector of quaternion"""
@@ -228,7 +228,7 @@ def visualize_transition(circuit, trace=False, saveas=None, fpg=100, spg=2):
 
     for gate in circuit._data:
         if gate[0].name not in implemented_gates:
-            raise VisualizationError("Gate {} is not supported".format(gate[0].name))
+            raise VisualizationError(f"Gate {gate[0].name} is not supported")
         if gate[0].name in simple_gates:
             list_of_circuit_gates.append(gates[gate[0].name])
         else:

--- a/test/ipynb/results.py
+++ b/test/ipynb/results.py
@@ -125,7 +125,7 @@ class Results:
 
             if os.path.exists(os.path.join(SWD, fullpath_reference)):
                 ratio, diff_name = Results._similarity_ratio(fullpath_name, fullpath_reference)
-                title = "<tt><b>%s</b> | %s </tt> | ratio: %s" % (
+                title = "<tt><b>{}</b> | {} </tt> | ratio: {}".format(
                     name,
                     self.data[name]["testname"],
                     ratio,

--- a/test/python/algorithms/test_amplitude_estimators.py
+++ b/test/python/algorithms/test_amplitude_estimators.py
@@ -134,7 +134,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
         self._statevector.reset_execution_results()
         for key, value in expect.items():
             self.assertAlmostEqual(
-                value, getattr(result, key), places=3, msg="estimate `{}` failed".format(key)
+                value, getattr(result, key), places=3, msg=f"estimate `{key}` failed"
             )
 
     @idata(
@@ -166,7 +166,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
         result = qae.estimate(problem)
         for key, value in expect.items():
             self.assertAlmostEqual(
-                value, getattr(result, key), places=3, msg="estimate `{}` failed".format(key)
+                value, getattr(result, key), places=3, msg=f"estimate `{key}` failed"
             )
 
     @data(True, False)
@@ -357,7 +357,7 @@ class TestSineIntegral(QiskitAlgorithmsTestCase):
         self._statevector.reset_execution_results()
         for key, value in expect.items():
             self.assertAlmostEqual(
-                value, getattr(result, key), places=3, msg="estimate `{}` failed".format(key)
+                value, getattr(result, key), places=3, msg=f"estimate `{key}` failed"
             )
 
     @idata(
@@ -378,7 +378,7 @@ class TestSineIntegral(QiskitAlgorithmsTestCase):
         result = qae.estimate(estimation_problem)
         for key, value in expect.items():
             self.assertAlmostEqual(
-                value, getattr(result, key), places=3, msg="estimate `{}` failed".format(key)
+                value, getattr(result, key), places=3, msg=f"estimate `{key}` failed"
             )
 
     @idata(

--- a/test/python/algorithms/test_backendv1.py
+++ b/test/python/algorithms/test_backendv1.py
@@ -100,7 +100,7 @@ class TestBackendV1(QiskitAlgorithmsTestCase):
             from qiskit.ignis.mitigation.measurement import CompleteMeasFitter
             from qiskit.providers.aer import noise
         except ImportError as ex:
-            self.skipTest("Package doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Package doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         algorithm_globals.random_seed = 0

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -34,7 +34,7 @@ class TestMeasurementErrorMitigation(QiskitAlgorithmsTestCase):
             from qiskit import Aer
             from qiskit.providers.aer import noise
         except ImportError as ex:
-            self.skipTest("Package doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Package doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         algorithm_globals.random_seed = 0
@@ -87,7 +87,7 @@ class TestMeasurementErrorMitigation(QiskitAlgorithmsTestCase):
             from qiskit import Aer
             from qiskit.providers.aer import noise
         except ImportError as ex:
-            self.skipTest("Package doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Package doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         algorithm_globals.random_seed = 0

--- a/test/python/algorithms/test_phase_estimator.py
+++ b/test/python/algorithms/test_phase_estimator.py
@@ -136,7 +136,7 @@ class TestHamiltonianPhaseEstimation(QiskitAlgorithmsTestCase):
     def _setup_from_bound(self, evolution, op_class):
         hamiltonian = 0.5 * X + Y + Z
         state_preparation = None
-        bound = 1.2 * sum([abs(hamiltonian.coeff * coeff) for coeff in hamiltonian.coeffs])
+        bound = 1.2 * sum(abs(hamiltonian.coeff * coeff) for coeff in hamiltonian.coeffs)
         if op_class == "MatrixOp":
             hamiltonian = hamiltonian.to_matrix_op()
         backend = qiskit.BasicAer.get_backend("statevector_simulator")

--- a/test/python/algorithms/test_skip_qobj_validation.py
+++ b/test/python/algorithms/test_skip_qobj_validation.py
@@ -101,7 +101,7 @@ class TestSkipQobjValidation(QiskitAlgorithmsTestCase):
 
             self.backend = Aer.get_backend("qasm_simulator")
         except ImportError as ex:
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         probs_given0 = [0.9, 0.1]

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -210,7 +210,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.assertWarns(DeprecationWarning):
             optimal_vector = vqe.get_optimal_vector()
 
-        self.assertAlmostEqual(sum([v ** 2 for v in optimal_vector.values()]), 1.0, places=4)
+        self.assertAlmostEqual(sum(v ** 2 for v in optimal_vector.values()), 1.0, places=4)
 
     @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
     def test_with_aer_statevector(self):

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -207,7 +207,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
         )
 
         optimal_vector = vqe.get_optimal_vector()
-        self.assertAlmostEqual(sum([v ** 2 for v in optimal_vector.values()]), 1.0, places=4)
+        self.assertAlmostEqual(sum(v ** 2 for v in optimal_vector.values()), 1.0, places=4)
 
     @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
     def test_with_aer_statevector(self):
@@ -448,7 +448,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
         try:
             vqe.quantum_instance = BasicAer.get_backend("qasm_simulator")
         except Exception as ex:  # pylint: disable=broad-except
-            self.fail("Failed to change backend. Error: '{}'".format(str(ex)))
+            self.fail(f"Failed to change backend. Error: '{str(ex)}'")
             return
 
         result1 = vqe.compute_minimum_eigenvalue(operator=self.h2_op)

--- a/test/python/circuit/library/test_integer_comparator.py
+++ b/test/python/circuit/library/test_integer_comparator.py
@@ -40,7 +40,7 @@ class TestIntegerComparator(QiskitTestCase):
             if prob > 1e-6:
                 # equal superposition
                 self.assertEqual(True, np.isclose(1.0, prob * 2.0 ** num_state_qubits))
-                b_value = "{0:b}".format(i).rjust(qc.width(), "0")
+                b_value = f"{i:b}".rjust(qc.width(), "0")
                 x = int(b_value[(-num_state_qubits):], 2)
                 comp_result = int(b_value[-num_state_qubits - 1], 2)
                 if geq:

--- a/test/python/circuit/library/test_mcmt.py
+++ b/test/python/circuit/library/test_mcmt.py
@@ -140,7 +140,7 @@ class TestMCMT(QiskitTestCase):
                         h_tot = np.kron(h_tot, h_i)
                     vec_exp = np.dot(h_tot, vec_exp)
             else:
-                raise ValueError("Test not implement for gate: {}".format(cgate))
+                raise ValueError(f"Test not implement for gate: {cgate}")
 
             # append the remaining part of the state
             vec_exp = np.concatenate(

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -183,7 +183,7 @@ class TestNLocal(QiskitTestCase):
         for other in others:
             nlocal = NLocal(num_qubits, entanglement_blocks=first_circuit, reps=1)
             nlocal += other
-            with self.subTest(msg="type: {}".format(type(other))):
+            with self.subTest(msg=f"type: {type(other)}"):
                 self.assertCircuitEqual(nlocal, reference)
 
     def test_parameter_getter_from_automatic_repetition(self):
@@ -210,7 +210,7 @@ class TestNLocal(QiskitTestCase):
         nlocal = NLocal(2, entanglement_blocks=circuit, reps=reps)
         nlocal.assign_parameters(params, inplace=True)
 
-        param_set = set(p for p in params if isinstance(p, ParameterExpression))
+        param_set = {p for p in params if isinstance(p, ParameterExpression)}
         with self.subTest(msg="Test the parameters of the non-transpiled circuit"):
             # check the parameters of the final circuit
             self.assertEqual(nlocal.parameters, param_set)
@@ -233,7 +233,7 @@ class TestNLocal(QiskitTestCase):
         nlocal = NLocal(1, entanglement_blocks=circuit, reps=1)
         nlocal.assign_parameters(params, inplace=True)
 
-        param_set = set(p for p in params if isinstance(p, ParameterExpression))
+        param_set = {p for p in params if isinstance(p, ParameterExpression)}
         with self.subTest(msg="Test the parameters of the non-transpiled circuit"):
             # check the parameters of the final circuit
             self.assertEqual(nlocal.parameters, param_set)
@@ -285,7 +285,7 @@ class TestNLocal(QiskitTestCase):
                     skip_unentangled_qubits=True,
                 )
 
-                skipped_set = set(nlocal.qubits[i] for i in skipped)
+                skipped_set = {nlocal.qubits[i] for i in skipped}
                 dag = circuit_to_dag(nlocal)
                 idle = set(dag.idle_wires())
                 self.assertEqual(skipped_set, idle)
@@ -493,7 +493,7 @@ class TestTwoLocal(QiskitTestCase):
         """Test different possibilities to set parameters."""
         two = TwoLocal(3, rotation_blocks="rx", entanglement="cz", reps=2)
         params = [0, 1, 2, Parameter("x"), Parameter("y"), Parameter("z"), 6, 7, 0]
-        params_set = set(param for param in params if isinstance(param, Parameter))
+        params_set = {param for param in params if isinstance(param, Parameter)}
 
         with self.subTest(msg="dict assign and copy"):
             ordered = two.ordered_parameters

--- a/test/python/circuit/library/test_probability_distributions.py
+++ b/test/python/circuit/library/test_probability_distributions.py
@@ -58,13 +58,13 @@ class TestNormalDistribution(QiskitTestCase):
 
         # compute the points
         meshgrid = np.meshgrid(
-            *[
+            *(
                 np.linspace(bound[0], bound[1], num=2 ** num_qubits[i])
                 for i, bound in enumerate(bounds)
-            ],
+            ),
             indexing="ij",
         )
-        x = list(zip(*[grid.flatten() for grid in meshgrid]))
+        x = list(zip(*(grid.flatten() for grid in meshgrid)))
 
         # compute the normalized, truncated probabilities
         probabilities = multivariate_normal.pdf(x, mu, sigma)
@@ -163,13 +163,13 @@ class TestLogNormalDistribution(QiskitTestCase):
 
         # compute the points
         meshgrid = np.meshgrid(
-            *[
+            *(
                 np.linspace(bound[0], bound[1], num=2 ** num_qubits[i])
                 for i, bound in enumerate(bounds)
-            ],
+            ),
             indexing="ij",
         )
-        x = list(zip(*[grid.flatten() for grid in meshgrid]))
+        x = list(zip(*(grid.flatten() for grid in meshgrid)))
 
         # compute the normalized, truncated probabilities
         probabilities = []

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -424,7 +424,7 @@ class TestControlledGate(QiskitTestCase):
 
             base = PhaseGate(lam).to_matrix()
             expected = _compute_control_matrix(base, num_controls, ctrl_state=ctrl_state)
-            with self.subTest(msg="control state = {}".format(ctrl_state)):
+            with self.subTest(msg=f"control state = {ctrl_state}"):
                 self.assertTrue(matrix_equal(simulated, expected))
 
     @data(1, 2, 3, 4)
@@ -590,7 +590,7 @@ class TestControlledGate(QiskitTestCase):
                 rot_mat = U1Gate(theta).to_matrix()
 
             expected = _compute_control_matrix(rot_mat, num_controls, ctrl_state=ctrl_state)
-            with self.subTest(msg="control state = {}".format(ctrl_state)):
+            with self.subTest(msg=f"control state = {ctrl_state}"):
                 self.assertTrue(matrix_equal(simulated, expected))
 
     @combine(num_controls=[1, 2, 4], use_basis_gates=[True, False])
@@ -646,7 +646,7 @@ class TestControlledGate(QiskitTestCase):
 
             expected = _compute_control_matrix(rot_mat, num_controls, ctrl_state=ctrl_state)
 
-            with self.subTest(msg="control state = {}".format(ctrl_state)):
+            with self.subTest(msg=f"control state = {ctrl_state}"):
                 self.assertTrue(matrix_equal(simulated, expected))
 
     def test_mcry_defaults_to_vchain(self):
@@ -1290,7 +1290,7 @@ class TestControlledStandardGates(QiskitTestCase):
         gate = gate_class(*args)
 
         for ctrl_state in {ctrl_state_ones, ctrl_state_zeros, ctrl_state_mixed}:
-            with self.subTest(i="{}, ctrl_state={}".format(gate_class.__name__, ctrl_state)):
+            with self.subTest(i=f"{gate_class.__name__}, ctrl_state={ctrl_state}"):
                 if hasattr(gate, "num_ancilla_qubits") and gate.num_ancilla_qubits > 0:
                     # skip matrices that include ancilla qubits
                     continue

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -46,7 +46,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_deterministic_state(self):
@@ -62,7 +62,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_statevector(self):
@@ -87,7 +87,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_ghz_state(self):
@@ -103,7 +103,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_initialize_register(self):
@@ -120,7 +120,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_initialize_one_by_one(self):
@@ -143,7 +143,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_single_qubit(self):
@@ -159,7 +159,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_random_3qubit(self):
@@ -184,7 +184,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_random_4qubit(self):
@@ -217,7 +217,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_malformed_amplitudes(self):
@@ -305,7 +305,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_combiner(self):
@@ -327,7 +327,7 @@ class TestInitialize(QiskitTestCase):
         self.assertGreater(
             fidelity,
             self._desired_fidelity,
-            "Initializer has low fidelity {:.2g}.".format(fidelity),
+            f"Initializer has low fidelity {fidelity:.2g}.",
         )
 
     def test_equivalence(self):

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -199,7 +199,7 @@ class TestParameters(QiskitTestCase):
             [a, x[0], x[1], x[2], x[3], x[10], x[11], z]
 
         """
-        a, b, some_name, z = [Parameter(name) for name in ["a", "b", "some_name", "z"]]
+        a, b, some_name, z = (Parameter(name) for name in ["a", "b", "some_name", "z"])
         x = ParameterVector("x", 12)
         a_vector = ParameterVector("a_vector", 15)
 
@@ -607,7 +607,7 @@ class TestParameters(QiskitTestCase):
                 qobj = assemble(circs)
                 for index, theta_i in enumerate(theta_list):
                     res = float(qobj.experiments[index].instructions[0].params[0])
-                    self.assertTrue(math.isclose(res, theta_i), "%s != %s" % (res, theta_i))
+                    self.assertTrue(math.isclose(res, theta_i), f"{res} != {theta_i}")
 
     def test_circuit_composition(self):
         """Test preservation of parameters when combining circuits."""
@@ -715,7 +715,7 @@ class TestParameters(QiskitTestCase):
         paramvecs = []
         qc = QuantumCircuit(qubits)
         for i in range(depth):
-            theta_l = ParameterVector("θ{}".format(i + 1), length=len(ryrz.qubits) * 2)
+            theta_l = ParameterVector(f"θ{i + 1}", length=len(ryrz.qubits) * 2)
             ryrz_inst = ryrz.to_instruction(parameter_map={theta: theta_l})
             paramvecs += [theta_l]
             qc.append(ryrz_inst, qargs=qc.qubits)
@@ -759,7 +759,7 @@ class TestParameters(QiskitTestCase):
         cr = ClassicalRegister(3)
 
         circuit = QuantumCircuit(qr, cr)
-        parameters = [Parameter("x{}".format(i)) for i in range(num_processes)]
+        parameters = [Parameter(f"x{i}") for i in range(num_processes)]
 
         results = parallel_map(
             _construct_circuit, parameters, task_args=(qr,), num_processes=num_processes
@@ -1257,7 +1257,7 @@ class TestParameterExpressions(QiskitTestCase):
 
                 res = complex(bound_expr)
                 expected = op(2.3, const)
-                self.assertTrue(cmath.isclose(res, expected), "%s != %s" % (res, expected))
+                self.assertTrue(cmath.isclose(res, expected), f"{res} != {expected}")
 
     def test_complex_parameter_bound_to_real(self):
         """Test a complex parameter expression can be real if bound correctly."""

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -38,7 +38,7 @@ class TestUnitaryGate(QiskitTestCase):
             UnitaryGate([[0, 1], [1, 0]])
         # pylint: disable=broad-except
         except Exception as err:
-            self.fail("unexpected exception in init of Unitary: {}".format(err))
+            self.fail(f"unexpected exception in init of Unitary: {err}")
 
     def test_set_matrix_raises(self):
         """test non-unitary"""

--- a/test/python/classical_function_compiler/utils.py
+++ b/test/python/classical_function_compiler/utils.py
@@ -22,7 +22,7 @@ def get_truthtable_from_function(function):
     result = ""
     for decimal in range(2 ** amount_bit_input):
         entry = bin(decimal)[2:].rjust(amount_bit_input, "0")
-        result += str(int(function(*[i == "1" for i in entry[::-1]])))
+        result += str(int(function(*(i == "1" for i in entry[::-1]))))
     return result[::-1]
 
 

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -272,9 +272,9 @@ class TestCircuitAssembler(QiskitTestCase):
         qobj = assemble(qc)
         validate_qobj_against_schema(qobj)
 
-        first_measure, second_measure = [
+        first_measure, second_measure = (
             op for op in qobj.experiments[0].instructions if op.name == "measure"
-        ]
+        )
 
         self.assertTrue(hasattr(first_measure, "register"))
         self.assertEqual(first_measure.register, first_measure.memory)

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -63,7 +63,7 @@ def raise_if_dagcircuit_invalid(dag):
         elif node.type == "op":
             continue
         else:
-            raise DAGCircuitError("Found node of unexpected type: {}".format(node.type))
+            raise DAGCircuitError(f"Found node of unexpected type: {node.type}")
 
     # Shape of node.op should match shape of node.
     for node in dag.op_nodes():
@@ -120,7 +120,7 @@ def raise_if_dagcircuit_invalid(dag):
 
         all_bits = node_qubits | node_clbits | node_cond_bits
 
-        assert in_wires == all_bits, "In-edge wires {} != node bits {}".format(in_wires, all_bits)
+        assert in_wires == all_bits, f"In-edge wires {in_wires} != node bits {all_bits}"
         assert out_wires == all_bits, "Out-edge wires {} != node bits {}".format(
             out_wires, all_bits
         )

--- a/test/python/dagcircuit/test_dagdependency.py
+++ b/test/python/dagcircuit/test_dagdependency.py
@@ -45,7 +45,7 @@ def raise_if_dagdependency_invalid(dag):
     # Every node should be of type op.
     for node in dag.get_nodes():
         if node.type != "op":
-            raise DAGDependencyError("Found node of unexpected type: {}".format(node.type))
+            raise DAGDependencyError(f"Found node of unexpected type: {node.type}")
 
 
 class TestDagRegisters(QiskitTestCase):

--- a/test/python/opflow/test_abelian_grouper.py
+++ b/test/python/opflow/test_abelian_grouper.py
@@ -85,7 +85,7 @@ class TestAbelianGrouper(QiskitOpflowTestCase):
                 self.assertEqual(grouped_sum, expected)
             else:
                 self.assertSetEqual(
-                    frozenset([frozenset(grouped_sum[i].primitive.to_list()) for i in range(2)]),
+                    frozenset(frozenset(grouped_sum[i].primitive.to_list()) for i in range(2)),
                     frozenset({frozenset({("ZY", 3)}), frozenset({("IX", 1), ("XX", 2)})}),
                 )
 
@@ -99,7 +99,7 @@ class TestAbelianGrouper(QiskitOpflowTestCase):
                 self.assertEqual(grouped_sum, paulis)
             else:
                 self.assertSetEqual(
-                    frozenset(sum([grouped_sum[i].primitive.to_list() for i in range(3)], [])),
+                    frozenset(sum((grouped_sum[i].primitive.to_list() for i in range(3)), [])),
                     frozenset([("X", 1), ("Y", 2), ("Z", 3)]),
                 )
 

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -57,7 +57,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
             self.sampler = CircuitSampler(q_instance, attach_results=True)
             self.expect = AerPauliExpectation()
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
     def test_pauli_expect_pair(self):
@@ -185,7 +185,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
             actual_sampled = sut.convert(expect_op, params=param_bindings).eval()
             self.assertTrue(
                 np.allclose(actual_sampled, expect_sampled),
-                "%s != %s" % (actual_sampled, expect_sampled),
+                f"{actual_sampled} != {expect_sampled}",
             )
 
         def get_circuit_templates(sampler):

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -892,9 +892,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
         indented_str = op._indent(initial_str)
         starts_with_indent = indented_str.startswith(op.INDENTATION)
         self.assertTrue(starts_with_indent)
-        indented_str_content = (indented_str[len(op.INDENTATION) :]).split(
-            "\n{}".format(op.INDENTATION)
-        )
+        indented_str_content = (indented_str[len(op.INDENTATION) :]).split(f"\n{op.INDENTATION}")
         self.assertListEqual(indented_str_content, initial_str.split("\n"))
 
     def test_composed_op_immutable_under_eval(self):
@@ -920,7 +918,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
         l = Parameter("λ")
         op = PrimitiveOp(qc, coeff=l)
 
-        params = set([phi, l, *theta.params])
+        params = {phi, l, *theta.params}
 
         self.assertEqual(params, op.parameters)
         self.assertEqual(params, StateFn(op).parameters)

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -67,7 +67,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
         with self.subTest("zero coeff in SummedOp"):
             op = 0 * (I + Z)
@@ -92,7 +92,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
         backend = Aer.get_backend("aer_simulator")
         q_instance = QuantumInstance(backend)  # no seeds needed since no values are compared
@@ -105,7 +105,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
         x, y = Parameter("x"), Parameter("y")
 
@@ -140,7 +140,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         x = Parameter("x")
@@ -160,7 +160,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
 
         x = Parameter("x")
@@ -210,7 +210,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         try:
             from qiskit.providers.aer import AerSimulator
         except Exception as ex:  # pylint: disable=broad-except
-            self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
+            self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
 
         backend = AerSimulator(shots=10)
         sampler = CircuitSampler(backend)

--- a/test/python/providers/test_faulty_backend.py
+++ b/test/python/providers/test_faulty_backend.py
@@ -47,7 +47,7 @@ class FaultyGate13BackendTestCase(QiskitTestCase):
         gates = self.backend.properties().faulty_gates()
         self.assertEqual(len(gates), 2)
         self.assertEqual([gate.gate for gate in gates], ["cx", "cx"])
-        self.assertEqual(sorted([gate.qubits for gate in gates]), [[1, 3], [3, 1]])
+        self.assertEqual(sorted(gate.qubits for gate in gates), [[1, 3], [3, 1]])
 
 
 class FaultyGate01BackendTestCase(QiskitTestCase):
@@ -66,4 +66,4 @@ class FaultyGate01BackendTestCase(QiskitTestCase):
         gates = self.backend.properties().faulty_gates()
         self.assertEqual(len(gates), 2)
         self.assertEqual([gate.gate for gate in gates], ["cx", "cx"])
-        self.assertEqual(sorted([gate.qubits for gate in gates]), [[0, 1], [1, 0]])
+        self.assertEqual(sorted(gate.qubits for gate in gates), [[0, 1], [1, 0]])

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -243,7 +243,7 @@ class TestScheduleBuilding(BaseTestSchedule):
         sched = sched.append(Play(lp0, self.config.drive(0)))  # child
         sched = sched.append(subsched)
 
-        start_times = sorted([shft + instr.start_time for shft, instr in sched.instructions])
+        start_times = sorted(shft + instr.start_time for shft, instr in sched.instructions)
         self.assertEqual([0, 30, 40], start_times)
 
     def test_shift_schedule(self):
@@ -260,7 +260,7 @@ class TestScheduleBuilding(BaseTestSchedule):
 
         shift = sched.shift(100)
 
-        start_times = sorted([shft + instr.start_time for shft, instr in shift.instructions])
+        start_times = sorted(shft + instr.start_time for shft, instr in shift.instructions)
 
         self.assertEqual([100, 130, 140], start_times)
 

--- a/test/python/qobj/test_pulse_converter.py
+++ b/test/python/qobj/test_pulse_converter.py
@@ -220,7 +220,7 @@ class TestQobjToInstructionConverter(QiskitTestCase):
         """Test converted qobj from ParametricInstruction without label."""
         base_str = "gaussian_[('amp', (-0.5+0.2j)), ('duration', 25), ('sigma', 15)]"
         short_pulse_id = hashlib.md5(base_str.encode("utf-8")).hexdigest()[:4]
-        pulse_name = "gaussian_{}".format(short_pulse_id)
+        pulse_name = f"gaussian_{short_pulse_id}"
 
         qobj = PulseQobjInstruction(
             name="parametric_pulse",

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -333,7 +333,7 @@ class TestCliffordGates(QiskitTestCase):
 
         for gate_name in ("cx", "cz", "swap"):
             for qubits in ([0, 1], [1, 0]):
-                with self.subTest(msg="append gate %s %s" % (gate_name, qubits)):
+                with self.subTest(msg=f"append gate {gate_name} {qubits}"):
                     cliff = Clifford(np.eye(4))
                     cliff1 = cliff.copy()
                     cliff = _append_circuit(cliff, gate_name, qubits)
@@ -428,7 +428,7 @@ class TestCliffordSynthesis(QiskitTestCase):
     def test_decompose_1q(self):
         """Test synthesis for all 1-qubit Cliffords"""
         for cliff in self._cliffords_1q():
-            with self.subTest(msg="Test circuit {}".format(cliff)):
+            with self.subTest(msg=f"Test circuit {cliff}"):
                 target = cliff
                 value = Clifford(cliff.to_circuit())
                 self.assertEqual(target, value)

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -144,7 +144,7 @@ class TestPauliProperties(QiskitTestCase):
         target = _phase_from_label(coeff)
         self.assertEqual(pauli.phase, target)
 
-    @data(*[(p, q) for p in ["I", "X", "Y", "Z"] for q in range(4)])
+    @data(*((p, q) for p in ["I", "X", "Y", "Z"] for q in range(4)))
     @unpack
     def test_phase_setter(self, pauli, phase):
         """Test phase setter"""
@@ -167,10 +167,10 @@ class TestPauliProperties(QiskitTestCase):
         self.assertEqual(pauli, Pauli("ZZ"))
 
     @data(
-        *[
+        *(
             ("IXYZ", i)
             for i in [0, 1, 2, 3, slice(None, None, None), slice(None, 2, None), [0, 3], [2, 1, 3]]
-        ]
+        )
     )
     @unpack
     def test_getitem(self, label, qubits):
@@ -179,7 +179,7 @@ class TestPauliProperties(QiskitTestCase):
         value = str(pauli[qubits])
         val_array = np.array(list(reversed(label)))[qubits]
         target = "".join(reversed(val_array.tolist()))
-        self.assertEqual(value, target, msg="indices = {}".format(qubits))
+        self.assertEqual(value, target, msg=f"indices = {qubits}")
 
     @data(
         (0, "iY", "iIIY"),

--- a/test/python/quantum_info/operators/symplectic/test_pauli_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_table.py
@@ -36,7 +36,7 @@ def pauli_mat(label):
         elif i == "Z":
             mat = np.kron(mat, np.array([[1, 0], [0, -1]], dtype=complex))
         else:
-            raise QiskitError("Invalid Pauli string {}".format(i))
+            raise QiskitError(f"Invalid Pauli string {i}")
     return mat
 
 
@@ -1055,19 +1055,19 @@ class TestPauliTableMethods(QiskitTestCase):
             target0 = PauliTable.from_labels([j * "I", j * "X"])
             target1 = PauliTable.from_labels([j * "X", j * "I"])
 
-            with self.subTest(msg="single row from str ({})".format(j)):
+            with self.subTest(msg=f"single row from str ({j})"):
                 value0 = pauli.insert(0, j * "I")
                 self.assertEqual(value0, target0)
                 value1 = pauli.insert(1, j * "I")
                 self.assertEqual(value1, target1)
 
-            with self.subTest(msg="single row from PauliTable ({})".format(j)):
+            with self.subTest(msg=f"single row from PauliTable ({j})"):
                 value0 = pauli.insert(0, PauliTable(j * "I"))
                 self.assertEqual(value0, target0)
                 value1 = pauli.insert(1, PauliTable(j * "I"))
                 self.assertEqual(value1, target1)
 
-            with self.subTest(msg="single row from array ({})".format(j)):
+            with self.subTest(msg=f"single row from array ({j})"):
                 value0 = pauli.insert(0, PauliTable(j * "I").array)
                 self.assertEqual(value0, target0)
                 value1 = pauli.insert(1, PauliTable(j * "I").array)
@@ -1080,13 +1080,13 @@ class TestPauliTableMethods(QiskitTestCase):
             target0 = insert + pauli
             target1 = pauli + insert
 
-            with self.subTest(msg="multiple-rows from PauliTable ({})".format(j)):
+            with self.subTest(msg=f"multiple-rows from PauliTable ({j})"):
                 value0 = pauli.insert(0, insert)
                 self.assertEqual(value0, target0)
                 value1 = pauli.insert(1, insert)
                 self.assertEqual(value1, target1)
 
-            with self.subTest(msg="multiple-rows from array ({})".format(j)):
+            with self.subTest(msg=f"multiple-rows from array ({j})"):
                 value0 = pauli.insert(0, insert.array)
                 self.assertEqual(value0, target0)
                 value1 = pauli.insert(1, insert.array)

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -37,7 +37,7 @@ def pauli_mat(label):
         elif i == "Z":
             mat = np.kron(mat, np.array([[1, 0], [0, -1]], dtype=complex))
         else:
-            raise QiskitError("Invalid Pauli string {}".format(i))
+            raise QiskitError(f"Invalid Pauli string {i}")
     return mat
 
 

--- a/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
+++ b/test/python/quantum_info/operators/symplectic/test_stabilizer_table.py
@@ -39,7 +39,7 @@ def stab_mat(label):
         elif i == "Z":
             mat = np.kron(mat, np.array([[1, 0], [0, -1]]))
         else:
-            raise QiskitError("Invalid stabilizer string {}".format(i))
+            raise QiskitError(f"Invalid stabilizer string {i}")
     return mat
 
 
@@ -717,13 +717,13 @@ class TestStabilizerTableMethods(QiskitTestCase):
             target0 = StabilizerTable.from_labels([l_mi, l_px])
             target1 = StabilizerTable.from_labels([l_px, l_mi])
 
-            with self.subTest(msg="single row from str ({})".format(j)):
+            with self.subTest(msg=f"single row from str ({j})"):
                 value0 = stab.insert(0, l_mi)
                 self.assertEqual(value0, target0)
                 value1 = stab.insert(1, l_mi)
                 self.assertEqual(value1, target1)
 
-            with self.subTest(msg="single row from StabilizerTable ({})".format(j)):
+            with self.subTest(msg=f"single row from StabilizerTable ({j})"):
                 value0 = stab.insert(0, StabilizerTable(l_mi))
                 self.assertEqual(value0, target0)
                 value1 = stab.insert(1, StabilizerTable(l_mi))
@@ -736,7 +736,7 @@ class TestStabilizerTableMethods(QiskitTestCase):
             target0 = insert + stab
             target1 = stab + insert
 
-            with self.subTest(msg="multiple-rows from StabilizerTable ({})".format(j)):
+            with self.subTest(msg=f"multiple-rows from StabilizerTable ({j})"):
                 value0 = stab.insert(0, insert)
                 self.assertEqual(value0, target0)
                 value1 = stab.insert(1, insert)

--- a/test/python/quantum_info/operators/test_scalar_op.py
+++ b/test/python/quantum_info/operators/test_scalar_op.py
@@ -217,12 +217,12 @@ class TestScalarOpLinearMethods(ScalarOpTestCase):
         dims = (2, 2)
         iden = ScalarOp(4, coeff=coeff)
         op = Operator.from_label(label)
-        with self.subTest(msg="{} + Operator({})".format(iden, label)):
+        with self.subTest(msg=f"{iden} + Operator({label})"):
             val = iden + op
             target = coeff * Operator.from_label("II") + op
             self.assertOperator(val, dims, target)
 
-        with self.subTest(msg="Operator({}) + {}".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}) + {iden}"):
             val = op + iden
             target = coeff * Operator.from_label("II") + op
             self.assertOperator(val, dims, target)
@@ -233,12 +233,12 @@ class TestScalarOpLinearMethods(ScalarOpTestCase):
         dims = (2, 2)
         iden = ScalarOp(4, coeff=coeff)
         op = Operator.from_label(label)
-        with self.subTest(msg="{} - Operator({})".format(iden, label)):
+        with self.subTest(msg=f"{iden} - Operator({label})"):
             val = iden - op
             target = coeff * Operator.from_label("II") - op
             self.assertOperator(val, dims, target)
 
-        with self.subTest(msg="Operator({}) - {}".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}) - {iden}"):
             val = op - iden
             target = op - coeff * Operator.from_label("II")
             self.assertOperator(val, dims, target)
@@ -315,22 +315,22 @@ class TestScalarOpTensor(ScalarOpTestCase):
         iden = ScalarOp(dim, coeff=coeff)
         op = Operator.from_label(label)
 
-        with self.subTest(msg="{}.expand(Operator({}))".format(iden, label)):
+        with self.subTest(msg=f"{iden}.expand(Operator({label}))"):
             val = iden.expand(op)
             target = iden.to_operator().expand(op)
             self.assertOperator(val, (3, 2), target)
 
-        with self.subTest(msg="Operator({}).expand({})".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}).expand({iden})"):
             val = op.expand(iden)
             target = op.expand(iden.to_operator())
             self.assertOperator(val, (2, 3), target)
 
-        with self.subTest(msg="{}.tensor(Operator({}))".format(iden, label)):
+        with self.subTest(msg=f"{iden}.tensor(Operator({label}))"):
             val = iden.tensor(op)
             target = iden.to_operator().tensor(op)
             self.assertOperator(val, (2, 3), target)
 
-        with self.subTest(msg="Operator({}).tensor({})".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}).tensor({iden})"):
             val = op.tensor(iden)
             target = op.tensor(iden.to_operator())
             self.assertOperator(val, (3, 2), target)
@@ -390,17 +390,17 @@ class TestScalarOpCompose(ScalarOpTestCase):
         op2 = ScalarOp(2, coeff=coeff2)
         op3 = ScalarOp(3, coeff=coeff2)
 
-        with self.subTest(msg="{}.compose({}, qargs=[0])".format(op1, op2)):
+        with self.subTest(msg=f"{op1}.compose({op2}, qargs=[0])"):
             val = op1.compose(op2, qargs=[0])
             target = coeff1 * coeff2
             self.assertScalarOp(val, dims, target)
 
-        with self.subTest(msg="{}.compose({}, qargs=[1])".format(op1, op3)):
+        with self.subTest(msg=f"{op1}.compose({op3}, qargs=[1])"):
             val = op1.compose(op3, qargs=[1])
             target = coeff1 * coeff2
             self.assertScalarOp(val, dims, target)
 
-        with self.subTest(msg="{}.dot({}, qargs=[0])".format(op1, op2)):
+        with self.subTest(msg=f"{op1}.dot({op2}, qargs=[0])"):
             val = op1.dot(op2, qargs=[0])
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -408,7 +408,7 @@ class TestScalarOpCompose(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), dims)
             self.assertAlmostEqual(val.coeff, target)
 
-        with self.subTest(msg="{}.dot({}, qargs=[1])".format(op1, op3)):
+        with self.subTest(msg=f"{op1}.dot({op3}, qargs=[1])"):
             val = op1.dot(op3, qargs=[1])
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -416,7 +416,7 @@ class TestScalarOpCompose(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), dims)
             self.assertAlmostEqual(val.coeff, target)
 
-        with self.subTest(msg="{} & {}([0])".format(op1, op2)):
+        with self.subTest(msg=f"{op1} & {op2}([0])"):
             val = op1 & op2([0])
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -424,7 +424,7 @@ class TestScalarOpCompose(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), dims)
             self.assertAlmostEqual(val.coeff, target)
 
-        with self.subTest(msg="{} & {}([1])".format(op1, op3)):
+        with self.subTest(msg=f"{op1} & {op3}([1])"):
             val = op1 & op3([1])
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -432,7 +432,7 @@ class TestScalarOpCompose(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), dims)
             self.assertAlmostEqual(val.coeff, target)
 
-        with self.subTest(msg="{} * {}([0])".format(op1, op2)):
+        with self.subTest(msg=f"{op1} * {op2}([0])"):
             val = op1.dot(op2([0]))
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -440,7 +440,7 @@ class TestScalarOpCompose(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), dims)
             self.assertAlmostEqual(val.coeff, target)
 
-        with self.subTest(msg="{} * {}([1])".format(op1, op3)):
+        with self.subTest(msg=f"{op1} * {op3}([1])"):
             val = op1.dot(op3([1]))
             target = coeff1 * coeff2
             self.assertTrue(isinstance(val, ScalarOp))
@@ -460,7 +460,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
         iden = ScalarOp(dim, coeff=coeff)
         op = Operator.from_label(label)
 
-        with self.subTest(msg="{}.compose(Operator({}))".format(iden, label)):
+        with self.subTest(msg=f"{iden}.compose(Operator({label}))"):
             val = iden.compose(op)
             target = iden.to_operator().compose(op)
             self.assertTrue(isinstance(val, Operator))
@@ -468,7 +468,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="Operator({}).compose({})".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}).compose({iden})"):
             val = op.compose(iden)
             target = op.compose(iden.to_operator())
             self.assertTrue(isinstance(val, Operator))
@@ -476,7 +476,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{}.dot(Operator({}))".format(iden, label)):
+        with self.subTest(msg=f"{iden}.dot(Operator({label}))"):
             val = iden.dot(op)
             target = iden.to_operator().dot(op)
             self.assertTrue(isinstance(val, Operator))
@@ -484,7 +484,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="Operator({}).dot({})".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}).dot({iden})"):
             val = op.dot(iden)
             target = op.dot(iden.to_operator())
             self.assertTrue(isinstance(val, Operator))
@@ -492,7 +492,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} & Operator({})".format(iden, label)):
+        with self.subTest(msg=f"{iden} & Operator({label})"):
             val = iden & op
             target = iden.to_operator().compose(op)
             self.assertTrue(isinstance(val, Operator))
@@ -500,7 +500,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="Operator({}) & {}".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}) & {iden}"):
             val = op & iden
             target = op.compose(iden.to_operator())
             self.assertTrue(isinstance(val, Operator))
@@ -508,7 +508,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} * Operator({})".format(iden, label)):
+        with self.subTest(msg=f"{iden} * Operator({label})"):
             val = iden * op
             target = iden.to_operator().dot(op)
             self.assertTrue(isinstance(val, Operator))
@@ -516,7 +516,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="Operator({}) * {}".format(label, iden)):
+        with self.subTest(msg=f"Operator({label}) * {iden}"):
             val = op * iden
             target = op.dot(iden.to_operator())
             self.assertTrue(isinstance(val, Operator))
@@ -530,7 +530,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
         iden = ScalarOp((2, 2), coeff=coeff)
         op = Operator.from_label(label)
 
-        with self.subTest(msg="{}.compose(Operator({}), qargs=[0])".format(iden, label)):
+        with self.subTest(msg=f"{iden}.compose(Operator({label}), qargs=[0])"):
             val = iden.compose(op, qargs=[0])
             target = iden.to_operator().compose(op, qargs=[0])
             self.assertTrue(isinstance(val, Operator))
@@ -538,7 +538,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{}.compose(Operator({}), qargs=[1])".format(iden, label)):
+        with self.subTest(msg=f"{iden}.compose(Operator({label}), qargs=[1])"):
             val = iden.compose(op, qargs=[1])
             target = iden.to_operator().compose(op, qargs=[1])
             self.assertTrue(isinstance(val, Operator))
@@ -546,7 +546,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{}.dot(Operator({}), qargs=[0])".format(iden, label)):
+        with self.subTest(msg=f"{iden}.dot(Operator({label}), qargs=[0])"):
             val = iden.dot(op, qargs=[0])
             target = iden.to_operator().dot(op, qargs=[0])
             self.assertTrue(isinstance(val, Operator))
@@ -554,7 +554,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{}.dot(Operator({}), qargs=[1])".format(iden, label)):
+        with self.subTest(msg=f"{iden}.dot(Operator({label}), qargs=[1])"):
             val = iden.dot(op, qargs=[1])
             target = iden.to_operator().dot(op, qargs=[1])
             self.assertTrue(isinstance(val, Operator))
@@ -562,7 +562,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} & Operator({})([0])".format(iden, label)):
+        with self.subTest(msg=f"{iden} & Operator({label})([0])"):
             val = iden & op([0])
             target = iden.to_operator().compose(op, qargs=[0])
             self.assertTrue(isinstance(val, Operator))
@@ -570,7 +570,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} & Operator({})([1])".format(iden, label)):
+        with self.subTest(msg=f"{iden} & Operator({label})([1])"):
             val = iden & op([1])
             target = iden.to_operator().compose(op, qargs=[1])
             self.assertTrue(isinstance(val, Operator))
@@ -578,7 +578,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} * Operator({})([0])".format(iden, label)):
+        with self.subTest(msg=f"{iden} * Operator({label})([0])"):
             val = iden * op([0])
             target = iden.to_operator().dot(op, qargs=[0])
             self.assertTrue(isinstance(val, Operator))
@@ -586,7 +586,7 @@ class TestScalarOpComposeOperator(ScalarOpTestCase):
             self.assertEqual(val.output_dims(), (2, 2))
             self.assertEqual(val, target)
 
-        with self.subTest(msg="{} * Operator({})([1])".format(iden, label)):
+        with self.subTest(msg=f"{iden} * Operator({label})([1])"):
             val = iden * op([1])
             target = iden.to_operator().dot(op, qargs=[1])
             self.assertTrue(isinstance(val, Operator))

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -453,21 +453,21 @@ class TestDensityMatrix(QiskitTestCase):
         # 3-qubit qargs
         target = np.array([0.5, 0, 0, 0, 0, 0, 0, 0.5])
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 2-qubit qargs
         target = np.array([0.5, 0, 0, 0.5])
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 1-qubit qargs
         target = np.array([0.5, 0.5])
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
@@ -484,21 +484,21 @@ class TestDensityMatrix(QiskitTestCase):
         # 3-qubit qargs
         target = np.array([0, 1 / 3, 1 / 3, 0, 1 / 3, 0, 0, 0])
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 2-qubit qargs
         target = np.array([1 / 3, 1 / 3, 1 / 3, 0])
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 1-qubit qargs
         target = np.array([2 / 3, 1 / 3])
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
@@ -543,21 +543,21 @@ class TestDensityMatrix(QiskitTestCase):
         # 3-qubit qargs
         target = {"000": 0.5, "111": 0.5}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 2-qubit qargs
         target = {"00": 0.5, "11": 0.5}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 1-qubit qargs
         target = {"0": 0.5, "1": 0.5}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
@@ -575,21 +575,21 @@ class TestDensityMatrix(QiskitTestCase):
         target = np.array([0, 1 / 3, 1 / 3, 0, 1 / 3, 0, 0, 0])
         target = {"001": 1 / 3, "010": 1 / 3, "100": 1 / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 2-qubit qargs
         target = {"00": 1 / 3, "01": 1 / 3, "10": 1 / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 1-qubit qargs
         target = {"0": 2 / 3, "1": 1 / 3}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
@@ -607,7 +607,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"000": shots / 2, "111": shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -615,7 +615,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"00": shots / 2, "11": shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -623,7 +623,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"0": shots / 2, "1": shots / 2}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -644,7 +644,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"001": shots / 3, "010": shots / 3, "100": shots / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -652,7 +652,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"00": shots / 3, "01": shots / 3, "10": shots / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -660,7 +660,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"0": 2 * shots / 3, "1": shots / 3}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -690,7 +690,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"000": shots / 2, "111": shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -699,7 +699,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"00": shots / 2, "11": shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -708,7 +708,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"0": shots / 2, "1": shots / 2}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -729,7 +729,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"001": shots / 3, "010": shots / 3, "100": shots / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -738,7 +738,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"00": shots / 3, "01": shots / 3, "10": shots / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -747,7 +747,7 @@ class TestDensityMatrix(QiskitTestCase):
         target = {"0": 2 * shots / 3, "1": shots / 3}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -920,7 +920,7 @@ class TestDensityMatrix(QiskitTestCase):
             ("ZX", 0),
             ("YI", 0),
         ]:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = rho.expectation_value(op)
                 self.assertAlmostEqual(expval, target)
@@ -934,7 +934,7 @@ class TestDensityMatrix(QiskitTestCase):
             ("XYZ", 0),
             ("YIY", 0),
         ]:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = rho.expectation_value(op)
                 self.assertAlmostEqual(expval, target)

--- a/test/python/quantum_info/states/test_stabilizerstate.py
+++ b/test/python/quantum_info/states/test_stabilizerstate.py
@@ -252,7 +252,7 @@ class TestStabilizerState(QiskitTestCase):
 
         for _ in range(self.samples):
             for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-                with self.subTest(msg="reset (qargs={})".format(qargs)):
+                with self.subTest(msg=f"reset (qargs={qargs})"):
                     stab = StabilizerState(qc)
                     res = stab.reset(qargs)
                     value = res.measure()[0]
@@ -281,7 +281,7 @@ class TestStabilizerState(QiskitTestCase):
 
         for _ in range(self.samples):
             for qargs in [[0, 1], [1, 0]]:
-                with self.subTest(msg="reset (qargs={})".format(qargs)):
+                with self.subTest(msg=f"reset (qargs={qargs})"):
                     stab = StabilizerState(qc)
                     res = stab.reset(qargs)
                     value = res.measure()[0]
@@ -289,7 +289,7 @@ class TestStabilizerState(QiskitTestCase):
 
         for _ in range(self.samples):
             for qargs in [[0, 2], [2, 0]]:
-                with self.subTest(msg="reset (qargs={})".format(qargs)):
+                with self.subTest(msg=f"reset (qargs={qargs})"):
                     stab = StabilizerState(qc)
                     res = stab.reset(qargs)
                     value = res.measure()[0]
@@ -297,7 +297,7 @@ class TestStabilizerState(QiskitTestCase):
 
         for _ in range(self.samples):
             for qargs in [[1, 2], [2, 1]]:
-                with self.subTest(msg="reset (qargs={})".format(qargs)):
+                with self.subTest(msg=f"reset (qargs={qargs})"):
                     stab = StabilizerState(qc)
                     res = stab.reset(qargs)
                     value = res.measure()[0]
@@ -479,7 +479,7 @@ class TestStabilizerState(QiskitTestCase):
 
         # 3-qubit qargs
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = stab.probabilities_dict(qargs)
                 target = {"000": 0.5, "111": 0.5}
                 self.assertDictAlmostEqual(probs, target)
@@ -489,7 +489,7 @@ class TestStabilizerState(QiskitTestCase):
 
         # 2-qubit qargs
         for qargs in [[0, 1], [2, 1], [1, 0], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = stab.probabilities_dict(qargs)
                 target = {"00": 0.5, "11": 0.5}
                 self.assertDictAlmostEqual(probs, target)
@@ -499,7 +499,7 @@ class TestStabilizerState(QiskitTestCase):
 
         # 1-qubit qargs
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = stab.probabilities_dict(qargs)
                 target = {"0": 0.5, "1": 0.5}
                 self.assertDictAlmostEqual(probs, target)
@@ -534,7 +534,7 @@ class TestStabilizerState(QiskitTestCase):
         stab = StabilizerState(qc)
         pairs = [("Z", 1), ("X", 0), ("Y", 0), ("I", 1)]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -544,7 +544,7 @@ class TestStabilizerState(QiskitTestCase):
         stab = StabilizerState(qc)
         pairs = [("Z", -1), ("X", 0), ("Y", 0), ("I", 1)]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -554,7 +554,7 @@ class TestStabilizerState(QiskitTestCase):
         stab = StabilizerState(qc)
         pairs = [("Z", 0), ("X", 1), ("Y", 0), ("I", 1)]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -579,7 +579,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -601,7 +601,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -623,7 +623,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -645,7 +645,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -667,7 +667,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -690,7 +690,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -716,7 +716,7 @@ class TestStabilizerState(QiskitTestCase):
             ("YZ", 0),
         ]
         for label, target in pairs:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = stab.expectation_value(op)
                 self.assertEqual(expval, target)
@@ -786,11 +786,11 @@ class TestStabilizerState(QiskitTestCase):
         # 3-qubit qargs
         target = {"000": self.shots / 2, "111": self.shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))
@@ -798,11 +798,11 @@ class TestStabilizerState(QiskitTestCase):
         # 2-qubit qargs
         target = {"00": self.shots / 2, "11": self.shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 0]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))
@@ -810,11 +810,11 @@ class TestStabilizerState(QiskitTestCase):
         # 1-qubit qargs
         target = {"0": self.shots / 2, "1": self.shots / 2}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))
@@ -841,11 +841,11 @@ class TestStabilizerState(QiskitTestCase):
             "111": self.shots / 8,
         }
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))
@@ -858,11 +858,11 @@ class TestStabilizerState(QiskitTestCase):
             "11": self.shots / 4,
         }
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 0]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))
@@ -870,11 +870,11 @@ class TestStabilizerState(QiskitTestCase):
         # 1-qubit qargs
         target = {"0": self.shots / 2, "1": self.shots / 2}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = stab.sample_counts(self.shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, self.threshold)
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = stab.sample_memory(self.shots, qargs=qargs)
                 self.assertEqual(len(memory), self.shots)
                 self.assertEqual(set(memory), set(target))

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -409,7 +409,7 @@ class TestStatevector(QiskitTestCase):
             target = {}
             for i in range(11):
                 for j in range(2):
-                    key = "{},{}".format(i, j)
+                    key = f"{i},{j}"
                     target[key] = 2 * i + j + 1
             self.assertDictAlmostEqual(target, vec.to_dict())
 
@@ -453,21 +453,21 @@ class TestStatevector(QiskitTestCase):
         # 3-qubit qargs
         target = np.array([0.5, 0, 0, 0, 0, 0, 0, 0.5])
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 2-qubit qargs
         target = np.array([0.5, 0, 0, 0.5])
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 1-qubit qargs
         target = np.array([0.5, 0.5])
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
@@ -483,21 +483,21 @@ class TestStatevector(QiskitTestCase):
         # 3-qubit qargs
         target = np.array([0, 1 / 3, 1 / 3, 0, 1 / 3, 0, 0, 0])
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 2-qubit qargs
         target = np.array([1 / 3, 1 / 3, 1 / 3, 0])
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
         # 1-qubit qargs
         target = np.array([2 / 3, 1 / 3])
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities(qargs)
                 self.assertTrue(np.allclose(probs, target))
 
@@ -541,21 +541,21 @@ class TestStatevector(QiskitTestCase):
         # 3-qubit qargs
         target = {"000": 0.5, "111": 0.5}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 2-qubit qargs
         target = {"00": 0.5, "11": 0.5}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 1-qubit qargs
         target = {"0": 0.5, "1": 0.5}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
@@ -572,21 +572,21 @@ class TestStatevector(QiskitTestCase):
         target = np.array([0, 1 / 3, 1 / 3, 0, 1 / 3, 0, 0, 0])
         target = {"001": 1 / 3, "010": 1 / 3, "100": 1 / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 2-qubit qargs
         target = {"00": 1 / 3, "01": 1 / 3, "10": 1 / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
         # 1-qubit qargs
         target = {"0": 2 / 3, "1": 1 / 3}
         for qargs in [[0], [1], [2]]:
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 probs = state.probabilities_dict(qargs)
                 self.assertDictAlmostEqual(probs, target)
 
@@ -602,7 +602,7 @@ class TestStatevector(QiskitTestCase):
         target = {"000": shots / 2, "111": shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -610,7 +610,7 @@ class TestStatevector(QiskitTestCase):
         target = {"00": shots / 2, "11": shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -618,7 +618,7 @@ class TestStatevector(QiskitTestCase):
         target = {"0": shots / 2, "1": shots / 2}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="counts (qargs={})".format(qargs)):
+            with self.subTest(msg=f"counts (qargs={qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -636,7 +636,7 @@ class TestStatevector(QiskitTestCase):
         target = {"001": shots / 3, "010": shots / 3, "100": shots / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -644,7 +644,7 @@ class TestStatevector(QiskitTestCase):
         target = {"00": shots / 3, "01": shots / 3, "10": shots / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -652,7 +652,7 @@ class TestStatevector(QiskitTestCase):
         target = {"0": 2 * shots / 3, "1": shots / 3}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="P({})".format(qargs)):
+            with self.subTest(msg=f"P({qargs})"):
                 counts = state.sample_counts(shots, qargs=qargs)
                 self.assertDictAlmostEqual(counts, target, threshold)
 
@@ -680,7 +680,7 @@ class TestStatevector(QiskitTestCase):
         target = {"000": shots / 2, "111": shots / 2}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -689,7 +689,7 @@ class TestStatevector(QiskitTestCase):
         target = {"00": shots / 2, "11": shots / 2}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -698,7 +698,7 @@ class TestStatevector(QiskitTestCase):
         target = {"0": shots / 2, "1": shots / 2}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -716,7 +716,7 @@ class TestStatevector(QiskitTestCase):
         target = {"001": shots / 3, "010": shots / 3, "100": shots / 3}
         for qargs in [[0, 1, 2], [2, 1, 0], [1, 2, 0], [1, 0, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -725,7 +725,7 @@ class TestStatevector(QiskitTestCase):
         target = {"00": shots / 3, "01": shots / 3, "10": shots / 3}
         for qargs in [[0, 1], [2, 1], [1, 2], [1, 2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -734,7 +734,7 @@ class TestStatevector(QiskitTestCase):
         target = {"0": 2 * shots / 3, "1": shots / 3}
         for qargs in [[0], [1], [2]]:
 
-            with self.subTest(msg="memory (qargs={})".format(qargs)):
+            with self.subTest(msg=f"memory (qargs={qargs})"):
                 memory = state.sample_memory(shots, qargs=qargs)
                 self.assertEqual(len(memory), shots)
                 self.assertEqual(set(memory), set(target))
@@ -908,7 +908,7 @@ class TestStatevector(QiskitTestCase):
             ("ZX", 0),
             ("YI", 0),
         ]:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = psi.expectation_value(op)
                 self.assertAlmostEqual(expval, target)
@@ -921,7 +921,7 @@ class TestStatevector(QiskitTestCase):
             ("XYZ", 0),
             ("YIY", 0),
         ]:
-            with self.subTest(msg="<{}>".format(label)):
+            with self.subTest(msg=f"<{label}>"):
                 op = Pauli(label)
                 expval = psi.expectation_value(op)
                 self.assertAlmostEqual(expval, target)
@@ -1018,7 +1018,7 @@ class TestStatevector(QiskitTestCase):
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
 
-    @data(*[qargs for i in range(4) for qargs in permutations(range(4), r=i + 1)])
+    @data(*(qargs for i in range(4) for qargs in permutations(range(4), r=i + 1)))
     def test_probabilities_qargs(self, qargs):
         """Test probabilities method with qargs"""
         # Get initial state

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -127,7 +127,7 @@ class CheckDecompositions(QiskitTestCase):
             decomp_unitary = Operator(decomposer(target_unitary, simplify=simplify)).data
         maxdist = np.max(np.abs(target_unitary - decomp_unitary))
         self.assertTrue(
-            np.abs(maxdist) < tolerance, "Operator {}: Worst distance {}".format(operator, maxdist)
+            np.abs(maxdist) < tolerance, f"Operator {operator}: Worst distance {maxdist}"
         )
 
     @contextlib.contextmanager
@@ -237,7 +237,7 @@ class CheckDecompositions(QiskitTestCase):
         maxdist = np.max(np.abs(target_unitary - decomp_unitary))
         self.assertTrue(
             np.abs(maxdist) < tolerance,
-            "Unitary {}: Worst distance {}".format(target_unitary, maxdist),
+            f"Unitary {target_unitary}: Worst distance {maxdist}",
         )
 
 

--- a/test/python/test_examples.py
+++ b/test/python/test_examples.py
@@ -51,11 +51,11 @@ class TestPythonExamples(QiskitTestCase):
                     env={**os.environ, "PYTHONIOENCODING": "utf8"},
                 )
                 stdout, stderr = run_example.communicate()
-                error_string = "Running example %s failed with return code %s\n" % (
+                error_string = "Running example {} failed with return code {}\n".format(
                     example,
                     run_example.returncode,
                 )
-                error_string += "stdout:%s\nstderr: %s" % (stdout, stderr)
+                error_string += f"stdout:{stdout}\nstderr: {stderr}"
                 self.assertEqual(run_example.returncode, 0, error_string)
 
     @unittest.skipIf(
@@ -84,9 +84,9 @@ class TestPythonExamples(QiskitTestCase):
                     env={**os.environ, "PYTHONIOENCODING": "utf8"},
                 )
                 stdout, stderr = run_example.communicate()
-                error_string = "Running example %s failed with return code %s\n" % (
+                error_string = "Running example {} failed with return code {}\n".format(
                     example,
                     run_example.returncode,
                 )
-                error_string += "\tstdout:%s\n\tstderr: %s" % (stdout, stderr)
+                error_string += f"\tstdout:{stdout}\n\tstderr: {stderr}"
                 self.assertEqual(run_example.returncode, 0, error_string)

--- a/test/python/transpiler/test_commutation_analysis.py
+++ b/test/python/transpiler/test_commutation_analysis.py
@@ -40,7 +40,7 @@ class TestCommutationAnalysis(QiskitTestCase):
                 continue
             result_to_compare[qbit] = []
             for commutation_set in sets:
-                result_to_compare[qbit].append(sorted([node._node_id for node in commutation_set]))
+                result_to_compare[qbit].append(sorted(node._node_id for node in commutation_set))
 
         for qbit, sets in expected.items():
             for commutation_set in sets:

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -136,7 +136,7 @@ class CommonUtilitiesMixin:
 
     def assertResult(self, result, circuit):
         """Fetches the QASM in circuit.name file and compares it with result."""
-        qasm_name = "%s_%s.qasm" % (type(self).__name__, circuit.name)
+        qasm_name = f"{type(self).__name__}_{circuit.name}.qasm"
         qasm_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "qasm")
         filename = os.path.join(qasm_dir, qasm_name)
 

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -112,7 +112,7 @@ class TestPresetPassManager(QiskitTestCase):
         )
 
         dag = circuit_to_dag(result)
-        circuit_ops = set(node.name for node in dag.topological_op_nodes())
+        circuit_ops = {node.name for node in dag.topological_op_nodes()}
         self.assertEqual(circuit_ops.union(set(basis_gates)), set(basis_gates))
 
 

--- a/test/python/visualization/pulse_v2/test_core.py
+++ b/test/python/visualization/pulse_v2/test_core.py
@@ -337,8 +337,7 @@ class TestDrawCanvas(QiskitTestCase):
         names = ["D0", "D1"]
         chans = [[pulse.DriveChannel(0)], [pulse.DriveChannel(1)]]
 
-        for name, chan in zip(names, chans):
-            yield name, chan
+        yield from zip(names, chans)
 
     def generate_dummy_obj(self, data: types.PulseInstruction, **kwargs):
         dummy_obj = drawings.ElementaryData(

--- a/test/python/visualization/pulse_v2/test_generators.py
+++ b/test/python/visualization/pulse_v2/test_generators.py
@@ -495,7 +495,7 @@ class TestChartGenerators(QiskitTestCase):
 
         # data check
         self.assertListEqual(obj.channels, [pulse.DriveChannel(0)])
-        self.assertEqual(obj.text, "x{scale}".format(scale=types.DynamicString.SCALE))
+        self.assertEqual(obj.text, f"x{types.DynamicString.SCALE}")
 
         # style check
         ref_style = {

--- a/test/python/visualization/visualization.py
+++ b/test/python/visualization/visualization.py
@@ -71,8 +71,8 @@ class QiskitVisualizationTestCase(QiskitTestCase):
         similarity_ratio = black_pixels / total_pixels
         self.assertTrue(
             1 - similarity_ratio < diff_tolerance,
-            "The images are different by {}%".format((1 - similarity_ratio) * 100)
-            + " which is more than the allowed {}%".format(diff_tolerance * 100),
+            f"The images are different by {(1 - similarity_ratio) * 100}%"
+            f" which is more than the allowed {diff_tolerance * 100}%",
         )
 
 

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -247,9 +247,7 @@ class QCircuitMachine(RuleBasedStateMachine):
 
         """
 
-        print(
-            "Evaluating circuit at level {} on {}:\n{}".format(opt_level, backend, self.qc.qasm())
-        )
+        print(f"Evaluating circuit at level {opt_level} on {backend}:\n{self.qc.qasm()}")
 
         assume(backend is None or backend.configuration().n_qubits >= len(self.qc.qubits))
 

--- a/tools/find_optional_imports.py
+++ b/tools/find_optional_imports.py
@@ -63,7 +63,7 @@ def main():
             matched_module = module_name
         if indent > 0:
             if line_indent < indent:
-                print("ERROR: %s is imported via %s" % (matched_module, module_name))
+                print(f"ERROR: {matched_module} is imported via {module_name}")
                 indent = -1
                 matched_module = None
 

--- a/tools/report_ci_failure.py
+++ b/tools/report_ci_failure.py
@@ -68,7 +68,7 @@ class CIFailureReporter:
             return ""
 
     def _get_report_issue_number(self, key_label):
-        query = 'state:open label:"{}" repo:{}'.format(key_label, self._repo)
+        query = f'state:open label:"{key_label}" repo:{self._repo}'
         results = self._api.search_issues(query=query)
         try:
             return results[0].number
@@ -80,7 +80,7 @@ class CIFailureReporter:
         report_exists = self._check_report_existence(issue_number, stamp)
         if not report_exists:
             _, body = _branch_is_failing_template(branch, commit, infourl)
-            message_body = "{}\n{}".format(stamp, body)
+            message_body = f"{stamp}\n{body}"
             self._post_new_comment(issue_number, message_body)
 
     def _check_report_existence(self, issue_number, target):
@@ -99,7 +99,7 @@ class CIFailureReporter:
         repo = self._api.get_repo(self._repo)
         stamp = _branch_is_failing_stamp(branch, commit)
         title, body = _branch_is_failing_template(branch, commit, infourl)
-        message_body = "{}\n{}".format(stamp, body)
+        message_body = f"{stamp}\n{body}"
         repo.create_issue(title=title, body=message_body, labels=[key_label])
 
     def _post_new_comment(self, issue_number, body):
@@ -109,15 +109,15 @@ class CIFailureReporter:
 
 
 def _branch_is_failing_template(branch, commit, infourl):
-    title = "Branch `{}` is failing".format(branch)
-    body = "Trying to build `{}` at commit {} failed.".format(branch, commit)
+    title = f"Branch `{branch}` is failing"
+    body = f"Trying to build `{branch}` at commit {commit} failed."
     if infourl:
-        body += "\nMore info at: {}".format(infourl)
+        body += f"\nMore info at: {infourl}"
     return title, body
 
 
 def _branch_is_failing_stamp(branch, commit):
-    return "<!-- commit {}@{} -->".format(commit, branch)
+    return f"<!-- commit {commit}@{branch} -->"
 
 
 _REPOSITORY = "Qiskit/qiskit-terra"
@@ -143,11 +143,11 @@ def _get_job_name():
 def _get_info_url():
     if os.getenv("TRAVIS"):
         job_id = os.getenv("TRAVIS_JOB_ID")
-        return "https://travis-ci.com/{}/jobs/{}".format(_REPOSITORY, job_id)
+        return f"https://travis-ci.com/{_REPOSITORY}/jobs/{job_id}"
 
     if os.getenv("APPVEYOR"):
         build_id = os.getenv("APPVEYOR_BUILD_ID")
-        return "https://ci.appveyor.com/project/{}/build/{}".format(_REPOSITORY, build_id)
+        return f"https://ci.appveyor.com/project/{_REPOSITORY}/build/{build_id}"
 
     return None
 


### PR DESCRIPTION
I used pyupgrade to upgrade the codebase to take advantage of python 3.6 features. The vast majority of changes are to use f-strings. Pyupgrade is fairly conservative and only switches to f-strings in cases where it thinks it won't make the expression more complicated, and it seems to do a good job, but I did take a manual pass and tweak quite a few spots.

There are still remaining places that use % substitution or .format() since they were too involved for pyupgrade to mess with them, and it might be go through by hand at some point and simplify those also.