### PR TITLE
Adding Pauli and city to the draw option for statevector

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -132,11 +132,15 @@ class Statevector(QuantumState, TolerancesMixin):
 
         **bloch**: Matplotlib figure, rendering of statevector using `plot_bloch_multivector()`.
 
+        **city**: Matplotlib figure, rendering of statevector using `plot_state_city()`.
+
+        **paulivec**: Matplotlib figure, rendering of statevector using `plot_state_paulivec()`.
+
         Args:
             output (str): Select the output method to use for drawing the
                 state. Valid choices are `repr`, `text`, `latex`, `latex_source`,
-                `qsphere`, `hinton`, or `bloch`. Default is `repr`. Default can
-                be changed by adding the line ``state_drawer = <default>`` to
+                `qsphere`, `hinton`, `bloch`, `city`, or `paulivec`. Default is `repr`.
+                Default can be changed by adding the line ``state_drawer = <default>`` to
                 ``~/.qiskit/settings.conf`` under ``[default]``.
             drawer_args: Arguments to be passed directly to the relevant drawing
                 function or constructor (`TextMatrix()`, `array_to_latex()`,

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -1145,10 +1145,15 @@ def state_drawer(state,
 
         **bloch**: Matplotlib figure, rendering of statevector using `plot_bloch_multivector()`.
 
+        **city**: Matplotlib figure, rendering of statevector using `plot_state_city()`.
+
+        **paulivec**: Matplotlib figure, rendering of statevector using `plot_state_paulivec()`.
+
         Args:
             output (str): Select the output method to use for drawing the
                 circuit. Valid choices are ``text``, ``latex``, ``latex_source``,
-                ``qsphere``, ``hinton``, or ``bloch``. Default is `'text`'.
+                ``qsphere``, ``hinton``, ``bloch``, ``city`` or ``paulivec``.
+                Default is `'text`'.
             drawer_args: Arguments to be passed to the relevant drawer. For
                 'latex' and 'latex_source' see ``array_to_latex``
 
@@ -1175,7 +1180,9 @@ def state_drawer(state,
                'latex_source': state_to_latex,
                'qsphere': plot_state_qsphere,
                'hinton': plot_state_hinton,
-               'bloch': plot_bloch_multivector}
+               'bloch': plot_bloch_multivector,
+               'city': plot_state_city,
+               'paulivec': plot_state_paulivec}
     if output == 'latex':
         try:
             from IPython.display import Latex
@@ -1197,4 +1204,4 @@ def state_drawer(state,
         raise ValueError(
             """'{}' is not a valid option for drawing {} objects. Please choose from:
             'text', 'latex', 'latex_source', 'qsphere', 'hinton',
-            'bloch' or 'auto'.""".format(output, type(state).__name__)) from err
+            'bloch', 'city' or 'paulivec'.""".format(output, type(state).__name__)) from err


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
In the new draw method in the statevector we did not port the paulivec and the city. Both of these are common and should be there as they offer a different way of viewing the state. Paulivec is common for states that are stabilizers and city gives better feel for the size of the bars than Hinton. 


### Details and comments


