### PR TITLE
pin tweedledum version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ sphinx-autodoc-typehints
 jupyter-sphinx
 sphinx-panels
 pygments>=2.4
-tweedledum
+tweedledum==0.1b0
 networkx>=2.2
 scikit-learn>=0.20.0
 scikit-quant;platform_system != 'Windows'

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
         'visualization': ['matplotlib>=2.1', 'ipywidgets>=7.3.0',
                           'pydot', "pillow>=4.2.1", "pylatexenc>=1.4",
                           "seaborn>=0.9.0", "pygments>=2.4"],
-        'classical-function-compiler': ['tweedledum'],
+        'classical-function-compiler': ['tweedledum==0.1b0'],
         'full-featured-simulators': ['qiskit-aer>=0.1'],
         'crosstalk-pass': ['z3-solver>=4.7'],
     },


### PR DESCRIPTION
Tweedledum is highly unstable piece of software that might break backward compatibility, as in mentioned in https://github.com/Qiskit/qiskit-terra/issues/5852

Pinning tweedledum version fixes https://github.com/Qiskit/qiskit-terra/issues/5852