### PR TITLE
Fix multiple appends of '_dg' in name attribute on calling inverse()

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -337,18 +337,20 @@ class Instruction:
 
         from qiskit.circuit import QuantumCircuit, Gate  # pylint: disable=cyclic-import
 
+        if self.name.endswith("_dg"):
+            name = self.name[:-3]
+        else:
+            name = self.name + "_dg"
         if self.num_clbits:
             inverse_gate = Instruction(
-                name=self.name + "_dg",
+                name=name,
                 num_qubits=self.num_qubits,
                 num_clbits=self.num_clbits,
                 params=self.params.copy(),
             )
 
         else:
-            inverse_gate = Gate(
-                name=self.name + "_dg", num_qubits=self.num_qubits, params=self.params.copy()
-            )
+            inverse_gate = Gate(name=name, num_qubits=self.num_qubits, params=self.params.copy())
 
         inverse_gate.definition = QuantumCircuit(
             *self.definition.qregs,

--- a/releasenotes/notes/bugfix-gate-inverse-name-3401093a18813ace.yaml
+++ b/releasenotes/notes/bugfix-gate-inverse-name-3401093a18813ace.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed bug in assigning name attribute to ``inverse()`` function of 
+    :class:`~qiskit.circuit.Gate` (inherited from :class:`~qiskit.circuit.Instruction`).
+    Earlier, the inverse() function returned a gate with label None. Now 
+    the label of inverse is built using the label calling it.

--- a/releasenotes/notes/bugfix-gate-inverse-name-3401093a18813ace.yaml
+++ b/releasenotes/notes/bugfix-gate-inverse-name-3401093a18813ace.yaml
@@ -5,3 +5,4 @@ fixes:
     :class:`~qiskit.circuit.Gate` (inherited from :class:`~qiskit.circuit.Instruction`).
     Earlier, the inverse() function returned a gate with label None. Now 
     the label of inverse is built using the label calling it.
+    `#6563 <https://github.com/Qiskit/qiskit-terra/pull/6563>` for more details.

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -350,6 +350,17 @@ class TestInstructions(QiskitTestCase):
         gate_inverse = circ.to_instruction()
         self.assertEqual(gate.inverse().definition, gate_inverse.definition)
 
+    def test_inverse_with_label(self):
+        """test inverting gate initialized with label attribute."""
+        q = QuantumRegister(2)
+        qc = QuantumCircuit(q, name="circ")
+        qc.cx(0, 1)
+        qc_gate = qc.to_gate()
+        qc_gate_inverse = qc_gate.inverse()
+        self.assertEqual(qc_gate.name + "_dg", qc_gate_inverse.name)
+        qc_gate_inverse_inverse = qc_gate_inverse.inverse()
+        self.assertEqual(qc_gate_inverse_inverse.name, qc_gate.name)
+
     def test_no_broadcast(self):
         """See https://github.com/Qiskit/qiskit-terra/issues/2777
         When creating custom instructions, do not broadcast parameters"""


### PR DESCRIPTION
Summary
Each call to a gate's `inverse` method appends '_dg' to the name attribute of the gate.

Details and comments

Upon running the following code,

```
qc = QuantumCircuit(2)
qc.cx(0,1)
qc_gate = qc.to_gate(name='qc_gate')
qc_gate_inv = qc_gate.inverse()
qc_gate_inv_inv = qc_gate_inv.inverse()

print(qc_gate.name)
print(qc_gate_inv.name)
print(qc_gate_inv_inv.name)
```

The output was:
```
circuit_name
circuit_name_dg
circuit_name_dg_dg
```

The output after the proposed changes is:
```
circuit_name
circuit_name_dg
circuit_name
```
