### PR TITLE
plot_histogram does not raise for neg values

### DIFF
--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -172,8 +172,7 @@ def plot_histogram(data, figsize=(7, 5), color=None, number_to_keep=None,
     # add some text for labels, title, and axes ticks
     ax.set_ylabel('Probabilities', fontsize=14)
     all_vals = np.concatenate(all_pvalues).ravel()
-    ax.set_ylim([min(0, min(val for val in all_vals)),
-                 min(1.2, max(1.2 * val for val in all_vals))])
+    ax.set_ylim([0, min(1.2, max(1.2 * val for val in all_vals))])
     if sort == 'desc':
         ax.invert_xaxis()
 

--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -172,8 +172,8 @@ def plot_histogram(data, figsize=(7, 5), color=None, number_to_keep=None,
     # add some text for labels, title, and axes ticks
     ax.set_ylabel('Probabilities', fontsize=14)
     all_vals = np.concatenate(all_pvalues).ravel()
-    ax.set_ylim([min(0, min([val for val in all_vals])),
-                 min([1.2, max([1.2 * val for val in all_vals])])])
+    ax.set_ylim([min(0, min(val for val in all_vals)),
+                 min(1.2, max(1.2 * val for val in all_vals))])
     if sort == 'desc':
         ax.invert_xaxis()
 

--- a/qiskit/visualization/counts_visualization.py
+++ b/qiskit/visualization/counts_visualization.py
@@ -172,7 +172,8 @@ def plot_histogram(data, figsize=(7, 5), color=None, number_to_keep=None,
     # add some text for labels, title, and axes ticks
     ax.set_ylabel('Probabilities', fontsize=14)
     all_vals = np.concatenate(all_pvalues).ravel()
-    ax.set_ylim([0., min([1.2, max([1.2 * val for val in all_vals])])])
+    ax.set_ylim([min(0, min([val for val in all_vals])),
+                 min([1.2, max([1.2 * val for val in all_vals])])])
     if sort == 'desc':
         ax.invert_xaxis()
 
@@ -231,7 +232,7 @@ def _plot_histogram_data(data, labels, number_to_keep):
                 labels_dict[key] = 1
                 values.append(execution[key])
         values = np.array(values, dtype=float)
-        where_idx = np.where(values >= 0)[0]
+        where_idx = np.where(values != 0)[0]
         pvalues = values[where_idx] / sum(values[where_idx])
 
         all_pvalues.append(pvalues)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
`plot_histogram` previously only worked for positive values, as expected given that the results are derived from counts.  However, as mentioned in #6267 we need a viewer for quasiprobabilities that can include negative values.  Doing the necessary work for #6267 is likely not going to be done on time given the myriad of other things needed, so a stop gap is to fix `plot_histogram` so that it does not crash when given small (~1e-3) negative values.  This does that.  This will not elucidate the quasiprobabilities, but it does allow for quick viewing without converting to the closest true probability dist. 

<img width="729" alt="Screen Shot 2021-05-02 at 06 30 05" src="https://user-images.githubusercontent.com/1249193/116810122-dae17580-ab0f-11eb-9504-92ac6d9c81be.png">

### Details and comments


