### PR TITLE
Fix Matplotlib renderer.M deprecation

### DIFF
--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -65,7 +65,7 @@ class Arrow3D(FancyArrowPatch):
 
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
+        x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
         self.set_positions((x_s[0], y_s[0]), (x_s[1], y_s[1]))
         FancyArrowPatch.draw(self, renderer)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When plotting a bloch sphere using Matplotlib version ```3.4.2```, the following deprecation warning is given:
```
/opt/conda/lib/python3.8/site-packages/qiskit/visualization/bloch.py:69: MatplotlibDeprecationWarning: 
The M attribute was deprecated in Matplotlib 3.4 and will be removed two minor releases later. Use self.axes.M instead.
  x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)
```

By changing ```x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, renderer.M)``` to ```x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)```, the warning is fixed.



### Details and comments

Version information:

Qiskit Software | Version
-- | --
Qiskit | 0.27.0
Terra | 0.17.4
Aer | 0.8.2
Ignis | 0.6.0
Aqua | 0.9.2
Matplotlib | 3.4.2