### PR TITLE
QuantumInstance use circuit instead of qobj for all backends

### DIFF
--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -82,6 +82,8 @@ class CircuitSampler(ConverterBase):
         self._statevector = (
             statevector if statevector is not None else self.quantum_instance.is_statevector
         )
+        # Set to False until https://github.com/Qiskit/qiskit-aer/issues/1249 is closed.
+        param_qobj = False
         self._param_qobj = param_qobj
         self._attach_results = attach_results
 

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -138,9 +138,11 @@ def is_statevector_backend(backend):
         bool: True is statevector
     """
     if has_aer():
-        from qiskit.providers.aer.backends import StatevectorSimulator
+        from qiskit.providers.aer.backends import AerSimulator, StatevectorSimulator
 
         if isinstance(backend, StatevectorSimulator):
+            return True
+        if isinstance(backend, AerSimulator) and backend.name() == "aer_simulator_statevector":
             return True
     return backend.name().startswith("statevector") if backend is not None else False
 

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -672,4 +672,24 @@ def _run_circuits_on_backend(
     run_config: Dict,
 ) -> BaseJob:
     """run on backend"""
-    return backend.run(circuits, **backend_options, **noise_config, **run_config)
+    run_kwargs = {}
+    if is_aer_provider(backend) or is_basicaer_provider(backend):
+        for key, value in backend_options.items():
+            if key == "backend_options":
+                for k, v in value.items():
+                    run_kwargs[k] = v
+            else:
+                run_kwargs[key] = value
+    else:
+        run_kwargs.update(backend_options)
+
+    run_kwargs.update(noise_config)
+    run_kwargs.update(run_config)
+
+    if is_basicaer_provider(backend):
+        # BasicAer emits warning if option is not in its list
+        for key in list(run_kwargs.keys()):
+            if not hasattr(backend.options, key):
+                del run_kwargs[key]
+
+    return backend.run(circuits, **run_kwargs)

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -234,7 +234,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
     @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
     def test_with_aer_qasm(self):
         """Test VQE with Aer's qasm_simulator."""
-        backend = Aer.get_backend("qasm_simulator")
+        backend = Aer.get_backend("aer_simulator")
         optimizer = SPSA(maxiter=200, last_avg=5)
         wavefunction = self.ry_wavefunction
 
@@ -259,7 +259,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
     def test_with_aer_qasm_snapshot_mode(self):
         """Test the VQE using Aer's qasm_simulator snapshot mode."""
 
-        backend = Aer.get_backend("qasm_simulator")
+        backend = Aer.get_backend("aer_simulator")
         optimizer = L_BFGS_B()
         wavefunction = self.ry_wavefunction
 
@@ -412,7 +412,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
     @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
     def test_vqe_expectation_select(self):
         """Test expectation selection with Aer's qasm_simulator."""
-        backend = Aer.get_backend("qasm_simulator")
+        backend = Aer.get_backend("aer_simulator")
 
         with self.subTest("Defaults"):
             vqe = VQE(quantum_instance=backend)

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -50,7 +50,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
             from qiskit import Aer
 
             self.seed = 97
-            self.backend = Aer.get_backend("qasm_simulator")
+            self.backend = Aer.get_backend("aer_simulator")
             q_instance = QuantumInstance(
                 self.backend, seed_simulator=self.seed, seed_transpiler=self.seed
             )
@@ -149,6 +149,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
             sampled_plus.eval(), [1, 0.5 ** 0.5, (1 + 0.5 ** 0.5), 1], decimal=1
         )
 
