### PR TITLE
[WIP] Change attribute `most_likely_phase` to `phase` in PhaseEstimator

### DIFF
--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
@@ -14,6 +14,7 @@
 
 
 from typing import Dict, Union, cast
+from qiskit.utils.deprecation import deprecate_function
 from qiskit.algorithms.algorithm_result import AlgorithmResult
 from .phase_estimation_result import PhaseEstimationResult
 from .phase_estimation_scale import PhaseEstimationScale
@@ -80,6 +81,17 @@ class HamiltonianPhaseEstimationResult(AlgorithmResult):
                                                                         self._id_coefficient))
         else:
             return cast(Dict, phases)
+
+    @property
+    @deprecate_function('The HamiltonianPhaseEstimationResult.most_likely_phase attribute '
+                        'is deprecated. Use the phase attribute.')
+    def most_likely_phase(self) -> float:
+        """DEPRECATED - The most likely phase of the unitary corresponding to the Hamiltonian.
+
+        Returns:
+            The most likely phase.
+        """
+        return self.phase
 
     @property
     def phase(self) -> float:

--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
@@ -83,9 +83,9 @@ class HamiltonianPhaseEstimationResult(AlgorithmResult):
             return cast(Dict, phases)
 
     @property
-    @deprecate_function("The 'HamiltonianPhaseEstimationResult.most_likely_phase' attribute "
-                        "is deprecated as of 0.18.0 and will be removed no earlier than 3 months "
-                        "after the release date. It has been renamed as the 'phase' attribute.")
+    @deprecate_function("""The 'HamiltonianPhaseEstimationResult.most_likely_phase' attribute
+                        is deprecated as of 0.18.0 and will be removed no earlier than 3 months
+                        after the release date. It has been renamed as the 'phase' attribute.""")
     def most_likely_phase(self) -> float:
         """DEPRECATED - The most likely phase of the unitary corresponding to the Hamiltonian.
 

--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
@@ -82,13 +82,13 @@ class HamiltonianPhaseEstimationResult(AlgorithmResult):
             return cast(Dict, phases)
 
     @property
-    def most_likely_phase(self) -> float:
+    def phase(self) -> float:
         """The most likely phase of the unitary corresponding to the Hamiltonian.
 
         Returns:
             The most likely phase.
         """
-        return self._phase_estimation_result.most_likely_phase
+        return self._phase_estimation_result.phase
 
     @property
     def most_likely_eigenvalue(self) -> float:
@@ -100,5 +100,5 @@ class HamiltonianPhaseEstimationResult(AlgorithmResult):
         Returns:
             The most likely eigenvalue of the Hamiltonian.
         """
-        phase = self._phase_estimation_result.most_likely_phase
+        phase = self.phase
         return self._phase_estimation_scale.scale_phase(phase, self._id_coefficient)

--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation_result.py
@@ -83,8 +83,9 @@ class HamiltonianPhaseEstimationResult(AlgorithmResult):
             return cast(Dict, phases)
 
     @property
