### PR TITLE
PauliSumOp.__str__() does not show negligible imaginary part

### DIFF
--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -238,7 +238,8 @@ class PauliSumOp(PrimitiveOp):
 
     def __str__(self) -> str:
         def format_sign(x):
-            return x.real if np.isreal(x) else x
+            threshold = 1e-10
+            return x.real if np.abs(x.imag) < threshold else x
 
         def format_number(x):
             x = format_sign(x)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This improves the display of PauliSumOp.
For example,

<img width="533" alt="image" src="https://user-images.githubusercontent.com/6814928/112433707-f8d7ef80-8d85-11eb-8615-6b6c19565dd4.png">

