### PR TITLE
Add f to f-strings in mpl tester results.py

### DIFF
--- a/test/ipynb/results.py
+++ b/test/ipynb/results.py
@@ -147,14 +147,14 @@ class Results:
         ret = ""
 
         if len(self.mismatch) >= 2:
-            Results._zipfiles(self.mismatch, "{self.directory}/mismatch.zip")
+            Results._zipfiles(self.mismatch, f"{self.directory}/mismatch.zip")
             ret += (
                 '<div><a href="{self.directory}/mismatch.zip">'
                 "Download %s mismatch results as a zip</a></div>" % len(self.mismatch)
             )
 
         if len(self.missing) >= 2:
-            Results._zipfiles(self.missing, "{self.directory}/missing.zip")
+            Results._zipfiles(self.missing, f"{self.directory}/missing.zip")
             ret += (
                 '<div><a href="{self.directory}/missing.zip">'
                 "Download %s missing results as a zip</a></div>" % len(self.missing)

--- a/test/ipynb/results.py
+++ b/test/ipynb/results.py
@@ -149,14 +149,14 @@ class Results:
         if len(self.mismatch) >= 2:
             Results._zipfiles(self.mismatch, f"{self.directory}/mismatch.zip")
             ret += (
-                '<div><a href="{self.directory}/mismatch.zip">'
+                f'<div><a href="{self.directory}/mismatch.zip">'
                 "Download %s mismatch results as a zip</a></div>" % len(self.mismatch)
             )
 
         if len(self.missing) >= 2:
             Results._zipfiles(self.missing, f"{self.directory}/missing.zip")
             ret += (
-                '<div><a href="{self.directory}/missing.zip">'
+                f'<div><a href="{self.directory}/missing.zip">'
                 "Download %s missing results as a zip</a></div>" % len(self.missing)
             )
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

In #6672, graphs were added to the binder tests. As part of this, there were 2 directories created which meant that the zip files for the mismatched images now had a variable directory name which was put in an f-string, but the f was left off. This adds the f.