-    @deprecate_function('The HamiltonianPhaseEstimationResult.most_likely_phase attribute '
-                        'is deprecated. Use the phase attribute.')
+    @deprecate_function("The 'HamiltonianPhaseEstimationResult.most_likely_phase' attribute "
+                        "is deprecated as of 0.18.0 and will be removed no earlier than 3 months "
+                        "after the release date. It has been renamed as the 'phase' attribute.")
     def most_likely_phase(self) -> float:
         """DEPRECATED - The most likely phase of the unitary corresponding to the Hamiltonian.
 

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -65,8 +65,9 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         return self._circuit_result
 
     @property
-    @deprecate_function('The PhaseEstimationResult.most_likely_phase attribute is deprecated. '
-                        'Use the phase attribute.')
+    @deprecate_function("The 'PhaseEstimationResult.most_likely_phase' attribute "
+                        "is deprecated as of 0.18.0 and will be removed no earlier than 3 months "
+                        "after the release date. It has been renamed as the 'phase' attribute.")
     def most_likely_phase(self) -> float:
         r"""DEPRECATED - Return the most likely phase as a number in :math:`[0.0, 1.0)`.
 

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -21,10 +21,13 @@ from .phase_estimator import PhaseEstimatorResult
 class PhaseEstimationResult(PhaseEstimatorResult):
     """Store and manipulate results from running `PhaseEstimation`.
 
-    This class is instantiated by the `PhaseEstimation` class, not via user code.
-    The `PhaseEstimation` class generates a list of phases and corresponding weights. Upon
+    This class is instantiated by the ``PhaseEstimation`` class, not via user code.
+    The ``PhaseEstimation`` class generates a list of phases and corresponding weights. Upon
     completion it returns the results as an instance of this class. The main method for
     accessing the results is `filter_phases`.
+
+    The canonical phase satisfying the ``PhaseEstimator`` interface, returned by the
+    attribute `phase`, is the most likely phase.
     """
 
     def __init__(self, num_evaluation_qubits: int,
@@ -60,12 +63,11 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         return self._circuit_result
 
     @property
-    def most_likely_phase(self) -> float:
-        r"""Return the estimated phase as a number in :math:`[0.0, 1.0)`.
+    def phase(self) -> float:
+        r"""Return the most likely phase as a number in :math:`[0.0, 1.0)`.
 
-        1.0 corresponds to a phase of :math:`2\pi`. It is assumed that the input vector is an
-        eigenvector of the unitary so that the peak of the probability density occurs at the bit
-        string that most closely approximates the true phase.
+        1.0 corresponds to a phase of :math:`2\pi`. This selects the phase corresponding
+        to the bit string with the highesest probability. This is the most likely phase.
         """
         if isinstance(self.phases, dict):
             binary_phase_string = max(self.phases, key=self.phases.get)

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -14,6 +14,8 @@
 
 from typing import Dict, Union
 import numpy
+
+from qiskit.utils.deprecation import deprecate_function
 from qiskit.result import Result
 from .phase_estimator import PhaseEstimatorResult
 
@@ -61,6 +63,17 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         This is useful for inspecting and troubleshooting the QPE algorithm.
         """
         return self._circuit_result
+
+    @property
+    @deprecate_function('The PhaseEstimationResult.most_likely_phase attribute is deprecated. '
+                        'Use the phase attribute.')
+    def most_likely_phase(self) -> float:
+        r"""DEPRECATED - Return the most likely phase as a number in :math:`[0.0, 1.0)`.
+
+        1.0 corresponds to a phase of :math:`2\pi`. This selects the phase corresponding
+        to the bit string with the highesest probability. This is the most likely phase.
+        """
+        return self.phase
 
     @property
     def phase(self) -> float:

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -65,9 +65,9 @@ class PhaseEstimationResult(PhaseEstimatorResult):
         return self._circuit_result
 
     @property
-    @deprecate_function("The 'PhaseEstimationResult.most_likely_phase' attribute "
-                        "is deprecated as of 0.18.0 and will be removed no earlier than 3 months "
-                        "after the release date. It has been renamed as the 'phase' attribute.")
+    @deprecate_function("""The 'PhaseEstimationResult.most_likely_phase' attribute
+                        is deprecated as of 0.18.0 and will be removed no earlier than 3 months
+                        after the release date. It has been renamed as the 'phase' attribute.""")
     def most_likely_phase(self) -> float:
         r"""DEPRECATED - Return the most likely phase as a number in :math:`[0.0, 1.0)`.
 

--- a/qiskit/algorithms/phase_estimators/phase_estimator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimator.py
@@ -21,9 +21,12 @@ from qiskit.algorithms.algorithm_result import AlgorithmResult
 class PhaseEstimator(ABC):
     """The Phase Estimator interface.
 
-    Algorithms that can compute a phase for a unitary operator and
-    initial state may implement this interface to allow different
-    algorithms to be used interchangeably.
+    Algorithms that can compute a phase for a unitary operator and initial state may implement this
+    interface to allow different algorithms to be used interchangeably.
+
+    The phase returned is a canonical phase determined by the specific algorithm, such as the most
+    likely phase. In addition, the algorithm may provide an interface to retrieve phases by other
+    criteria.
     """
 
     @abstractmethod
@@ -40,11 +43,11 @@ class PhaseEstimatorResult(AlgorithmResult):
     """Phase Estimator Result."""
 
     @abstractproperty
-    def most_likely_phase(self) -> float:
+    def phase(self) -> float:
         r"""Return the estimated phase as a number in :math:`[0.0, 1.0)`.
 
-        1.0 corresponds to a phase of :math:`2\pi`. It is assumed that the input vector is an
-        eigenvector of the unitary so that the peak of the probability density occurs at the bit
-        string that most closely approximates the true phase.
+        1.0 corresponds to a phase of :math:`2\pi`. In case the phase estimation algorithm
+        computes more than one phase, this attribute returns a canonical single phase; for
+        example, the most likely phase.
         """
         raise NotImplementedError

--- a/test/python/algorithms/test_phase_estimator.py
+++ b/test/python/algorithms/test_phase_estimator.py
@@ -99,7 +99,7 @@ class TestHamiltonianPhaseEstimation(QiskitAlgorithmsTestCase):
         with self.subTest('Most likely eigenvalues'):
             self.assertAlmostEqual(result.most_likely_eigenvalue, -1.855, delta=.001)
         with self.subTest('Most likely phase'):
-            self.assertAlmostEqual(result.most_likely_phase, 0.5937, delta=.001)
+            self.assertAlmostEqual(result.phase, 0.5937, delta=.001)
         with self.subTest('All eigenvalues'):
             phase_dict = result.filter_phases(0.1)
             phases = list(phase_dict.keys())
@@ -177,7 +177,7 @@ class TestPhaseEstimation(QiskitAlgorithmsTestCase):
                                 quantum_instance=qi)
         result = p_est.estimate(unitary=unitary_circuit,
                                 state_preparation=state_preparation)
-        phase = result.most_likely_phase
+        phase = result.phase
         return phase
 
     @data('qasm_simulator', 'statevector_simulator')


### PR DESCRIPTION
IterativePhaseEstimation #6096 will satisfy the PhaseEstimator interface.
However, the property for retrieving the phase is currently
`PhaseEstimator.most_likely_phase`, which is too specific to accomodate
IterativePhaseEstimation, which only computes a single phase in any
case. This PR renames this property to `phase`, and leaves the
definition of `phase` to the specific implementation.

This PR currently does not include a deprecated version of the previous attribute `most_likely_phase`. Perhaps it should.
