### PR TITLE
Fixes deprecator decorator order on VQE optimal_params property

### DIFF
--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -644,6 +644,7 @@ queried as VQEResult.eigenvector."""
 
         return state
 
+    @property
     @deprecate_function(
         """
 The VQE.optimal_params property is deprecated as of Qiskit Terra 0.18.0
@@ -651,7 +652,6 @@ and will be removed no sooner than 3 months after the releasedate.
 This information is part of the returned result object and can be
 queried as VQEResult.optimal_point."""
     )
-    @property
     def optimal_params(self) -> np.ndarray:
         """The optimal parameters for the ansatz."""
         if self._ret.optimal_point is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
If you have the `deprecate_function` above `property` it will return wrapper instead of the property.
This PR inverts the order.


### Details and comments


