### PR TITLE
Revert "Set sympy.evaluate(False) on frequent code paths for phase tracking. (#6072)"

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -996,10 +996,7 @@ class DAGCircuit:
                 in_dag.apply_operation_back(replay_node.op, replay_node.qargs, replay_node.cargs)
 
         if in_dag.global_phase:
-            from sympy import evaluate
-
-            with evaluate(False):
-                self.global_phase += in_dag.global_phase
+            self.global_phase += in_dag.global_phase
 
         if wires is None:
             wires = in_dag.wires

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -181,10 +181,7 @@ class BasisTranslator(TransformationPass):
                     dag.substitute_node(node, dag_op, inplace=True)
 
                     if bound_target_dag.global_phase:
-                        from sympy import evaluate
-
-                        with evaluate(False):
-                            dag.global_phase += bound_target_dag.global_phase
+                        dag.global_phase += bound_target_dag.global_phase
                 else:
                     dag.substitute_node_with_dag(node, bound_target_dag)
             else:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary


With recent adoption of symengine for the performance critical path
with ParameterExpressions the workaround for large expression evaluation
in #6072 is no longer needed or applicable, except in environments
without symengine. However, with symengine available using the sympy
evaluate context adds noticeable overhead, both to import sympy (which
wouldn't be used otherwise) and to load the sympy evalue context
wrapper. This commit removes these as we shouldn't compromise performance
in the performance path to try and speed up a path with degraded
performance because symengine isn't available (32bit platforms).

### Details and comments

This reverts commit f436f5ab7ef903e14d46a89f2d9f1c8d9c3b4b92.
