### PR TITLE
BasisTranslator skips translating gates already in target basis

### DIFF
--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -271,7 +271,7 @@ def _basis_search(equiv_lib, source_basis, target_basis, heuristic):
         for gate_name, gate_num_qubits in current_basis:
             if gate_name in target_basis:
                 continue
-            
+
             equivs = equiv_lib._get_equivalences((gate_name, gate_num_qubits))
 
             basis_remain = current_basis - {(gate_name, gate_num_qubits)}

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -269,6 +269,9 @@ def _basis_search(equiv_lib, source_basis, target_basis, heuristic):
         closed_set.add(current_basis)
 
         for gate_name, gate_num_qubits in current_basis:
+            if gate_name in target_basis:
+                continue
+            
             equivs = equiv_lib._get_equivalences((gate_name, gate_num_qubits))
 
             basis_remain = current_basis - {(gate_name, gate_num_qubits)}

--- a/releasenotes/notes/bugfix-skip-target-basis-translation-12a9fa02c9ceef25.yaml
+++ b/releasenotes/notes/bugfix-skip-target-basis-translation-12a9fa02c9ceef25.yaml
@@ -1,5 +1,5 @@
 ---
 fixes:
   - |
-    Fixed an issue with :class:`~qiskit.transpiler.passes.basis.BasisTranslator` where in some
+    Fixed an issue with :class:`~qiskit.transpiler.passes.BasisTranslator` where in some
     cases it would translate gates already in the target basis.

--- a/releasenotes/notes/bugfix-skip-target-basis-translation-12a9fa02c9ceef25.yaml
+++ b/releasenotes/notes/bugfix-skip-target-basis-translation-12a9fa02c9ceef25.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue with :class:`~qiskit.transpiler.passes.basis.BasisTranslator` where in some
+    cases it would translate gates already in the target basis.


### PR DESCRIPTION
### Summary
Fixes #6085. 


### Details and comments
This commit fixes a bug in the `basis_translator.py` that was causing translation of gates already in the target basis. For example, target basis gate CX was unnecessarily translated with 4 CX gates. The fix will check gate names in the `current_basis` during translation, and if it matches with any gate on the target basis, it will skip equivalence checking (and possible translation) for that gate.

I ran `tox`, and the tests are passing. However, I did not add any tests. 