### PR TITLE
Drop local import-outside-toplevel suppressions

### DIFF
--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -501,7 +501,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     def get_optimal_vector(self) -> Union[List[float], Dict[str, int]]:
         """Get the simulation outcome of the optimal circuit. """
-        # pylint: disable=import-outside-toplevel
         from qiskit.utils.run_circuits import find_regs_by_name
 
         if self._ret.optimal_point is None:

--- a/qiskit/opflow/evolutions/evolved_op.py
+++ b/qiskit/opflow/evolutions/evolved_op.py
@@ -49,7 +49,7 @@ class EvolvedOp(PrimitiveOp):
         return self.primitive.num_qubits  # type: ignore
 
     def add(self, other: OperatorBase) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.summed_op import SummedOp
         if not self.num_qubits == other.num_qubits:
             raise ValueError(
@@ -78,7 +78,7 @@ class EvolvedOp(PrimitiveOp):
         return self.primitive == other.primitive
 
     def tensor(self, other: OperatorBase) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.tensored_op import TensoredOp
         if isinstance(other, TensoredOp):
             return TensoredOp([self] + other.oplist)  # type: ignore
@@ -86,7 +86,7 @@ class EvolvedOp(PrimitiveOp):
         return TensoredOp([self, other])
 
     def _expand_dim(self, num_qubits: int) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..operator_globals import I
 
         return self.tensor(I ^ num_qubits)
@@ -96,7 +96,7 @@ class EvolvedOp(PrimitiveOp):
 
     def compose(self, other: OperatorBase,
                 permutation: Optional[List[int]] = None, front: bool = False) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.composed_op import ComposedOp
         new_self, other = self._expand_shorter_operator_and_permute(other, permutation)
         if front:
@@ -120,7 +120,7 @@ class EvolvedOp(PrimitiveOp):
         return EvolvedOp(self.primitive.reduce(), coeff=self.coeff)  # type: ignore
 
     def assign_parameters(self, param_dict: dict) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops import ListOp
         param_value = self.coeff
         if isinstance(self.coeff, ParameterExpression):
@@ -139,7 +139,7 @@ class EvolvedOp(PrimitiveOp):
         return cast(Union[OperatorBase, float, complex], self.to_matrix_op().eval(front=front))
 
     def to_matrix(self, massive: bool = False) -> Union[np.ndarray, List[np.ndarray]]:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops import ListOp
         if self.primitive.__class__.__name__ == ListOp.__name__:
             return [
@@ -154,7 +154,7 @@ class EvolvedOp(PrimitiveOp):
 
     def to_matrix_op(self, massive: bool = False) -> OperatorBase:
         """ Returns a ``MatrixOp`` equivalent to this Operator. """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops import ListOp
         from ..primitive_ops.matrix_op import MatrixOp
         if self.primitive.__class__.__name__ == ListOp.__name__:

--- a/qiskit/opflow/expectations/aer_pauli_expectation.py
+++ b/qiskit/opflow/expectations/aer_pauli_expectation.py
@@ -52,7 +52,7 @@ class AerPauliExpectation(ExpectationBase):
         else:
             return operator
 
-    # pylint: disable=inconsistent-return-statements,import-outside-toplevel
+    # pylint: disable=inconsistent-return-statements
     @classmethod
     def _replace_pauli_sums(cls, operator):
         try:

--- a/qiskit/opflow/expectations/expectation_factory.py
+++ b/qiskit/opflow/expectations/expectation_factory.py
@@ -64,7 +64,7 @@ class ExpectationFactory:
         """
         backend_to_check = backend.backend if isinstance(backend, QuantumInstance) else backend
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         primitives = operator.primitive_strings()
         if primitives in ({'Pauli'}, {'SparsePauliOp'}):
 

--- a/qiskit/opflow/list_ops/composed_op.py
+++ b/qiskit/opflow/list_ops/composed_op.py
@@ -68,7 +68,7 @@ class ComposedOp(ListOp):
         Raises:
             OpflowError: for operators where a single underlying circuit can not be obtained.
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..state_fns.circuit_state_fn import CircuitStateFn
         from ..primitive_ops.primitive_op import PrimitiveOp
         circuit_op = self.to_circuit_op()
@@ -109,7 +109,7 @@ class ComposedOp(ListOp):
     def eval(self,
              front: Union[str, dict, np.ndarray,
                           OperatorBase] = None) -> Union[OperatorBase, float, complex]:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..state_fns.state_fn import StateFn
 
         def tree_recursive_eval(r, l_arg):

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -160,7 +160,7 @@ class ListOp(OperatorBase):
             return self.mul(2.0)
 
         # Avoid circular dependency
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .summed_op import SummedOp
         return SummedOp([self, other])
 
@@ -217,7 +217,7 @@ class ListOp(OperatorBase):
 
     def tensor(self, other: OperatorBase) -> OperatorBase:
         # Avoid circular dependency
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .tensored_op import TensoredOp
         return TensoredOp([self, other])
 
@@ -229,7 +229,7 @@ class ListOp(OperatorBase):
             raise TypeError('Tensorpower can only take positive int arguments')
 
         # Avoid circular dependency
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .tensored_op import TensoredOp
         return TensoredOp([self] * other)
 
@@ -273,7 +273,7 @@ class ListOp(OperatorBase):
         for trans in transpositions:
             qc.swap(trans[0], trans[1])
 
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..primitive_ops.circuit_op import CircuitOp
 
         return CircuitOp(qc.reverse_ops()) @ new_self @ CircuitOp(qc)
@@ -287,7 +287,7 @@ class ListOp(OperatorBase):
         if front:
             return other.compose(new_self)
         # Avoid circular dependency
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .composed_op import ComposedOp
         return ComposedOp([new_self, other])
 
@@ -296,7 +296,7 @@ class ListOp(OperatorBase):
             raise TypeError('power can only take positive int arguments')
 
         # Avoid circular dependency
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .composed_op import ComposedOp
         return ComposedOp([self] * exponent)
 
@@ -398,7 +398,6 @@ class ListOp(OperatorBase):
             return ListOp([op.exp_i() for op in self.oplist],  # type: ignore
                           **self._state(abelian=False))
 
-        # pylint: disable=import-outside-toplevel
         from ..evolutions.evolved_op import EvolvedOp
         return EvolvedOp(self)
 

--- a/qiskit/opflow/list_ops/summed_op.py
+++ b/qiskit/opflow/list_ops/summed_op.py
@@ -85,7 +85,7 @@ class SummedOp(ListOp):
         Returns:
             A simplified ``SummedOp`` equivalent to self.
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..primitive_ops.primitive_op import PrimitiveOp
         oplist = []  # type: List[OperatorBase]
         coeffs = []  # type: List[Union[int, float, complex, ParameterExpression]]
@@ -125,7 +125,7 @@ class SummedOp(ListOp):
         if isinstance(reduced_ops, SummedOp):
             reduced_ops = reduced_ops.collapse_summands()
 
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..primitive_ops.pauli_sum_op import PauliSumOp
         if isinstance(reduced_ops, PauliSumOp):
             reduced_ops = reduced_ops.reduce()
@@ -151,7 +151,7 @@ class SummedOp(ListOp):
             OpflowError: if SummedOp can not be converted to MatrixOp (e.g. SummedOp is composed of
             parameterized PrimitiveOps).
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..primitive_ops.matrix_op import MatrixOp
         matrix_op = self.to_matrix_op()
         if isinstance(matrix_op, MatrixOp):
@@ -169,7 +169,7 @@ class SummedOp(ListOp):
         return accum * self.coeff
 
     def to_pauli_op(self, massive: bool = False) -> OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..state_fns.state_fn import StateFn
         pauli_sum = SummedOp(
             [

--- a/qiskit/opflow/list_ops/tensored_op.py
+++ b/qiskit/opflow/list_ops/tensored_op.py
@@ -59,7 +59,7 @@ class TensoredOp(ListOp):
         Returns:
             TensoredOp expanded with identity operator.
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..operator_globals import I
         return TensoredOp(self.oplist + [I ^ num_qubits], coeff=self.coeff)
 
@@ -94,7 +94,7 @@ class TensoredOp(ListOp):
         Raises:
             OpflowError: for operators where a single underlying circuit can not be produced.
         """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..state_fns.circuit_state_fn import CircuitStateFn
         circuit_op = self.to_circuit_op()
         if isinstance(circuit_op, (PrimitiveOp, CircuitStateFn)):

--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -521,7 +521,7 @@ class OperatorBase(ABC):
             other = other.permute(permutation)
         new_self = self
         if not self.num_qubits == other.num_qubits:
-            # pylint: disable=cyclic-import,import-outside-toplevel
+            # pylint: disable=cyclic-import
             from .operator_globals import Zero
             if other == Zero:
                 # Zero is special - we'll expand it to the correct qubit number.

--- a/qiskit/opflow/primitive_ops/circuit_op.py
+++ b/qiskit/opflow/primitive_ops/circuit_op.py
@@ -73,7 +73,7 @@ class CircuitOp(PrimitiveOp):
             return CircuitOp(self.primitive, coeff=self.coeff + other.coeff)
 
         # Covers all else.
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.summed_op import SummedOp
         return SummedOp([self, other])
 
@@ -87,7 +87,7 @@ class CircuitOp(PrimitiveOp):
         return self.primitive == other.primitive
 
     def tensor(self, other: OperatorBase) -> OperatorBase:
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .pauli_op import PauliOp
         from .matrix_op import MatrixOp
         if isinstance(other, (PauliOp, CircuitOp, MatrixOp)):
@@ -114,7 +114,7 @@ class CircuitOp(PrimitiveOp):
         if front:
             return other.compose(new_self)
         # ignore
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..operator_globals import Zero
         from ..state_fns import CircuitStateFn
         from .pauli_op import PauliOp
@@ -156,7 +156,6 @@ class CircuitOp(PrimitiveOp):
         if isinstance(self.coeff, ParameterExpression) or self.primitive.parameters:  # type: ignore
             unrolled_dict = self._unroll_param_dict(param_dict)
             if isinstance(unrolled_dict, list):
-                # pylint: disable=import-outside-toplevel
                 from ..list_ops.list_op import ListOp
                 return ListOp([self.assign_parameters(param_dict) for param_dict in unrolled_dict])
             if isinstance(self.coeff, ParameterExpression) \
@@ -177,7 +176,6 @@ class CircuitOp(PrimitiveOp):
     def eval(self,
              front: Optional[Union[str, Dict[str, complex], np.ndarray, OperatorBase]] = None
              ) -> Union[OperatorBase, float, complex]:
-        # pylint: disable=import-outside-toplevel
         from ..state_fns import CircuitStateFn
         from ..list_ops import ListOp
         from .pauli_op import PauliOp

--- a/qiskit/opflow/primitive_ops/matrix_op.py
+++ b/qiskit/opflow/primitive_ops/matrix_op.py
@@ -182,7 +182,7 @@ class MatrixOp(PrimitiveOp):
         if front is None:
             return self
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..list_ops import ListOp
         from ..state_fns import StateFn, OperatorStateFn
 

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -102,7 +102,7 @@ class PauliOp(PrimitiveOp):
             op_copy = Pauli((other.primitive.z, other.primitive.x))  # type: ignore
             return PauliOp(self.primitive.tensor(op_copy), coeff=self.coeff * other.coeff)
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .circuit_op import CircuitOp
         if isinstance(other, CircuitOp):
             return self.to_circuit_op().tensor(other)
@@ -156,7 +156,7 @@ class PauliOp(PrimitiveOp):
                 coeff=new_self.coeff * other.coeff,
             )
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .circuit_op import CircuitOp
         from ..state_fns.circuit_state_fn import CircuitStateFn
         if isinstance(other, (CircuitOp, CircuitStateFn)):
@@ -192,7 +192,7 @@ class PauliOp(PrimitiveOp):
         if front is None:
             return self.to_matrix_op()
 
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..state_fns.state_fn import StateFn
         from ..state_fns.dict_state_fn import DictStateFn
         from ..state_fns.circuit_state_fn import CircuitStateFn
@@ -257,7 +257,6 @@ class PauliOp(PrimitiveOp):
         # if only one qubit is significant, we can perform the evolution
         corrected_x = self.primitive.x[::-1]  # type: ignore
         corrected_z = self.primitive.z[::-1]  # type: ignore
-        # pylint: disable=import-outside-toplevel
         sig_qubits = np.logical_or(corrected_x, corrected_z)
         if np.sum(sig_qubits) == 0:
             # e^I is just a global phase, but we can keep track of it! Should we?

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -220,7 +220,6 @@ class PauliSumOp(PrimitiveOp):
                 new_self.primitive * other.primitive,  # type:ignore
                 coeff=new_self.coeff * other.coeff,
             )
