### PR TITLE
Ensure we include all cython files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,8 @@ include requirements.txt
 include qiskit/qasm/libs/*.inc
 include qiskit/schemas/*.json
 include qiskit/VERSION.txt
-include qiskit/transpiler/passes/routing/cython/stochastic_swap/*.pyx
-include qiskit/transpiler/passes/routing/cython/stochastic_swap/*.pxd
+recursive-include qiskit *.pyx
+recursive-include qiskit *.pxd
 include qiskit/visualization/styles/*.json
 recursive-include qiskit/test/mock/backends *.json
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recent terra 0.17.0 release the sdist on pypi is not buildable,
this is because it didn't include the cython pyx file for the pauli
expectation values function that was new for 0.17.0. This was not caught
in CI or local testing because the missing file is present in a git
checkout, but since it's not a *py file they are not included in the
sdist. This commit fixes this issue by updating the MANIFSET.in file to
include all cython files in qiskit instead of just the stochastic swap
file. Making this more broad is a good idea as there will likely be
additional cython modules added over time and this will ensure this
error doesn't happen again.

### Details and comments