### PR TITLE
Pin matlotlib in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ coverage>=4.4.0
 hypothesis>=4.24.3
 ipywidgets>=7.3.0
 jupyter
-matplotlib>=2.1
+matplotlib>=2.1,<3.4
 pillow>=4.2.1
 pycodestyle
 pydot


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

PR #6087 attempted to fix CI by fixing compatibility with the recent
matplotlib release 3.4.0. However to fix the deprecated API usage we
need new features from matplotlib 3.4.0 which would break compatibility
for users on older matplotlib (as our tutorials job caught since it pins
mpl to avoid a performance regression). As an alternative to that this
commit just pins matplotlib in CI so we do not install the version
emitting deprecation warnings. This means that users will see
deprecation warnings when they use some function (mainly qsphere and
bloch sphere), but until we're ready to raise our minimum supported
matplotlib version to 3.4.0 that is unavoidable.

### Details and comments