### PR TITLE
Make DictStateFn.num_qubits more efficient

### DIFF
--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -81,7 +81,7 @@ class DictStateFn(StateFn):
 
     @property
     def num_qubits(self) -> int:
-        return len(list(self.primitive.keys())[0])
+        return len(next(iter(self.primitive)))
 
     def add(self, other: OperatorBase) -> OperatorBase:
         if not self.num_qubits == other.num_qubits:


### PR DESCRIPTION
This makes the implementation of `DictStateFn.num_qubits` more performant.

In the previous implementation, a list of each of the terms in the state function is constructed, and the number of qubits (length) of the first one is returned. (It is assumed that the `DictStateFn` is constructed correctly so that each term (a string) is of the same length.)

In this PR, the intermediate list is not constructed. An iterator over the keys is used instead.

This is also more elegant and should be the canonical way to get and operate on the first key in a dict.

fixes #5803