### PR TITLE
Enable ConsolidateBlocks pass to handle 1-length blocks.

### DIFF
--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1050,6 +1050,52 @@ class TestTranspile(QiskitTestCase):
         self.assertEqual(len(out.qubits), FakeAlmaden().configuration().num_qubits)
         self.assertEqual(out.clbits, clbits)
 
+    @data(0, 1, 2, 3)
+    def test_synthesis_translation_method_with_single_qubit_gates(self, optimization_level):
+        """Test that synthesis basis translation works for solely 1q circuit"""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.h(1)
+        qc.h(2)
+        res = transpile(qc, basis_gates=['id', 'rz', 'x', 'sx', 'cx'],
+                        translation_method='synthesis', optimization_level=optimization_level)
+        expected = QuantumCircuit(3, global_phase=3*np.pi/4)
+        expected.rz(np.pi / 2, 0)
+        expected.rz(np.pi / 2, 1)
+        expected.rz(np.pi / 2, 2)
+        expected.sx(0)
+        expected.sx(1)
+        expected.sx(2)
+        expected.rz(np.pi / 2, 0)
+        expected.rz(np.pi / 2, 1)
+        expected.rz(np.pi / 2, 2)
+        self.assertEqual(res, expected)
+
+    @data(0, 1, 2, 3)
+    def test_synthesis_translation_method_with_gates_outside_basis(self, optimization_level):
+        """Test that synthesis translation works for circuits with single gates outside bassis"""
+        qc = QuantumCircuit(2)
+        qc.swap(0, 1)
+        res = transpile(qc, basis_gates=['id', 'rz', 'x', 'sx', 'cx'],
+                        translation_method='synthesis', optimization_level=optimization_level)
+        if optimization_level != 3:
+            self.assertTrue(Operator(qc).equiv(res))
+            self.assertNotIn('swap', res.count_ops())
+        else:
+            # Optimization level 3 eliminates the pointless swap
+            self.assertEqual(res, QuantumCircuit(2))
+
+    @data(0, 1, 2, 3)
+    def test_synthesis_translation_with_1_qubit_circuits(self, optimization_level):
+        """Test that synthesis translation works for circuits with just one qubit"""
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        res = transpile(qc, basis_gates=['id', 'rz', 'x', 'sx', 'cx'],
+                        translation_method='synthesis', optimization_level=optimization_level)
+
+        self.assertTrue(Operator(qc).equiv(res))
+        self.assertNotIn('h', res.count_ops())
+
 
 class StreamHandlerRaiseException(StreamHandler):
     """Handler class that will raise an exception on formatting errors."""

--- a/test/python/transpiler/test_consolidate_blocks.py
+++ b/test/python/transpiler/test_consolidate_blocks.py
@@ -304,6 +304,22 @@ class TestConsolidateBlocks(QiskitTestCase):
         res = consolidate_blocks_pass.run(dag)
         self.assertEqual(res, dag)
 
+    def test_single_gate_block_outside_basis(self):
+        """Test that a single gate block outside the configured basis gets converted."""
+        qc = QuantumCircuit(2)
+        qc.swap(0, 1)
+        consolidate_block_pass = ConsolidateBlocks(
+            basis_gates=['id', 'cx', 'rz', 'sx', 'x'])
+        pass_manager = PassManager()
+        pass_manager.append(Collect2qBlocks())
+        pass_manager.append(consolidate_block_pass)
+        expected = QuantumCircuit(2)
+        expected.unitary(np.array([[1, 0, 0, 0],
+                                   [0, 0, 1, 0],
+                                   [0, 1, 0, 0],
+                                   [0, 0, 0, 1]]), [0, 1])
+        self.assertEqual(expected, pass_manager.run(qc))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes 5967

ConsolidateBlocks replaces a block of consecutive gates with a single
unitary although it ignores blocks of length 1. This was causing
failures in the 'synthesis' translation mode where this pass is used
to calculate the unitaries used for the actual synthesis since
gates not in the basis but in 1-length blocks were added to the circuit
unchanged.

### Details and comments

This commit identifies the cases where consolidation is not possible
and ignores consolidation for only those cases:

- When the node is not a gate.
- When the node is parameterized.

A further modification is also included in this commit to avoid calculating
the number of 2-qubit basis gates when the circuit has only 1-qubit.


