### PR TITLE
Fix wrapping of ``GroverOperator``

### DIFF
--- a/qiskit/circuit/library/grover_operator.py
+++ b/qiskit/circuit/library/grover_operator.py
@@ -15,6 +15,7 @@
 from typing import List, Optional, Union
 import numpy
 from qiskit.circuit import QuantumCircuit, QuantumRegister, AncillaRegister
+from qiskit.exceptions import QiskitError
 from qiskit.quantum_info import Statevector, Operator, DensityMatrix
 from .standard_gates import MCXGate
 
@@ -274,10 +275,10 @@ class GroverOperator(QuantumCircuit):
         circuit.global_phase = numpy.pi
 
         self.add_register(*circuit.qregs)
-        if self._insert_barriers:
-            circuit_wrapped = circuit.to_instruction()
-        else:
+        try:
             circuit_wrapped = circuit.to_gate()
+        except QiskitError:
+            circuit_wrapped = circuit.to_instruction()
 
         self.compose(circuit_wrapped, qubits=self.qubits, inplace=True)
 

--- a/test/python/circuit/library/test_grover_operator.py
+++ b/test/python/circuit/library/test_grover_operator.py
@@ -69,6 +69,21 @@ class TestGroverOperator(QiskitTestCase):
             grover_op, oracle=np.diag((-1) ** mark.data), zero_reflection=diffuse.data
         )
 
+    def test_stateprep_contains_instruction(self):
+        """Test wrapping works if the state preparation is not unitary."""
+        oracle = QuantumCircuit(1)
+        oracle.z(0)
+
+        instr = QuantumCircuit(1)
+        instr.s(0)
+        instr = instr.to_instruction()
+
+        stateprep = QuantumCircuit(1)
+        stateprep.append(instr, [0])
+
+        grover_op = GroverOperator(oracle, stateprep)
+        self.assertEqual(grover_op.num_qubits, 1)
+
     def test_reflection_qubits(self):
         """Test setting idle qubits doesn't apply any operations on these qubits."""
         oracle = QuantumCircuit(4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes the finance tutorials (see also https://github.com/Qiskit/qiskit-finance/pull/71).

### Details and comments

Due to our current distinction into `Gate` and `Instruction` and their different features, we have to explicitly try converting the library circuits to gates and only to instructions when the gate conversion fails. 


