### PR TITLE
Prepare for renaming default branch to main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ jobs:
         - coveralls || true
         - coverage xml || true
         - pip install diff-cover || true
-        - diff-cover --compare-branch master coverage.xml || true
+        - diff-cover --compare-branch main coverage.xml || true
 
     # Randomized testing
     - name: Randomized tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,11 +323,11 @@ previous version in the release notes.
 
 ### Branches
 
-* `master`:
+* `main`:
 
-The master branch is used for development of the next version of qiskit-terra.
+The main branch is used for development of the next version of qiskit-terra.
 It will be updated frequently and should not be considered stable. The API
-can and will change on master as we introduce and refine new features.
+can and will change on main as we introduce and refine new features.
 
 * `stable/*` branches:
 Branches under `stable/*` are used to maintain released versions of qiskit-terra.
@@ -341,13 +341,13 @@ merged to it are bugfixes.
 When it is time to release a new minor version of qiskit-terra we will:
 
 1.  Create a new tag with the version number and push it to github
-2.  Change the `master` version to the next release version.
+2.  Change the `main` version to the next release version.
 
 The release automation processes will be triggered by the new tag and perform
 the following steps:
 
 1.  Create a stable branch for the new minor version from the release tag
-    on the `master` branch
+    on the `main` branch
 2.  Build and upload binary wheels to pypi
 3.  Create a github release page with a generated changelog
 4.  Generate a PR on the meta-repository to bump the terra version and

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
       - stable/*
   tags:
     include:

--- a/qiskit/test/testing_options.py
+++ b/qiskit/test/testing_options.py
@@ -85,7 +85,7 @@ def _is_ci_fork_pull_request():
 
     Returns:
         bool: True if the tests are executed inside a CI tool, and the changes
-            are not against the "master" branch.
+            are not against the "main" branch.
     """
     if os.getenv('TRAVIS'):
         # Using Travis CI.

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -45,7 +45,7 @@ def _minimal_ext_cmd(cmd):
 
 def git_version():
     """Get the current git head sha1."""
-    # Determine if we're at master
+    # Determine if we're at main
     try:
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
         git_revision = out.strip().decode('ascii')

--- a/tools/report_ci_failure.py
+++ b/tools/report_ci_failure.py
@@ -47,7 +47,7 @@ class CIFailureReporter:
                 build logs.
             job_name (str): name of the failed ci job.
         """
-        if branch != 'master' and not self.stable_branch_regex.search(branch):
+        if branch != 'main' and not self.stable_branch_regex.search(branch):
             return None
         key_label = self._key_label(branch, job_name)
         issue_number = self._get_report_issue_number(key_label)
@@ -61,8 +61,8 @@ class CIFailureReporter:
             return 'randomized test'
         elif job_name == 'Benchmarks':
             return 'benchmarks failing'
-        elif branch_name == 'master':
-            return 'master failing'
+        elif branch_name == 'main':
+            return 'main failing'
         elif branch_name.startswith('stable/'):
             return 'stable failing'
         else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the pending support being added to qiskit-bot in
Qiskit/qiskit-bot#9 we're able to rename the default branch for the
repository to 'main'. However, when we do that several things will need
to be updated, most importantly the CI trigger was hardcoded to the
previous default branch 'master. This commit fixes these references and
should be merged after we rename the branch to re-enable CI.

### Details and comments