### PR TITLE
Don't enable multiprocessing by default on Python 3.9

### DIFF
--- a/qiskit/tools/parallel.py
+++ b/qiskit/tools/parallel.py
@@ -65,6 +65,9 @@ else:
     # Default False on Windows
     if sys.platform == "win32":
         PARALLEL_DEFAULT = False
+    # On python 3.9 default false to avoid deadlock issues
+    elif sys.version_info[0] == 3 and sys.version_info[1] == 9:
+        PARALLEL_DEFAULT = False
     # On macOS default false on Python >=3.8
     elif sys.platform == "darwin":
         if sys.version_info[0] == 3 and sys.version_info[1] >= 8:

--- a/releasenotes/notes/disable-39-multirpc-8618c89aeaa620f9.yaml
+++ b/releasenotes/notes/disable-39-multirpc-8618c89aeaa620f9.yaml
@@ -1,0 +1,20 @@
+---
+issues:
+  - |
+    When running :func:`~qiskit.tools.parallel_map` (and functions that
+    internally call :func:`~qiskit.tools.parallel_map` such as
+    :func:`~qiskit.compiler.transpile` and :func:`~qiskit.compiler.assemble`)
+    on Python 3.9 with ``QISKIT_PARALLEL`` set to True in some scenarios it is
+    possible for the program to deadlock and never finish running. To avoid
+    this from happening the default for Python 3.9 was changed to not run in
+    parallel, but if ``QISKIT_PARALLEL`` is explicitly enabled then this
+    can still occur.
+upgrade:
+  - |
+    The default value for ``QISKIT_PARALLEL`` on Python 3.9 environments has
+    changed to ``False``, this means that when running on Python 3.9 by default
+    multiprocessing will not be used. This was done to avoid a potential
+    deadlock/hanging issue that can occur when running multiprocessing on
+    Python 3.9 (see the known issues section for more detail). It is still
+    possible to manual enable it by explicitly setting the ``QISKIT_PARALLEL``
+    environment variable to ``TRUE``.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We've recently been hitting a slew of job timeouts in python 3.9 CI jobs
recently. This was originally reported in #6188 but the frequency of
these timeouts have spiked since #6270 merged which added sympy to the
default mulitprocessing path (for pickling symengine expressions by
first converting it to a sympy expression). Trying to debug this locally
is tricky but when I've reproduced it seems to be just hanging
indefinitely on pickling. I think whatever is causing the issue as
reported in #6188 was just made worse by adding a sympy import to the
pickling process (assuming there is a parameter expression in the
circuit). To workaround this issue until we can come up with a solution
for whatever is causing things to hang this commit disables
multiprocessing on python 3.9 by default (it can still be enabled by
users if they desire.

### Details and comments