### PR TITLE
Make computation of bound for phase estimation more efficient

### DIFF
--- a/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
@@ -137,5 +137,5 @@ class PhaseEstimationScale():
                 '`pauli_sum` must be a sum of Pauli operators. Got primitives {}.'.format(
                     pauli_sum.primitive_strings()))
 
-        bound = sum([abs(pauli_sum.coeff * pauli.coeff) for pauli in pauli_sum])
+        bound = abs(pauli_sum.coeff) * sum(abs(pauli.coeff) for pauli in pauli_sum)
         return PhaseEstimationScale(bound)


### PR DESCRIPTION
This makes the computation of the eigenvalue bound  for Hamiltonian phase estimation slightly more efficient.
* Factors a factor out of a sum
* Avoid construction of a list