### PR TITLE
Fix the endian bug in PauliSumOp

### DIFF
--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -291,8 +291,8 @@ class PauliSumOp(PrimitiveOp):
 
             if isinstance(front, DictStateFn):
                 new_dict = defaultdict(int)
-                corrected_x_bits = self.primitive.table.X
-                corrected_z_bits = self.primitive.table.Z
+                corrected_x_bits = self.primitive.table.X[::, ::-1]
+                corrected_z_bits = self.primitive.table.Z[::, ::-1]
                 coeffs = self.primitive.coeffs
                 for bstr, v in front.primitive.items():
                     bitstr = np.fromiter(bstr, dtype=int).astype(bool)

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -314,7 +314,7 @@ class TestQAOA(QiskitAlgorithmsTestCase):
         qaoa = QAOA(optimizer=NELDER_MEAD(disp=True), reps=1, quantum_instance=q_i)
         _ = qaoa.compute_minimum_eigenvalue(operator=qubit_op)
 
-        np.testing.assert_almost_equal([-0.237, 0.342], qaoa.optimal_params, decimal=3)
+        np.testing.assert_almost_equal([-0.879, 0.395], qaoa.optimal_params, decimal=3)
 
     def _get_operator(self, weight_matrix):
         """Generate Hamiltonian for the max-cut problem of a graph.

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -147,7 +147,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
         # TODO benchmark this later.
         result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
-        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=3)
+        self.assertAlmostEqual(result.eigenvalue.real, -1.86823, places=2)
 
     def test_qasm_aux_operators_normalized(self):
         """Test VQE with qasm_simulator returns normalized aux_operator eigenvalues."""

--- a/test/python/opflow/test_pauli_sum_op.py
+++ b/test/python/opflow/test_pauli_sum_op.py
@@ -13,11 +13,14 @@
 """ Test PauliSumOp """
 
 import unittest
+from itertools import product
 from test.python.opflow import QiskitOpflowTestCase
+
 import numpy as np
 from scipy.sparse import csr_matrix
 
 from qiskit import QuantumCircuit, transpile
+from qiskit.circuit import Parameter, ParameterVector
 from qiskit.opflow import (
     CX,
     CircuitStateFn,
@@ -33,8 +36,7 @@ from qiskit.opflow import (
     Z,
     Zero,
 )
-from qiskit.circuit import Parameter, ParameterVector
-from qiskit.quantum_info import Pauli, SparsePauliOp, PauliTable
+from qiskit.quantum_info import Pauli, PauliTable, SparsePauliOp
 
 
 class TestPauliSumOp(QiskitOpflowTestCase):
@@ -176,7 +178,7 @@ class TestPauliSumOp(QiskitOpflowTestCase):
         """ eval test """
         target0 = (2 * (X ^ Y ^ Z) + 3 * (X ^ X ^ Z)).eval("000")
         target1 = (2 * (X ^ Y ^ Z) + 3 * (X ^ X ^ Z)).eval(Zero ^ 3)
-        expected = DictStateFn({"011": (3 + 2j)})
+        expected = DictStateFn({"110": (3 + 2j)})
         self.assertEqual(target0, expected)
         self.assertEqual(target1, expected)
 
@@ -191,6 +193,12 @@ class TestPauliSumOp(QiskitOpflowTestCase):
         self.assertEqual((~OperatorStateFn(h2)@phi).eval(), 0.5)
         self.assertEqual((~OperatorStateFn(h2a)@phi).eval(), 0.25)
         self.assertEqual((~OperatorStateFn(h2b)@phi).eval(), 0.25)
+
+        pauli_op = (Z ^ I ^ X) + (I ^ I ^ Y)
+        mat_op = pauli_op.to_matrix_op()
+        full_basis = [''.join(b) for b in product('01', repeat=pauli_op.num_qubits)]
+        for bstr1, bstr2 in product(full_basis, full_basis):
+            self.assertEqual(pauli_op.eval(bstr1).eval(bstr2), mat_op.eval(bstr1).eval(bstr2))
 
     def test_exp_i(self):
         """ exp_i test """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I misunderstood about the endian in the PauliSumOp.
I think this endian is correct, but please double check it.

[test_vqe.py](https://github.com/Qiskit/qiskit-terra/compare/master...ikkoham:fix-paulisumop-eval?expand=1#diff-5d988c768c31118bf11473a07191e32dbb3a7dfde87f5631c7b34fb7d0e602d6R150) is the revert of the previous PR https://github.com/Qiskit/qiskit-terra/pull/5623.