### PR TITLE
Ensure uniqueness of nodes in neighbors()

### DIFF
--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -121,7 +121,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
                     self.swap_reliabs[i][j] = self.cx_reliability[(j, i)]
                 else:
                     best_reliab = 0.0
-                    for n in self.swap_graph.neighbors(j):
+                    for n in set(self.swap_graph.neighbors(j)):
                         if (n, j) in self.cx_reliability:
                             reliab = math.exp(-swap_reliabs_ro[i][n])*self.cx_reliability[(n, j)]
                         else:
@@ -192,7 +192,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         """Select the best remaining hardware qubit for the next program qubit."""
         reliab_store = {}
         if prog_qubit not in self.prog_neighbors:
-            self.prog_neighbors[prog_qubit] = self.prog_graph.neighbors(prog_qubit)
+            self.prog_neighbors[prog_qubit] = set(self.prog_graph.neighbors(prog_qubit))
         for hw_qubit in self.available_hw_qubits:
             reliab = 1
             for n in self.prog_neighbors[prog_qubit]:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5530 

Changes in #5411, to use retworkx's neighbors() function, replaces the
returned dict with an iterator. In the dict version, neighbor node indices
are the keys and therefore, they are unique. In the iterator version, node
indices appear multiple times, once per edge in multigraphs.

This commit uses a Python set to preserve the semantics of the old version
ensuring the uniqueness of the nodes.

### Details and comments