### PR TITLE
Add string parameter handling to QPY

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -96,6 +96,7 @@ Generalized Gates
    GRY
    GRZ
    RVGate
+   PauliGate
 
 Boolean Logic Circuits
 ======================
@@ -349,6 +350,7 @@ from .generalized_gates import (
     GRY,
     GRZ,
     RVGate,
+    PauliGate,
 )
 from .boolean_logic import (
     AND,

--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -202,14 +202,15 @@ The contents of each INSTRUCTION_PARAM is:
     }
 
 After each INSTRUCTION_PARAM the next ``size`` bytes are the parameter's data.
-The ``type`` field can be ``'i'``, ``'f'``, ``'p'``, 'e', or ``'n'`` which dictate
-the format. For ``'i'`` it's an integer, ``'f'`` it's a double, ``'p'`` defines
-a :class:`~qiskit.circuit.Paramter` object  which is represented by a PARAM
+The ``type`` field can be ``'i'``, ``'f'``, ``'p'``, ``'e'``, ``'s'``,
+or ``'n'`` which dictate the format. For ``'i'`` it's an integer, ``'f'`` it's
+a double, ``'s'`` if it's a string (encoded as utf8), ``'p'`` defines a
+:class:`~qiskit.circuit.Paramter` object  which is represented by a PARAM
 struct (see below), ``e`` defines a :class:`~qiskit.circuit.ParameterExpression`
 object (that's not a :class:`~qiskit.circuit.Paramter`) which is represented by
-a PARAM_EXPR struct (see below), and ``'n'`` represents an object from numpy (
-either an ``ndarray`` or a numpy type) which means the data is .npy format [#f2]_
-data.
+a PARAM_EXPR struct (see below), and ``'n'`` represents an object from numpy
+(either an ``ndarray`` or a numpy type) which means the data is .npy
+format [#f2]_ data.
 
 
 PARAMETER
@@ -519,6 +520,8 @@ def _read_instruction(file_obj, circuit, registers, custom_instructions):
         elif type_str == "n":
             container = io.BytesIO(data)
             param = np.load(container)
+        elif type_str == "s":
+            param = data.decode("utf8")
         elif type_str == "p":
             container = io.BytesIO(data)
             param = _read_parameter(container)
@@ -702,6 +705,10 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
             type_key = "f"
             data = struct.pack("<d", param)
             size = struct.calcsize("<d")
+        elif isinstance(param, str):
+            type_key = "s"
+            data = param.encode("utf8")
+            size = len(data)
         elif isinstance(param, Parameter):
             type_key = "p"
             _write_parameter(container, param)

--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -205,7 +205,7 @@ After each INSTRUCTION_PARAM the next ``size`` bytes are the parameter's data.
 The ``type`` field can be ``'i'``, ``'f'``, ``'p'``, ``'e'``, ``'s'``,
 or ``'n'`` which dictate the format. For ``'i'`` it's an integer, ``'f'`` it's
 a double, ``'s'`` if it's a string (encoded as utf8), ``'p'`` defines a
-:class:`~qiskit.circuit.Paramter` object  which is represented by a PARAM
+:class:`~qiskit.circuit.Parameter` object  which is represented by a PARAM
 struct (see below), ``e`` defines a :class:`~qiskit.circuit.ParameterExpression`
 object (that's not a :class:`~qiskit.circuit.Paramter`) which is represented by
 a PARAM_EXPR struct (see below), and ``'n'`` represents an object from numpy

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -22,6 +22,7 @@ from qiskit.circuit.random import random_circuit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameter import Parameter
+from qiskit.opflow import X, Y, Z
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.qpy_serialization import dump, load
 
@@ -248,6 +249,15 @@ class TestLoadFromQPY(QiskitTestCase):
         qpy_file.seek(0)
         new_circuit = load(qpy_file)[0]
         self.assertEqual(qc, new_circuit)
+
+    def test_string_parameter(self):
+        """Test a PauliGate instruction that has string parameters."""
+        circ = (X ^ Y ^ Z).to_circuit_op().to_circuit()
+        qpy_file = io.BytesIO()
+        dump(circ, qpy_file)
+        qpy_file.seek(0)
+        new_circuit = load(qpy_file)[0]
+        self.assertEqual(circ, new_circuit)
 
     def test_multiple_circuits(self):
         """Test multiple circuits can be serialized together."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds string parameter handling to the qpy serialization
format. The PauliGate generalized gate class uses pauli strings as a
parameter to the constructor. If there was a PauliGate in the circuit
the qpy serialization would fail because the string parameters weren't
handled. This commit fixes that by adding string as an allowed type for
qpy parameters.

To fix the reported issue of PauliGate serialization with qpy though the
PauliGate class needs to be exported in the __init__.py for the
qiskit.circuit.library path. Without this qpy doesn't know about the
special PauliGate constructor that allows strings and tries to treat it
as a normal custom gate which will fail when trying to create it with a
string parameter.

### Details and comments

Fixes #6660
