### PR TITLE
Add additional basis gates rz, sx, x to basicaer.

### DIFF
--- a/qiskit/providers/basicaer/basicaertools.py
+++ b/qiskit/providers/basicaer/basicaertools.py
@@ -34,6 +34,9 @@ def single_gate_matrix(gate: str, params: Optional[List[float]] = None):
         params: the operation parameters op['params']
     Returns:
         array: A numpy array representing the matrix
+    Raises:
+        QiskitError: If a gate outside the supported set is passed in for the
+            ``Gate`` argument.
     """
     if params is None:
         params = []

--- a/qiskit/providers/basicaer/basicaertools.py
+++ b/qiskit/providers/basicaer/basicaertools.py
@@ -15,51 +15,52 @@
 """
 
 from string import ascii_uppercase, ascii_lowercase
+from typing import List, Optional
+
 import numpy as np
+
+import qiskit.circuit.library.standard_gates as gates
 from qiskit.exceptions import QiskitError
 
-
-def single_gate_params(gate, params=None):
-    """Apply a single qubit gate to the qubit.
-
-    Args:
-        gate(str): the single qubit gate name
-        params(list): the operation parameters op['params']
-    Returns:
-        tuple: a tuple of U gate parameters (theta, phi, lam)
-    Raises:
-        QiskitError: if the gate name is not valid
-    """
-    if gate in ('U', 'u3'):
-        return params[0], params[1], params[2]
-    elif gate == 'u2':
-        return np.pi / 2, params[0], params[1]
-    elif gate == 'u1':
-        return 0, 0, params[0]
-    elif gate == 'id':
-        return 0, 0, 0
-    raise QiskitError('Gate is not among the valid types: %s' % gate)
+# Single qubit gates supported by ``single_gate_params``.
+SINGLE_QUBIT_GATES = ('U', 'u1', 'u2', 'u3', 'rz', 'sx', 'x')
 
 
-def single_gate_matrix(gate, params=None):
+def single_gate_matrix(gate: str, params: Optional[List[float]] = None):
     """Get the matrix for a single qubit.
 
     Args:
-        gate(str): the single qubit gate name
-        params(list): the operation parameters op['params']
+        gate: the single qubit gate name
+        params: the operation parameters op['params']
     Returns:
         array: A numpy array representing the matrix
     """
+    if params is None:
+        params = []
 
-    # Converting sym to floats improves the performance of the simulator 10x.
-    # This a is a probable a FIXME since it might show bugs in the simulator.
-    (theta, phi, lam) = map(float, single_gate_params(gate, params))
+    if gate == 'U':
+        gc = gates.UGate
+    elif gate == 'u3':
+        gc = gates.U3Gate
+    elif gate == 'u2':
+        gc = gates.U2Gate
+    elif gate == 'u1':
+        gc = gates.U1Gate
+    elif gate == 'rz':
+        gc = gates.RZGate
+    elif gate == 'id':
+        gc = gates.IGate
+    elif gate == 'sx':
+        gc = gates.SXGate
+    elif gate == 'x':
+        gc = gates.XGate
+    else:
+        raise QiskitError('Gate is not a valid basis gate for this simulator: %s' % gate)
 
-    return np.array([[np.cos(theta / 2),
-                      -np.exp(1j * lam) * np.sin(theta / 2)],
-                     [np.exp(1j * phi) * np.sin(theta / 2),
-                      np.exp(1j * phi + 1j * lam) * np.cos(theta / 2)]])
+    return gc(*params).to_matrix()
 
+# Cache CX matrix as no parameters.
+_CX_MATRIX = gates.CXGate().to_matrix()
 
 def cx_gate_matrix():
     """Get the matrix for a controlled-NOT gate."""

--- a/qiskit/providers/basicaer/basicaertools.py
+++ b/qiskit/providers/basicaer/basicaertools.py
@@ -59,8 +59,10 @@ def single_gate_matrix(gate: str, params: Optional[List[float]] = None):
 
     return gc(*params).to_matrix()
 
+
 # Cache CX matrix as no parameters.
 _CX_MATRIX = gates.CXGate().to_matrix()
+
 
 def cx_gate_matrix():
     """Get the matrix for a controlled-NOT gate."""

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -43,6 +43,7 @@ from qiskit.providers import BaseBackend
 from qiskit.providers.basicaer.basicaerjob import BasicAerJob
 from .exceptions import BasicAerError
 from .basicaertools import single_gate_matrix
