### PR TITLE
Fix SPSA recalibration

### DIFF
--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -257,19 +257,19 @@ class SPSA(Optimizer):
         return gradient
 
     def _minimize(self, loss, initial_point):
-        # ensure learning rate and perturbation are set
+        # ensure learning rate and perturbation are correctly set: either none or both
         # this happens only here because for the calibration the loss function is required
         if self.learning_rate is None and self.perturbation is None:
             get_learning_rate, get_perturbation = self.calibrate(loss, initial_point)
-            self.learning_rate = get_learning_rate
-            self.perturbation = get_perturbation
-
-        if self.learning_rate is None or self.perturbation is None:
+            # get iterator
+            eta = get_learning_rate()
+            eps = get_perturbation()
+        elif self.learning_rate is None or self.perturbation is None:
             raise ValueError('If one of learning rate or perturbation is set, both must be set.')
-
-        # get iterator
-        eta = self.learning_rate()
-        eps = self.perturbation()
+        else:
+            # get iterator
+            eta = self.learning_rate()
+            eps = self.perturbation()
 
         # prepare some initials
         x = np.asarray(initial_point)

--- a/releasenotes/notes/fix-spsa-recalibration-cbdae6fab0b8ef8b.yaml
+++ b/releasenotes/notes/fix-spsa-recalibration-cbdae6fab0b8ef8b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix a bug where using :class:`~qiskit.algorithms.optimizers.SPSA` with automatic
+    calibration of the learning rate and perturbation (i.e. ``learning_rate`` and
+    ``perturbation`` are ``None`` in the initializer), stores the calibration for all
+    future optimizations. Instead, the calibration should be done for each new objective
+    function.

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -52,3 +52,14 @@ class TestSPSA(QiskitAlgorithmsTestCase):
 
         self.assertLess(result[1], -0.95)  # final loss
         self.assertEqual(result[2], 301)  # function evaluations
+
+    def test_recalibrate_at_optimize(self):
+        """Test SPSA calibrates anew upon each optimization run, if no autocalibration is set."""
+        def objective(x):
+            return -(x ** 2)
+
+        spsa = SPSA(maxiter=1)
+        _ = spsa.optimize(1, objective, initial_point=np.array([0.5]))
+
+        self.assertIsNone(spsa.learning_rate)
+        self.assertIsNone(spsa.perturbation)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix a bug where using :class:`~qiskit.algorithms.optimizers.SPSA` with automatic
calibration of the learning rate and perturbation (i.e. ``learning_rate`` and
``perturbation`` are ``None`` in the initializer), stores the calibration for all
future optimizations. Instead, the calibration should be done for each new objective
function


### Details 

E.g. running
```python
def f1(x): return -(x ** 2)

def f2(x): return -10000 * (x ** 2)

spsa = SPSA(maxiter=100)
result1 = spsa.optimize(1, f1, initial_point=[0.5])  # calibrates learning rate and perturbation according to f1
result2 = spsa.optimize(1, f2, initial_point=[0.5])  # uses the calibrations from f1 instead of recalibrating for f2!
```
