### PR TITLE
Pin networkx for CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,3 +3,4 @@ numpy>=1.20.0 ; python_version>'3.6'
 decorator==4.4.2
 jax==0.2.13
 jaxlib==0.1.67
+networkx==2.5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Networkx 2.6 released a few hours ago and is causing a version conflict
with the matplotlib version we install in the tutorials job. The version
we use in the tutorials job was specifically pinned because of
performance issues we were seeing with newer matplotlib releases
(admittedly a while ago) to side step the issue and get 0.18.0 out the
door this commit pins the networkx version we use in the constraints
file. After 0.18.0 releases we can investigate removing the matplotlib
pin in the tutorials job and this constraint.

### Details and comments