### PR TITLE
Create string_initialization function

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -460,6 +460,24 @@ class QuantumCircuit:
             inverse_circ._append(inst.inverse(), qargs, cargs)
         return inverse_circ
 
+    def binary_input_to_initialized_state(self, string):
+        """map chars and strings to initializations"""
+        from .library.standard_gates.x import XGate
+
+        to_string = "".join(format(i, "08b") for i in bytearray(string, encoding="utf-8"))
+        qubits = self.qubits
+
+        if (len(qubits)) >= len(to_string):
+            # print(to_string)
+            i = 1
+            for i in range(len(to_string)):
+                if to_string[i] == "1":
+                    # print("index", i)
+                    self.append(XGate(), [qubits[i]], [])
+            # return print("successful")
+        else:
+            raise CircuitError("Circuit has less qubits than the provided binary number length. ")
+
     def repeat(self, reps):
         """Repeat this circuit ``reps`` times.
 
@@ -2103,10 +2121,6 @@ class QuantumCircuit:
 
         # return as parameter view, which implements the set and list interface
         return ParameterView(self._parameters)
-    
-    @classmethod 
-    def binary_input_to_initialized_state(self):
-        return 
 
     @property
     def num_parameters(self):

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -460,21 +460,19 @@ class QuantumCircuit:
             inverse_circ._append(inst.inverse(), qargs, cargs)
         return inverse_circ
 
-    def binary_input_to_initialized_state(self, string):
+    def string_initialization(self, string):
         """map chars and strings to initializations"""
         from .library.standard_gates.x import XGate
-
+        
         to_string = "".join(format(i, "08b") for i in bytearray(string, encoding="utf-8"))
+        reversed_binary = (to_string)[::-1]
         qubits = self.qubits
 
         if (len(qubits)) >= len(to_string):
-            # print(to_string)
             i = 1
             for i in range(len(to_string)):
-                if to_string[i] == "1":
-                    # print("index", i)
+                if reversed_binary[i] == "1":
                     self.append(XGate(), [qubits[i]], [])
-            # return print("successful")
         else:
             raise CircuitError("Circuit has less qubits than the provided binary number length. ")
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2103,6 +2103,10 @@ class QuantumCircuit:
 
         # return as parameter view, which implements the set and list interface
         return ParameterView(self._parameters)
+    
+    @classmethod 
+    def binary_input_to_initialized_state(self):
+        return 
 
     @property
     def num_parameters(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The goal is to eventually map chars and strings to initializations, in the case that the following might yield more use cases and unique results: a -- > binary (01000001)--> initialized state --> QuantumCircuit Output (result 1); followed by, b -- > binary (01000010) --> initialized state --> QuantumCircuit Output (result 2). Comparing result1 and result 2 when applying some set of gates, may help form more algorithms possibly.


### Details and comments
Creates a class that takes a classical input like 'a', converts to binary (in this case: 01000001), and then maps that to an initialized state for the QuantumCircuit.

Note: Should throw an error if the output of the converted char (or string eventually), is less than the (2**qubits function that's a WIP Pull Request at the moment).

Note2: This is a Work-In-Progress, and suggestions on where this function should be located in Terra (or if it's better to do this as a class) would be appreciated. 


