### PR TITLE
Issue6624

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -547,9 +547,8 @@ class Pauli(BasePauli):
         """
         return np.logical_not(self.commutes(other, qargs=qargs))
 
-    def qwc_anticommutes(self, other):
-        """Return True if Paulis are anticommutable using the Qubit Wise Commutativity (QWC)
-        definition.
+    def qw_anticommutes(self, other):
+        """Return True if Paulis anticommute using the Qubit Wise Commutativity (QWC) definition.
 
         Args:
             other (Pauli): another Pauli operator

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -547,7 +547,7 @@ class Pauli(BasePauli):
         """
         return np.logical_not(self.commutes(other, qargs=qargs))
 
-    def qwc_anticommutes(self,other):
+    def qwc_anticommutes(self, other):
         """Return True if Paulis are anticommutable using the Qubit Wise Commutativity (QWC)
         definition.
 
@@ -557,7 +557,7 @@ class Pauli(BasePauli):
         Returns:
             bool: True if Pauli's anticommute, False if they commute.
         """
-        for i,pauliop in enumerate(self):
+        for i, pauliop in enumerate(self):
             if pauliop.anticommutes(other[i]):
                 return True
         return False

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -550,13 +550,15 @@ class Pauli(BasePauli):
     def qwc_anticommutes(self,other):
         """Return True if Paulis are anticommutable using the Qubit Wise Commutativity (QWC)
         definition.
+
         Args:
-            other: Pauli operator
+            other (Pauli): another Pauli operator
+
         Returns:
             bool: True if Pauli's anticommute, False if they commute.
         """
-        for i in range(len(self)):
-            if self[i].anticommutes(other[i]):
+        for i,pauliop in enumerate(self):
+            if pauliop.anticommutes(other[i]):
                 return True
         return False
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -547,6 +547,19 @@ class Pauli(BasePauli):
         """
         return np.logical_not(self.commutes(other, qargs=qargs))
 
+    def qwc_anticommutes(self,other):
+        """Return True if Paulis are anticommutable using the Qubit Wise Commutativity (QWC)
+        definition.
+        Args:
+            other: Pauli operator
+        Returns:
+            bool: True if Pauli's anticommute, False if they commute.
+        """
+        for i in range(len(self)):
+            if self[i].anticommutes(other[i]):
+                return True
+        return False
+
     def evolve(self, other, qargs=None):
         r"""Heisenberg picture evolution of a Pauli by a Clifford.
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -551,7 +551,7 @@ class Pauli(BasePauli):
         """Return True if Paulis anticommute using the Qubit Wise Commutativity (QWC) definition.
 
         Args:
-            other (Pauli): another Pauli operator
+            other (Pauli): another Pauli operator.
 
         Returns:
             bool: True if Pauli's anticommute, False if they commute.

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1063,31 +1063,30 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         base_z, base_x, base_phase = cls._from_array(z, x, phase)
         return cls(BasePauli(base_z, base_x, base_phase))
 
-    def _qwc_anti_commutation_graph(self):
-        """Create anti commutation graph with edges (i, j) if i and j are not commutable.
+    def _qw_anticommutation_graph(self):
+        """Create qubit wise anti commutation graph with edges (i, j) if i and j are not commutable.
+
         Returns:
-            List[Tuple(int,int)]: A list of pairs of indices of the PauliList that are not commutable
+            List[Tuple(int,int)]: A list of pairs of indices of the PauliList that are not commutable.
         """
         anti_commutation_graph = []
         for i in range(self._num_paulis):
             for j in range(i, self._num_paulis):
-                if i != j and self[i].qwc_anticommutes(self[j]):
+                if i != j and self[i].qw_anticommutes(self[j]):
                     anti_commutation_graph.append((i, j))
         return anti_commutation_graph
 
     def group_subops_pauli_list(self):