-        # pylint: disable=import-outside-toplevel
         from .pauli_op import PauliOp
         if isinstance(other, PauliOp):
             other_primitive = SparsePauliOp(other.primitive)
@@ -229,7 +228,7 @@ class PauliSumOp(PrimitiveOp):
                 coeff=new_self.coeff * other.coeff,
             )
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..state_fns.circuit_state_fn import CircuitStateFn
         from .circuit_op import CircuitOp
 
@@ -273,7 +272,7 @@ class PauliSumOp(PrimitiveOp):
         if front is None:
             return self.to_matrix_op()
 
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.list_op import ListOp
         from ..state_fns.circuit_state_fn import CircuitStateFn
         from ..state_fns.dict_state_fn import DictStateFn

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -66,7 +66,7 @@ class PrimitiveOp(OperatorBase):
         Raises:
             TypeError: Unsupported primitive type passed.
         """
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         if isinstance(primitive, (Instruction, QuantumCircuit)):
             from .circuit_op import CircuitOp
             return CircuitOp.__new__(CircuitOp)
@@ -159,7 +159,7 @@ class PrimitiveOp(OperatorBase):
     def compose(self, other: OperatorBase,
                 permutation: Optional[List[int]] = None, front: bool = False) -> \
             OperatorBase:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.composed_op import ComposedOp
         new_self, other = self._expand_shorter_operator_and_permute(other, permutation)
         if isinstance(other, ComposedOp):
@@ -187,7 +187,7 @@ class PrimitiveOp(OperatorBase):
 
     def exp_i(self) -> OperatorBase:
         """ Return Operator exponentiation, equaling e^(-i * op)"""
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..evolutions.evolved_op import EvolvedOp
         return EvolvedOp(self)
 
@@ -226,7 +226,7 @@ class PrimitiveOp(OperatorBase):
         if isinstance(self.coeff, ParameterExpression):
             unrolled_dict = self._unroll_param_dict(param_dict)
             if isinstance(unrolled_dict, list):
-                # pylint: disable=import-outside-toplevel,cyclic-import
+                # pylint: disable=cyclic-import
                 from ..list_ops.list_op import ListOp
                 return ListOp([self.assign_parameters(param_dict) for param_dict in unrolled_dict])
             if self.coeff.parameters <= set(unrolled_dict.keys()):
@@ -243,7 +243,6 @@ class PrimitiveOp(OperatorBase):
 
     def to_matrix_op(self, massive: bool = False) -> OperatorBase:
         """ Returns a ``MatrixOp`` equivalent to this Operator. """
-        # pylint: disable=import-outside-toplevel
         prim_mat = self.__class__(self.primitive).to_matrix(massive=massive)
         from .matrix_op import MatrixOp
         return MatrixOp(prim_mat, coeff=self.coeff)
@@ -260,7 +259,6 @@ class PrimitiveOp(OperatorBase):
 
     def to_circuit_op(self) -> OperatorBase:
         """ Returns a ``CircuitOp`` equivalent to this Operator. """
-        # pylint: disable=import-outside-toplevel
         from .circuit_op import CircuitOp
         if self.coeff == 0:
             return CircuitOp(QuantumCircuit(self.num_qubits), coeff=0)
@@ -268,12 +266,11 @@ class PrimitiveOp(OperatorBase):
 
     def to_pauli_op(self, massive: bool = False) -> OperatorBase:
         """ Returns a sum of ``PauliOp`` s equivalent to this Operator. """
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..list_ops.summed_op import SummedOp
         mat_op = self.to_matrix_op(massive=massive)
         sparse_pauli = SparsePauliOp.from_operator(mat_op.primitive)  # type: ignore
         if not sparse_pauli.to_list():
-            # pylint: disable=import-outside-toplevel
             from ..operator_globals import I
             return (I ^ self.num_qubits) * 0.0
         if len(sparse_pauli) == 1:

--- a/qiskit/opflow/state_fns/circuit_state_fn.py
+++ b/qiskit/opflow/state_fns/circuit_state_fn.py
@@ -141,7 +141,7 @@ class CircuitStateFn(StateFn):
         if front:
             return other.compose(new_self)
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..primitive_ops.circuit_op import CircuitOp
         from ..primitive_ops.pauli_op import PauliOp
         from ..primitive_ops.matrix_op import MatrixOp
@@ -184,7 +184,6 @@ class CircuitStateFn(StateFn):
         Returns:
             An ``OperatorBase`` equivalent to the tensor product of self and other.
         """
