### PR TITLE
Fixed issue #6006 and fixed a typo

### DIFF
--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -66,7 +66,7 @@ class UGate(Gate):
     def inverse(self):
         r"""Return inverted U gate.
 
-        :math:`U(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\phi,-\lambda)`)
+        :math:`U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\lambda,-\phi)`)
         """
         return UGate(-self.params[0], -self.params[2], -self.params[1])
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -65,7 +65,7 @@ class U3Gate(Gate):
     def inverse(self):
         r"""Return inverted U3 gate.
 
-        :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\phi,-\lambda)`)
+        :math:`U3(\theta,\phi,\lambda)^{\dagger} =U3(-\theta,-\lambda,-\phi)`)
         """
         return U3Gate(-self.params[0], -self.params[2], -self.params[1])
 


### PR DESCRIPTION
### Summary
Fixes #6006 

### Details and comments
1. Match the order of phi and lambda in [inverse U](https://qiskit.org/documentation/stubs/qiskit.circuit.library.UGate.html#qiskit.circuit.library.UGate.inverse) and [inverse U3](https://qiskit.org/documentation/stubs/qiskit.circuit.library.U3Gate.html#qiskit.circuit.library.U3Gate.inverse) to function return, as mentioned in issue #6006 .
2. fixed a typo in [inverse U gate](https://qiskit.org/documentation/stubs/qiskit.circuit.library.UGate.html#qiskit.circuit.library.UGate.inverse) docstring, which should be U(\theta,\phi,\lambda)^{\dagger} =U(-\theta,-\phi,-\lambda).


