### PR TITLE
Update for typo fix of controlled swap gate documentation

### DIFF
--- a/qiskit/circuit/library/standard_gates/swap.py
+++ b/qiskit/circuit/library/standard_gates/swap.py
@@ -106,7 +106,7 @@ class SwapGate(Gate):
 
 
 class CSwapGate(ControlledGate):
-    r"""Controlled-X gate.
+    r"""Controlled swap gate.
 
     **Circuit symbol:**
 


### PR DESCRIPTION
In response to Issue #6352

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The controlled swap gate was incorrectly mentioned as a controlled-X gate. The typo fix is now written as controlled swap gate.

### Details and comments


