### PR TITLE
Replace np.int for int on opflow due to new numpy

### DIFF
--- a/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
@@ -216,7 +216,7 @@ class Z2Symmetries:
             stacked_paulis.append(
                 np.concatenate(
                     (pauli.primitive.table.X[0], pauli.primitive.table.Z[0]), axis=0
-                ).astype(np.int)
+                ).astype(int)
             )
 
         stacked_matrix = np.array(np.stack(stacked_paulis))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This single line was printing a lot of deprecate messages in chemistry.

### Details and comments


