### PR TITLE
* Aligned the CalibrationCreator to the removal of Qubit.index.

### DIFF
--- a/qiskit/transpiler/passes/scheduling/calibration_creators.py
+++ b/qiskit/transpiler/passes/scheduling/calibration_creators.py
@@ -45,11 +45,13 @@ class CalibrationCreator(TransformationPass):
         Returns:
             DAGCircuit: A DAG with calibrations added to it.
         """
+        bit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
+
         for node in dag.nodes():
             if node.type == 'op':
                 if self.supported(node.op):
                     params = node.op.params
-                    qubits = [_.index for _ in node.qargs]
+                    qubits = [bit_indices[qarg] for qarg in node.qargs]
 
                     schedule = self.get_calibration(params, qubits)
 

--- a/releasenotes/notes/calibration-builder-index-fix-779f3f40fae040d8.yaml
+++ b/releasenotes/notes/calibration-builder-index-fix-779f3f40fae040d8.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Qubit.index has been deprecated. The CalibrationCreator was still using
+    this functionality which this PR fixes.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

PR #6069 deprecated Bit.index which the CalibrationCreator was using. This PR aligns the CalibrationCreator to the new methodology.

### Details and comments

The code now uses the methodology based on:
```
bit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
```

