### PR TITLE
Small fixes in the ``SparseVectorStateFn``

### DIFF
--- a/qiskit/opflow/__init__.py
+++ b/qiskit/opflow/__init__.py
@@ -147,7 +147,7 @@ from .operator_base import OperatorBase
 from .primitive_ops import (PrimitiveOp, PauliOp, MatrixOp, CircuitOp, PauliSumOp,
                             TaperedPauliSumOp, Z2Symmetries)
 from .state_fns import (StateFn, DictStateFn, VectorStateFn, CVaRMeasurement,
-                        CircuitStateFn, OperatorStateFn)
+                        CircuitStateFn, OperatorStateFn, SparseVectorStateFn)
 from .list_ops import ListOp, SummedOp, ComposedOp, TensoredOp
 from .converters import (ConverterBase, CircuitSampler, PauliBasisChange,
                          DictToCircuitSum, AbelianGrouper, TwoQubitReduction)
@@ -175,7 +175,7 @@ __all__ = [
     'OperatorBase',
     'PrimitiveOp', 'PauliOp', 'MatrixOp', 'CircuitOp', 'PauliSumOp', 'TaperedPauliSumOp',
     'StateFn', 'DictStateFn', 'VectorStateFn', 'CircuitStateFn', 'OperatorStateFn',
-    'CVaRMeasurement',
+    'SparseVectorStateFn', 'CVaRMeasurement',
     'ListOp', 'SummedOp', 'ComposedOp', 'TensoredOp',
     # Converters
     'ConverterBase', 'CircuitSampler', 'AbelianGrouper', 'DictToCircuitSum', 'PauliBasisChange',

--- a/qiskit/opflow/state_fns/__init__.py
+++ b/qiskit/opflow/state_fns/__init__.py
@@ -47,6 +47,7 @@ State Functions
    CircuitStateFn
    DictStateFn
    VectorStateFn
+   SparseVectorStateFn
    OperatorStateFn
    CVaRMeasurement
 
@@ -56,6 +57,7 @@ from .state_fn import StateFn
 from .dict_state_fn import DictStateFn
 from .operator_state_fn import OperatorStateFn
 from .vector_state_fn import VectorStateFn
+from .sparse_vector_state_fn import SparseVectorStateFn
 from .circuit_state_fn import CircuitStateFn
 from .cvar_measurement import CVaRMeasurement
 

--- a/qiskit/opflow/state_fns/sparse_vector_state_fn.py
+++ b/qiskit/opflow/state_fns/sparse_vector_state_fn.py
@@ -87,6 +87,19 @@ class SparseVectorStateFn(StateFn):
                                    coeff=self.coeff.conjugate(),
                                    is_measurement=(not self.is_measurement))
 
+    def equals(self, other: OperatorBase) -> bool:
+        if not isinstance(other, SparseVectorStateFn) or not self.coeff == other.coeff:
+            return False
+
+        if self.primitive.shape != other.primitive.shape:
+            return False
+
+        if self.primitive.count_nonzero() != other.primitive.count_nonzero():
+            return False
+
+        # equal if no elements are different (using != for efficiency)
+        return (self.primitive != other.primitive).nnz == 0
+
     def to_dict_fn(self) -> StateFn:
         """Convert this state function to a ``DictStateFn``.
 
@@ -97,7 +110,7 @@ class SparseVectorStateFn(StateFn):
 
         num_qubits = self.num_qubits
         dok = self.primitive.todok()
-        new_dict = {format(i[0], 'b').zfill(num_qubits): v for i, v in dok.items()}
+        new_dict = {format(i[1], 'b').zfill(num_qubits): v for i, v in dok.items()}
         return DictStateFn(new_dict, coeff=self.coeff, is_measurement=self.is_measurement)
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:

--- a/releasenotes/notes/fix-sparse-statefn-equality-and-to-dict-96d1a1ae98bcdb52.yaml
+++ b/releasenotes/notes/fix-sparse-statefn-equality-and-to-dict-96d1a1ae98bcdb52.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fix the :meth:`qiskit.opflow.SparseVectorStateFn.to_dict_fn` method, which
+    previously had at most one entry for the all zero state due to an index error.
+  - |
+    Fix the :meth:`qiskit.opflow.SparseVectorStateFn.equals` method to return 
+    `True` or `False` instead of a sparse vector comparison of the single elements.

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -31,7 +31,7 @@ from qiskit.circuit.library import CZGate, ZGate
 from qiskit.opflow import (
     X, Y, Z, I, CX, T, H, Minus, PrimitiveOp, PauliOp, CircuitOp, MatrixOp, EvolvedOp, StateFn,
     CircuitStateFn, VectorStateFn, DictStateFn, OperatorStateFn, ListOp, ComposedOp, TensoredOp,
-    SummedOp, OperatorBase, Zero, OpflowError
+    SummedOp, OperatorBase, Zero, OpflowError, SparseVectorStateFn
 )
 
 
@@ -918,6 +918,19 @@ class TestOpConstruction(QiskitOpflowTestCase):
         op = DictStateFn({'0': 1})
         expected = scipy.sparse.csr_matrix([[1, 0]])
         self.assertFalse((op.eval().primitive != expected).toarray().any())
+
+    def test_sparse_to_dict(self):
+        """Test converting a sparse vector state function to a dict state function."""
+        isqrt2 = 1 / np.sqrt(2)
+        sparse = scipy.sparse.csr_matrix([[0, isqrt2, 0, isqrt2]])
+        sparse_fn = SparseVectorStateFn(sparse)
+        dict_fn = DictStateFn({'01': isqrt2, '11': isqrt2})
+
+        with self.subTest('sparse to dict'):
+            self.assertEqual(dict_fn, sparse_fn.to_dict_fn())
+
+        with self.subTest('dict to sparse'):
+            self.assertEqual(dict_fn.to_spmatrix_op(), sparse_fn)
 
     def test_to_circuit_op(self):
         """Test to_circuit_op method."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix the `to_dict_fn` and `equals` methods and add the class to the `qiskit.opflow` and `qiskit.opflow.state_fns` init files.

### Details and comments

The `to_dict_fn` method previously had at most one entry for the all zero state due to an index error.

The `equals` method to returns now `True` or `False` instead of a sparse vector comparison of the single elements.
