### PR TITLE
Don't remove swaps with conditions in OptimizeSwapBeforeMeasure

### DIFF
--- a/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_scale.py
@@ -137,5 +137,5 @@ class PhaseEstimationScale():
                 '`pauli_sum` must be a sum of Pauli operators. Got primitives {}.'.format(
                     pauli_sum.primitive_strings()))
 
-        bound = sum([abs(pauli_sum.coeff * pauli.coeff) for pauli in pauli_sum])
+        bound = abs(pauli_sum.coeff) * sum(abs(pauli.coeff) for pauli in pauli_sum)
         return PhaseEstimationScale(bound)

--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -37,6 +37,8 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
         """
         swaps = dag.op_nodes(SwapGate)
         for swap in swaps[::-1]:
+            if swap.op.condition is not None:
+                continue
             final_successor = []
             for successor in dag.successors(swap):
                 final_successor.append(successor.type == 'out' or (successor.type == 'op' and

--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -41,8 +41,9 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
                 continue
             final_successor = []
             for successor in dag.successors(swap):
-                final_successor.append(successor.type == 'out' or (successor.type == 'op' and
-                                                                   successor.op.name == 'measure'))
+                final_successor.append(successor.type == 'out' or
+                                       (successor.type == 'op' and
+                                        isinstance(successor.op, Measure)))
             if all(final_successor):
                 # the node swap needs to be removed and, if a measure follows, needs to be adapted
                 swap_qargs = swap.qargs

--- a/releasenotes/notes/optimize-swap-condition-a8ac54e6cb3d9ba4.yaml
+++ b/releasenotes/notes/optimize-swap-condition-a8ac54e6cb3d9ba4.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Previously when :class:`~qiskit.transpiler.OptimizeSwapBeforeMeasure' was run,
+    Previously when :class:`~qiskit.transpiler.OptimizeSwapBeforeMeasure` was run,
     a swap gate that contained a condition could be removed in some cases. This
     fix prevents swaps with conditions from being removed.

--- a/releasenotes/notes/optimize-swap-condition-a8ac54e6cb3d9ba4.yaml
+++ b/releasenotes/notes/optimize-swap-condition-a8ac54e6cb3d9ba4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Previously when :class:`~qiskit.transpiler.OptimizeSwapBeforeMeasure' was run,
+    a swap gate that contained a condition could be removed in some cases. This
+    fix prevents swaps with conditions from being removed.

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -218,6 +218,30 @@ class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
 
         self.assertEqual(expected, after)
 
+    def test_no_optimize_swap_with_condition(self):
+        """ Do not remove swap if it has a condition
+            qr0:--X--m--       qr0:--X--m--
+                  |  |               |  |
+            qr1:--X--|--  ==>  qr1:--X--|--
+                  |  |               |  |
+            cr0:--1--.--       cr0:--1--.--
+        """
+        qr = QuantumRegister(2, 'qr')
+        cr = ClassicalRegister(1, 'cr')
+        circuit = QuantumCircuit(qr, cr)
+        circuit.swap(qr[0], qr[1]).c_if(cr, 1)
+        circuit.measure(qr[0], cr[0])
+        dag = circuit_to_dag(circuit)
+
+        expected = QuantumCircuit(qr, cr)
+        expected.swap(qr[0], qr[1]).c_if(cr, 1)
+        expected.measure(qr[0], cr[0])
+
+        pass_ = OptimizeSwapBeforeMeasure()
+        after = pass_.run(dag)
+
+        self.assertEqual(circuit_to_dag(expected), after)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6192

### Details and comments

If a `SwapGate `has a condition on it, this PR will not remove that swap or change the `Measure `when running `OptimizeSwapBeforeMeasure`.