+    @unittest.skip("Skip until https://github.com/Qiskit/qiskit-aer/issues/1249 is closed.")
     def test_parameterized_qobj(self):
         """grouped pauli expectation test"""
         two_qubit_h2 = (

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -37,7 +37,7 @@ from qiskit.opflow import I, X, Y, Z, StateFn, CircuitStateFn, ListOp, CircuitSa
 from qiskit.opflow.gradients import Gradient, NaturalGradient, Hessian
 from qiskit.opflow.gradients.qfi import QFI
 from qiskit.opflow.gradients.circuit_qfis import LinCombFull, OverlapBlockDiag, OverlapDiag
-from qiskit.circuit import Parameter, ParameterExpression
+from qiskit.circuit import Parameter
 from qiskit.circuit import ParameterVector
 from qiskit.circuit.library import RealAmplitudes
 
@@ -1020,26 +1020,26 @@ class TestParameterGradients(QiskitOpflowTestCase):
         with self.subTest("linear"):
             expr = 2 * x + y
 
-            grad = Gradient.parameter_expression_grad(expr, x)
+            grad = expr.gradient(x)
             self.assertEqual(grad, 2)
 
-            grad = Gradient.parameter_expression_grad(expr, y)
+            grad = expr.gradient(y)
             self.assertEqual(grad, 1)
 
         with self.subTest("polynomial"):
             expr = x * x * x - x * y + y * y
 
-            grad = Gradient.parameter_expression_grad(expr, x)
+            grad = expr.gradient(x)
             self.assertEqual(grad, 3 * x * x - y)
 
-            grad = Gradient.parameter_expression_grad(expr, y)
+            grad = expr.gradient(y)
             self.assertEqual(grad, -1 * x + 2 * y)
 
     def test_converted_to_float_if_bound(self):
         """Test the gradient is a float when no free symbols are left."""
         x = Parameter("x")
         expr = 2 * x + 1
-        grad = Gradient.parameter_expression_grad(expr, x)
+        grad = expr.gradient(x)
         self.assertIsInstance(grad, float)
 
 

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2020.
+# (C) Copyright IBM 2018, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -74,7 +74,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
             state = Plus
             self.assertEqual((~StateFn(op) @ state).eval(), 0j)
 
-        backend = Aer.get_backend("qasm_simulator")
+        backend = Aer.get_backend("aer_simulator")
         q_instance = QuantumInstance(backend, seed_simulator=97, seed_transpiler=97)
         op = I
         with self.subTest("zero coeff in summed StateFn and CircuitSampler"):
@@ -94,7 +94,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
             return
-        backend = Aer.get_backend("qasm_simulator")
+        backend = Aer.get_backend("aer_simulator")
         q_instance = QuantumInstance(backend)  # no seeds needed since no values are compared
         state = Plus
         sampler = CircuitSampler(q_instance).convert(~state @ state)
@@ -119,7 +119,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         bindings = {x: -0.4, y: 0.4}
         listop = ListOp([StateFn(circuit) for circuit in [circuit1, circuit2, circuit3]])
 
-        sampler = CircuitSampler(Aer.get_backend("qasm_simulator"))
+        sampler = CircuitSampler(Aer.get_backend("aer_simulator"))
         sampled = sampler.convert(listop, params=bindings)
 
         self.assertTrue(all(len(op.parameters) == 0 for op in sampled.oplist))
@@ -148,7 +148,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         circuit.ry(x, 0)
         expr = ~StateFn(H) @ StateFn(circuit)
 
-        sampler = CircuitSampler(Aer.get_backend("statevector_simulator"))
+        sampler = CircuitSampler(Aer.get_backend("aer_simulator_statevector"))
 
         res = sampler.convert(expr, params={x: 0}).eval()
 
@@ -169,7 +169,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         expr1 = ~StateFn(H) @ StateFn(circuit)
         expr2 = ~StateFn(X) @ StateFn(circuit)
 
-        sampler = CircuitSampler(Aer.get_backend("statevector_simulator"), caching=caching)
+        sampler = CircuitSampler(Aer.get_backend("aer_simulator_statevector"), caching=caching)
 
         res1 = sampler.convert(expr1, params={x: 0}).eval()
         res2 = sampler.convert(expr2, params={x: 0}).eval()
@@ -208,11 +208,11 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_quantum_instance_with_backend_shots(self):
         """Test sampling a circuit where the backend has shots attached."""
         try:
-            from qiskit.providers.aer import QasmSimulator
+            from qiskit.providers.aer import AerSimulator
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest("Aer doesn't appear to be installed. Error: '{}'".format(str(ex)))
 
-        backend = QasmSimulator(shots=10)
+        backend = AerSimulator(shots=10)
         sampler = CircuitSampler(backend)
         res = sampler.convert(~Plus @ Plus).eval()
         self.assertAlmostEqual(res, 1 + 0j, places=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comment
This adds a test for statevector simulator and save_statevector in QuantumInstance in case it is not in the circuit already. This solution may not be optimal.

Also, passes circuits instead of qobj to backends.