### PR TITLE
Switch slow algorithm tests to aer and tag slow

### DIFF
--- a/test/python/algorithms/test_optimizer_aqgd.py
+++ b/test/python/algorithms/test_optimizer_aqgd.py
@@ -14,15 +14,17 @@
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase
-from qiskit import BasicAer
+from qiskit import Aer
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.opflow import PauliSumOp
 from qiskit.algorithms.optimizers import AQGD
 from qiskit.algorithms import VQE, AlgorithmError
 from qiskit.opflow.gradients import Gradient
+from qiskit.test import slow_test
 
 
+@unittest.skipUnless(Aer, 'Aer is required to run these tests')
 class TestOptimizerAQGD(QiskitAlgorithmsTestCase):
     """ Test AQGD optimizer using RY for analytic gradient with VQE """
 
@@ -38,9 +40,10 @@ class TestOptimizerAQGD(QiskitAlgorithmsTestCase):
             ("XX", 0.18093119978423156),
         ])
 
+    @slow_test
     def test_simple(self):
         """ test AQGD optimizer with the parameters as single values."""
-        q_instance = QuantumInstance(BasicAer.get_backend('statevector_simulator'),
+        q_instance = QuantumInstance(Aer.get_backend('statevector_simulator'),
                                      seed_simulator=algorithm_globals.random_seed,
                                      seed_transpiler=algorithm_globals.random_seed)
 
@@ -54,7 +57,7 @@ class TestOptimizerAQGD(QiskitAlgorithmsTestCase):
 
     def test_list(self):
         """ test AQGD optimizer with the parameters as lists. """
-        q_instance = QuantumInstance(BasicAer.get_backend('statevector_simulator'),
+        q_instance = QuantumInstance(Aer.get_backend('statevector_simulator'),
                                      seed_simulator=algorithm_globals.random_seed,
                                      seed_transpiler=algorithm_globals.random_seed)
 
@@ -69,9 +72,10 @@ class TestOptimizerAQGD(QiskitAlgorithmsTestCase):
         """ tests that AQGD raises an exception when incorrect values are passed. """
         self.assertRaises(AlgorithmError, AQGD, maxiter=[1000], eta=[1.0, 0.5], momentum=[0.0, 0.5])
 
+    @slow_test
     def test_int_values(self):
         """ test AQGD with int values passed as eta and momentum. """
-        q_instance = QuantumInstance(BasicAer.get_backend('statevector_simulator'),
+        q_instance = QuantumInstance(Aer.get_backend('statevector_simulator'),
                                      seed_simulator=algorithm_globals.random_seed,
                                      seed_transpiler=algorithm_globals.random_seed)
 

--- a/test/python/algorithms/test_shor.py
+++ b/test/python/algorithms/test_shor.py
@@ -17,11 +17,12 @@ import math
 from test.python.algorithms import QiskitAlgorithmsTestCase
 from ddt import ddt, data, idata, unpack
 
-from qiskit import BasicAer
+from qiskit import Aer
 from qiskit.utils import QuantumInstance
 from qiskit.algorithms import Shor
 
 
+@unittest.skipUnless(Aer, "qiskit-aer is required for these tests")
 @ddt
 class TestShor(QiskitAlgorithmsTestCase):
     """test Shor's algorithm"""
@@ -32,7 +33,7 @@ class TestShor(QiskitAlgorithmsTestCase):
     @unpack
     def test_shor_factoring(self, n_v, backend, factors):
         """ shor factoring test """
-        shor = Shor(quantum_instance=QuantumInstance(BasicAer.get_backend(backend), shots=1000))
+        shor = Shor(quantum_instance=QuantumInstance(Aer.get_backend(backend), shots=1000))
         result = shor.factor(N=n_v)
         self.assertListEqual(result.factors[0], factors)
         self.assertTrue(result.total_counts >= result.successful_counts)
@@ -40,7 +41,7 @@ class TestShor(QiskitAlgorithmsTestCase):
     @data(5, 7)
     def test_shor_no_factors(self, n_v):
         """ shor no factors test """
-        backend = BasicAer.get_backend('qasm_simulator')
+        backend = Aer.get_backend('qasm_simulator')
         shor = Shor(quantum_instance=QuantumInstance(backend, shots=1000))
         result = shor.factor(N=n_v)
         self.assertTrue(result.factors == [])
@@ -54,7 +55,7 @@ class TestShor(QiskitAlgorithmsTestCase):
     def test_shor_power(self, base, power):
         """ shor power test """
         n_v = int(math.pow(base, power))
-        backend = BasicAer.get_backend('qasm_simulator')
+        backend = Aer.get_backend('qasm_simulator')
         shor = Shor(quantum_instance=QuantumInstance(backend, shots=1000))
         result = shor.factor(N=n_v)
         self.assertTrue(result.factors == [base])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit changes 3 of the slowest tests to use Aer (and skip if it's
not present) instead of basicaer and also tag tests that take >=1 min
as slow (so they're skipped by default).

Recently our CI test jobs have been growing in duration. Looking at the
statistics show the 3 slowest tests are:

`test.python.algorithms.test_optimizer_aqgd.TestOptimizerAQGD.test_simple`
`test.python.algorithms.test_optimizer_aqgd.TestOptimizerAQGD.test_int_values`
`test.python.algorithms.test_shor.TestShor.test_shor_factoring_1__15___qasm_simulator____3__5__`

which take up a signficant fraction of the total runtime. All of these
tests were using basic aer which is definitely contributing to the poor
performance. This commit switches both test modules,
`test.python.algorithms.test_optimizer_aqgd` and
`test.python.algorithms.test_shor`, to use Aer. Then in the case of the 2
slowest tests a slow_test decorator is added so they're not included int
the default runs because even with Aer they still take >=1min.

### Details and comments


