### PR TITLE
Add FullPassManager class for pass manager with defined stages

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -312,3 +312,157 @@ class PassManager:
                 item["flow_controllers"] = {}
             ret.append(item)
         return ret
+
+
+class FullPassManager(PassManager):
+    """A full Pass manager pipeline for a backend
+
+    Instances of FullPassManager define a full compilation pipeline from a abstract virtual
+    circuit to one that is optimized and capable of running on the specified backend. It is
+    built using predefined stages:
+
+    1. Init - any initial passes that are run before we start embedding the circuit to the backend
+    2. Layout - This stage runs layout and maps the virtual qubits in the
+    circuit to the physical qubits on a backend
+    3. Routing - This stage runs after a layout has been run and will insert any
+        necessary gates to move the qubit states around until it can be run on
+        backend's compuling map.
+    4. Translation - Perform the basis gate translation, in other words translate the gates
+        in the circuit to the target backend's basis set
+    5. Pre-Optimization - Any passes to run before the main optimization loop
+    6. Optimization - The main optimization loop, this will typically run in a loop trying to optimize
+        the circuit until a condtion (such as fixed depth) is reached.
+    7. Post-Optimization - Any passes to run after the main optimization loop
+
+    """
+
+    phases = [
+        "init",
+        "layout",
+        "routing",
+        "translation",
+        "pre_optimization",
+        "optimization",
+        "post_optimization",
+    ]
+
+    def __init__(
+        self,
+        init=None,
+        layout=None,
+        routing=None,
+        translation=None,
+        pre_optimization=None,
+        optimization=None,
+        post_optimization=None,
+    ):
+        """Initialize a new FullPassManager object
+
+        Args:
+            init (PassManager): A passmanager to run for the initial stage of the
+                compilation.
+            layout (PassManager): A passmanager to run for the layout stage of the
+                compilation.
+            routing (PassManager): A pass manager to run for the routing stage
+                of the compilation
+            translation (PassManager): A pass manager to run for the translation
+                stage of the compilation
+            pre_opt (PassManager): A pass manager to run before the optimization
+                loop
+            optimization (PassManager): A pass manager to run for the
+                optimization loop stage
+            post_opt (PassManager): A pass manager to run after the optimization
+                loop
+        """
+        super().__init__()
+        self._init = init
+        self._layout = layout
+        self._routing = routing
+        self._translation = translation
+        self._pre_optimization = pre_optimization
+        self._optimization = optimization
+        self._post_optimization = post_optimization
+        self._update_passmanager()
+
+    def _update_passmanager(self):
+        self._pass_sets = []
+        if self._init:
+            self._pass_sets.extend(self._init._pass_sets)
+        if self._layout:
+            self._pass_sets.extend(self._layout._pass_sets)
+        if self._routing:
+            self._pass_sets.extend(self._routing._pass_sets)
+        if self._translation:
+            self._pass_sets.extend(self._translation._pass_sets)
+        if self._pre_optimization:
+            self._pass_sets.extend(self._pre_optimization._pass_sets)
+        if self._optimization:
+            self._pass_sets.extend(self._optimization._pass_sets)
+        if self._post_optimization:
+            self._pass_sets.extend(self._post_optimization._pass_sets)
+
+    @property
+    def init(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the init stage."""
+        return self._init
+
+    @init.setter
+    def init(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the init stage."""
+        self._init = value
+        self._update_passmanager()
+
+    @property
+    def layout(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the layout stage."""
+        return self._layout
+
+    @layout.setter
+    def layout(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the layout stage."""
+        self._layout = value
+        self._update_passmanager()
+
+    @property
+    def routing(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the routing stage."""
+        return self._routing
+
+    @routing.setter
+    def routing(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the routing stage."""
+        self._routing = value
+        self._update_passmanager()
+
+    @property
+    def pre_optimization(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the pre_optimization stage."""
+        return self._pre_optimization
+
+    @pre_optimization.setter
+    def pre_optimization(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the pre_optimization stage."""
+        self._pre_optimization = value
+        self._update_passmanager()
+
+    @property
+    def optimization(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the optimization stage."""
+        return self._optimization
+
+    @optimization.setter
+    def optimization(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the optimization stage."""
+        self._optimization = value
+        self._update_passmanager()
+
+    @property
+    def post_optimization(self):
+        """Get the :class:`~qiskit.transpiler.PassManager` for the post_optimization stage."""
+        return self._post_optimization
+
+    @post_optimization.setter
+    def post_optimization(self, value):
+        """Set the :class:`~qiskit.transpiler.PassManager` for the post_optimization stage."""
+        self._post_optimization = value
+        self._update_passmanager()

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -19,6 +19,8 @@ gate cancellation using commutativity rules and unitary synthesis.
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 from qiskit.transpiler.passmanager import PassManager
+from qiskit.transpiler.passmanager import FullPassManager
+
 
 from qiskit.transpiler.passes import Unroller
 from qiskit.transpiler.passes import BasisTranslator
@@ -246,23 +248,37 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             raise TranspilerError("Invalid scheduling method %s." % scheduling_method)
 
     # Build pass manager
-    pm3 = PassManager()
-    pm3.append(_unroll3q)
-    pm3.append(_reset + _meas)
+    init = PassManager()
+    init.append(_unroll3q)
+    init.append(_reset + _meas)
     if coupling_map or initial_layout:
-        pm3.append(_given_layout)
-        pm3.append(_choose_layout_0, condition=_choose_layout_condition)
-        pm3.append(_choose_layout_1, condition=_trivial_not_perfect)
-        pm3.append(_choose_layout_2, condition=_csp_not_found_match)
-        pm3.append(_embed)
-        pm3.append(_swap_check)
-        pm3.append(_swap, condition=_swap_condition)
-    pm3.append(_unroll)
+        layout = PassManager()
+        layout.append(_given_layout)
+        layout.append(_choose_layout_0, condition=_choose_layout_condition)
+        layout.append(_choose_layout_1, condition=_trivial_not_perfect)
+        layout.append(_choose_layout_2, condition=_csp_not_found_match)
+        layout.append(_embed)
+        routing = PassManager()
+        routing.append(_swap_check)
+        routing.append(_swap, condition=_swap_condition)
+    else:
+        layout = None
+        routing = None
+    translation = PassManager(_unroll)
+    pre_optimization = PassManager()
     if coupling_map and not coupling_map.is_symmetric:
-        pm3.append(_direction_check)
-        pm3.append(_direction, condition=_direction_condition)
-    pm3.append(_reset)
-    pm3.append(_depth_check + _opt + _unroll, do_while=_opt_control)
-    pm3.append(_scheduling)
-
-    return pm3
+        pre_optimization.append(_direction_check)
+        pre_optimization.append(_direction, condition=_direction_condition)
+    pre_optimization.append(_reset)
+    optimization = PassManager()
+    optimization.append(_depth_check + _opt + _unroll, do_while=_opt_control)
+    post_optimization = PassManager(_scheduling)
+    return FullPassManager(
+        init=init,
+        layout=layout,
+        routing=routing,
+        translation=translation,
+        pre_optimization=pre_optimization,
+        optimization=optimization,
+        post_optimization=post_optimization,
+    )

--- a/releasenotes/notes/add-full-passmanager-5a377f1b71480f72.yaml
+++ b/releasenotes/notes/add-full-passmanager-5a377f1b71480f72.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    Added a new class, :class:`qiskit.transpiler.FullPassManager`, which is
+    a :class:`~qiskit.transpiler.PassManager` subclass that has a pipeline
+    with defined phases to the circuit compilation. Each phase is a
+    :class:`~qiskit.transpiler.PassManager` object that will get executed
+    in a fixed order. For example::
+
+      from qiskit.transpiler.passes import *
+      from qiskit.transpiler import PassManager, FullPassManager
+
+      basis_gates = ['rx', 'ry', 'rxx']
+      init = PassManager([UnitarySynthesis(basis_gates), Unroll3qOrMore()])
+      translate = PassManager([Collect2qBlocks(),
+                               ConsolidateBlocks(basis_gates=basis_gates),
+                               UnitarySynthesis(basis_gates)])
+
+      full_pass_manager = FullPassManager(init=init, translation=translate)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new PassManager subclass, FullPassManager. This class
is used to have a PassManager with a defined structure and stages for
the normal transpile workflow. The preset pass managers are then updated
to be FullPassManager objects they conform to the fixed structure. Having
a class with defined phases gives us flexibility in the future for making
the transpiler pluggable with external plugins (similar to what's done in
PR #6124) and also have backend hook points before or after different
phases of the transpile.

### Details and comments

Fixes #5978