### PR TITLE
[WIP] Add github actions jobs to build ppc64le and s390x wheels

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,7 @@ jobs:
           CIBW_BEFORE_BUILD: pip install -U Cython
           CIBW_SKIP: cp27-* cp34-* cp35-* pp*
           CIBW_TEST_COMMAND: python {project}/examples/python/stochastic_swap.py
-          CIBW_BEFORE_ALL: yum install -y openblas-devel lapack-devel gcc-gfortran
-
+          CIBW_BEFORE_ALL: "yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm && yum install -y openblas-devel lapack-devel gcc-gfortran"
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on non-x86
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.9.0
+        env:
+          CIBW_ARCHS_LINUX: ppc64le s390x
+          CIBW_BEFORE_BUILD: pip install -U Cython
+          CIBW_SKIP: cp27-* cp34-* cp35-* pp*
+          CIBW_TEST_COMMAND: python {project}/examples/python/stochastic_swap.py
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheels on non-x86
+    name: Build wheels on ppc64le
     runs-on: ubuntu-20.04
 
     steps:
@@ -24,10 +24,41 @@ jobs:
       - name: Build wheels
         uses: joerick/cibuildwheel@v1.9.0
         env:
-          CIBW_ARCHS_LINUX: ppc64le s390x
+          CIBW_ARCHS_LINUX: ppc64le
           CIBW_BEFORE_BUILD: pip install -U Cython
           CIBW_SKIP: cp27-* cp34-* cp35-* pp*
           CIBW_TEST_COMMAND: python {project}/examples/python/stochastic_swap.py
+          CIBW_BEFORE_ALL: yum install -y openblas-devel lapack-devel gcc-gfortran
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+  build_wheels_s390x:
+    name: Build wheels on s390x
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v1.9.0
+        env:
+          CIBW_ARCHS_LINUX: s390x
+          CIBW_BEFORE_BUILD: pip install -U Cython
+          CIBW_SKIP: cp27-* cp34-* cp35-* pp*
+          CIBW_TEST_COMMAND: python {project}/examples/python/stochastic_swap.py
+          CIBW_BEFORE_ALL: yum install -y openblas-devel lapack-devel gcc-gfortran
 
       - uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new job to build precompiled binaries on s390x and
ppc64le. These platforms do not have precompiled wheels for any upstream
dependencies (except for retworkx, which publishes binaries on them).
Since building wheels for terra and all its upstream dependencies to test
that everything worked will take some time, we do not have the time
budget in travis which is the only CI service that provides nodes with
these platforms. However, github actions provides a 6 hour job limit
which should be enough, even though it does not offer native ppc64le and
s390x jobs. To get around this issue, this commit relies on qemu
emulation which will likely be quite slow, but since this job will only
run at release time it's not a big deal since it won't block anything.

### Details and comments

TODO:

- [ ] Verify wheels built run on hardware
- [ ] Setup jobs to only run on tags
- [ ] Add twine uploading to pypi