### PR TITLE
Add SparseVectorStateFn and enable efficient return types for probability gradients

### DIFF
--- a/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
@@ -18,6 +18,7 @@ from functools import partial
 from itertools import product
 from typing import List, Optional, Tuple, Union
 
+import scipy
 import numpy as np
 from qiskit.circuit import Gate, Instruction
 from qiskit.circuit import (QuantumCircuit, QuantumRegister, ParameterVector,
@@ -42,6 +43,7 @@ from ...state_fns.state_fn import StateFn
 from ...state_fns.circuit_state_fn import CircuitStateFn
 from ...state_fns.dict_state_fn import DictStateFn
 from ...state_fns.vector_state_fn import VectorStateFn
+from ...state_fns.sparse_vector_state_fn import SparseVectorStateFn
 from ...exceptions import OpflowError
 from .circuit_gradient import CircuitGradient
 
@@ -199,7 +201,7 @@ class LinComb(CircuitGradient):
     @staticmethod
     def _grad_combo_fn(x, state_op):
         def get_result(item):
-            if isinstance(item, DictStateFn):
+            if isinstance(item, (DictStateFn, SparseVectorStateFn)):
                 item = item.primitive
             if isinstance(item, VectorStateFn):
                 item = item.primitive.data
@@ -214,13 +216,17 @@ class LinComb(CircuitGradient):
                 for key in prob_dict:
                     prob_dict[key] *= 2
                 return prob_dict
+            elif isinstance(item, scipy.sparse.spmatrix):
+                # Generate the operator which computes the linear combination
+                trace = _z_exp(item)
+                return trace
             elif isinstance(item, Iterable):
                 # Generate the operator which computes the linear combination
                 lin_comb_op = 2 * Z ^ (I ^ state_op.num_qubits)
                 lin_comb_op = lin_comb_op.to_matrix()
-                return list(np.diag(
-                    partial_trace(lin_comb_op.dot(np.outer(item, np.conj(item))),
-                                  [state_op.num_qubits]).data))
+                outer = np.outer(item, item.conj())
+                return list(np.diag(partial_trace(lin_comb_op.dot(outer),
+                                                  [state_op.num_qubits]).data))
             else:
                 raise TypeError(
                     'The state result should be either a DictStateFn or a VectorStateFn.')
@@ -235,7 +241,7 @@ class LinComb(CircuitGradient):
                 result.append(get_result(item))
             return result
 
-    @staticmethod
+    @ staticmethod
     def _hess_combo_fn(x, state_op):
         def get_result(item):
             if isinstance(item, DictStateFn):
@@ -274,7 +280,7 @@ class LinComb(CircuitGradient):
                 result.append(get_result(item))
             return result
 
-    @staticmethod
+    @ staticmethod
     def _gate_gradient_dict(gate: Gate) -> List[Tuple[List[complex], List[Instruction]]]:
         r"""Given a parameterized gate U(theta) with derivative
         dU(theta)/dtheta = sum_ia_iU(theta)V_i.
@@ -378,7 +384,7 @@ class LinComb(CircuitGradient):
 
         raise TypeError('Unrecognized parameterized gate, {}'.format(gate))
 
-    @staticmethod
+    @ staticmethod
     def apply_grad_gate(circuit, gate, param_index, grad_gate, grad_coeff, qr_superpos,
                         open_ctrl=False, trim_after_grad_gate=False):
         """Util function to apply a gradient gate for the linear combination of unitaries method.
@@ -676,3 +682,19 @@ class LinComb(CircuitGradient):
                 oplist += [SummedOp(sub_oplist) if len(sub_oplist) > 1 else sub_oplist[0]]
 
         return ListOp(oplist) if len(oplist) > 1 else oplist[0]
+
+
+def _z_exp(spmatrix):
+    """Compute the sampling probabilities of the qubits after applying Z on the ancilla."""
+
+    dok = spmatrix.todok()
+    num_qubits = int(np.log2(dok.shape[1]))
+    exp = scipy.sparse.dok_matrix((1, 2 ** (num_qubits - 1)))
+
+    for index, amplitude in dok.items():
+        binary = bin(index[1])[2:].zfill(num_qubits)
+        sign = -1 if binary[0] == '1' else 1
+        new_index = int(binary[1:], 2)
+        exp[(0, new_index)] = exp[(0, new_index)] + 2 * sign * np.abs(amplitude) ** 2
+
+    return exp

--- a/qiskit/opflow/gradients/circuit_gradients/param_shift.py
+++ b/qiskit/opflow/gradients/circuit_gradients/param_shift.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 from functools import partial
 from typing import List, Union, Tuple, Dict
 
+import scipy
 import numpy as np
 from qiskit import transpile, QuantumCircuit
 from qiskit.circuit import Parameter, ParameterExpression, ParameterVector
@@ -31,6 +32,7 @@ from ...list_ops.list_op import ListOp
 from ...list_ops.composed_op import ComposedOp
 from ...state_fns.dict_state_fn import DictStateFn
 from ...state_fns.vector_state_fn import VectorStateFn
+from ...state_fns.sparse_vector_state_fn import SparseVectorStateFn
 from ...exceptions import OpflowError
 from ..derivative_base import DerivativeBase
 
@@ -244,8 +246,8 @@ class ParamShift(CircuitGradient):
                 return SummedOp(shifted_ops).reduce()
 
     @staticmethod
-    def _prob_combo_fn(x: Union[DictStateFn, VectorStateFn,
-                                List[Union[DictStateFn, VectorStateFn]]],
+    def _prob_combo_fn(x: Union[DictStateFn, VectorStateFn, SparseVectorStateFn,
+                                List[Union[DictStateFn, VectorStateFn, SparseVectorStateFn]]],
                        shift_constant: float) -> Union[Dict, np.ndarray]:
         """Implement the combo_fn used to evaluate probability gradients
 
@@ -260,11 +262,11 @@ class ParamShift(CircuitGradient):
             TypeError: if ``x`` is not DictStateFn, VectorStateFn or their list.
 
         """
-
         # In the probability gradient case, the amplitudes still need to be converted
         # into sampling probabilities.
+
         def get_primitives(item):
-            if isinstance(item, DictStateFn):
+            if isinstance(item, (DictStateFn, SparseVectorStateFn)):
                 item = item.primitive
             if isinstance(item, VectorStateFn):
                 item = item.primitive.data
@@ -288,6 +290,18 @@ class ParamShift(CircuitGradient):
                     prob_dict[key] = prob_dict.get(key, 0) + \
                                      shift_constant * ((-1) ** i) * prob_counts
             return prob_dict
+        elif isinstance(items[0], scipy.sparse.spmatrix):
+            # If x was given as StateFn the state amplitudes need to be multiplied in order to
+            # evaluate the sampling probabilities which are then subtracted according to the
+            # parameter shift rule.
+            if is_statefn:
+                return shift_constant * np.subtract(items[0].multiply(np.conj(items[0])),
+                                                    items[1].multiply(np.conj(items[1])))
+            # If x was not given as a StateFn the state amplitudes were already converted into
+            # sampling probabilities which are then only subtracted according to the
+            # parameter shift rule.
+            else:
+                return shift_constant * np.subtract(items[0], items[1])
         elif isinstance(items[0], Iterable):
             # If x was given as StateFn the state amplitudes need to be multiplied in order to
             # evaluate the sampling probabilities which are then subtracted according to the

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -367,6 +367,7 @@ class ListOp(OperatorBase):
         # pylint: disable=cyclic-import
         from ..state_fns.dict_state_fn import DictStateFn
         from ..state_fns.vector_state_fn import VectorStateFn
+        from ..state_fns.sparse_vector_state_fn import SparseVectorStateFn
 
         # The below code only works for distributive ListOps, e.g. ListOp and SummedOp
         if not self.distributive:
@@ -378,7 +379,8 @@ class ListOp(OperatorBase):
         # Handle application of combo_fn for DictStateFn resp VectorStateFn operators
         if self._combo_fn != ListOp([])._combo_fn:
             if all(isinstance(op, DictStateFn) for op in evals) or \
-                    all(isinstance(op, VectorStateFn) for op in evals):
+                    all(isinstance(op, VectorStateFn) for op in evals) or \
+                    all(isinstance(op, SparseVectorStateFn) for op in evals):
                 if not all(
                     op.is_measurement == evals[0].is_measurement for op in evals  # type: ignore
                 ):

--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -176,6 +176,10 @@ class DictStateFn(StateFn):
                                   shape=(1, 2**self.num_qubits))
         return spvec if not self.is_measurement else spvec.transpose()
 
+    def to_spmatrix_op(self) -> OperatorBase:
+        from .sparse_vector_state_fn import SparseVectorStateFn
+        return SparseVectorStateFn(self.to_spmatrix(), self.coeff, self.is_measurement)
+
     def to_circuit_op(self) -> OperatorBase:
         """ Return ``StateFnCircuit`` corresponding to this StateFn."""
         from .circuit_state_fn import CircuitStateFn
@@ -201,9 +205,9 @@ class DictStateFn(StateFn):
         ] = None,
     ) -> Union[OperatorBase, complex]:
         if front is None:
