### PR TITLE
Set character encoding in windows CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -352,11 +352,15 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            chcp.com 65001
             source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
+          env:
+            LANG: 'C.UTF-8'
+            PYTHONIOENCODING: 'utf-8:backslashreplace'
         - task: CopyFiles@2
           condition: failed()
           displayName: 'Copy images'
@@ -424,10 +428,14 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            chcp.com 65001
             source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
+          env:
+            LANG: 'C.UTF-8'
+            PYTHONIOENCODING: 'utf-8:backslashreplace'
           displayName: 'Run tests'
         - task: CopyFiles@2
           condition: failed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -352,15 +352,11 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            chcp.com 65001
             source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
           displayName: 'Run tests'
-          env:
-            LANG: 'C.UTF-8'
-            PYTHONIOENCODING: 'utf-8:backslashreplace'
         - task: CopyFiles@2
           condition: failed()
           displayName: 'Copy images'
@@ -428,14 +424,10 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
-            chcp.com 65001
             source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
-          env:
-            LANG: 'C.UTF-8'
-            PYTHONIOENCODING: 'utf-8:backslashreplace'
           displayName: 'Run tests'
         - task: CopyFiles@2
           condition: failed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -407,10 +407,14 @@ stages:
           displayName: 'Install dependencies'
         - bash: |
             set -e
+            chcp.com 65001
             source test-job/Scripts/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 1024))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
+          env:
+            LANG: 'C.UTF-8'
+            PYTHONIOENCODING: 'utf-8:backslashreplace'
           displayName: 'Run tests'
         - task: CopyFiles@2
           condition: failed()

--- a/test/python/algorithms/algorithms_test_case.py
+++ b/test/python/algorithms/algorithms_test_case.py
@@ -19,15 +19,4 @@ from qiskit.test import QiskitTestCase
 
 class QiskitAlgorithmsTestCase(QiskitTestCase):
     """Algorithms test Case"""
-    def setUp(self):
-        super().setUp()
-        # disable logging due to Unicode logging error
-        if platform.system() == 'Windows':
-            self.disable_logging()
-
-    def disable_logging(self):
-        """ Disable Qiskit logging"""
-        logger = logging.getLogger('qiskit')
-        for handler in reversed(logger.handlers):
-            self.addCleanup(logger.addHandler, handler)
-            logger.removeHandler(handler)
+    pass

--- a/test/python/algorithms/algorithms_test_case.py
+++ b/test/python/algorithms/algorithms_test_case.py
@@ -12,8 +12,6 @@
 
 """ Algorithms Test Case """
 
-import platform
-import logging
 from qiskit.test import QiskitTestCase
 
 

--- a/test/python/opflow/opflow_test_case.py
+++ b/test/python/opflow/opflow_test_case.py
@@ -19,15 +19,4 @@ from qiskit.test import QiskitTestCase
 
 class QiskitOpflowTestCase(QiskitTestCase):
     """Opflow test Case"""
-    def setUp(self):
-        super().setUp()
-        # disable logging due to Unicode logging error
-        if platform.system() == 'Windows':
-            self.disable_logging()
-
-    def disable_logging(self):
-        """ Disable Qiskit logging"""
-        logger = logging.getLogger('qiskit')
-        for handler in reversed(logger.handlers):
-            self.addCleanup(logger.addHandler, handler)
-            logger.removeHandler(handler)
+    pass

--- a/test/python/opflow/opflow_test_case.py
+++ b/test/python/opflow/opflow_test_case.py
@@ -12,8 +12,6 @@
 
 """ Opflow Test Case """
 
-import platform
-import logging
 from qiskit.test import QiskitTestCase
 
 

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1292,6 +1292,18 @@ class TestTextDrawerParams(QiskitTestCase):
         circuit.rx((pi - x) * (pi - y), 0)
         self.assertEqual(circuit.draw(output='text').single_string(), expected)
 
+    def test_text_utf8(self):
+        """Test that utf8 characters work in windows CI env."""
+        expected = '\n'.join(["     ┌─────────┐",
+                              "q_0: ┤ U2(φ,λ) ├",
+                              "     └─────────┘"])
+
+        phi, lam = Parameter('φ'), Parameter('λ')
+        circuit = QuantumCircuit(1)
+        circuit.u2(phi, lam, 0)
+        print(circuit)
+        self.assertEqual(circuit.draw(output='text').single_string(), expected)
+
 
 class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
     """Test vertical_compression='low' """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit is an attempt to fix the CI configuration around character
encoding in windows when running tests. The test jobs all rely on stestr
for running the tests which spawns multiple worker processes to execute
the tests using python's stdlib subprocess.Popen. This however can
cause issues with the default character encoding on windows (as reported
in mtreinish/stestr#295) where either the worker processes or the pipe
used for interprocess communication on windows does not carry over the
same character encoding as the parent process and reverts to the default
windows encoding of cp1252. This commit tries setting the character
encoding both through the change code page command and through setting
the LANG env variable.


### Details and comments

For testing purposes a test is added to purposefully emit utf8
characters to stdout to verify if this works or not. This can be removed
prior to merging (although it doesn't do any harm by itself).
