### PR TITLE
Modify linux 3.7 CI job to install from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,8 +3,8 @@ include requirements.txt
 include qiskit/qasm/libs/*.inc
 include qiskit/schemas/*.json
 include qiskit/VERSION.txt
-include qiskit/transpiler/passes/routing/cython/stochastic_swap/*.pyx
-include qiskit/transpiler/passes/routing/cython/stochastic_swap/*.pxd
+recursive-include qiskit *.pyx
+recursive-include qiskit *.pxd
 include qiskit/visualization/styles/*.json
 recursive-include qiskit/test/mock/backends *.json
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include LICENSE.txt
 include requirements.txt
 include qiskit/qasm/libs/*.inc
 include qiskit/schemas/*.json
+include qiskit/schemas/examples/*.json
 include qiskit/VERSION.txt
 recursive-include qiskit *.pyx
 recursive-include qiskit *.pxd

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -163,9 +163,9 @@ stages:
             virtualenv test-job
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
-            pip install -U -c constraints.txt .
+            python setup.py sdist
+            pip install -U -c constraints.txt dist/qiskit-terra*.tar.gz
             pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
-            python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
           displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,15 +166,20 @@ stages:
             python setup.py sdist
             pip install -U -c constraints.txt dist/qiskit-terra*.tar.gz
             pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
+            mkdir -p /tmp/terra-tests
+            cp -r test /tmp/terra-tests/.
+            cp .stestr.conf /tmp/terra-tests/.
             sudo apt install -y graphviz
             pip check
           displayName: 'Install dependencies'
         - bash: |
             set -e
             source test-job/bin/activate
+            pushd /tmp/terra-tests
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
             stestr run
+            popd
           displayName: 'Run tests'
         - task: CopyFiles@2
           condition: failed()
@@ -192,8 +197,10 @@ stages:
             set -e
             source test-job/bin/activate
             pip install -U junitxml
+            pushd /tmp/terra-tests
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
+            popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -200,7 +200,7 @@ stages:
             pip install -U junitxml
             pushd /tmp/terra-tests
             mkdir -p junit
-            stestr last --subunit | subunit_to_junit.py -o junit/test-results.xml
+            stestr last --subunit | ./subunit_to_junit.py -o junit/test-results.xml
             popd
             cp -r /tmp/terra-tests/junit .
           condition: succeededOrFailed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -196,11 +196,13 @@ stages:
         - bash: |
             set -e
             source test-job/bin/activate
+            cp tools/subunit_to_junit.py /tmp/terra-tests/.
             pip install -U junitxml
             pushd /tmp/terra-tests
             mkdir -p junit
-            stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
+            stestr last --subunit | subunit_to_junit.py -o junit/test-results.xml
             popd
+            cp -r /tmp/terra-tests/junit .
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -24,7 +24,6 @@ from qiskit import execute
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import transpile, assemble
 from qiskit.providers.basicaer import QasmSimulatorPy
-from qiskit.test import Path
 from qiskit.test import providers
 
 

--- a/test/python/basicaer/test_qasm_simulator.py
+++ b/test/python/basicaer/test_qasm_simulator.py
@@ -12,6 +12,7 @@
 
 """Test QASM simulator."""
 
+import os
 import unittest
 import io
 from logging import StreamHandler, getLogger
@@ -43,7 +44,10 @@ class TestBasicAerQasmSimulator(providers.BackendTestCase):
         super().setUp()
 
         self.seed = 88
-        qasm_filename = self._get_resource_path('example.qasm', Path.QASMS)
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        qasm_filename = os.path.join(qasm_dir, 'example.qasm')
         transpiled_circuit = QuantumCircuit.from_qasm_file(qasm_filename)
         transpiled_circuit.name = 'test'
         transpiled_circuit = transpile(transpiled_circuit, backend=self.backend)

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -13,10 +13,12 @@
 
 """Test cases for the circuit qasm_file and qasm_string method."""
 
+import os
+
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit import Gate, Parameter
 from qiskit.exceptions import QiskitError
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 from qiskit.transpiler.passes import Unroller
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 
@@ -27,7 +29,10 @@ class LoadFromQasmTest(QiskitTestCase):
     def setUp(self):
         super().setUp()
         self.qasm_file_name = 'entangled_registers.qasm'
-        self.qasm_file_path = self._get_resource_path('qasm/' + self.qasm_file_name, Path.EXAMPLES)
+        self.qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        self.qasm_file_path = os.path.join(self.qasm_dir, self.qasm_file_name)
 
     def test_qasm_file(self):
         """
@@ -52,7 +57,7 @@ class LoadFromQasmTest(QiskitTestCase):
     def test_loading_all_qelib1_gates(self):
         """Test setting up a circuit with all gates defined in qiskit/qasm/libs/qelib1.inc."""
         from qiskit.circuit.library import U1Gate, U2Gate, U3Gate, CU1Gate, CU3Gate, UGate
-        all_gates_qasm = self._get_resource_path('all_gates.qasm', Path.QASMS)
+        all_gates_qasm = os.path.join(self.qasm_dir, 'all_gates.qasm')
         qasm_circuit = QuantumCircuit.from_qasm_file(all_gates_qasm)
 
         ref_circuit = QuantumCircuit(3, 3)
@@ -209,7 +214,7 @@ class LoadFromQasmTest(QiskitTestCase):
 
     def test_qasm_example_file(self):
         """Loads qasm/example.qasm."""
-        qasm_filename = self._get_resource_path('example.qasm', Path.QASMS)
+        qasm_filename = os.path.join(self.qasm_dir, 'example.qasm')
         expected_circuit = QuantumCircuit.from_qasm_str('\n'.join(["OPENQASM 2.0;",
                                                                    "include \"qelib1.inc\";",
                                                                    "qreg q[3];",

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -21,7 +21,7 @@ from qiskit.transpiler import PassManager
 from qiskit import execute
 from qiskit.circuit.library import U1Gate, U2Gate
 from qiskit.compiler import transpile, assemble
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeRueschlikon, FakeTenerife
 from qiskit.qobj import QasmQobj
 
@@ -356,7 +356,7 @@ class TestCompiler(QiskitTestCase):
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             'qasm')
         circ = QuantumCircuit.from_qasm_file(
-            os.path.join(qasm_dir,'random_n5_d5.qasm'))
+            os.path.join(qasm_dir, 'random_n5_d5.qasm'))
         coupling_map = [[0, 1], [1, 2], [2, 3], [3, 4]]
         shots = 1024
         qobj = execute(circ, backend=self.backend,

--- a/test/python/compiler/test_compiler.py
+++ b/test/python/compiler/test_compiler.py
@@ -12,6 +12,7 @@
 
 """Compiler Test."""
 
+import os
 import unittest
 
 from qiskit import BasicAer
@@ -351,8 +352,11 @@ class TestCompiler(QiskitTestCase):
 
     def test_random_parameter_circuit(self):
         """Run a circuit with randomly generated parameters."""
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
         circ = QuantumCircuit.from_qasm_file(
-            self._get_resource_path('random_n5_d5.qasm', Path.QASMS))
+            os.path.join(qasm_dir,'random_n5_d5.qasm'))
         coupling_map = [[0, 1], [1, 2], [2, 3], [3, 4]]
         shots = 1024
         qobj = execute(circ, backend=self.backend,

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -15,6 +15,7 @@
 """Tests basic functionality of the transpile function"""
 
 import io
+import os
 import sys
 import math
 
@@ -507,8 +508,11 @@ class TestTranspile(QiskitTestCase):
 
     def test_final_measurement_barrier_for_devices(self):
         """Verify BarrierBeforeFinalMeasurements pass is called in default pipeline for devices."""
-
-        circ = QuantumCircuit.from_qasm_file(self._get_resource_path('example.qasm', Path.QASMS))
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        circ = QuantumCircuit.from_qasm_file(
+            os.path.join(qasm_dir, 'example.qasm'))
         layout = Layout.generate_trivial_layout(*circ.qregs)
         orig_pass = BarrierBeforeFinalMeasurements()
         with patch.object(BarrierBeforeFinalMeasurements, 'run', wraps=orig_pass.run) as mock_pass:
@@ -518,8 +522,11 @@ class TestTranspile(QiskitTestCase):
 
     def test_do_not_run_gatedirection_with_symmetric_cm(self):
         """When the coupling map is symmetric, do not run GateDirection."""
-
-        circ = QuantumCircuit.from_qasm_file(self._get_resource_path('example.qasm', Path.QASMS))
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        circ = QuantumCircuit.from_qasm_file(
+            os.path.join(qasm_dir, 'example.qasm'))
         layout = Layout.generate_trivial_layout(*circ.qregs)
         coupling_map = []
         for node1, node2 in FakeRueschlikon().configuration().coupling_map:
@@ -578,8 +585,11 @@ class TestTranspile(QiskitTestCase):
         """
         backend = FakeRueschlikon()
         cmap = backend.configuration().coupling_map
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
         circ = QuantumCircuit.from_qasm_file(
-            self._get_resource_path('move_measurements.qasm', Path.QASMS))
+            os.path.join(qasm_dir, 'move_measurements.qasm'))
 
         lay = [0, 1, 15, 2, 14, 3, 13, 4, 12, 5, 11, 6]
         out = transpile(circ, initial_layout=lay, coupling_map=cmap)

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -34,7 +34,7 @@ from qiskit.circuit import Parameter, Gate, Qubit, Clbit
 from qiskit.compiler import transpile
 from qiskit.converters import circuit_to_dag
 from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate, RZGate
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeMelbourne, FakeRueschlikon, FakeAlmaden
 from qiskit.transpiler import Layout, CouplingMap
 from qiskit.transpiler import PassManager

--- a/test/python/converters/test_ast_to_dag.py
+++ b/test/python/converters/test_ast_to_dag.py
@@ -18,7 +18,7 @@ import unittest
 from qiskit.converters import ast_to_dag, circuit_to_dag
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit import qasm
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 
 
 class TestAstToDag(QiskitTestCase):

--- a/test/python/converters/test_ast_to_dag.py
+++ b/test/python/converters/test_ast_to_dag.py
@@ -12,6 +12,7 @@
 
 """Tests for the converters."""
 
+import os
 import unittest
 
 from qiskit.converters import ast_to_dag, circuit_to_dag
@@ -34,8 +35,10 @@ class TestAstToDag(QiskitTestCase):
 
     def test_from_ast_to_dag(self):
         """Test Unroller.execute()"""
-        ast = qasm.Qasm(filename=self._get_resource_path('example.qasm',
-                                                         Path.QASMS)).parse()
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        ast = qasm.Qasm(os.path.join(qasm_dir, 'example.qasm')).parse()
         dag_circuit = ast_to_dag(ast)
         expected_result = """\
 OPENQASM 2.0;

--- a/test/python/qasm/entangled_registers.qasm
+++ b/test/python/qasm/entangled_registers.qasm
@@ -1,0 +1,20 @@
+// A simple 8 qubit example entangling two 4 qubit registers
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg a[4];
+qreg b[4];
+creg c[4];
+creg d[4];
+h a;
+cx a, b;
+barrier a;
+barrier b;
+measure a[0]->c[0];
+measure a[1]->c[1];
+measure a[2]->c[2];
+measure a[3]->c[3];
+measure b[0]->d[0];
+measure b[1]->d[1];
+measure b[2]->d[2];
+measure b[3]->d[3];

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -12,6 +12,7 @@
 
 """Test for the QASM parser"""
 
+import os
 import unittest
 import ply
 
@@ -35,11 +36,12 @@ class TestParser(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.qasm_file_path = self._get_resource_path('example.qasm', Path.QASMS)
-        self.qasm_file_path_fail = self._get_resource_path(
-            'example_fail.qasm', Path.QASMS)
-        self.qasm_file_path_if = self._get_resource_path(
-            'example_if.qasm', Path.QASMS)
+        self.qasm_dir = self.qasm_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            'qasm')
+        self.qasm_file_path = os.path.join(self.qasm_dir, 'example.qasm')
+        self.qasm_file_path_fail = os.path.join(self.qasm_dir, 'example_fail.qasm')
+        self.qasm_file_path_if = os.path.join(self.qasm_dir, 'example_if.qasm')
 
     def test_parser(self):
         """should return a correct response for a valid circuit."""

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -18,7 +18,7 @@ import ply
 
 from qiskit.qasm import Qasm, QasmError
 from qiskit.qasm.node.node import Node
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 
 
 def parse(file_path):

--- a/test/python/test_qasm_parser.py
+++ b/test/python/test_qasm_parser.py
@@ -36,7 +36,7 @@ class TestParser(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.qasm_dir = self.qasm_dir = os.path.join(
+        self.qasm_dir = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
             'qasm')
         self.qasm_file_path = os.path.join(self.qasm_dir, 'example.qasm')

--- a/test/python/test_schemas.py
+++ b/test/python/test_schemas.py
@@ -19,8 +19,12 @@ from qiskit.validation.jsonschema.schema_validation import (
     validate_json_against_schema, _get_validator)
 from qiskit.providers.models import (QasmBackendConfiguration, PulseBackendConfiguration,
                                      BackendProperties, BackendStatus, JobStatus, PulseDefaults)
+import qiskit
 from qiskit.result import Result
 from qiskit.test import QiskitTestCase, Path
+
+SCHEMAS_PATH = os.path.join(os.path.dirname(os.path.abspath(qiskit.__file__)),
+                            'schemas')
 
 
 class TestSchemaExamples(QiskitTestCase):
@@ -57,8 +61,7 @@ class TestSchemaExamples(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        self.examples_base_path = self._get_resource_path('examples',
-                                                          Path.SCHEMAS)
+        self.examples_base_path = os.path.join(SCHEMAS_PATH, 'examples')
 
     def test_examples_are_valid(self):
         """Validate example json files against respective schemas"""

--- a/test/python/test_schemas.py
+++ b/test/python/test_schemas.py
@@ -21,7 +21,7 @@ from qiskit.providers.models import (QasmBackendConfiguration, PulseBackendConfi
                                      BackendProperties, BackendStatus, JobStatus, PulseDefaults)
 import qiskit
 from qiskit.result import Result
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 
 SCHEMAS_PATH = os.path.join(os.path.dirname(os.path.abspath(qiskit.__file__)),
                             'schemas')

--- a/test/python/tools/jupyter/test_notebooks.py
+++ b/test/python/tools/jupyter/test_notebooks.py
@@ -33,6 +33,10 @@ class TestJupyter(QiskitTestCase):
     def setUp(self):
         super().setUp()
         self.execution_path = os.path.join(Path.SDK.value, '..')
+        self.notebook_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.dirname(
+                os.path.abspath(__file__)))),
+            'notebooks')
 
     def _execute_notebook(self, filename):
         # Create the preprocessor.
@@ -73,15 +77,13 @@ class TestJupyter(QiskitTestCase):
         sys.platform != 'linux', 'Fails with Python >=3.8 on osx and windows')
     def test_jupyter_jobs_pbars(self):
         """Test Jupyter progress bars and job status functionality"""
-        self._execute_notebook(self._get_resource_path(
-            'notebooks/test_pbar_status.ipynb'))
+        self._execute_notebook(os.path.join(self.notebook_dir, 'test_pbar_status.ipynb'))
 
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @slow_test
     def test_backend_tools(self):
         """Test Jupyter backend tools."""
-        self._execute_notebook(self._get_resource_path(
-            'notebooks/test_backend_tools.ipynb'))
+        self._execute_notebook(os.path.join(self.notebook_dir, 'test_backend_tools.ipynb'))
 
 
 if __name__ == '__main__':

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -79,7 +79,7 @@ from qiskit.transpiler.passes import BasicSwap, LookaheadSwap, StochasticSwap, S
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler import CouplingMap, Layout
 
-from qiskit.test import QiskitTestCase, Path
+from qiskit.test import QiskitTestCase
 
 
 class CommonUtilitiesMixin:

--- a/test/python/transpiler/test_mappers.py
+++ b/test/python/transpiler/test_mappers.py
@@ -69,6 +69,7 @@ For example::
 # pylint: disable=attribute-defined-outside-init
 
 import unittest
+import os
 import sys
 
 from qiskit import execute
@@ -131,7 +132,10 @@ class CommonUtilitiesMixin:
     def assertResult(self, result, circuit):
         """Fetches the QASM in circuit.name file and compares it with result."""
         qasm_name = '%s_%s.qasm' % (type(self).__name__, circuit.name)
-        filename = QiskitTestCase._get_resource_path(qasm_name, Path.QASMS)
+        qasm_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'qasm')
+        filename = os.path.join(qasm_dir, qasm_name)
 
         if self.regenerate_expected:
             # Run result in backend to test that is valid.

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -12,6 +12,7 @@
 
 """Tests for visualization of circuit with Latex drawer."""
 
+import os
 import unittest
 import math
 import numpy as np
@@ -31,6 +32,10 @@ pi = np.pi
 
 class TestLatexSourceGenerator(QiskitVisualizationTestCase):
     """Qiskit latex source generator tests."""
+
+    def _get_resource_path(self, filename):
+        reference_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(reference_dir, filename)
 
     def test_empty_circuit(self):
         """Test draw an empty circuit"""

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=arguments-differ
+
 """Tests for visualization of circuit with Latex drawer."""
 
 import os

--- a/test/python/visualization/test_circuit_visualization_output.py
+++ b/test/python/visualization/test_circuit_visualization_output.py
@@ -83,7 +83,7 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
     # decide if the backend is available or not.
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_latex_drawer(self):
-        filename = self._get_resource_path('current_latex.png')
+        filename = 'current_latex.png'
         qc = self.sample_circuit()
         circuit_drawer(qc, filename=filename, output='latex')
         self.assertImagesAreEqual(filename, self.latex_reference)
@@ -94,14 +94,14 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_matplotlib_drawer(self):
-        filename = self._get_resource_path('current_matplot.png')
+        filename = 'current_matplot.png'
         qc = self.sample_circuit()
         circuit_drawer(qc, filename=filename, output='mpl')
         self.assertImagesAreEqual(filename, self.matplotlib_reference)
         os.remove(filename)
 
     def test_text_drawer_utf8(self):
-        filename = self._get_resource_path('current_textplot_utf8.txt')
+        filename = 'current_textplot_utf8.txt'
         qc = self.sample_circuit()
         output = _text_circuit_drawer(qc, filename=filename, fold=-1,
                                       initial_state=True, cregbundle=False, encoding='utf8')
@@ -113,7 +113,7 @@ class TestCircuitVisualizationImplementation(QiskitVisualizationTestCase):
         os.remove(filename)
 
     def test_text_drawer_cp437(self):
-        filename = self._get_resource_path('current_textplot_cp437.txt')
+        filename = 'current_textplot_cp437.txt'
         qc = self.sample_circuit()
         output = _text_circuit_drawer(qc, filename=filename, fold=-1,
                                       initial_state=True, cregbundle=False, encoding='cp437')

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -72,7 +72,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_GRAPHVIZ, 'Graphviz not installed.')
     def test_pass_manager_drawer_basic(self):
         """Test to see if the drawer draws a normal pass manager correctly"""
-        filename = self._get_resource_path('current_standard.dot')
+        filename = 'current_standard.dot'
         self.pass_manager.draw(filename=filename, raw=True)
 
         self.assertFilesAreEqual(filename, path_to_diagram_reference('pass_manager_standard.dot'))
@@ -87,7 +87,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
                  EnlargeWithAncilla: 'pink',
                  RemoveResetInZeroState: 'grey'}
 
-        filename = self._get_resource_path('current_style.dot')
+        filename = 'current_style.dot'
         self.pass_manager.draw(filename=filename, style=style, raw=True)
 
         self.assertFilesAreEqual(filename, path_to_diagram_reference('pass_manager_style.dot'))

--- a/test/python/visualization/test_pulse_visualization_output.py
+++ b/test/python/visualization/test_pulse_visualization_output.py
@@ -83,7 +83,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_parametric_pulse_schedule(self):
         """Test that parametric instructions/schedules can be drawn."""
-        filename = self._get_resource_path('current_parametric_matplotlib_ref.png')
+        filename = 'current_parametric_matplotlib_ref.png'
         schedule = Schedule(name='test_parametric')
         schedule += Play(library.Gaussian(duration=25, sigma=4, amp=0.5j), DriveChannel(0))
         pulse_drawer(schedule, filename=filename)
@@ -96,7 +96,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
         """Test that Play instructions can be drawn. The output should be the same as the
         parametric_pulse_schedule test.
         """
-        filename = self._get_resource_path('current_play_matplotlib_ref.png')
+        filename = 'current_play_matplotlib_ref.png'
         schedule = Schedule(name='test_parametric')
         schedule += Play(library.Gaussian(duration=25, sigma=4, amp=0.5j), DriveChannel(0))
         pulse_drawer(schedule, filename=filename)
@@ -108,7 +108,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_pulse_matplotlib_drawer(self):
-        filename = self._get_resource_path('current_pulse_matplotlib_ref.png')
+        filename = 'current_pulse_matplotlib_ref.png'
         pulse = self.sample_pulse()
         pulse_drawer(pulse, filename=filename)
         self.assertImagesAreEqual(filename, self.pulse_matplotlib_reference)
@@ -119,7 +119,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_instruction_matplotlib_drawer(self):
-        filename = self._get_resource_path('current_instruction_matplotlib_ref.png')
+        filename = 'current_instruction_matplotlib_ref.png'
         pulse_instruction = self.sample_instruction()
         pulse_drawer(pulse_instruction, filename=filename)
         self.assertImagesAreEqual(filename, self.instr_matplotlib_reference)
@@ -130,7 +130,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_schedule_matplotlib_drawer(self):
-        filename = self._get_resource_path('current_schedule_matplotlib_ref.png')
+        filename = 'current_schedule_matplotlib_ref.png'
         schedule = self.sample_schedule()
         pulse_drawer(schedule, filename=filename)
         self.assertImagesAreEqual(filename, self.schedule_matplotlib_reference)
@@ -141,7 +141,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_truncated_schedule_matplotlib_drawer(self):
-        filename = self._get_resource_path('current_truncated_schedule_matplotlib_ref.png')
+        filename = 'current_truncated_schedule_matplotlib_ref.png'
         schedule = self.sample_schedule()
         pulse_drawer(schedule, plot_range=(150, 300), filename=filename)
         self.assertImagesAreEqual(filename, self.trunc_sched_mpl_reference)
@@ -164,7 +164,7 @@ class TestPulseVisualizationImplementation(QiskitVisualizationTestCase):
     @unittest.skipIf(not HAS_MATPLOTLIB, 'matplotlib not available.')
     @unittest.skip('Useful for refactoring purposes, skipping by default.')
     def test_schedule_drawer_show_framechange(self):
-        filename = self._get_resource_path('current_show_framechange_ref.png')
+        filename = 'current_show_framechange_ref.png'
         gp0 = library.gaussian(duration=20, amp=1.0, sigma=1.0)
         sched = Schedule(name='test_schedule')
         sched = sched.append(Play(gp0, DriveChannel(0)))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously we were never explicitly testing the generation of an sdist
and whether we could build a package from that generated sdist. This
caught us by surprise in the 0.17.0 release because of an oversight
in #5941 we forgot to update the MANIFEST.in to include the new cython
source files which resulted in an sdist that could not be built. To
prevent potential issues like this in the future this commit modifies
one of the existing test jobs to explicitly generate an sdist and
install from that sdist instead of just pip installing the repo. This
will prevent such issues in the future.

### Details and comments