-        # pylint: disable=import-outside-toplevel
         if isinstance(other, CircuitStateFn) and other.is_measurement == self.is_measurement:
             # Avoid reimplementing tensor, just use CircuitOp's
             from ..primitive_ops.circuit_op import CircuitOp
@@ -245,7 +244,6 @@ class CircuitStateFn(StateFn):
         if isinstance(self.coeff, ParameterExpression) or self.primitive.parameters:
             unrolled_dict = self._unroll_param_dict(param_dict)
             if isinstance(unrolled_dict, list):
-                # pylint: disable=import-outside-toplevel
                 from ..list_ops.list_op import ListOp
                 return ListOp([self.assign_parameters(param_dict) for param_dict in unrolled_dict])
             if isinstance(self.coeff, ParameterExpression) \
@@ -275,7 +273,6 @@ class CircuitStateFn(StateFn):
                 'Cannot compute overlap with StateFn or Operator if not Measurement. Try taking '
                 'sf.adjoint() first to convert to measurement.')
 
-        # pylint: disable=import-outside-toplevel
         from ..list_ops.list_op import ListOp
         from ..primitive_ops.pauli_op import PauliOp
         from ..primitive_ops.matrix_op import MatrixOp

--- a/qiskit/opflow/state_fns/cvar_measurement.py
+++ b/qiskit/opflow/state_fns/cvar_measurement.py
@@ -121,7 +121,7 @@ class CVaRMeasurement(OperatorStateFn):
         if isinstance(other, OperatorStateFn):
             return StateFn(self.primitive.tensor(other.primitive),
                            coeff=self.coeff * other.coeff)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .. import TensoredOp
         return TensoredOp([self, other])
 

