### PR TITLE
Remove np.bool and np.int in the unit tests

### DIFF
--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -333,8 +333,8 @@ class TestQAOA(QiskitAlgorithmsTestCase):
         for i in range(num_nodes):
             for j in range(i):
                 if weight_matrix[i, j] != 0:
-                    x_p = np.zeros(num_nodes, dtype=np.bool)
-                    z_p = np.zeros(num_nodes, dtype=np.bool)
+                    x_p = np.zeros(num_nodes, dtype=bool)
+                    z_p = np.zeros(num_nodes, dtype=bool)
                     z_p[i] = True
                     z_p[j] = True
                     pauli_list.append([0.5 * weight_matrix[i, j], Pauli((z_p, x_p))])

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -25,7 +25,7 @@ from qiskit.algorithms.optimizers import COBYLA, NELDER_MEAD
 
 from qiskit.opflow import I, X, PauliSumOp
 
-from qiskit import BasicAer, QuantumCircuit, QuantumRegister, execute
+from qiskit import BasicAer, QuantumCircuit, QuantumRegister
 
 from qiskit.circuit import Parameter
 from qiskit.quantum_info import Pauli

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -255,7 +255,6 @@ class TestQAOA(QiskitAlgorithmsTestCase):
 
         self.assertEqual(len(zero_circuits), len(custom_circuits))
 
-        backend = BasicAer.get_backend('statevector_simulator')
         for zero_circ, custom_circ in zip(zero_circuits, custom_circuits):
 
             z_length = len(zero_circ.data)
@@ -273,8 +272,8 @@ class TestQAOA(QiskitAlgorithmsTestCase):
             else:
                 original_init_qc = initial_state
 
-            job_init_state = execute(original_init_qc, backend)
-            job_qaoa_init_state = execute(custom_init_qc, backend)
+            job_init_state = execute(original_init_qc, self.statevector_simulator.backend)
+            job_qaoa_init_state = execute(custom_init_qc, self.statevector_simulator.backend)
 
             statevector_original = job_init_state.result().get_statevector(original_init_qc)
             statevector_custom = job_qaoa_init_state.result().get_statevector(custom_init_qc)

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -272,11 +272,11 @@ class TestQAOA(QiskitAlgorithmsTestCase):
             else:
                 original_init_qc = initial_state
 
-            job_init_state = execute(original_init_qc, self.statevector_simulator.backend)
-            job_qaoa_init_state = execute(custom_init_qc, self.statevector_simulator.backend)
+            job_init_state = self.statevector_simulator.execute(original_init_qc)
+            job_qaoa_init_state = self.statevector_simulator.execute(custom_init_qc)
 
-            statevector_original = job_init_state.result().get_statevector(original_init_qc)
-            statevector_custom = job_qaoa_init_state.result().get_statevector(custom_init_qc)
+            statevector_original = job_init_state.get_statevector(original_init_qc)
+            statevector_custom = job_qaoa_init_state.get_statevector(custom_init_qc)
 
             self.assertListEqual(statevector_original.tolist(), statevector_custom.tolist())
 

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -94,7 +94,7 @@ class TestCircuitRegisters(QiskitTestCase):
         """Test attempt to pass different types of integer as indices
         of QuantumRegister and ClassicalRegister
         """
-        ints = [int(2), np.int(2), np.int32(2), np.int64(2)]
+        ints = [int(2), np.int32(2), np.int64(2)]
         for index in ints:
             with self.subTest(index=index):
                 qr = QuantumRegister(4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Replace `np.bool` and `np.int` with `bool` and `int`, respectively.
See #5758 for details.

### Details and comments

This PR also fixes a random seed of test_qaoa.
