### PR TITLE
Pin sphinx-panels version for docs builds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,7 +22,7 @@ Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx
-sphinx-panels
+sphinx-panels<0.6.0
 pygments>=2.4
 tweedledum>=1.0,<2.0
 networkx>=2.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since the recent release of the sphinx-panels plugin the docs jobs have
all been failing CI. Since the only recent related release was this
sphinx plugin this commit caps the version to be less than the recent
version to unblock CI.

### Details and comments


