### PR TITLE
Use quantum info Statevector over BasicAer in Opflow

### DIFF
--- a/qiskit/opflow/state_fns/circuit_state_fn.py
+++ b/qiskit/opflow/state_fns/circuit_state_fn.py
@@ -17,7 +17,7 @@ from typing import Dict, List, Optional, Set, Union, cast
 
 import numpy as np
 
-from qiskit import BasicAer, ClassicalRegister, QuantumCircuit, execute
+from qiskit import ClassicalRegister, QuantumCircuit
 from qiskit.circuit import Instruction, ParameterExpression
 from qiskit.circuit.library import IGate
 from qiskit.extensions import Initialize
@@ -219,10 +219,8 @@ class CircuitStateFn(StateFn):
         if self.is_measurement:
             return np.conj(self.adjoint().to_matrix(massive=massive))
         qc = self.to_circuit(meas=False)
-        statevector_backend = BasicAer.get_backend('statevector_simulator')
-        statevector = execute(qc,
-                              statevector_backend,
-                              optimization_level=0).result().get_statevector()
+        statevector = Statevector(qc).data
+
         from ..operator_globals import EVAL_SIG_DIGITS
         return np.round(statevector * self.coeff, decimals=EVAL_SIG_DIGITS)
 
@@ -314,8 +312,8 @@ class CircuitStateFn(StateFn):
         """
         OperatorBase._check_massive('sample', False, self.num_qubits, massive)
         qc = self.to_circuit(meas=True)
-        qasm_backend = BasicAer.get_backend('qasm_simulator')
-        counts = execute(qc, qasm_backend, optimization_level=0, shots=shots).result().get_counts()
+        statevector = Statevector(qc)  # possibly we should cache the statevector
+        counts = statevector.sample_counts(shots)
         if reverse_endianness:
             scaled_dict = {bstr[::-1]: (prob / shots) for (bstr, prob) in counts.items()}
         else:

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -184,6 +184,14 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         else:
             self.assertEqual(len(sampler._cached_ops.keys()), 2)
 
+    def test_global_phase_in_circuit_state_fn(self):
+        """Test that circuits using isometry are evaluated correctly in CircuitStateFn."""
+        vector = numpy.array([1, 2, 3, 1])
+        circuit = QuantumCircuit(2)
+        circuit.isometry(vector / numpy.linalg.norm(vector), [0, 1], None)
+        result = (~StateFn(I ^ I) @ StateFn(circuit)).eval()
+        self.assertAlmostEqual(result, 1+0j)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Instead of simulating the statevector and sampling counts via the `BasicAer` backend in `CircuitStateFn.eval` and `sample`, use quantum info's Statevector object. The Statevector class is more reliable (e.g. it doesn't introduce the bug from #6004) and more efficient for small numbers of qubits. Since for large numbers of qubits `eval` and `sample` are not supposed to be called anyways, the Statevector class is preferable.

Fixes #6004 and unblocks #5698.


