### PR TITLE
`assemble` preserves circuit name with a single `parameter_binds` parameter

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -443,12 +443,17 @@ def _expand_parameters(circuits, run_config):
                  'Parameter binds: {} ' +
                  'Circuit parameters: {}').format(all_bind_parameters, all_circuit_parameters))
 
-        circuits = [circuit.bind_parameters(binds)
-                    for circuit in circuits
-                    for binds in parameter_binds]
+        bound_circuits = []
+        for circuit in circuits:
+            if len(parameter_binds) == 1:
+                bound_circuit = circuit.bind_parameters(parameter_binds[0])
+                bound_circuit.name = circuit.name
+                bound_circuits.append(bound_circuit)
+            else:
+                bound_circuits += [circuit.bind_parameters(binds) for binds in parameter_binds]
 
         # All parameters have been expanded and bound, so remove from run_config
         run_config = copy.deepcopy(run_config)
         run_config.parameter_binds = []
 
-    return circuits, run_config
+    return bound_circuits, run_config

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -455,5 +455,6 @@ def _expand_parameters(circuits, run_config):
         # All parameters have been expanded and bound, so remove from run_config
         run_config = copy.deepcopy(run_config)
         run_config.parameter_binds = []
+        circuits = bound_circuits
 
-    return bound_circuits, run_config
+    return circuits, run_config

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -433,6 +433,20 @@ class TestCircuitAssembler(QiskitTestCase):
         self.assertEqual(_qobj_inst_params(7, 0), [1, 0, 0])
         self.assertEqual(_qobj_inst_params(8, 0), [2, 1, 0])
 
+
+    def test_6200(self):
+        """Test single parameter_binds should preserve the circuit name.
+        See https://github.com/Qiskit/qiskit-terra/issues/6200"""
+        x = Parameter('x')
+
+        circuit = QuantumCircuit(1, name='a_particular_name')
+        circuit.rx(x, 0)
+
+        qobj = assemble(circuit, parameter_binds=[{x: 1}])
+
+        self.assertEqual(len(qobj.experiments), 1)
+        self.assertEqual(qobj.experiments[0].header.name, 'a_particular_name')
+
     def test_init_qubits_default(self):
         """Check that the init_qubits=None assemble option is passed on to the qobj."""
         qobj = assemble(self.circ)

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -433,7 +433,6 @@ class TestCircuitAssembler(QiskitTestCase):
         self.assertEqual(_qobj_inst_params(7, 0), [1, 0, 0])
         self.assertEqual(_qobj_inst_params(8, 0), [2, 1, 0])
 
-
     def test_6200(self):
         """Test single parameter_binds should preserve the circuit name.
         See https://github.com/Qiskit/qiskit-terra/issues/6200"""


### PR DESCRIPTION
I think `bind_parameters` should preserve `circuit.name` in the returned copy of the circuit. However, that was not not decision when https://github.com/Qiskit/qiskit-terra/issues/5185 was fixed. Therefore, fixing this at `assemble` time. 

Fixes #6200