### PR TITLE
Make Register and Bit hashed attrs immutable

### DIFF
--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -61,15 +61,6 @@ class Bit:
 
         return self._register
 
-    @register.setter
-    def register(self, value):
-        """Set bit's register."""
-        if (self._register, self._index) == (None, None):
-            raise CircuitError('Attmped to set register of a new-style Bit.')
-
-        self._register = value
-        self._update_hash()
-
     @property
     def index(self):
         """Get bit's index."""
@@ -77,15 +68,6 @@ class Bit:
             raise CircuitError('Attmped to query index of a new-style Bit.')
 
         return self._index
-
-    @index.setter
-    def index(self, value):
-        """Set bit's index."""
-        if (self._register, self._index) == (None, None):
-            raise CircuitError('Attmped to set index of a new-style Bit.')
-
-        self._index = value
-        self._update_hash()
 
     def __repr__(self):
         """Return the official string representing the bit."""

--- a/qiskit/circuit/bit.py
+++ b/qiskit/circuit/bit.py
@@ -46,12 +46,9 @@ class Bit:
 
             self._register = register
             self._index = index
-            self._update_hash()
-
-    def _update_hash(self):
-        self._hash = hash((self._register, self._index))
-        self._repr = "%s(%s, %s)" % (self.__class__.__name__,
-                                     self._register, self._index)
+            self._hash = hash((self._register, self._index))
+            self._repr = "%s(%s, %s)" % (self.__class__.__name__,
+                                         self._register, self._index)
 
     @property
     def register(self):

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -112,10 +112,6 @@ class Register:
         else:
             self._bits = [self.bit_type(self, idx) for idx in range(size)]
 
-    def _update_bits_hash(self):
-        for bit in self._bits:
-            bit._update_hash()
-
     @property
     def name(self):
         """Get the register name."""

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -121,29 +121,10 @@ class Register:
         """Get the register name."""
         return self._name
 
-    @name.setter
-    def name(self, value):
-        """Set the register name."""
-        if self.name_format.match(value) is None:
-            raise CircuitError("%s is an invalid OPENQASM register name. See appendix"
-                               " A of https://arxiv.org/pdf/1707.03429v2.pdf." % value)
-        self._name = value
-        self._hash = hash((type(self), self._name, self._size))
-        self._repr = "%s(%d, '%s')" % (self.__class__.__qualname__, self.size, self.name)
-        self._update_bits_hash()
-
     @property
     def size(self):
         """Get the register size."""
         return self._size
-
-    @size.setter
-    def size(self, value):
-        """Set the register size."""
-        self._size = value
-        self._hash = hash((type(self), self._name, self._size))
-        self._repr = "%s(%d, '%s')" % (self.__class__.__qualname__, self.size, self.name)
-        self._update_bits_hash()
 
     def __repr__(self):
         """Return the official string representing the register."""

