### PR TITLE
Fix QuantumState._subsystem_probabilities

### DIFF
--- a/releasenotes/notes/fix-state-probabilities-qargs-f5f2a29dc07e69cd.yaml
+++ b/releasenotes/notes/fix-state-probabilities-qargs-f5f2a29dc07e69cd.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes a bug in :class:`~qiskit.quantum_info.Statevector` and
+    :class:`~qiskit.quantum_info.DensityMatrix` probability methods
+    :meth:`~qiskit.quantum_info.Statevector.probabilities`,
+    :meth:`~qiskit.quantum_info.Statevector.probabilities_dict`,
+    :meth:`~qiskit.quantum_info.DensityMatrix.probabilities`,
+    :meth:`~qiskit.quantum_info.DensityMatrix.probabilities_dict`
+    where the returned probabilities could have incorrect ordering
+    for certain values of the ``qargs`` kwarg.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -15,6 +15,7 @@
 
 import unittest
 import logging
+from itertools import permutations
 from ddt import ddt, data
 import numpy as np
 from numpy.testing import assert_allclose
@@ -24,6 +25,7 @@ from qiskit import QiskitError
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit import transpile
 from qiskit.circuit.library import HGate, QFT
+from qiskit.providers.basicaer import QasmSimulatorPy
 
 from qiskit.quantum_info.random import (
     random_unitary, random_statevector, random_pauli)
@@ -946,6 +948,35 @@ class TestStatevector(QiskitTestCase):
         target = state.expectation_value(op.to_matrix(), qubits)
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
+
+    @data(*[qargs for i in range(4) for qargs in permutations(range(4), r=i+1)])
+    def test_probabilities_qargs(self, qargs):
+        """Test probabilities method with qargs"""
+        # Get initial state
+        nq = 4
+        nc = len(qargs)
+        state_circ = QuantumCircuit(nq, nc)
+        for i in range(nq):
+            state_circ.ry((i + 1) * np.pi / (nq + 1), i)
+
+        # Get probabilities
+        state = Statevector(state_circ)
+        probs = state.probabilities(qargs)
+
+        # Estimate target probs from simulator measurement
+        sim = QasmSimulatorPy()
+        shots = 5000
+        seed = 100
+        circ = transpile(state_circ, sim)
+        circ.measure(qargs, range(nc))
+        result = sim.run(
+            circ, shots=shots, seed_simulator=seed).result()
+        target = np.zeros(2 ** nc, dtype=float)
+        for i, p in result.get_counts(0).int_outcomes().items():
+            target[i] = p / shots
+        # Compare
+        delta = np.linalg.norm(probs - target)
+        self.assertLess(delta, 0.05)
 
     def test_global_phase(self):
         """Test global phase is handled correctly when evolving statevector."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6320 

### Details and comments

Fixes bug in how permuted probabilities were calculated for non-trivial `qargs` kwarg in Statevector and DensityMatrix probabilities.
