### PR TITLE
Fix process_fidelity documentation

### DIFF
--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -42,10 +42,10 @@ def process_fidelity(channel, target=None, require_cp=True, require_tp=True):
     r"""Return the process fidelity of a noisy quantum channel.
 
 
-    The process fidelity :math:`F_{\text{pro}}(\mathcal{E}, \methcal{F})`
+    The process fidelity :math:`F_{\text{pro}}(\mathcal{E}, \mathcal{F})`
     between two quantum channels :math:`\mathcal{E}, \mathcal{F}` is given by
 
-    .. math:
+    .. math::
         F_{\text{pro}}(\mathcal{E}, \mathcal{F})
             = F(\rho_{\mathcal{E}}, \rho_{\mathcal{F}})
 


### PR DESCRIPTION
Fixed two typos in the `process_fidelity` docstring that prevented the rendering of maths formulas in the function's description.