### PR TITLE
Respect max_experiments in QuantumInstance BackendV1 path

### DIFF
--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -457,71 +457,22 @@ def run_circuits(
     run_config = run_config or {}
     with_autorecover = not is_simulator_backend(backend)
 
-    job, job_id = _safe_submit_circuits(
-        circuits,
-        backend,
-        qjob_config=qjob_config,
-        backend_options=backend_options,
-        noise_config=noise_config,
-        run_config=run_config,
-    )
-    result = None
-    if with_autorecover:
-        logger.info("Backend status: %s", backend.status())
-        logger.info("There is one jobs are submitted: id: %s", job_id)
-        while True:
-            logger.info("Running job id: %s", job_id)
-            # try to get result if possible
-            while True:
-                job_status = _safe_get_job_status(job, job_id)
-                queue_position = 0
-                if job_status in JOB_FINAL_STATES:
-                    # do callback again after the job is in the final states
-                    if job_callback is not None:
-                        job_callback(job_id, job_status, queue_position, job)
-                    break
-                if job_status == JobStatus.QUEUED and hasattr(job, queue_position):
-                    queue_position = job.queue_position()
-                    logger.info("Job id: %s is queued at position %s", job_id, queue_position)
-                else:
-                    logger.info("Job id: %s, status: %s", job_id, job_status)
-                if job_callback is not None:
-                    job_callback(job_id, job_status, queue_position, job)
-                time.sleep(qjob_config["wait"])
+    if MAX_CIRCUITS_PER_JOB is not None:
+        max_circuits_per_job = int(MAX_CIRCUITS_PER_JOB)
+    else:
+        if is_local_backend(backend):
+            max_circuits_per_job = sys.maxsize
+        else:
+            max_circuits_per_job = backend.configuration().max_experiments
 
-            # get result after the status is DONE
-            if job_status == JobStatus.DONE:
-                while True:
-                    result = job.result()
-                    if result.success:
-                        logger.info("COMPLETED: job id: %s", job_id)
-                        break
-
-                    logger.warning("FAILURE: Job id: %s", job_id)
-                    logger.warning(
-                        "Job (%s) is completed anyway, retrieve result " "from backend again.",
-                        job_id,
-                    )
-                    job = backend.retrieve_job(job_id)
-                break
-            # for other cases, resubmit the circuit until the result is available.
-            # since if there is no result returned, there is no way algorithm can do any process
-            if job_status == JobStatus.CANCELLED:
-                logger.warning("FAILURE: Job id: %s is cancelled. Re-submit the circuits.", job_id)
-            elif job_status == JobStatus.ERROR:
-                logger.warning(
-                    "FAILURE: Job id: %s encounters the error. "
-                    "Error is : %s. Re-submit the circuits.",
-                    job_id,
-                    job.error_message(),
-                )
-            else:
-                logging.warning(
-                    "FAILURE: Job id: %s. Unknown status: %s. " "Re-submit the circuits.",
-                    job_id,
-                    job_status,
-                )
-
+    if len(circuits) > max_circuits_per_job:
+        jobs = []
+        job_ids = []
+        split_circuits = []
+        count = 0
+        while count < len(circuits):
+            some_circuits = circuits[count : count + max_circuits_per_job]
+            circuits.append(some_circuits)
             job, job_id = _safe_submit_circuits(
                 circuits,
                 backend,
@@ -530,6 +481,94 @@ def run_circuits(
                 noise_config=noise_config,
                 run_config=run_config,
             )
+            jobs.append(job)
+            job_ids.append(job_id)
+            count += max_circuits_per_job
+    else:
+        job, job_id = _safe_submit_circuits(
+            circuits,
+            backend,
+            qjob_config=qjob_config,
+            backend_options=backend_options,
+            noise_config=noise_config,
+            run_config=run_config,
+        )
+        jobs = [job]
+        job_ids = [job_id]
+        split_circuits = [circuits]
+    result = None
+    if with_autorecover:
+        logger.info("Backend status: %s", backend.status())
+        logger.info("There are %s jobs are submitted.", len(jobs))
+        logger.info("All job ids:\n%s", job_ids)
+        for idx, _ in enumerate(jobs):
+            logger.info("Backend status: %s", backend.status())
+            logger.info("There is one jobs are submitted: id: %s", job_id)
+            job = jobs[idx]
+            job_id = job_ids[idx]
+            while True:
+                logger.info("Running job id: %s", job_id)
+                # try to get result if possible
+                while True:
+                    job_status = _safe_get_job_status(job, job_id)
+                    queue_position = 0
+                    if job_status in JOB_FINAL_STATES:
+                        # do callback again after the job is in the final states
+                        if job_callback is not None:
+                            job_callback(job_id, job_status, queue_position, job)
+                        break
+                    if job_status == JobStatus.QUEUED and hasattr(job, queue_position):
+                        queue_position = job.queue_position()
+                        logger.info("Job id: %s is queued at position %s", job_id, queue_position)
+                    else:
+                        logger.info("Job id: %s, status: %s", job_id, job_status)
+                    if job_callback is not None:
+                        job_callback(job_id, job_status, queue_position, job)
+                    time.sleep(qjob_config["wait"])
+
+                # get result after the status is DONE
+                if job_status == JobStatus.DONE:
+                    while True:
+                        result = job.result()
+                        if result.success:
+                            logger.info("COMPLETED: job id: %s", job_id)
+                            break
+
+                        logger.warning("FAILURE: Job id: %s", job_id)
+                        logger.warning(
+                            "Job (%s) is completed anyway, retrieve result " "from backend again.",
+                            job_id,
+                        )
+                        job = backend.retrieve_job(job_id)
+                    break
+                # for other cases, resubmit the circuit until the result is available.
+                # since if there is no result returned, there is no way algorithm can do any process
+                if job_status == JobStatus.CANCELLED:
+                    logger.warning(
+                        "FAILURE: Job id: %s is cancelled. Re-submit the circuits.", job_id
+                    )
+                elif job_status == JobStatus.ERROR:
+                    logger.warning(
+                        "FAILURE: Job id: %s encounters the error. "
+                        "Error is : %s. Re-submit the circuits.",
+                        job_id,
+                        job.error_message(),
+                    )
+                else:
+                    logging.warning(
+                        "FAILURE: Job id: %s. Unknown status: %s. " "Re-submit the circuits.",
+                        job_id,
+                        job_status,
+                    )
+
+                job, job_id = _safe_submit_circuits(
+                    split_circuits[idx],
+                    backend,
+                    qjob_config=qjob_config,
+                    backend_options=backend_options,
+                    noise_config=noise_config,
+                    run_config=run_config,
+                )
     else:
         result = job.result()
 

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -518,7 +518,7 @@ def run_circuits(
                         if job_callback is not None:
                             job_callback(job_id, job_status, queue_position, job)
                         break
-                    if job_status == JobStatus.QUEUED and hasattr(job, queue_position):
+                    if job_status == JobStatus.QUEUED and hasattr(job, "queue_position"):
                         queue_position = job.queue_position()
                         logger.info("Job id: %s is queued at position %s", job_id, queue_position)
                     else:

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -574,7 +574,7 @@ def run_circuits(
     else:
         results = []
         for job in jobs:
-            results.append(job.result(**qjob_config))
+            results.append(job.result())
 
     result = _combine_result_objects(results) if results else None
 

--- a/releasenotes/notes/respect-max-experiments-quantum-instance-aae99429034aab52.yaml
+++ b/releasenotes/notes/respect-max-experiments-quantum-instance-aae99429034aab52.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed an issue with the :class:`~qiskit.utils.QuantumInstance` with
-    :class:`~qiskit.providers.BackendV1` backends with the 
+    :class:`~qiskit.providers.BackendV1` backends with the
     :attr:`~qiskit.providers.models.BackendConfiguration.`max_experiments`
     attribute set to a value less than the number of circuits to run. Previously
     the :class:`~qiskit.utils.QuantumInstance` would not correctly split the

--- a/releasenotes/notes/respect-max-experiments-quantum-instance-aae99429034aab52.yaml
+++ b/releasenotes/notes/respect-max-experiments-quantum-instance-aae99429034aab52.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~qiskit.utils.QuantumInstance` with
+    :class:`~qiskit.providers.BackendV1` backends with the 
+    :attr:`~qiskit.providers.models.BackendConfiguration.`max_experiments`
+    attribute set to a value less than the number of circuits to run. Previously
+    the :class:`~qiskit.utils.QuantumInstance` would not correctly split the
+    circuits to run into separate jobs, which has been corrected.

--- a/test/python/algorithms/test_backendv1.py
+++ b/test/python/algorithms/test_backendv1.py
@@ -80,6 +80,20 @@ class TestBackendV1(QiskitAlgorithmsTestCase):
         result = grover.amplify(problem)
         self.assertIn(result.top_measurement, ["11"])
 
+    def test_run_circuit_oracle_single_experiment_backend(self):
+        """Test execution with a quantum circuit oracle"""
+        oracle = QuantumCircuit(2)
+        oracle.cz(0, 1)
+        problem = AmplificationProblem(oracle, is_good_state=["11"])
+        backend = self._provider.get_backend("fake_yorktown")
+        backend._configuration.max_experiments = 1
+        qi = QuantumInstance(
+            self._provider.get_backend("fake_yorktown"), seed_simulator=12, seed_transpiler=32
+        )
+        grover = Grover(quantum_instance=qi)
+        result = grover.amplify(problem)
+        self.assertIn(result.top_measurement, ["11"])
+
     def test_measurement_error_mitigation_with_vqe(self):
         """measurement error mitigation test with vqe"""
         try:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #6299 support was fixed for strict BackendV1 backends that only take
QuantumCircuit objects (instead of qobj) for the input. That was fixed
by adding a parallel path when running with a new backend. However that
parallel path wasn't identical and was missing the support the qobj path
had for splitting an algorithm run into multiple jobs if the backend if
the number of circuits was greater than the max_experiments set in the
backend. This would result on some providers' backends, such as ionq and
aqt, both of which have max_experiments set to 1. This commit fixes this
issue by splitting the circuits list into smaller sublists when the
len(circuits) > max_experiments (or the old env var, which we should
change the name of at some point).

### Details and comments