### PR TITLE
Latex drawings now show numbering of active wires in custom instructions

### DIFF
--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -438,10 +438,16 @@ class QCircuitImage:
         else:
             wire_min = min(wire_list)
             wire_max = max(wire_list)
-            self._latex[wire_min][col] = "\\multigate{%s}{%s}" % \
-                (wire_max - wire_min, gate_text)
+            wire_ind = wire_list.index(wire_min)
+            self._latex[wire_min][col] = "\\multigate{%s}{%s}_" % \
+                (wire_max - wire_min, gate_text) + "<"*(len(str(wire_ind))+2) + "{%s}" % wire_ind
             for wire in range(wire_min + 1, wire_max + 1):
-                self._latex[wire][col] = "\\ghost{%s}" % gate_text
+                if wire in wire_list:
+                    wire_ind = wire_list.index(wire)
+                    self._latex[wire][col] = "\\ghost{%s}_" % gate_text +\
+                        "<"*(len(str(wire_ind))+2) + "{%s}" % wire_ind
+                else:
+                    self._latex[wire][col] = "\\ghost{%s}" % gate_text
         return num_cols_op
 
     def _build_ctrl_gate(self, op, gate_text, wire_list, col):

--- a/test/python/visualization/references/test_latex_big_gates.tex
+++ b/test/python/visualization/references/test_latex_big_gates.tex
@@ -16,12 +16,12 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=1.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \multigate{2}{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}} & \gate{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}} & \multigate{1}{\mathrm{Hamiltonian}} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}} & \ghost{\mathrm{Hamiltonian}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \multigate{2}{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}} & \multigate{1}{\mathrm{Isometry}} & \qw & \qw\\
-	 	\lstick{ {q}_{4} :  } & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}} & \ghost{\mathrm{Isometry}} & \qw & \qw\\
-	 	\lstick{ {q}_{5} :  } & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}} & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \multigate{2}{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}}_<<<{0} & \gate{\mathrm{Unitary}} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}}_<<<{1} & \multigate{1}{\mathrm{Hamiltonian}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{iqp:[[6\,5\,3];\,[5\,4\,5];\,[3\,5\,1]]}}_<<<{2} & \ghost{\mathrm{Hamiltonian}}_<<<{1} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \multigate{2}{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}}_<<<{0} & \multigate{1}{\mathrm{Isometry}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}}_<<<{1} & \ghost{\mathrm{Isometry}}_<<<{1} & \qw & \qw\\
+	 	\lstick{ {q}_{5} :  } & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0.25\jmath},\mathrm{0.3536},\mathrm{0.25+0.25\jmath},\mathrm{0},...\mathrm{)}}_<<<{2} & \qw & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_ghz_to_gate.tex
+++ b/test/python/visualization/references/test_latex_ghz_to_gate.tex
@@ -17,9 +17,9 @@
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.2em @!R {
 	 	\lstick{ {q}_{0} :  } & \ctrl{1} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \multigate{2}{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \multigate{2}{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}}_<<<{2} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Ctrl\mbox{-}GHZ\,Circuit}}_<<<{1} & \qw & \qw\\
 	 	\lstick{ {q}_{4} :  } & \ctrlo{-1} & \qw & \qw\\
 	 }
 \end{equation*}