-            vector_state_fn = self.to_matrix_op().eval()
-            vector_state_fn = cast(OperatorBase, vector_state_fn)
-            return vector_state_fn
+            sparse_vector_state_fn = self.to_spmatrix_op().eval()
+            sparse_vector_state_fn = cast(OperatorBase, sparse_vector_state_fn)
+            return sparse_vector_state_fn
 
         if not self.is_measurement and isinstance(front, OperatorBase):
             raise ValueError(

--- a/qiskit/opflow/state_fns/sparse_vector_state_fn.py
+++ b/qiskit/opflow/state_fns/sparse_vector_state_fn.py
@@ -1,0 +1,198 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+""" VectorStateFn Class """
+
+
+from typing import Dict, List, Optional, Set, Union, cast
+
+import numpy as np
+import scipy
+
+from qiskit import QuantumCircuit
+from qiskit.circuit import ParameterExpression
+from qiskit.opflow.list_ops.list_op import ListOp
+from qiskit.opflow.list_ops.summed_op import SummedOp
+from qiskit.opflow.operator_base import OperatorBase
+from qiskit.opflow.state_fns.state_fn import StateFn
+from qiskit.opflow.state_fns.vector_state_fn import VectorStateFn
+from qiskit.quantum_info import Statevector
+from qiskit.utils import algorithm_globals, arithmetic
+
+
+class SparseVectorStateFn(StateFn):
+    """A class for sparse state functions and measurements in vector representation.
+
+    This class uses ``scipy.sparse.spmatrix`` for the internal representation.
+    """
+    primitive: scipy.sparse.spmatrix
+
+    # TODO allow normalization somehow?
+    def __init__(self,
+                 primitive: scipy.sparse.spmatrix,
+                 coeff: Union[complex, ParameterExpression] = 1.0,
+                 is_measurement: bool = False) -> None:
+        """
+        Args:
+            primitive: The underlying sparse vector.
+            coeff: A coefficient multiplying the state function.
+            is_measurement: Whether the StateFn is a measurement operator
+
+        Raises:
+            ValueError: If the primitive is not a column vector.
+            ValueError: If the number of elements in the primitive is not a power of 2.
+
+        """
+        if primitive.shape[0] != 1:
+            raise ValueError('The primitive must be a row vector of shape (x, 1).')
+
+        # check if the primitive is a statevector of 2^n elements
+        self._num_qubits = int(np.log2(primitive.shape[1]))
+        if np.log2(primitive.shape[1]) != self._num_qubits:
+            raise ValueError('The number of vector elements must be a power of 2.')
+
+        super().__init__(primitive, coeff=coeff, is_measurement=is_measurement)
+
+    def primitive_strings(self) -> Set[str]:
+        return {'SparseVector'}
+
+    @property
+    def num_qubits(self) -> int:
+        return self._num_qubits
+
+    def add(self, other: OperatorBase) -> OperatorBase:
+        if not self.num_qubits == other.num_qubits:
+            raise ValueError(
+                'Sum over statefns with different numbers of qubits, {} and {}, is not well '
+                'defined'.format(self.num_qubits, other.num_qubits))
+
+        # Right now doesn't make sense to add a StateFn to a Measurement
+        if isinstance(other, SparseVectorStateFn) and self.is_measurement == other.is_measurement:
+            # Covers Statevector and custom.
+            added = self.coeff * self.primitive + other.primitive * other.coeff
+            return SparseVectorStateFn(added, is_measurement=self._is_measurement)
+
+        return SummedOp([self, other])
+
+    def adjoint(self) -> "VectorStateFn":
+        return SparseVectorStateFn(self.primitive.conjugate(),
+                                   coeff=self.coeff.conjugate(),
+                                   is_measurement=(not self.is_measurement))
+
+    def to_dict_fn(self) -> StateFn:
+        """Creates the equivalent state function of type DictStateFn.
+
+        Returns:
+            A new DictStateFn equivalent to ``self``.
+        """
+        from .dict_state_fn import DictStateFn
+
+        num_qubits = self.num_qubits
+        dok = self.primitive.todok()
+        new_dict = {format(i[0], 'b').zfill(num_qubits): v for i, v in dok.items()}
+        return DictStateFn(new_dict, coeff=self.coeff, is_measurement=self.is_measurement)
+
+    def to_matrix(self, massive: bool = False) -> np.ndarray:
+        OperatorBase._check_massive('to_matrix', False, self.num_qubits, massive)
+        vec = self.primitive.toarray() * self.coeff
+        return vec if not self.is_measurement else vec.reshape(1, -1)
+
+    def to_matrix_op(self, massive: bool = False) -> OperatorBase:
+        return VectorStateFn(self.to_matrix())
+
+    def to_spmatrix(self) -> OperatorBase:
+        return self
+
+    def to_circuit_op(self) -> OperatorBase:
+        """ Return ``StateFnCircuit`` corresponding to this StateFn."""
+        # pylint: disable=cyclic-import
+        from .circuit_state_fn import CircuitStateFn
+        csfn = CircuitStateFn.from_vector(self.primitive) * self.coeff
+        return csfn.adjoint() if self.is_measurement else csfn
+
+    def __str__(self) -> str:
+        prim_str = str(self.primitive)
+        if self.coeff == 1.0:
+            return "{}({})".format('SparseVectorStateFn' if not self.is_measurement
+                                   else 'MeasurementSparseVector', prim_str)
+        else:
+            return "{}({}) * {}".format('SparseVectorStateFn' if not self.is_measurement
+                                        else 'SparseMeasurementVector',
+                                        prim_str,
+                                        self.coeff)
+
+    # pylint: disable=too-many-return-statements
+    def eval(
+        self,
+        front: Optional[
+            Union[str, Dict[str, complex], np.ndarray, Statevector, OperatorBase]
+        ] = None,
+    ) -> Union[OperatorBase, complex]:
+        if front is None:
+            return self
+
+        if not self.is_measurement and isinstance(front, OperatorBase):
+            raise ValueError(
+                'Cannot compute overlap with StateFn or Operator if not Measurement. Try taking '
+                'sf.adjoint() first to convert to measurement.')
+
+        if isinstance(front, ListOp) and front.distributive:
+            return front.combo_fn([self.eval(front.coeff * front_elem)
+                                   for front_elem in front.oplist])
+
+        if not isinstance(front, OperatorBase):
+            front = StateFn(front)
+
+        # pylint: disable=cyclic-import
+        from ..operator_globals import EVAL_SIG_DIGITS
+        from .operator_state_fn import OperatorStateFn
+        from .circuit_state_fn import CircuitStateFn
+        from .dict_state_fn import DictStateFn
+        if isinstance(front, DictStateFn):
+            return np.round(sum([v * self.primitive.data[int(b, 2)] * front.coeff
+                                 for (b, v) in front.primitive.items()]) * self.coeff,
+                            decimals=EVAL_SIG_DIGITS)
+
+        if isinstance(front, VectorStateFn):
+            # Need to extract the element or np.array([1]) is returned.
+            return np.round(np.dot(self.to_matrix(), front.to_matrix())[0],
+                            decimals=EVAL_SIG_DIGITS)
+
+        if isinstance(front, CircuitStateFn):
+            # Don't reimplement logic from CircuitStateFn
+            return np.conj(front.adjoint().eval(self.adjoint().primitive)) * self.coeff
+
+        if isinstance(front, OperatorStateFn):
+            return front.adjoint().eval(self.primitive) * self.coeff
+
+        return front.adjoint().eval(self.adjoint().primitive).adjoint() * self.coeff  # type: ignore
+
+    def sample(self,
+               shots: int = 1024,
+               massive: bool = False,
+               reverse_endianness: bool = False) -> dict:
+        as_dict = self.to_dict_fn().primitive
+        all_states = sum(as_dict.keys())
+        deterministic_counts = {key: value / all_states for key, value in as_dict.items()}
+        # Don't need to square because probabilities_dict already does.
+        probs = np.array(list(deterministic_counts.values()))
+        unique, counts = np.unique(
+            algorithm_globals.random.choice(list(deterministic_counts.keys()),
+                                            size=shots,
+                                            p=(probs / sum(probs))),
+            return_counts=True)
+        counts = dict(zip(unique, counts))
+        if reverse_endianness:
+            scaled_dict = {bstr[::-1]: (prob / shots) for (bstr, prob) in counts.items()}
+        else:
+            scaled_dict = {bstr: (prob / shots) for (bstr, prob) in counts.items()}
+        return dict(sorted(scaled_dict.items(), key=lambda x: x[1], reverse=True))

--- a/qiskit/opflow/state_fns/sparse_vector_state_fn.py
+++ b/qiskit/opflow/state_fns/sparse_vector_state_fn.py
@@ -10,15 +10,14 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" VectorStateFn Class """
+"""SparseVectorStateFn class."""
 
 
-from typing import Dict, List, Optional, Set, Union, cast
+from typing import Dict, Optional, Set, Union
 
 import numpy as np
 import scipy
 
-from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterExpression
 from qiskit.opflow.list_ops.list_op import ListOp
 from qiskit.opflow.list_ops.summed_op import SummedOp
@@ -26,7 +25,7 @@ from qiskit.opflow.operator_base import OperatorBase
 from qiskit.opflow.state_fns.state_fn import StateFn
 from qiskit.opflow.state_fns.vector_state_fn import VectorStateFn
 from qiskit.quantum_info import Statevector
-from qiskit.utils import algorithm_globals, arithmetic
+from qiskit.utils import algorithm_globals
 
 
 class SparseVectorStateFn(StateFn):

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -19,6 +19,7 @@ from itertools import product
 import numpy as np
 from ddt import ddt, data, idata, unpack
 from sympy import Symbol, cos
+from scipy.sparse import csr_matrix
 
 try:
     import jax.numpy as jnp
@@ -812,11 +813,14 @@ class TestGradients(QiskitOpflowTestCase):
                 params=params)
         else:
             prob_grad = Gradient(grad_method=method).convert(operator=op, params=params)
