### PR TITLE
Fix spelling in several docstrings

### DIFF
--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -439,19 +439,19 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     def _energy_evaluation(self,
                            parameters: Union[List[float], np.ndarray]
                            ) -> Union[float, List[float]]:
-        """Evaluate energy at given parameters for the ansats.
+        """Evaluate energy at given parameters for the ansatz.
 
         This is the objective function to be passed to the optimizer that is used for evaluation.
 
         Args:
-            parameters: The parameters for the ansats.
+            parameters: The parameters for the ansatz.
 
         Returns:
             Energy of the hamiltonian of each parameter.
 
 
         Raises:
-            RuntimeError: If the ansats has no parameters.
+            RuntimeError: If the ansatz has no parameters.
         """
         num_parameters = self.ansatz.num_parameters
         if self._ansatz.num_parameters == 0:
@@ -522,7 +522,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     @property
     def optimal_params(self) -> List[float]:
-        """The optimal parameters for the ansats."""
+        """The optimal parameters for the ansatz."""
         if self._ret.optimal_point is None:
             raise AlgorithmError("Cannot find optimal params before running the algorithm.")
         return self._ret.optimal_point

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -272,7 +272,7 @@ class DAGDependency:
 
     def get_all_edges(self):
         """
-        Enumaration of all edges.
+        Enumeration of all edges.
 
         Returns:
             List: corresponding to the label.

--- a/qiskit/dagcircuit/dagdepnode.py
+++ b/qiskit/dagcircuit/dagdepnode.py
@@ -104,7 +104,7 @@ class DAGDepNode:
         """
         Function to copy a DAGDepNode object.
         Returns:
-            DAGDepNode: a copy of a DAGDepNode objectto.
+            DAGDepNode: a copy of a DAGDepNode object.
         """
 
         dagdepnode = DAGDepNode()

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -37,7 +37,7 @@ Version Changes
 ----------------
 
 Each minor version release of qiskit-terra **may** increment the version of any
-providers interface a single version number. It will be an aggreagate of all
+providers interface a single version number. It will be an aggregate of all
 the interface changes for that release on that interface.
 
 Version Support Policy
@@ -278,7 +278,7 @@ set. For example::
 
 The key thing to ensure is that for any custom gates in your Backend's basis set
 your custom gate's name attribute (the first param on
-``super().__init__()`` in the ``__init__`` defintion above) does not conflict
+``super().__init__()`` in the ``__init__`` definition above) does not conflict
 with the name of any other gates. The name attribute is what is used to
 identify the gate in the basis set for the transpiler. If there is a conflict
 the transpiler will not know which gate to use.

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -93,7 +93,7 @@ class QuantumChannel(LinearOp):
         r"""Return the transpose quantum channel.
 
         .. note::
-            This is equivalent to the matrix tranpsose in the
+            This is equivalent to the matrix transpose in the
             :class:`~qiskit.quantum_info.SuperOp` representation,
             ie. for a channel :math:`\mathcal{E}`, the SuperOp of
             the transpose channel :math:`\mathcal{{E}}^T` is

--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -116,7 +116,7 @@ class Clifford(BaseOperator, AdjointMixin):
         # Initialize from ScalarOp as N-qubit identity discarding any global phase
         elif isinstance(data, ScalarOp):
             if not data.num_qubits or not data.is_unitary():
-                raise QiskitError("Can only initalize from N-qubit identity ScalarOp.")
+                raise QiskitError("Can only initialize from N-qubit identity ScalarOp.")
             self._table = StabilizerTable(
                 np.eye(2 * data.num_qubits, dtype=bool))
 

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -280,7 +280,7 @@ class SparsePauliOp(LinearOp):
                 and not np.any(val.table.X) and not np.any(val.table.Z))
 
     def simplify(self, atol=None, rtol=None):
-        """Simplify PauliTable by combining duplicaties and removing zeros.
+        """Simplify PauliTable by combining duplicates and removing zeros.
 
         Args:
             atol (float): Optional. Absolute tolerance for checking if

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -624,7 +624,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
                 rho = DensityMatrix(mat, dims=(3, 3))
                 print(rho.to_dict())
 
-            For large subsystem dimensions delimeters are required. The
+            For large subsystem dimensions delimiters are required. The
             following example is for a 20-dimensional system consisting of
             a qubit and 10-dimensional qudit.
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -690,7 +690,7 @@ class Statevector(QuantumState, TolerancesMixin):
                 psi = Statevector(vec, dims=(3, 3))
                 print(psi.to_dict())
 
-            For large subsystem dimensions delimeters are required. The
+            For large subsystem dimensions delimiters are required. The
             following example is for a 20-dimensional system consisting of
             a qubit and 10-dimensional qudit.
 

--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -117,8 +117,8 @@ class OneQubitEulerDecomposer:
         Args:
             unitary (Operator or Gate or array): 1-qubit unitary matrix
             simplify (bool): reduce gate count in decomposition [Default: True].
-            atol (float): absolute tolerance for checking angles when simplifing
-                         returnd circuit [Default: 1e-12].
+            atol (float): absolute tolerance for checking angles when simplifying
+                         returned circuit [Default: 1e-12].
         Returns:
             QuantumCircuit: the decomposed single-qubit gate circuit
 
@@ -134,7 +134,7 @@ class OneQubitEulerDecomposer:
             # If input is Gate subclass or some other class object that has
             # a to_matrix method this will call that method.
             unitary = unitary.to_matrix()
-        # Convert to numpy array incase not already an array
+        # Convert to numpy array in case not already an array
         unitary = np.asarray(unitary, dtype=complex)
 
         # Check input is a 2-qubit unitary

--- a/qiskit/transpiler/passes/optimization/collect_2q_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_2q_blocks.py
@@ -22,7 +22,7 @@ class Collect2qBlocks(AnalysisPass):
     """Collect sequences of uninterrupted gates acting on 2 qubits.
 
     Traverse the DAG and find blocks of gates that act consecutively on
