### PR TITLE
Fix density matrix expval cython function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ src/qasm-simulator-cpp/test/qubit_vector_tests
 
 # Cython pass
 qiskit/transpiler/passes/**/cython/**/*.cpp
+qiskit/quantum_info/states/cython/*.cpp
 
 docs/stubs/*
 

--- a/qiskit/quantum_info/states/cython/exp_value.pyx
+++ b/qiskit/quantum_info/states/cython/exp_value.pyx
@@ -17,14 +17,20 @@
 cimport cython
 import numpy as np
 
+cdef unsigned long long m1 = 0x5555555555555555
+cdef unsigned long long m2 = 0x3333333333333333
+cdef unsigned long long m4 = 0x0f0f0f0f0f0f0f0f
+cdef unsigned long long m8 = 0x00ff00ff00ff00ff
+cdef unsigned long long m16 = 0x0000ffff0000ffff
+cdef unsigned long long m32 = 0x00000000ffffffff
 
 cdef unsigned long long popcount(unsigned long long count):
-  count = (count & 0x5555555555555555) + ((count >> 1) & 0x5555555555555555);
-  count = (count & 0x3333333333333333) + ((count >> 2) & 0x3333333333333333);
-  count = (count & 0x0f0f0f0f0f0f0f0f) + ((count >> 4) & 0x0f0f0f0f0f0f0f0f);
-  count = (count & 0x00ff00ff00ff00ff) + ((count >> 8) & 0x00ff00ff00ff00ff);
-  count = (count & 0x0000ffff0000ffff) + ((count >> 16) & 0x0000ffff0000ffff);
-  count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
+  count = (count & m1) + ((count >> 1) & m1);
+  count = (count & m2) + ((count >> 2) & m2);
+  count = (count & m4) + ((count >> 4) & m4);
+  count = (count & m8) + ((count >> 8) & m8);
+  count = (count & m16) + ((count >> 16) & m16);
+  count = (count & m32) + ((count >> 32) & m32);
   return count
 
 

--- a/qiskit/quantum_info/states/cython/exp_value.pyx
+++ b/qiskit/quantum_info/states/cython/exp_value.pyx
@@ -15,7 +15,6 @@
 # that they have been altered from the originals.
 
 cimport cython
-from libcpp cimport bool
 import numpy as np
 
 cdef unsigned long long popcount(unsigned long long count):

--- a/qiskit/quantum_info/states/cython/exp_value.pyx
+++ b/qiskit/quantum_info/states/cython/exp_value.pyx
@@ -15,6 +15,7 @@
 # that they have been altered from the originals.
 
 cimport cython
+from libcpp cimport bool
 import numpy as np
 
 cdef unsigned long long popcount(unsigned long long count):
@@ -26,20 +27,27 @@ cdef unsigned long long popcount(unsigned long long count):
   count = (count & 0x00000000ffffffff) + ((count >> 32) & 0x00000000ffffffff);
   return count
 
-def expval_pauli_no_x(complex[::1] data, unsigned long long z_mask, complex phase):
+def expval_pauli_no_x(complex[::1] data,
+                      unsigned long long num_qubits,
+                      unsigned long long z_mask,
+                      complex phase):
     cdef double val = 0
     cdef int i
     cdef current_val
-    for i in range(data.shape[0]):
+    cdef unsigned long long size = 1 << num_qubits
+    for i in range(size):
         current_val = (phase * (data[i].real*data[i].real+data[i].imag*data[i].imag)).real
         if popcount(i & z_mask) & 1 != 0:
             current_val *= -1
         val += current_val
     return val
 
-def expval_pauli_with_x(complex[::1] data, unsigned long long z_mask,
-                          unsigned long long x_mask, complex phase,
-                          unsigned int x_max):
+def expval_pauli_with_x(complex[::1] data,
+                        unsigned long long num_qubits,
+                        unsigned long long z_mask,
+                        unsigned long long x_mask,
+                        complex phase,
+                        unsigned int x_max):
         cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1) & 0xffffffffffffffff
         cdef unsigned long long mask_l = 2**(x_max) - 1
         cdef double val = 0
@@ -48,7 +56,8 @@ def expval_pauli_with_x(complex[::1] data, unsigned long long z_mask,
         cdef unsigned long long index_1
         cdef double current_val_0
         cdef double current_val_1
-        for i in range(data.shape[0] // 2):
+        cdef unsigned long long size = 1 << (num_qubits - 1)
+        for i in range(size):
             index_0 = ((i << 1) & mask_u) | (i & mask_l)
             index_1 = index_0 ^ x_mask
 
@@ -77,19 +86,25 @@ def expval_pauli_with_x(complex[::1] data, unsigned long long z_mask,
                 val += current_val_1
         return val
 
-def density_expval_pauli_no_x(complex[:, ::1] data, unsigned long long z_mask):
+def density_expval_pauli_no_x(complex[::1] data,
+                              unsigned long long num_qubits,
+                              unsigned long long z_mask):
     cdef double val = 0
     cdef int i
-    cdef current_val
-    for i in range(data.shape[0]):
-        current_val = (data[i][i]).real
+    cdef unsigned long long nrows = 1 << num_qubits
+    cdef unsigned long long stride = 1 + nrows
+    for i in range(nrows):
+        current_val = (data[i * stride]).real
         if popcount(i & z_mask) & 1 != 0:
             current_val *= -1
         val += current_val
     return val
 
-def density_expval_pauli_with_x(complex[:, ::1] data, unsigned long long z_mask,
-                                unsigned long long x_mask, complex phase,
+def density_expval_pauli_with_x(complex[::1] data,
+                                unsigned long long num_qubits,
+                                unsigned long long z_mask,
+                                unsigned long long x_mask,
+                                complex phase,
                                 unsigned int x_max):
         cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1) & 0xffffffffffffffff
         cdef unsigned long long mask_l = 2**(x_max) - 1
@@ -98,11 +113,12 @@ def density_expval_pauli_with_x(complex[:, ::1] data, unsigned long long z_mask,
         cdef unsigned long long index_0
         cdef unsigned long long index_1
         cdef double current_val
-        for i in range(data.shape[0] // 2):
-            index_0 = ((i << 1) & mask_u) | (i & mask_l)
-            index_1 = index_0 ^ x_mask
-            current_val = 2 * (phase * data[index_1][index_0]).real
-            if popcount(index_0 & z_mask) & 1 != 0:
+        cdef unsigned long long nrows = 1 << num_qubits
+        for i in range(nrows >> 1):
+            index_vec = ((i << 1) & mask_u) | (i & mask_l)
+            index_mat = index_0 ^ x_mask + nrows * index_vec
+            current_val = 2 * (phase * data[index_mat]).real
+            if popcount(index_vec & z_mask) & 1 != 0:
                 current_val *= -1
             val += current_val
         return val

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -351,17 +351,19 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         # pylint: disable=no-name-in-module
         from .cython.exp_value import density_expval_pauli_no_x, density_expval_pauli_with_x
         n_pauli = len(pauli)
-        x_mask = np.dot(1 << np.arange(n_pauli), pauli.x)
-        z_mask = np.dot(1 << np.arange(n_pauli), pauli.z)
+        qubits = np.arange(n_pauli)
+        x_mask = np.dot(1 << qubits, pauli.x)
+        z_mask = np.dot(1 << qubits, pauli.z)
         phase = (-1j) ** np.sum(pauli.x & pauli.z)
         if x_mask + z_mask == 0:
             return self.trace()
 
+        data = np.ravel(self.data, order='F')
         if x_mask == 0:
-            return density_expval_pauli_no_x(self.data, z_mask)
-
-        x_max = max([k for k in range(len(pauli)) if pauli.x[k]])
-        return density_expval_pauli_with_x(self.data, z_mask, x_mask, phase, x_max)
+            return density_expval_pauli_no_x(data, self.num_qubits, z_mask)
+        x_max = qubits[pauli.x][-1]
+        return density_expval_pauli_with_x(
+            data, self.num_qubits, z_mask, x_mask, phase, x_max)
 
     def expectation_value(self, oper, qargs=None):
         """Compute the expectation value of an operator.

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -32,6 +32,9 @@ from qiskit.quantum_info.operators.predicates import is_positive_semidefinite_ma
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.operators.channel.superop import SuperOp
 
+# pylint: disable=no-name-in-module
+from .cython.exp_value import density_expval_pauli_no_x, density_expval_pauli_with_x
+
 
 class DensityMatrix(QuantumState, TolerancesMixin):
     """DensityMatrix class"""
@@ -348,8 +351,6 @@ class DensityMatrix(QuantumState, TolerancesMixin):
             Returns:
                 complex: the expectation value.
             """
-        # pylint: disable=no-name-in-module
-        from .cython.exp_value import density_expval_pauli_no_x, density_expval_pauli_with_x
         n_pauli = len(pauli)
         qubits = np.arange(n_pauli)
         x_mask = np.dot(1 << qubits, pauli.x)

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -372,8 +372,9 @@ class Statevector(QuantumState, TolerancesMixin):
         # pylint: disable=no-name-in-module
         from .cython.exp_value import expval_pauli_no_x, expval_pauli_with_x
         n_pauli = len(pauli)
-        x_mask = np.dot(1 << np.arange(n_pauli), pauli.x)
-        z_mask = np.dot(1 << np.arange(n_pauli), pauli.z)
+        qubits = np.arange(n_pauli)
+        x_mask = np.dot(1 << qubits, pauli.x)
+        z_mask = np.dot(1 << qubits, pauli.z)
         phase = (-1j) ** np.sum(pauli.x & pauli.z)
         if x_mask + z_mask == 0:
             return np.linalg.norm(self.data)
@@ -381,7 +382,7 @@ class Statevector(QuantumState, TolerancesMixin):
         if x_mask == 0:
             return expval_pauli_no_x(self.data, self.num_qubits, z_mask, phase)
 
-        x_max = max([k for k in range(len(pauli)) if pauli.x[k]])
+        x_max = qubits[pauli.x][-1]
         return expval_pauli_with_x(
             self.data, self.num_qubits, z_mask, x_mask, phase, x_max)
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -375,16 +375,19 @@ class Statevector(QuantumState, TolerancesMixin):
         qubits = np.arange(n_pauli)
         x_mask = np.dot(1 << qubits, pauli.x)
         z_mask = np.dot(1 << qubits, pauli.z)
-        phase = (-1j) ** np.sum(pauli.x & pauli.z)
+        pauli_phase = (-1j) ** pauli.phase if pauli.phase else 1
+
         if x_mask + z_mask == 0:
-            return np.linalg.norm(self.data)
+            return pauli_phase * np.linalg.norm(self.data)
 
         if x_mask == 0:
-            return expval_pauli_no_x(self.data, self.num_qubits, z_mask, phase)
+            return pauli_phase * expval_pauli_no_x(self.data, self.num_qubits, z_mask)
 
         x_max = qubits[pauli.x][-1]
-        return expval_pauli_with_x(
-            self.data, self.num_qubits, z_mask, x_mask, phase, x_max)
+        y_phase = (-1j) ** np.sum(pauli.x & pauli.z)
+
+        return pauli_phase * expval_pauli_with_x(
+            self.data, self.num_qubits, z_mask, x_mask, y_phase, x_max)
 
     def expectation_value(self, oper, qargs=None):
         """Compute the expectation value of an operator.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -379,10 +379,11 @@ class Statevector(QuantumState, TolerancesMixin):
             return np.linalg.norm(self.data)
 
         if x_mask == 0:
-            return expval_pauli_no_x(self.data, z_mask, phase)
+            return expval_pauli_no_x(self.data, self.num_qubits, z_mask, phase)
 
         x_max = max([k for k in range(len(pauli)) if pauli.x[k]])
-        return expval_pauli_with_x(self.data, z_mask, x_mask, phase, x_max)
+        return expval_pauli_with_x(
+            self.data, self.num_qubits, z_mask, x_mask, phase, x_max)
 
     def expectation_value(self, oper, qargs=None):
         """Compute the expectation value of an operator.

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -30,6 +30,9 @@ from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
 from qiskit.quantum_info.operators.op_shape import OpShape
 from qiskit.quantum_info.operators.predicates import matrix_equal
 
+# pylint: disable=no-name-in-module
+from .cython.exp_value import expval_pauli_no_x, expval_pauli_with_x
+
 
 class Statevector(QuantumState, TolerancesMixin):
     """Statevector class"""
@@ -369,8 +372,6 @@ class Statevector(QuantumState, TolerancesMixin):
             Returns:
                 complex: the expectation value.
             """
-        # pylint: disable=no-name-in-module
-        from .cython.exp_value import expval_pauli_no_x, expval_pauli_with_x
         n_pauli = len(pauli)
         qubits = np.arange(n_pauli)
         x_mask = np.dot(1 << qubits, pauli.x)

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -12,6 +12,7 @@
 
 """Tests for DensityMatrix quantum state class."""
 
+from ddt import ddt, data
 import unittest
 import logging
 import numpy as np
@@ -22,8 +23,7 @@ from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import HGate, QFT
 
-from qiskit.quantum_info.random import (
-    random_unitary, random_density_matrix, random_pauli)
+from qiskit.quantum_info.random import random_unitary, random_density_matrix
 from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
@@ -31,6 +31,7 @@ from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
 logger = logging.getLogger(__name__)
 
 
+@ddt
 class TestDensityMatrix(QiskitTestCase):
     """Tests for DensityMatrix class."""
 
@@ -913,38 +914,42 @@ class TestDensityMatrix(QiskitTestCase):
         target = 25.121320343559642 + 0.7071067811865476j
         self.assertAlmostEqual(expval, target)
 
-    def test_expval_pauli_noise(self):
-        """Test expectation_value method"""
-        seed = 1000
-        nqubits = 3
-        rho = random_density_matrix(2 ** nqubits, seed=seed)
-        pauli = random_pauli(nqubits, seed=seed)
-        target = rho.expectation_value(pauli.to_matrix()).real
-        expval = rho.expectation_value(pauli)
-        self.assertAlmostEqual(expval, target)
-
-    def test_expval_pauli_f_contiguous(self):
-        """Test expectation_value method"""
+    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ',
+          '-II', '-IX', '-IY', '-IZ', '-XI', '-XX', '-XY', '-XZ',
+          '-YI', '-YX', '-YY', '-YZ', '-ZI', '-ZX', '-ZY', '-ZZ',
+          'iII', 'iIX', 'iIY', 'iIZ', 'iXI', 'iXX', 'iXY', 'iXZ',
+          'iYI', 'iYX', 'iYY', 'iYZ', 'iZI', 'iZX', 'iZY', 'iZZ',
+          '-iII', '-iIX', '-iIY', '-iIZ', '-iXI', '-iXX', '-iXY', '-iXZ',
+          '-iYI', '-iYX', '-iYY', '-iYZ', '-iZI', '-iZX', '-iZY', '-iZZ')
+    def test_expval_pauli_f_contiguous(self, pauli):
+        """Test expectation_value method for Pauli op"""
         seed = 1020
-        nqubits = 3
-        rho = random_density_matrix(2 ** nqubits, seed=seed)
+        op = Pauli(pauli)
+        rho = random_density_matrix(2**op.num_qubits, seed=seed)
         rho._data = np.reshape(rho.data.flatten(order='F'),
                                rho.data.shape, order='F')
-        pauli = random_pauli(nqubits, seed=seed)
-        target = rho.expectation_value(pauli.to_matrix()).real
-        expval = rho.expectation_value(pauli)
+        target = rho.expectation_value(op.to_matrix())
+        expval = rho.expectation_value(op)
         self.assertAlmostEqual(expval, target)
 
-    def test_expval_pauli_c_contiguous(self):
-        """Test expectation_value method"""
+    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ',
+          '-II', '-IX', '-IY', '-IZ', '-XI', '-XX', '-XY', '-XZ',
+          '-YI', '-YX', '-YY', '-YZ', '-ZI', '-ZX', '-ZY', '-ZZ',
+          'iII', 'iIX', 'iIY', 'iIZ', 'iXI', 'iXX', 'iXY', 'iXZ',
+          'iYI', 'iYX', 'iYY', 'iYZ', 'iZI', 'iZX', 'iZY', 'iZZ',
+          '-iII', '-iIX', '-iIY', '-iIZ', '-iXI', '-iXX', '-iXY', '-iXZ',
+          '-iYI', '-iYX', '-iYY', '-iYZ', '-iZI', '-iZX', '-iZY', '-iZZ')
+    def test_expval_pauli_c_contiguous(self, pauli):
+        """Test expectation_value method for Pauli op"""
         seed = 1020
-        nqubits = 3
-        rho = random_density_matrix(2 ** nqubits, seed=seed)
+        op = Pauli(pauli)
+        rho = random_density_matrix(2**op.num_qubits, seed=seed)
         rho._data = np.reshape(rho.data.flatten(order='C'),
                                rho.data.shape, order='C')
-        pauli = random_pauli(nqubits, seed=seed)
-        target = rho.expectation_value(pauli.to_matrix()).real
-        expval = rho.expectation_value(pauli)
+        target = rho.expectation_value(op.to_matrix())
+        expval = rho.expectation_value(op)
         self.assertAlmostEqual(expval, target)
 
     def test_reverse_qargs(self):

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -12,9 +12,9 @@
 
 """Tests for DensityMatrix quantum state class."""
 
-from ddt import ddt, data
 import unittest
 import logging
+from ddt import ddt, data
 import numpy as np
 from numpy.testing import assert_allclose
 

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -22,7 +22,8 @@ from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import HGate, QFT
 
-from qiskit.quantum_info.random import random_unitary
+from qiskit.quantum_info.random import (
+    random_unitary, random_density_matrix, random_pauli)
 from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
@@ -910,6 +911,40 @@ class TestDensityMatrix(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(list(zip(labels, coeffs)))
         expval = rho.expectation_value(spp_op)
         target = 25.121320343559642 + 0.7071067811865476j
+        self.assertAlmostEqual(expval, target)
+
+    def test_expval_pauli_noise(self):
+        """Test expectation_value method"""
+        seed = 1000
+        nqubits = 3
+        rho = random_density_matrix(2 ** nqubits, seed=seed)
+        pauli = random_pauli(nqubits, seed=seed)
+        target = rho.expectation_value(pauli.to_matrix()).real
+        expval = rho.expectation_value(pauli)
+        self.assertAlmostEqual(expval, target)
+
+    def test_expval_pauli_f_contiguous(self):
+        """Test expectation_value method"""
+        seed = 1020
+        nqubits = 3
+        rho = random_density_matrix(2 ** nqubits, seed=seed)
+        rho._data = np.reshape(rho.data.flatten(order='F'),
+                               rho.data.shape, order='F')
+        pauli = random_pauli(nqubits, seed=seed)
+        target = rho.expectation_value(pauli.to_matrix()).real
+        expval = rho.expectation_value(pauli)
+        self.assertAlmostEqual(expval, target)
+
+    def test_expval_pauli_c_contiguous(self):
+        """Test expectation_value method"""
+        seed = 1020
+        nqubits = 3
+        rho = random_density_matrix(2 ** nqubits, seed=seed)
+        rho._data = np.reshape(rho.data.flatten(order='C'),
+                               rho.data.shape, order='C')
+        pauli = random_pauli(nqubits, seed=seed)
+        target = rho.expectation_value(pauli.to_matrix()).real
+        expval = rho.expectation_value(pauli)
         self.assertAlmostEqual(expval, target)
 
     def test_reverse_qargs(self):

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -13,9 +13,9 @@
 
 """Tests for Statevector quantum state class."""
 
-from ddt import ddt, data
 import unittest
 import logging
+from ddt import ddt, data
 import numpy as np
 from numpy.testing import assert_allclose
 

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -13,6 +13,7 @@
 
 """Tests for Statevector quantum state class."""
 
+from ddt import ddt, data
 import unittest
 import logging
 import numpy as np
@@ -24,7 +25,7 @@ from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
 from qiskit.circuit.library import HGate, QFT
 
-from qiskit.quantum_info.random import random_unitary
+from qiskit.quantum_info.random import random_unitary, random_statevector
 from qiskit.quantum_info.states import Statevector
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
@@ -33,6 +34,7 @@ from qiskit.quantum_info.operators.predicates import matrix_equal
 logger = logging.getLogger(__name__)
 
 
+@ddt
 class TestStatevector(QiskitTestCase):
     """Tests for Statevector class."""
 
@@ -915,6 +917,23 @@ class TestStatevector(QiskitTestCase):
         spp_op = SparsePauliOp.from_list(list(zip(labels, coeffs)))
         expval = psi.expectation_value(spp_op)
         target = 25.121320343559642+0.7071067811865476j
+        self.assertAlmostEqual(expval, target)
+
+    @data('II', 'IX', 'IY', 'IZ', 'XI', 'XX', 'XY', 'XZ',
+          'YI', 'YX', 'YY', 'YZ', 'ZI', 'ZX', 'ZY', 'ZZ',
+          '-II', '-IX', '-IY', '-IZ', '-XI', '-XX', '-XY', '-XZ',
+          '-YI', '-YX', '-YY', '-YZ', '-ZI', '-ZX', '-ZY', '-ZZ',
+          'iII', 'iIX', 'iIY', 'iIZ', 'iXI', 'iXX', 'iXY', 'iXZ',
+          'iYI', 'iYX', 'iYY', 'iYZ', 'iZI', 'iZX', 'iZY', 'iZZ',
+          '-iII', '-iIX', '-iIY', '-iIZ', '-iXI', '-iXX', '-iXY', '-iXZ',
+          '-iYI', '-iYX', '-iYY', '-iYZ', '-iZI', '-iZX', '-iZY', '-iZZ')
+    def test_expval_pauli(self, pauli):
+        """Test expectation_value method for Pauli op"""
+        seed = 1020
+        op = Pauli(pauli)
+        state = random_statevector(2**op.num_qubits, seed=seed)
+        target = state.expectation_value(op.to_matrix())
+        expval = state.expectation_value(op)
         self.assertAlmostEqual(expval, target)
 
     def test_global_phase(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in #5941 that showed up in Aer CI tests.

Also fixed the phase coefficient of the `Pauli` operator not being applied if it was not `1`.

### Details and comments

The cython function for density matrix expectation value only worked if the matrix memory was a C-contiguous array, which isnt always true since superop evolution vectorizes the array using Fortran ordering (col-vec). This updates the cython function to work on a flattened array assuming F ordering and adds some extra tests to check it works with both C- and F-ordered data arrays in density matrix.