### PR TITLE
Add use_dag kwarg to TwoQubitBasisDecomposer

### DIFF
--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -536,6 +536,6 @@ class OneQubitEulerDecomposer:
 
 def _mod2pi(angle):
     if angle >= 0:
-        return np.mod(angle, 2*np.pi)
+        return math.fmod(angle, 2*np.pi)
     else:
-        return np.mod(angle, -2*np.pi)
+        return math.fmod(angle, -2*np.pi)

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -131,15 +131,17 @@ class OneQubitEulerDecomposer:
     def __call__(self,
                  unitary,
                  simplify=True,
-                 atol=DEFAULT_ATOL):
+                 atol=DEFAULT_ATOL,
+                 check_unitary=True):
         """Decompose single qubit gate into a circuit.
 
         Args:
             unitary (Operator or Gate or array): 1-qubit unitary matrix
             simplify (bool): reduce gate count in decomposition [Default: True].
-            atol (bool): absolute tolerance for checking angles when simplifing
+            atol (float): absolute tolerance for checking angles when simplifing
                          returnd circuit [Default: 1e-12].
-
+            check_unitary (bool): If set to false the input is assumed to be a
+                                  2-qubit unitary and this is not checked.
         Returns:
             QuantumCircuit: the decomposed single-qubit gate circuit
 
@@ -159,12 +161,13 @@ class OneQubitEulerDecomposer:
         unitary = np.asarray(unitary, dtype=complex)
 
         # Check input is a 2-qubit unitary
-        if unitary.shape != (2, 2):
-            raise QiskitError("OneQubitEulerDecomposer: "
-                              "expected 2x2 input matrix")
-        if not is_unitary_matrix(unitary):
-            raise QiskitError("OneQubitEulerDecomposer: "
-                              "input matrix is not unitary.")
+        if check_unitary:
+            if unitary.shape != (2, 2):
+                raise QiskitError("OneQubitEulerDecomposer: "
+                                  "expected 2x2 input matrix")
+            if not is_unitary_matrix(unitary):
+                raise QiskitError("OneQubitEulerDecomposer: "
+                                  "input matrix is not unitary.")
         theta, phi, lam, phase = self._params(unitary)
         circuit = self._circuit(theta, phi, lam, phase,
                                 simplify=simplify,

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -19,6 +19,7 @@ import numpy as np
 import scipy.linalg as la
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.library.standard_gates import (UGate, PhaseGate, U3Gate,
                                                    U2Gate, U1Gate, RXGate, RYGate,
                                                    RZGate, RGate, SXGate)
@@ -268,16 +269,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RZGate(phi + lam), [0])
+            circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RZGate(lam), [0])
+            circuit._append(RZGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit._append(RYGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RZGate(phi), [0])
+            circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -287,16 +289,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RZGate(phi + lam), [0])
+            circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RZGate(lam), [0])
+            circuit._append(RZGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(theta), [0])
+            circuit._append(RXGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RZGate(phi), [0])
+            circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -306,16 +309,17 @@ class OneQubitEulerDecomposer:
                      phase,
                      simplify=True,
                      atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RXGate(phi + lam), [0])
+            circuit._append(RXGate(phi + lam), [qr[0]], [])
             return circuit
         if not simplify or not np.isclose(lam, 0.0, atol=atol):
-            circuit.append(RXGate(lam), [0])
+            circuit._append(RXGate(lam), [qr[0]], [])
         if not simplify or not np.isclose(theta, 0.0, atol=atol):
-            circuit.append(RYGate(theta), [0])
+            circuit._append(RYGate(theta), [qr[0]], [])
         if not simplify or not np.isclose(phi, 0.0, atol=atol):
-            circuit.append(RXGate(phi), [0])
+            circuit._append(RXGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -326,8 +330,9 @@ class OneQubitEulerDecomposer:
                     simplify=True,
                     atol=DEFAULT_ATOL):
         # pylint: disable=unused-argument
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(U3Gate(theta, phi, lam), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -338,14 +343,15 @@ class OneQubitEulerDecomposer:
                       simplify=True,
                       atol=DEFAULT_ATOL):
         rtol = 1e-9  # default is 1e-5, too far from atol=1e-12
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if simplify and (np.isclose(theta, 0.0, atol=atol, rtol=rtol)):
             if not np.isclose(phi+lam, [0.0, 2*np.pi], atol=atol, rtol=rtol).any():
-                circuit.append(U1Gate(_mod2pi(phi+lam)), [0])
+                circuit._append(U1Gate(_mod2pi(phi+lam)), [qr[0]], [])
         elif simplify and np.isclose(theta, np.pi/2, atol=atol, rtol=rtol):
-            circuit.append(U2Gate(phi, lam), [0])
+            circuit._append(U2Gate(phi, lam), [qr[0]], [])
         else:
-            circuit.append(U3Gate(theta, phi, lam), [0])
+            circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -356,8 +362,9 @@ class OneQubitEulerDecomposer:
                    simplify=True,
                    atol=DEFAULT_ATOL):
         # pylint: disable=unused-argument
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(UGate(theta, phi, lam), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(UGate(theta, phi, lam), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -371,33 +378,34 @@ class OneQubitEulerDecomposer:
         # Phase(phi+pi).SX.Phase(theta+pi).SX.Phase(lam)
         theta = _mod2pi(theta + np.pi)
         phi = _mod2pi(phi + np.pi)
-        circuit = QuantumCircuit(1, global_phase=phase - np.pi / 2)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             if not np.isclose(_mod2pi(abs(lam + phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(lam + phi + theta)), [0])
+                circuit._append(PhaseGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
             circuit.global_phase += np.pi / 2
         elif simplify and np.isclose(abs(theta),
                                      [np.pi/2, 3*np.pi/2], atol=atol).any():
             if not np.isclose(_mod2pi(abs(lam + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(lam + theta)), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(_mod2pi(lam + theta)), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(_mod2pi(abs(phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(_mod2pi(phi + theta)), [0])
+                circuit._append(PhaseGate(_mod2pi(phi + theta)), [qr[0]], [])
             if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
                 circuit.global_phase += np.pi / 2
         else:
             if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(lam), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(lam), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(theta), [0])
-            circuit.append(SXGate(), [0])
+                circuit._append(PhaseGate(theta), [qr[0]], [])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
-                circuit.append(PhaseGate(phi), [0])
+                circuit._append(PhaseGate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -411,38 +419,39 @@ class OneQubitEulerDecomposer:
         # RZ(phi+pi).SX.RZ(theta+pi).SX.RZ(lam)
         theta = _mod2pi(theta + np.pi)
         phi = _mod2pi(phi + np.pi)
-        circuit = QuantumCircuit(1, global_phase=phase - np.pi / 2)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             if not np.isclose(_mod2pi(abs(lam + phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(lam + phi + theta)), [0])
+                circuit._append(RZGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(lam + phi + theta)
             circuit.global_phase += np.pi / 2
         elif simplify and np.isclose(abs(theta),
                                      [np.pi/2, 3*np.pi/2], atol=atol).any():
             if not np.isclose(_mod2pi(abs(lam + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(lam + theta)), [0])
+                circuit._append(RZGate(_mod2pi(lam + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(lam + theta)
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(_mod2pi(abs(phi + theta)),
                               [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(_mod2pi(phi + theta)), [0])
+                circuit._append(RZGate(_mod2pi(phi + theta)), [qr[0]], [])
                 circuit.global_phase += 0.5 * _mod2pi(phi + theta)
             if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
                 circuit.global_phase += np.pi / 2
         else:
             if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(lam), [0])
+                circuit._append(RZGate(lam), [qr[0]], [])
                 circuit.global_phase += 0.5 * lam
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(theta), [0])
+                circuit._append(RZGate(theta), [qr[0]], [])
                 circuit.global_phase += 0.5 * theta
-            circuit.append(SXGate(), [0])
+            circuit._append(SXGate(), [qr[0]], [])
             if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
-                circuit.append(RZGate(phi), [0])
+                circuit._append(RZGate(phi), [qr[0]], [])
                 circuit.global_phase += 0.5 * phi
         return circuit
 
@@ -460,23 +469,26 @@ class OneQubitEulerDecomposer:
         # Check for decomposition into minimimal number required X90 pulses
         if simplify and np.isclose(abs(theta), np.pi, atol=atol):
             # Zero X90 gate decomposition
-            circuit = QuantumCircuit(1, global_phase=phase)
-            circuit.append(U1Gate(lam + phi + theta), [0])
+            qr = QuantumRegister(1, 'qr')
+            circuit = QuantumCircuit(qr, global_phase=phase)
+            circuit._append(U1Gate(lam + phi + theta), [qr[0]], [])
             return circuit
         if simplify and np.isclose(abs(theta), np.pi/2, atol=atol):
             # Single X90 gate decomposition
-            circuit = QuantumCircuit(1, global_phase=phase)
-            circuit.append(U1Gate(lam + theta), [0])
-            circuit.append(RXGate(np.pi / 2), [0])
-            circuit.append(U1Gate(phi + theta), [0])
+            qr = QuantumRegister(1, 'qr')
+            circuit = QuantumCircuit(qr, global_phase=phase)
+            circuit._append(U1Gate(lam + theta), [qr[0]], [])
+            circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+            circuit._append(U1Gate(phi + theta), [qr[0]], [])
             return circuit
         # General two-X90 gate decomposition
-        circuit = QuantumCircuit(1, global_phase=phase)
-        circuit.append(U1Gate(lam), [0])
-        circuit.append(RXGate(np.pi / 2), [0])
-        circuit.append(U1Gate(theta), [0])
-        circuit.append(RXGate(np.pi / 2), [0])
-        circuit.append(U1Gate(phi), [0])
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
+        circuit._append(U1Gate(lam), [qr[0]], [])
+        circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+        circuit._append(U1Gate(theta), [qr[0]], [])
+        circuit._append(RXGate(np.pi / 2), [qr[0]], [])
+        circuit._append(U1Gate(phi), [qr[0]], [])
         return circuit
 
     @staticmethod
@@ -486,10 +498,11 @@ class OneQubitEulerDecomposer:
                     phase,
                     simplify=True,
                     atol=DEFAULT_ATOL):
-        circuit = QuantumCircuit(1, global_phase=phase)
+        qr = QuantumRegister(1, 'qr')
+        circuit = QuantumCircuit(qr, global_phase=phase)
         if not simplify or not np.isclose(theta, -np.pi, atol=atol):
-            circuit.append(RGate(theta + np.pi, np.pi / 2 - lam), [0])
-        circuit.append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [0])
+            circuit._append(RGate(theta + np.pi, np.pi / 2 - lam), [qr[0]], [])
+        circuit._append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [qr[0]], [])
         return circuit
 
 

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -271,14 +271,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RZGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RYGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
@@ -291,14 +291,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RZGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RXGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RZGate(phi), [qr[0]], [])
         return circuit
 
@@ -311,14 +311,14 @@ class OneQubitEulerDecomposer:
                      atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and np.isclose(theta, 0.0, atol=atol):
+        if simplify and math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RXGate(phi + lam), [qr[0]], [])
             return circuit
-        if not simplify or not np.isclose(lam, 0.0, atol=atol):
+        if not simplify or not math.isclose(lam, 0.0, abs_tol=atol):
             circuit._append(RXGate(lam), [qr[0]], [])
-        if not simplify or not np.isclose(theta, 0.0, atol=atol):
+        if not simplify or not math.isclose(theta, 0.0, abs_tol=atol):
             circuit._append(RYGate(theta), [qr[0]], [])
-        if not simplify or not np.isclose(phi, 0.0, atol=atol):
+        if not simplify or not math.isclose(phi, 0.0, abs_tol=atol):
             circuit._append(RXGate(phi), [qr[0]], [])
         return circuit
 
@@ -345,10 +345,12 @@ class OneQubitEulerDecomposer:
         rtol = 1e-9  # default is 1e-5, too far from atol=1e-12
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if simplify and (np.isclose(theta, 0.0, atol=atol, rtol=rtol)):
-            if not np.isclose(phi+lam, [0.0, 2*np.pi], atol=atol, rtol=rtol).any():
+        if simplify and (math.isclose(theta, 0.0, abs_tol=atol, rel_tol=rtol)):
+            phi_lam = phi + lam
+            if not (math.isclose(phi_lam, 0.0, abs_tol=atol, rel_tol=rtol) or
+                    math.isclose(phi_lam, 2*np.pi, abs_tol=atol, rel_tol=rtol)):
                 circuit._append(U1Gate(_mod2pi(phi+lam)), [qr[0]], [])
-        elif simplify and np.isclose(theta, np.pi/2, atol=atol, rtol=rtol):
+        elif simplify and math.isclose(theta, np.pi/2, abs_tol=atol, rel_tol=rtol):
             circuit._append(U2Gate(phi, lam), [qr[0]], [])
         else:
             circuit._append(U3Gate(theta, phi, lam), [qr[0]], [])
@@ -381,30 +383,43 @@ class OneQubitEulerDecomposer:
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
-            if not np.isclose(_mod2pi(abs(lam + phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(PhaseGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
+        abs_theta = abs(theta)
+        if simplify and math.isclose(abs_theta, np.pi, abs_tol=atol):
+            lam_phi_theta = _mod2pi(lam + phi + theta)
+            abs_lam_phi_theta = _mod2pi(abs(lam + phi + theta))
+            if not (math.isclose(abs_lam_phi_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_lam_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(PhaseGate(lam_phi_theta), [qr[0]], [])
             circuit.global_phase += np.pi / 2
-        elif simplify and np.isclose(abs(theta),
-                                     [np.pi/2, 3*np.pi/2], atol=atol).any():
-            if not np.isclose(_mod2pi(abs(lam + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(PhaseGate(_mod2pi(lam + theta)), [qr[0]], [])
+        elif simplify and (math.isclose(abs_theta, np.pi/2, abs_tol=atol) or
+                           math.isclose(abs_theta, 3*np.pi/2, abs_tol=atol)):
+            lam_theta = _mod2pi(lam + theta)
+            abs_lam_theta = _mod2pi(abs(lam + theta))
+            if not (math.isclose(abs_lam_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_lam_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(PhaseGate(lam_theta), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(_mod2pi(abs(phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
+            phi_theta = _mod2pi(phi + theta)
+            abs_phi_theta = _mod2pi(abs(phi_theta))
+            if not (math.isclose(abs_phi_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_phi_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(_mod2pi(phi + theta)), [qr[0]], [])
-            if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
+            if (math.isclose(theta, -np.pi / 2, abs_tol=atol) or math.isclose(
+                    theta, 3 * np.pi / 2, abs_tol=atol)):
                 circuit.global_phase += np.pi / 2
         else:
-            if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
+            abs_lam = abs(lam)
+            if not (math.isclose(abs_lam, 0., abs_tol=atol) or
+                    math.isclose(abs_lam, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(lam), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
+            if not (math.isclose(abs_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(theta), [qr[0]], [])
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
+            abs_phi = abs(phi)
+            if not (math.isclose(abs_phi, 0., abs_tol=atol) or
+                    math.isclose(abs_phi, 2*np.pi, abs_tol=atol)):
                 circuit._append(PhaseGate(phi), [qr[0]], [])
         return circuit
 
@@ -422,35 +437,48 @@ class OneQubitEulerDecomposer:
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase - np.pi / 2)
         # Check for decomposition into minimimal number required SX gates
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
-            if not np.isclose(_mod2pi(abs(lam + phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(lam + phi + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(lam + phi + theta)
+        abs_theta = abs(theta)
+        if simplify and math.isclose(abs_theta, np.pi, abs_tol=atol):
+            lam_phi_theta = _mod2pi(lam + phi + theta)
+            abs_lam_phi_theta = _mod2pi(abs(lam + phi + theta))
+            if not (math.isclose(abs_lam_phi_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_lam_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(lam_phi_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * lam_phi_theta
             circuit.global_phase += np.pi / 2
-        elif simplify and np.isclose(abs(theta),
-                                     [np.pi/2, 3*np.pi/2], atol=atol).any():
-            if not np.isclose(_mod2pi(abs(lam + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(lam + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(lam + theta)
+        elif simplify and (math.isclose(abs_theta, np.pi/2, abs_tol=atol) or
+                           math.isclose(abs_theta, 3*np.pi/2, abs_tol=atol)):
+            lam_theta = _mod2pi(lam + theta)
+            abs_lam_theta = _mod2pi(abs(lam + theta))
+            if not (math.isclose(abs_lam_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_lam_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(lam_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * lam_theta
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(_mod2pi(abs(phi + theta)),
-                              [0., 2*np.pi], atol=atol).any():
-                circuit._append(RZGate(_mod2pi(phi + theta)), [qr[0]], [])
-                circuit.global_phase += 0.5 * _mod2pi(phi + theta)
-            if np.isclose(theta, [-np.pi / 2, 3 * np.pi / 2], atol=atol).any():
+            phi_theta = _mod2pi(phi + theta)
+            abs_phi_theta = _mod2pi(abs(phi_theta))
+            if not (math.isclose(abs_phi_theta, 0, abs_tol=atol) or
+                    math.isclose(abs_phi_theta, 2*np.pi, abs_tol=atol)):
+                circuit._append(RZGate(phi_theta), [qr[0]], [])
+                circuit.global_phase += 0.5 * phi_theta
+            if (math.isclose(theta, -np.pi / 2, abs_tol=atol) or
+                    math.isclose(theta, 3 * np.pi / 2, abs_tol=atol)):
                 circuit.global_phase += np.pi / 2
         else:
-            if not np.isclose(abs(lam), [0., 2*np.pi], atol=atol).any():
+            abs_lam = abs(lam)
+            if not (math.isclose(abs_lam, 0., abs_tol=atol) or
+                    math.isclose(abs_lam, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(lam), [qr[0]], [])
                 circuit.global_phase += 0.5 * lam
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(theta), [0., 2*np.pi], atol=atol).any():
+            if not (math.isclose(abs_theta, 0., abs_tol=atol) or
+                    math.isclose(abs_theta, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(theta), [qr[0]], [])
                 circuit.global_phase += 0.5 * theta
             circuit._append(SXGate(), [qr[0]], [])
-            if not np.isclose(abs(phi), [0., 2*np.pi], atol=atol).any():
+            abs_phi = abs(phi)
+            if not (math.isclose(abs_phi, 0., abs_tol=atol) or
+                    math.isclose(abs_phi, 2*np.pi, abs_tol=atol)):
                 circuit._append(RZGate(phi), [qr[0]], [])
                 circuit.global_phase += 0.5 * phi
         return circuit
@@ -467,13 +495,13 @@ class OneQubitEulerDecomposer:
         theta += np.pi
         phi += np.pi
         # Check for decomposition into minimimal number required X90 pulses
-        if simplify and np.isclose(abs(theta), np.pi, atol=atol):
+        if simplify and math.isclose(abs(theta), np.pi, abs_tol=atol):
             # Zero X90 gate decomposition
             qr = QuantumRegister(1, 'qr')
             circuit = QuantumCircuit(qr, global_phase=phase)
             circuit._append(U1Gate(lam + phi + theta), [qr[0]], [])
             return circuit
-        if simplify and np.isclose(abs(theta), np.pi/2, atol=atol):
+        if simplify and math.isclose(abs(theta), np.pi/2, abs_tol=atol):
             # Single X90 gate decomposition
             qr = QuantumRegister(1, 'qr')
             circuit = QuantumCircuit(qr, global_phase=phase)
@@ -500,7 +528,7 @@ class OneQubitEulerDecomposer:
                     atol=DEFAULT_ATOL):
         qr = QuantumRegister(1, 'qr')
         circuit = QuantumCircuit(qr, global_phase=phase)
-        if not simplify or not np.isclose(theta, -np.pi, atol=atol):
+        if not simplify or not math.isclose(theta, -np.pi, abs_tol=atol):
             circuit._append(RGate(theta + np.pi, np.pi / 2 - lam), [qr[0]], [])
         circuit._append(RGate(-np.pi, 0.5 * (phi - lam + np.pi)), [qr[0]], [])
         return circuit

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -33,6 +33,7 @@ from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates.x import CXGate
 from qiskit.circuit.tools import pi_check
+from qiskit.dagcircuit.dagcircuit import DAGCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix
@@ -228,10 +229,10 @@ class TwoQubitWeylDecomposition:
 def Ud(a, b, c):
     """Generates the array Exp(i(a xx + b yy + c zz))
     """
-    return np.array([[np.exp(1j*c)*np.cos(a-b), 0, 0, 1j*np.exp(1j*c)*np.sin(a-b)],
-                     [0, np.exp(-1j*c)*np.cos(a+b), 1j*np.exp(-1j*c)*np.sin(a+b), 0],
-                     [0, 1j*np.exp(-1j*c)*np.sin(a+b), np.exp(-1j*c)*np.cos(a+b), 0],
-                     [1j*np.exp(1j*c)*np.sin(a-b), 0, 0, np.exp(1j*c)*np.cos(a-b)]], dtype=complex)
+    return np.array([[np.exp(1j*c)*np.cos(a-b), 0, 0, 1j*np.exp(1j*c)*math.sin(a-b)],
+                     [0, np.exp(-1j*c)*np.cos(a+b), 1j*np.exp(-1j*c)*math.sin(a+b), 0],
+                     [0, 1j*np.exp(-1j*c)*math.sin(a+b), np.exp(-1j*c)*np.cos(a+b), 0],
+                     [1j*np.exp(1j*c)*math.sin(a-b), 0, 0, np.exp(1j*c)*np.cos(a-b)]], dtype=complex)
 
 
 def trace_to_fid(trace):
@@ -261,18 +262,19 @@ class TwoQubitBasisDecomposer():
             Default 'U3'.
     """
 
