### PR TITLE
Bugfix in clifford instruction name

### DIFF
--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -72,12 +72,12 @@ def decompose_clifford(clifford, method=None):
 def decompose_clifford_bm(clifford):
     """Decompose a clifford"""
     num_qubits = clifford.num_qubits
+    clifford_name = str(clifford)
 
     if num_qubits == 1:
         return _decompose_clifford_1q(
             clifford.table.array, clifford.table.phase)
 
-    ret_circ = QuantumCircuit(num_qubits, name=str(clifford))
     # Inverse of final decomposed circuit
     inv_circuit = QuantumCircuit(num_qubits, name='inv_circ')
 
@@ -89,7 +89,7 @@ def decompose_clifford_bm(clifford):
         clifford, inv_circuit, cost = _reduce_cost(clifford, inv_circuit, cost)
 
     # Decompose the remaining product of 1-qubit cliffords
-
+    ret_circ = QuantumCircuit(num_qubits, name=clifford_name)
     for qubit in range(num_qubits):
         pos = [qubit, qubit + num_qubits]
         table = clifford.table.array[pos][:, pos]

--- a/qiskit/quantum_info/synthesis/clifford_decompose.py
+++ b/qiskit/quantum_info/synthesis/clifford_decompose.py
@@ -77,6 +77,7 @@ def decompose_clifford_bm(clifford):
         return _decompose_clifford_1q(
             clifford.table.array, clifford.table.phase)
 
+    ret_circ = QuantumCircuit(num_qubits, name=str(clifford))
     # Inverse of final decomposed circuit
     inv_circuit = QuantumCircuit(num_qubits, name='inv_circ')
 
@@ -88,7 +89,7 @@ def decompose_clifford_bm(clifford):
         clifford, inv_circuit, cost = _reduce_cost(clifford, inv_circuit, cost)
 
     # Decompose the remaining product of 1-qubit cliffords
-    ret_circ = QuantumCircuit(num_qubits, name=str(clifford))
+
     for qubit in range(num_qubits):
         pos = [qubit, qubit + num_qubits]
         table = clifford.table.array[pos][:, pos]

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -29,7 +29,7 @@ from qiskit.quantum_info.operators import Clifford, Operator
 from qiskit.quantum_info.operators.symplectic.clifford_circuits import _append_circuit
 from qiskit.quantum_info.synthesis.clifford_decompose import (
     decompose_clifford_ag, decompose_clifford_bm, decompose_clifford_greedy)
-
+from qiskit.quantum_info import random_clifford
 
 class VGate(Gate):
     """V Gate used in Clifford synthesis."""

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -813,6 +813,12 @@ class TestCliffordOperators(QiskitTestCase):
         target = CI.tensor(CX).tensor(CY).tensor(CZ).tensor(CH).tensor(CS)
         self.assertEqual(Clifford.from_label(label), target)
 
+    def test_instruction_name(self):
+        """Test to verify the correct clifford name is maintained
+        after converting to instruction"""
+        clifford = random_clifford(2, seed=777)
+        self.assertEqual(clifford.to_instruction().name, str(clifford))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -31,6 +31,7 @@ from qiskit.quantum_info.synthesis.clifford_decompose import (
     decompose_clifford_ag, decompose_clifford_bm, decompose_clifford_greedy)
 from qiskit.quantum_info import random_clifford
 
+
 class VGate(Gate):
     """V Gate used in Clifford synthesis."""
     def __init__(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes a small bug in clifford instruction naming, caused by `def decompose_clifford_` simplifying the giving clifford, changing its name in the process, before using the name for the resulting instruction. This results in correct behavior but wrong naming. 


### Details and comments


