### PR TITLE
Improve Performance of eval() of OperatorStateFn @ VectorStateFn by > 1000 times

### DIFF
--- a/qiskit/opflow/state_fns/operator_state_fn.py
+++ b/qiskit/opflow/state_fns/operator_state_fn.py
@@ -211,7 +211,7 @@ class OperatorStateFn(StateFn):
         if isinstance(self.primitive, PauliSumOp) and isinstance(front, VectorStateFn):
             return (
                 front.primitive.expectation_value(self.primitive.primitive)
-                * self.coeff.conjugate()
+                * self.coeff
                 * front.coeff
             )
 

--- a/qiskit/opflow/state_fns/operator_state_fn.py
+++ b/qiskit/opflow/state_fns/operator_state_fn.py
@@ -22,6 +22,7 @@ from qiskit.opflow.list_ops.summed_op import SummedOp
 from qiskit.opflow.list_ops.tensored_op import TensoredOp
 from qiskit.opflow.operator_base import OperatorBase
 from qiskit.opflow.primitive_ops.matrix_op import MatrixOp
+from qiskit.opflow.primitive_ops.pauli_sum_op import PauliSumOp
 from qiskit.opflow.state_fns.state_fn import StateFn
 from qiskit.opflow.state_fns.circuit_state_fn import CircuitStateFn
 from qiskit.quantum_info import Statevector
@@ -204,6 +205,15 @@ class OperatorStateFn(StateFn):
                 multiplied = self.primitive.coeff * self.coeff * np.array(result)
                 return multiplied.tolist()
             return result * self.coeff * self.primitive.coeff
+
+        # pylint: disable=cyclic-import
+        from .vector_state_fn import VectorStateFn
+        if isinstance(self.primitive, PauliSumOp) and isinstance(front, VectorStateFn):
+            return (
+                front.primitive.expectation_value(self.primitive.primitive)
+                * self.coeff.conjugate()
+                * front.coeff
+            )
 
         # Need an ListOp-specific carve-out here to make sure measurement over a ListOp doesn't
         # produce two-dimensional ListOp from composing from both sides of primitive.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR improves the performance of `eval() of (OperatorStateFn @ VectorStateFn)`.


### Details and comments

When I implemented PauliSumOp, I took a profile for QEOM. https://github.com/Qiskit/qiskit-terra/pull/5537

<img width="2109" alt="image" src="https://user-images.githubusercontent.com/6814928/115662678-4beb9500-a37a-11eb-84c4-c0c9ec0de4be.png">

As you can see on the right side of this profile, `eval()` of `OperatorStateFn` spends a lot of time.

This PR changes to use the expectation_value in quantum_info and it achieves more than 1000 times performance improvement.

<img width="923" alt="image" src="https://user-images.githubusercontent.com/6814928/115663220-27dc8380-a37b-11eb-9d0b-d3ced22440c2.png">
