### PR TITLE
Rearrange CI jobs back into two stages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ stages:
             twine upload wheelhouse\*
           env:
             TWINE_PASSWORD: $(TWINE_PASSWORD)
-  - stage: 'Lint_and_Tests'
+  - stage: 'Lint_Docs_and_Tests'
     dependsOn: []
     jobs:
     - job: 'Linux_Tests'
@@ -295,6 +295,52 @@ stages:
             python tools/find_optional_imports.py
             reno lint
           displayName: 'Style and lint'
+    - job: 'Docs'
+      pool: {vmImage: 'ubuntu-latest'}
+      strategy:
+        matrix:
+          Python37:
+            python.version: '3.7'
+      variables:
+        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      steps:
+        - checkout: self
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
+        - task: Cache@2
+          inputs:
+            key: 'pip | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
+            restoreKeys: |
+              pip | "$(Agent.OS)" | "$(python.version)"
+              pip | "$(Agent.OS)"
+              pip
+            path: $(PIP_CACHE_DIR)
+          displayName: Cache pip
+        - bash: |
+            set -e
+            python -m pip install --upgrade pip setuptools wheel
+            pip install -U tox
+            python setup.py build_ext --inplace
+            sudo apt install -y graphviz
+          displayName: 'Install dependencies'
+        - bash: |
+            tox -edocs
+          displayName: 'Run Docs build'
+        - task: ArchiveFiles@2
+          inputs:
+            rootFolderOrFile: 'docs/_build/html'
+            archiveType: tar
+            archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
+            verbose: true
+        - task: PublishBuildArtifacts@1
+          displayName: 'Publish docs'
+          inputs:
+            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: 'html_docs'
+            Parallel: true
+            ParallelCount: 8
     - job: 'MacOS_Catalina_Tests'
       pool: {vmImage: 'macOS-latest'}
       strategy:
@@ -451,8 +497,8 @@ stages:
           inputs:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for Windows Python $(python.version)'
-  - stage: 'Python_Tests'
-    condition: and(succeeded('Lint_and_Tests'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags')))
+  - stage: 'Python_Tests_and_Tutorials'
+    condition: and(succeeded('Lint_Docs_and_Tests'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags')))
     jobs:
     - job: 'Windows_Tests'
       pool: {vmImage: 'windows-latest'}
@@ -701,55 +747,6 @@ stages:
           inputs:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for macOS Python $(python.version)'
-  - stage: 'Docs_and_Tutorials'
-    condition: and(succeeded('Python_Tests'), not(startsWith(variables['Build.SourceBranch'], 'refs/tags')))
-    jobs:
-    - job: 'Docs'
-      pool: {vmImage: 'ubuntu-latest'}
-      strategy:
-        matrix:
-          Python37:
-            python.version: '3.7'
-      variables:
-        PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
-      steps:
-        - checkout: self
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '$(python.version)'
-          displayName: 'Use Python $(python.version)'
-        - task: Cache@2
-          inputs:
-            key: 'pip | "$(Agent.OS)" | "$(python.version)" | "$(Build.BuildNumber)"'
-            restoreKeys: |
-              pip | "$(Agent.OS)" | "$(python.version)"
-              pip | "$(Agent.OS)"
-              pip
-            path: $(PIP_CACHE_DIR)
-          displayName: Cache pip
-        - bash: |
-            set -e
-            python -m pip install --upgrade pip setuptools wheel
-            pip install -U tox
-            python setup.py build_ext --inplace
-            sudo apt install -y graphviz
-          displayName: 'Install dependencies'
-        - bash: |
-            tox -edocs
-          displayName: 'Run Docs build'
-        - task: ArchiveFiles@2
-          inputs:
-            rootFolderOrFile: 'docs/_build/html'
-            archiveType: tar
-            archiveFile: '$(Build.ArtifactStagingDirectory)/html_docs.tar.gz'
-            verbose: true
-        - task: PublishBuildArtifacts@1
-          displayName: 'Publish docs'
-          inputs:
-            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'html_docs'
-            Parallel: true
-            ParallelCount: 8
     - job: 'Tutorials'
       pool: {vmImage: 'ubuntu-latest'}
       strategy:


### PR DESCRIPTION
### Summary

After 0cdacec (#6865) sped up the docs build to a reasonable time again,
they are no longer a CI bottleneck.  This splits the last CI stage
between the other two, increasing the parallelisation of the stages, and
hopefully getting total CI times down quite a lot.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


