### PR TITLE
Fix more bugs in OverlapQFI on multi-parameter gates

### DIFF
--- a/qiskit/opflow/gradients/circuit_qfis/overlap_diag.py
+++ b/qiskit/opflow/gradients/circuit_qfis/overlap_diag.py
@@ -221,12 +221,14 @@ def _get_generators(params, circuit):
 
     for layer in layers:
         instr = layer['graph'].op_nodes()[0].op
-        if len(instr.params) == 0:
+        # if no gate is parameterized, skip
+        if not any(isinstance(param, ParameterExpression) for param in instr.params):
             continue
-        assert len(instr.params) == 1, "Circuit was not properly decomposed"
+
+        if len(instr.params) != 1:
+            raise NotImplementedError('The QFI diagonal approximation currently only supports '
+                                      'gates with a single free parameter.')
         param_value = instr.params[0]
-        if not isinstance(param_value, ParameterExpression):
-            continue
 
         for param in params:
             if param in param_value.parameters:
@@ -238,7 +240,7 @@ def _get_generators(params, circuit):
                 elif isinstance(instr, RXGate):
                     generator = X
                 else:
-                    raise NotImplementedError
+                    raise NotImplementedError(f'Generator for gate {instr.name} not implemented.')
 
                 # get all qubit indices in this layer where the param parameterizes
                 # an operation.

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -1118,6 +1118,36 @@ class TestQFI(QiskitOpflowTestCase):
                     self.assertEqual(base.compose(composed_op[1].primitive),
                                      base.compose(reference))
 
+    def test_overlap_qfi_bound_parameters(self):
+        """Test the overlap QFI works on a circuit with multi-parameter bound gates."""
+        x = Parameter('x')
+        circuit = QuantumCircuit(1)
+        circuit.u(1, 2, 3, 0)
+        circuit.rx(x, 0)
+
+        qfi = QFI('overlap_diag').convert(StateFn(circuit), [x])
+        value = qfi.bind_parameters({x: 1}).eval()[0][0]
+        ref = 0.87737713
+        self.assertAlmostEqual(value, ref)
+
+    def test_overlap_qfi_raises_on_multiparam(self):
+        """Test the overlap QFI raises an appropriate error on multi-param unbound gates."""
+        x = ParameterVector('x', 2)
+        circuit = QuantumCircuit(1)
+        circuit.u(x[0], x[1], 2, 0)
+
+        with self.assertRaises(NotImplementedError):
+            _ = QFI('overlap_diag').convert(StateFn(circuit), [x])
+
+    def test_overlap_qfi_raises_on_unsupported_gate(self):
+        """Test the overlap QFI raises an appropriate error on multi-param unbound gates."""
+        x = Parameter('x')
+        circuit = QuantumCircuit(1)
+        circuit.p(x, 0)
+
+        with self.assertRaises(NotImplementedError):
+            _ = QFI('overlap_diag').convert(StateFn(circuit), [x])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* Allow multi-parameter gates if all parameter are bound.
* Don't use bare assertion.
* Add error message on unsupported gate.

### Details

E.g. the following circuit was not supported due to the U-gate.
```python
circuit = QuantumCircuit(1)
circuit.u(1, 1, 1, 0)
circuit.ry(parameter, 0)
```



