### PR TITLE
Remove scikit-quant from requirements-dev.txt list

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -164,7 +164,7 @@ stages:
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -U -c constraints.txt .
-            pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U "qiskit-aer" "z3-solver" "scikit-quant" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
@@ -513,7 +513,7 @@ stages:
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -U -c constraints.txt -e .
-            pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U "qiskit-aer" "z3-solver" "scikit-quant" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,5 @@ pygments>=2.4
 tweedledum==0.1b0
 networkx>=2.2
 scikit-learn>=0.20.0
-scikit-quant;platform_system != 'Windows'
 jax;platform_system != 'Windows'
 jaxlib;platform_system != 'Windows'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The scikit-quant package has packaging issues. It only ships precompiled
wheels on linux >=3.7 which doesn't cover all our supported
environments. While it typically builds from source fine on macOS and
linux python 3.6 it has been raised that this isn't always the case.
Since it's only an optional requirement for a small subset of the
algorithms module we don't need to require all developers to install it,
just those working on places where it is used. To ensure we do not lose
test coverage though this commit also manually installs scikit-quant in
all the linux CI test jobs.

### Details and comments

Fixes Qiskit/qiskit#1189