### PR TITLE
Fix deprecate msg in Measurement Error Mitigation

### DIFF
--- a/qiskit/utils/measurement_error_mitigation.py
+++ b/qiskit/utils/measurement_error_mitigation.py
@@ -41,7 +41,11 @@ def get_measured_qubits(transpiled_circuits):
         for inst, qargs, _ in qc.data:
             if inst.name != "measure":
                 continue
-            measured_qubits.append(qargs[0].index)
+            for qreg in qc.qregs:
+                if qargs[0] in qreg:
+                    index = qreg[:].index(qargs[0])
+                    measured_qubits.append(index)
+                    break
         measured_qubits_str = "_".join([str(x) for x in measured_qubits])
         if measured_qubits_str not in qubit_mappings:
             qubit_mappings[measured_qubits_str] = []


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes the code that was showing the msg: "DeprecationWarning: Back-references to from Bit instances to their containing Registers have been deprecated. Instead, inspect Registers to find their contained Bits."


### Details and comments


