### PR TITLE
Fix issue 6465 by adding ctrl_state parameter to ccx function in quantumcircuit.py file

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2772,11 +2772,15 @@ class QuantumCircuit:
 
         return self.append(DCXGate(), [qubit1, qubit2], [])
 
-    def ccx(self, control_qubit1, control_qubit2, target_qubit):
+    def ccx(self, control_qubit1, control_qubit2, target_qubit, ctrl_state=None):
         """Apply :class:`~qiskit.circuit.library.CCXGate`."""
         from .library.standard_gates.x import CCXGate
 
-        return self.append(CCXGate(), [control_qubit1, control_qubit2, target_qubit], [])
+        return self.append(
+            CCXGate(label=label, ctrl_state=ctrl_state),
+            [control_qubit1, control_qubit2, target_qubit],
+            []
+        )
 
     def toffoli(self, control_qubit1, control_qubit2, target_qubit):
         """Apply :class:`~qiskit.circuit.library.CCXGate`."""

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2777,7 +2777,7 @@ class QuantumCircuit:
         from .library.standard_gates.x import CCXGate
 
         return self.append(
-            CCXGate(label=label, ctrl_state=ctrl_state),
+            CCXGate(ctrl_state=ctrl_state),
             [control_qubit1, control_qubit2, target_qubit],
             []
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6465 

### Details and comments
`ccx` function in the quantumcircuit.py file was missing the 'ctrl_state' parameter that was raising the error. 

