### PR TITLE
Pin jax version in constraints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,5 @@
 appnope==0.1.0
 numpy>=1.20.0 ; python_version>'3.6'
 decorator==4.4.2
+jax==0.2.13
+jaxlib==0.1.67


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I have seen a couple instances of jobs failing due to segfaults or other
system errors when running tests that leverage jax. Looking at the
release history for jax and jaxlib, there have been multiple releases
the past few days. Until the project stabilizes these issues this commit
just pins the version we run in CI to the last release from May which
wa stable in CI.

### Details and comments


