### PR TITLE
Insert actual path to source when generating docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,16 +22,15 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 """
 Sphinx documentation builder
 """
 
-import os
 # Set env flag so that we can doc functions that may otherwise not be loaded
 # see for example interactive visualizations in qiskit.visualization.
 os.environ['QISKIT_DOCS'] = 'TRUE'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I would like to propose a PR to follow-up on a change we introduced in the application modules last week (https://github.com/Qiskit/qiskit-nature/pull/176). My motivation is identical to my reasoning outlined there but I will replicate it here for completeness and ease of discussion.

**Disclaimer:** this does _NOT_ affect the existing workflow!

I propose to insert the actual path of the Qiskit Terra source code in `sys.path` when generating the docs with Sphinx.
This is a common configuration option to enable as can be seen by the fact that I merely uncommented some lines adapted the relative path to Terra's project structure.


### Details and comments

Another disclaimer: When I try to generate the docs locally for me editable isntall via `tox -edocs`, the build fails with the following error message:
```
Warning, treated as error:
Cannot resolve forward reference in type annotations of "qiskit.assembler.assemble_schedules": name 'Schedule' is not defined
ERROR: InvocationError for command /home/oss/Files/Qiskit/src/qiskit-terra/main/.tox/docs/bin/sphinx-build -W -b html -j auto docs/ docs/_build/html (exited with code 2)
```
This happens both, prior and after this PR! Thus, I resolve to use `make -C docs html` to generate the documentation locally.

Now, for some more explanations:

The reason why I would like to apply this change is the following: I am trying out a new workflow involving [git worktrees](https://git-scm.com/docs/git-worktree).

In my usecase I have a project structure like the following:
```
qiskit-terra/
    COMMIT_EDITMSG
    FETCH_HEAD
    HEAD
    ORIG_HEAD
    branches
    config
    description
    feature/
        <feature branch worktrees>
    hooks
    index
    info
    logs
    main/ <main branch worktree>
    objects
    packed-refs
    refs
    worktrees
```
As you can see, this means I have a bare clone of the qiskit-terra repo with different worktrees for the branches I am currently working on. This is very useful because it allows rapid switching between multiple branches without having to stash or commit all my WIP changes all the time.
It also essentially allows me to have multiple versions of qiskit-terra installed at the same time, because I can create virtual environments which derive of the main one.

To be more concrete, my main virtual environment contains an editable install pointing to `.../qiskit-terra/main`.
In my feature branches I then have virtual environments which derive of the main one and only update the editable install path of Qiskit Terra to `../qiskit-terra/feature/some_branch`.
In this way I never have to reinstall everything and can simply source the environment of the feature which I want to test.

Now with all that said, sphinx is the only problem because its path is the following **prior** to my change (please excuse the absolute paths):
```
['/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra/main', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-ibmq-provider', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```
After my change, it looks like the following (when in `qiskit-terra/main`):
```
['/home/oss/Files/Qiskit/src/qiskit-terra/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra/main', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-ibmq-provider', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```
and like the following in one of the feature worktrees:
```
['/home/oss/Files/Qiskit/src/qiskit-terra/feature/sphinx-conf-upgrade', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/bin', '/usr/lib64/python39.zip', '/usr/lib64/python3.9', '/usr/lib64/python3.9/lib-dynload', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib64/python3.9/site-packages', '/home/oss/Files/Qiskit/src/qiskit-terra/main', '/home/oss/Files/Qiskit/src/qiskit-ignis', '/home/oss/Files/Qiskit/src/qiskit-ibmq-provider', '/home/oss/Files/Qiskit/src/qiskit-nature/main', '/home/oss/Files/Qiskit/.direnv/python-3.9.4/lib/python3.9/site-packages']
```

With the first path pointing to the actual source I am interested in, the docs get generated correctly and not always for the "installed" source.
