### PR TITLE
Add the option to wrap circuits in ``QuantumCircuit.compose``

### DIFF
--- a/qiskit/circuit/library/blueprintcircuit.py
+++ b/qiskit/circuit/library/blueprintcircuit.py
@@ -115,10 +115,10 @@ class BlueprintCircuit(QuantumCircuit, ABC):
             self._build()
         return super().append(instruction, qargs, cargs)
 
-    def compose(self, other, qubits=None, clbits=None, front=False, inplace=False):
+    def compose(self, other, qubits=None, clbits=None, front=False, inplace=False, wrap=False):
         if self._data is None:
             self._build()
-        return super().compose(other, qubits, clbits, front, inplace)
+        return super().compose(other, qubits, clbits, front, inplace, wrap)
 
     def inverse(self):
         if self._data is None:

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -667,7 +667,7 @@ class QuantumCircuit:
 
         return self
 
-    def compose(self, other, qubits=None, clbits=None, front=False, inplace=False):
+    def compose(self, other, qubits=None, clbits=None, front=False, inplace=False, wrap=False):
         """Compose circuit with ``other`` circuit or instruction, optionally permuting wires.
 
         ``other`` can be narrower or of equal width to ``self``.
@@ -679,6 +679,8 @@ class QuantumCircuit:
             clbits (list[Clbit|int]): clbits of self to compose onto.
             front (bool): If True, front composition will be performed (not implemented yet).
             inplace (bool): If True, modify the object. Otherwise return composed circuit.
+            wrap (bool): If True, wraps the other circuit into a gate (or instruction, depending on
+                whether it contains only unitary instructions) before composing it onto self.
 
         Returns:
             QuantumCircuit: the composed circuit (returns None if inplace==True).
@@ -715,7 +717,19 @@ class QuantumCircuit:
         else:
             dest = self.copy()
 
+        if wrap:
+            try:
+                other = other.to_gate()
+            except QiskitError:
+                other = other.to_instruction()
+
         if not isinstance(other, QuantumCircuit):
+            if qubits is None:
+                qubits = list(range(other.num_qubits))
+
+            if clbits is None:
+                clbits = list(range(other.num_clbits))
+
             if front:
                 dest.data.insert(0, (other, qubits, clbits))
             else:

--- a/releasenotes/notes/compose-can-wrap-e839c29e426051e8.yaml
+++ b/releasenotes/notes/compose-can-wrap-e839c29e426051e8.yaml
@@ -1,0 +1,19 @@
+---
+features:  
+  - |
+    The :meth:`QuantumCircuit.compose` method includes now a ``wrap`` keyword
+    that allows to choose whether composed circuits should be wrapped into
+    an instruction of not. Per default this keyword is ``False``, i.e. no wrapping.
+
+    For instance
+
+    .. jupyter-execute::
+
+        from qiskit import QuantumCircuit
+        circuit = QuantumCircuit(2)
+        circuit.h([0, 1])
+        other = QuantumCircuit(2)
+        other.x([0, 1])
+        print(circuit.compose(other, wrap=True))  # wrapped
+        print(circuit.compose(other, wrap=False))  # not wrapped
+

--- a/releasenotes/notes/compose-can-wrap-e839c29e426051e8.yaml
+++ b/releasenotes/notes/compose-can-wrap-e839c29e426051e8.yaml
@@ -3,7 +3,7 @@ features:
   - |
     The :meth:`QuantumCircuit.compose` method includes now a ``wrap`` keyword
     that allows to choose whether composed circuits should be wrapped into
-    an instruction of not. Per default this keyword is ``False``, i.e. no wrapping.
+    an instruction or not. Per default this keyword is ``False``, i.e. no wrapping.
 
     For instance
 
@@ -16,4 +16,3 @@ features:
         other.x([0, 1])
         print(circuit.compose(other, wrap=True))  # wrapped
         print(circuit.compose(other, wrap=False))  # not wrapped
-

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -18,7 +18,14 @@ import unittest
 
 from qiskit import transpile
 from qiskit.pulse import Schedule
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Parameter, Gate, Instruction
+from qiskit.circuit import (
+    QuantumRegister,
+    ClassicalRegister,
+    QuantumCircuit,
+    Parameter,
+    Gate,
+    Instruction,
+)
 from qiskit.circuit.library import HGate, RZGate, CXGate, CCXGate
 from qiskit.test import QiskitTestCase
 
@@ -558,20 +565,20 @@ class TestCircuitCompose(QiskitTestCase):
         qc_a = QuantumCircuit(1)
         qc_a.x(0)
 
-        qc_b = QuantumCircuit(1, name='B')
+        qc_b = QuantumCircuit(1, name="B")
         qc_b.h(0)
 
         qc_a.compose(qc_b, wrap=True, inplace=True)
 
-        self.assertDictEqual(qc_a.count_ops(), {'B': 1, 'x': 1})
-        self.assertDictEqual(qc_a.decompose().count_ops(), {'h': 1, 'u3': 1})
+        self.assertDictEqual(qc_a.count_ops(), {"B": 1, "x": 1})
+        self.assertDictEqual(qc_a.decompose().count_ops(), {"h": 1, "u3": 1})
 
     def test_wrapping_unitary_circuit(self):
         """Test a unitary circuit will be wrapped as Gate, else as Instruction."""
         qc_init = QuantumCircuit(1)
         qc_init.x(0)
 
-        qc_unitary = QuantumCircuit(1, name='a')
+        qc_unitary = QuantumCircuit(1, name="a")
         qc_unitary.ry(0.23, 0)
 
         qc_nonunitary = QuantumCircuit(1)

--- a/test/python/circuit/test_compose.py
+++ b/test/python/circuit/test_compose.py
@@ -18,7 +18,7 @@ import unittest
 
 from qiskit import transpile
 from qiskit.pulse import Schedule
-from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Parameter
+from qiskit.circuit import QuantumRegister, ClassicalRegister, QuantumCircuit, Parameter, Gate, Instruction
 from qiskit.circuit.library import HGate, RZGate, CXGate, CCXGate
 from qiskit.test import QiskitTestCase
 
@@ -552,6 +552,38 @@ class TestCircuitCompose(QiskitTestCase):
         with self.subTest("compose with other circuit in-place"):
             qc_a.compose(qc_b, inplace=True)
             self.assertEqual(qc_a.parameters, {a, b})
+
+    def test_wrapped_compose(self):
+        """Test wrapping the circuit upon composition works."""
+        qc_a = QuantumCircuit(1)
+        qc_a.x(0)
+
+        qc_b = QuantumCircuit(1, name='B')
+        qc_b.h(0)
+
+        qc_a.compose(qc_b, wrap=True, inplace=True)
+
+        self.assertDictEqual(qc_a.count_ops(), {'B': 1, 'x': 1})
+        self.assertDictEqual(qc_a.decompose().count_ops(), {'h': 1, 'u3': 1})
+
+    def test_wrapping_unitary_circuit(self):
+        """Test a unitary circuit will be wrapped as Gate, else as Instruction."""
+        qc_init = QuantumCircuit(1)
+        qc_init.x(0)
+
+        qc_unitary = QuantumCircuit(1, name='a')
+        qc_unitary.ry(0.23, 0)
+
+        qc_nonunitary = QuantumCircuit(1)
+        qc_nonunitary.reset(0)
+
+        with self.subTest("wrapping a unitary circuit"):
+            qc = qc_init.compose(qc_unitary, wrap=True)
+            self.assertIsInstance(qc.data[1][0], Gate)
+
+        with self.subTest("wrapping a non-unitary circuit"):
+            qc = qc_init.compose(qc_nonunitary, wrap=True)
+            self.assertIsInstance(qc.data[1][0], Instruction)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add the option to wrap circuits in ``QuantumCircuit.compose``. This makes ``append`` for circuits obsolete so that for circuit compositions only ``compose`` is used.

### Details and comments

If the circuit to compose is unitary and `wrap=True`, it will be added as `Gate` to maintain access to unitary operations such as control, otherwise as `Instruction`.

Here's a brief example:
```python
from qiskit.circuit import QuantumCircuit

oracle = QuantumCircuit(2, name='Oracle')
oracle.cz(0, 1)

qc = QuantumCircuit(2)
qc.h(range(2))

qc.compose(oracle, wrap=True, inplace=True)
print(qc.draw())
```
yields
```
     ┌───┐┌─────────┐
q_0: ┤ H ├┤0        ├
     ├───┤│  Oracle │
q_1: ┤ H ├┤1        ├
     └───┘└─────────┘
```
