### PR TITLE
RVGate rotation as multiple of pi radians, and RV synthesis routine

### DIFF
--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -18,15 +18,15 @@ from qiskit.circuit.exceptions import CircuitError
 
 
 class RVGate(Gate):
-    r"""Rotation around arbitrary rotation axis v where |v| is
-    angle of rotation in radians.
+    r"""Single-qubit rotation around arbitrary rotation
+    axis v, where ||v|| is angle of rotation in radians.
 
     **Circuit symbol:**
 
     .. parsed-literal::
 
              ┌─────────────────┐
-        q_0: ┤ RV(v_x,v_y,v_z) ├
+        q_0: ┤   RV(vx,vy,vz)  ├
              └─────────────────┘
 
     **Matrix Representation:**
@@ -34,27 +34,26 @@ class RVGate(Gate):
     .. math::
 
     \newcommand{\th}{|\vec{v}|}
-    \newcommand{\sinc}{\text{sinc}}
         R(\vec{v}) = e^{-i \vec{v}\cdot\vec{\sigma}} =
             \begin{pmatrix}
-                \cos{\th} -i v_z \sinc(\th) & -(i v_x + v_y) \sinc(\th) \\
-                -(i v_x - v_y) \sinc(\th) & \cos(\th) + i v_z \sinc(\th)
+                \cos{\th} -i v_z \sin(\th) & -(i v_x + v_y) \sin(\th) \\
+                -(i v_x - v_y) \sin(\th) & \cos(\th) + i v_z \sin(\th)
             \end{pmatrix}
     """
 
-    def __init__(self, v_x, v_y, v_z, basis='U'):
+    def __init__(self, vx, vy, vz, basis='U'):
         """Create new rv single-qubit gate.
 
         Args:
-            v_x (float): x-component
-            v_y (float): y-component
-            v_z (float): z-component
+            vx (float): x-component
+            vy (float): y-component
+            vz (float): z-component
             basis (str, optional): basis (see
                 :class:`~qiskit.quantum_info.synthesis.one_qubit_decompose.OneQubitEulerDecomposer`)
         """
         # pylint: disable=cyclic-import
         from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
-        super().__init__('rv', 1, [v_x, v_y, v_z])
+        super().__init__('rv', 1, [vx, vy, vz])
         self._decomposer = OneQubitEulerDecomposer(basis=basis)
 
     def _define(self):
@@ -72,10 +71,13 @@ class RVGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the R(v) gate."""
         v = numpy.asarray(self.params, dtype=float)
-        angle = numpy.sqrt(v.dot(v))
+        angle = numpy.pi * numpy.sqrt(v.dot(v))
+        print('angle: ', angle)
         if angle == 0:
             return numpy.array([[1, 0], [0, 1]])
