### PR TITLE
Cleanup stestr caching to only what's necessary

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -325,7 +325,7 @@ stages:
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
-            ls | grep -P "^\d" | xargs -n1 rm -f
+            ls | grep -e '^[[:digit:]]' | xargs -n1 rm -f
             popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
@@ -652,7 +652,7 @@ stages:
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
-            ls | grep -P "^\d" | xargs -n1 rm -f
+            ls | grep -e '^[[:digit:]]' | xargs -n1 rm -f
             popd
           condition: succeededOrFailed()
           displayName: 'Generate results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,6 +148,7 @@ stages:
               pip | "$(Agent.OS)"
               pip
             path: $(PIP_CACHE_DIR)
+          displayName: Cache pip
         - task: Cache@2
           inputs:
             key: 'stestr | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
@@ -156,7 +157,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
-          displayName: Cache pip
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -203,6 +204,9 @@ stages:
             stestr last --subunit | ./subunit_to_junit.py -o junit/test-results.xml
             popd
             cp -r /tmp/terra-tests/junit .
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd .stestr
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2
@@ -283,6 +287,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -319,6 +324,9 @@ stages:
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2
@@ -348,6 +356,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -389,6 +398,9 @@ stages:
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd
           condition: succeededOrFailed()
           env:
             LANG: 'C.UTF-8'
@@ -428,6 +440,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -469,6 +482,9 @@ stages:
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd .stestr
           condition: succeededOrFailed()
           env:
             LANG: 'C.UTF-8'
@@ -515,6 +531,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -552,6 +569,9 @@ stages:
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd .stestr
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2
@@ -595,6 +615,7 @@ stages:
               stestr | "$(Agent.OS)"
               stestr
             path: .stestr
+          displayName: Cache stestr
         - bash: |
             set -e
             python -m pip install --upgrade pip setuptools wheel virtualenv
@@ -610,7 +631,7 @@ stages:
             source test-job/bin/activate
             export PYTHONHASHSEED=$(python -S -c "import random; print(random.randint(1, 4294967295))")
             echo "PYTHONHASHSEED=$PYTHONHASHSEED"
-            stestr run --concurrency 2
+            stestr run
           displayName: 'Run tests'
         - task: CopyFiles@2
           condition: failed()
@@ -630,6 +651,9 @@ stages:
             pip install -U junitxml
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
+            pushd .stestr
+            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            popd .stestr
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -325,7 +325,7 @@ stages:
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
-            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            ls | grep -P "^\d" | xargs -n1 rm -f
             popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
@@ -652,7 +652,7 @@ stages:
             mkdir -p junit
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
-            ls | grep -P "^\d" | xargs -d "\n" rm -f
+            ls | grep -P "^\d" | xargs -n1 rm -f
             popd
           condition: succeededOrFailed()
           displayName: 'Generate results'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,7 @@ stages:
             cp -r /tmp/terra-tests/junit .
             pushd .stestr
             ls | grep -P "^\d" | xargs -d "\n" rm -f
-            popd .stestr
+            popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2
@@ -484,7 +484,7 @@ stages:
             stestr last --subunit | python tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
             ls | grep -P "^\d" | xargs -d "\n" rm -f
-            popd .stestr
+            popd
           condition: succeededOrFailed()
           env:
             LANG: 'C.UTF-8'
@@ -571,7 +571,7 @@ stages:
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
             ls | grep -P "^\d" | xargs -d "\n" rm -f
-            popd .stestr
+            popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2
@@ -653,7 +653,7 @@ stages:
             stestr last --subunit | tools/subunit_to_junit.py -o junit/test-results.xml
             pushd .stestr
             ls | grep -P "^\d" | xargs -d "\n" rm -f
-            popd .stestr
+            popd
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

stestr maintains a local repository of run history which is used for
both local debugging (like for automated bisecting of failures between
runs) and also to provide data for parallel test scheduling based on the
the previous run time. In #5451 we added a cache step to the azure ci
configuration to cache the .stestr directory (the default location of
the stestr local repository) to preserve the run history to improve
parallel test scheduling to try and improve throughput. This however had
the unintended side effect of growing the stestr repository directory
significantly. Right now the stestr cache is several gigabytes in size.
This is because stestr will keep a history of all the runs in that
directory and by preserving it in a cache it's growing every time we
commit to the branch. However since we're only concerned with the timing
data we don't need the result streams for the runs to be preserved. This
commit adds a step to the CI jobs before we update the cache to remove
the results streams (which are just integer filenames in the repository
directory) and leave the dbm database of timing data. This will
significantly reduce the size of the data to cache, and also will limit
cache size growth to be a function of the number of tests in the suite
vs the number of runs in CI.

### Details and comments

In a future stestr release there will be a command we can run to do this
for us (see mtreinish/stestr#306) but until that is released this commit
just manually deletes all the unecessary files prior to updating the
cache.
