### PR TITLE
fixes issue 5748 by changing default round off error

### DIFF
--- a/qiskit/quantum_info/states/quantum_state.py
+++ b/qiskit/quantum_info/states/quantum_state.py
@@ -229,11 +229,15 @@ class QuantumState:
             qargs (None or list): subsystems to return probabilities for,
                 if None return for all subsystems (Default: None).
             decimals (None or int): the number of decimal places to round
-                values. If None no rounding is done (Default: None).
+                values. If None, rounding is done upto 15 places (Default: None).
 
         Returns:
             dict: The measurement probabilities in dict (ket) form.
         """
+
+        if decimals is None:
+            decimals = 15
+
         return self._vector_to_dict(
             self.probabilities(qargs=qargs, decimals=decimals), self.dims(qargs), string_labels=True
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5748 

### Details and comments
The initial working of `statevector.probabilities_dict()` had a parameter decimals which did not round off the probabilities being returned. This PR changes the limit to the precision upto **15 places** if None is mentioned.

This is an image showing the target working as suggested by @nonhermitian :


![issue_5748](https://user-images.githubusercontent.com/57539040/121234264-26c2cf80-c8b1-11eb-83ba-36c579dafa25.PNG)



