### PR TITLE
Fix schedule inline transform

### DIFF
--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -143,7 +143,8 @@ class ParameterSetter(NodeVisitor):
     def visit_Schedule(self, node: Schedule):
         """Visit ``Schedule``. Recursively visit schedule children and overwrite."""
         # accessing to private member
-        node._children = [(t0, self.visit(sched)) for t0, sched in node.instructions]
+        # TODO: consider updating Schedule to handle this more gracefully
+        node._Schedule__children = [(t0, self.visit(sched)) for t0, sched in node.instructions]
         node._renew_timeslots()
 
         self._update_parameter_manager(node)

--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -143,8 +143,7 @@ class ParameterSetter(NodeVisitor):
     def visit_Schedule(self, node: Schedule):
         """Visit ``Schedule``. Recursively visit schedule children and overwrite."""
         # accessing to private member
-        # TODO: consider updating Schedule to handle this more gracefully
-        node._Schedule__children = [(t0, self.visit(sched)) for t0, sched in node.instructions]
+        node._children = [(t0, self.visit(sched)) for t0, sched in node.instructions]
         node._renew_timeslots()
 
         self._update_parameter_manager(node)

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -214,7 +214,7 @@ class Schedule:
             scheduled time of each ``NamedValue`` and the component
             itself.
         """
-        warnings.warn('Schedule._children is now public method Schedule.children. '
+        warnings.warn('Schedule._children is now available as the public property Schedule.children. '
                       'Access to the private member is being deprecated.', DeprecationWarning)
         return tuple(self.__children)
 

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -334,8 +334,7 @@ class Schedule:
 
         self._duration = self._duration + time
         self._timeslots = timeslots
-        self._children = [(orig_time + time, child) for
-                           orig_time, child in self.children]
+        self._children = [(orig_time + time, child) for orig_time, child in self.children]
         return self
 
     def insert(self,

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -141,7 +141,7 @@ class Schedule:
 
         # These attributes are populated by ``_mutable_insert``
         self._timeslots = {}
-        self.__children = []
+        self._children = []
         for sched_pair in schedules:
             try:
                 time, sched = sched_pair
@@ -201,16 +201,20 @@ class Schedule:
         return tuple(self._timeslots.keys())
 
     @property
-    def _children(self) -> Tuple[Tuple[int, ScheduleComponent], ...]:
-        """Return the child``NamedValues``s of this ``Schedule`` in the
+    def children(self) -> Tuple[Tuple[int, ScheduleComponent], ...]:
+        """Return the child schedule components of this ``Schedule`` in the
         order they were added to the schedule.
+
+        Notes:
+            Nested schedules are returned as-is. If you want to collect only instructions,
+            use py:meth:`~Schedule.instructions` instead.
 
         Returns:
             A tuple, where each element is a two-tuple containing the initial
             scheduled time of each ``NamedValue`` and the component
             itself.
         """
-        return tuple(self.__children)
+        return tuple(self._children)
 
     @property
     def instructions(self) -> Tuple[Tuple[int, Instruction]]:
@@ -272,7 +276,7 @@ class Schedule:
                 :class:`~qiskit.pulse.Instruction`
                 starts at and the flattened :class:`~qiskit.pulse.Instruction` s.
         """
-        for insert_time, child_sched in self._children:
+        for insert_time, child_sched in self.children:
             yield from child_sched._instructions(time + insert_time)
 
     def shift(self,
@@ -330,8 +334,8 @@ class Schedule:
 
         self._duration = self._duration + time
         self._timeslots = timeslots
-        self.__children = [(orig_time + time, child) for
-                           orig_time, child in self._children]
+        self._children = [(orig_time + time, child) for
+                           orig_time, child in self.children]
         return self
 
     def insert(self,
@@ -364,7 +368,7 @@ class Schedule:
             schedule: Schedule to mutably insert.
         """
         self._add_timeslots(start_time, schedule)
-        self.__children.append((start_time, schedule))
+        self._children.append((start_time, schedule))
         self._parameter_manager.update_parameter_table(schedule)
         return self
 
@@ -651,7 +655,7 @@ class Schedule:
         new_children = []
         new_parameters = ParameterManager()
 
-        for time, child in self._children:
+        for time, child in self.children:
             if child == old:
                 new_children.append((time, new))
                 new_parameters.update_parameter_table(new)
@@ -660,7 +664,7 @@ class Schedule:
                 new_parameters.update_parameter_table(child)
 
         if inplace:
-            self.__children = new_children
+            self._children = new_children
             self._parameter_manager = new_parameters
             self._renew_timeslots()
             return self

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -141,7 +141,7 @@ class Schedule:
 
         # These attributes are populated by ``_mutable_insert``
         self._timeslots = {}
-        self._children = []
+        self.__children = []
         for sched_pair in schedules:
             try:
                 time, sched = sched_pair
@@ -201,6 +201,24 @@ class Schedule:
         return tuple(self._timeslots.keys())
 
     @property