+from .basicaertools import SINGLE_QUBIT_GATES
 from .basicaertools import cx_gate_matrix
 from .basicaertools import einsum_vecmul_index
 
@@ -56,7 +57,7 @@ class QasmSimulatorPy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'backend_name': 'qasm_simulator',
-        'backend_version': '2.0.0',
+        'backend_version': '2.1.0',
         'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
@@ -67,7 +68,7 @@ class QasmSimulatorPy(BaseBackend):
         'max_shots': 65536,
         'coupling_map': None,
         'description': 'A python simulator for qasm experiments',
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'unitary'],
+        'basis_gates': ['u1', 'u2', 'u3', 'rz', 'sx', 'x', 'cx', 'id', 'unitary'],
         'gates': [
             {
                 'name': 'u1',
@@ -85,13 +86,28 @@ class QasmSimulatorPy(BaseBackend):
                 'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }'
             },
             {
+                'name': 'rz',
+                'parameters': ['phi'],
+                'qasm_def': 'gate rz(phi) q { U(0,0,phi) q; }'
+            },
+            {
+                'name': 'sx',
+                'parameters': [],
+                'qasm_def': 'gate sx(phi) q { U(pi/2,7*pi/2,pi/2) q; }'
+            },
+            {
+                'name': 'x',
+                'parameters': [],
+                'qasm_def': 'gate x q { U(pi,7*pi/2,pi/2) q; }'
+            },
+            {
                 'name': 'cx',
-                'parameters': ['c', 't'],
+                'parameters': [],
                 'qasm_def': 'gate cx c,t { CX c,t; }'
             },
             {
                 'name': 'id',
-                'parameters': ['a'],
+                'parameters': [],
                 'qasm_def': 'gate id a { U(0,0,0) a; }'
             },
             {
@@ -512,7 +528,7 @@ class QasmSimulatorPy(BaseBackend):
                     qubits = operation.qubits
                     gate = operation.params[0]
                     self._add_unitary(gate, qubits)
-                elif operation.name in ('U', 'u1', 'u2', 'u3'):
+                elif operation.name in SINGLE_QUBIT_GATES:
                     params = getattr(operation, 'params', None)
                     qubit = operation.qubits[0]
                     gate = single_gate_matrix(operation.name, params)

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -40,7 +40,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
 
     DEFAULT_CONFIGURATION = {
         'backend_name': 'statevector_simulator',
-        'backend_version': '1.0.0',
+        'backend_version': '1.1.0',
         'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
@@ -51,7 +51,7 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
         'max_shots': 65536,
         'coupling_map': None,
         'description': 'A Python statevector simulator for qobj files',
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'unitary'],
+        'basis_gates': ['u1', 'u2', 'u3', 'rz', 'sx', 'x', 'cx', 'id', 'unitary'],
         'gates': [
             {
                 'name': 'u1',
@@ -69,13 +69,28 @@ class StatevectorSimulatorPy(QasmSimulatorPy):
                 'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }'
             },
             {
+                'name': 'rz',
+                'parameters': ['phi'],
+                'qasm_def': 'gate rz(phi) q { U(0,0,phi) q; }'
+            },
+            {
+                'name': 'sx',
+                'parameters': [],
+                'qasm_def': 'gate sx(phi) q { U(pi/2,7*pi/2,pi/2) q; }'
+            },
+            {
+                'name': 'x',
+                'parameters': [],
+                'qasm_def': 'gate x q { U(pi,7*pi/2,pi/2) q; }'
+            },
+            {
                 'name': 'cx',
-                'parameters': ['c', 't'],
+                'parameters': [],
                 'qasm_def': 'gate cx c,t { CX c,t; }'
             },
             {
                 'name': 'id',
-                'parameters': ['a'],
+                'parameters': [],
                 'qasm_def': 'gate id a { U(0,0,0) a; }'
             },
             {

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -38,6 +38,7 @@ from qiskit.providers.basicaer.basicaerjob import BasicAerJob
 from qiskit.result import Result
 from .exceptions import BasicAerError
 from .basicaertools import single_gate_matrix
+from .basicaertools import SINGLE_QUBIT_GATES
 from .basicaertools import cx_gate_matrix
 from .basicaertools import einsum_matmul_index
 
@@ -55,7 +56,7 @@ class UnitarySimulatorPy(BaseBackend):
 
     DEFAULT_CONFIGURATION = {
         'backend_name': 'unitary_simulator',
-        'backend_version': '1.0.0',
+        'backend_version': '1.1.0',
         'n_qubits': min(24, MAX_QUBITS_MEMORY),
         'url': 'https://github.com/Qiskit/qiskit-terra',
         'simulator': True,
@@ -66,7 +67,7 @@ class UnitarySimulatorPy(BaseBackend):
         'max_shots': 65536,
         'coupling_map': None,
         'description': 'A python simulator for unitary matrix corresponding to a circuit',
-        'basis_gates': ['u1', 'u2', 'u3', 'cx', 'id', 'unitary'],
+        'basis_gates': ['u1', 'u2', 'u3', 'rz', 'sx', 'x', 'cx', 'id', 'unitary'],
         'gates': [
             {
                 'name': 'u1',
@@ -84,13 +85,28 @@ class UnitarySimulatorPy(BaseBackend):
                 'qasm_def': 'gate u3(theta,phi,lambda) q { U(theta,phi,lambda) q; }'
             },
             {
+                'name': 'rz',
+                'parameters': ['phi'],
+                'qasm_def': 'gate rz(phi) q { U(0,0,phi) q; }'
+            },
+            {
+                'name': 'sx',
+                'parameters': [],
+                'qasm_def': 'gate sx(phi) q { U(pi/2,7*pi/2,pi/2) q; }'
+            },
+            {
+                'name': 'x',
+                'parameters': [],
+                'qasm_def': 'gate x q { U(pi,7*pi/2,pi/2) q; }'
+            },
+            {
                 'name': 'cx',
-                'parameters': ['c', 't'],
+                'parameters': [],
                 'qasm_def': 'gate cx c,t { CX c,t; }'
             },
             {
                 'name': 'id',
-                'parameters': ['a'],
+                'parameters': [],
                 'qasm_def': 'gate id a { U(0,0,0) a; }'
             },
             {
@@ -317,7 +333,7 @@ class UnitarySimulatorPy(BaseBackend):
                 gate = operation.params[0]
                 self._add_unitary(gate, qubits)
             # Check if single  gate
-            elif operation.name in ('U', 'u1', 'u2', 'u3'):
+            elif operation.name in SINGLE_QUBIT_GATES:
                 params = getattr(operation, 'params', None)
                 qubit = operation.qubits[0]
                 gate = single_gate_matrix(operation.name, params)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -32,7 +32,7 @@ from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, pulse
 from qiskit.circuit import Parameter, Gate, Qubit, Clbit
 from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag
-from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate
+from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate, RZGate
 from qiskit.test import QiskitTestCase, Path
 from qiskit.test.mock import FakeMelbourne, FakeRueschlikon, FakeAlmaden
 from qiskit.transpiler import Layout, CouplingMap
@@ -450,9 +450,8 @@ class TestTranspile(QiskitTestCase):
 
         transpiled_qc = transpile(qc, backend=BasicAer.get_backend('qasm_simulator'))
 
-        expected_qc = QuantumCircuit(qr, global_phase=-1 * theta / 2.0)
-        expected_qc.append(U1Gate(theta), [qr[0]])
-
+        expected_qc = QuantumCircuit(qr)
+        expected_qc.append(RZGate(theta), [qr[0]])
         self.assertEqual(expected_qc, transpiled_qc)
 
     def test_parameterized_circuit_for_device(self):
@@ -484,8 +483,8 @@ class TestTranspile(QiskitTestCase):
 
         transpiled_qc = transpile(qc, backend=BasicAer.get_backend('qasm_simulator'))
 
-        expected_qc = QuantumCircuit(qr, global_phase=-1 * square / 2.0)
-        expected_qc.append(U1Gate(square), [qr[0]])
+        expected_qc = QuantumCircuit(qr)
+        expected_qc.append(RZGate(square), [qr[0]])
         self.assertEqual(expected_qc, transpiled_qc)
 
     def test_parameter_expression_circuit_for_device(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the Rz SX and X gates to basic aer simulators basis
gate set. This is necessary for running simulations of the fake backends
which are using the new basis set for the ibmq gates.

### Details and comments

This was written by @taalexander and extracted from #5577 which is blocked on
unrelated issues. However the lack of the new basis in basicaer is blocking #6021 (which
itself has partial with #5577) overlap for test jobs where aer isn't installed. To unblock
#6021 and any other use case where basic aer not supporting the new ibmq basis
is blocking this splits out the basic aer component into a separate PR.