### PR TITLE
Fix builder call_subroutine to accept parameterized duration

### DIFF
--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -1218,3 +1218,16 @@ class TestSubroutineCall(TestBuilder):
         self.assertEqual(play_0.pulse.sigma, 40)
         self.assertEqual(play_1.pulse.amp, 0.2)
         self.assertEqual(play_1.pulse.sigma, 40)
+
+    def test_call_subroutine_with_parametrized_duration(self):
+        """Test call subroutine containing a parametrized duration."""
+        dur = circuit.Parameter('dur')
+
+        with pulse.build() as subroutine:
+            pulse.play(pulse.Constant(dur, 0.1), pulse.DriveChannel(0))
+            pulse.play(pulse.Constant(dur, 0.2), pulse.DriveChannel(0))
+
+        with pulse.build() as main:
+            pulse.call(subroutine)
+
+        self.assertEqual(len(main.blocks), 1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #6323 


### Details and comments
This bug was induced by method name upgrade for backward compatibility. `.instructions` returns `Tuple[t0, Instruction]`, but this requires block-to-schedule conversion. Since the subroutine call just checks number of stored instructions, this conversion is not necessary.

Conditional branch just for the method name seems to be redundant. Renaming `ScheduleBlock.blocks` to `ScheduleBlock.children` is alternative approach.
