### PR TITLE
Cast numpy fixed precision types for symengine subs

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -114,8 +114,6 @@ class ParameterExpression:
             # see symengine/symengine.py#351 for more details
             if isinstance(value, numpy.floating):
                 symbol_values[param_expr] = float(value)
-            elif isinstance(value, numpy.integer):
-                symbol_values[param_expr] = int(value)
             else:
                 symbol_values[param_expr] = value
 

--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -107,10 +107,18 @@ class ParameterExpression:
         self._raise_if_passed_unknown_parameters(parameter_values.keys())
         self._raise_if_passed_nan(parameter_values)
 
-        symbol_values = {
-            self._parameter_symbols[parameter]: value
-            for parameter, value in parameter_values.items()
-        }
+        symbol_values = {}
+        for parameter, value in parameter_values.items():
+            param_expr = self._parameter_symbols[parameter]
+            # TODO: Remove after symengine supports single precision floats
+            # see symengine/symengine.py#351 for more details
+            if isinstance(value, numpy.floating):
+                symbol_values[param_expr] = float(value)
+            elif isinstance(value, numpy.integer):
+                symbol_values[param_expr] = int(value)
+            else:
+                symbol_values[param_expr] = value
+
         bound_symbol_expr = self._symbol_expr.subs(symbol_values)
 
         # Don't use sympy.free_symbols to count remaining parameters here.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As reported in symengine/symengine.py#351 and
Qiskit/qiskit-machine-learning#84 when trying to use a single precision
numpy float symengine raises an error. To workaround this (and unblock
machine-learning) this commit just casts to a python float before we
pass the value to symengine. This should avoid the incompatibility and
enable machine learning to continue to use np.float32 until support is
added in symengine.

### Details and comments

Fixes Qiskit/qiskit-machine-learning#84