### PR TITLE
Remove DagNode.__hash__()

### DIFF
--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -90,12 +90,6 @@ class DAGNode:
     def __gt__(self, other):
         return self._node_id > other._node_id
 
-    def __hash__(self):
-        """Needed for ancestors function, which returns a set.
-        To be in a set requires the object to be hashable
-        """
-        return hash(id(self))
-
     def __str__(self):
         # TODO is this used anywhere other than in DAG drawing?
         # needs to be unique as it is what pydot uses to distinguish nodes


### PR DESCRIPTION
Defining a `__hash__` without also defining `__eq__` goes [against the python data model](https://docs.python.org/3/reference/datamodel.html#object.__hash__).

It looks like in the past there was a custom `__eq__` but that was removed in #2006 at which time `__hash__` should have been removed also.

Its also not necessary in this case as a hash based on the object `id` is what you get by default.

Its also a performance issue: microbenchmarking reveals that set and dict operations are around 10x slower with custom hash compared to default. I didn't check but I wonder how much this was at issue in #5952 and #5685.