### PR TITLE
Remove delays from Acquire Channels

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -203,7 +203,8 @@ def _assemble_instructions(
                 name=name)
             user_pulselib[name] = instruction.pulse.samples
 
-        # ignore delay instrs on acq channels (don't matter w/ absolute timing)
+        # ignore explicit delay instrs on acq channels as they are invalid on IBMQ backends;
+        # timing of other instrs will still be shifted appropriately
         if (isinstance(instruction, instructions.Delay) and
                 isinstance(instruction.channel, channels.AcquireChannel)):
             continue

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Tuple, Union
 from qiskit import qobj, pulse
 from qiskit.assembler.run_config import RunConfig
 from qiskit.exceptions import QiskitError
-from qiskit.pulse import instructions, transforms, library, schedule
+from qiskit.pulse import instructions, transforms, library, schedule, channels
 from qiskit.qobj import utils as qobj_utils, converters
 from qiskit.qobj.converters.pulse_instruction import ParametricPulseShapes
 
@@ -202,6 +202,11 @@ def _assemble_instructions(
                 channel=instruction.channel,
                 name=name)
             user_pulselib[name] = instruction.pulse.samples
+
+        # ignore delay instrs on acq channels (don't matter w/ absolute timing)
+        if (isinstance(instruction, instructions.Delay) and
+                isinstance(instruction.channel, channels.AcquireChannel)):
+            continue
 
         if isinstance(instruction, instructions.Acquire):
             if instruction.mem_slot:

--- a/qiskit/pulse/instructions/play.py
+++ b/qiskit/pulse/instructions/play.py
@@ -47,6 +47,9 @@ class Play(Instruction):
         """
         if not isinstance(pulse, Pulse):
             raise PulseError("The `pulse` argument to `Play` must be of type `library.Pulse`.")
+        if not isinstance(channel, PulseChannel):
+            raise PulseError("The `channel` argument to `Play` must be of type "
+                             "`channels.PulseChannel`.")
         if name is None:
             name = pulse.name
         super().__init__((pulse, channel), None, (channel,), name=name)

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -890,7 +890,7 @@ class TestPulseAssembler(QiskitTestCase):
         self.assertEqual(len(qobj.config.pulse_library), 3)
 
     def test_assemble_with_delay(self):
-        """Test that delay instruction is ignored in assembly."""
+        """Test that delay instruction is not ignored in assembly."""
         delay_schedule = pulse.Delay(10, self.backend_config.drive(0))
         delay_schedule += self.schedule
         delay_qobj = assemble(delay_schedule, self.backend)
@@ -898,9 +898,12 @@ class TestPulseAssembler(QiskitTestCase):
         validate_qobj_against_schema(delay_qobj)
         self.assertEqual(delay_qobj.experiments[0].instructions[0].name, "delay")
         self.assertEqual(delay_qobj.experiments[0].instructions[0].duration, 10)
+        self.assertEqual(delay_qobj.experiments[0].instructions[0].t0, 0)
 
     def test_delay_removed_on_acq_ch(self):
-        """Test that delay instructions on acquire channels are skipped on assembly."""
+        """Test that delay instructions on acquire channels are skipped on assembly with times
+        shifted properly.
+        """
         delay0 = pulse.Delay(5, self.backend_config.acquire(0))
         delay1 = pulse.Delay(7, self.backend_config.acquire(1))
 
@@ -927,6 +930,14 @@ class TestPulseAssembler(QiskitTestCase):
                     is_acq_delay = True
 
         self.assertFalse(is_acq_delay)
+
+        # check that acquire instr are shifted from ``t0=5`` as needed
+        self.assertEqual(delay_qobj.experiments[0].instructions[1].t0, 10)
+        self.assertEqual(delay_qobj.experiments[0].instructions[1].name, "acquire")
+        self.assertEqual(delay_qobj.experiments[1].instructions[1].t0, 5)
+        self.assertEqual(delay_qobj.experiments[1].instructions[1].name, "acquire")
+        self.assertEqual(delay_qobj.experiments[2].instructions[1].t0, 12)
+        self.assertEqual(delay_qobj.experiments[2].instructions[1].name, "acquire")
 
     def test_assemble_schedule_enum(self):
         """Test assembling a schedule with enum input values to assemble."""

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -15,7 +15,7 @@
 import numpy as np
 
 from qiskit import pulse, circuit
-from qiskit.pulse import channels, configuration, instructions, library
+from qiskit.pulse import channels, configuration, instructions, library, exceptions
 from qiskit.test import QiskitTestCase
 
 
@@ -191,18 +191,27 @@ class TestSnapshot(QiskitTestCase):
 class TestPlay(QiskitTestCase):
     """Play tests."""
 
+    def setUp(self):
+        """Setup play tests."""
+        super().setUp()
+        self.duration = 4
+        self.pulse_op = library.Waveform([1.0] * self.duration, name='test')
+
     def test_play(self):
         """Test basic play instruction."""
-        duration = 4
-        pulse_op = library.Waveform([1.0] * duration, name='test')
-        play = instructions.Play(pulse_op, channels.DriveChannel(1))
+        play = instructions.Play(self.pulse_op, channels.DriveChannel(1))
 
         self.assertIsInstance(play.id, int)
-        self.assertEqual(play.name, pulse_op.name)
-        self.assertEqual(play.duration, duration)
+        self.assertEqual(play.name, self.pulse_op.name)
+        self.assertEqual(play.duration, self.duration)
         self.assertEqual(repr(play),
                          "Play(Waveform(array([1.+0.j, 1.+0.j, 1.+0.j, 1.+0.j]), name='test'),"
                          " DriveChannel(1), name='test')")
+
+    def test_play_non_pulse_ch_raises(self):
+        """Test that play instruction on non-pulse channel raises a pulse error."""
+        with self.assertRaises(exceptions.PulseError):
+            instructions.Play(self.pulse_op, channels.AcquireChannel(0))
 
 
 class TestDirectives(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR removes pulse `delay` instructions from the qobj if they are on `Acquire` channels. They are unnecessary as pulse instructions are already absolutely timed. 

Additionally, an error is included when `Acquire` channels are used on `Play`.

The net result is that pulses excluding the `Acquire` instruction will not be passed into the qobj.
