### PR TITLE
Fix type hints for AmplificationProblem

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
+++ b/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
@@ -58,7 +58,7 @@ class AmplificationProblem:
         self._is_good_state = is_good_state
 
     @property
-    def oracle(self) -> QuantumCircuit:
+    def oracle(self) -> Union[QuantumCircuit, Statevector]:
         """Return the oracle.
 
         Returns:
@@ -67,7 +67,7 @@ class AmplificationProblem:
         return self._oracle
 
     @oracle.setter
-    def oracle(self, oracle: QuantumCircuit) -> None:
+    def oracle(self, oracle: Union[QuantumCircuit, Statevector]) -> None:
         """Set the oracle.
 
         Args:

--- a/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
+++ b/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
@@ -28,12 +28,13 @@ class AmplificationProblem:
     """
 
     def __init__(self,
-                 oracle: QuantumCircuit,
+                 oracle: Union[QuantumCircuit, Statevector],
                  state_preparation: Optional[QuantumCircuit] = None,
                  grover_operator: Optional[QuantumCircuit] = None,
                  post_processing: Optional[Callable[[str], Any]] = None,
                  objective_qubits: Optional[Union[int, List[int]]] = None,
-                 is_good_state: Optional[Callable[[str], bool]] = None,
+                 is_good_state: Optional[Union[
+                     Callable[[str], bool], List[int], List[str], Statevector]] = None,
                  ) -> None:
         r"""
         Args:
@@ -145,7 +146,7 @@ class AmplificationProblem:
         self._objective_qubits = objective_qubits
 
     @property
-    def is_good_state(self) -> Callable[[str], float]:
+    def is_good_state(self) -> Callable[[str], bool]:
         """Check whether a provided bitstring is a good state or not.
 
         Returns:

--- a/test/python/algorithms/test_grover.py
+++ b/test/python/algorithms/test_grover.py
@@ -52,17 +52,19 @@ class TestAmplificationProblem(QiskitAlgorithmsTestCase):
 
         self.assertEqual(Operator(expected), Operator(problem.grover_operator))
 
-    @data('list', 'statevector', 'callable')
+    @data('list_str', 'list_int', 'statevector', 'callable')
     def test_is_good_state(self, kind):
         """Test is_good_state works on different input types."""
-        if kind == 'list':
-            is_good_state = ['00', '11']
+        if kind == 'list_str':
+            is_good_state = ['01', '11']
+        elif kind == 'list_int':
+            is_good_state = [1]    # means bitstr[1] == '1'
         elif kind == 'statevector':
-            is_good_state = Statevector(np.array([1, 0, 0, 1]) / np.sqrt(2))
+            is_good_state = Statevector(np.array([0, 1, 0, 1]) / np.sqrt(2))
         else:
             def is_good_state(bitstr):
-                # same as ``bitstr in ['00', '11']``
-                return sum(int(bit) for bit in bitstr) % 2 == 0
+                # same as ``bitstr in ['01', '11']``
+                return bitstr[1] == '1'
 
         possible_states = [''.join(list(map(str, item)))
                            for item in itertools.product([0, 1], repeat=2)]
@@ -70,7 +72,7 @@ class TestAmplificationProblem(QiskitAlgorithmsTestCase):
         oracle = QuantumCircuit(2)
         problem = AmplificationProblem(oracle, is_good_state=is_good_state)
 
-        expected = [state in ['00', '11'] for state in possible_states]
+        expected = [state in ['01', '11'] for state in possible_states]
         # pylint: disable=not-callable
         actual = [problem.is_good_state(state) for state in possible_states]
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix type hints for AmplificationProblem, and revise the test case accordingly.

### Details and comments

Fit the type hint for the oracle parameter of the constructor of the AmplificationProblem class, according to the corresponding parameter of the GroverOperator class and to the code to instantiate the class in test_grover.py

FIx the type hint for the is_good_state parameter of the constructor of the AmplificationProblem class, according to the corresponding property method which handles four different types. 

Revise the test for the property method in test_grover.py, so that it exercises all the four types.  This led me to change the good state used in the test to keep the one-state-for-all "principle".

