### PR TITLE
Remove unnecessary parameter table from pulse program

### DIFF
--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -21,14 +21,12 @@ channel types can be created. Then, they must be supported in the PulseQobj sche
 assembler.
 """
 from abc import ABCMeta
-from typing import Any, Set, Union
+from typing import Any, Union
 
 import numpy as np
 
-from qiskit.circuit import Parameter
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.exceptions import PulseError
-from qiskit.pulse.utils import deprecated_functionality
 
 
 class Channel(metaclass=ABCMeta):
@@ -71,10 +69,6 @@ class Channel(metaclass=ABCMeta):
         self._index = index
         self._hash = hash((self.__class__.__name__, self._index))
 
-        self._parameters = set()
-        if isinstance(index, ParameterExpression):
-            self._parameters = index.parameters
-
     @property
     def index(self) -> Union[int, ParameterExpression]:
         """Return the index of this channel. The index is a label for a control signal line
@@ -101,40 +95,9 @@ class Channel(metaclass=ABCMeta):
         if not isinstance(index, (int, np.integer)) and index < 0:
             raise PulseError('Channel index must be a nonnegative integer')
 
-    @property
-    @deprecated_functionality
-    def parameters(self) -> Set:
-        """Parameters which determine the channel index."""
-        return self._parameters
-
     def is_parameterized(self) -> bool:
         """Return True iff the channel is parameterized."""
         return isinstance(self.index, ParameterExpression)
-
-    @deprecated_functionality
-    def assign(self, parameter: Parameter, value: ParameterValueType) -> 'Channel':
-        """Return a new channel with the input Parameter assigned to value.
-
-        Args:
-            parameter: A parameter in this expression whose value will be updated.
-            value: The new value to bind to.
-
-        Returns:
-            A new channel with updated parameters.
-
-        Raises:
-            PulseError: If the parameter is not present in the channel.
-        """
-        if parameter not in self.parameters:
-            raise PulseError('Cannot bind parameters ({}) not present in the channel.'
-                             ''.format(parameter))
-
-        new_index = self.index.assign(parameter, value)
-        if not new_index.parameters:
-            self._validate_index(new_index)
-            new_index = int(new_index)
-
-        return type(self)(new_index)
 
     @property
     def name(self) -> str:

--- a/qiskit/pulse/instructions/call.py
+++ b/qiskit/pulse/instructions/call.py
@@ -12,13 +12,12 @@
 
 """Call instruction that represents calling a schedule as a subroutine."""
 
-from typing import Optional, Union, Dict, Tuple, Any, Set
+from typing import Optional, Union, Dict, Tuple
 
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.channels import Channel
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.instructions import instruction
-from qiskit.pulse.utils import format_parameter_value, deprecated_functionality
 
 
 class Call(instruction.Instruction):
@@ -54,7 +53,6 @@ class Call(instruction.Instruction):
         value_dict = value_dict or dict()
 
         # initialize parameter template
-        # TODO remove self._parameter_table
         self._arguments = dict()
         if subroutine.is_parameterized():
             for param in subroutine.parameters:
@@ -113,70 +111,9 @@ class Call(instruction.Instruction):
 
         return subroutine
 
-    def _initialize_parameter_table(self,
-                                    operands: Tuple[Any]):
-        """A helper method to initialize parameter table.
-
-        The behavior of the parameter table of the ``Call`` instruction is slightly different from
-        other instructions. The actual parameter mapper object is defined only in the
-        subroutine, thus the call instruction doesn't have operand of ``ParameterExpression`` type.
-        The parameter table is defined as a mapping of parameter objects to assigned values,
-        whereas the standard instruction stores the mapping to the operand tuple index.
-
-        Note that this instruction doesn't immediately bind parameter values when the
-        :meth:`assign_parameters` method is called with the parameter dictionary.
-        Instead, this instruction separately keeps the parameter values from the subroutine.
-        This logic enables the compiler to reuse the subroutine with different parameters.
-
-        Args:
-            operands: List of operands associated with this instruction.
-        """
-        if operands[0].is_parameterized():
-            for value in operands[0].parameters:
-                self._parameter_table[value] = value
-
-    @deprecated_functionality
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'Call':
-        """Store parameters which will be later assigned to the subroutine.
-
-        Parameter values are not immediately assigned. The subroutine with parameters
-        assigned according to the populated parameter table will be generated only when
-        :func:`~qiskit.pulse.transforms.inline_subroutines` function is applied to this
-        instruction. Note that parameter assignment logic creates a copy of subroutine
-        to avoid the mutation problem. This function is usually applied by the Qiskit
-        compiler when the program is submitted to the backend.
-
-        Args:
-            value_dict: A mapping from Parameters to either numeric values or another
-                Parameter expression.
-
-        Returns:
-            Self with updated parameters.
-        """
-        for param_obj, assigned_value in value_dict.items():
-            for key_obj, value in self._parameter_table.items():
-                # assign value to parameter expression (it can consist of multiple parameters)
-                if isinstance(value, ParameterExpression) and param_obj in value.parameters:
-                    new_value = format_parameter_value(value.assign(param_obj, assigned_value))
-                    self._parameter_table[key_obj] = new_value
-
-        return self
-
     def is_parameterized(self) -> bool:
         """Return True iff the instruction is parameterized."""
         return any(isinstance(value, ParameterExpression) for value in self.arguments.values())