--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -100,7 +100,7 @@ class DictStateFn(StateFn):
                 new_dict.update({b: v * other.coeff for (b, v) in other.primitive.items()
                                  if b not in self.primitive})
                 return StateFn(new_dict, is_measurement=self._is_measurement)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..list_ops.summed_op import SummedOp
         return SummedOp([self, other])
 
@@ -137,7 +137,7 @@ class DictStateFn(StateFn):
             return StateFn(new_dict,
                            coeff=self.coeff * other.coeff,
                            is_measurement=self.is_measurement)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..list_ops.tensored_op import TensoredOp
         return TensoredOp([self, other])
 
@@ -213,7 +213,7 @@ class DictStateFn(StateFn):
         if not isinstance(front, OperatorBase):
             front = StateFn(front)
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS
 
         # If the primitive is a lookup of bitstrings,

--- a/qiskit/opflow/state_fns/operator_state_fn.py
+++ b/qiskit/opflow/state_fns/operator_state_fn.py
@@ -96,7 +96,7 @@ class OperatorStateFn(StateFn):
             return StateFn(self.primitive.tensor(other.primitive),
                            coeff=self.coeff * other.coeff,
                            is_measurement=self.is_measurement)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .. import TensoredOp
         return TensoredOp([self, other])
 

--- a/qiskit/opflow/state_fns/state_fn.py
+++ b/qiskit/opflow/state_fns/state_fn.py
@@ -73,7 +73,7 @@ class StateFn(OperatorBase):
         if cls.__name__ != StateFn.__name__:
             return super().__new__(cls)
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         if isinstance(primitive, (str, dict, Result)):
             from .dict_state_fn import DictStateFn
             return DictStateFn.__new__(DictStateFn)