--- a/test/python/visualization/references/test_latex_init_reset.tex
+++ b/test/python/visualization/references/test_latex_init_reset.tex
@@ -16,8 +16,8 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=1.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \gate{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1}\mathrm{)}} & \multigate{1}{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1},\mathrm{0},\mathrm{0}\mathrm{)}} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \gate{\left|0\right\rangle} & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1},\mathrm{0},\mathrm{0}\mathrm{)}} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \gate{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1}\mathrm{)}} & \multigate{1}{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1},\mathrm{0},\mathrm{0}\mathrm{)}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \gate{\left|0\right\rangle} & \ghost{|\psi\rangle\,\mathrm{(}\mathrm{0},\mathrm{1},\mathrm{0},\mathrm{0}\mathrm{)}}_<<<{1} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_iqx.tex
+++ b/test/python/visualization/references/test_latex_iqx.tex
@@ -16,13 +16,13 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.2em @!R {
-	 	\lstick{ {q}_{0} :  } & \gate{\mathrm{H}} & \gate{\mathrm{X}} & \qw & \qw & \qw & \ctrl{1} & \ctrl{1} & \qswap & \ctrl{1} & \ctrl{1} & \multigate{1}{\mathrm{Dcx}} & \ctrl{1} & \ctrl{1} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \qw & \qw & \qw & \qw & \qw & \targ & \ctrl{1} & \qswap \qwx[-1] & \qswap & \ctrl{1} & \ghost{\mathrm{Dcx}} & \multigate{1}{\mathrm{Dcx}} & \ctrl{1} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \qw & \qw & \qw & \qw & \qw & \qw & \targ & \qw & \qswap \qwx[-1] & \qswap & \qw & \ghost{\mathrm{Dcx}} & \multigate{1}{\mathrm{Dcx}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qswap \qwx[-1] & \qw & \qw & \ghost{\mathrm{Dcx}} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \gate{\mathrm{H}} & \gate{\mathrm{X}} & \qw & \qw & \qw & \ctrl{1} & \ctrl{1} & \qswap & \ctrl{1} & \ctrl{1} & \multigate{1}{\mathrm{Dcx}}_<<<{0} & \ctrl{1} & \ctrl{1} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \qw & \qw & \qw & \qw & \qw & \targ & \ctrl{1} & \qswap \qwx[-1] & \qswap & \ctrl{1} & \ghost{\mathrm{Dcx}}_<<<{1} & \multigate{1}{\mathrm{Dcx}}_<<<{0} & \ctrl{1} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \qw & \qw & \qw & \qw & \qw & \qw & \targ & \qw & \qswap \qwx[-1] & \qswap & \qw & \ghost{\mathrm{Dcx}}_<<<{1} & \multigate{1}{\mathrm{Dcx}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qw & \qswap \qwx[-1] & \qw & \qw & \ghost{\mathrm{Dcx}}_<<<{1} & \qw & \qw\\
 	 	\lstick{ {q}_{4} :  } & \gate{\mathrm{Z}} & \gate{\mathrm{S}} & \qw & \qw & \qw & \gate{\mathrm{S}^\dagger} & \gate{\mathrm{T}} & \gate{\mathrm{T}^\dagger} & \gate{\mathrm{P}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \gate{\mathrm{U}_1\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \qw & \qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{5} :  } & \ctrl{1} & \ctrl{1} & \dstick{\hspace{2.0em}\mathrm{U}_1\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} \qw & \qw & \qw & \gate{\mathrm{Y}} & \gate{\mathrm{R}_\mathrm{X}\,\mathrm{(}\mathrm{\frac{\pi}{3}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \gate{\mathrm{U}_2\,\mathrm{(}\mathrm{\frac{\pi}{2}},\mathrm{\frac{\pi}{2}}\mathrm{)}} \barrier[0em]{1} & \qw & \gate{\left|0\right\rangle} & \qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{6} :  } & \control\qw & \control \qw & \qw & \qw & \qw & \qw & \qw & \ghost{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{5} :  } & \ctrl{1} & \ctrl{1} & \dstick{\hspace{2.0em}\mathrm{U}_1\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} \qw & \qw & \qw & \gate{\mathrm{Y}} & \gate{\mathrm{R}_\mathrm{X}\,\mathrm{(}\mathrm{\frac{\pi}{3}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}}_<<<{0} & \gate{\mathrm{U}_2\,\mathrm{(}\mathrm{\frac{\pi}{2}},\mathrm{\frac{\pi}{2}}\mathrm{)}} \barrier[0em]{1} & \qw & \gate{\left|0\right\rangle} & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{6} :  } & \control\qw & \control \qw & \qw & \qw & \qw & \qw & \qw & \ghost{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}}_<<<{1} & \qw & \qw & \qw & \qw & \qw & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_pauli_clifford.tex
+++ b/test/python/visualization/references/test_latex_pauli_clifford.tex
@@ -19,8 +19,8 @@
 	 	\lstick{ {q}_{0} :  } & \gate{\mathrm{X}} & \gate{\mathrm{Y}} & \gate{\mathrm{Z}} & \gate{\mathrm{I}} & \qw & \qw & \qw\\
 	 	\lstick{ {q}_{1} :  } & \gate{\mathrm{H}} & \ctrl{1} & \ctrl{1} & \ctrl{1} & \qw & \qw & \qw\\
 	 	\lstick{ {q}_{2} :  } & \qw & \targ & \gate{\mathrm{Y}} & \control\qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \qswap & \gate{\mathrm{S}} & \gate{\mathrm{S}^\dagger} & \multigate{1}{\mathrm{Iswap}} & \multigate{1}{\mathrm{Dcx}} & \qw & \qw\\
-	 	\lstick{ {q}_{4} :  } & \qswap \qwx[-1] & \qw & \qw & \ghost{\mathrm{Iswap}} & \ghost{\mathrm{Dcx}} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \qswap & \gate{\mathrm{S}} & \gate{\mathrm{S}^\dagger} & \multigate{1}{\mathrm{Iswap}}_<<<{0} & \multigate{1}{\mathrm{Dcx}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \qswap \qwx[-1] & \qw & \qw & \ghost{\mathrm{Iswap}}_<<<{1} & \ghost{\mathrm{Dcx}}_<<<{1} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_r_gates.tex
+++ b/test/python/visualization/references/test_latex_r_gates.tex
@@ -16,10 +16,10 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=0.2em @!R {
-	 	\lstick{ {q}_{0} :  } & \gate{\mathrm{R}\,\mathrm{(}\mathrm{\frac{3\pi}{4}},\mathrm{\frac{3\pi}{8}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{XX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}} & \qw & \qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \gate{\mathrm{R}_\mathrm{X}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \ghost{\mathrm{R}_{\mathrm{XX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \ghost{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}} & \qw & \qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \gate{\mathrm{R}_\mathrm{Y}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{YY}}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}} & \ctrl{1} & \dstick{\hspace{2.0em}\mathrm{ZZ}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} \qw & \qw & \qw & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \gate{\mathrm{R}_\mathrm{Z}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}} & \ghost{\mathrm{R}_{\mathrm{YY}}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}} & \control \qw & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \gate{\mathrm{R}\,\mathrm{(}\mathrm{\frac{3\pi}{4}},\mathrm{\frac{3\pi}{8}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{XX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}}_<<<{0} & \multigate{1}{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}}_<<<{0} & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \gate{\mathrm{R}_\mathrm{X}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} & \ghost{\mathrm{R}_{\mathrm{XX}}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}}_<<<{1} & \ghost{\mathrm{R}_{\mathrm{ZX}}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}}_<<<{1} & \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \gate{\mathrm{R}_\mathrm{Y}\,\mathrm{(}\mathrm{\frac{-\pi}{2}}\mathrm{)}} & \multigate{1}{\mathrm{R}_{\mathrm{YY}}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}}_<<<{0} & \ctrl{1} & \dstick{\hspace{2.0em}\mathrm{ZZ}\,\mathrm{(}\mathrm{\frac{\pi}{2}}\mathrm{)}} \qw & \qw & \qw & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \gate{\mathrm{R}_\mathrm{Z}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}} & \ghost{\mathrm{R}_{\mathrm{YY}}\,\mathrm{(}\mathrm{\frac{3\pi}{4}}\mathrm{)}}_<<<{1} & \control \qw & \qw & \qw & \qw & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_scale_default.tex
+++ b/test/python/visualization/references/test_latex_scale_default.tex
@@ -16,11 +16,11 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=1.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}}_<<<{1} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}}_<<<{2} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}}_<<<{3} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}}_<<<{4} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_scale_double.tex
+++ b/test/python/visualization/references/test_latex_scale_double.tex
@@ -16,11 +16,11 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=1.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}}_<<<{1} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}}_<<<{2} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}}_<<<{3} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}}_<<<{4} & \qw & \qw\\
 	 }
 \end{equation*}
 

