### PR TITLE
Add DAGCircuit output option to OneQubitEulerDecomposer

### DIFF
--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -536,6 +536,6 @@ class OneQubitEulerDecomposer:
 
 def _mod2pi(angle):
     if angle >= 0:
-        return np.mod(angle, 2*np.pi)
+        return math.fmod(angle, 2*np.pi)
     else:
-        return np.mod(angle, -2*np.pi)
+        return math.fmod(angle, -2*np.pi)

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.linalg as la
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.library.standard_gates import (UGate, PhaseGate, U3Gate,
                                                    U2Gate, U1Gate, RXGate, RYGate,
                                                    RZGate, RGate, SXGate)
@@ -268,16 +269,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RZGate(phi + lam), [0])
+            circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RZGate(lam), [0])
+            circuit._append(RZGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit._append(RYGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RZGate(phi), [0])
+            circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -287,16 +289,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RZGate(phi + lam), [0])
+            circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RZGate(lam), [0])
+            circuit._append(RZGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(theta), [0])
+            circuit._append(RXGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RZGate(phi), [0])
+            circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -306,16 +309,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(phi + lam), [0])
+            circuit._append(RXGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RXGate(lam), [0])
+            circuit._append(RXGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit._append(RYGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RXGate(phi), [0])
+            circuit._append(RXGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -326,8 +330,9 @@ class OneQubitEulerDecomposer:
                     simplify=True,
                     atol=DEFAULT_ATOL):
         # pylint: disable=unused-argument
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(U3Gate(theta, phi, lam), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -338,14 +343,15 @@ class OneQubitEulerDecomposer:
                       simplify=True,
                       atol=DEFAULT_ATOL):
         rtol = 1e-9  # default is 1e-5, too far from atol=1e-12
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and (np.isclose(theta, 0.0, atol=atol, rtol=rtol)):
             if not np.isclose(phi+lam, [0.0, 2*np.pi], atol=atol, rtol=rtol).any():
-                circuit.append(U1Gate(_mod2pi(phi+lam)), [0])
+                circuit._append(U1Gate(_mod2pi(phi+lam)), [qr[0]], [])
         elif simplify and np.isclose(theta, np.pi/2, atol=atol, rtol=rtol):
-            circuit.append(U2Gate(phi, lam), [0])
+            circuit._append(U2Gate(phi, lam), [qr[0]], [])
         else:
-            circuit.append(U3Gate(theta, phi, lam), [0])
+            circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -356,8 +362,9 @@ class OneQubitEulerDecomposer:
                    simplify=True,
                    atol=DEFAULT_ATOL):
         # pylint: disable=unused-argument
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(UGate(theta, phi, lam), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(UGate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -371,33 +378,34 @@ class OneQubitEulerDecomposer:
         # Phase(phi+pi).SX.Phase(theta+pi).SX.Phase(lam)
         theta = _mod2pi(theta + np.pi)
         phi = _mod2pi(phi + np.pi)
-        circuit = QuantumCircuit(1, global_phase=phase - np.pi / 2)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             if not np.isclose(_mod2pi(abs(lam + phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(lam + phi + theta)), [0])
+                circuit._append(PhaseGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
             circuit.global_phase += np.pi / 2
         elif simplify and np.isclose(abs(theta),
                                      [np.pi/2, 3*np.pi/2], atol=atol).any():
             if not np.isclose(_mod2pi(abs(lam + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(lam + theta)), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(_mod2pi(lam + theta)), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(_mod2pi(abs(phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(phi + theta)), [0])
+                circuit._append(PhaseGate(_mod2pi(phi + theta)), [qr[0]], [])
             if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
                 circuit.global_phase += np.pi / 2
         else:
             if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(lam), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(lam), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(theta), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(theta), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(phi), [0])
+                circuit._append(PhaseGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -411,38 +419,39 @@ class OneQubitEulerDecomposer:
         # RZ(phi+pi).SX.RZ(theta+pi).SX.RZ(lam)
         theta = _mod2pi(theta + np.pi)
         phi = _mod2pi(phi + np.pi)
-        circuit = QuantumCircuit(1, global_phase=phase - np.pi / 2)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             if not np.isclose(_mod2pi(abs(lam + phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(lam + phi + theta)), [0])
+                circuit._append(RZGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(lam + phi + theta)
             circuit.global_phase += np.pi / 2
         elif simplify and np.isclose(abs(theta),
                                      [np.pi/2, 3*np.pi/2], atol=atol).any():
             if not np.isclose(_mod2pi(abs(lam + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(lam + theta)), [0])
+                circuit._append(RZGate(_mod2pi(lam + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(lam + theta)
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(_mod2pi(abs(phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(phi + theta)), [0])
+                circuit._append(RZGate(_mod2pi(phi + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(phi + theta)
             if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
                 circuit.global_phase += np.pi / 2
         else:
             if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(lam), [0])
+                circuit._append(RZGate(lam), [qr[0]], [])
                 circuit.global_phase += 0.5 * lam
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(theta), [0])
+                circuit._append(RZGate(theta), [qr[0]], [])
                 circuit.global_phase += 0.5 * theta
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(phi), [0])
+                circuit._append(RZGate(phi), [qr[0]], [])
                 circuit.global_phase += 0.5 * phi
         return circuit
 
@@ -460,23 +469,26 @@ class OneQubitEulerDecomposer:
         # Check for decomposition into minimimal number required X90 pulses
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             # Zero X90 gate decomposition
-            circuit = QuantumCircuit(1, global_phase=phase)
-            circuit.append(U1Gate(lam + phi + theta), [0])
+            qr = QuantumRegister(1, 'qr')
+            circuit = QuantumCircuit(qr, global_phase=phase)
+            circuit._append(U1Gate(lam + phi + theta), [qr[0]], [])
             return circuit
         if simplify and np.isclose(abs(theta), np.pi/2, atol=atol):
             # Single X90 gate decomposition
-            circuit = QuantumCircuit(1, global_phase=phase)
-            circuit.append(U1Gate(lam + theta), [0])
-            circuit.append(RXGate(np.pi / 2), [0])
-            circuit.append(U1Gate(phi + theta), [0])
+            qr = QuantumRegister(1, 'qr')
+            circuit = QuantumCircuit(qr, global_phase=phase)
+            circuit._append(U1Gate(lam + theta), [qr[0]], [])
+            circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+            circuit._append(U1Gate(phi + theta), [qr[0]], [])
             return circuit
         # General two-X90 gate decomposition
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(U1Gate(lam), [0])
-        circuit.append(RXGate(np.pi / 2), [0])
-        circuit.append(U1Gate(theta), [0])
-        circuit.append(RXGate(np.pi / 2), [0])
-        circuit.append(U1Gate(phi), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(U1Gate(lam), [qr[0]], [])
+        circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+        circuit._append(U1Gate(theta), [qr[0]], [])
+        circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+        circuit._append(U1Gate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -486,10 +498,11 @@ class OneQubitEulerDecomposer:
                     phase,
                     simplify=True,
                     atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if not simplify or not np.isclose(theta, -np.pi, atol=atol):
-            circuit.append(RGate(theta + np.pi, np.pi / 2 - lam), [0])
-        circuit.append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [0])
+            circuit._append(RGate(theta + np.pi, np.pi / 2 - lam), [qr[0]], [])
+        circuit._append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [qr[0]], [])
         return circuit
 
 

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -271,14 +271,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RZGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RYGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
@@ -291,14 +291,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RZGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RXGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
@@ -311,14 +311,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RXGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RXGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RYGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RXGate(phi), [qr[0]], [])
         return circuit
 
@@ -345,10 +345,12 @@ class OneQubitEulerDecomposer:
         rtol = 1e-9  # default is 1e-5, too far from atol=1e-12
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and (np.isclose(theta, 0.0, atol=atol, rtol=rtol)):
-            if not np.isclose(phi+lam, [0.0, 2*np.pi], atol=atol, rtol=rtol).any():
+        if simplify and (math.isclose(theta, 0.0, abs_tol=atol, rel_tol=rtol)):
+            phi_lam = phi + lam
+            if not (math.isclose(phi_lam, 0.0, abs_tol=atol, rel_tol=rtol) or
+                    math.isclose(phi_lam, 2*np.pi, abs_tol=atol, rel_tol=rtol)):
                 circuit._append(U1Gate(_mod2pi(phi+lam)), [qr[0]], [])
-        elif simplify and np.isclose(theta, np.pi/2, atol=atol, rtol=rtol):
+        elif simplify and math.isclose(theta, np.pi/2, abs_tol=atol, rel_tol=rtol):
             circuit._append(U2Gate(phi, lam), [qr[0]], [])
         else:
             circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
@@ -381,30 +383,43 @@ class OneQubitEulerDecomposer:
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
-            if not np.isclose(_mod2pi(abs(lam + phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(PhaseGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
+        abs_theta = abs(theta)
+        if simplify and math.isclose(abs_theta, np.pi, abs_tol=atol):
+            lam_phi_theta = _mod2pi(lam + phi + theta)
+            abs_lam_phi_theta = _mod2pi(abs(lam + phi + theta))
+            if not (math.isclose(abs_lam_phi_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_lam_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(PhaseGate(lam_phi_theta), [qr[0]], [])
             circuit.global_phase += np.pi / 2
-        elif simplify and np.isclose(abs(theta),
-                                     [np.pi/2, 3*np.pi/2], atol=atol).any():
-            if not np.isclose(_mod2pi(abs(lam + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(PhaseGate(_mod2pi(lam + theta)), [qr[0]], [])
+        elif simplify and (math.isclose(abs_theta, np.pi/2, abs_tol=atol) or
+                           math.isclose(abs_theta, 3*np.pi/2, abs_tol=atol)):
+            lam_theta = _mod2pi(lam + theta)
+            abs_lam_theta = _mod2pi(abs(lam + theta))
+            if not (math.isclose(abs_lam_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_lam_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(PhaseGate(lam_theta), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(_mod2pi(abs(phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
+            phi_theta = _mod2pi(phi + theta)
+            abs_phi_theta = _mod2pi(abs(phi_theta))
+            if not (math.isclose(abs_phi_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_phi_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(_mod2pi(phi + theta)), [qr[0]], [])
-            if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
+            if (math.isclose(theta, -np.pi / 2, abs_tol=atol) or math.isclose(
+                    theta, 3 * np.pi / 2, abs_tol=atol)):
                 circuit.global_phase += np.pi / 2
         else:
-            if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
+            abs_lam = abs(lam)
+            if not (math.isclose(abs_lam, 0., abs_tol=atol) or
+                    math.isclose(abs_lam, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(lam), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
+            if not (math.isclose(abs_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(theta), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
+            abs_phi = abs(phi)
+            if not (math.isclose(abs_phi, 0., abs_tol=atol) or
+                    math.isclose(abs_phi, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(phi), [qr[0]], [])
         return circuit
 
@@ -422,35 +437,48 @@ class OneQubitEulerDecomposer:
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
-            if not np.isclose(_mod2pi(abs(lam + phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(lam + phi + theta)
+        abs_theta = abs(theta)
+        if simplify and math.isclose(abs_theta, np.pi, abs_tol=atol):
+            lam_phi_theta = _mod2pi(lam + phi + theta)
+            abs_lam_phi_theta = _mod2pi(abs(lam + phi + theta))
+            if not (math.isclose(abs_lam_phi_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_lam_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(lam_phi_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * lam_phi_theta
             circuit.global_phase += np.pi / 2
-        elif simplify and np.isclose(abs(theta),
-                                     [np.pi/2, 3*np.pi/2], atol=atol).any():
-            if not np.isclose(_mod2pi(abs(lam + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(lam + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(lam + theta)
+        elif simplify and (math.isclose(abs_theta, np.pi/2, abs_tol=atol) or
+                           math.isclose(abs_theta, 3*np.pi/2, abs_tol=atol)):
+            lam_theta = _mod2pi(lam + theta)
+            abs_lam_theta = _mod2pi(abs(lam + theta))
+            if not (math.isclose(abs_lam_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_lam_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(lam_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * lam_theta
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(_mod2pi(abs(phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(phi + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(phi + theta)
-            if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
+            phi_theta = _mod2pi(phi + theta)
+            abs_phi_theta = _mod2pi(abs(phi_theta))
+            if not (math.isclose(abs_phi_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(phi_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * phi_theta
+            if (math.isclose(theta, -np.pi / 2, abs_tol=atol) or
+                    math.isclose(theta, 3 * np.pi / 2, abs_tol=atol)):
                 circuit.global_phase += np.pi / 2
         else:
-            if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
+            abs_lam = abs(lam)
+            if not (math.isclose(abs_lam, 0., abs_tol=atol) or
+                    math.isclose(abs_lam, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(lam), [qr[0]], [])
                 circuit.global_phase += 0.5 * lam
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
+            if not (math.isclose(abs_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(theta), [qr[0]], [])
                 circuit.global_phase += 0.5 * theta
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
+            abs_phi = abs(phi)
+            if not (math.isclose(abs_phi, 0., abs_tol=atol) or
+                    math.isclose(abs_phi, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(phi), [qr[0]], [])
                 circuit.global_phase += 0.5 * phi
         return circuit
@@ -467,13 +495,13 @@ class OneQubitEulerDecomposer:
         theta += np.pi
         phi += np.pi
         # Check for decomposition into minimimal number required X90 pulses
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
+        if simplify and math.isclose(abs(theta), np.pi, abs_tol=atol):
             # Zero X90 gate decomposition
             qr = QuantumRegister(1, 'qr')
             circuit = QuantumCircuit(qr, global_phase=phase)
             circuit._append(U1Gate(lam + phi + theta), [qr[0]], [])
             return circuit
-        if simplify and np.isclose(abs(theta), np.pi/2, atol=atol):
+        if simplify and math.isclose(abs(theta), np.pi/2, abs_tol=atol):
             # Single X90 gate decomposition
             qr = QuantumRegister(1, 'qr')
             circuit = QuantumCircuit(qr, global_phase=phase)
@@ -500,7 +528,7 @@ class OneQubitEulerDecomposer:
                     atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if not simplify or not np.isclose(theta, -np.pi, atol=atol):
+        if not simplify or not math.isclose(theta, -np.pi, abs_tol=atol):
             circuit._append(RGate(theta + np.pi, np.pi / 2 - lam), [qr[0]], [])
         circuit._append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [qr[0]], [])
         return circuit

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -79,7 +79,7 @@ class UnitarySynthesis(TransformationPass):
 
         decomposer1q, decomposer2q = None, None
         if euler_basis is not None:
-            decomposer1q = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis)
+            decomposer1q = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis, use_dag=True)
         if kak_gate is not None:
             decomposer2q = TwoQubitBasisDecomposer(kak_gate, euler_basis=euler_basis)
 
@@ -89,7 +89,7 @@ class UnitarySynthesis(TransformationPass):
             if len(node.qargs) == 1:
                 if decomposer1q is None:
                     continue
-                synth_dag = circuit_to_dag(decomposer1q(node.op.to_matrix()))
+                synth_dag = decomposer1q(node.op.to_matrix())
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new option to the euler one qubit decomposer class,
use_dag, which when set to True will return a DAGCircuit object for the
decomposed matrix instead of a QuantumCircuit object. This is useful for
transpiler passes that call the decomposer so that they don't have to
convert from a circuit to a dag. The passes that use the decomposer are
also updated to use this new option.

### Details and comments

This is based on top of #5915 and is blocked until #5915 merges.