### PR TITLE
Remove redundant docstring in quantum_info.Kraus

### DIFF
--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -33,9 +33,6 @@ from qiskit.quantum_info.operators.mixins import generate_apidocs
 class Kraus(QuantumChannel):
     r"""Kraus representation of a quantum channel.
 
-    The Kraus representation for a quantum channel :math:`\mathcal{E}` is a
-    set of matrices :math:`[A_0,...,A_{K-1}]` such that
-
     For a quantum channel :math:`\mathcal{E}`, the Kraus representation is
     given by a set of matrices :math:`[A_0,...,A_{K-1}]` such that the
     evolution of a :class:`~qiskit.quantum_info.DensityMatrix`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #6144 

The documentation for quantum_info.Kraus had an incomplete and redundant statement: 'The Kraus representation for a quantum channel $\mathcal{E}$ is a set of matrices $[A_0, ... A_{K-1}]$ such that'. This line has been removed from the docstring, as the remaining documentation conveys the required information completely.

### Details and comments