-
-    @property
-    def parameters(self) -> Set:
-        """Unassigned parameters which determine the instruction behavior."""
-        params = set()
-        for value in self._arguments.values():
-            if isinstance(value, ParameterExpression):
-                for param in value.parameters:
-                    params.add(param)
-        return params
 
     @property
     def arguments(self) -> Dict[ParameterExpression, ParameterValueType]:

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -23,13 +23,10 @@ For example::
 """
 import warnings
 from abc import ABC, abstractproperty
-from collections import defaultdict
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Any
+from typing import Callable, Iterable, List, Optional, Tuple
 
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.channels import Channel
 from qiskit.pulse.exceptions import PulseError
-from qiskit.pulse.utils import format_parameter_value, deprecated_functionality
 
 
 # pylint: disable=missing-return-doc
@@ -73,9 +70,6 @@ class Instruction(ABC):
         self._operands = operands
         self._name = name
         self._hash = None
-
-        self._parameter_table = defaultdict(list)
-        self._initialize_parameter_table(operands)
 
         for channel in self.channels:
             if not isinstance(channel, Channel):
@@ -229,69 +223,9 @@ class Instruction(ABC):
         time = self.ch_stop_time(*common_channels)
         return self.insert(time, schedule, name=name)
 
-    @property
-    @deprecated_functionality
-    def parameters(self) -> Set:
-        """Parameters which determine the instruction behavior."""
-        return set(self._parameter_table.keys())
-
     def is_parameterized(self) -> bool:
         """Return True iff the instruction is parameterized."""
         return any(chan.is_parameterized() for chan in self.channels)
-
-    def _initialize_parameter_table(self,
-                                    operands: Tuple[Any]):
-        """A helper method to initialize parameter table.
-
-        Args:
-            operands: List of operands associated with this instruction.
-        """
-        for idx, op in enumerate(operands):
-            if isinstance(op, ParameterExpression):
-                for param in op.parameters:
-                    self._parameter_table[param].append(idx)
-            elif isinstance(op, Channel) and isinstance(op.index, ParameterExpression):
-                for param in op.index.parameters:
-                    self._parameter_table[param].append(idx)
-
-    @deprecated_functionality
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'Instruction':
-        """Modify and return self with parameters assigned according to the input.
-
-        Args:
-            value_dict: A mapping from Parameters to either numeric values or another
-                Parameter expression.
-
-        Returns:
-            Self with updated parameters.
-        """
-        new_operands = list(self.operands)
-
-        for parameter in self.parameters:
-            if parameter not in value_dict:
-                continue
-
-            value = value_dict[parameter]
-            op_indices = self._parameter_table[parameter]
-            for op_idx in op_indices:
-                param_expr = new_operands[op_idx]
-                new_operands[op_idx] = format_parameter_value(param_expr.assign(parameter, value))
-
-            # Update parameter table
-            entry = self._parameter_table.pop(parameter)
-            if isinstance(value, ParameterExpression):
-                for new_parameter in value.parameters:
-                    if new_parameter in self._parameter_table:
-                        new_entry = set(entry + self._parameter_table[new_parameter])
-                        self._parameter_table[new_parameter] = list(new_entry)
-                    else:
-                        self._parameter_table[new_parameter] = entry
-
-        self._operands = tuple(new_operands)
-
-        return self
 
     def draw(self, dt: float = 1, style=None,
              filename: Optional[str] = None, interp_method: Optional[Callable] = None,

--- a/qiskit/pulse/instructions/play.py
+++ b/qiskit/pulse/instructions/play.py
@@ -13,14 +13,13 @@
 """An instruction to transmit a given pulse on a ``PulseChannel`` (i.e., those which support
 transmitted pulses, such as ``DriveChannel``).
 """
-from typing import Dict, Optional, Union, Tuple, Any
+from typing import Optional, Union, Tuple
 
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.channels import PulseChannel
 from qiskit.pulse.exceptions import PulseError
-from qiskit.pulse.library.pulse import Pulse
 from qiskit.pulse.instructions.instruction import Instruction
-from qiskit.pulse.utils import deprecated_functionality
+from qiskit.pulse.library.pulse import Pulse
 
 
 class Play(Instruction):
@@ -76,31 +75,6 @@ class Play(Instruction):
     def duration(self) -> Union[int, ParameterExpression]:
         """Duration of this instruction."""
         return self.pulse.duration
-
-    def _initialize_parameter_table(self,
-                                    operands: Tuple[Any]):
-        """A helper method to initialize parameter table.
-
-        Args:
-            operands: List of operands associated with this instruction.
-        """
-        super()._initialize_parameter_table(operands)
-
-        if any(isinstance(val, ParameterExpression) for val in self.pulse.parameters.values()):
-            for value in self.pulse.parameters.values():
-                if isinstance(value, ParameterExpression):
-                    for param in value.parameters:
-                        # Table maps parameter to operand index, 0 for ``pulse``
-                        self._parameter_table[param].append(0)
-
-    @deprecated_functionality
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'Play':
-        super().assign_parameters(value_dict)
-        pulse = self.pulse.assign_parameters(value_dict)
-        self._operands = (pulse, self.channel)
-        return self
 
     def is_parameterized(self) -> bool:
         """Return True iff the instruction is parameterized."""

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -42,13 +42,12 @@ from typing import Any, Dict, Optional, Union
 import math
 import numpy as np
 
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
+from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.library import continuous
 from qiskit.pulse.library.discrete import gaussian, gaussian_square, drag, constant
 from qiskit.pulse.library.pulse import Pulse
 from qiskit.pulse.library.waveform import Waveform
-from qiskit.pulse.utils import format_parameter_value, deprecated_functionality
 
 
 class ParametricPulse(Pulse):
@@ -87,38 +86,6 @@ class ParametricPulse(Pulse):
     def is_parameterized(self) -> bool:
         """Return True iff the instruction is parameterized."""
         return any(_is_parameterized(val) for val in self.parameters.values())
-
-    @deprecated_functionality
-    def assign(self, parameter: ParameterExpression,
-               value: ParameterValueType) -> 'ParametricPulse':
-        """Assign one parameter to a value, which can either be numeric or another parameter
-        expression.
-        """
-        return self.assign_parameters({parameter: value})
-
-    @deprecated_functionality
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'ParametricPulse':
-        """Return a new ParametricPulse with parameters assigned.
-
-        Args:
-            value_dict: A mapping from Parameters to either numeric values or another
-                Parameter expression.
-
-        Returns:
-            New pulse with updated parameters.
-        """
-        if not self.is_parameterized():
-            return self
-
-        new_parameters = {}
-        for op, op_value in self.parameters.items():
-            for parameter, value in value_dict.items():
-                if _is_parameterized(op_value) and parameter in op_value.parameters:
-                    op_value = format_parameter_value(op_value.assign(parameter, value))
-                new_parameters[op] = op_value
-        return type(self)(**new_parameters, name=self.name)
 
     def __eq__(self, other: Pulse) -> bool:
         return super().__eq__(other) and self.parameters == other.parameters

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -17,8 +17,7 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Any, Tuple, Union
 
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
-from qiskit.pulse.utils import deprecated_functionality
+from qiskit.circuit.parameterexpression import ParameterExpression
 
 
 class Pulse(ABC):
@@ -46,22 +45,6 @@ class Pulse(ABC):
 
     def is_parameterized(self) -> bool:
         """Return True iff the instruction is parameterized."""
-        raise NotImplementedError
-
-    @deprecated_functionality
-    @abstractmethod
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'Pulse':
-        """Return a new pulse with parameters assigned.
-
-        Args:
-            value_dict: A mapping from Parameters to either numeric values or another
-                Parameter expression.
-
-        Returns:
-            New pulse with updated parameters.
-        """
         raise NotImplementedError
 
     def draw(self,

--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -15,10 +15,8 @@ from typing import Dict, List, Optional, Union, Any
 
 import numpy as np
 
-from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.library.pulse import Pulse
-from qiskit.pulse.utils import deprecated_functionality
 
 
 class Waveform(Pulse):
@@ -103,13 +101,6 @@ class Waveform(Pulse):
     def parameters(self) -> Dict[str, Any]:
         """Return a dictionary containing the pulse's parameters."""
         return dict()
