### PR TITLE
Cap ipython and ipykernel in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,4 +2,4 @@ docplex==2.15.194
 appnope==0.1.0
 numpy>=1.20.0 ; python_version>'3.6'
 ipython==7.21.0
-ipykernel==5.5.2
+ipykernel==5.5.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,5 @@
 docplex==2.15.194
 appnope==0.1.0
 numpy>=1.20.0 ; python_version>'3.6'
+ipython==7.21.0
+ipykernel==5.5.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,3 @@
 docplex==2.15.194
 appnope==0.1.0
 numpy>=1.20.0 ; python_version>'3.6'
-ipython==7.21.0
-ipykernel==5.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 coverage>=4.4.0
 hypothesis>=4.24.3
+ipython<7.22.0
+ipykernel<5.5.2
 ipywidgets>=7.3.0
 jupyter
 matplotlib>=2.1,<3.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

ipython and ipykernel have both recently released and since that release
a large portion of our CI jobs have started failing with exceptions in
these packages. In order to unblock CI this commit pins the packages in
the constraints files (as they're not direct dependencies).


### Details and comments


