### PR TITLE
Consolidate quick CI jobs into 3.7 linux unittest job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -242,7 +242,7 @@ stages:
             pushd test/qpy_compat
             ./run_tests.sh
             popd
-            displayName: 'Run QPY backwards compat tests'
+          displayName: 'Run QPY backwards compat tests'
         - bash: |
             set -e
             virtualenv image_tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -237,6 +237,24 @@ stages:
           inputs:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for Linux Python $(python.version)'
+        - bash: |
+            set -e
+            pushd test/qpy_compat
+            ./run_tests.sh
+            popd
+            displayName: 'Run QPY backwards compat tests'
+        - bash: |
+            set -e
+            virtualenv image_tests
+            image_tests/bin/pip install -U -r requirements.txt -c constraints.txt
+            image_tests/bin/pip install -U -c constraints.txt -e .
+            image_tests/bin/pip install -U "matplotlib<3.3.0" pylatexenc pillow
+            image_tests/bin/python setup.py build_ext --inplace
+            sudo apt install -y graphviz pandoc
+            image_tests/bin/pip check
+          displayName: 'Install dependencies'
+        - bash: image_tests/bin/python -m unittest discover -v test/ipynb
+          displayName: 'Run image test'
     - job: 'Lint'
       pool: {vmImage: 'ubuntu-latest'}
       strategy:
@@ -786,65 +804,3 @@ stages:
             artifactName: 'html_tutorials'
             Parallel: true
             ParallelCount: 8
-    - job: 'Image_tests'
-      pool: {vmImage: 'ubuntu-latest'}
-      strategy:
-        matrix:
-          Python38:
-            python.version: '3.8'
-      variables:
-        QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
-        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '$(python.version)'
-          displayName: 'Use Python $(python.version)'
-        - task: Cache@2
-          inputs:
-            key: 'pip | "$(Agent.OS)" | "$(python.version)"'
-            restoreKeys: |
-              pip | "$(Agent.OS)"
-              pip
-            path: $(PIP_CACHE_DIR)
-          displayName: Cache pip
-        - bash: |
-            set -e
-            python -m pip install --upgrade pip
-            pip install -U -r requirements.txt -c constraints.txt
-            pip install -U -c constraints.txt -e .
-            pip install -U "matplotlib<3.3.0" pylatexenc pillow
-            python setup.py build_ext --inplace
-            sudo apt install -y graphviz pandoc
-            pip check
-          displayName: 'Install dependencies'
-        - bash: python -m unittest discover -v test/ipynb
-          displayName: 'Run image test'
-    - job: 'qpy_tests'
-      pool: {vmImage: 'ubuntu-latest'}
-      strategy:
-        matrix:
-          Python38:
-            python.version: '3.8'
-      variables:
-        QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y
-        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '$(python.version)'
-          displayName: 'Use Python $(python.version)'
-        - task: Cache@2
-          inputs:
-            key: 'pip | "$(Agent.OS)" | "$(python.version)"'
-            restoreKeys: |
-              pip | "$(Agent.OS)"
-              pip
-            path: $(PIP_CACHE_DIR)
-          displayName: Cache pip
-        - bash: |
-            set -e
-            pushd test/qpy_compat
-            ./run_tests.sh
-            popd
-          displayName: 'Run backwards compat tests'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit consolidates the 2 fast executing CI jobs for the QPY
compatibility testing and image comparison test validation to be stages
at the end of the linux 3.7 CI job. Our primary resource constraint in
CI is the number of concurrent jobs we can run (which is currently 10
jobs). These two jobs typically take < 3minutes total which includes
provision time, git checkout, and pip dependency installation time.
Since these jobs execute so quickly there is no reason to waste a CI
node to run them when we can just append these to the end of an existing
job. This commit makes this change and adds runs these test job as
separate stages at the end of the linux 3.7 job. This should hopefully
reduce the resource contention in CI slightly and improve CI throughput.

### Details and comments


