### PR TITLE
Remove useless all 1s masks

### DIFF
--- a/qiskit/quantum_info/states/cython/exp_value.pyx
+++ b/qiskit/quantum_info/states/cython/exp_value.pyx
@@ -40,7 +40,7 @@ def expval_pauli_no_x(complex[::1] data, unsigned long long z_mask, complex phas
 def expval_pauli_with_x(complex[::1] data, unsigned long long z_mask,
                           unsigned long long x_mask, complex phase,
                           unsigned int x_max):
-        cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1) & 0xffffffffffffffff
+        cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1)
         cdef unsigned long long mask_l = 2**(x_max) - 1
         cdef double val = 0
         cdef unsigned int i
@@ -91,7 +91,7 @@ def density_expval_pauli_no_x(complex[:, ::1] data, unsigned long long z_mask):
 def density_expval_pauli_with_x(complex[:, ::1] data, unsigned long long z_mask,
                                 unsigned long long x_mask, complex phase,
                                 unsigned int x_max):
-        cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1) & 0xffffffffffffffff
+        cdef unsigned long long mask_u = ~(2 ** (x_max + 1) - 1)
         cdef unsigned long long mask_l = 2**(x_max) - 1
         cdef double val = 0
         cdef unsigned int i


### PR DESCRIPTION
A quantity is anded with a bitmask of all 1s. This should be a noop.
This PR removes anding with such a mask in two places.

If the function where the change is made is not sufficiently tested, then this PR should add a test. There doesn't appear
to be a unit test for the function in question yet.