-    def __init__(self, gate, basis_fidelity=1.0, euler_basis=None):
+    def __init__(self, gate, basis_fidelity=1.0, euler_basis=None, use_dag=False):
         self.gate = gate
         self.basis_fidelity = basis_fidelity
+        self.use_dag = use_dag
 
         basis = self.basis = TwoQubitWeylDecomposition(Operator(gate).data)
         if euler_basis is not None:
-            self._decomposer1q = OneQubitEulerDecomposer(euler_basis)
+            self._decomposer1q = OneQubitEulerDecomposer(euler_basis, use_dag=use_dag)
         else:
-            self._decomposer1q = OneQubitEulerDecomposer('U3')
+            self._decomposer1q = OneQubitEulerDecomposer('U3', use_dag=use_dag)
 
         # FIXME: find good tolerances
-        self.is_supercontrolled = np.isclose(basis.a, np.pi/4) and np.isclose(basis.c, 0.)
+        self.is_supercontrolled = math.isclose(basis.a, np.pi/4) and math.isclose(basis.c, 0.)
 
         # Create some useful matrices U1, U2, U3 are equivalent to the basis,
         # expand as Ui = Ki1.Ubasis.Ki2
@@ -285,8 +287,8 @@ class TwoQubitBasisDecomposer():
                                     [-1, 1]], dtype=complex)
         K12r = 1/np.sqrt(2) * np.array([[1j, 1],
                                         [-1, -1j]], dtype=complex)
