### PR TITLE
Add option to 1q euler decomposer for disabling unitary check

### DIFF
--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -111,8 +111,7 @@ class OneQubitEulerDecomposer:
     def __call__(self,
                  unitary,
                  simplify=True,
-                 atol=DEFAULT_ATOL,
-                 check_unitary=True):
+                 atol=DEFAULT_ATOL):
         """Decompose single qubit gate into a circuit.
 
         Args:
@@ -120,8 +119,6 @@ class OneQubitEulerDecomposer:
             simplify (bool): reduce gate count in decomposition [Default: True].
             atol (float): absolute tolerance for checking angles when simplifing
                          returnd circuit [Default: 1e-12].
-            check_unitary (bool): If set to false the input is assumed to be a
-                                  2-qubit unitary and this is not checked.
         Returns:
             QuantumCircuit: the decomposed single-qubit gate circuit
 
@@ -141,13 +138,15 @@ class OneQubitEulerDecomposer:
         unitary = np.asarray(unitary, dtype=complex)
 
         # Check input is a 2-qubit unitary
-        if check_unitary:
-            if unitary.shape != (2, 2):
-                raise QiskitError("OneQubitEulerDecomposer: "
-                                  "expected 2x2 input matrix")
-            if not is_unitary_matrix(unitary):
-                raise QiskitError("OneQubitEulerDecomposer: "
-                                  "input matrix is not unitary.")
+        if unitary.shape != (2, 2):
+            raise QiskitError("OneQubitEulerDecomposer: "
+                              "expected 2x2 input matrix")
+        if not is_unitary_matrix(unitary):
+            raise QiskitError("OneQubitEulerDecomposer: "
+                              "input matrix is not unitary.")
+        return self._decompose(unitary, simplify=simplify, atol=atol)
+
+    def _decompose(self, unitary, simplify=True, atol=DEFAULT_ATOL):
         theta, phi, lam, phase = self._params(unitary)
         circuit = self._circuit(theta, phi, lam, phase,
                                 simplify=simplify,

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -111,15 +111,17 @@ class OneQubitEulerDecomposer:
     def __call__(self,
                  unitary,
                  simplify=True,
-                 atol=DEFAULT_ATOL):
+                 atol=DEFAULT_ATOL,
+                 check_unitary=True):
         """Decompose single qubit gate into a circuit.
 
         Args:
             unitary (Operator or Gate or array): 1-qubit unitary matrix
             simplify (bool): reduce gate count in decomposition [Default: True].
-            atol (bool): absolute tolerance for checking angles when simplifing
+            atol (float): absolute tolerance for checking angles when simplifing
                          returnd circuit [Default: 1e-12].
-
+            check_unitary (bool): If set to false the input is assumed to be a
+                                  2-qubit unitary and this is not checked.
         Returns:
             QuantumCircuit: the decomposed single-qubit gate circuit
 
@@ -139,12 +141,13 @@ class OneQubitEulerDecomposer:
         unitary = np.asarray(unitary, dtype=complex)
 
         # Check input is a 2-qubit unitary