-        """Given a PauliList, group commutable Paulis in the PauliList
-        (using the Qubit Wise Commutativity(QWC) definition which is assumed
-        for Abelian Grouping.
-            Returns:
-                List[PauliList]: List of PauliLists where each PauliList contains grouped Pauli operators
-                that are commutable
+        """Given a PauliList, group commutable Paulis using the Qubit Wise Commutativity (QWC) definition.
+
+        Returns:
+            List[PauliList]: List of PauliLists where each PauliList contains commutable Pauli operators.
         """
         import retworkx as rx
         from collections import defaultdict
 
         nodes = range(self._num_paulis)
-        edges = self._qwc_anti_commutation_graph()
+        edges = self._qw_anticommutation_graph()
         graph = rx.PyGraph()
         graph.add_nodes_from(nodes)
         graph.add_edges_from_no_data(edges)

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1063,15 +1063,11 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         base_z, base_x, base_phase = cls._from_array(z, x, phase)
         return cls(BasePauli(base_z, base_x, base_phase))
 
-    
     def _qwc_anti_commutation_graph(self):
-        """Create edges (i, j) if i and j are not commutable.
-            Args:
-                None
-            Returns:
-                A list of pairs of indices of the PauliList that are not commutable
-            """
-        #creating the anti commutation graph
+        """Create anti commutation graph with edges (i, j) if i and j are not commutable.
+        Returns:
+            List[Tuple(int,int)]: A list of pairs of indices of the PauliList that are not commutable
+        """
         anti_commutation_graph=[]
         for i in range(self._num_paulis):
             for j in range(i,self._num_paulis):
@@ -1080,18 +1076,17 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return anti_commutation_graph
 
     def group_subops_pauli_list(self):
-        """Given a PauliList, group commutable Paulis in the PauliList (using the Qubit Wise Commutativity(QWC)
-        definition which is assumed for Abelian Grouping.
-            Args:
-                None
+        """Given a PauliList, group commutable Paulis in the PauliList
+        (using the Qubit Wise Commutativity(QWC) definition which is assumed
+        for Abelian Grouping.
             Returns:
-                List of PauliLists where each PauliList contains grouped Pauli operators that are commutable
+                List[PauliList]: List of PauliLists where each PauliList contains grouped Pauli operators
+                that are commutable
         """
         import retworkx as rx
         from collections import defaultdict
         nodes = range(self._num_paulis)
         edges = self._qwc_anti_commutation_graph()
-        
         graph = rx.PyGraph()
         graph.add_nodes_from(nodes)
         graph.add_edges_from_no_data(edges)
@@ -1099,6 +1094,5 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         coloring_dict = rx.graph_greedy_color(graph)
         groups = defaultdict(list)
         for idx, color in coloring_dict.items():
-            groups[color].append(idx)   
+            groups[color].append(idx)
         return [PauliList([self[i] for i in x]) for x in groups.values()]
-

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1068,11 +1068,11 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         Returns:
             List[Tuple(int,int)]: A list of pairs of indices of the PauliList that are not commutable
         """
-        anti_commutation_graph=[]
+        anti_commutation_graph = []
         for i in range(self._num_paulis):
-            for j in range(i,self._num_paulis):
-                if i!=j and self[i].qwc_anticommutes(self[j]):
-                    anti_commutation_graph.append((i,j))
+            for j in range(i, self._num_paulis):
+                if i != j and self[i].qwc_anticommutes(self[j]):
+                    anti_commutation_graph.append((i, j))
         return anti_commutation_graph
 
     def group_subops_pauli_list(self):
@@ -1085,6 +1085,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         """
         import retworkx as rx
         from collections import defaultdict
+
         nodes = range(self._num_paulis)
         edges = self._qwc_anti_commutation_graph()
         graph = rx.PyGraph()

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1077,7 +1077,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return anti_commutation_graph
 
     def group_subops_pauli_list(self):
-        """Given a PauliList, group commutable Paulis using the Qubit Wise Commutativity (QWC) definition.
+        """Partition a  PauliList into sets of mutually qubit-wise commuting Pauli strings.
 
         Returns:
             List[PauliList]: List of PauliLists where each PauliList contains commutable Pauli operators.

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -1062,3 +1062,43 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         """
         base_z, base_x, base_phase = cls._from_array(z, x, phase)
         return cls(BasePauli(base_z, base_x, base_phase))
+
+    
+    def _qwc_anti_commutation_graph(self):
+        """Create edges (i, j) if i and j are not commutable.
+            Args:
+                None
+            Returns:
+                A list of pairs of indices of the PauliList that are not commutable
+            """
+        #creating the anti commutation graph
+        anti_commutation_graph=[]
+        for i in range(self._num_paulis):
+            for j in range(i,self._num_paulis):
+                if i!=j and self[i].qwc_anticommutes(self[j]):
+                    anti_commutation_graph.append((i,j))
+        return anti_commutation_graph
+
+    def group_subops_pauli_list(self):
+        """Given a PauliList, group commutable Paulis in the PauliList (using the Qubit Wise Commutativity(QWC)
+        definition which is assumed for Abelian Grouping.
+            Args:
+                None
+            Returns:
+                List of PauliLists where each PauliList contains grouped Pauli operators that are commutable
+        """
+        import retworkx as rx
+        from collections import defaultdict
+        nodes = range(self._num_paulis)
+        edges = self._qwc_anti_commutation_graph()
+        
+        graph = rx.PyGraph()
+        graph.add_nodes_from(nodes)
+        graph.add_edges_from_no_data(edges)
+        # Keys in coloring_dict are nodes, values are colors
+        coloring_dict = rx.graph_greedy_color(graph)
+        groups = defaultdict(list)
+        for idx, color in coloring_dict.items():
+            groups[color].append(idx)   
+        return [PauliList([self[i] for i in x]) for x in groups.values()]
+


### PR DESCRIPTION


### Summary

This PR is the first step in implementing #6624. This implements grouping commuting Pauli strings in quantum_info. The second step, which will be addressed in another PR, is to rewrite the abelian-grouping code in opflow to call the code in the present PR.

### Details and comments

Here is an example of the functions created: 

```python

from qiskit.quantum_info import PauliList,Pauli

pauli_list=PauliList([Pauli("II"),Pauli("IX"), Pauli("IY"), Pauli("XX"),Pauli("YY"),Pauli("YX")])

pauli_list.group_subops_pauli_list()
#returns [PauliList(['YX']), PauliList(['XX', 'IX']), PauliList(['IY', 'II', 'YY'])]

pauli_list[3].qw_anticommutes(pauli_list[4])
#returns False because pauli_list[0]=Pauli("XX") qubit-wise anticommutes with pauli_list[1]=Pauli("YY")

```
