### PR TITLE
Added to_gate methods to PrimitiveOp subclasses (#5711)

### DIFF
--- a/qiskit/opflow/primitive_ops/circuit_op.py
+++ b/qiskit/opflow/primitive_ops/circuit_op.py
@@ -18,7 +18,7 @@ import numpy as np
 
 import qiskit
 from qiskit import QuantumCircuit
-from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.circuit import Instruction, ParameterExpression, Gate
 from qiskit.circuit.library import IGate
 from qiskit.opflow.list_ops.tensored_op import TensoredOp
 from qiskit.opflow.operator_base import OperatorBase
@@ -213,6 +213,9 @@ class CircuitOp(PrimitiveOp):
 
     def to_instruction(self) -> Instruction:
         return self.primitive.to_instruction()
+
+    def to_gate(self) -> Gate:
+        return self.primitive.to_gate()
 
     # Warning - modifying immutable object!!
     def reduce(self) -> OperatorBase:

--- a/qiskit/opflow/primitive_ops/matrix_op.py
+++ b/qiskit/opflow/primitive_ops/matrix_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy.sparse import spmatrix
 
 from qiskit import QuantumCircuit
-from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.circuit import Instruction, ParameterExpression, Gate
 from qiskit.extensions.hamiltonian_gate import HamiltonianGate
 from qiskit.opflow.exceptions import OpflowError
 from qiskit.opflow.list_ops.summed_op import SummedOp
@@ -229,3 +229,6 @@ class MatrixOp(PrimitiveOp):
 
     def to_instruction(self) -> Instruction:
         return (self.coeff * self.primitive).to_instruction()
+
+    def to_gate(self) -> Gate:
+        return self.exp_i().to_gate()

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy.sparse import spmatrix
 
 from qiskit import QuantumCircuit
-from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.circuit import Instruction, ParameterExpression, Gate
 from qiskit.circuit.library import IGate, RXGate, RYGate, RZGate, XGate, YGate, ZGate
 from qiskit.opflow.exceptions import OpflowError
 from qiskit.opflow.list_ops.summed_op import SummedOp
@@ -332,6 +332,9 @@ class PauliOp(PrimitiveOp):
         # return PrimitiveOp(self.primitive.to_instruction(), coeff=self.coeff).reduce()
 
         return self.to_circuit().to_instruction()
+
+    def to_gate(self) -> Gate:
+        return self.to_circuit().to_gate()
 
     def to_pauli_op(self, massive: bool = False) -> "PauliOp":
         return self

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -18,7 +18,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union, cast
 import numpy as np
 from scipy.sparse import spmatrix
 
-from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.circuit import Instruction, ParameterExpression, Gate
 from qiskit.opflow.exceptions import OpflowError
 from qiskit.opflow.list_ops.summed_op import SummedOp
 from qiskit.opflow.list_ops.tensored_op import TensoredOp
@@ -334,6 +334,9 @@ class PauliSumOp(PrimitiveOp):
 
     def to_instruction(self) -> Instruction:
         return self.to_matrix_op().to_circuit().to_instruction()  # type: ignore
+
+    def to_gate(self) -> Gate:
+        return self.to_matrix_op().to_circuit().to_gate()
 
     def to_pauli_op(self, massive: bool = False) -> Union[PauliOp, SummedOp]:
         def to_native(x):

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -19,7 +19,7 @@ import scipy.linalg
 from scipy.sparse import spmatrix
 
 from qiskit import QuantumCircuit
-from qiskit.circuit import Instruction, ParameterExpression
+from qiskit.circuit import Instruction, ParameterExpression, Gate
 from qiskit.opflow.operator_base import OperatorBase
 from qiskit.quantum_info import Operator, Pauli, SparsePauliOp, Statevector
 
@@ -271,6 +271,10 @@ class PrimitiveOp(OperatorBase):
 
     def to_instruction(self) -> Instruction:
         """Returns an ``Instruction`` equivalent to this Operator."""
+        raise NotImplementedError
+
+    def to_gate(self) -> Gate:
+        """Returns an ``Gate`` equivalent to this Operator."""
         raise NotImplementedError
 
     def to_circuit(self) -> QuantumCircuit:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #5711

### Details and comments

Added `to_gate` methods to `CircuitOp`, `MatrixOp`, `PauliOp`, and `PauliSumOp`. I did this by mimicking the functionality of the `to_instruction` methods. This involved transforming the operator to a `QuantumCircuit` class which has the `to_gate` method defined.
