### PR TITLE
Remove set() cast in noise adaptive layout

### DIFF
--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -121,7 +121,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
                     self.swap_reliabs[i][j] = self.cx_reliability[(j, i)]
                 else:
                     best_reliab = 0.0
-                    for n in set(self.swap_graph.neighbors(j)):
+                    for n in self.swap_graph.neighbors(j):
                         if (n, j) in self.cx_reliability:
                             reliab = math.exp(-swap_reliabs_ro[i][n])*self.cx_reliability[(n, j)]
                         else:
@@ -192,7 +192,7 @@ class NoiseAdaptiveLayout(AnalysisPass):
         """Select the best remaining hardware qubit for the next program qubit."""
         reliab_store = {}
         if prog_qubit not in self.prog_neighbors:
-            self.prog_neighbors[prog_qubit] = set(self.prog_graph.neighbors(prog_qubit))
+            self.prog_neighbors[prog_qubit] = self.prog_graph.neighbors(prog_qubit)
         for hw_qubit in self.available_hw_qubits:
             reliab = 1
             for n in self.prog_neighbors[prog_qubit]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 contextvars>=2.4;python_version<'3.7'
 jsonschema>=2.6
-retworkx>=0.7.0
+retworkx>=0.8.0
 numpy>=1.17
 ply>=3.10
 psutil>=5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5847 we added a set() cast to calls to retworkx's graph neighbors
method. This was to workaround a bug in retworkx where duplicate node
indices would be returned if there were parallel edges to a successor
node. In the recent retworkx 0.8.0 release this issue has been fixed
[1][2] so there is no need to cast to a set anymore. Removing the set
cast will remove a duplicate iteration (to generate the set) over the
neighbors list, marginally improving performance.

### Details and comments

[1] https://retworkx.readthedocs.io/en/stable/release_notes.html#bug-fixes
[2] https://github.com/Qiskit/retworkx/commit/49727f82c4d93ea8dfd76c69a2751173af38501e