### PR TITLE
Fix for "Add Operator Settings #6650"

### DIFF
--- a/qiskit/opflow/gradients/gradient.py
+++ b/qiskit/opflow/gradients/gradient.py
@@ -189,6 +189,7 @@ class Gradient(GradientBase):
         elif isinstance(operator, ListOp):
             grad_ops = [self.get_gradient(op, param) for op in operator.oplist]
 
+            # pylint: disable=comparison-with-callable
             if operator.combo_fn == ListOp.default_combo_fn:  # If using default
                 return ListOp(oplist=grad_ops)
             elif isinstance(operator, SummedOp):

--- a/qiskit/opflow/gradients/gradient.py
+++ b/qiskit/opflow/gradients/gradient.py
@@ -189,7 +189,7 @@ class Gradient(GradientBase):
         elif isinstance(operator, ListOp):
             grad_ops = [self.get_gradient(op, param) for op in operator.oplist]
 
-            if operator._combo_fn is None:  # If using default
+            if operator.combo_fn == ListOp.default_combo_fn:  # If using default
                 return ListOp(oplist=grad_ops)
             elif isinstance(operator, SummedOp):
                 return SummedOp(oplist=[grad for grad in grad_ops if grad != ~Zero @ One]).reduce()

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -14,7 +14,7 @@
 
 from functools import reduce
 from numbers import Number
-from typing import Callable, Dict, Iterator, List, Optional, Set, Sequence, Union, cast
+from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Sequence, Union, cast
 
 import numpy as np
 from scipy.sparse import spmatrix
@@ -122,6 +122,11 @@ class ListOp(OperatorBase):
         """
         return self._oplist
 
+    @staticmethod
+    def default_combo_fn(x: Any) -> Any:
+        """ListOp default combo function i.e. lambda x: x"""
+        return x
+
     @property
     def combo_fn(self) -> Callable:
         """The function defining how to combine ``oplist`` (or Numbers, or NumPy arrays) to
@@ -132,7 +137,7 @@ class ListOp(OperatorBase):
             The combination function.
         """
         if self._combo_fn is None:
-            return lambda x: x
+            return ListOp.default_combo_fn
         return self._combo_fn
 
     @property


### PR DESCRIPTION
This fixes a breakage that showed up in Machine Learning Tests that stemmed from the change to how Gradient detected that this was a regular Listop using its default combo_fn.

In the past it checked against `ListOp([])._combo_fn` since that was set to `lamdba x: x` when None. Now #6650 was done to serialize operators and we cannot serialize callables. So things were changed to make the default on the constructor None instead of lambda x: x and internally if its None the the property combo_fn returns lambda x: x.

So instead of checking `operator._combo_fn` with `ListOp([])._combo_fn` it was changed to check against `None`. This looks like it would work. Thing is when we doing certain operators on the ListOp it will return a copy building out the new ListOp from the modified contents and copying across the combo function. So we may end up with ListOps still using the default combo fn, but now it's not created from None anymore.

To set things back more as they were I created a default_combo_fn and pass this out when None is supplied. In gradient we can check identity with that function so as/when ListOps get altered and copies made the gradient combo test works again in the same way it did before #6650