### PR TITLE
Remove sphinx pin

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0
 seaborn>=0.9.0
 reno>=3.2.0
-Sphinx>=1.8.3,<3.1.0
+Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #4556 we pinned sphinx to workaround some CI failures related to new
warnings being emitted by sphinx with the release sphinx 3.1.0. Since
then there have been several releases of sphinx with new features and
more importantly several bug fixes, and the warnings previously being
emitted no longer seem to be an issue (at least for local builds on
python 3.8). This commit removes the pin so we can use the latest
version of sphinx in CI and locally.

### Details and comments