### PR TITLE
Exclude bip-mapper extra from all

### DIFF
--- a/qiskit/transpiler/passes/routing/bip_mapping.py
+++ b/qiskit/transpiler/passes/routing/bip_mapping.py
@@ -104,6 +104,7 @@ class BIPMapping(TransformationPass):
                 libname="bip-mapper",
                 name="BIP-based mapping pass",
                 pip_install="pip install 'qiskit-terra[bip-mapper]'",
+                msg="This may not be possible for Python 3.6 or 3.9",
             )
         super().__init__()
         self.coupling_map = coupling_map

--- a/qiskit/transpiler/passes/routing/bip_mapping.py
+++ b/qiskit/transpiler/passes/routing/bip_mapping.py
@@ -104,7 +104,7 @@ class BIPMapping(TransformationPass):
                 libname="bip-mapper",
                 name="BIP-based mapping pass",
                 pip_install="pip install 'qiskit-terra[bip-mapper]'",
-                msg="This may not be possible for Python 3.6 or 3.9",
+                msg="This may not be possible for all Python versions and OSes",
             )
         super().__init__()
         self.coupling_map = coupling_map

--- a/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
+++ b/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix ``pip install qiskit-terra[all]`` on Python 3.6 and 3.9.  On these
+    versions, the ``bip-mapper`` target constraints cannot be satisfied due to
+    the ``cplex`` package only supporting Python 3.7 and 3.8.  Requesting the
+    ``all`` target on these versions will now not attempt to install the
+    unsolvable dependency, though you can still attempt to install the
+    ``bip-mapper`` extra directly if you want to force pip to try and resolve
+    the package.

--- a/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
+++ b/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
@@ -1,13 +1,11 @@
 ---
-fixes:
+upgrade:
   - |
