### PR TITLE
Fix #6307 (PauliExpectation takes unnecessary adjoint when it converts operators)

### DIFF
--- a/qiskit/opflow/converters/pauli_basis_change.py
+++ b/qiskit/opflow/converters/pauli_basis_change.py
@@ -230,7 +230,7 @@ class PauliBasisChange(ConverterBase):
             The ``~StateFn @ CircuitOp`` composition equivalent to a measurement by the original
             ``PauliOp``.
         """
-        return PauliBasisChange.statefn_replacement_fn(cob_instr_op, dest_pauli_op).adjoint()
+        return ComposedOp([StateFn(dest_pauli_op, is_measurement=True), cob_instr_op])
 
     @staticmethod
     def statefn_replacement_fn(cob_instr_op: PrimitiveOp,

--- a/releasenotes/notes/fix-expectation-for-non-hermitian-op-880a3b9b13320574.yaml
+++ b/releasenotes/notes/fix-expectation-for-non-hermitian-op-880a3b9b13320574.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the bug that :meth:`~qiskit.opflow.PauliExpectation.convert`
+    converts non-Hermitian observables to it's adjoint.

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -222,6 +222,11 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
         np.testing.assert_array_almost_equal(val1, val3, decimal=2)
         np.testing.assert_array_almost_equal([val1] * 2, val4, decimal=2)
 
+    def test_pauli_expectation_non_hermite_op(self):
+        """ Test PauliExpectation for non hermitian operator """
+        exp = ~StateFn(1j * Z) @ One
+        self.assertEqual(self.sampler.convert(self.expect.convert(exp)).eval(), 1j)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -692,7 +692,7 @@ class TestGradients(QiskitOpflowTestCase):
         coeff_0 = Parameter('c_0')
         coeff_1 = Parameter('c_1')
         ham = coeff_0 * X + coeff_1 * Z
-        op = ~StateFn(ham) @ CircuitStateFn(primitive=qc, coeff=1.0)
+        op = StateFn(ham, is_measurement=True) @ CircuitStateFn(primitive=qc, coeff=1.0)
         gradient_coeffs = [coeff_0, coeff_1]
         coeff_grad = Gradient(grad_method=method).convert(op, gradient_coeffs)
         values_dict = [{coeff_0: 0.5, coeff_1: -1, a: np.pi / 4, b: np.pi},
@@ -727,7 +727,7 @@ class TestGradients(QiskitOpflowTestCase):
         coeff_0 = Parameter('c_0')
         coeff_1 = Parameter('c_1')
         ham = coeff_0 * coeff_0 * X + coeff_1 * coeff_0 * Z
-        op = ~StateFn(ham) @ CircuitStateFn(primitive=qc, coeff=1.)
+        op = StateFn(ham, is_measurement=True) @ CircuitStateFn(primitive=qc, coeff=1.)
         gradient_coeffs = [(coeff_0, coeff_0), (coeff_0, coeff_1), (coeff_1, coeff_1)]
         coeff_grad = Hessian(hess_method=method).convert(op, gradient_coeffs)
         values_dict = [{coeff_0: 0.5, coeff_1: -1, a: np.pi / 4, b: np.pi},

--- a/test/python/opflow/test_matrix_expectation.py
+++ b/test/python/opflow/test_matrix_expectation.py
@@ -144,6 +144,11 @@ class TestMatrixExpectation(QiskitOpflowTestCase):
                                              [1, .5**.5, (1 + .5**.5), 1],
                                              decimal=1)
 
+    def test_matrix_expectation_non_hermite_op(self):
+        """ Test MatrixExpectation for non hermitian operator """
+        exp = ~StateFn(1j * Z) @ One
+        self.assertEqual(self.expect.convert(exp).eval(), 1j)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/python/opflow/test_pauli_expectation.py
+++ b/test/python/opflow/test_pauli_expectation.py
@@ -233,6 +233,11 @@ class TestPauliExpectation(QiskitOpflowTestCase):
                                              [1, .5**.5, (1 + .5**.5), 1],
                                              decimal=1)
 
+    def test_pauli_expectation_non_hermite_op(self):
+        """ Test PauliExpectation for non hermitian operator """
+        exp = ~StateFn(1j * Z) @ One
+        self.assertEqual(self.expect.convert(exp).eval(), 1j)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #6307
Remove adjoint() when PauliBasisChange converts operators.
I've fixed the test of gradient, which originally worked by taking the complex conjugate twice.

- [x] add tests
- [x] add reno