### PR TITLE
Handle complex parameters and blueprint circuits in QPY (#6713)

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -528,6 +528,8 @@ def _read_instruction(file_obj, circuit, registers, custom_instructions):
             param = struct.unpack("<q", data)[0]
         elif type_str == "f":
             param = struct.unpack("<d", data)[0]
+        elif type_str == "c":
+            param = complex(*struct.unpack(COMPLEX_PACK, data))
         elif type_str == "n":
             container = io.BytesIO(data)
             param = np.load(container)
@@ -551,6 +553,13 @@ def _read_instruction(file_obj, circuit, registers, custom_instructions):
             inst_obj.label = label
         circuit._append(inst_obj, qargs, cargs)
         return
+    elif gate_name in custom_instructions:
+        inst_obj = _parse_custom_instruction(custom_instructions, gate_name, params)
+        inst_obj.condition = condition_tuple
+        if label_size > 0:
+            inst_obj.label = label
+        circuit._append(inst_obj, qargs, cargs)
+        return
     elif hasattr(library, gate_name):
         gate_class = getattr(library, gate_name)
     elif hasattr(circuit_mod, gate_name):
@@ -559,22 +568,21 @@ def _read_instruction(file_obj, circuit, registers, custom_instructions):
         gate_class = getattr(extensions, gate_name)
     elif hasattr(quantum_initializer, gate_name):
         gate_class = getattr(quantum_initializer, gate_name)
-    elif gate_name in custom_instructions:
-        inst_obj = _parse_custom_instruction(custom_instructions, gate_name, params)
-        inst_obj.condition = condition_tuple
-        if label_size > 0:
-            inst_obj.label = label
-        circuit._append(inst_obj, qargs, cargs)
-        return
     else:
         raise AttributeError("Invalid instruction type: %s" % gate_name)
-    if gate_name == "Barrier":
-        params = [len(qargs)]
-    gate = gate_class(*params)
+    if gate_name == "Initialize":
+        gate = gate_class(params)
+    else:
+        if gate_name == "Barrier":
+            params = [len(qargs)]
+        gate = gate_class(*params)
     gate.condition = condition_tuple
     if label_size > 0:
         gate.label = label
-    circuit._append(gate, qargs, cargs)
+    if not isinstance(gate, Instruction):
+        circuit.append(gate, qargs, cargs)
+    else:
+        circuit._append(gate, qargs, cargs)
 
 
 def _parse_custom_instruction(custom_instructions, gate_name, params):
@@ -677,6 +685,7 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
         )
         or gate_class_name == "Gate"
         or gate_class_name == "Instruction"
+        or isinstance(instruction_tuple[0], library.BlueprintCircuit)
     ):
         if instruction_tuple[0].name not in custom_instructions:
             custom_instructions[instruction_tuple[0].name] = instruction_tuple[0]
@@ -745,7 +754,11 @@ def _write_instruction(file_obj, instruction_tuple, custom_instructions, index_m
             container.seek(0)
             data = container.read()
             size = len(data)
-        elif isinstance(param, (np.integer, np.floating, np.ndarray)):
+        elif isinstance(param, complex):
+            type_key = "c"
+            data = struct.pack(COMPLEX_PACK, param.real, param.imag)
+            size = struct.calcsize(COMPLEX_PACK)
+        elif isinstance(param, (np.integer, np.floating, np.ndarray, np.complexfloating)):
             type_key = "n"
             np.save(container, param)
             container.seek(0)

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -23,7 +23,7 @@ from qiskit.circuit.classicalregister import Clbit
 from qiskit.circuit.quantumregister import Qubit
 from qiskit.circuit.random import random_circuit
 from qiskit.circuit.gate import Gate
-from qiskit.circuit.library import XGate
+from qiskit.circuit.library import XGate, QFT
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameter import Parameter
 from qiskit.extensions import UnitaryGate
@@ -468,6 +468,34 @@ class TestLoadFromQPY(QiskitTestCase):
         gate = XGate(label="My conditional x gate")
         gate.c_if(qc.cregs[0], 1)
         qc.append(gate, [0])
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circ = load(qpy_file)[0]
+        self.assertEqual(qc, new_circ)
+        self.assertEqual([x[0].label for x in qc.data], [x[0].label for x in new_circ.data])
+
+    def test_initialize_qft(self):
+        """Test that initialize with a complex statevector and qft work."""
+        k = 5
+        state = (1 / np.sqrt(8)) * np.array(
+            [
+                np.exp(-1j * 2 * np.pi * k * (0) / 8),
+                np.exp(-1j * 2 * np.pi * k * (1) / 8),
+                np.exp(-1j * 2 * np.pi * k * (2) / 8),
+                np.exp(-1j * 2 * np.pi * k * 3 / 8),
+                np.exp(-1j * 2 * np.pi * k * 4 / 8),
+                np.exp(-1j * 2 * np.pi * k * 5 / 8),
+                np.exp(-1j * 2 * np.pi * k * 6 / 8),
+                np.exp(-1j * 2 * np.pi * k * 7 / 8),
+            ]
+        )
+
+        qubits = 3
+        qc = QuantumCircuit(qubits, qubits)
+        qc.initialize(state)
+        qc.append(QFT(qubits), range(qubits))
+        qc.measure(range(qubits), range(qubits))
         qpy_file = io.BytesIO()
         dump(qc, qpy_file)
         qpy_file.seek(0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with generating and loading QPY files with
complex instruction parameters (initialize) or blueprint circuits that
were in a circuit. Normally complex parameter types aren't valid on
gates or instructions, however initialize uses them as the statevector
elements are stored as the parameter list for the object (instead of as
a numpy array parameter like unitary). So to fix this we need to be able
to handle this edge case and save complex numbers for parameters too.

Similarly there was an issue found when trying to deserialize a blueprint
circuit object. It doesn't seem possible to reconstruct an instance of a
blueprint circuit reliably from just the parameters list for the
circuit. This causes an issue when deserializing as the gate
reconstructed from the qpy data is not valid. The only way to fix this
is to treat any blueprint circuit as a custom gate or instruction
instead of a discrete library element.

In case this merges after 0.18.0 and needs to be backported to 0.18.1
this is still a backwards compatible change from the QPY guarantee PoV.
While the complex parameter type wasn't present prior to this commit it
does not change the file format at all, and works with in the
constraints of QPY v1. Any QPY file generated with 0.18.0 will still be
loadable by 0.18.1 (assuming this commit is included in a 0.18.1
release). This is really just a bug fix because you could not generate a
QPY in 0.18.0 with initialize using complex parameters. It's also worth
pointing out from a compatibility PoV a QFT in a circuit would generate
a QPY file in 0.18.0 however this QPY file could never be loaded as we
can't create a QFT from what 0.18.0 stored in the qpy data.

### Details and comments

Fixes #6710

Backported from #6713 
(cherry picked from commit f69e39758890cc51291d33d171a02974ea13536f)
