### PR TITLE
Remove stray np.int usage

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -287,7 +287,7 @@ class Clifford(BaseOperator, AdjointMixin):
         phase = np.mod(array2.dot(phase1) + phase2, 2)
 
         # Correcting for phase due to Pauli multiplication
-        ifacts = np.zeros(2 * num_qubits, dtype=np.int)
+        ifacts = np.zeros(2 * num_qubits, dtype=int)
 
         for k in range(2 * num_qubits):
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5617 a single usage of np.int slipped in to the clifford module.
This type is deprecated in numpy 1.20.0 and is just an alias for
python's stdlib int type (see #5788 and #5758 for the earlier fixes).
This usage is causing downstream failures in other project's CI that
use this module in environment's where warnings aren't allowed (mainly
ignis's docs builds). This commit fixes this stray np.int usage to
unblock CI and remove the deprecation warning from anything using the
clifford module.

### Details and comments


