### PR TITLE
Move `Gate.label` to parent `Instruction` class

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -36,9 +36,8 @@ class Gate(Instruction):
             params: A list of parameters.
             label: An optional label for the gate.
         """
-        self._label = label
         self.definition = None
-        super().__init__(name, num_qubits, 0, params)
+        super().__init__(name, num_qubits, 0, params, label=label)
 
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20
@@ -91,33 +90,6 @@ class Gate(Instruction):
 
     def _return_repeat(self, exponent: float) -> "Gate":
         return Gate(name=f"{self.name}*{exponent}", num_qubits=self.num_qubits, params=self.params)
-
-    def assemble(self) -> "Instruction":
-        """Assemble a QasmQobjInstruction"""
-        instruction = super().assemble()
-        if self.label:
-            instruction.label = self.label
-        return instruction
-
-    @property
-    def label(self) -> str:
-        """Return gate label"""
-        return self._label
-
-    @label.setter
-    def label(self, name: str):
-        """Set gate label to name
-
-        Args:
-            name (str or None): label to assign unitary
-
-        Raises:
-            TypeError: name is not string or None.
-        """
-        if isinstance(name, (str, type(None))):
-            self._label = name
-        else:
-            raise TypeError("label expects a string or None")
 
     def control(
         self,

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -64,7 +64,7 @@ class Instruction:
                 list of parameters
             duration (int or float): instruction's duration. it must be integer if ``unit`` is 'dt'
             unit (str): time unit of duration
-            label: An optional label for identifying the instruction.
+            label (str or None): An optional label for identifying the instruction.
 
         Raises:
             CircuitError: when the register is not in the correct format.

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -53,7 +53,7 @@ class Instruction:
     # NOTE: Using this attribute may change in the future (See issue # 5811)
     _directive = False
 
-    def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit="dt"):
+    def __init__(self, name, num_qubits, num_clbits, params, duration=None, unit="dt", label=None):
         """Create a new instruction.
 
         Args:
@@ -64,6 +64,7 @@ class Instruction:
                 list of parameters
             duration (int or float): instruction's duration. it must be integer if ``unit`` is 'dt'
             unit (str): time unit of duration
+            label: An optional label for identifying the instruction.
 
         Raises:
             CircuitError: when the register is not in the correct format.
@@ -79,7 +80,8 @@ class Instruction:
         self.num_clbits = num_clbits
 
         self._params = []  # a list of gate params stored
-
+        # Custom instruction label
+        self._label = label
         # tuple (ClassicalRegister, int), tuple (Clbit, bool) or tuple (Clbit, int)
         # when the instruction has a conditional ("if")
         self.condition = None
@@ -275,12 +277,35 @@ class Instruction:
             instruction.qubits = list(range(self.num_qubits))
         if self.num_clbits:
             instruction.memory = list(range(self.num_clbits))
+        # Add label if defined
+        if self.label:
+            instruction.label = self.label
         # Add condition parameters for assembler. This is needed to convert
         # to a qobj conditional instruction at assemble time and after
         # conversion will be deleted by the assembler.
         if self.condition:
             instruction._condition = self.condition
         return instruction
+
+    @property
+    def label(self) -> str:
+        """Return instruction label"""
+        return self._label
+
+    @label.setter
+    def label(self, name: str):
+        """Set instruction label to name
+
+        Args:
+            name (str or None): label to assign instruction
+
+        Raises:
+            TypeError: name is not string or None.
+        """
+        if isinstance(name, (str, type(None))):
+            self._label = name
+        else:
+            raise TypeError("label expects a string or None")
 
     def mirror(self):
         """DEPRECATED: use instruction.reverse_ops().

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -84,7 +84,7 @@ class Instruction:
         # NOTE: The conditional statement checking if the `_label` attribute is
         #       already set is a temporary work around that can be removed after
         #       the next stable qiskit-aer release
-        if label is not None or not hasattr(self, '_label'):
+        if label is not None or not hasattr(self, "_label"):
             self._label = label
         # tuple (ClassicalRegister, int), tuple (Clbit, bool) or tuple (Clbit, int)
         # when the instruction has a conditional ("if")

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -81,7 +81,11 @@ class Instruction:
 
         self._params = []  # a list of gate params stored
         # Custom instruction label
-        self._label = label
+        # NOTE: The conditional statement checking if the `_label` attribute is
+        #       already set is a temporary work around that can be removed after
+        #       the next stable qiskit-aer release
+        if label is not None or not hasattr(self, '_label'):
+            self._label = label
         # tuple (ClassicalRegister, int), tuple (Clbit, bool) or tuple (Clbit, int)
         # when the instruction has a conditional ("if")
         self.condition = None

--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -136,10 +136,10 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().size()
 
-    def to_instruction(self, parameter_map=None):
+    def to_instruction(self, parameter_map=None, label=None):
         if self._data is None:
             self._build()
-        return super().to_instruction(parameter_map)
+        return super().to_instruction(parameter_map, label=label)
 
     def to_gate(self, parameter_map=None, label=None):
         if self._data is None:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1235,7 +1235,7 @@ class QuantumCircuit:
                parameters in the circuit to parameters to be used in the
                instruction. If None, existing circuit parameters will also
                parameterize the instruction.
-               label (str): Optional gate label.
+            label (str): Optional gate label.
 
         Returns:
             qiskit.circuit.Instruction: a composite instruction encapsulating this circuit

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1227,7 +1227,7 @@ class QuantumCircuit:
         if not set(cargs).issubset(self._clbit_set):
             raise CircuitError("cargs not in this circuit")
 
-    def to_instruction(self, parameter_map=None):
+    def to_instruction(self, parameter_map=None, label=None):
         """Create an Instruction out of this circuit.
 
         Args:
