### PR TITLE
Remove useless _keys property from ParameterTable

### DIFF
--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -22,7 +22,7 @@ from .instruction import Instruction
 class ParameterTable(MutableMapping):
     """Class for managing and setting circuit parameters"""
 
-    __slots__ = ['_table', '_keys', '_names']
+    __slots__ = ['_table', '_names']
 
     def __init__(self, *args, **kwargs):
         """
@@ -30,7 +30,6 @@ class ParameterTable(MutableMapping):
            {var_object: [(instruction_object, parameter_index), ...]}
         """
         self._table = dict(*args, **kwargs)
-        self._keys = set(self._table)
         self._names = {x.name for x in self._table}
 
     def __getitem__(self, key):
@@ -49,7 +48,6 @@ class ParameterTable(MutableMapping):
             assert isinstance(instruction, Instruction)
             assert isinstance(param_index, int)
         self._table[parameter] = instr_params
-        self._keys.add(parameter)
         self._names.add(parameter.name)
 
     def get_keys(self):
@@ -58,7 +56,7 @@ class ParameterTable(MutableMapping):
         Returns:
             set: A set of all the keys in the parameter table
         """
-        return self._keys
+        return set(self._table)
 
     def get_names(self):
         """Return a set of all parameter names in the parameter table
@@ -70,7 +68,6 @@ class ParameterTable(MutableMapping):
 
     def __delitem__(self, key):
         del self._table[key]
-        self._keys.discard(key)
         self._names.discard(key.name)
 
     def __iter__(self):


### PR DESCRIPTION
`ParameterTable` maintains a `dict`, as well as a set of its keys. But, a `dict` maintains its own key list. This is redundant. This PR removes the property `_keys` from `ParameterTable`.
