### PR TITLE
Speedup binding circuit parameters -- revisited

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2016,10 +2016,11 @@ class QuantumCircuit:
         if isinstance(parameters, dict):
             # unroll the parameter dictionary (needed if e.g. it contains a ParameterVector)
             unrolled_param_dict = self._unroll_param_dict(parameters)
+            unsorted_parameters = self._unsorted_parameters()
 
             # check that all param_dict items are in the _parameter_table for this circuit
             params_not_in_circuit = [param_key for param_key in unrolled_param_dict
-                                     if param_key not in self._unsorted_parameters()]
+                                     if param_key not in unsorted_parameters]
             if len(params_not_in_circuit) > 0:
                 raise CircuitError('Cannot bind parameters ({}) not present in the circuit.'.format(
                     ', '.join(map(str, params_not_in_circuit))))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As suggested by @kdk in https://github.com/Qiskit/qiskit-terra/issues/5965#issuecomment-809721248 this PR moves the call to `QuantumCircuit._unsorted_parameters` outside of the list comprehension where it is used.

### Details and comments

This is the profile with the function call in the comprehension (current status)
![image](https://user-images.githubusercontent.com/5978796/112968472-a06d6d00-914c-11eb-8663-352f3264497f.png)

this is the profile with this PR:
![image](https://user-images.githubusercontent.com/5978796/112968591-bbd87800-914c-11eb-9035-64e905d9494a.png)

which is pretty much the same as what it used to be before #5759:
![image](https://user-images.githubusercontent.com/5978796/112968699-d4e12900-914c-11eb-86f1-dd2a6dc104cb.png)


