### PR TITLE
Fix expval pauli qargs bug

### DIFF
--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -345,17 +345,21 @@ class DensityMatrix(QuantumState, TolerancesMixin):
         ret._op_shape = self._op_shape.reverse()
         return ret
 
-    def _expectation_value_pauli(self, pauli):
+    def _expectation_value_pauli(self, pauli, qargs=None):
         """Compute the expectation value of a Pauli.
 
             Args:
                 pauli (Pauli): a Pauli operator to evaluate expval of.
+                qargs (None or list): subsystems to apply operator on.
 
             Returns:
                 complex: the expectation value.
             """
         n_pauli = len(pauli)
-        qubits = np.arange(n_pauli)
+        if qargs is None:
+            qubits = np.arange(n_pauli)
+        else:
+            qubits = np.array(qargs)
         x_mask = np.dot(1 << qubits, pauli.x)
         z_mask = np.dot(1 << qubits, pauli.z)
         pauli_phase = (-1j) ** pauli.phase if pauli.phase else 1
@@ -383,10 +387,10 @@ class DensityMatrix(QuantumState, TolerancesMixin):
             complex: the expectation value.
         """
         if isinstance(oper, Pauli):
-            return self._expectation_value_pauli(oper)
+            return self._expectation_value_pauli(oper, qargs)
 
         if isinstance(oper, SparsePauliOp):
-            return sum([coeff * self._expectation_value_pauli(Pauli((z, x)))
+            return sum([coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
                         for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)])
 
         if not isinstance(oper, Operator):

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -370,17 +370,22 @@ class Statevector(QuantumState, TolerancesMixin):
         ret._op_shape = self._op_shape.reverse()
         return ret
 
-    def _expectation_value_pauli(self, pauli):
+    def _expectation_value_pauli(self, pauli, qargs=None):
         """Compute the expectation value of a Pauli.
 
             Args:
                 pauli (Pauli): a Pauli operator to evaluate expval of.
+                qargs (None or list): subsystems to apply operator on.
 
             Returns:
                 complex: the expectation value.
-            """
+        """
         n_pauli = len(pauli)
-        qubits = np.arange(n_pauli)
+        if qargs is None:
+            qubits = np.arange(n_pauli)
+        else:
+            qubits = np.array(qargs)
+
         x_mask = np.dot(1 << qubits, pauli.x)
         z_mask = np.dot(1 << qubits, pauli.z)
         pauli_phase = (-1j) ** pauli.phase if pauli.phase else 1
@@ -408,10 +413,10 @@ class Statevector(QuantumState, TolerancesMixin):
             complex: the expectation value.
         """
         if isinstance(oper, Pauli):
-            return self._expectation_value_pauli(oper)
+            return self._expectation_value_pauli(oper, qargs)
 
         if isinstance(oper, SparsePauliOp):
-            return sum([coeff * self._expectation_value_pauli(Pauli((z, x)))
+            return sum([coeff * self._expectation_value_pauli(Pauli((z, x)), qargs)
                         for z, x, coeff in zip(oper.table.Z, oper.table.X, oper.coeffs)])
 
         val = self.evolve(oper, qargs=qargs)

--- a/releasenotes/notes/fix-expval-pauli-qargs-183843993ca83f71.yaml
+++ b/releasenotes/notes/fix-expval-pauli-qargs-183843993ca83f71.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes bug in :meth:`qiskit.quantum_info.Statevector.expectation_value`
+    and :meth:`qiskit.quantum_info.DensityMatrix.expectation_value` where
+    the ``qargs`` kwarg was ignored if the operator was a
+    :class:`~qiskit.quantum_info.Pauli` or
+    :class:`~qiskit.quantum_info.SparsePauliOp` operator.

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -23,7 +23,8 @@ from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit.library import HGate, QFT
 
-from qiskit.quantum_info.random import random_unitary, random_density_matrix
+from qiskit.quantum_info.random import (
+    random_unitary, random_density_matrix, random_pauli)
 from qiskit.quantum_info.states import DensityMatrix, Statevector
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
@@ -950,6 +951,16 @@ class TestDensityMatrix(QiskitTestCase):
                                rho.data.shape, order='C')
         target = rho.expectation_value(op.to_matrix())
         expval = rho.expectation_value(op)
+        self.assertAlmostEqual(expval, target)
+
+    @data([0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1])
+    def test_expval_pauli_qargs(self, qubits):
+        """Test expectation_value method for Pauli op"""
+        seed = 1020
+        op = random_pauli(2, seed=seed)
+        state = random_density_matrix(2**3, seed=seed)
+        target = state.expectation_value(op.to_matrix(), qubits)
+        expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
 
     def test_reverse_qargs(self):

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -25,7 +25,8 @@ from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
 from qiskit.circuit.library import HGate, QFT
 
-from qiskit.quantum_info.random import random_unitary, random_statevector
+from qiskit.quantum_info.random import (
+    random_unitary, random_statevector, random_pauli)
 from qiskit.quantum_info.states import Statevector
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
@@ -934,6 +935,16 @@ class TestStatevector(QiskitTestCase):
         state = random_statevector(2**op.num_qubits, seed=seed)
         target = state.expectation_value(op.to_matrix())
         expval = state.expectation_value(op)
+        self.assertAlmostEqual(expval, target)
+
+    @data([0, 1], [0, 2], [1, 0], [1, 2], [2, 0], [2, 1])
+    def test_expval_pauli_qargs(self, qubits):
+        """Test expectation_value method for Pauli op"""
+        seed = 1020
+        op = random_pauli(2, seed=seed)
+        state = random_statevector(2**3, seed=seed)
+        target = state.expectation_value(op.to_matrix(), qubits)
+        expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
 
     def test_global_phase(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6303 

### Details and comments

Fixes bug in Statevector and DensityMatrix expectation_value method where the qargs kwarg was ignored if the operator was a Pauli or SparsePauliOp.