### PR TITLE
Add macos universal2 wheel job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,11 @@ pr:
 
 stages:
   - stage: 'Wheel_Builds'
-    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:
     - job: 'linux'
       pool: {vmImage: 'Ubuntu-16.04'}
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         python.version: '3.7'
         CIBW_BEFORE_BUILD: pip install -U Cython
@@ -42,32 +42,32 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-        - bash: |
-            twine upload wheelhouse/*
-          env:
-            TWINE_PASSWORD: $(TWINE_PASSWORD)
-    - job: 'sdist'
-      pool: {vmImage: 'Ubuntu-16.04'}
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-      variables:
-        TWINE_USERNAME: qiskit
-        python.version: '3.7'
-      steps:
-        - task: UsePythonVersion@0
-        - bash: |
-            set -e
-            python -m pip install --upgrade pip
-            pip install -U twine
-            python setup.py sdist
-        - task: PublishBuildArtifacts@1
-          inputs: {pathtoPublish: 'dist'}
-          condition: succeededOrFailed()
-        - bash: |
-            twine upload dist/*
-          env:
-            TWINE_PASSWORD: $(TWINE_PASSWORD)
+#        - bash: |
+#            twine upload wheelhouse/*
+#          env:
+#            TWINE_PASSWORD: $(TWINE_PASSWORD)
+#    - job: 'sdist'
+#      pool: {vmImage: 'Ubuntu-16.04'}
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      variables:
+#        TWINE_USERNAME: qiskit
+#        python.version: '3.7'
+#      steps:
+#        - task: UsePythonVersion@0
+#        - bash: |
+#            set -e
+#            python -m pip install --upgrade pip
+#            pip install -U twine
+#            python setup.py sdist
+#        - task: PublishBuildArtifacts@1
+#          inputs: {pathtoPublish: 'dist'}
+#          condition: succeededOrFailed()
+#        - bash: |
+#            twine upload dist/*
+#          env:
+#            TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos'
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       pool: {vmImage: 'macOS-latest'}
       variables:
         python.version: '3.7'
@@ -86,12 +86,12 @@ stages:
       - task: PublishBuildArtifacts@1
         inputs: {pathtoPublish: 'wheelhouse'}
         condition: succeededOrFailed()
-      - bash: |
-          twine upload wheelhouse/*
-        env:
-          TWINE_PASSWORD: $(TWINE_PASSWORD)
+#      - bash: |
+#          twine upload wheelhouse/*
+#        env:
+#          TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos-arm'
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       pool: {vmImage: 'macOS-latest'}
       variables:
         python.version: '3.7'
@@ -111,13 +111,13 @@ stages:
       - task: PublishBuildArtifacts@1
         inputs: {pathtoPublish: 'wheelhouse'}
         condition: succeededOrFailed()
-      - bash: |
-          twine upload wheelhouse/*
-        env:
-          TWINE_PASSWORD: $(TWINE_PASSWORD)
+#      - bash: |
+#          twine upload wheelhouse/*
+#        env:
+#          TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows'
       pool: {vmImage: 'vs2017-win2016'}
-      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         CIBW_BEFORE_BUILD: pip install -U Cython
         CIBW_SKIP: cp27-* cp34-* cp35-* pp*
@@ -143,10 +143,10 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-        - script: |
-            twine upload wheelhouse\*
-          env:
-            TWINE_PASSWORD: $(TWINE_PASSWORD)
+#        - script: |
+#            twine upload wheelhouse\*
+#          env:
+#            TWINE_PASSWORD: $(TWINE_PASSWORD)
   - stage: 'Lint_and_Tests'
     dependsOn: []
     jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ stages:
 #          twine upload wheelhouse/*
 #        env:
 #          TWINE_PASSWORD: $(TWINE_PASSWORD)
-    - job: 'macos-arm'
+    - job: 'macos_arm'
 #      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       pool: {vmImage: 'macOS-latest'}
       variables:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ stages:
         - bash: |
             set -e
             python -m pip install --upgrade pip
-            pip install cibuildwheel==1.7.1
+            pip install cibuildwheel==1.10.0
             pip install -U twine
             cibuildwheel --output-dir wheelhouse .
         - task: PublishBuildArtifacts@1
@@ -80,7 +80,32 @@ stages:
       - bash: |
           set -e
           python -m pip install --upgrade pip
-          pip install cibuildwheel==1.7.1
+          pip install cibuildwheel==1.10.0
+          pip install -U twine
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishBuildArtifacts@1
+        inputs: {pathtoPublish: 'wheelhouse'}
+        condition: succeededOrFailed()
+      - bash: |
+          twine upload wheelhouse/*
+        env:
+          TWINE_PASSWORD: $(TWINE_PASSWORD)
+    - job: 'macos-arm'
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      pool: {vmImage: 'macOS-latest'}
+      variables:
+        python.version: '3.7'
+        CIBW_BEFORE_BUILD: pip install -U Cython
+        CIBW_SKIP: cp27-* cp34-* cp35-* pp*
+        CIBW_ARCHS_MACOS: universal2
+        TWINE_USERNAME: qiskit
+        CIBW_TEST_COMMAND: python {project}/examples/python/stochastic_swap.py
+      steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          set -e
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==1.10.0
           pip install -U twine
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
@@ -112,7 +137,7 @@ stages:
         - bash: |
             set -e
             python -m pip install --upgrade pip
-            pip install cibuildwheel==1.7.1
+            pip install cibuildwheel==1.10.0
             pip install -U twine
             cibuildwheel --output-dir wheelhouse
         - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,11 @@ pr:
 
 stages:
   - stage: 'Wheel_Builds'
-#    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+    condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     jobs:
     - job: 'linux'
       pool: {vmImage: 'Ubuntu-16.04'}
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         python.version: '3.7'
         CIBW_BEFORE_BUILD: pip install -U Cython
@@ -42,32 +42,32 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-#        - bash: |
-#            twine upload wheelhouse/*
-#          env:
-#            TWINE_PASSWORD: $(TWINE_PASSWORD)
-#    - job: 'sdist'
-#      pool: {vmImage: 'Ubuntu-16.04'}
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-#      variables:
-#        TWINE_USERNAME: qiskit
-#        python.version: '3.7'
-#      steps:
-#        - task: UsePythonVersion@0
-#        - bash: |
-#            set -e
-#            python -m pip install --upgrade pip
-#            pip install -U twine
-#            python setup.py sdist
-#        - task: PublishBuildArtifacts@1
-#          inputs: {pathtoPublish: 'dist'}
-#          condition: succeededOrFailed()
-#        - bash: |
-#            twine upload dist/*
-#          env:
-#            TWINE_PASSWORD: $(TWINE_PASSWORD)
+        - bash: |
+            twine upload wheelhouse/*
+          env:
+            TWINE_PASSWORD: $(TWINE_PASSWORD)
+    - job: 'sdist'
+      pool: {vmImage: 'Ubuntu-16.04'}
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      variables:
+        TWINE_USERNAME: qiskit
+        python.version: '3.7'
+      steps:
+        - task: UsePythonVersion@0
+        - bash: |
+            set -e
+            python -m pip install --upgrade pip
+            pip install -U twine
+            python setup.py sdist
+        - task: PublishBuildArtifacts@1
+          inputs: {pathtoPublish: 'dist'}
+          condition: succeededOrFailed()
+        - bash: |
+            twine upload dist/*
+          env:
+            TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos'
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       pool: {vmImage: 'macOS-latest'}
       variables:
         python.version: '3.7'
@@ -86,12 +86,12 @@ stages:
       - task: PublishBuildArtifacts@1
         inputs: {pathtoPublish: 'wheelhouse'}
         condition: succeededOrFailed()
-#      - bash: |
-#          twine upload wheelhouse/*
-#        env:
-#          TWINE_PASSWORD: $(TWINE_PASSWORD)
+      - bash: |
+          twine upload wheelhouse/*
+        env:
+          TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos_arm'
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       pool: {vmImage: 'macOS-latest'}
       variables:
         python.version: '3.7'
@@ -111,13 +111,13 @@ stages:
       - task: PublishBuildArtifacts@1
         inputs: {pathtoPublish: 'wheelhouse'}
         condition: succeededOrFailed()
-#      - bash: |
-#          twine upload wheelhouse/*
-#        env:
-#          TWINE_PASSWORD: $(TWINE_PASSWORD)
+      - bash: |
+          twine upload wheelhouse/*
+        env:
+          TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows'
       pool: {vmImage: 'vs2017-win2016'}
-#      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
+      condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         CIBW_BEFORE_BUILD: pip install -U Cython
         CIBW_SKIP: cp27-* cp34-* cp35-* pp*
@@ -143,10 +143,10 @@ stages:
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'wheelhouse'}
           condition: succeededOrFailed()
-#        - script: |
-#            twine upload wheelhouse\*
-#          env:
-#            TWINE_PASSWORD: $(TWINE_PASSWORD)
+        - script: |
+            twine upload wheelhouse\*
+          env:
+            TWINE_PASSWORD: $(TWINE_PASSWORD)
   - stage: 'Lint_and_Tests'
     dependsOn: []
     jobs:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new wheel job for building universal2 wheels for
macOS. The universal2 wheels will enable running on arm64 macOS systems.
As we don't have any arm64 mac hardware available in CI systems yet
these jobs are cross-compiling arm64 binaries from an x86_64 mac, we
also can't test the arm64 binary component as part of the job because of
this.

This commit also takes the opportunity to update the cibuildwheel
version used for CI to the latest release 1.10.0, since we need to 
use >=1.9.0 for arm on macOS support.

### Details and comments

Related to Qiskit/qiskit#1201