### PR TITLE
Fix error in plot_state_city if only real axis is specified

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -382,8 +382,7 @@ def plot_state_city(state, title="", figsize=None, color=None,
     elif ax_real is not None:
         fig = ax_real.get_figure()
         ax1 = ax_real
-        if ax_imag is not None:
-            ax2 = ax_imag
+        ax2 = ax_imag
     else:
         fig = ax_imag.get_figure()
         ax1 = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes an error that is generated when only a single axis is specified for the `plot_state_city` method.

### Details and comments

A minimal example that shows the original problem:
```
import matplotlib.pyplot as plt
from qiskit import QuantumCircuit, Aer, execute
from qiskit.tools.visualization import plot_state_city
from mpl_toolkits.mplot3d import Axes3D

qc = QuantumCircuit(2, 2)
c=qc.cregs
qc.h(0)

simulator = Aer.get_backend('statevector_simulator')

result = execute(qc, simulator).result()
statevector = result.get_statevector(qc)
fig=plt.figure(20);plt.clf()
ax = Axes3D(fig)
plot_state_city(statevector, title='Bell state', ax_real=ax, ax_imag=None)
```
