### PR TITLE
Correct typo in docstring of ``IBMQWrapper``

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -95,7 +95,7 @@ class AerWrapper:
 
 
 class IBMQWrapper:
-    """Lazy loading wraooer for IBMQ provider."""
+    """Lazy loading wrapper for IBMQ provider."""
 
     def __init__(self):
         self.ibmq = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [n] I have added the tests to cover my changes.
- [y] I have updated the documentation accordingly.
- [y] I have read the CONTRIBUTING document.
-->

### Summary
There is a typo in the docstring fro class IBMQWrapper.


### Details and comments
Should read: "wrapper"
Reads: "wraooer"

