### PR TITLE
More Schedule-ScheduleBlock integration

### DIFF
--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -24,7 +24,7 @@ For example::
 import warnings
 from abc import ABC, abstractproperty
 from collections import defaultdict
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Any
+from typing import Callable, Dict, List, Optional, Set, Tuple, Any, Union
 
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.channels import Channel
@@ -118,10 +118,11 @@ class Instruction(ABC):
         return self.duration
 
     @property
-    def duration(self) -> int:
+    def duration(self) -> Union[int, ParameterExpression]:
         """Duration of this instruction."""
         raise NotImplementedError
 
+    @deprecated_functionality
     @property
     def _children(self) -> Tuple["Instruction"]:
         """Instruction has no child nodes."""
@@ -130,7 +131,7 @@ class Instruction(ABC):
     @property
     def instructions(self) -> Tuple[Tuple[int, "Instruction"]]:
         """Iterable for getting instructions from Schedule tree."""
-        return tuple(self._instructions())
+        return tuple((tuple((0, self)),))
 
     def ch_duration(self, *channels: List[Channel]) -> int:
         """Return duration of the supplied channels in this Instruction.
@@ -158,18 +159,6 @@ class Instruction(ABC):
         if any(chan in self.channels for chan in channels):
             return self.duration
         return 0
-
-    def _instructions(self, time: int = 0) -> Iterable[Tuple[int, "Instruction"]]:
-        """Iterable for flattening Schedule tree.
-
-        Args:
-            time: Shifted time of this node due to parent
-
-        Yields:
-            Tuple[int, Union['Schedule, 'Instruction']]: Tuple of the form
-                (start_time, instruction).
-        """
-        yield (time, self)
 
     def flatten(self) -> "Instruction":
         """Return itself as already single instruction."""

--- a/qiskit/pulse/transforms/__init__.py
+++ b/qiskit/pulse/transforms/__init__.py
@@ -44,6 +44,7 @@ Openpulse backends.
 
    add_implicit_acquires
    align_measures
+   allocate_node_time
    block_to_schedule
    compress_pulses
    flatten
@@ -51,6 +52,7 @@ Openpulse backends.
    pad
    remove_directives
    remove_trivial_barriers
+   schedule_to_block
 
 
 DAG
@@ -95,6 +97,7 @@ from qiskit.pulse.transforms.base_transforms import target_qobj_transform
 from qiskit.pulse.transforms.canonicalization import (
     add_implicit_acquires,
     align_measures,
+    allocate_node_time,
     block_to_schedule,
     compress_pulses,
     flatten,
@@ -102,6 +105,7 @@ from qiskit.pulse.transforms.canonicalization import (
     pad,
     remove_directives,
     remove_trivial_barriers,
+    schedule_to_block,
 )
 
 from qiskit.pulse.transforms.dag import block_to_dag

--- a/qiskit/pulse/transforms/dag.py
+++ b/qiskit/pulse/transforms/dag.py
@@ -71,8 +71,8 @@ def _sequential_allocation(block: ScheduleBlock) -> rx.PyDAG:
 
     prev_node = None
     edges = []
-    for inst in block.blocks:
-        current_node = dag_blocks.add_node(inst)
+    for node in block.nodes():
+        current_node = dag_blocks.add_node(node.data)
         if prev_node is not None:
             edges.append((prev_node, current_node))
         prev_node = current_node
@@ -87,9 +87,9 @@ def _parallel_allocation(block: ScheduleBlock) -> rx.PyDAG:
 
     slots = dict()
     edges = []
-    for inst in block.blocks:
-        current_node = dag_blocks.add_node(inst)
-        for chan in inst.channels:
+    for node in block.nodes():
+        current_node = dag_blocks.add_node(node.data)
+        for chan in node.data.channels:
             prev_node = slots.pop(chan, None)
             if prev_node is not None:
                 edges.append((prev_node, current_node))

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -42,7 +42,7 @@ def format_meas_map(meas_map: List[List[int]]) -> Dict[int, List[int]]:
 
 @functools.lru_cache(maxsize=None)
 def format_parameter_value(
-    operand: Union[ParameterExpression],
+    operand: Union[ParameterExpression, int, float, complex],
 ) -> Union[ParameterExpression, int, float, complex]:
     """Convert ParameterExpression into the most suitable data type.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Currently the data representation of `Schedule` and `ScheduleBlock` are quite different and most of transform functions support only `Schedule`. Thus we always need to convert block to schedule before using these transforms. This conversion is irreversible and we lost alignment context due to this conversion. 

This PR attempts to introduce `ScheduleNode` that has `data, time, location` as variable. With this we can redefine block (schedule) as a sequence of node with unassigned (assigned) node time. Note that we are still able to assign time to the nodes of the blocks (if all node durations are fixed), and we can schedule the block while keeping the alignment context. Thus we can use most of transformation function without converting it into schedule.

Note that we can update node time and node data (i.e. node is mutable object) without breaking the structure of schedule. Since each node is managed by unique `location` (uuid4) id.

This also unifies representation of schedule and block. Thus we can add `schedule_to_block` conversion with a special context of `Frozen` (this doesn't perform alignment but returns node sequence as-is since it's already scheduled).

Now the builder can return time-assigned nodes if possible.

### Details and comments

This is an example of what can be done with this PR.
```python
with pulse.build() as sched:
    pulse.shift_phase(1.57, pulse.DriveChannel(0))
    pulse.play(pulse.Gaussian(160, 0.1, 40), pulse.DriveChannel(0))
    with pulse.align_right():
        pulse.play(pulse.Gaussian(80, 0.1, 20), pulse.DriveChannel(1))
        pulse.play(pulse.Gaussian(160, 0.3, 40), pulse.DriveChannel(0))
    pulse.shift_phase(1.57, pulse.DriveChannel(1))
    with pulse.align_sequential():
        pulse.play(pulse.Gaussian(80, 0.1, 20), pulse.DriveChannel(2))
        pulse.shift_phase(1.57, pulse.DriveChannel(0))
        pulse.play(pulse.Gaussian(160, 0.1, 40), pulse.DriveChannel(1))
    pulse.shift_phase(1.57, pulse.DriveChannel(0))

filt_sched = filters.filter_instructions(sched, filters.with_intervals([[0, 300]]))

type(filt_sched)  # qiskit.pulse.schedule.ScheduleBlock
```
Since all `sched` instructions have fixed duration, we can assign node time when the builder returns the root block. We can filter returned `sched` by time interval without converting it into a schedule.

Comments:
Still this PR has lots of bugs and there is no unittest for transform of schedule block. Before going into detailed design and bug fixes, I'd like to hear feedback about this approach. If this doesn't make sense I'll just close this PR. It seems like we can completely integrate schedule and block at some point.

Since this is large PR it might be efficient to start from `qiskit/pulse/schedule.py` to grasp rough framework of this PR.