### PR TITLE
Fix failing pulse simulator tests

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -249,8 +249,7 @@ def _validate_meas_map(instruction_map: Dict[Tuple[int, instructions.Acquire],
     sorted_inst_map = sorted(instruction_map.items(), key=lambda item: item[0])
     meas_map_sets = [set(m) for m in meas_map]
 
-    # if there is time overlap:
-    #    - if the overlap is in the same meas_map -- Raise Error
+    # error if there is time overlap between qubits in the same meas_map
     for idx, inst in enumerate(sorted_inst_map[:-1]):
         inst_end_time = inst[0][0] + inst[0][1]
         next_inst = sorted_inst_map[idx+1]

--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -248,14 +248,8 @@ def _validate_meas_map(instruction_map: Dict[Tuple[int, instructions.Acquire],
     """
     sorted_inst_map = sorted(instruction_map.items(), key=lambda item: item[0])
     meas_map_sets = [set(m) for m in meas_map]
-    all_measured_qubits = [inst.channel.index for _, insts in sorted_inst_map
-                           for inst in insts]
 
-    # 1. if the qubits are not in the meas_map -- Raise Error
-    if not set(all_measured_qubits).issubset(set.union(*meas_map_sets)):
-        raise QiskitError("The measured qubits - {} is not in the measurement "
-                          "map - {}".format(all_measured_qubits, meas_map))
-    # 2. if there is time overlap:
+    # if there is time overlap:
     #    - if the overlap is in the same meas_map -- Raise Error
     for idx, inst in enumerate(sorted_inst_map[:-1]):
         inst_end_time = inst[0][0] + inst[0][1]

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -1224,24 +1224,6 @@ class TestPulseAssembler(QiskitTestCase):
         qobj = assemble(inst, self.backend)
         validate_qobj_against_schema(qobj)
 
-    def test_assemble_qubits_not_in_meas_map(self):
-        """Testing that the assembly errors when measured qubits not in meas_map."""
-        schedule = Schedule()
-        schedule = schedule.append(
-            Acquire(5, AcquireChannel(0), MemorySlot(0)),
-        )
-        schedule = schedule.append(
-            Acquire(5, AcquireChannel(1), MemorySlot(1)) << 1,
-        )
-        schedule = schedule.append(
-            Acquire(10, AcquireChannel(3), MemorySlot(3)) << 1,
-        )
-        with self.assertRaises(QiskitError):
-            assemble(schedule,
-                     qubit_lo_freq=self.default_qubit_lo_freq,
-                     meas_lo_freq=self.default_meas_lo_freq,
-                     meas_map=[[0, 1]])
-
     def test_assemble_overlapping_time(self):
         """Test that assembly errors when qubits are measured in overlapping time."""
         schedule = Schedule()


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

#5971 broke the pulse simulator tests. This PR removes the condition that breaks it.

### Details and comments

Removed the condition, if the qubits are not in the meas_map -- Raise Error

