### PR TITLE
Fixed issue 6612 by covering ibmq examples by lint check

### DIFF
--- a/Make.bat
+++ b/Make.bat
@@ -42,6 +42,9 @@ GOTO :next
 
 :lint
 pylint qiskit test
+python "tools/verify_headers.py" qiskit test tools examples
+pylint -rn --disable="C0103, W0621, E0611, E0401" examples
+python "tools/find_optional_imports.py"
 IF errorlevel 9009 GOTO :error
 GOTO :next
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ env:
 lint:
 	pylint -rn qiskit test tools
 	tools/verify_headers.py qiskit test tools examples
-	pylint -rn --disable='C0103, C0114, W0621' examples/python/*.py
+	pylint -rn --disable='C0103, W0621, E0611, E0401' examples
 	tools/find_optional_imports.py
 
 style:

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,13 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Simple examples to demonstrate the usage of Qiskit Terra."""

--- a/examples/python/__init__.py
+++ b/examples/python/__init__.py
@@ -1,0 +1,13 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Simple examples to demonstrate the usage of Qiskit Terra."""

--- a/examples/python/commutation_relation.py
+++ b/examples/python/commutation_relation.py
@@ -10,6 +10,11 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+"""
+Example showing how to cancel redundant gates in a quantum circuit using
+Qiskit.
+"""
+
 from qiskit import QuantumCircuit
 
 from qiskit.transpiler import PassManager

--- a/examples/python/ibmq/__init__.py
+++ b/examples/python/ibmq/__init__.py
@@ -1,0 +1,14 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Simple examples to demonstrate the usage of Qiskit Terra on the remote IBMQ
+provider."""

--- a/examples/python/ibmq/hello_quantum.py
+++ b/examples/python/ibmq/hello_quantum.py
@@ -13,9 +13,11 @@
 """Example used in the README. In this example a Bell state is made."""
 
 # Import Qiskit
+import sys
 from qiskit import QuantumCircuit
 from qiskit import execute, IBMQ, BasicAer
 from qiskit.providers.ibmq import least_busy
+from qiskit.providers.ibmq.exceptions import IBMQProviderError, IBMQAccountCredentialsNotFound
 
 # Create a Quantum Circuit
 qc = QuantumCircuit(2, 2)
@@ -42,13 +44,13 @@ print(result_sim.get_counts(qc))
 # Authenticate for access to remote backends
 try:
     provider = IBMQ.load_account()
-except:
+except IBMQAccountCredentialsNotFound:
     print(
         """WARNING: No valid IBMQ credentials found on disk.
              You must store your credentials using IBMQ.save_account(token, url).
              For now, there's only access to local simulator backends..."""
     )
-    exit(0)
+    sys.exit()
 
 # see a list of available remote backends
 ibmq_backends = provider.backends()
@@ -60,7 +62,7 @@ try:
     least_busy_device = least_busy(
         provider.backends(filters=lambda x: x.configuration().n_qubits >= 2, simulator=False)
     )
-except:
+except IBMQProviderError:
     print("All devices are currently unavailable.")
 
 print("Running on current least busy device: ", least_busy_device)

--- a/examples/python/ibmq/using_qiskit_terra_level_0.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_0.py
@@ -16,18 +16,18 @@ Example showing how to use Qiskit-Terra at level 0 (novice).
 This example shows the most basic way to user Terra. It builds some circuits
 and runs them on both the BasicAer (local Qiskit provider) or IBMQ (remote IBMQ provider).
 
-To control the compile parameters we have provided a transpile function which can be used 
+To control the compile parameters we have provided a transpile function which can be used
 as a level 1 user.
 
 """
 
-import time
 
 # Import the Qiskit modules
 from qiskit import QuantumCircuit
 from qiskit import execute, IBMQ, BasicAer
 from qiskit.providers.ibmq import least_busy
 from qiskit.tools.monitor import job_monitor
+from qiskit.providers.ibmq.exceptions import IBMQProviderError
 
 
 provider = IBMQ.load_account()
@@ -64,7 +64,7 @@ print(IBMQ.providers()[0].backends())
 try:
     # select least busy available device and execute.
     least_busy_device = least_busy(provider.backends(simulator=False))
-except:
+except IBMQProviderError:
     print("All devices are currently unavailable.")
 
 print("Running on current least busy device: ", least_busy_device)

--- a/examples/python/ibmq/using_qiskit_terra_level_1.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_1.py
@@ -33,6 +33,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.compiler import transpile, assemble
 from qiskit.providers.ibmq import least_busy
 from qiskit.tools.monitor import job_monitor
+from qiskit.providers.ibmq.exceptions import IBMQProviderError
 
 provider = IBMQ.load_account()
 
@@ -63,7 +64,7 @@ for backend in provider.backends():
 try:
     # select least busy available device and execute.
     least_busy_device = least_busy(provider.backends(simulator=False))
-except:
+except IBMQProviderError:
     print("All devices are currently unavailable.")
 
 print("Running on current least busy device: ", least_busy_device)

--- a/examples/python/ibmq/using_qiskit_terra_level_2.py
+++ b/examples/python/ibmq/using_qiskit_terra_level_2.py
@@ -35,6 +35,8 @@ from qiskit.transpiler.passes import Decompose
 from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import LookaheadSwap
 
+from qiskit.providers.ibmq.exceptions import IBMQProviderError
+
 
 provider = IBMQ.load_account()
 
@@ -68,7 +70,7 @@ for backend in provider.backends():
 try:
     # select least busy available device and execute.
     least_busy_device = least_busy(provider.backends(simulator=False))
-except:
+except IBMQProviderError:
     print("All devices are currently unavailable.")
 
 print("Running on current least busy device: ", least_busy_device)

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ basepython = python3
 commands =
   black --check {posargs} qiskit test tools examples setup.py
   pylint -rn qiskit test tools
+  pylint -rn --disable='C0103, W0621, E0611, E0401' examples
   {toxinidir}/tools/verify_headers.py qiskit test tools examples
   {toxinidir}/tools/find_optional_imports.py
   reno lint


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6612 


### Details and comments

The ibmq examples were not being covered by lint checks. This PR fixes lint errors in ibmq examples and covers them by the lint checks.

1. Added `__init__.py` files to convert qiskit examples to package to facilitate lint checking
2. Updated Makefile and tox.ini lint targets to cover ibmq examples as well
3. Updated Make.bat batch file to make it consistent with these and other recent changes
4. Fixed up lint errors found
5. The check C0114 (missing module docstring) is no longer disabled in examples, as it is good to have docstrings.

