### PR TITLE
Add missing snapshot from unroller custom def

### DIFF
--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -353,7 +353,7 @@ class DAGDependency:
             cargs (list[Clbit]): list of classical wires to attach to.
         """
         directives = ['measure']
-        if operation._directive or operation.name not in directives:
+        if not operation._directive and operation.name not in directives:
             qindices_list = []
             for elem in qargs:
                 qindices_list.append(self.qubits.index(elem))

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -57,6 +57,9 @@ class UnrollCustomDefinitions(TransformationPass):
 
         for node in dag.op_nodes():
 
+            if node.op._directive:
+                continue
+
             if dag.has_calibration_for(node):
                 continue
 
@@ -65,10 +68,6 @@ class UnrollCustomDefinitions(TransformationPass):
                     pass
                 else:
                     continue
-
-            if node.op._directive:
-                raise QiskitError(
-                    'Cannot unroll unsupported directive instruction {}'.format(node.name))
 
             try:
                 rule = node.op.definition.data

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -52,7 +52,7 @@ class UnrollCustomDefinitions(TransformationPass):
         if self._basis_gates is None:
             return dag
 
-        basic_insts = {'measure', 'reset', 'barrier', 'delay'}
+        basic_insts = {'measure', 'reset', 'barrier', 'snapshot', 'delay'}
         device_insts = basic_insts | set(self._basis_gates)
 
         for node in dag.op_nodes():

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -51,21 +51,22 @@ class Unroller(TransformationPass):
         if self.basis is None:
             return dag
         # Walk through the DAG and expand each non-basis node
+        basic_insts = ['measure', 'reset', 'barrier', 'snapshot', 'delay']
         for node in dag.op_nodes():
-            basic_insts = ['measure', 'reset', 'barrier', 'snapshot', 'delay']
+            if node.op._directive:
+                continue
+
             if node.name in basic_insts:
                 # TODO: this is legacy behavior.Basis_insts should be removed that these
                 #  instructions should be part of the device-reported basis. Currently, no
                 #  backend reports "measure", for example.
                 continue
+
             if node.name in self.basis:  # If already a base, ignore.
                 if isinstance(node.op, ControlledGate) and node.op._open_ctrl:
                     pass
                 else:
                     continue
-            if node.op._directive:
-                raise QiskitError(
-                    'Cannot unroll unsupported directive instruction {}'.format(node.name))
 
             # TODO: allow choosing other possible decompositions
             try:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Legacy snapshot unrolling was intended to be preserved in #5701, however this was only done `unroller.py` not `unroll_custom_definitions.py`. This fixes by adding 'snapshot' back to basic_instructions for unroller custom definitions.

### Details and comments