-        values_dict = [{a: [np.pi / 4], b: [0]}, {params[0]: [np.pi / 4], params[1]: [np.pi / 4]},
+        values_dict = [{a: [np.pi / 4], b: [0]},
+                       {params[0]: [np.pi / 4], params[1]: [np.pi / 4]},
                        {params[0]: [np.pi / 2], params[1]: [np.pi]}]
-        correct_values = [[[0, 0], [1 / (2 * np.sqrt(2)), - 1 / (2 * np.sqrt(2))]],
-                          [[1 / 4, -1 / 4], [1 / 4, - 1 / 4]],
-                          [[0, 0], [- 1 / 2, 1 / 2]]]
+        correct_values = [
+            [[0, 0], [1 / (2 * np.sqrt(2)), - 1 / (2 * np.sqrt(2))]],
+            [[1 / 4, -1 / 4], [1 / 4, - 1 / 4]],
+            [[0, 0], [-1 / 2, 1 / 2]]
+        ]
 
         backend = BasicAer.get_backend('qasm_simulator')
         q_instance = QuantumInstance(backend=backend, shots=shots)
@@ -824,11 +828,12 @@ class TestGradients(QiskitOpflowTestCase):
         for i, value_dict in enumerate(values_dict):
             sampler = CircuitSampler(backend=q_instance).convert(prob_grad,
                                                                  params=value_dict)
-            result = sampler.eval()
-            np.testing.assert_array_almost_equal(result[0], correct_values[i], decimal=1)
+            result = sampler.eval()[0]
+            self.assertTrue(np.allclose(result[0].toarray(), correct_values[i][0], atol=0.1))
+            self.assertTrue(np.allclose(result[1].toarray(), correct_values[i][1], atol=0.1))
 
     @idata(['statevector_simulator', 'qasm_simulator'])
-    def test_gradient_wrapper(self, backend):
+    def test_gradient_wrapper(self, backend_type):
         """Test the gradient wrapper for probability gradients
         dp0/da = cos(a)sin(b) / 2
         dp1/da = - cos(a)sin(b) / 2
@@ -849,7 +854,7 @@ class TestGradients(QiskitOpflowTestCase):
         op = CircuitStateFn(primitive=qc, coeff=1.)
 
         shots = 8000
-        backend = BasicAer.get_backend(backend)
+        backend = BasicAer.get_backend(backend_type)
         q_instance = QuantumInstance(backend=backend, shots=shots)
         if method == 'fin_diff':
             np.random.seed(8)
@@ -865,7 +870,11 @@ class TestGradients(QiskitOpflowTestCase):
                           [[0, 0], [- 1 / 2, 1 / 2]]]
         for i, value in enumerate(values):
             result = prob_grad(value)
-            np.testing.assert_array_almost_equal(result, correct_values[i], decimal=1)
+            if backend_type == 'qasm_simulator':  # sparse result
+                result = [result[0].toarray(), result[1].toarray()]
+
+            self.assertTrue(np.allclose(result[0], correct_values[i][0], atol=0.1))
+            self.assertTrue(np.allclose(result[1], correct_values[i][1], atol=0.1))
 
     @slow_test
     def test_vqe(self):

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -895,7 +895,6 @@ class TestOpConstruction(QiskitOpflowTestCase):
         self.assertEqual(list_op.parameters, set(params))
 
     @data(VectorStateFn([1, 0]),
-          DictStateFn({'0': 1}),
           CircuitStateFn(QuantumCircuit(1)),
           OperatorStateFn(I),
           OperatorStateFn(MatrixOp([[1, 0], [0, 1]])),
@@ -904,6 +903,12 @@ class TestOpConstruction(QiskitOpflowTestCase):
         """Test calling eval on StateFn returns the statevector."""
         expected = Statevector([1, 0])
         self.assertEqual(op.eval().primitive, expected)
+
+    def test_sparse_eval(self):
+        """Test calling eval on a DictStateFn returns a sparse statevector."""
+        op = DictStateFn({'0': 1})
+        expected = scipy.sparse.csr_matrix([[1, 0]])
+        self.assertFalse((op.eval().primitive != expected).toarray().any())
 
     def test_to_circuit_op(self):
         """Test to_circuit_op method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5995.

### Details and comments

* introduce a `SparseVectorStateFn` type that is returned when a `DictStateFn` is evaluated, instead of a dense `VectorStateFn`. The sparse vector is essentially an adjusted copy of the vector state function.
* accomodate handling of sparse vectors in the gradient combo functions.
