### PR TITLE
Fixes Release Notes 0.15 canonical form yaml

### DIFF
--- a/releasenotes/notes/0.15/Add-canonical-form-47e0466ed57640f3.yaml
+++ b/releasenotes/notes/0.15/Add-canonical-form-47e0466ed57640f3.yaml
@@ -18,7 +18,7 @@ features:
     * :func:`~qiskit.converters.dag_to_dagdependency` to convert from
       a :class:`~qiskit.dagcircuit.DAGCircuit` object to a
       :class:`~qiskit.dagcircuit.DAGDependency` object.
-    * :func:`~qiskit.converters.dagdependency_to_ciruit` to convert from
+    * :func:`~qiskit.converters.dagdependency_to_dag` to convert from
       a :class:`~qiskit.dagcircuit.DAGDependency` object to a
       :class:`~qiskit.dagcircuit.DAGCircuit` object.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes Reference to `dagdependency_to_dag()` in [add-canoical-form-*.yaml](https://github.com/Qiskit/qiskit-terra/blob/98130dd6158d1f1474e44dd5aeacbc619174ad63/releasenotes/notes/0.15/Add-canonical-form-47e0466ed57640f3.yaml) wrt Issue #4930 

### Details and comments

Change `~qiskit.converters.dagdependency_to_ciruit` to `~qiskit.converters.dagdependency_to_dag`


