### PR TITLE
Stop using networkx for qaoa tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 docplex==2.15.194
 appnope==0.1.0
 numpy>=1.20.0 ; python_version>'3.6'
+decorator==4.4.2

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -16,8 +16,8 @@ import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase
 
 import math
-import networkx as nx
 import numpy as np
+import retworkx as rx
 from ddt import ddt, idata, unpack
 
 from qiskit.algorithms import QAOA
@@ -282,13 +282,13 @@ class TestQAOA(QiskitAlgorithmsTestCase):
 
     def test_qaoa_random_initial_point(self):
         """ QAOA random initial point """
-        w = nx.adjacency_matrix(
-            nx.fast_gnp_random_graph(5, 0.5, seed=algorithm_globals.random_seed)).toarray()
+        w = rx.adjacency_matrix(
+            rx.undirected_gnp_random_graph(5, 0.5, seed=algorithm_globals.random_seed))
         qubit_op, _ = self._get_operator(w)
         qaoa = QAOA(optimizer=NELDER_MEAD(disp=True), reps=1, quantum_instance=self.qasm_simulator)
         _ = qaoa.compute_minimum_eigenvalue(operator=qubit_op)
 
-        np.testing.assert_almost_equal([-0.879, 0.395], qaoa.optimal_params, decimal=3)
+        np.testing.assert_almost_equal([-0.560, 0.315], qaoa.optimal_params, decimal=3)
 
     def _get_operator(self, weight_matrix):
         """Generate Hamiltonian for the max-cut problem of a graph.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the qaoa tests networkx was being used to generate a random
adjancency matrix as an input. This would work fine especially as the
graph size is small so performance isn't an issue. However, with the
recent release of decorator 5.0.0 earlier today these tests are
failing because of an [internal incompatibility](https://github.com/networkx/networkx/issues/4718) with the random state
decorator networkx is using for random_gnp_graph() function. Instead
of pinning decorator in the constraints file and hoping people running
tests without tox know to use it, this commit just switches that test to
use retworkx instead. retworkx doesn't have an external dependency on
decorator (or anything except numpy) and can generate an adjacency
matrix for a gnp random graph in basically the same exact way without
this incompatibility.

### Details and comments