### PR TITLE
Removed redundant definition of `__rand__`

### DIFF
--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -290,5 +290,4 @@ class ParameterView(MappingView):
         return x in self.data
 
     __hash__: None  # type: ignore
-    __rand__ = __and__
     __ror__ = __or__


### PR DESCRIPTION
Removed redundant definition of `__rand__` as discussed in Qiskit Slack https://qiskit.slack.com/archives/C7SS31917/p1621176935254800

- No doc update
- No test added
- Have signed CLA

### Summary
`__rand__` defined twice in qiskit/circuit/parametertable.py


### Details and comments
Acknowledged by @mtreinish and @1ucian0 in Qiskit Slack