-        if unitary.shape != (2, 2):
-            raise QiskitError("OneQubitEulerDecomposer: "
-                              "expected 2x2 input matrix")
-        if not is_unitary_matrix(unitary):
-            raise QiskitError("OneQubitEulerDecomposer: "
-                              "input matrix is not unitary.")
+        if check_unitary:
+            if unitary.shape != (2, 2):
+                raise QiskitError("OneQubitEulerDecomposer: "
+                                  "expected 2x2 input matrix")
+            if not is_unitary_matrix(unitary):
+                raise QiskitError("OneQubitEulerDecomposer: "
+                                  "input matrix is not unitary.")
         theta, phi, lam, phase = self._params(unitary)
         circuit = self._circuit(theta, phi, lam, phase,
                                 simplify=simplify,

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -450,7 +450,7 @@ class TwoQubitBasisDecomposer():
 
         best_nbasis = np.argmax(expected_fidelities)
         decomposition = self.decomposition_fns[best_nbasis](target_decomposed)
-        decomposition_euler = [self._decomposer1q(x, check_unitary=False) for x in decomposition]
+        decomposition_euler = [self._decomposer1q._decompose(x) for x in decomposition]
 
         q = QuantumRegister(2)
         return_circuit = QuantumCircuit(q)

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -450,7 +450,7 @@ class TwoQubitBasisDecomposer():
 
         best_nbasis = np.argmax(expected_fidelities)
         decomposition = self.decomposition_fns[best_nbasis](target_decomposed)
-        decomposition_euler = [self._decomposer1q(x) for x in decomposition]
+        decomposition_euler = [self._decomposer1q(x, check_unitary=False) for x in decomposition]
 
         q = QuantumRegister(2)
         return_circuit = QuantumCircuit(q)

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -12,8 +12,9 @@
 
 """Optimize chains of single-qubit gates using Euler 1q decomposer"""
 
-import logging
 import copy
+import logging
+import math
 
 import numpy as np
 
@@ -82,10 +83,13 @@ class Optimize1qGatesDecomposition(TransformationPass):
                                                       identity_matrix):
                     dag.remove_op_node(run[0])
                     continue
-                if (isinstance(run[0].op, U3Gate) and
-                        np.isclose(float(params[0]), [0, np.pi/2],
-                                   atol=1e-12, rtol=0).any()):
-                    single_u3 = True
+                if isinstance(run[0].op, U3Gate):
+                    param = float(params[0])
+                    if math.isclose(param, 0, rel_tol=0, abs_tol=1e-12) or math.isclose(
+                            param, np.pi/2, abs_tol=1e-12, rel_tol=0):
+                        single_u3 = True
+                    else:
+                        continue
                 else:
                     continue
 
@@ -94,7 +98,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
             for gate in run[1:]:
                 operator = gate.op.to_matrix().dot(operator)
             for decomposer in self.basis:
-                new_circs.append(decomposer(operator))
+                new_circs.append(decomposer(operator, check_unitary=False))
             if new_circs:
                 new_circ = min(new_circs, key=len)
                 if (len(run) > len(new_circ) or (single_u3 and

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -98,7 +98,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
             for gate in run[1:]:
                 operator = gate.op.to_matrix().dot(operator)
             for decomposer in self.basis:
-                new_circs.append(decomposer(operator, check_unitary=False))
+                new_circs.append(decomposer._decompose(operator))
             if new_circs:
                 new_circ = min(new_circs, key=len)
                 if (len(run) > len(new_circ) or (single_u3 and

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -89,7 +89,7 @@ class UnitarySynthesis(TransformationPass):
             if len(node.qargs) == 1:
                 if decomposer1q is None:
                     continue
-                synth_dag = circuit_to_dag(decomposer1q(node.op.to_matrix(), check_unitary=False))
+                synth_dag = circuit_to_dag(decomposer1q._decompose(node.op.to_matrix()))
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -89,7 +89,7 @@ class UnitarySynthesis(TransformationPass):
             if len(node.qargs) == 1:
                 if decomposer1q is None:
                     continue
-                synth_dag = circuit_to_dag(decomposer1q(node.op.to_matrix()))
+                synth_dag = circuit_to_dag(decomposer1q(node.op.to_matrix(), check_unitary=False))
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously when running the `OneQubitEulerDecomposer` the first step
it would perform is a check that the input matrix is a 1 qubit unitary.
However, in situations when we're explicitly generating a unitary matrix
and know the input we're passing is unitary there is no need to run this
check and it adds unnecessary overhead to the process. This commit adds a
new kwarg, check_unitary, to the `__call__` method on the
`OneQubitEulerDecomposer` which when set to False will skip the unitary
check to avoid this overhead. The flag is then set
when the decomposer is called from the `Optimize1qGatesDecomposition`,
`UnitarySynthesis` passes, and `TwoQubitBasisDecomposer` to avoid the
overhead when we know the input is unitary.

### Details and comments

~This depends on #5926~