+    def _children(self) -> Tuple[Tuple[int, ScheduleComponent], ...]:
+        """Deprecated. Return the child schedule components of this ``Schedule`` in the
+        order they were added to the schedule.
+
+        Notes:
+            Nested schedules are returned as-is. If you want to collect only instructions,
+            use py:meth:`~Schedule.instructions` instead.
+
+        Returns:
+            A tuple, where each element is a two-tuple containing the initial
+            scheduled time of each ``NamedValue`` and the component
+            itself.
+        """
+        warnings.warn('Schedule._children is now public method Schedule.children. '
+                      'Access to the private member is being deprecated.', DeprecationWarning)
+        return tuple(self.__children)
+
+    @property
     def children(self) -> Tuple[Tuple[int, ScheduleComponent], ...]:
         """Return the child schedule components of this ``Schedule`` in the
         order they were added to the schedule.
@@ -214,7 +232,7 @@ class Schedule:
             scheduled time of each ``NamedValue`` and the component
             itself.
         """
-        return tuple(self._children)
+        return tuple(self.__children)
 
     @property
     def instructions(self) -> Tuple[Tuple[int, Instruction]]:
@@ -334,7 +352,7 @@ class Schedule:
 
         self._duration = self._duration + time
         self._timeslots = timeslots
-        self._children = [(orig_time + time, child) for orig_time, child in self.children]
+        self.__children = [(orig_time + time, child) for orig_time, child in self.children]
         return self
 
     def insert(self,
@@ -367,7 +385,7 @@ class Schedule:
             schedule: Schedule to mutably insert.
         """
         self._add_timeslots(start_time, schedule)
-        self._children.append((start_time, schedule))
+        self.__children.append((start_time, schedule))
         self._parameter_manager.update_parameter_table(schedule)
         return self
 
@@ -663,7 +681,7 @@ class Schedule:
                 new_parameters.update_parameter_table(child)
 
         if inplace:
-            self._children = new_children
+            self.__children = new_children
             self._parameter_manager = new_parameters
             self._renew_timeslots()
             return self

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -215,7 +215,7 @@ class Schedule:
             itself.
         """
         warnings.warn('Schedule._children is now available as the public property Schedule.children. '
-                      'Access to the private member is being deprecated.', DeprecationWarning)
+                      'Access to this private property is being deprecated.', DeprecationWarning)
         return tuple(self.__children)
 
     @property

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -214,8 +214,9 @@ class Schedule:
             scheduled time of each ``NamedValue`` and the component
             itself.
         """
-        warnings.warn('Schedule._children is now available as the public property Schedule.children. '
-                      'Access to this private property is being deprecated.', DeprecationWarning)
+        warnings.warn('Schedule._children is now available as the public property '
+                      'Schedule.children. Access to this private property is being deprecated.',
+                      DeprecationWarning)
         return tuple(self.__children)
 
     @property

--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -81,7 +81,7 @@ class AlignLeft(AlignmentKind):
             Schedule with reallocated instructions.
         """
         aligned = Schedule()
-        for _, child in schedule._children:
+        for _, child in schedule.children:
             self._push_left_append(aligned, child)
 
         return aligned
@@ -139,7 +139,7 @@ class AlignRight(AlignmentKind):
             Schedule with reallocated instructions.
         """
         aligned = Schedule()
-        for _, child in reversed(schedule._children):
+        for _, child in reversed(schedule.children):
             aligned = self._push_right_prepend(aligned, child)
 
         return aligned
@@ -200,7 +200,7 @@ class AlignSequential(AlignmentKind):
             Schedule with reallocated instructions.
         """
         aligned = Schedule()
-        for _, child in schedule._children:
+        for _, child in schedule.children:
             aligned.insert(aligned.duration, child, inplace=True)
 
         return aligned
@@ -247,17 +247,17 @@ class AlignEquispaced(AlignmentKind):
         """
         instruction_duration_validation(self.duration)
 
-        total_duration = sum([child.duration for _, child in schedule._children])
+        total_duration = sum([child.duration for _, child in schedule.children])
         if self.duration < total_duration:
             return schedule
 
         total_delay = self.duration - total_duration
 
-        if len(schedule._children) > 1:
+        if len(schedule.children) > 1:
             # Calculate the interval in between sub-schedules.
             # If the duration cannot be divided by the number of sub-schedules,
             # the modulo is appended and prepended to the input schedule.
-            interval, mod = np.divmod(total_delay, len(schedule._children) - 1)
+            interval, mod = np.divmod(total_delay, len(schedule.children) - 1)
         else:
             interval = 0
             mod = total_delay
@@ -268,7 +268,7 @@ class AlignEquispaced(AlignmentKind):
         aligned = Schedule()
         # Insert sub-schedules with interval
         _t0 = int(aligned.stop_time + delay + mod)
-        for _, child in schedule._children:
+        for _, child in schedule.children:
             aligned.insert(_t0, child, inplace=True)
             _t0 = int(aligned.stop_time + interval)
 
@@ -338,7 +338,7 @@ class AlignFunc(AlignmentKind):
             return schedule
 
         aligned = Schedule()
-        for ind, (_, child) in enumerate(schedule._children):
+        for ind, (_, child) in enumerate(schedule.children):
             _t_center = self.duration * self._func(ind + 1)
             _t0 = int(_t_center - 0.5 * child.duration)
             if _t0 < 0 or _t0 > self.duration:

--- a/qiskit/pulse/transforms/canonicalization.py
+++ b/qiskit/pulse/transforms/canonicalization.py
@@ -157,7 +157,7 @@ def _inline_schedule(schedule: Schedule) -> Schedule:
     """
     ret_schedule = Schedule(name=schedule.name,
                             metadata=schedule.metadata)