-        K32lK21l = 1/np.sqrt(2) * np.array([[1+1j*np.cos(2*b), 1j*np.sin(2*b)],
-                                            [1j*np.sin(2*b), 1-1j*np.cos(2*b)]], dtype=complex)
+        K32lK21l = 1/np.sqrt(2) * np.array([[1+1j*np.cos(2*b), 1j*math.sin(2*b)],
+                                            [1j*math.sin(2*b), 1-1j*np.cos(2*b)]], dtype=complex)
         K21r = 1/(1-1j) * np.array([[-1j*np.exp(-2j*b), np.exp(-2j*b)],
                                     [1j*np.exp(2j*b), np.exp(2j*b)]], dtype=complex)
         K22l = 1/np.sqrt(2) * np.array([[1, -1],
@@ -344,9 +346,9 @@ class TwoQubitBasisDecomposer():
         # This doesn't come up if either c1==0 or c2==0 but otherwise be careful.
 
         return [4*(np.cos(target.a)*np.cos(target.b)*np.cos(target.c) +
-                   1j*np.sin(target.a)*np.sin(target.b)*np.sin(target.c)),
+                   1j*math.sin(target.a)*math.sin(target.b)*math.sin(target.c)),
                 4*(np.cos(np.pi/4-target.a)*np.cos(self.basis.b-target.b)*np.cos(target.c) +
-                   1j*np.sin(np.pi/4-target.a)*np.sin(self.basis.b-target.b)*np.sin(target.c)),
+                   1j*math.sin(np.pi/4-target.a)*math.sin(self.basis.b-target.b)*math.sin(target.c)),
                 4*np.cos(target.c),
                 4]
 
