### PR TITLE
Visualization: fix histograms (#6692)

### DIFF
--- a/test/python/visualization/test_plot_histogram.py
+++ b/test/python/visualization/test_plot_histogram.py
@@ -13,15 +13,18 @@
 """Tests for plot_histogram."""
 
 import unittest
-import matplotlib as mpl
 
 from qiskit.test import QiskitTestCase
-from qiskit.tools.visualization import plot_histogram
+from qiskit.tools.visualization import plot_histogram, HAS_MATPLOTLIB
+
+if HAS_MATPLOTLIB:
+    import matplotlib as mpl
 
 
 class TestPlotHistogram(QiskitTestCase):
     """Qiskit plot_histogram tests."""
 
+    @unittest.skipIf(not HAS_MATPLOTLIB, "matplotlib not available.")
     def test_different_counts_lengths(self):
         """Test plotting two different length dists works"""
         exact_dist = {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6692.

The issue was caused by calculating the most-common elements for the data separately for each dictionary, which caused different labels to be chosen for different dictionaries, and thus the output didn't align.
This resolves it by calculating the states to keep together, and getting values for all of those kept states for each dictionary.

### Details and comments

Adds tests for setting ``plot_histogram(..., number_to_keep=int)``. Note that the other arguments to ``plot_histogram()`` appear untested still.
