### PR TITLE
Don't call opflow methods on non-OperatorBase objects

### DIFF
--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -72,11 +72,18 @@ class ListOp(OperatorBase):
             identity - it accepts the list of values, and returns them in a list.
         """
         super().__init__()
-        self._oplist = oplist
+        self._oplist = self._get_op_list(oplist)
         self._combo_fn = combo_fn
         self._coeff = coeff
         self._abelian = abelian
         self._grad_combo_fn = grad_combo_fn
+
+    def _get_op_list(self, oplist):
+        if all(isinstance(x, (OperatorBase, float)) for x in oplist):
+            return list(oplist)
+        else:
+            badval = next(x for x in oplist if not isinstance(x, (OperatorBase, float)))
+            raise ValueError(f'ListOp expecting OperatorBase objects, got {badval}')
 
     def _state(self,
                coeff: Optional[Union[int, float, complex, ParameterExpression]] = None,

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -33,7 +33,7 @@ from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.utils import algorithm_globals
 from qiskit.algorithms import VQE
 from qiskit.algorithms.optimizers import CG
-from qiskit.opflow import I, X, Y, Z, StateFn, CircuitStateFn, ListOp, CircuitSampler
+from qiskit.opflow import I, X, Y, Z, StateFn, CircuitStateFn, ListOp, CircuitSampler, PauliSumOp
 from qiskit.opflow.gradients import Gradient, NaturalGradient, Hessian
 from qiskit.opflow.gradients.qfi import QFI
 from qiskit.opflow.gradients.circuit_qfis import LinCombFull, OverlapBlockDiag, OverlapDiag
@@ -925,6 +925,28 @@ class TestGradients(QiskitOpflowTestCase):
                 qfi = QFI(method)
                 value = np.real(qfi.convert(state, [x]).bind_parameters({x: 0.12}).eval())
                 self.assertAlmostEqual(value[0][0], reference)
+
+    def test_numbers_in_opflow_expression(self):
+        """Test explicit numbers are supported in opflow expression."""
+
+        x, y = Parameter('x'), Parameter('y')
+        param_values = {x: 1, y: 3}
+
+        H = StateFn(PauliSumOp.from_list([('Z', 1.0), ('X', 1.0)]))
+
+        qc_x = QuantumCircuit(1)
+        qc_x.ry(x, 0)
+        op_x = ~H @ CircuitStateFn(qc_x)
+
+        qc_y = QuantumCircuit(1)
+        qc_y.ry(y, 0)
+        op_y = ~H @ CircuitStateFn(qc_y)
+
+        op = ListOp([op_x, op_y])
+
+        gradient = Gradient()
+        grad_op = gradient.convert(op, [x, y])
+        grad_op.bind_parameters(param_values).eval()
 
 
 @ddt


### PR DESCRIPTION
This PR checks in some places that elements of opflow expressions are of type `OperatorBase` before calling the method `eval` or substituting parameters. This allows, for example, numbers to be passed through. This is useful since some opflow expressions are reduced to numbers.

Closes #5992 
