### PR TITLE
Mergify to fasttrack merging of PRs already based on master.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -8,7 +8,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: smart
+        strict: smart+fasttrack
   - name: backport
     conditions:
       - label=stable backport potential


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

@mtreinish noticed that `strict: smart+fasttrack` would be better than `strict: smart`, in that it will move PRs already based on master to the head of the merge queue.

### Details and comments