--- a/releasenotes/notes/bit-register-immutable-7a06a212400b3b60.yaml
+++ b/releasenotes/notes/bit-register-immutable-7a06a212400b3b60.yaml
@@ -1,0 +1,19 @@
+---
+upgrade:
+  - |
+    :class:`~qiskit.circuit.Register` and :class:`~qiskit.circuit.Bit` objects
+    are now immutable. In previous releases it was possible to adjust the value
+    of a :attr:`~qiskit.circuit.Register.size` or
+    :attr:`~qiskit.circuit.Register.name` attributes of a
+    :class:`~qiskit.circuit.Register` object and the
+    :attr:`~qiskit.circuit.Bit.index` or :attr:`~qiskit.circuit.Bit.register`
+    attributes of a :class:`~qiskit.circuit.Bit` object after it was initially
+    created. However this would lead to unsound behavior that would corrupt
+    container structure that rely on a hash (such as a `dict`) since these
+    attributes are treated as immutable properties of a register or bit (see
+    `#4705 <https://github.com/Qiskit/qiskit-terra/issues/4705>`__ for more
+    details). To avoid this unsound behavior this attributes of a
+    :class:`~qiskit.circuit.Register` and :class:`~qiskit.circuit.Bit` are
+    no longer settable after initial creation. If you were previously adjusting
+    the objects at runtime you will now need to create a new ``Register`
+    or ``Bit`` object with the new values.

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -25,66 +25,6 @@ from qiskit.circuit import classicalregister
 class TestBitClass(QiskitTestCase):
     """Test library of boolean logic quantum circuits."""
 
-    def test_bit_hash_update_reg(self):
-        orig_reg = mock.MagicMock()
-        orig_reg.size = 3
-        new_reg = mock.MagicMock()
-        orig_reg.size = 4
-        test_bit = bit.Bit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.register = new_reg
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_bit_hash_update_index(self):
-        orig_reg = mock.MagicMock()
-        orig_reg.size = 4
-        test_bit = bit.Bit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.index = 2
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_qubit_hash_update_reg(self):
-        orig_reg = mock.MagicMock(spec=quantumregister.QuantumRegister)
-        orig_reg.size = 3
-        new_reg = mock.MagicMock(spec=quantumregister.QuantumRegister)
-        new_reg.size = 6
-        test_bit = quantumregister.Qubit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.register = new_reg
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_qubit_hash_update_index(self):
-        orig_reg = mock.MagicMock(spec=quantumregister.QuantumRegister)
-        orig_reg.size = 67
-        test_bit = quantumregister.Qubit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.index = 2
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_clbit_hash_update_reg(self):
-        orig_reg = mock.MagicMock(spec=classicalregister.ClassicalRegister)
-        orig_reg.size = 5
-        new_reg = mock.MagicMock(spec=classicalregister.ClassicalRegister)
-        new_reg.size = 53
-        test_bit = classicalregister.Clbit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.register = new_reg
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_clbit_hash_update_index(self):
-        orig_reg = mock.MagicMock(spec=classicalregister.ClassicalRegister)
-        orig_reg.size = 42
-        test_bit = classicalregister.Clbit(orig_reg, 0)
-        orig_hash = hash(test_bit)
-        test_bit.index = 2
-        new_hash = hash(test_bit)
-        self.assertNotEqual(orig_hash, new_hash)
-
     def test_bit_eq_invalid_type_comparison(self):
         orig_reg = mock.MagicMock()
         orig_reg.size = 3

--- a/test/python/circuit/test_bit.py
+++ b/test/python/circuit/test_bit.py
@@ -18,8 +18,6 @@ from unittest import mock
 
 from qiskit.test import QiskitTestCase
 from qiskit.circuit import bit
-from qiskit.circuit import quantumregister
-from qiskit.circuit import classicalregister
 
 
 class TestBitClass(QiskitTestCase):

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -47,14 +47,6 @@ class TestCircuitRegisters(QiskitTestCase):
         self.assertEqual(cr1.size, 10)
         self.assertEqual(type(cr1), ClassicalRegister)
 
-    def test_qreg_name_set_invalid(self):
-        """Test attempt to set an invalid name
-        """
-        qr1 = QuantumRegister(1)
-        # As per OPENQASM requirement, name cannot start with '_'
-        with self.assertRaises(CircuitError):
-            qr1.name = '_q'
-
     def test_aregs(self):
         """Test getting ancilla registers from circuit.
         """
@@ -508,43 +500,3 @@ class TestCircuitRegisters(QiskitTestCase):
         for (gate, qargs, _) in circ.data:
             self.assertEqual(gate.name, 'unitary')
             self.assertEqual(len(qargs), 4)
-
-    def test_quantumregister_hash_upate_name(self):
-        """Test QuantumRegister hash changes on name update."""
-        test_reg = QuantumRegister(2)
-        orig_hash = hash(test_reg)
-        orig_bit_hashes = [hash(x) for x in test_reg]
-        test_reg.name = 'test_quantum'
-        new_hash = hash(test_reg)
-        new_bit_hashes = [hash(x) for x in test_reg]
-        self.assertNotEqual(orig_hash, new_hash)
-        for x in range(2):
-            self.assertNotEqual(orig_bit_hashes[x], new_bit_hashes[x])
-
-    def test_quantumregister_hash_upate_size(self):
-        """Test QuantumRegister hash changes on size update."""
-        test_reg = QuantumRegister(2)
-        orig_hash = hash(test_reg)
-        test_reg.size = 3
-        new_hash = hash(test_reg)
-        self.assertNotEqual(orig_hash, new_hash)
-
-    def test_classicalregister_hash_upate_name(self):
-        """Test ClassicalRegister hash changes on name update."""
-        test_reg = ClassicalRegister(2)
-        orig_hash = hash(test_reg)
-        orig_bit_hashes = [hash(x) for x in test_reg]
-        test_reg.name = 'test_classical'
-        new_hash = hash(test_reg)
-        new_bit_hashes = [hash(x) for x in test_reg]
-        self.assertNotEqual(orig_hash, new_hash)
-        for x in range(2):
-            self.assertNotEqual(orig_bit_hashes[x], new_bit_hashes[x])
-
-    def test_classicalregister_hash_upate_size(self):
-        """Test ClassicalRegister hash changes on size update."""
-        test_reg = ClassicalRegister(2)
-        orig_hash = hash(test_reg)
-        test_reg.size = 3
-        new_hash = hash(test_reg)
-        self.assertNotEqual(orig_hash, new_hash)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit changes the Register and Bit classes to make the attributes
used in the hash of an object immutable. We previously would allow these
attributes to be settable after object creation. However this would lead to
unsound behavior that would corrupt container structure that rely on a hash
(such as a `dict`) since these attributes are treated as immutable
properties of a register or bit. [1] To avoid this unsound behavior the
attributes of a Register and Bit are no longer settable after initial
creation. This is technically a breaking API change, but because doing
this operation before would result in breaking Python's `__hash__` API and
potentially result in unsound behavior this is necessary.

### Details and comments

Fixes #4705
[1] https://docs.python.org/3/glossary.html#term-hashable
