### PR TITLE
Fix draw object generation in v2 pulse visualizer

### DIFF
--- a/qiskit/visualization/pulse_v2/generators/frame.py
+++ b/qiskit/visualization/pulse_v2/generators/frame.py
@@ -309,13 +309,13 @@ def gen_frame_symbol(data: types.PulseInstruction,
                 program.append('{}({:.2e} Hz)'.format(inst.__class__.__name__, inst.frequency))
             except TypeError:
                 # parameter expression
-                program.append('{}({})'.format(inst.__class__.__name__, inst.frequency.name))
+                program.append('{}({})'.format(inst.__class__.__name__, inst.frequency))
         elif isinstance(inst, (instructions.SetPhase, instructions.ShiftPhase)):
             try:
                 program.append('{}({:.2f} rad.)'.format(inst.__class__.__name__, inst.phase))
             except TypeError:
                 # parameter expression
-                program.append('{}({})'.format(inst.__class__.__name__, inst.phase.name))
+                program.append('{}({})'.format(inst.__class__.__name__, inst.phase))
 
     meta = {'total phase change': data.frame.phase,
             'total frequency change': data.frame.freq,

--- a/qiskit/visualization/pulse_v2/generators/waveform.py
+++ b/qiskit/visualization/pulse_v2/generators/waveform.py
@@ -170,9 +170,6 @@ def gen_ibmq_latex_waveform_name(data: types.PulseInstruction,
     elif isinstance(data.inst, instructions.Delay):
         systematic_name = data.inst.name or 'Delay'
         latex_name = None
-    elif isinstance(data.inst.channel, pulse.channels.MeasureChannel):
-        systematic_name = 'Measure'
-        latex_name = None
     else:
         systematic_name = data.inst.pulse.name or data.inst.pulse.__class__.__name__
 

--- a/test/python/visualization/pulse_v2/test_generators.py
+++ b/test/python/visualization/pulse_v2/test_generators.py
@@ -669,6 +669,26 @@ class TestFrameGenerators(QiskitTestCase):
                      'ha': 'center'}
         self.assertDictEqual(obj.styles, ref_style)
 
+    def gen_frame_symbol_with_parameters(self):
+        """Test gen_frame_symbol with parameterized frame."""
+        theta = -1.0 * circuit.Parameter('P0')
+        fcs = [pulse.ShiftPhase(theta, pulse.DriveChannel(0))]
+        inst_data = create_instruction(fcs, np.pi / 2, 1e6, 5, 0.1)
+
+        obj = frame.gen_frame_symbol(inst_data,
+                                     formatter=self.formatter,
+                                     device=self.device)[0]
+
+        # metadata check
+        ref_meta = {
+            'total phase change': np.pi/2,
+            'total frequency change': 1e6,
+            'program': ['ShiftPhase(-1.0*P0)'],
+            't0 (cycle time)': 5,
+            't0 (sec)': 0.5
+        }
+        self.assertDictEqual(obj.meta, ref_meta)
+
 
 class TestSnapshotGenerators(QiskitTestCase):
     """Tests for snapshot generators."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
General object generation fix for v2 pulse visualizer.

Fix #5951 


### Details and comments
The bug is induced by accessing to the `.name` property of `ParameterExpression` which doesn't exist. The object is now directly passed to string formatter. Along with this fix, I updated pulse name generation logic which is currently force overriding pulse names in the measurement channel as `Measure`. This may hurt user experience in some corner case, see [Qiskit Textbook 6.6](https://qiskit.org/textbook/ch-quantum-hardware/ac-Stark-shift.html). M channel is used as a off-resonant drive channel to induce Stark shift. Pulse name of this pulse is `resonator tone` in this example.