### PR TITLE
Reorganize CI jobs and stages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,52 +242,6 @@ stages:
             python tools/find_optional_imports.py
             reno lint
           displayName: 'Style and lint'
-    - job: 'Docs'
-      pool: {vmImage: 'ubuntu-latest'}
-      strategy:
-        matrix:
-          Python37:
-            python.version: '3.7'
-      variables:
-        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      steps:
-        - checkout: self
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '$(python.version)'
-          displayName: 'Use Python $(python.version)'
-        - task: Cache@2
-          inputs:
-            key: 'pip | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
-            restoreKeys: |
-              pip | "$(Agent.OS)" | "$(python.version)"
-              pip | "$(Agent.OS)"
-              pip
-            path: $(PIP_CACHE_DIR)
-          displayName: Cache pip
-        - bash: |
-            set -e
-            python -m pip install --upgrade pip setuptools wheel
-            pip install -U tox
-            python setup.py build_ext --inplace
-            sudo apt install -y graphviz
-          displayName: 'Install dependencies'
-        - bash: |
-            tox -edocs
-          displayName: 'Run Docs build'
-        - task: ArchiveFiles@2
-          inputs:
-            rootFolderOrFile: 'docs/_build/html'
-            archiveType: tar
-            archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
-            verbose: true
-        - task: PublishBuildArtifacts@1
-          displayName: 'Publish docs'
-          inputs:
-            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'html_docs'
-            Parallel: true
-            ParallelCount: 8
     - job: 'MacOS_Catalina_Tests'
       pool: {vmImage: 'macOS-latest'}
       strategy:
@@ -363,6 +317,71 @@ stages:
           inputs:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for macOS Python $(python.version)'
+    - job: 'Windows_Tests'
+      pool: {vmImage: 'windows-latest'}
+      strategy:
+        matrix:
+          Python37:
+            python.version: '3.7'
+      variables:
+        QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
+        QISKIT_TEST_CAPTURE_STREAMS: 1
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
+        - task: Cache@2
+          inputs:
+            key: 'stestr | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
+            restoreKeys: |
+              stestr | "$(Agent.OS)" | "$(python.version)"
+              stestr | "$(Agent.OS)"
+              stestr
+            path: .stestr
+        - bash: |
+            set -e
+            python -m pip install --upgrade pip setuptools wheel virtualenv
+            virtualenv test-job
+            source test-job/Scripts/activate
+            pip install -r requirements.txt -r requirements-dev.txt -c constraints.txt
+            pip install -c constraints.txt -e .
+            pip install "z3-solver" -c constraints.txt
+            python setup.py build_ext --inplace
+            pip check
+          displayName: 'Install dependencies'
+        - bash: |
+            set -e
+            source test-job/Scripts/activate
+            export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
+            echo "PYTHONHASHSEED=$PYTHONHASHSEED"
+            stestr run
+          displayName: 'Run tests'
+        - task: CopyFiles@2
+          condition: failed()
+          displayName: 'Copy images'
+          inputs:
+            contents: '**/*.png'
+            targetFolder: $(Build.ArtifactStagingDirectory)
+        - task: PublishBuildArtifacts@1
+          condition: failed()
+          displayName: 'Publish images'
+          inputs:
+            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: 'drop_windows'
+        - bash: |
+            set -e
+            source test-job/Scripts/activate
+            pip install -U junitxml
+            mkdir -p junit
+            stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
+          condition: succeededOrFailed()
+          displayName: 'Generate results'
+        - task: PublishTestResults@2
+          condition: succeededOrFailed()
+          inputs:
+            testResultsFiles: '**/test-*.xml'
+            testRunTitle: 'Test results for Windows Python $(python.version)'
   - stage: 'Python_Tests'
     condition: and(succeeded('Lint_and_Tests'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags')))
     jobs:
@@ -372,8 +391,6 @@ stages:
         matrix:
           Python36:
             python.version: '3.6'
-          Python37:
-            python.version: '3.7'
           Python38:
             python.version: '3.8'
           Python39:
@@ -595,6 +612,55 @@ stages:
           inputs:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for macOS Python $(python.version)'
+  - stage: 'Docs_and_Tutorials'
+    condition: and(succeeded('Python_Tests'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags')))
+    jobs:
+    - job: 'Docs'
+      pool: {vmImage: 'ubuntu-latest'}
+      strategy:
+        matrix:
+          Python37:
+            python.version: '3.7'
+      variables:
+        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      steps:
+        - checkout: self
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
+        - task: Cache@2
+          inputs:
+            key: 'pip | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
+            restoreKeys: |
+              pip | "$(Agent.OS)" | "$(python.version)"
+              pip | "$(Agent.OS)"
+              pip
+            path: $(PIP_CACHE_DIR)
+          displayName: Cache pip
+        - bash: |
+            set -e
+            python -m pip install --upgrade pip setuptools wheel
+            pip install -U tox
+            python setup.py build_ext --inplace
+            sudo apt install -y graphviz
+          displayName: 'Install dependencies'
+        - bash: |
+            tox -edocs
+          displayName: 'Run Docs build'
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: 'docs/_build/html'
+            archiveType: tar
+            archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
+            verbose: true
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish docs'
+          inputs:
+            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: 'html_docs'
+            Parallel: true
+            ParallelCount: 8
     - job: 'Tutorials'
       pool: {vmImage: 'ubuntu-latest'}
       strategy:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit reorganizes the stages and job structure of our CI jobs to
try and improve overall project throughput. It moves to a 3 stage
pipeline instead of the 2 we used before. The first stage runs python
3.7 on all OSes and lint, the second runs the remaining unittest jobs
(for 3.6, 3.7, and 3.8), and the final stage runs the docs builds and
tutorials job (which are the slowest jobs). The goal is by splitting
thing up into more stages and making the slowest jobs run last that this
will improve overall efficiency of CI.

### Details and comments