### PR TITLE
Type docstring fix qiskit.quantum_info.operators.symplectic.SparsePauliOp(data) 

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -46,7 +46,8 @@ class SparsePauliOp(LinearOp):
         """Initialize an operator object.
 
         Args:
-            data (PauliTable): Pauli table of terms.
+            data (array or str or or SparsePauliOp, ScalarOp or PauliTable): input data to construct a
+                :class:`~qiskit.quantum_info.PauliTable`.
             coeffs (np.ndarray): complex coefficients for Pauli terms.
 
         Raises:


### PR DESCRIPTION
I think there is a small typo in the `qiskit.quantum_info.operators.symplectic.sparse_pauli_op.SparsePauliOp.__init__`. Currently, it looks like this:
```
        Args:
            data (PauliTable): Pauli table of terms.
```

However, the type can be all the accepted types by `PauliTable`, plus `SparsePauliOp`:

```
        Args:
            data (array or str or or SparsePauliOp, ScalarOp or PauliTable): input data to construct a
                :class:`~qiskit.quantum_info.PauliTable`.
```