### PR TITLE
Fix to carry over calibrations with __iadd__ and __add__

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -566,6 +566,11 @@ class QuantumCircuit:
         for instruction_context in itertools.chain(self.data, rhs.data):
             circuit._append(*instruction_context)
         circuit.global_phase = self.global_phase + rhs.global_phase
+
+        # Add the calibrations
+        for gate, cals in rhs.calibrations.items():
+            circuit._calibrations[gate].update(cals)
+
         return circuit
 
     def extend(self, rhs):
@@ -610,6 +615,11 @@ class QuantumCircuit:
         for instruction_context in data:
             self._append(*instruction_context)
         self.global_phase += rhs.global_phase
+
+        # Add calibrations
+        for gate, cals in rhs.calibrations.items():
+            self._calibrations[gate].update(cals)
+
         return self
 
     def compose(self, other, qubits=None, clbits=None, front=False, inplace=False):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -569,7 +569,8 @@ class QuantumCircuit:
 
         # Add the calibrations
         for gate, cals in rhs.calibrations.items():
-            circuit._calibrations[gate].update(cals)
+            for key, sched in cals.items():
+                circuit.add_calibration(gate, qubits=key[0], schedule=sched, params=key[1])
 
         return circuit
 
@@ -618,7 +619,8 @@ class QuantumCircuit:
 
         # Add calibrations
         for gate, cals in rhs.calibrations.items():
-            self._calibrations[gate].update(cals)
+            for key, sched in cals.items():
+                self.add_calibration(gate, qubits=key[0], schedule=sched, params=key[1])
 
         return self
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -567,7 +567,6 @@ class QuantumCircuit:
             circuit._append(*instruction_context)
         circuit.global_phase = self.global_phase + rhs.global_phase
 
-        # Add the calibrations
         for gate, cals in rhs.calibrations.items():
             for key, sched in cals.items():
                 circuit.add_calibration(gate, qubits=key[0], schedule=sched, params=key[1])
@@ -617,7 +616,6 @@ class QuantumCircuit:
             self._append(*instruction_context)
         self.global_phase += rhs.global_phase
 
-        # Add calibrations
         for gate, cals in rhs.calibrations.items():
             for key, sched in cals.items():
                 self.add_calibration(gate, qubits=key[0], schedule=sched, params=key[1])

--- a/releasenotes/notes/calibrations-add-iadd-265b92f42ffce92a.yaml
+++ b/releasenotes/notes/calibrations-add-iadd-265b92f42ffce92a.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Quantum circuit Calibrations are now carried over when the operators += and +
+    are used.

--- a/test/python/circuit/test_calibrations.py
+++ b/test/python/circuit/test_calibrations.py
@@ -46,5 +46,6 @@ class TestCalibrations(QiskitTestCase):
         self.assertEqual(qc.calibrations[RZXGate], {((0, 1), (0.5,)): Schedule(name="test")})
         self.assertEqual(qc_cal.calibrations, qc.calibrations)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/circuit/test_calibrations.py
+++ b/test/python/circuit/test_calibrations.py
@@ -1,0 +1,50 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test calibrations in quantum circuits."""
+
+import unittest
+
+from qiskit.pulse import Schedule
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import RZXGate
+from qiskit.test import QiskitTestCase
+
+
+class TestCalibrations(QiskitTestCase):
+    """Test composition of two circuits."""
+
+    def test_iadd(self):
+        """Test that __iadd__ keeps the calibrations."""
+        qc_cal = QuantumCircuit(2)
+        qc_cal.rzx(0.5, 0, 1)
+        qc_cal.add_calibration(RZXGate, (0, 1), params=[0.5], schedule=Schedule())
+
+        qc = QuantumCircuit(2)
+        qc += qc_cal
+
+        self.assertEqual(qc.calibrations[RZXGate], {((0, 1), (0.5,)): Schedule(name="test")})
+        self.assertEqual(qc_cal.calibrations, qc.calibrations)
+
+    def test_add(self):
+        """Test that __add__ keeps the calibrations."""
+        qc_cal = QuantumCircuit(2)
+        qc_cal.rzx(0.5, 0, 1)
+        qc_cal.add_calibration(RZXGate, (0, 1), params=[0.5], schedule=Schedule())
+
+        qc = QuantumCircuit(2) + qc_cal
+
+        self.assertEqual(qc.calibrations[RZXGate], {((0, 1), (0.5,)): Schedule(name="test")})
+        self.assertEqual(qc_cal.calibrations, qc.calibrations)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary
Fixes #5908

### Details and comments
Added the calibrations to methods `combine` and `extend`.