@@ -205,7 +205,7 @@ class StateFn(OperatorBase):
     def _expand_shorter_operator_and_permute(self, other: OperatorBase,
                                              permutation: Optional[List[int]] = None) \
             -> Tuple[OperatorBase, OperatorBase]:
-        # pylint: disable=import-outside-toplevel,cyclic-import
+        # pylint: disable=cyclic-import
         from ..operator_globals import Zero
 
         if self == StateFn({'0': 1}, is_measurement=True):
@@ -263,7 +263,6 @@ class StateFn(OperatorBase):
         if front:
             return other.compose(self)
         # TODO maybe include some reduction here in the subclasses - vector and Op, op and Op, etc.
-        # pylint: disable=import-outside-toplevel
         from ..primitive_ops.circuit_op import CircuitOp
 
         if self.primitive == {'0' * self.num_qubits: 1.0} and isinstance(other, CircuitOp):
@@ -320,7 +319,6 @@ class StateFn(OperatorBase):
         if isinstance(self.coeff, ParameterExpression):
             unrolled_dict = self._unroll_param_dict(param_dict)
             if isinstance(unrolled_dict, list):
-                # pylint: disable=import-outside-toplevel
                 from ..list_ops.list_op import ListOp
                 return ListOp([self.assign_parameters(param_dict) for param_dict in unrolled_dict])
             if self.coeff.parameters <= set(unrolled_dict.keys()):
