### PR TITLE
DAG compose carries over calibrations

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -695,6 +695,9 @@ class DAGCircuit:
             dag = copy.deepcopy(self)
         dag.global_phase += other.global_phase
 
+        for gate, cals in other.calibrations.items():
+            dag._calibrations[gate].update(cals)
+
         for nd in other.topological_nodes():
             if nd.type == "in":
                 # if in edge_map, get new name, else use existing name


### PR DESCRIPTION
### Summary
This fixes #5999 

### Details and comments
Calibrations in compose of DAGCircuit are now carried over. A test has also been added.

