### PR TITLE
Properly clear parameter table on remove_final_measurement

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1847,6 +1847,7 @@ class QuantumCircuit:
 
         # Set circ cregs and instructions to match the new DAGCircuit's
         circ.data.clear()
+        circ._parameter_table.clear()
         circ.cregs = list(new_dag.cregs.values())
 
         for node in new_dag.topological_op_nodes():

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -353,6 +353,23 @@ class TestCircuitOperations(QiskitTestCase):
         self.assertEqual(expected, new_circuit)
         self.assertTrue('measure' in circuit.count_ops().keys())
 
+    def test_remove_final_measurements_copy_with_parameters(self):
+        """Test remove_final_measurements doesn't corrupt ParameterTable
+
+        See https://github.com/Qiskit/qiskit-terra/issues/6108 for more details
+        """
+        qr = QuantumRegister(2)
+        cr = ClassicalRegister(2, 'meas')
+        theta = Parameter('theta')
+
+        circuit = QuantumCircuit(qr, cr)
+        circuit.rz(theta, qr)
+        circuit.measure(qr, cr)
+        circuit.remove_final_measurements()
+        copy = circuit.copy()
+
+        self.assertEqual(copy, circuit)
+
     def test_remove_final_measurements_multiple_measures(self):
         """Test remove_final_measurements only removes measurements at the end of the circuit
         remove_final_measurements should not remove measurements in the beginning or middle of the


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When `remove_final_measurements()` is run it converts the circuit to a
dag, removes the measurements at the end of the dag, clears the circuit,
and then iterates over the modified dag copying the instructions back
into the circuit. As part of this process though the parameter table is
not cleared, this resulted in duplicate entries in the table for each
parameter, one with the old instructions and the other for the new
copies. In practice this didn't really do anything, as the old
instructions weren't in the circuit, until someone went to run the
`copy()` method which iterates over the parameter table to ensure things
are updated, in which case the duplicates would result in a `KeyError`.
This commit fixes this issue by clearing the parameter table in
`remove_final_measurements` too so there are no duplicates entries after
the method is run.

### Details and comments

Fixes #6108
