### PR TITLE
Preserve global phase in `Unroller`

### DIFF
--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -70,9 +70,7 @@ class Unroller(TransformationPass):
 
             # TODO: allow choosing other possible decompositions
             try:
-                phase = 0
-                if node.op.definition and node.op.definition.global_phase:
-                    phase += node.op.definition.global_phase
+                phase = node.op.definition.global_phase
                 rule = node.op.definition.data
             except TypeError as err:
                 raise QiskitError(f'Error decomposing node {node.name}: {err}') from err

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -70,6 +70,9 @@ class Unroller(TransformationPass):
 
             # TODO: allow choosing other possible decompositions
             try:
+                phase = 0
+                if node.op.definition and node.op.definition.global_phase:
+                    phase += node.op.definition.global_phase
                 rule = node.op.definition.data
             except TypeError as err:
                 raise QiskitError(f'Error decomposing node {node.name}: {err}') from err
@@ -80,11 +83,11 @@ class Unroller(TransformationPass):
             # different that the width of the node.
             while rule and len(rule) == 1 and len(node.qargs) == len(rule[0][1]) == 1:
                 if rule[0][0].name in self.basis:
-                    if node.op.definition and node.op.definition.global_phase:
-                        dag.global_phase += node.op.definition.global_phase
+                    dag.global_phase += phase
                     dag.substitute_node(node, rule[0][0], inplace=True)
                     break
                 try:
+                    phase += rule[0][0].definition.global_phase
                     rule = rule[0][0].definition.data
                 except (TypeError, AttributeError) as err:
                     raise QiskitError(f'Error decomposing node {node.name}: {err}') from err
@@ -93,6 +96,7 @@ class Unroller(TransformationPass):
                 if not rule:
                     if rule == []:  # empty node
                         dag.remove_op_node(node)
+                        dag.global_phase += phase
                         continue
                     # opaque node
                     raise QiskitError("Cannot unroll the circuit to the given basis, %s. "

--- a/releasenotes/notes/bugfix-global-phase-unroller-d1ac1a248558c1d8.yaml
+++ b/releasenotes/notes/bugfix-global-phase-unroller-d1ac1a248558c1d8.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where :class:`~qiskit.transpiler.passes.Unroller` didn't
+    preserve global phase in case of nested instructions with one rule in
+    their definition.

--- a/test/python/transpiler/test_unroller.py
+++ b/test/python/transpiler/test_unroller.py
@@ -284,6 +284,24 @@ class TestUnroller(QiskitTestCase):
 
         self.assertEqual(Operator(qc), Operator(qcd))
 
+    def test_unrolling_global_phase_nested_gates(self):
+        """Test unrolling a nested gate preseveres global phase."""
+        qc = QuantumCircuit(1, global_phase=pi)
+        qc.x(0)
+        gate = qc.to_gate()
+
+        qc = QuantumCircuit(1)
+        qc.append(gate, [0])
+        gate = qc.to_gate()
+
+        qc = QuantumCircuit(1)
+        qc.append(gate, [0])
+        dag = circuit_to_dag(qc)
+        out_dag = Unroller(['x', 'u']).run(dag)
+        qcd = dag_to_circuit(out_dag)
+
+        self.assertEqual(Operator(qc), Operator(qcd))
+
 
 class TestUnrollAllInstructions(QiskitTestCase):
     """Test unrolling a circuit containing all standard instructions."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Resolves #6134.

`Unroller` doesn't preserve global phase in case of an instruction with nested "simple" (one rule) definitions. To fix this the global phase should be accumulated while traversing the rules.


### Details and comments