-
-    @deprecated_functionality
-    def assign_parameters(self,
-                          value_dict: Dict[ParameterExpression, ParameterValueType]
-                          ) -> 'Waveform':
-        # Waveforms don't accept parameters
-        return self
 
     def __eq__(self, other: Pulse) -> bool:
         return super().__eq__(other) and self.samples.shape == other.samples.shape and \

--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -297,8 +297,9 @@ class ParameterGetter(NodeVisitor):
         .. note:: ``Call`` instruction has a special parameter handling logic.
             This instruction separately keeps parameters and program.
         """
-        for parameter in node.parameters:
-            self.parameters.add(parameter)
+        for parameter in node.arguments.values():
+            if isinstance(parameter, ParameterExpression):
+                self._add_parameters(parameter)
 
     def visit_Instruction(self, node: instructions.Instruction):
         """Get parameters from general pulse instruction.

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -266,7 +266,7 @@ class TestCall(QiskitTestCase):
         call = instructions.Call(subroutine=self.function)
 
         self.assertTrue(call.is_parameterized())
-        self.assertEqual(len(call.parameters), 2)
+        self.assertEqual(len(call.arguments), 2)
 
     def test_assign_parameters_to_call(self):
         """Test create schedule by calling subroutine and assign parameters to it."""

--- a/test/python/pulse/test_parameters.py
+++ b/test/python/pulse/test_parameters.py
@@ -11,7 +11,6 @@
 # that they have been altered from the originals.
 
 """Test cases for parameters used in Schedules."""
