### PR TITLE
[WIP] Support frames

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -94,11 +94,15 @@ def _assemble_experiments(
     instruction_converter = instruction_converter(qobj.PulseQobjInstruction,
                                                   **run_config.to_dict())
 
-    schedules = [
-        sched if isinstance(sched, pulse.Schedule) else pulse.Schedule(sched) for sched in schedules
-    ]
-    resolved_frames = transforms.resolve_frames(schedules, getattr(run_config, 'frames', None))
-    compressed_schedules = transforms.compress_pulses(resolved_frames)
+    schedules = []
+    frames_map = getattr(run_config, 'frames', None)
+    for sched in schedules:
+        if not isinstance(sched, pulse.Schedule):
+            sched = pulse.Schedule(sched)
+
+        schedules.append(transforms.resolve_frames(sched, frames_map))
+
+    compressed_schedules = transforms.compress_pulses(schedules)
 
     user_pulselib = {}
     experiments = []

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -94,15 +94,15 @@ def _assemble_experiments(
     instruction_converter = instruction_converter(qobj.PulseQobjInstruction,
                                                   **run_config.to_dict())
 
-    schedules = []
+    resolved_frames = []
     frames_map = getattr(run_config, 'frames', None)
     for sched in schedules:
         if not isinstance(sched, pulse.Schedule):
             sched = pulse.Schedule(sched)
 
-        schedules.append(transforms.resolve_frames(sched, frames_map))
+        resolved_frames.append(transforms.resolve_frames(sched, frames_map))
 
-    compressed_schedules = transforms.compress_pulses(schedules)
+    compressed_schedules = transforms.compress_pulses(resolved_frames)
 
     user_pulselib = {}
     experiments = []

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -27,7 +27,7 @@ from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.validation.jsonschema import SchemaValidationError
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend
-from qiskit.pulse.channels import PulseChannel, DriveChannel
+from qiskit.pulse.channels import PulseChannel
 from qiskit.pulse import Schedule
 
 logger = logging.getLogger(__name__)

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -27,7 +27,7 @@ from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.validation.jsonschema import SchemaValidationError
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend
-from qiskit.pulse.channels import PulseChannel
+from qiskit.pulse.channels import PulseChannel, DriveChannel
 from qiskit.pulse import Schedule
 
 logger = logging.getLogger(__name__)
@@ -301,6 +301,10 @@ def _parse_pulse_args(backend, qubit_lo_freq, meas_lo_freq, qubit_lo_range,
     qubit_lo_range = qubit_lo_range or getattr(backend_config, 'qubit_lo_range', None)
     meas_lo_range = meas_lo_range or getattr(backend_config, 'meas_lo_range', None)
 
+    frames = None
+    if hasattr(backend_config, 'frames'):
+        frames = backend_config.frames()
+
     dynamic_reprate_enabled = getattr(backend_config, 'dynamic_reprate_enabled', False)
 
     rep_time = rep_time or getattr(backend_config, 'rep_times', None)
@@ -326,6 +330,7 @@ def _parse_pulse_args(backend, qubit_lo_freq, meas_lo_freq, qubit_lo_range,
                            memory_slot_size=memory_slot_size,
                            rep_time=rep_time,
                            parametric_pulses=parametric_pulses,
+                           frames=frames,
                            **run_config)
     run_config = RunConfig(**{k: v for k, v in run_config_dict.items() if v is not None})
 

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -757,14 +757,20 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
                                             "information.".format(self.backend_name))
 
     def frames(self) -> List[Channel]:
-        """Gets the frames of the backend"""
+        """
+        Gets the frames of the backend in serializable format.
+
+        Returns:
+            frames: A List of lists. Sublist i is a list of channel names that belong
+                to frame i.
+        """
         n_qubits = self.n_qubits
         frames = []
         for qubit in range(n_qubits):
-            frame_ = [DriveChannel(qubit)]
+            frame_ = [DriveChannel(qubit).name]
             for ctrl in range(n_qubits):
                 try:
-                    frame_ += self.control((ctrl, qubit))
+                    frame_ += [_.name for _ in self.control((ctrl, qubit))]
                 except BackendConfigurationError:
                     pass
 

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -765,7 +765,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             for ctrl in range(n_qubits):
                 try:
                     frame_ += self.control((ctrl, qubit))
-                except QiskitError:
+                except BackendConfigurationError:
                     pass
 
             frames.append(frame_)

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -756,6 +756,22 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             raise BackendConfigurationError("This backend - '{}' does not provide channel "
                                             "information.".format(self.backend_name))
 
+    def frames(self) -> List[Channel]:
+        """Gets the frames of the backend"""
+        n_qubits = self.n_qubits
+        frames = []
+        for qubit in range(n_qubits):
+            frame_ = [DriveChannel(qubit)]
+            for ctrl in range(n_qubits):
+                try:
+                    frame_ += self.control((ctrl, qubit))
+                except QiskitError:
+                    pass
+
+            frames.append(frame_)
+
+        return frames
+
     def get_channel_qubits(self, channel: Channel) -> List[int]:
         """
         Return a list of indices for qubits which are operated on directly by the given ``channel``.

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -434,6 +434,7 @@ from qiskit.pulse.channels import (
     AcquireChannel,
     ControlChannel,
     DriveChannel,
+    Frame,
     MeasureChannel,
     MemorySlot,
     RegisterSlot,

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -204,7 +204,7 @@ class Frame(PulseChannel):
         if isinstance(index, ParameterExpression):
             self._parameters.update(index.parameters)
 
-        self._channels = channels
+        self._channels = set(channels)
         for ch in self._channels:
             self._parameters.update(ch.parameters)
 
@@ -257,19 +257,19 @@ class Frame(PulseChannel):
                                                     ParameterValueType]) -> List['Channel']:
         """
         Args:
-            parameter:
-            value:
+            value_dict:
 
         Returns:
              Frame: A Frame in which the parameter has been assigned.
         """
         sub_channels = []
         for ch in self._channels:
-            for param, value in value_dict.items():
-                if param in ch.parameters:
-                    sub_channels.append(ch.assign(param, value))
-            else:
-                sub_channels.append(ch)
+            if isinstance(ch.index, ParameterExpression):
+                for param, value in value_dict.items():
+                    if param in ch.parameters:
+                        ch = ch.assign(param, value)
+
+            sub_channels.append(ch)
 
         return sub_channels
 

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -21,7 +21,7 @@ channel types can be created. Then, they must be supported in the PulseQobj sche
 assembler.
 """
 from abc import ABCMeta
-from typing import Any, Set
+from typing import Any, Set, List, Union
 
 import numpy as np
 
@@ -185,6 +185,19 @@ class Frame(PulseChannel):
     """Channel to manage frames."""
     prefix = 'f'
 
+    def __init__(self, index: Union[int, Parameter], channels: List[Channel]):
+        """
+        Args:
+            index: The index of the frame.
+            channels: List of channels tied together by this frame.
+        """
+        super().__init__(index)
+        self._channels = [ch for ch in channels]
+
+    @property
+    def channels(self):
+        """Returns the channels tied together by this frame."""
+        return self._channels
 
 class AcquireChannel(Channel):
     """Acquire channels are used to collect data."""

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -130,6 +130,18 @@ class Channel(metaclass=ABCMeta):
             self._validate_index(new_index)
             new_index = int(new_index)
 
+        if isinstance(self, Frame):
+            # Preserve any coupling between frame parameter and the parameter
+            # of any referenced channel.
+            sub_channels = []
+            for ch in self.channels:
+                if parameter in ch.parameters:
+                    sub_channels.append(type(ch)(new_index))
+                else:
+                    sub_channels.append(ch)
+
+            return type(self)(new_index, sub_channels)
+
         return type(self)(new_index)
 
     @property

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -181,6 +181,11 @@ class ControlChannel(PulseChannel):
     prefix = 'u'
 
 
+class Frame(PulseChannel):
+    """Channel to manage frames."""
+    prefix = 'f'
+
+
 class AcquireChannel(Channel):
     """Acquire channels are used to collect data."""
     prefix = 'a'

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
-from qiskit.pulse.channels import Channel
+from qiskit.pulse.channels import Channel, Frame
 from qiskit.pulse.exceptions import PulseError
 # pylint: disable=cyclic-import
 from qiskit.pulse.instructions import Instruction
@@ -732,6 +732,11 @@ class Schedule(abc.ABC):
 
         # Update timeslots according to new channel keys
         for chan in copy.copy(self._timeslots):
+
+            # Frames contain references to other channels that may have parameters.
+            if isinstance(chan, Frame):
+                chan = chan.assign_parameters(value_dict)
+
             if isinstance(chan.index, ParameterExpression):
                 chan_timeslots = self._timeslots.pop(chan)
 

--- a/qiskit/pulse/transforms.py
+++ b/qiskit/pulse/transforms.py
@@ -331,6 +331,10 @@ def resolve_frames(schedules: List[Schedule], frames: List[List[str]]) -> List[S
     Returns:
         new_schedules: A list of new schedules where frames have been replaced with
             their corresponding Drive, Control, and/or Measure channels.
+
+    Raises:
+        PulseError: if an instruction other than ShiftPhase, SetPhase, ShiftFrequency,
+            SetFrequency is applied to a Frame.
     """
     if frames is None:
         return schedules
@@ -376,6 +380,10 @@ def _resolve_channel(name: str) -> chans.Channel:
 
     Returns:
         channel: The channel of the appropriate type.
+
+    Raises:
+        PulseError: If the channel is not a DriveChannel, ControlChannel, or
+            MeasureChannel.
     """
     if name[0] == 'd':
         return chans.DriveChannel(int(name[1:]))

--- a/qiskit/visualization/pulse_v2/layouts.py
+++ b/qiskit/visualization/pulse_v2/layouts.py
@@ -233,6 +233,9 @@ def channel_index_grouped_sort_u(channels: List[pulse.channels.Channel],
     d_chans = chan_type_dict.get(pulse.DriveChannel, [])
     d_chans = sorted(d_chans, key=lambda x: x.index, reverse=True)
 
+    f_chans = chan_type_dict.get(pulse.Frame, [])
+    f_chans = sorted(f_chans, key=lambda x: x.index, reverse=True)
+
     m_chans = chan_type_dict.get(pulse.MeasureChannel, [])
     m_chans = sorted(m_chans, key=lambda x: x.index, reverse=True)
 
@@ -251,6 +254,9 @@ def channel_index_grouped_sort_u(channels: List[pulse.channels.Channel],
         # measure channel
         if len(m_chans) > 0 and m_chans[-1].index == ind:
             ordered_channels.append(m_chans.pop())
+        # frames
+        if len(f_chans) > 0 and f_chans[-1].index == ind:
+            ordered_channels.append(f_chans.pop())
         # acquire channel
         if formatter['control.show_acquire_channel']:
             if len(a_chans) > 0 and a_chans[-1].index == ind:

--- a/test/python/pulse/test_channels.py
+++ b/test/python/pulse/test_channels.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+from qiskit.circuit import Parameter
 from qiskit.pulse.channels import (AcquireChannel, Channel, DriveChannel, Frame,
                                    ControlChannel, MeasureChannel, MemorySlot,
                                    PulseChannel, RegisterSlot, SnapshotChannel)
@@ -143,6 +144,34 @@ class TestFrame(QiskitTestCase):
         self.assertEqual(frame.index, 123)
         self.assertEqual(frame.name, 'f123')
         self.assertEqual(frame.channels, [DriveChannel(1), ControlChannel(0)])
+
+    def test_assign_parameter(self):
+        """Test that parameter assignment works."""
+
+        # Test coupling between frame parameter and a referenced channel
+        f0 = Parameter('name')
+        d0 = DriveChannel(f0)
+        frame = Frame(f0, [d0, ControlChannel(4)])
+
+        self.assertEqual(frame.index.name, 'name')
+        self.assertEqual(frame.channels, [d0, ControlChannel(4)])
+
+        new_frame = frame.assign(f0, 123)
+        self.assertEqual(new_frame.index, 123)
+        self.assertEqual(new_frame.channels, [DriveChannel(123), ControlChannel(4)])
+
+        # Test coupling between frame parameter and a referenced channel
+        p0 = Parameter('p0')
+        p1 = Parameter('p1')
+        d0 = DriveChannel(p1)
+        frame = Frame(p0, [d0, ControlChannel(4)])
+
+        self.assertEqual(frame.index.name, 'p0')
+        self.assertEqual(frame.channels, [d0, ControlChannel(4)])
+
+        new_frame = frame.assign(p0, 123)
+        self.assertEqual(new_frame.index, 123)
+        self.assertEqual(new_frame.channels, [DriveChannel(p1), ControlChannel(4)])
 
 
 if __name__ == '__main__':

--- a/test/python/pulse/test_channels.py
+++ b/test/python/pulse/test_channels.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from qiskit.pulse.channels import (AcquireChannel, Channel, DriveChannel,
+from qiskit.pulse.channels import (AcquireChannel, Channel, DriveChannel, Frame,
                                    ControlChannel, MeasureChannel, MemorySlot,
                                    PulseChannel, RegisterSlot, SnapshotChannel)
 from qiskit.test import QiskitTestCase
@@ -131,6 +131,18 @@ class TestMeasureChannel(QiskitTestCase):
 
         self.assertEqual(measure_channel.index, 123)
         self.assertEqual(measure_channel.name, 'm123')
+
+
+class TestFrame(QiskitTestCase):
+    """Frame tests."""
+
+    def test_default(self):
+        """Test default Frame."""
+        frame = Frame(123, [DriveChannel(1), ControlChannel(0)])
+
+        self.assertEqual(frame.index, 123)
+        self.assertEqual(frame.name, 'f123')
+        self.assertEqual(frame.channels, [DriveChannel(1), ControlChannel(0)])
 
 
 if __name__ == '__main__':

--- a/test/python/pulse/test_parameters.py
+++ b/test/python/pulse/test_parameters.py
@@ -276,6 +276,22 @@ class TestPulseParameters(QiskitTestCase):
 
         self.assertEqual(len(schedule.get_parameters('amp')), 2)
 
+    def test_schedule_and_frame_parameters(self):
+        d0 = Parameter('d0')
+        d1 = Parameter('d1')
+        u0 = Parameter('u0.1')  # control.target
+
+        dch0 = DriveChannel(d0)
+        dch1 = DriveChannel(d1)
+        uch0 = ControlChannel(u0)
+        f0 = Frame(d0, [dch0])
+        f1 = Frame(d1, [dch1, uch0])
+
+        with pulse.build() as sched:
+            with pulse.align_left():
+                pulse.shift_phase(-np.pi / 2, f0)
+                pulse.shift_phase(-np.pi, f1)
+
 
 class TestParameterDuration(QiskitTestCase):
     """Tests parametrization of instruction duration."""


### PR DESCRIPTION
### Summary
Qiskit pulse currently lacks the concept of frames this PR introduces a light-weight frame concept in which SetFrequency, ShiftFrequency, SetPhase, and ShiftPhase instructions can be applied to a frame which represents a grouping of Drive, Control, and Measure channels.

### Details and comments
A new Channel is introduced, i.e. `Frame`. Frequency and phase instructions can be applied to this channel, e.g.:
```python
with pulse.build() as test1:
    pulse.shift_phase(2.0, Frame(0))
```
which, depending on how the frames are defined, is equivalent to
```python
with pulse.build() as test2:
    pulse.shift_phase(2.0, DriveChannel(0))
    pulse.shift_phase(2.0, ControlChannel(1))
```
In this PR the frames are resolved at assembly time using `transforms.resolve_frames`. This pass will replace instructions on `Frame` with instructions on the corresponding `DriveChannel`, `ControlChannel`, and `MeasureChannel`. The mapping between frames and channels is defined in the `PulseBackendConfiguration`.

TODO

- [ ] Propagate parameter assignment in Frames.