### PR TITLE
Improve performance of ``Pauli.evolve``

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -575,11 +575,15 @@ class Pauli(BasePauli):
         if qargs is not None and len(qargs) != other.num_qubits:
             raise QiskitError(
                 "Incorrect number of qubits for Clifford ({} != {}).".format(
-                    other.num_qubits, len(qargs)))
+                    other.num_qubits, len(qargs)
+                )
+            )
         if qargs is None and self.num_qubits != other.num_qubits:
             raise QiskitError(
                 "Incorrect number of qubits for Clifford ({} != {}).".format(
-                    other.num_qubits, self.num_qubits))
+                    other.num_qubits, self.num_qubits
+                )
+            )
 
         if qargs is None:
             idx = slice(None)

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -581,20 +581,25 @@ class Pauli(BasePauli):
                 "Incorrect number of qubits for Clifford ({} != {}).".format(
                     other.num_qubits, self.num_qubits))
 
-        # Initialize return to phase * I
+        if qargs is None:
+            idx = slice(None)
+        else:
+            idx = list(qargs)
+
+        # Set return to I on qargs
         ret = self.copy()
-        ret.x = 0
-        ret.z = 0
-        
+        ret.x[idx] = 0
+        ret.z[idx] = 0
+
         # Get action of Pauli's from Clifford
         adj = other.adjoint()
-        for row in adj.stabilizer[self.z]:
+        for row in adj.stabilizer[self.z[idx]]:
             row_pauli = Pauli((row.Z[0], row.X[0], 2 * row.phase[0]))
-            ret = ret.dot(row_pauli)
+            ret = ret.dot(row_pauli, qargs=qargs)
         
-        for row in adj.destabilizer[self.x]:
+        for row in adj.destabilizer[self.x[idx]]:
             row_pauli = Pauli((row.Z[0], row.X[0], 2 * row.phase[0]))
-            ret = ret.dot(row_pauli)
+            ret = ret.dot(row_pauli, qargs=qargs)
 
         return ret
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -596,7 +596,6 @@ class Pauli(BasePauli):
         for row in adj.stabilizer[self.z[idx]]:
             row_pauli = Pauli((row.Z[0], row.X[0], 2 * row.phase[0]))
             ret = ret.dot(row_pauli, qargs=qargs)
-        
         for row in adj.destabilizer[self.x[idx]]:
             row_pauli = Pauli((row.Z[0], row.X[0], 2 * row.phase[0]))
             ret = ret.dot(row_pauli, qargs=qargs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Improves the performance of `Pauli.evolve` when evolving by a `Clifford` operator.

### Details and comments

Computes the evolution directly from the Clifford table without converting to a circuit first.


