### PR TITLE
Fix Gaussian Square Curve Docstring 

### DIFF
--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -215,7 +215,7 @@ class GaussianSquare(ParametricPulse):
 
         0 <= x < risefall
 
-        f(x) = amp * exp( -(1/2) * (x - risefall/2)^2 / sigma^2) )
+        f(x) = amp * exp( -(1/2) * (x - risefall)^2 / sigma^2) )
 
         risefall <= x < risefall + width
 
@@ -223,7 +223,7 @@ class GaussianSquare(ParametricPulse):
 
         risefall + width <= x < duration
 
-        f(x) = amp * exp( -(1/2) * (x - (risefall + width)/2)^2 / sigma^2) )
+        f(x) = amp * exp( -(1/2) * (x - (risefall + width))^2 / sigma^2) )
 
     """
 

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -132,7 +132,7 @@ class Gaussian(ParametricPulse):
 
     .. math::
 
-        f(x) = amp * exp( -(1/2) * (x - duration/2)^2 / sigma^2) )  ,  0 <= x < duration
+        f(x) = amp * exp( -(1/2) * (x - duration/2)^2 / sigma^2 )  ,  0 <= x < duration
     """
 
     def __init__(
@@ -215,7 +215,7 @@ class GaussianSquare(ParametricPulse):
 
         0 <= x < risefall
 
-        f(x) = amp * exp( -(1/2) * (x - risefall)^2 / sigma^2) )
+        f(x) = amp * exp( -(1/2) * (x - risefall)^2 / sigma^2 )
 
         risefall <= x < risefall + width
 
@@ -223,7 +223,7 @@ class GaussianSquare(ParametricPulse):
 
         risefall + width <= x < duration
 
-        f(x) = amp * exp( -(1/2) * (x - (risefall + width))^2 / sigma^2) )
+        f(x) = amp * exp( -(1/2) * (x - (risefall + width))^2 / sigma^2 )
 
     """
 
@@ -356,7 +356,7 @@ class Drag(ParametricPulse):
 
     .. math::
 
-        Gaussian(x, amp, sigma) = amp * exp( -(1/2) * (x - duration/2)^2 / sigma^2) )
+        Gaussian(x, amp, sigma) = amp * exp( -(1/2) * (x - duration/2)^2 / sigma^2 )
 
     References:
         1. |citation1|_


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #6691 

Fixes docstring which had the Gaussian square pulse equation wrong, and also removes erroneous close parentheses from multiple docstrings.

### Details and comments

It was pointed out that the GaussianSquare class's docstring was inconsistent with the actual code implementation. Specifically, the code correctly computed the mean of the pulse (risefall), but the docstring divided this in half twice instead of once. See the issue for more details.

Additionally, I noticed that there was an extra close parenthesis on multiple docstrings in the file, so I fixed those as well.