@@ -367,7 +365,7 @@ class StateFn(OperatorBase):
         Returns:
             A VectorStateFn equivalent to self.
         """
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .vector_state_fn import VectorStateFn
         return VectorStateFn(self.to_matrix(massive=massive), is_measurement=self.is_measurement)
 

--- a/qiskit/opflow/state_fns/vector_state_fn.py
+++ b/qiskit/opflow/state_fns/vector_state_fn.py
@@ -68,7 +68,7 @@ class VectorStateFn(StateFn):
             # Covers Statevector and custom.
             return VectorStateFn((self.coeff * self.primitive) + (other.primitive * other.coeff),
                                  is_measurement=self._is_measurement)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .. import SummedOp
         return SummedOp([self, other])
 
@@ -127,7 +127,7 @@ class VectorStateFn(StateFn):
             return StateFn(self.primitive.tensor(other.primitive),
                            coeff=self.coeff * other.coeff,
                            is_measurement=self.is_measurement)
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from .. import TensoredOp
         return TensoredOp([self, other])
 
@@ -179,7 +179,7 @@ class VectorStateFn(StateFn):
         if not isinstance(front, OperatorBase):
             front = StateFn(front)
 
-        # pylint: disable=cyclic-import,import-outside-toplevel
+        # pylint: disable=cyclic-import
         from ..operator_globals import EVAL_SIG_DIGITS
         from .operator_state_fn import OperatorStateFn
         from .circuit_state_fn import CircuitStateFn

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -321,7 +321,7 @@ class Operator(LinearOp):
             QiskitError: if other is not an operator, or has incompatible
                          dimensions.
         """
-        # pylint: disable=import-outside-toplevel, cyclic-import
+        # pylint: disable=cyclic-import
         from qiskit.quantum_info.operators.scalar_op import ScalarOp
 
         if qargs is None:

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -38,7 +38,6 @@ def has_ibmq():
     """ Check if IBMQ is installed """
     if not _PROVIDER_CHECK.checked_ibmq:
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.ibmq import IBMQFactory
             from qiskit.providers.ibmq.accountprovider import AccountProvider
             _PROVIDER_CHECK.has_ibmq = True
@@ -55,7 +54,6 @@ def has_aer():
     """ check if Aer is installed """
     if not _PROVIDER_CHECK.checked_aer:
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import AerProvider
             _PROVIDER_CHECK.has_aer = True
         except Exception as ex:  # pylint: disable=broad-except
@@ -76,7 +74,6 @@ def is_aer_provider(backend):
         bool: True is AerProvider
     """
     if has_aer():
-        # pylint: disable=import-outside-toplevel
         from qiskit.providers.aer import AerProvider
         return isinstance(backend.provider(), AerProvider)
 
@@ -91,7 +88,6 @@ def is_basicaer_provider(backend):
     Returns:
         bool: True is BasicAer
     """
