### PR TITLE
Tame 1Q simplification warning

### DIFF
--- a/test/python/transpiler/test_optimize_1q_decomposition.py
+++ b/test/python/transpiler/test_optimize_1q_decomposition.py
@@ -23,6 +23,7 @@ from qiskit.circuit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.circuit.library.standard_gates import UGate, SXGate, PhaseGate
 from qiskit.circuit.library.standard_gates import U3Gate, U2Gate, U1Gate
 from qiskit.circuit.random import random_circuit
+from qiskit.compiler import transpile
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import Optimize1qGatesDecomposition
 from qiskit.transpiler.passes import BasisTranslator
@@ -523,6 +524,23 @@ class TestOptimize1qGatesDecomposition(QiskitTestCase):
         result = passmanager.run(qc)
         expected = QuantumCircuit(1)
         expected.p(np.pi / 6, 0)
+        msg = f"expected:\n{expected}\nresult:\n{result}"
+        self.assertEqual(expected, result, msg=msg)
+
+    def test_no_warning_on_hadamard(self):
+        """
+        Test Hadamards don't trigger the inefficiency warning when they're part of the basis.
+
+        See #6848.
+        """
+        qc = QuantumCircuit(2)
+        qc.cz(0, 1)
+        basis = ["h", "cx", "rz", "sx", "x"]
+        result = transpile(qc, basis_gates=basis)
+        expected = QuantumCircuit(2)
+        expected.h(1)
+        expected.cx(0, 1)
+        expected.h(1)
         msg = f"expected:\n{expected}\nresult:\n{result}"
         self.assertEqual(expected, result, msg=msg)
 


### PR DESCRIPTION
closes #6848 

### Summary

Tames an overly active warning which is triggered during synthesis-based 1Q simplification.

### Details and comments

In #6553, we added a warning in `Optimize1qGatesDecomposition.__call__` which was meant to check that gate sequences emitted by an operator-based 1Q synthesis routine were always more efficient (i.e., shorter) than the sequence used to form the input. The idea was that this would warn us if a synthesis routine were ever to emit a sequence which is not maximally efficient.

We made a mistake in the definition of 'maximally efficient'. In general, a synthesis routine promises to emit gates whose types form a _subset_ of some larger set of native gates, and it cannot make guarantees (nor be expected to make guarantees) about optimality of its circuits within the larger set, but only within the smaller set. For instance, PSX decomposition emits `p(pi/2) ; sx ; p(pi/2)` as a circuit embodying `h`. Its output `["p", "sx"]` conforms to the set of native gates `["p", "sx", "h"]` _and_ the emitted circuit is depth-optimal within `["p", "sx"]`, but it is not depth-optimal within the larger set — a lone `h` is shorter.

I don't believe it's possible to reason about optimality over unions of synthesis targets. So, instead, this PR modifies the predicate which guards the warning about increased depth, specializing it to each synthesis routine. In order to do this specialization, we have to remember which routines target which sets of output, and this is the primary source of diff size. (In retrospect, it might have been preferable to use the `.basis` slot, rather than retaining the information locally...)

(This isn't exactly a bug — a gnat, at worst — so I've elected not to mention it in the change log.)