### PR TITLE
Add linux arm64 release wheel jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,3 +65,20 @@ jobs:
       - python setup.py build_ext --inplace
       - pip install "qiskit-aer"
       - make test_randomized
+
+    - name: Build aarch64 wheels
+      arch: arm64
+      services:
+        - docker
+      install:
+        - echo ""
+      env:
+        - CIBW_BEFORE_BUILD="pip install -U Cython"
+        - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
+        - TWINE_USERNAME=qiskit
+        - CIBW_TEST_COMMAND="python {project}/examples/python/stochastic_swap.py"
+      if: tag IS present
+      script:
+        - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
+        - cibuildwheel --output-dir wheelhouse
+        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ jobs:
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/examples/python/stochastic_swap.py"
-      if: tag IS present
+#      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-        - twine upload wheelhouse/*
+#        - twine upload wheelhouse/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,8 +77,8 @@ jobs:
         - CIBW_SKIP="cp27-* cp34-* cp35-* pp*"
         - TWINE_USERNAME=qiskit
         - CIBW_TEST_COMMAND="python {project}/examples/python/stochastic_swap.py"
-#      if: tag IS present
+      if: tag IS present
       script:
         - pip install -U twine importlib-metadata keyring cibuildwheel==1.9.0
         - cibuildwheel --output-dir wheelhouse
-#        - twine upload wheelhouse/*
+        - twine upload wheelhouse/*


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new CI job to publish precompiled binary wheels for
linux on aarch64 (arm64). Since the latest numpy and scipy releases now
publish wheels for aarch64 we can run CI jobs to do the same since we
won't be spending all our CI time budget compiling upstream dependencies
from source anymore. This enables users running on linux aarch64 systems
to install qiskit without having to compile everything from source
anymore.

### Details and comments