--- a/test/python/visualization/references/test_latex_scale_half.tex
+++ b/test/python/visualization/references/test_latex_scale_half.tex
@@ -16,11 +16,11 @@
 
 \begin{equation*}
     \Qcircuit @C=1.0em @R=1.0em @!R {
-	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
-	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}} & \qw & \qw\\
+	 	\lstick{ {q}_{0} :  } & \multigate{4}{\mathrm{Unitary}}_<<<{0} & \qw & \qw\\
+	 	\lstick{ {q}_{1} :  } & \ghost{\mathrm{Unitary}}_<<<{1} & \qw & \qw\\
+	 	\lstick{ {q}_{2} :  } & \ghost{\mathrm{Unitary}}_<<<{2} & \qw & \qw\\
+	 	\lstick{ {q}_{3} :  } & \ghost{\mathrm{Unitary}}_<<<{3} & \qw & \qw\\
+	 	\lstick{ {q}_{4} :  } & \ghost{\mathrm{Unitary}}_<<<{4} & \qw & \qw\\
 	 }
 \end{equation*}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #2092 .

### Details and comments

This PR introduces numbering of active wires when drawing custom instruction in latex drawer. This PR is a part of #5551 refactored to PR #5855. The latex tests containing multiqubit boxed instructions have been updated to adapt this change. Some examples of the modified circuits containing custom instructions are as below:

![image-2](https://user-images.githubusercontent.com/51048173/113521655-7981c180-95b8-11eb-8373-da4d0c7f4d40.png)

![image-1](https://user-images.githubusercontent.com/51048173/113521656-7be41b80-95b8-11eb-83c7-8b6233555b9d.png)