-import unittest
 from copy import deepcopy
 
 import numpy as np

--- a/test/python/pulse/test_parameters.py
+++ b/test/python/pulse/test_parameters.py
@@ -48,30 +48,6 @@ class TestPulseParameters(QiskitTestCase):
 
         self.backend = FakeAlmaden()
 
-    def test_parameter_attribute_channel(self):
-        """Test the ``parameter`` attributes."""
-        chan = DriveChannel(self.qubit*self.alpha)
-        self.assertTrue(chan.is_parameterized())
-        self.assertEqual(chan.parameters, {self.qubit, self.alpha})
-        chan = chan.assign(self.qubit, self.alpha)
-        self.assertEqual(chan.parameters, {self.alpha})
-        chan = chan.assign(self.alpha, self.beta)
-        self.assertEqual(chan.parameters, {self.beta})
-        chan = chan.assign(self.beta, 1)
-        self.assertFalse(chan.is_parameterized())
-
-    def test_parameter_attribute_instruction(self):
-        """Test the ``parameter`` attributes."""
-        inst = pulse.ShiftFrequency(self.alpha*self.qubit,
-                                    DriveChannel(self.qubit))
-        self.assertTrue(inst.is_parameterized())
-        self.assertEqual(inst.parameters, {self.alpha, self.qubit})
-        inst.assign_parameters({self.alpha: self.qubit})
-        self.assertEqual(inst.parameters, {self.qubit})
-        inst.assign_parameters({self.qubit: 1})
-        self.assertFalse(inst.is_parameterized())
-        self.assertEqual(inst.parameters, set())
-
     def test_parameter_attribute_schedule(self):
         """Test the ``parameter`` attributes."""
         schedule = pulse.Schedule()
@@ -239,34 +215,6 @@ class TestPulseParameters(QiskitTestCase):
         self.assertEqual(insts[0][1].pulse.amp, 0.2)
         self.assertEqual(insts[0][1].pulse.sigma, 4.)
 
