### PR TITLE
Specify version for Python 3.6 support ending

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -59,7 +59,7 @@ from .version import QiskitVersion  # noqa
 __qiskit_version__ = QiskitVersion()
 
 
-if sys.version_info[0] == 3 and sys.version_info[1] == 6:
+if sys.version_info < (3, 7):
     warnings.warn(
         "Using Qiskit with Python 3.6 is deprecated as of the 0.17.0 release. "
         "Support for running Qiskit with Python 3.6 will be removed in Terra 0.20.0.",

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -62,8 +62,7 @@ __qiskit_version__ = QiskitVersion()
 if sys.version_info[0] == 3 and sys.version_info[1] == 6:
     warnings.warn(
         "Using Qiskit with Python 3.6 is deprecated as of the 0.17.0 release. "
-        "Support for running Qiskit with Python 3.6 will be removed in a "
-        "future release.",
+        "Support for running Qiskit with Python 3.6 will be removed in Terra 0.20.0.",
         DeprecationWarning,
     )
 

--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -61,8 +61,8 @@ __qiskit_version__ = QiskitVersion()
 
 if sys.version_info < (3, 7):
     warnings.warn(
-        "Using Qiskit with Python 3.6 is deprecated as of the 0.17.0 release. "
-        "Support for running Qiskit with Python 3.6 will be removed in Terra 0.20.0.",
+        "Using Qiskit with Python 3.6 is deprecated as of qiskit-terra 0.17.0. "
+        "Support for running Qiskit with Python 3.6 will be removed in qiskit-terra 0.20.0.",
         DeprecationWarning,
     )
 


### PR DESCRIPTION
### Summary

The plan is that 0.19 will be the last version to support Python 3.6,
with a view to begin adding 3.10 support at the same time it is removed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


