### PR TITLE
Set utf8 character encoding for windows generate results steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -375,11 +375,15 @@ stages:
             artifactName: 'drop_windows'
         - bash: |
             set -e
+            chcp.com 65001
             source test-job/Scripts/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
           condition: succeededOrFailed()
+          env:
+            LANG: 'C.UTF-8'
+            PYTHONIOENCODING: 'utf-8:backslashreplace'
           displayName: 'Generate results'
         - task: PublishTestResults@2
           condition: succeededOrFailed()
@@ -451,11 +455,15 @@ stages:
             artifactName: 'drop_windows'
         - bash: |
             set -e
+            chcp.com 65001
             source test-job/Scripts/activate
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
           condition: succeededOrFailed()
+          env:
+            LANG: 'C.UTF-8'
+            PYTHONIOENCODING: 'utf-8:backslashreplace'
           displayName: 'Generate results'
         - task: PublishTestResults@2
           condition: succeededOrFailed()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #5988 we changed the character encoding used in windows CI jobs so
that it was explicitly using utf8 to avoid issues with characters being
emitted from the tests outside the default windows character encoding.
This was coming up because even though python is explicitly utf8 the
shell or the pipes used for interprocess communication in stestr did not
know we were using utf8 and would raise an encoder error when trying to
write out a string with utf8 characters. However, what that PR neglected
was the later step in the windows test jobs that we pipe the subunit
stream for the test run into a junitxml generator which would also
suffer from this problem. However we did not encounter this because only
the test id, runtime, and any failure or error messages are written out
on the process across the pipe so unless we were using characters
outside the default windows code page we wouldn't have any issues. But
as was recently discovered when a test error message included 'π' the
generate results step will fail on windows jobs. To address this edge
case this commit adds the same env variables and chcp command to the
generate results step of the windows test jobs so that if we have error
messages with utf8 characters in the output.

### Details and comments