-    def test_parametric_pulses_parameter_assignment(self):
-        """Test Parametric Pulses with parameters determined by ParameterExpressions."""
-        waveform = pulse.library.GaussianSquare(duration=1280, sigma=self.sigma,
-                                                amp=self.amp, width=1000)
-        waveform = waveform.assign_parameters({self.amp: 0.3, self.sigma: 12})
-        self.assertEqual(waveform.amp, 0.3)
-        self.assertEqual(waveform.sigma, 12)
-
-        waveform = pulse.library.Drag(duration=1280, sigma=self.sigma, amp=self.amp, beta=2)
-        waveform = waveform.assign_parameters({self.sigma: 12.7})
-        self.assertEqual(waveform.amp, self.amp)
-        self.assertEqual(waveform.sigma, 12.7)
-
-    @unittest.skip("Not yet supported by ParameterExpression")
-    def test_complex_value_assignment(self):
-        """Test that complex values can be assigned to Parameters."""
-        waveform = pulse.library.Constant(duration=1280, amp=self.amp)
-        waveform.assign_parameters({self.amp: 0.2j})
-        self.assertEqual(waveform.amp, 0.2j)
-
-    def test_invalid_parametric_pulses(self):
-        """Test that invalid parameters are still checked upon assignment."""
-        schedule = pulse.Schedule()
-        waveform = pulse.library.Constant(duration=1280, amp=2*self.amp)
-        schedule += pulse.Play(waveform, DriveChannel(0))
-        with self.assertRaises(PulseError):
-            waveform.assign_parameters({self.amp: 0.6})
-
     def test_get_parameter(self):
         """Test that get parameter by name."""
         param1 = Parameter('amp')
@@ -344,46 +292,6 @@ class TestPulseParameters(QiskitTestCase):
 
 class TestParameterDuration(QiskitTestCase):
     """Tests parametrization of instruction duration."""
-
-    def test_pulse_duration(self):
-        """Test parametrization of pulse duration."""
-        dur = Parameter('dur')
-
-        test_pulse = pulse.Gaussian(dur, 0.1, dur/4)
-        ref_pulse = pulse.Gaussian(160, 0.1, 40)
-
-        self.assertEqual(test_pulse.assign_parameters({dur: 160}), ref_pulse)
-
-    def test_play_duration(self):
-        """Test parametrization of play instruction duration."""
-        dur = Parameter('dur')
-        ch = pulse.DriveChannel(0)
-
-        test_play = pulse.Play(pulse.Gaussian(dur, 0.1, dur/4), ch)
-        test_play.assign_parameters({dur: 160})
-
-        self.assertEqual(test_play.duration, 160)
-
-    def test_delay_duration(self):
-        """Test parametrization of delay duration."""
-        dur = Parameter('dur')
-        ch = pulse.DriveChannel(0)
-
-        test_delay = pulse.Delay(dur, ch)
-        test_delay.assign_parameters({dur: 300})
-
-        self.assertEqual(test_delay.duration, 300)
-
-    def test_acquire_duration(self):
-        """Test parametrization of acquire duration."""
-        dur = Parameter('dur')
-        ch = pulse.AcquireChannel(0)
-        mem_slot = pulse.MemorySlot(0)
-
-        test_acquire = pulse.Acquire(dur, ch, mem_slot=mem_slot)
-        test_acquire.assign_parameters({dur: 300})
-
-        self.assertEqual(test_acquire.duration, 300)
 
     def test_is_parameterized(self):
         """Test is parameterized method for parameter duration."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
In #5854 parameter table is deprecated and `ParameterManager` is introduced. This PR removes unnecessary parameter tables and `.parameters`, `.assign_parameters` methods from pulse instructions and channels.


### Details and comments
Simple benchmark
```python
%%time

for _ in range(100):
    sched = pulse.ScheduleBlock()
    for _ in range(3000):
        sched += pulse.Play(pulse.Gaussian(circuit.Parameter('dur'), 
                                           circuit.Parameter('amp'), 
                                           circuit.Parameter('sigma')), 
                            pulse.DriveChannel(circuit.Parameter('ch')))
```
This PR:
CPU times: user 35.8 s, sys: 1.1 s, total: 36.9 s
Wall time: 36.9 s

master:
CPU times: user 46.2 s, sys: 1.36 s, total: 47.6 s
Wall time: 47.6 s

This improvement is simply thanks to the removal of parameter table. All instructions and channels had been initializing the table in the constructor, but this is just an overhead to create new instance. We just added deprecation warning in 0.17, perhaps this PR should be on hold. However, considering the performance improvement, it could be better to remove them soon.