### PR TITLE
[WIP] Support Dict[str, OperatorBase] for aux_operators (fix #6772)

### DIFF
--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -13,7 +13,7 @@
 """The Eigensolver interface"""
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Dict, Optional, Any
 
 import numpy as np
 from qiskit.opflow import OperatorBase
@@ -30,7 +30,7 @@ class Eigensolver(ABC):
 
     @abstractmethod
     def compute_eigenvalues(
-        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
+        self, operator: OperatorBase, aux_operators: Optional[Dict[str, Optional[OperatorBase]]] = None
     ) -> "EigensolverResult":
         """
         Computes eigenvalues. Operator and aux_operators can be supplied here and

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -13,7 +13,7 @@
 """The Eigensolver algorithm."""
 
 import logging
-from typing import List, Optional, Union, Tuple, Callable
+from typing import List, Optional, Union, Tuple, Callable, Dict
 
 import numpy as np
 from scipy import sparse as scisparse
@@ -46,7 +46,7 @@ class NumPyEigensolver(Eigensolver):
         self,
         k: int = 1,
         filter_criterion: Callable[
-            [Union[List, np.ndarray], float, Optional[List[float]]], bool
+            [Union[List, np.ndarray], float, Optional[Dict[str, float]]], bool
         ] = None,
     ) -> None:
         """
@@ -92,7 +92,7 @@ class NumPyEigensolver(Eigensolver):
     def filter_criterion(
         self,
         filter_criterion: Optional[
-            Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]
+            Callable[[Union[List, np.ndarray], float, Optional[Dict[str, float]]], bool]
         ],
     ) -> None:
         """set the filter criterion"""
@@ -141,7 +141,7 @@ class NumPyEigensolver(Eigensolver):
             self._solve(operator)
 
     def _get_energies(
-        self, operator: OperatorBase, aux_operators: Optional[List[OperatorBase]]
+        self, operator: OperatorBase, aux_operators: Optional[Dict[str, OperatorBase]]
     ) -> None:
         if self._ret.eigenvalues is None or self._ret.eigenstates is None:
             self._solve(operator)
@@ -156,12 +156,12 @@ class NumPyEigensolver(Eigensolver):
 
     @staticmethod
     def _eval_aux_operators(
-        aux_operators: List[OperatorBase], wavefn, threshold: float = 1e-12
-    ) -> np.ndarray:
-        values = []  # type: List[Tuple[float, int]]
-        for operator in aux_operators:
+        aux_operators: Dict[str, OperatorBase], wavefn, threshold: float = 1e-12
+    ) -> Dict[str, Optional[Tuple[float, int]]]:
+        values = {}  # type: Dict[str, Optional[Tuple[float, int]]]
+        for key, operator in aux_operators.items():
             if operator is None:
-                values.append(None)
+                values[key] = None
                 continue
             value = 0.0
             if operator.coeff != 0:
@@ -174,11 +174,11 @@ class NumPyEigensolver(Eigensolver):
                 else:
                     value = StateFn(operator, is_measurement=True).eval(wavefn)
                 value = value.real if abs(value.real) > threshold else 0.0
-            values.append((value, 0))
-        return np.array(values, dtype=object)
+            values[key] = (value, 0)
+        return values
 
     def compute_eigenvalues(
-        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
+        self, operator: OperatorBase, aux_operators: Optional[Dict[str, Optional[OperatorBase]]] = None
     ) -> EigensolverResult:
         super().compute_eigenvalues(operator, aux_operators)
 
@@ -189,7 +189,7 @@ class NumPyEigensolver(Eigensolver):
         if aux_operators:
             zero_op = I.tensorpower(operator.num_qubits) * 0.0
             # For some reason Chemistry passes aux_ops with 0 qubits and paulis sometimes.
-            aux_operators = [zero_op if op == 0 else op for op in aux_operators]
+            aux_operators = {key: zero_op if op == 0 else op for key, op in aux_operators.items()}
         else:
             aux_operators = None
 

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -13,7 +13,7 @@
 """The Minimum Eigensolver interface"""
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Dict, Optional
 
 import numpy as np
 from qiskit.opflow import OperatorBase
