### PR TITLE
Move array_to_latex from latex.py to array.py

### DIFF
--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -114,7 +114,7 @@ from qiskit.visualization.state_visualization import (plot_state_hinton,
                                                       plot_state_paulivec,
                                                       plot_state_qsphere)
 from qiskit.visualization.transition_visualization import visualize_transition
-from qiskit.visualization.latex import array_to_latex
+from qiskit.visualization.array import array_to_latex
 
 from .circuit_visualization import circuit_drawer
 from .dag_visualization import dag_drawer

--- a/qiskit/visualization/array.py
+++ b/qiskit/visualization/array.py
@@ -193,3 +193,58 @@ def _matrix_to_latex(matrix, precision=5, pretext="", max_size=(8, 8)):
         out_string += _rows_to_latex(matrix, max_width)
     out_string += "\\end{bmatrix}\n"
     return out_string
+
+
+def array_to_latex(array, precision=5, pretext="", source=False, max_size=8):
+    """Latex representation of a complex numpy array (with dimension 1 or 2)
+
+        Args:
+            array (ndarray): The array to be converted to latex, must have dimension 1 or 2 and
+                             contain only numerical data.
+            precision (int): For numbers not close to integers or common terms, the number of
+                             decimal places to round to.
+            pretext (str): Latex string to be prepended to the latex, intended for labels.
+            source (bool): If ``False``, will return IPython.display.Latex object. If display is
+                           ``True``, will instead return the LaTeX source string.
+            max_size (list(int) or int): The maximum size of the output Latex array.
+                      * If list(```int```), then the 0th element of the list specifies the maximum
+                        width (including dots characters) and the 1st specifies the maximum height
+                        (also inc. dots characters).
+                      * If a single ```int``` then this value sets the maximum width _and_ maximum
+                        height.
+
+        Returns:
+            if ``source`` is ``True``:
+                ``str``: LaTeX string representation of the array, wrapped in `$$`.
+            else:
+                ``IPython.display.Latex``: LaTeX representation of the array.
+
+        Raises:
+            TypeError: If array can not be interpreted as a numerical numpy array.
+            ValueError: If the dimension of array is not 1 or 2.
+            ImportError: If ``source`` is ``False`` and ``IPython.display.Latex`` cannot be
+                         imported.
+    """
+    try:
+        array = np.asarray(array)
+        _ = array[0]+1  # Test first element contains numerical data
+    except TypeError as err:
+        raise TypeError("""array_to_latex can only convert numpy arrays containing numerical data,
+        or types that can be converted to such arrays""") from err
+
+    if array.ndim <= 2:
+        if isinstance(max_size, int):
+            max_size = (max_size, max_size)
+        outstr = _matrix_to_latex(array, precision=precision, pretext=pretext, max_size=max_size)
+    else:
+        raise ValueError("array_to_latex can only convert numpy ndarrays of dimension 1 or 2")
+
+    if source is False:
+        try:
+            from IPython.display import Latex
+        except ImportError as err:
+            raise ImportError(str(err) + ". Try `pip install ipython` (If you just want the LaTeX"
+                                         " source string, set `source=True`).")
+        return Latex(outstr)
+    else:
+        return outstr

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -24,7 +24,6 @@ from qiskit.circuit.controlledgate import ControlledGate
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.visualization import exceptions
 from qiskit.circuit.tools.pi_check import pi_check
-from qiskit.visualization.array import _matrix_to_latex
 from .utils import generate_latex_label
 
 
@@ -1023,58 +1022,3 @@ def _truncate_float(matchobj, ndigits=3):
     if matchobj.group(0):
         return '%.{}g'.format(ndigits) % float(matchobj.group(0))
     return ''
-
-
-def array_to_latex(array, precision=5, pretext="", source=False, max_size=8):
-    """Latex representation of a complex numpy array (with dimension 1 or 2)
-
-        Args:
-            array (ndarray): The array to be converted to latex, must have dimension 1 or 2 and
-                             contain only numerical data.
-            precision (int): For numbers not close to integers or common terms, the number of
-                             decimal places to round to.
-            pretext (str): Latex string to be prepended to the latex, intended for labels.
-            source (bool): If ``False``, will return IPython.display.Latex object. If display is
-                           ``True``, will instead return the LaTeX source string.
-            max_size (list(int) or int): The maximum size of the output Latex array.
-                      * If list(```int```), then the 0th element of the list specifies the maximum
-                        width (including dots characters) and the 1st specifies the maximum height
-                        (also inc. dots characters).
-                      * If a single ```int``` then this value sets the maximum width _and_ maximum
-                        height.
-
-        Returns:
-            if ``source`` is ``True``:
-                ``str``: LaTeX string representation of the array, wrapped in `$$`.
-            else:
-                ``IPython.display.Latex``: LaTeX representation of the array.
-
-        Raises:
-            TypeError: If array can not be interpreted as a numerical numpy array.
-            ValueError: If the dimension of array is not 1 or 2.
-            ImportError: If ``source`` is ``False`` and ``IPython.display.Latex`` cannot be
-                         imported.
-    """
-    try:
-        array = np.asarray(array)
-        _ = array[0]+1  # Test first element contains numerical data
-    except TypeError as err:
-        raise TypeError("""array_to_latex can only convert numpy arrays containing numerical data,
-        or types that can be converted to such arrays""") from err
-
-    if array.ndim <= 2:
-        if isinstance(max_size, int):
-            max_size = (max_size, max_size)
-        outstr = _matrix_to_latex(array, precision=precision, pretext=pretext, max_size=max_size)
-    else:
-        raise ValueError("array_to_latex can only convert numpy ndarrays of dimension 1 or 2")
-
-    if source is False:
-        try:
-            from IPython.display import Latex
-        except ImportError as err:
-            raise ImportError(str(err) + ". Try `pip install ipython` (If you just want the LaTeX"
-                                         " source string, set `source=True`).")
-        return Latex(outstr)
-    else:
-        return outstr


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR moves the `array_to_latex `function from latex.py to array.py.

### Details and comments