-    pairs of qubits. Write the blocks to propert_set as a dictionary
+    pairs of qubits. Write the blocks to property_set as a dictionary
     of the form::
 
         {(q0, q1): [[g0, g1, g2], [g5]],

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -624,7 +624,7 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
 
     def create_updated_dag(self, layers, barriers):
         """
-        Given a set of layers and barries, construct a new dag
+        Given a set of layers and barriers, construct a new dag
         """
         new_dag = DAGCircuit()
         for qreg in self.dag.qregs.values():

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -204,7 +204,7 @@ class TestPassesInspection(QiskitTestCase):
         self.assertNotIn('CheckGateDirection', self.passes)
 
     @data(0, 1, 2, 3)
-    def test_inital_layout_fully_connected_cm(self, level):
+    def test_initial_layout_fully_connected_cm(self, level):
         """Honor initial_layout when coupling_map=None
         See: https://github.com/Qiskit/qiskit-terra/issues/5345
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fix spelling. Follow-up of #6160 

### Details and comments

I checked the code using `sphinxcontrib-spelling`. I leave typos in the release notes. If you wish, I can fix spelling of release notes too.
The typo of qiskit.qasm.OpenQASMLexer.get_tokens_unprocessed is part of pygments.

Spell check results with this PR
```
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:550: Spell check: passess: Two new transpiler passess, .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:550: Spell check: inteded:  module. These new passes are inteded to.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:655: Spell check: efficent: , with more efficent circuits based on.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:960: Spell check: apperance: New stylesheets can take callback functions that dynamically modify the apperance of.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:1234: Spell check: seperate: will run in a seperate thread or process like .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:1581: Spell check: potentical: . This was necessary to avoid a potentical.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:1596: Spell check: potentical: potentical name conflict between the modules and the re-exported function.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:1882: Spell check: clasess: the following clasess:.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:1999: Spell check: recieve: API schemas. Moving forward only those schemas will recieve updates and.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:2213: Spell check: undesireable: towards lower numbered qubits could be observed. This undesireable bias has.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:2734: Spell check: refering: circuit with registers refering to the parameter names. For example:.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:2808: Spell check: fuction: A new fuction .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:3237: Spell check: dictonary: has been removed. Using a dictonary for the first positional argument.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:3415: Spell check: appearence: appearence that setting .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:3573: Spell check: casses: Although, hopefully in such casses an issue will be opened with.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5243: Spell check: significanlty: be significanlty faster than in previous releases..
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5599: Spell check: representaiton: efficient representaiton of an N-qubit matrix that is sparse in the Pauli.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5609: Spell check: convered:  can be convered to a sparse.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5647: Spell check: concatination: Addition of two tables acts as list concatination of the terms in each.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5904: Spell check: reseting: allows reseting some or all subsystems to the .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:5928: Spell check: animtion: the dependencies for and configured globally a matplotlib animtion.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6002: Spell check: overriden: this can be overriden by setting the .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6420: Spell check: passsing: The previously deprecated (in the 0.11.0 release) support for passsing in.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6814: Spell check: extendee: (extendee) with another circuit (extension), the circuit is taken via.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6814: Spell check: extendee: loop as extendee and extension are the same. This bug has been resolved by.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6814: Spell check: extendee: copying the extension if it is the same object as the extendee..
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:6823: Spell check: expirement: for an expirement could not be referenced if the experiment was initialized.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:7219: Spell check: uneffected: block when using Python 3.8 on MacOS. Other environments are uneffected by.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:7306: Spell check: multiplciation: implemented scalar multiplciation..
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:8299: Spell check: preceeding: Removes all final measurements and preceeding .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:8816: Spell check: derviative: secant derviative .
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:8848: Spell check: maanger: passed a set of kwargs on each call with the state of the pass maanger after.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:9333: Spell check: suppressable: these warnings are easily suppressable using Python's standard library.
/Users/ima/tasks/1_2021/qiskit/terra/docs/release_notes.rst:9333: Spell check: thse: . Users can suppress the warnings by putting thse two lines.
Writing /Users/ima/tasks/1_2021/qiskit/terra/docs/_build/release_notes.spelling
/Users/ima/tasks/1_2021/qiskit/terra/docs/stubs/qiskit.qasm.OpenQASMLexer.get_tokens_unprocessed.rst:3: Spell check: inital:  is the inital stack (default: .
Writing /Users/ima/tasks/1_2021/qiskit/terra/docs/_build/stubs/qiskit.qasm.OpenQASMLexer.get_tokens_unprocessed.spelling
writing output... [100%] stubs/qiskit.visualization.visualize_transition
WARNING: Found 35 misspelled words
build succeeded, 9 warnings.
```
