### PR TITLE
fix global phase in Instruction.inverse

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -333,7 +333,7 @@ class Instruction:
                                 num_qubits=self.num_qubits,
                                 params=self.params.copy())
 
-        inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs, 
+        inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs,
                                                  global_phase=-self.definition.global_phase)
         inverse_gate.definition._data = [(inst.inverse(), qargs, cargs)
                                          for inst, qargs, cargs in reversed(self._definition)]

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -333,7 +333,8 @@ class Instruction:
                                 num_qubits=self.num_qubits,
                                 params=self.params.copy())
 
-        inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs)
+        inverse_gate.definition = QuantumCircuit(*self.definition.qregs, *self.definition.cregs, 
+                                                 global_phase=-self.definition.global_phase)
         inverse_gate.definition._data = [(inst.inverse(), qargs, cargs)
                                          for inst, qargs, cargs in reversed(self._definition)]
 

--- a/releasenotes/notes/fix-global-phase-in-instruction-inverse-2306e4539ffb0bee.yaml
+++ b/releasenotes/notes/fix-global-phase-in-instruction-inverse-2306e4539ffb0bee.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix the global phase of the output of ``instruction.inverse``. If an instruction
+    with a global phase in the definition is inverted, the global phase should be 
+    added with a minus sign.

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -323,6 +323,17 @@ class TestInstructions(QiskitTestCase):
         empty_gate = empty_circ.to_instruction()
         self.assertEqual(empty_gate.inverse().definition, empty_gate.definition)
 
+    def test_inverse_with_global_phase(self):
+        """test inverting instruction with global phase in definition."""
+        q = QuantumRegister(1)
+        circ = QuantumCircuit(q, name='circ', global_phase=np.pi / 3)
+        circ.x(q)
+        gate = circ.to_instruction()
+        circ = QuantumCircuit(q, name='circ', global_phase=-np.pi / 3)
+        circ.x(q)
+        gate_inverse = circ.to_instruction()
+        self.assertEqual(gate.inverse().definition, gate_inverse.definition)
+
     def test_no_broadcast(self):
         """See https://github.com/Qiskit/qiskit-terra/issues/2777
         When creating custom instructions, do not broadcast parameters"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`Instruction.inverse` ignores the global phase of `instruction.definition`.  This has been fixed.

Resolves #5914.



### Details and comments
Calling `instruction.inverse` and then adding control was causing a relative phase difference. This was the root of #5914 since the grover operator in the amplitude estimation circuit had a global phase in its definition.

