### PR TITLE
BooleanExpression expression breaks label in the latex circuit drawer

### DIFF
--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -358,6 +358,7 @@ def _latex_circuit_drawer(circuit,
                                initial_state=initial_state,
                                cregbundle=cregbundle)
         try:
+
             subprocess.run(["pdflatex", "-halt-on-error",
                             "-output-directory={}".format(tmpdirname),
                             "{}".format(tmpfilename + '.tex')],

--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -358,7 +358,6 @@ def _latex_circuit_drawer(circuit,
                                initial_state=initial_state,
                                cregbundle=cregbundle)
         try:
-
             subprocess.run(["pdflatex", "-halt-on-error",
                             "-output-directory={}".format(tmpdirname),
                             "{}".format(tmpfilename + '.tex')],

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -369,6 +369,9 @@ class QCircuitImage:
         else:
             gate_text = op.name
 
+        gate_text = self._escape_latex_chars(gate_text)
+        ctrl_text = self._escape_latex_chars(ctrl_text)
+
         if gate_text in self._style['disptex']:
             gate_text = self._style['disptex'][gate_text]
             # Only add mathmode formatting if not already mathmode in disptex
@@ -381,13 +384,28 @@ class QCircuitImage:
             gate_text = f"$\\mathrm{{{gate_text.capitalize()}}}$"
         else:
             gate_text = f"$\\mathrm{{{gate_text}}}$"
-            # Remove mathmode _, ^, and - formatting from user names and labels
-            gate_text = gate_text.replace('_', '\\_')
-            gate_text = gate_text.replace('^', '\\string^')
-            gate_text = gate_text.replace('-', '\\mbox{-}')
 
         ctrl_text = f"$\\mathrm{{{ctrl_text}}}$"
         return gate_text, ctrl_text
+
+    def _escape_latex_chars(self, string):
+        if string is None:
+            return string
+        chars = {
+            '\\': r'\letterbackslash{}',
+            '&': '\&',
+            '%': '\%',
+            '$': '\$',
+            '#': '\#',
+            '_': r'\letterunderscore{}',
+            '{': r'\letteropenbrace{}',
+            '}': r'\letterclosebrace{}',
+            '~': r'\sim{}',
+            '^': r'\letterhat{}'
+        }
+        for old, new in chars.items():
+            string = string.replace(old, new)
+        return string
 
     def _build_latex_array(self):
         """Returns an array of strings containing \\LaTeX for this circuit."""

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -376,7 +376,6 @@ class QCircuitImage:
                 gate_text = f"$\\mathrm{{{gate_text}}}$"
         elif ((gate_text == op.name and op_type is BooleanExpression)
               or (gate_text == base_name and base_type is BooleanExpression)):
-            # \ghost{ \texttt{$\neg$x \& (y | z) }
             gate_text = gate_text.replace('~', '$\\neg$').replace('&', '\\&')
             gate_text = f"$\\texttt{{{gate_text}}}$"
         # Only captitalize internally-created gate or instruction names


### PR DESCRIPTION
The following example fails in `main`:
```python
from qiskit.circuit import BooleanExpression, QuantumCircuit

expression = BooleanExpression('~x & (y | z)')
circuit = QuantumCircuit(4)
circuit.append(expression, [0, 1, 2, 3])
circuit.draw('latex')
```
```
CalledProcessError: Command '['pdflatex', '-halt-on-error', '-output-directory=/tmp', 'circuit.tex']' returned non-zero exit status 1.
```

Several reasons, but mostly because the `~`. This PR takes care of that corner case.
<img width="302" alt="Screenshot 2021-04-20 at 12 52 50" src="https://user-images.githubusercontent.com/766693/115385533-87e6f480-a1d8-11eb-88d8-27003fba7778.png">
