### PR TITLE
fix error when `dag_drawer` removes a temporary file that is still open

### DIFF
--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -170,7 +170,8 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
         with tempfile.TemporaryDirectory() as tmpdirname:
             tmp_path = os.path.join(tmpdirname, 'dag.png')
             dot.write_png(tmp_path)
-            image = Image.open(tmp_path)
+            with Image.open(tmp_path) as test_image:
+                image=test_image.copy()
             os.remove(tmp_path)
             return image
     else:

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -171,7 +171,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style='color'):
             tmp_path = os.path.join(tmpdirname, 'dag.png')
             dot.write_png(tmp_path)
             with Image.open(tmp_path) as test_image:
-                image=test_image.copy()
+                image = test_image.copy()
             os.remove(tmp_path)
             return image
     else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When drawing a DAG with `dag_drawer` an exception can occur when the method tries to remove the temporary file while the temporary file is still open in the PIL Image. The PR fixes the problem by making a copy of the `Image` and then closing the original `Image` before removing the file. Fixes #6256

### Details and comments

For opening and closing a context manager is used as provided by `PIL`.