@@ -1235,6 +1235,7 @@ class QuantumCircuit:
                parameters in the circuit to parameters to be used in the
                instruction. If None, existing circuit parameters will also
                parameterize the instruction.
+               label (str): Optional gate label.
 
         Returns:
             qiskit.circuit.Instruction: a composite instruction encapsulating this circuit
@@ -1242,7 +1243,7 @@ class QuantumCircuit:
         """
         from qiskit.converters.circuit_to_instruction import circuit_to_instruction
 
-        return circuit_to_instruction(self, parameter_map)
+        return circuit_to_instruction(self, parameter_map, label=label)
 
     def to_gate(self, parameter_map=None, label=None):
         """Create a Gate out of this circuit.

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -80,7 +80,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
         num_qubits=sum(qreg.size for qreg in circuit.qregs),
         num_clbits=sum(creg.size for creg in circuit.cregs),
         params=[*parameter_dict.values()],
-        label=label
+        label=label,
     )
     instruction.condition = None
 

--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -18,7 +18,7 @@ from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister
 
 
-def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None):
+def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None, label=None):
     """Build an ``Instruction`` object from a ``QuantumCircuit``.
 
     The instruction is anonymous (not tied to a named quantum register),
@@ -33,6 +33,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
            instruction.
         equivalence_library (EquivalenceLibrary): Optional equivalence library
            where the converted instruction will be registered.
+        label (str): Optional instruction label.
 
     Raises:
         QiskitError: if parameter_map is not compatible with circuit
@@ -79,6 +80,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
         num_qubits=sum(qreg.size for qreg in circuit.qregs),
         num_clbits=sum(creg.size for creg in circuit.cregs),
         params=[*parameter_dict.values()],
+        label=label
     )
     instruction.condition = None
 

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -31,7 +31,8 @@ class Snapshot(Instruction):
             label (str): the snapshot label for result data.
             snapshot_type (str): the type of the snapshot.
             num_qubits (int): the number of qubits for the snapshot type [Default: 0].
-            num_clbits (int): the number of classical bits for the snapshot type [Default: 0].
+            num_clbits (int): the number of classical bits for the snapshot type
+                              [Default: 0].
             params (list or None): the parameters for snapshot_type [Default: None].
 
         Raises:

--- a/qiskit/extensions/simulator/snapshot.py
+++ b/qiskit/extensions/simulator/snapshot.py
@@ -39,16 +39,14 @@ class Snapshot(Instruction):
         """
         if not isinstance(label, str):
             raise ExtensionError("Snapshot label must be a string.")
-        self._label = label
         self._snapshot_type = snapshot_type
         if params is None:
             params = []
-        super().__init__("snapshot", num_qubits, num_clbits, params)
+        super().__init__("snapshot", num_qubits, num_clbits, params, label=label)
 
     def assemble(self):
         """Assemble a QasmQobjInstruction"""
         instruction = super().assemble()
-        instruction.label = self._label
         instruction.snapshot_type = self._snapshot_type
         return instruction
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Moves `_label` attribute, and `label` getter/setter from `Gate` to its parent class `Instruction`.

### Details and comments

There isn't really any reason labels should be specific to `Gate` subclasses rather than part for the base `Instruction` class. This allows setting custom labels for general instructions using the `inst.label` setter.