### PR TITLE
Fix bug in ``Pauli.evolve`` for CZ, CY, Swap

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -570,19 +570,19 @@ def _evolve_cx(base_pauli, qctrl, qtrgt):
 
 def _evolve_cz(base_pauli, q1, q2):
     """Update P -> CZ.P.CZ"""
-    x1 = base_pauli._x[:, q1]
-    x2 = base_pauli._x[:, q2]
-    base_pauli._z[:, q1] ^= x1
-    base_pauli._z[:, q2] ^= x2
+    x1 = base_pauli._x[:, q1].copy()
+    x2 = base_pauli._x[:, q2].copy()
+    base_pauli._z[:, q1] ^= x2
+    base_pauli._z[:, q2] ^= x1
     base_pauli._phase += 2 * np.logical_and(x1, x2).T
     return base_pauli
 
 
 def _evolve_cy(base_pauli, qctrl, qtrgt):
     """Update P -> CY.P.CY"""
-    x1 = base_pauli._x[:, qctrl]
-    x2 = base_pauli._x[:, qtrgt]
-    z2 = base_pauli._z[:, qtrgt]
+    x1 = base_pauli._x[:, qctrl].copy()
+    x2 = base_pauli._x[:, qtrgt].copy()
+    z2 = base_pauli._z[:, qtrgt].copy()
     base_pauli._x[:, qtrgt] ^= x1
     base_pauli._z[:, qtrgt] ^= x1
     base_pauli._z[:, qctrl] ^= np.logical_xor(x2, z2)
@@ -592,8 +592,8 @@ def _evolve_cy(base_pauli, qctrl, qtrgt):
 
 def _evolve_swap(base_pauli, q1, q2):
     """Update P -> SWAP.P.SWAP"""
-    x1 = base_pauli._x[:, q1]
-    z1 = base_pauli._z[:, q1]
+    x1 = base_pauli._x[:, q1].copy()
+    z1 = base_pauli._z[:, q1].copy()
     base_pauli._x[:, q1] = base_pauli._x[:, q2]
     base_pauli._z[:, q1] = base_pauli._z[:, q2]
     base_pauli._x[:, q2] = x1

--- a/releasenotes/notes/fix-pauli-evolve-c6653853962885cd.yaml
+++ b/releasenotes/notes/fix-pauli-evolve-c6653853962885cd.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes a bug in :meth:`qiskit.quantum_info.Pauli.evolve` which could
+    result in the incorrect Pauli when evolving by a CZ, CY, or Swap gate.

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -29,7 +29,7 @@ from qiskit.circuit.library.generalized_gates import PauliGate
 from qiskit.test import QiskitTestCase
 
 from qiskit.quantum_info.random import random_clifford, random_pauli
-from qiskit.quantum_info.operators import Pauli, Operator, Clifford
+from qiskit.quantum_info.operators import Pauli, Operator
 from qiskit.quantum_info.operators.symplectic.pauli import (
     _split_pauli_label, _phase_from_label)
 

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -346,10 +346,9 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford1(self, gate, label):
         """Test evolve method for 1-qubit Clifford gates."""
-        cliff = Clifford(gate)
         op = Operator(gate)
         pauli = Pauli(label)
-        value = Operator(pauli.evolve(cliff))
+        value = Operator(pauli.evolve(gate))
         target = op.adjoint().dot(pauli).dot(op)
         self.assertEqual(value, target)
 
@@ -358,10 +357,9 @@ class TestPauli(QiskitTestCase):
     @unpack
     def test_evolve_clifford2(self, gate, label):
         """Test evolve method for 2-qubit Clifford gates."""
-        cliff = Clifford(gate)
         op = Operator(gate)
         pauli = Pauli(label)
-        value = Operator(pauli.evolve(cliff))
+        value = Operator(pauli.evolve(gate))
         target = op.adjoint().dot(pauli).dot(op)
         self.assertEqual(value, target)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes bug in the `Pauli.evolve` function when evolving CY, CZ, or Swap gates.

### Details and comments

Fixed the tests that should have caught this bug. These gates were being synthesized via clifford back to CX + 1 qubit clifford gates which were all working correctly.

