### PR TITLE
Fix TaperedPauliSumOp.to_matrix_op()

### DIFF
--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -14,6 +14,7 @@
 
 import itertools
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
@@ -556,6 +557,10 @@ class OperatorBase(ABC):
             elif other.num_qubits > self.num_qubits:
                 new_self = self._expand_dim(other.num_qubits - self.num_qubits)
         return new_self, other
+
+    def copy(self) -> "OperatorBase":
+        """Return a deep copy of the Operator."""
+        return deepcopy(self)
 
     # Composition
 

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -241,9 +241,12 @@ class PrimitiveOp(OperatorBase):
 
     def to_matrix_op(self, massive: bool = False) -> OperatorBase:
         """ Returns a ``MatrixOp`` equivalent to this Operator. """
-        prim_mat = self.__class__(self.primitive).to_matrix(massive=massive)
+        coeff = self.coeff
+        op = self.copy()
+        op._coeff = 1
+        prim_mat = op.to_matrix(massive=massive)
         from .matrix_op import MatrixOp
-        return MatrixOp(prim_mat, coeff=self.coeff)
+        return MatrixOp(prim_mat, coeff=coeff)
 
     def to_instruction(self) -> Instruction:
         """ Returns an ``Instruction`` equivalent to this Operator. """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix #6100.

### Details and comments

The arguments required for initialization may change in the operator in the future. So I fixed PrimitiveOp.to_matrix_op not to use the constructor.