@@ -451,21 +453,38 @@ class TwoQubitBasisDecomposer():
         best_nbasis = np.argmax(expected_fidelities)
         decomposition = self.decomposition_fns[best_nbasis](target_decomposed)
         decomposition_euler = [self._decomposer1q(x, check_unitary=False) for x in decomposition]
-
         q = QuantumRegister(2)
-        return_circuit = QuantumCircuit(q)
-        return_circuit.global_phase = target_decomposed.global_phase
-        return_circuit.global_phase -= best_nbasis * self.basis.global_phase
-        if best_nbasis == 2:
-            return_circuit.global_phase += np.pi
-        for i in range(best_nbasis):
-            return_circuit.compose(decomposition_euler[2*i], [q[0]], inplace=True)
-            return_circuit.compose(decomposition_euler[2*i+1], [q[1]], inplace=True)
-            return_circuit.append(self.gate, [q[0], q[1]])
-        return_circuit.compose(decomposition_euler[2*best_nbasis], [q[0]], inplace=True)
-        return_circuit.compose(decomposition_euler[2*best_nbasis+1], [q[1]], inplace=True)
-
-        return return_circuit
+        if self.use_dag:
+            return_dag = DAGCircuit()
+            return_dag.add_qreg(q)
+            return_dag.global_phase = target_decomposed.global_phase
+            return_dag.global_phase -= best_nbasis * self.basis.global_phase
+            if best_nbasis == 2:
+                return_dag.global_phase += np.pi
+            for i in range(best_nbasis):
+                return_dag.compose(decomposition_euler[2*i], qubits=[q[0]],
+                                   inplace=True)
+                return_dag.compose(decomposition_euler[2*i+1], qubits=[q[1]],
+                                   inplace=True)
+                return_dag.apply_operation_back(self.gate, [q[0], q[1]])
+            return_dag.compose(decomposition_euler[2*best_nbasis], qubits=[q[0]],
+                               inplace=True)
+            return_dag.compose(decomposition_euler[2*best_nbasis+1], qubits=[q[1]],
+                               inplace=True)
+            return return_dag
+        else:
+            return_circuit = QuantumCircuit(q)
+            return_circuit.global_phase = target_decomposed.global_phase
+            return_circuit.global_phase -= best_nbasis * self.basis.global_phase
+            if best_nbasis == 2:
+                return_circuit.global_phase += np.pi
+            for i in range(best_nbasis):
+                return_circuit.compose(decomposition_euler[2*i], [q[0]], inplace=True)
+                return_circuit.compose(decomposition_euler[2*i+1], [q[1]], inplace=True)
+                return_circuit.append(self.gate, [q[0], q[1]])
+            return_circuit.compose(decomposition_euler[2*best_nbasis], [q[0]], inplace=True)
+            return_circuit.compose(decomposition_euler[2*best_nbasis+1], [q[1]], inplace=True)
+            return return_circuit
 
     def num_basis_gates(self, unitary):
         """ Computes the number of basis gates needed in
@@ -477,9 +496,9 @@ class TwoQubitBasisDecomposer():
             unitary = unitary.to_matrix()
         unitary = np.asarray(unitary, dtype=complex)
         a, b, c = weyl_coordinates(unitary)[:]
-        traces = [4*(np.cos(a)*np.cos(b)*np.cos(c)+1j*np.sin(a)*np.sin(b)*np.sin(c)),
+        traces = [4*(np.cos(a)*np.cos(b)*np.cos(c)+1j*math.sin(a)*math.sin(b)*math.sin(c)),
                   4*(np.cos(np.pi/4-a)*np.cos(self.basis.b-b)*np.cos(c) +
-                     1j*np.sin(np.pi/4-a)*np.sin(self.basis.b-b)*np.sin(c)),
+                     1j*math.sin(np.pi/4-a)*math.sin(self.basis.b-b)*math.sin(c)),
                   4*np.cos(c),
                   4]
         return np.argmax([trace_to_fid(traces[i]) * self.basis_fidelity**i for i in range(4)])

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -450,7 +450,7 @@ class TwoQubitBasisDecomposer():
 
         best_nbasis = np.argmax(expected_fidelities)
         decomposition = self.decomposition_fns[best_nbasis](target_decomposed)
-        decomposition_euler = [self._decomposer1q(x) for x in decomposition]
+        decomposition_euler = [self._decomposer1q(x, check_unitary=False) for x in decomposition]
 
         q = QuantumRegister(2)
         return_circuit = QuantumCircuit(q)

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -89,7 +89,7 @@ class UnitarySynthesis(TransformationPass):
             if len(node.qargs) == 1:
                 if decomposer1q is None:
                     continue
-                synth_dag = decomposer1q(node.op.to_matrix())
+                synth_dag = decomposer1q(node.op.to_matrix(), check_unitary=False)
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -79,7 +79,7 @@ class UnitarySynthesis(TransformationPass):
 
         decomposer1q, decomposer2q = None, None
         if euler_basis is not None:
-            decomposer1q = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis)
+            decomposer1q = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis, use_dag=True)
         if kak_gate is not None:
             decomposer2q = TwoQubitBasisDecomposer(kak_gate, euler_basis=euler_basis)
 
@@ -89,7 +89,7 @@ class UnitarySynthesis(TransformationPass):
             if len(node.qargs) == 1:
                 if decomposer1q is None:
                     continue
-                synth_dag = circuit_to_dag(decomposer1q(node.op.to_matrix()))
+                synth_dag = decomposer1q(node.op.to_matrix())
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -81,7 +81,7 @@ class UnitarySynthesis(TransformationPass):
         if euler_basis is not None:
             decomposer1q = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis, use_dag=True)
         if kak_gate is not None:
-            decomposer2q = TwoQubitBasisDecomposer(kak_gate, euler_basis=euler_basis)
+            decomposer2q = TwoQubitBasisDecomposer(kak_gate, euler_basis=euler_basis, use_dag=True)
 
         for node in dag.named_nodes('unitary'):
 
@@ -93,7 +93,7 @@ class UnitarySynthesis(TransformationPass):
             elif len(node.qargs) == 2:
                 if decomposer2q is None:
                     continue
-                synth_dag = circuit_to_dag(decomposer2q(node.op.to_matrix()))
+                synth_dag = decomposer2q(node.op.to_matrix())
             else:
                 synth_dag = circuit_to_dag(
                     isometry.Isometry(node.op.to_matrix(), 0, 0).definition)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new kwarg to the `TwoQubitBasisDecomposer` constructor,
`use_dag`, which is used to specify whether the expected output from the
`__call__ `methods is going to be a `QuantumCircuit` or a `DAGCircuit` object.
This enables transpiler passes that are using the
`TwoQubitBasisDecomposer` to decompose a 2q unitary to skip the conversion
from circuit to dag and just natively generate a dag.


### Details and comments

This depends on #5928 