@@ -30,7 +30,7 @@ class MinimumEigensolver(ABC):
 
     @abstractmethod
     def compute_minimum_eigenvalue(
-        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
+        self, operator: OperatorBase, aux_operators: Optional[Dict[str, Optional[OperatorBase]]] = None
     ) -> "MinimumEigensolverResult":
         """
         Computes minimum eigenvalue. Operator and aux_operators can be supplied here and

--- a/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -12,7 +12,7 @@
 
 """The Numpy Minimum Eigensolver algorithm."""
 
-from typing import List, Optional, Union, Callable
+from typing import List, Optional, Union, Callable, Dict
 import logging
 import numpy as np
 
@@ -31,7 +31,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     def __init__(
         self,
         filter_criterion: Callable[
-            [Union[List, np.ndarray], float, Optional[List[float]]], bool
+            [Union[List, np.ndarray], float, Optional[Dict[str, float]]], bool
         ] = None,
     ) -> None:
         """
@@ -49,7 +49,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     @property
     def filter_criterion(
         self,
-    ) -> Optional[Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]]:
+    ) -> Optional[Callable[[Union[List, np.ndarray], float, Optional[Dict[str, float]]], bool]]:
         """returns the filter criterion if set"""
         return self._ces.filter_criterion
 
@@ -57,7 +57,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     def filter_criterion(
         self,
         filter_criterion: Optional[
-            Callable[[Union[List, np.ndarray], float, Optional[List[float]]], bool]
+            Callable[[Union[List, np.ndarray], float, Optional[Dict[str, float]]], bool]
         ],
     ) -> None:
         """set the filter criterion"""
@@ -68,7 +68,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         return NumPyEigensolver.supports_aux_operators()
 
     def compute_minimum_eigenvalue(
-        self, operator: OperatorBase, aux_operators: Optional[List[Optional[OperatorBase]]] = None
+        self, operator: OperatorBase, aux_operators: Optional[Dict[str, Optional[OperatorBase]]] = None
     ) -> MinimumEigensolverResult:
         super().compute_minimum_eigenvalue(operator, aux_operators)
         result_ces = self._ces.compute_eigenvalues(operator, aux_operators)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
A fix for https://github.com/Qiskit/qiskit-terra/issues/6772
The `aux_operators` argument defined in the `MinimumEigenSolver` and `EigenSolver` interfaces are now of type `Dict[str, Optional[OperatorBase]]` instead of `List[Optional[OperatorBase]]`


### Details and comments
I still need to look into the suggestion by @mrossinek to [add support for nested dictionaries.](https://github.com/Qiskit/qiskit-terra/issues/6772#issuecomment-892427077)

The `VQE` solver makes use of a `ListOp` to evaluate the `aux_operators` ([line 422](https://github.com/Qiskit/qiskit-terra/compare/main...CisterMoke:issue6772/dict_support_for_aux_ops?expand=1#diff-e058a38497350f6198cbb401e70fe7687e0aa0b7b3316f07ff751bc46fb4f6f9R422)). Since there is no `DictOp` I decided to pass a list of `aux_operators.values()` instead and assumed that the order does not matter in this case.

The eigenvalues obtained for the `aux_operators` are now also stored as a dictionary inside a NumPy array. However, [line 233](https://github.com/Qiskit/qiskit-terra/compare/main...CisterMoke:issue6772/dict_support_for_aux_ops?expand=1#diff-b081126e94a6bc7828738e7092c65159f12ad82752450e4f787895edc787fb54R233) of the `NumPyEigensolver` mentions that conversion to a NumPy array breaks even though [line 436](https://github.com/Qiskit/qiskit-terra/compare/main...CisterMoke:issue6772/dict_support_for_aux_ops?expand=1#diff-e058a38497350f6198cbb401e70fe7687e0aa0b7b3316f07ff751bc46fb4f6f9R436) in `VQE` mentions that it can be done by setting `dtype=object`. Should the `NumPyEigensolver` be updated accordingly?