-    # pylint: disable=import-outside-toplevel
     from qiskit.providers.basicaer import BasicAerProvider
 
     return isinstance(backend.provider(), BasicAerProvider)
@@ -106,7 +102,6 @@ def is_ibmq_provider(backend):
         bool: True is IBMQ
     """
     if has_ibmq():
-        # pylint: disable=import-outside-toplevel
         from qiskit.providers.ibmq.accountprovider import AccountProvider
         return isinstance(backend.provider(), AccountProvider)
 

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -224,7 +224,6 @@ class QuantumInstance:
         Returns:
             str: the info of the object.
         """
-        # pylint: disable=import-outside-toplevel
         from qiskit import __version__ as terra_version
 
         info = "\nQiskit Terra version: {}\n".format(terra_version)
@@ -290,7 +289,6 @@ class QuantumInstance:
         TODO: Maybe we can combine the circuits for the main ones and calibration circuits before
               assembling to the qobj.
         """
-        # pylint: disable=import-outside-toplevel
         from qiskit.utils.run_circuits import run_qobj
 
         from qiskit.utils.measurement_error_mitigation import \

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -29,7 +29,6 @@ class TestMeasurementErrorMitigation(QiskitAlgorithmsTestCase):
 
     def test_measurement_error_mitigation_with_diff_qubit_order(self):
         """ measurement error mitigation with different qubit order"""
-        # pylint: disable=import-outside-toplevel
         try:
             from qiskit.ignis.mitigation.measurement import CompleteMeasFitter
             from qiskit import Aer
@@ -82,7 +81,6 @@ class TestMeasurementErrorMitigation(QiskitAlgorithmsTestCase):
     def test_measurement_error_mitigation_with_vqe(self):
         """ measurement error mitigation test with vqe """
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.ignis.mitigation.measurement import CompleteMeasFitter
             from qiskit import Aer
             from qiskit.providers.aer import noise

--- a/test/python/algorithms/test_skip_qobj_validation.py
+++ b/test/python/algorithms/test_skip_qobj_validation.py
@@ -90,7 +90,6 @@ class TestSkipQobjValidation(QiskitAlgorithmsTestCase):
         # build noise model
         # Asymmetric readout error on qubit-0 only
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer.noise import NoiseModel
             from qiskit import Aer
             self.backend = Aer.get_backend('qasm_simulator')

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -168,7 +168,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
     def test_with_aer_statevector(self):
         """Test VQE with Aer's statevector_simulator."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
@@ -191,7 +190,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
     def test_with_aer_qasm(self):
         """Test VQE with Aer's qasm_simulator."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
@@ -216,7 +214,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
     def test_with_aer_qasm_snapshot_mode(self):
         """Test the VQE using Aer's qasm_simulator snapshot mode."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
@@ -309,7 +306,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
     def test_vqe_expectation_select(self):
         """Test expectation selection with Aer's qasm_simulator."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -63,7 +63,6 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_coefficients_correctly_propagated(self):
         """Test that the coefficients in SummedOp and states are correctly used."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
@@ -89,7 +88,6 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_is_measurement_correctly_propagated(self):
         """Test if is_measurement property of StateFn is propagated to converted StateFn."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
@@ -103,7 +101,6 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_parameter_binding_on_listop(self):
         """Test passing a ListOp with differing parameters works with the circuit sampler."""
         try:
-            # pylint: disable=import-outside-toplevel
             from qiskit.providers.aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))

--- a/test/python/quantum_info/operators/test_measures.py
+++ b/test/python/quantum_info/operators/test_measures.py
@@ -168,7 +168,6 @@ class TestOperatorMeasures(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3])
     def test_diamond_norm(self, num_qubits):
         """Test the diamond_norm for {num_qubits}-qubit pauli channel."""
-        # pylint: disable=import-outside-toplevel
         try:
             import cvxpy
         except ImportError:


### PR DESCRIPTION
Since it is suppressed in pylintrc this cleans up a lot of imported aqua code by removing local suppressions.

Follow on from #5826 
After: 663 local suppressions