-        nx, ny, nz = v / angle
+        nx, ny, nz = v
+        print('v: ', v)
+        print('nx, ny, nz: ', nx, ny, nz)
         sin = numpy.sin(angle / 2)
         cos = numpy.cos(angle / 2)
         return numpy.array([[cos - 1j * nz * sin, (-ny - 1j * nx) * sin],

--- a/qiskit/circuit/library/generalized_gates/rv.py
+++ b/qiskit/circuit/library/generalized_gates/rv.py
@@ -18,8 +18,7 @@ from qiskit.circuit.exceptions import CircuitError
 
 
 class RVGate(Gate):
-    r"""Single-qubit rotation around arbitrary rotation
-    axis v, where ||v|| is angle of rotation in radians.
+    r"""Single-qubit rotation around arbitrary axis v, with angle ||v||.
 
     **Circuit symbol:**
 
@@ -41,20 +40,18 @@ class RVGate(Gate):
             \end{pmatrix}
     """
 
-    def __init__(self, vx, vy, vz, basis='U'):
+    def __init__(self, vx, vy, vz):
         """Create new rv single-qubit gate.
 
         Args:
             vx (float): x-component
             vy (float): y-component
             vz (float): z-component
-            basis (str, optional): basis (see
-                :class:`~qiskit.quantum_info.synthesis.one_qubit_decompose.OneQubitEulerDecomposer`)
         """
         # pylint: disable=cyclic-import
         from qiskit.quantum_info.synthesis.one_qubit_decompose import OneQubitEulerDecomposer
         super().__init__('rv', 1, [vx, vy, vz])
-        self._decomposer = OneQubitEulerDecomposer(basis=basis)
+        self._decomposer = OneQubitEulerDecomposer(basis='U')
 
     def _define(self):
         try:

--- a/qiskit/circuit/library/standard_gates/rv.py
+++ b/qiskit/circuit/library/standard_gates/rv.py
@@ -71,13 +71,11 @@ class RVGate(Gate):
     def to_matrix(self):
         """Return a numpy.array for the R(v) gate."""
         v = numpy.asarray(self.params, dtype=float)
-        angle = numpy.pi * numpy.sqrt(v.dot(v))
-        print('angle: ', angle)
+        magnitude = numpy.sqrt(v.dot(v))
+        angle = numpy.pi * magnitude
         if angle == 0:
             return numpy.array([[1, 0], [0, 1]])
-        nx, ny, nz = v
-        print('v: ', v)
-        print('nx, ny, nz: ', nx, ny, nz)
+        nx, ny, nz = v / magnitude
         sin = numpy.sin(angle / 2)
         cos = numpy.cos(angle / 2)
         return numpy.array([[cos - 1j * nz * sin, (-ny - 1j * nx) * sin],

--- a/releasenotes/notes/rv-vector-rotation-gate-eb3311771ff7899b.yaml
+++ b/releasenotes/notes/rv-vector-rotation-gate-eb3311771ff7899b.yaml
@@ -1,7 +1,10 @@
 ---
 features:
   - |
-    This adds a general rotation gate, similar to the UGate, but instead of specifying
-    Euler angles the three components of a rotation vector are specified where the direction
-    of the vector specifies the rotation axis and the magnitude specifies the rotation angle
-    about the axis in radians.
+    Added a general single-qubit rotation gate
+    (:py:class:`~qiskit.circuit.library.generalized_gates.RVGate`) that has an
+    alternative parameterization compared to the UGate. Instead of specifying
+    Euler angles, the three components of a rotation vector (vx, vy, vz)
+    are specified where the direction of the vector specifies the rotation
+    axis and the vector magnitude specifies the rotation angle about the axis
+    as a multiple of pi radians.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -168,7 +168,7 @@ class TestOneQubitEulerDecomposer(CheckDecompositions):
                 maxdist = np.max(np.abs(target_unitary + decomp_unitary))
             self.assertTrue(np.abs(maxdist) < tolerance, "Worst distance {}".format(maxdist))
 
-    @combine(basis=['U3', 'U1X', 'PSX', 'ZSX', 'ZYZ', 'ZXZ', 'XYX', 'RR'],
+    @combine(basis=['U3', 'U1X', 'PSX', 'ZSX', 'ZYZ', 'ZXZ', 'XYX', 'RR', 'RV'],
              name='test_one_qubit_clifford_{basis}_basis')
     def test_one_qubit_clifford_all_basis(self, basis):
         """Verify for {basis} basis and all Cliffords."""
@@ -182,7 +182,8 @@ class TestOneQubitEulerDecomposer(CheckDecompositions):
                               ('U1X', 1e-7),
                               ('PSX', 1e-7),
                               ('ZSX', 1e-7),
-                              ('RR', 1e-12)],
+                              ('RR', 1e-12),
+                              ('RV', 1e-12)],
              name='test_one_qubit_hard_thetas_{basis_tolerance[0]}_basis')
     # Lower tolerance for U1X test since decomposition since it is
     # less numerically accurate. This is due to it having 5 matrix
@@ -193,8 +194,8 @@ class TestOneQubitEulerDecomposer(CheckDecompositions):
             self.check_one_qubit_euler_angles(Operator(gate), basis_tolerance[0],
                                               basis_tolerance[1])
 
-    @combine(basis=['U3', 'U1X', 'PSX', 'ZSX', 'ZYZ', 'ZXZ', 'XYX', 'RR'], seed=range(50),
-             name='test_one_qubit_random_{basis}_basis_{seed}')
+    @combine(basis=['U3', 'U1X', 'PSX', 'ZSX', 'ZYZ', 'ZXZ', 'XYX', 'RR', 'RV'],
+             seed=range(50), name='test_one_qubit_random_{basis}_basis_{seed}')
     def test_one_qubit_random_all_basis(self, basis, seed):
         """Verify for {basis} basis and random_unitary (seed={seed})."""
         unitary = random_unitary(2, seed=seed)
@@ -523,7 +524,7 @@ class TestTwoQubitDecomposeExact(CheckDecompositions):
 
     @combine(seed=range(10),
              euler_bases=[('U321', ['u3', 'u2', 'u1']), ('U3', ['u3']), ('U', ['u']),
-                          ('U1X', ['u1', 'rx']), ('RR', ['r']),
+                          ('U1X', ['u1', 'rx']), ('RR', ['r']), ('RV', ['rv']),
                           ('PSX', ['p', 'sx']), ('ZYZ', ['rz', 'ry']), ('ZXZ', ['rz', 'rx']),
                           ('XYX', ['rx', 'ry']), ('ZSX', ['rz', 'sx'])],
              kak_gates=[(CXGate(), 'cx'), (CZGate(), 'cz'), (iSwapGate(), 'iswap'),


### PR DESCRIPTION
The RVGate is modified so that the rotation angle is more natural in multiples of pi radians. This way gates can be represented as points on a unit ball. We have the following correspondences:
```
RV(1, 0, 0) --> X
RV(0, 1, 0) --> Y
RV(0, 0, 1) --> Z
RV(1/sqrt(2), 0, 1/sqrt(2)) --> H
RV(1/2, 0, 0) --> sqrt(X)
RV(0, 0, 1/4) --> T
```

Also I added a new synthesis so we can convert all single qubit gates to RV.