### PR TITLE
Fix for issue #6616 by updating plot_circuit_layout in gate_map.py

### DIFF
--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -540,7 +540,7 @@ def plot_circuit_layout(circuit, backend, view="virtual"):
 
     bit_locations = {
         bit: {"register": register, "index": index}
-        for register in circuit._layout.get_registers()
+        for register in circuit.qregs
         for index, bit in enumerate(register)
     }
     for index, qubit in enumerate(circuit._layout.get_virtual_bits()):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes issue #6616 

### Details and comments

One possible solution for issue #6616 could be to get, in the `plot_circuit_layout()` function, the registers directly from the circuit instead from the layout. This can be achieved by replacing `circuit._layout.get_registers()` by `circuit.qregs` in the `plot_circuit_layout()` function definition.

The `get_registers()` method from the `Layout` class in **layout.py** seems to always return an empty set even though there is a QuantumRegister associated to the circuit.

Another possible workaround for the issue could be, in the given example, to add the register explicitly to the layout by using the following code line: `circuit._layout.add_register(circuit.qregs[0])`.
