### PR TITLE
Remove stestr's grouping configuration

### DIFF
--- a/.stestr.conf
+++ b/.stestr.conf
@@ -1,3 +1,2 @@
 [DEFAULT]
 test_path=./test/python
-group_regex=([^\.]*\.)*

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -13,6 +13,7 @@
 # pylint: disable=missing-docstring
 
 import os
+from uuid import uuid4
 
 from qiskit import exceptions
 from qiskit.test import QiskitTestCase
@@ -20,9 +21,9 @@ from qiskit import user_config
 
 
 class TestUserConfig(QiskitTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.file_path = "temp.txt"
+    def setUp(self):
+        super().setUp()
+        self.file_path = "test_%s.conf" % uuid4()
 
     def test_empty_file_read(self):
         config = user_config.UserConfig(self.file_path)

--- a/test/python/visualization/test_gate_map.py
+++ b/test/python/visualization/test_gate_map.py
@@ -12,8 +12,9 @@
 
 """A test for visualizing device coupling maps"""
 import unittest
-import os
 
+from io import BytesIO
+from PIL import Image
 from ddt import ddt, data
 from qiskit.test.mock import FakeProvider
 from qiskit.test import QiskitTestCase
@@ -45,11 +46,12 @@ class TestGateMap(QiskitVisualizationTestCase):
         """tests plotting of gate map of a device (20 qubit, 16 qubit, 14 qubit and 5 qubit)"""
         n = backend.configuration().n_qubits
         img_ref = path_to_diagram_reference(str(n) + "bit_quantum_computer.png")
-        filename = "temp.png"
         fig = plot_gate_map(backend)
-        fig.savefig(filename)
-        self.assertImagesAreEqual(filename, img_ref, 0.2)
-        os.remove(filename)
+        with BytesIO() as img_buffer:
+            fig.savefig(img_buffer, format="png")
+            img_buffer.seek(0)
+            self.assertImagesAreEqual(Image.open(img_buffer), img_ref, 0.2)
+        plt.close(fig)
 
     @data(*backends)
     @unittest.skipIf(not HAS_MATPLOTLIB, "matplotlib not available.")
@@ -62,11 +64,12 @@ class TestGateMap(QiskitVisualizationTestCase):
         circuit._layout.add_register(qr)
         n = backend.configuration().n_qubits
         img_ref = path_to_diagram_reference(str(n) + "_plot_circuit_layout.png")
-        filename = str(n) + "_plot_circuit_layout_result.png"
         fig = plot_circuit_layout(circuit, backend)
-        fig.savefig(filename)
-        self.assertImagesAreEqual(filename, img_ref, 0.1)
-        os.remove(filename)
+        with BytesIO() as img_buffer:
+            fig.savefig(img_buffer, format="png")
+            img_buffer.seek(0)
+            self.assertImagesAreEqual(Image.open(img_buffer), img_ref, 0.1)
+        plt.close(fig)
 
 
 @unittest.skipIf(not HAS_MATPLOTLIB, "matplotlib not available.")


### PR DESCRIPTION
Removing  the grouping regex in .stestr.conf should allow stestr to pack its test workers better, and therefore improve the speed of test execution. However, pre-existing test cases utilizing non-unique tempfiles began to fail after the configuration change. This commit modifies such tests to pass under these new conditions. This also allows the test suite to properly execute using pytest-xdist.

Fixed #6105

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X ] I have added the tests to cover my changes.
- [X ] I have updated the documentation accordingly.
- [X ] I have read the CONTRIBUTING document.
-->

### Summary

Per #6105 a few tests (TestGateMap and TestUserConfig) were failing when using pytest-xdist.  Both tests were reliant on a hardcoded file name "temp.txt", which is the root source of the failures.  This pull modifies both to use less brittle file buffers. 

I also went ahead and removed the regex found in https://github.com/Qiskit/qiskit-terra/blob/master/.stestr.conf#L3 as discussed in the issue. After correcting the tests I have not seen any issues with the configuration change. I will adjust the merge request if any reviewers are uncomfortable removing it or if it fails in ci checks.

### Details and comments

For TestGateMap:
I modified the test so that it utilizes ```io.BytesIO``` instead of needlessly writing to the problamatic temp file.

For TestUserConfig:
I moved the "string" configurations to their own personal files found in test/python/configurations. This might make it a bit harder to tell what the test is testing i.e. in the future devs will have to open the configuration file. However, this avoids the write to the problematic temp file and should create a less brittle test.