-    Fixed ``pip install qiskit-terra[all]`` so that it will successfully install
-    when running on Python 3.6 and 3.9.  Previously, these Python versions would
-    fail to install the ``all`` target because the ``bip-mapper`` extra
-    requirements could not be satisfied due to the ``cplex`` package only
-    supporting Python 3.7 and 3.8.  Requesting the ``all`` target on these
-    Python versions will now no longer attempt to install the unsolvable
-    dependency (ie ``cplex`` will not longer be attempted to installed). The
-    ``bip-mapper`` extra will still attempt to install the
-    ``cplex`` and ``docplex`` packages on Python 3.6 and 3.9 (and likely fail as
-    ``cplex`` isn't available).
+    ``pip install qiskit-terra[all]`` will no longer attempt to install the
+    ``bip-mapper`` extra.  This is because the dependency ``cplex`` is not well
+    supported on the range of Python versions and OSes that Terra supports, and
+    a failed extra dependency would fail the entire package resolution.  If you
+    are using Python 3.7 or 3.8 and are on Linux-x64 or -ppc64le, macOS-x64 or
+    Windows-x64 you should be able to install ``qiskit-terra[bip-mapper]``
+    explicitly, if desired, while other combinations of OS, platform
+    architectures and Python versions will likely fail.

--- a/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
+++ b/releasenotes/notes/fix-bip-mapper-requirements-930c7dcd5a3b82ba.yaml
@@ -1,10 +1,13 @@
 ---
 fixes:
   - |
-    Fix ``pip install qiskit-terra[all]`` on Python 3.6 and 3.9.  On these
-    versions, the ``bip-mapper`` target constraints cannot be satisfied due to
-    the ``cplex`` package only supporting Python 3.7 and 3.8.  Requesting the
-    ``all`` target on these versions will now not attempt to install the
-    unsolvable dependency, though you can still attempt to install the
-    ``bip-mapper`` extra directly if you want to force pip to try and resolve
-    the package.
+    Fixed ``pip install qiskit-terra[all]`` so that it will successfully install
+    when running on Python 3.6 and 3.9.  Previously, these Python versions would
+    fail to install the ``all`` target because the ``bip-mapper`` extra
+    requirements could not be satisfied due to the ``cplex`` package only
+    supporting Python 3.7 and 3.8.  Requesting the ``all`` target on these
+    Python versions will now no longer attempt to install the unsolvable
+    dependency (ie ``cplex`` will not longer be attempted to installed). The
+    ``bip-mapper`` extra will still attempt to install the
+    ``cplex`` and ``docplex`` packages on Python 3.6 and 3.9 (and likely fail as
+    ``cplex`` isn't available).

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,20 @@ z3_requirements = [
 ]
 
 
+# Only add the constraints so that 'pip install qiskit-terra[all]' ignores bip-mapper on those
+# versions. If the user attempts to explicitly install 'pip install qiskit-terra[bip-mapper]', we
+# want to force pip to either degrade Terra or emit an error.
 bip_requirements = ["cplex", "docplex"]
+bip_constraints = 'python_version>"3.6" and python_version<"3.9"'
+
+all_requirements = sum(
+    [
+        visualization_extras,
+        z3_requirements,
+        [req + "; " + bip_constraints for req in bip_requirements],
+    ],
+    start=[],
+)
 
 
 setup(
@@ -132,7 +145,7 @@ setup(
         "visualization": visualization_extras,
         "bip-mapper": bip_requirements,
         "crosstalk-pass": z3_requirements,
-        "all": visualization_extras + z3_requirements + bip_requirements,
+        "all": all_requirements,
     },
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-terra/issues",

--- a/setup.py
+++ b/setup.py
@@ -97,16 +97,17 @@ z3_requirements = [
 # Only add the constraints so that 'pip install qiskit-terra[all]' ignores bip-mapper on those
 # versions. If the user attempts to explicitly install 'pip install qiskit-terra[bip-mapper]', we
 # want to force pip to either degrade Terra or emit an error.
-bip_requirements = ["cplex", "docplex"]
-bip_constraints = 'python_version>"3.6" and python_version<"3.9"'
+bip_requirements = [
+    ("cplex", 'python_version>"3.6" and python_version<"3.9"'),
+    ("docplex", ""),
+]
 
-all_requirements = sum(
+all_requirements = visualization_extras + z3_requirements
+all_requirements.extend(
     [
-        visualization_extras,
-        z3_requirements,
-        [req + "; " + bip_constraints for req in bip_requirements],
-    ],
-    start=[],
+        f"{requirement}; {constraint}" if constraint else requirement
+        for requirement, constraint in bip_requirements
+    ]
 )
 
 
@@ -143,7 +144,7 @@ setup(
     python_requires=">=3.6",
     extras_require={
         "visualization": visualization_extras,
-        "bip-mapper": bip_requirements,
+        "bip-mapper": [requirement for requirement, constraint in bip_requirements],
         "crosstalk-pass": z3_requirements,
         "all": all_requirements,
     },

--- a/setup.py
+++ b/setup.py
@@ -87,28 +87,10 @@ visualization_extras = [
     "seaborn>=0.9.0",
     "pygments>=2.4",
 ]
-
-
 z3_requirements = [
     "z3-solver>=4.7",
 ]
-
-
-# Only add the constraints so that 'pip install qiskit-terra[all]' ignores bip-mapper on those
-# versions. If the user attempts to explicitly install 'pip install qiskit-terra[bip-mapper]', we
-# want to force pip to either degrade Terra or emit an error.
-bip_requirements = [
-    ("cplex", 'python_version>"3.6" and python_version<"3.9"'),
-    ("docplex", ""),
-]
-
-all_requirements = visualization_extras + z3_requirements
-all_requirements.extend(
-    [
-        f"{requirement}; {constraint}" if constraint else requirement
-        for requirement, constraint in bip_requirements
-    ]
-)
+bip_requirements = ["cplex", "docplex"]
 
 
 setup(
@@ -144,9 +126,12 @@ setup(
     python_requires=">=3.6",
     extras_require={
         "visualization": visualization_extras,
-        "bip-mapper": [requirement for requirement, constraint in bip_requirements],
+        "bip-mapper": bip_requirements,
         "crosstalk-pass": z3_requirements,
-        "all": all_requirements,
+        # Note: 'all' does not include 'bip-mapper' because cplex is too fiddly and too little
+        # supported on various Python versions and OSes compared to Terra.  You have to ask for it
+        # explicitly.
+        "all": visualization_extras + z3_requirements,
     },
     project_urls={
         "Bug Tracker": "https://github.com/Qiskit/qiskit-terra/issues",


### PR DESCRIPTION
### Summary

The 'cplex' package is not (presently) available on Python 3.6 or 3.9.
This means that
    pip install qiskit-terra[all]
will fail on those Python versions, because the requirements cannot be
specified.

This patch makes it so that the 'all' target will treat requirements
from 'bip-mapper' as unnecessary on the relevant Python versions, but
will still enforce them if 'qiskit-terra[bip-mapper]' is specified
explicitly.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #6842.

