### PR TITLE
fix bug in layout deletion

### DIFF
--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -123,11 +123,11 @@ class Layout:
 
     def __delitem__(self, key):
         if isinstance(key, int):
-            del self._p2v[key]
             del self._v2p[self._p2v[key]]
+            del self._p2v[key]
         elif isinstance(key, Qubit):
-            del self._v2p[key]
             del self._p2v[self._v2p[key]]
+            del self._v2p[key]
         else:
             raise LayoutError(
                 "The key to remove should be of the form"

--- a/test/python/transpiler/test_layout.py
+++ b/test/python/transpiler/test_layout.py
@@ -78,6 +78,13 @@ class LayoutTest(QiskitTestCase):
         self.assertEqual(layout[self.qr[0]], 0)
         self.assertEqual(layout[0], self.qr[0])
 
+    def test_layout_del(self):
+        """Deleter"""
+        layout = Layout()
+        layout[self.qr[0]] = 0
+        del layout[self.qr[0]]
+        self.assertTrue(self.qr[0] not in layout)
+
     def test_layout_avoid_dangling_physical(self):
         """No dangling pointers for physical qubits."""
         layout = Layout({self.qr[0]: 0})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Layout supports `del` but it doesn't work

### Details and comments

`v2p` and `p2v` maintain bi-direction mapping.
If key is `int`, deletion must be processed

1.  delete `v2p` with `v2p[key]`
2. delete `p2v` with `key` 

else, vice versa.