### PR TITLE
Add qiskit application modules to __qiskit_version__

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -113,11 +113,34 @@ class QiskitVersion(Mapping):
             self._version_dict['qiskit-ibmq-provider'] = ibmq.__version__
         except Exception:
             self._version_dict['qiskit-ibmq-provider'] = None
+        # TODO: Remove aqua after deprecation is complete and it is removed from
+        # the metapackage
         try:
             from qiskit import aqua
             self._version_dict['qiskit-aqua'] = aqua.__version__
         except Exception:
             self._version_dict['qiskit-aqua'] = None
+        try:
+            import qiskit_nature
+            self._version_dict['qiskit-nature'] = qiskit_nature.__version__
+        except Exception:
+            self._version_dict['qiskit-nature'] = None
+        try:
+            import qiskit_finance
+            self._version_dict['qiskit-finance'] = qiskit_finance.__version__
+        except Exception:
+            self._version_dict['qiskit-finance'] = None
+        try:
+            import qiskit_optimization
+            self._version_dict['qiskit-optimization'] = qiskit_optimization.__version__
+        except Exception:
+            self._version_dict['qiskit-optimization'] = None
+        try:
+            import qiskit_finance
+            self._version_dict['qiskit-machine-learning'] = qiskit_machine_learning.__version__
+        except Exception:
+            self._version_dict['qiskit-machine-learning'] = None
+
         try:
             self._version_dict['qiskit'] = pkg_resources.get_distribution('qiskit').version
         except Exception:

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,broad-except,cyclic-import
+# pylint: disable=no-name-in-module,broad-except,cyclic-import,import-error
 
 """Contains the terra version."""
 
@@ -140,7 +140,6 @@ class QiskitVersion(Mapping):
             self._version_dict['qiskit-machine-learning'] = qiskit_machine_learning.__version__
         except Exception:
             self._version_dict['qiskit-machine-learning'] = None
-
         try:
             self._version_dict['qiskit'] = pkg_resources.get_distribution('qiskit').version
         except Exception:

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -136,7 +136,7 @@ class QiskitVersion(Mapping):
         except Exception:
             self._version_dict['qiskit-optimization'] = None
         try:
-            import qiskit_finance
+            import qiskit_machine_learning
             self._version_dict['qiskit-machine-learning'] = qiskit_machine_learning.__version__
         except Exception:
             self._version_dict['qiskit-machine-learning'] = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the release of the domain specific qiskit application packages,
qiskit-finance, qiskit-nature, qiskit-optimization, and
qiskit-machine-learning it would be useful to optionally include the
versions in the `__qiskit_version__` attribute which is used for
debugging and by the jupyter extension used in tutorials to show
package versions. This commit adds entries to the `__qiskit_version__`
dict so that if any of the application packages are installed their versions
will show up in the dictionary.

### Details and comments