### PR TITLE
Fix calibration handling of transpiler passes on gates with >2 qubits

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -31,6 +31,8 @@ class Unroll3qOrMore(TransformationPass):
             QiskitError: if a 3q+ gate is not decomposable
         """
         for node in dag.multi_qubit_ops():
+            if dag.has_calibration_for(node):
+                continue
             # TODO: allow choosing other possible decompositions
             rule = node.op.definition.data
             if not rule:

--- a/qiskit/transpiler/passes/utils/check_map.py
+++ b/qiskit/transpiler/passes/utils/check_map.py
@@ -49,6 +49,8 @@ class CheckMap(AnalysisPass):
         qubit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
 
         for gate in dag.two_qubit_ops():
+            if dag.has_calibration_for(gate):
+                continue
             physical_q0 = qubit_indices[gate.qargs[0]]
             physical_q1 = qubit_indices[gate.qargs[1]]
 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1123,6 +1123,49 @@ class TestTranspile(QiskitTestCase):
         self.assertEqual(out.duration, cal.duration)
 
     @data(0, 1, 2, 3)
+    def test_multiqubit_gates_calibrations(self, opt_level):
+        """Test multiqubit gate > 2q with calibrations works
+
+        Adapted from issue description in https://github.com/Qiskit/qiskit-terra/issues/6572
+        """
+        circ = QuantumCircuit(5)
+        custom_gate = Gate("my_custom_gate", 5, [])
+        circ.append(custom_gate, [0, 1, 2, 3, 4])
+        circ.measure_all()
+        backend = FakeAlmaden()
+        with pulse.build(backend, name="custom") as my_schedule:
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(0)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(1)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(2)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(3)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(4)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.ControlChannel(1)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.ControlChannel(2)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.ControlChannel(3)
+            )
+            pulse.play(
+                pulse.library.Gaussian(duration=128, amp=0.1, sigma=16), pulse.ControlChannel(4)
+            )
+        circ.add_calibration("my_custom_gate", [0, 1, 2, 3, 4], my_schedule, [])
+        trans_circ = transpile(circ, backend, optimization_level=opt_level)
+        self.assertEqual({"measure": 5, "my_custom_gate": 1, "barrier": 1}, trans_circ.count_ops())
+
+    @data(0, 1, 2, 3)
     def test_circuit_with_delay(self, optimization_level):
         """Verify a circuit with delay can transpile to a scheduled circuit."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in a couple of transpiler passes where a
multiqubit gate on >2 qubits that has a custom calibration. When a gate
has a calibration it should mostly be treated as a black box because the
pulse definition is passed directly to the backend for that gate.
However, previously for passes that worked on gates > 2 qubits weren't
correctly handling this which would result in an error. This has been
fixed so that if a multiqubit gate is in a circuit with a calibration
set it will be left as a black box and passed directly to the backend.

### Details and comments

Fixes #6572