-    for t0, inst in schedule._children:
+    for t0, inst in schedule.children:
         # note that schedule.instructions unintentionally flatten the nested schedule.
         # this should be performed by another transformer node.
         if isinstance(inst, instructions.Call):

--- a/releasenotes/notes/fix-inline-bug-6b9461fa213b0aae.yaml
+++ b/releasenotes/notes/fix-inline-bug-6b9461fa213b0aae.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix py:func:`~qiskit.pulse.transforms.inline_subroutines` to support subroutines
+    defined in the nested schedules.
+other:
+  - |
+    py:meth:`~qiskit.pulse.Schedule.children` becomes public. This returns tuple of
+    schedule components stored in the schedule. This returns nested schedules without flattening.

--- a/test/python/pulse/test_parameter_manager.py
+++ b/test/python/pulse/test_parameter_manager.py
@@ -249,7 +249,7 @@ class TestParameterSetter(ParameterTestBase):
 
         self.assertEqual(assigned, ref_obj)
 
-    def test_nested_assigment_partial_bind(self):
+    def test_nested_assignment_partial_bind(self):
         """Test nested schedule with call instruction.
         Inline the schedule and partially bind parameters."""
         context = AlignEquispaced(duration=self.context_dur)
@@ -271,14 +271,14 @@ class TestParameterSetter(ParameterTestBase):
 
         ref_context = AlignEquispaced(duration=1000)
         ref_subroutine = pulse.ScheduleBlock(alignment_context=ref_context)
-        ref_subroutine += pulse.Play(pulse.Gaussian(200, self.amp1_1 + self.amp1_2, 25),
+        ref_subroutine += pulse.Play(pulse.Gaussian(200, self.amp1_1 + self.amp1_2, 50),
                                      pulse.DriveChannel(1))
 
         ref_nested_block = pulse.ScheduleBlock()
         ref_nested_block += ref_subroutine
 
         ref_obj = pulse.ScheduleBlock()
-        ref_obj += nested_block
+        ref_obj += ref_nested_block
 
         self.assertEqual(assigned, ref_obj)
 

--- a/test/python/pulse/test_schedule.py
+++ b/test/python/pulse/test_schedule.py
@@ -191,7 +191,7 @@ class TestScheduleBuilding(BaseTestSchedule):
         self.assertEqual(0, sched.stop_time)
         self.assertEqual(0, sched.duration)
         self.assertEqual(0, len(sched))
-        self.assertEqual((), sched._children)
+        self.assertEqual((), sched.children)
         self.assertEqual({}, sched.timeslots)
         self.assertEqual([], list(sched.instructions))
         self.assertFalse(sched)

--- a/test/python/pulse/test_transforms.py
+++ b/test/python/pulse/test_transforms.py
@@ -885,6 +885,54 @@ class TestRemoveSubroutines(QiskitTestCase):
 
         self.assertEqual(target, reference)
 
+    def test_call_in_nested_schedule(self):
+        """Test that subroutines in nested schedule."""
+        d0 = pulse.DriveChannel(0)
+
+        subroutine = pulse.Schedule()
+        subroutine.insert(10, pulse.Delay(10, d0), inplace=True)
+
+        nested_sched = pulse.Schedule()
+        nested_sched.insert(0, pulse.instructions.Call(subroutine), inplace=True)
+
+        main_sched = pulse.Schedule()
+        main_sched.insert(0, nested_sched, inplace=True)
+
+        target = transforms.inline_subroutines(main_sched)
+
+        # no call instruction
+        reference_nested = pulse.Schedule()
+        reference_nested.insert(0, subroutine, inplace=True)
+
+        reference = pulse.Schedule()
+        reference.insert(0, reference_nested, inplace=True)
+
+        self.assertEqual(target, reference)
+
+    def test_call_in_nested_block(self):
+        """Test that subroutines in nested schedule."""
+        d0 = pulse.DriveChannel(0)
+
+        subroutine = pulse.ScheduleBlock()
+        subroutine.append(pulse.Delay(10, d0), inplace=True)
+
+        nested_block = pulse.ScheduleBlock()
+        nested_block.append(pulse.instructions.Call(subroutine), inplace=True)
+
+        main_block = pulse.ScheduleBlock()
+        main_block.append(nested_block, inplace=True)
+
+        target = transforms.inline_subroutines(main_block)
+
+        # no call instruction
+        reference_nested = pulse.ScheduleBlock()
+        reference_nested.append(subroutine, inplace=True)
+
+        reference = pulse.ScheduleBlock()
+        reference.append(reference_nested, inplace=True)
+
+        self.assertEqual(target, reference)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This is the high priority patch. These call instructions left in the schedule can crash job execution.

Fix #6321

### Details and comments


