### PR TITLE
Fix AncillaQubits added via .add_bits to be included in .qubits.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1091,7 +1091,8 @@ class QuantumCircuit:
         for bit in bits:
             if isinstance(bit, AncillaQubit):
                 self._ancillas.append(bit)
-            elif isinstance(bit, Qubit):
+
+            if isinstance(bit, Qubit):
                 self._qubits.append(bit)
                 self._qubit_set.add(bit)
             elif isinstance(bit, Clbit):

--- a/test/python/circuit/test_registerless_circuit.py
+++ b/test/python/circuit/test_registerless_circuit.py
@@ -55,7 +55,7 @@ class TestAddingBitsWithoutRegisters(QiskitTestCase):
 
         qc = QuantumCircuit(qubits, clbits, ancillas)
 
-        self.assertEqual(qc.qubits, qubits)
+        self.assertEqual(qc.qubits, qubits + ancillas)
         self.assertEqual(qc.clbits, clbits)
         self.assertEqual(qc.ancillas, ancillas)
 
@@ -97,6 +97,16 @@ class TestAddingBitsWithoutRegisters(QiskitTestCase):
 
         self.assertEqual(qc.qubits, list(qr) + [new_bit])
         self.assertEqual(qc.qregs, [qr])
+
+    def test_inserted_ancilla_bits_are_added_to_qubits(self):
+        """Verify AncillaQubits added via .add_bits are added to .qubits."""
+        anc = AncillaQubit()
+        qb = Qubit()
+
+        qc = QuantumCircuit()
+        qc.add_bits([anc, qb])
+
+        self.assertEqual(qc.qubits, [anc, qb])
 
 
 class TestGatesOnWires(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As reported by @Cryoris , `QuantumCircuit.add_bits` (added in #5486 ) was handling `AncillaQubit`s incorrectly, leading to the following:

```
>>> qr, ar = QuantumRegister(1), AncillaRegister(1)
>>> circuit = QuantumCircuit(ar, qr)
>>> circuit.x(0)

>>> circuit.draw()

      ┌───┐
a0_0: ┤ X ├
      └───┘
q0_0: ─────

>>> circuit.decompose.draw()

q0_0: ─────────────
      ┌───────────┐
a0_0: ┤ U3(π,0,π) ├
      └───────────┘

```

### Details and comments




