### PR TITLE
Add compatibility details to QPY documentation

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -53,6 +53,19 @@ API documentation
    load
    dump
 
+QPY Compatibility
+=================
+
+The QPY format is designed to be backwards compatible moving forward. This means
+you should be able to load a QPY with any newer Qiskit version than the one
+that generated it. However, loading a QPY file with an older Qiskit version is
+not supported and may not work.
+
+For example, if you generated a QPY file using qiskit-terra 0.18.1 you could
+load that QPY file with qiskit-terra 0.19.0 and a hypothetical qiskit-terra
+0.29.0. However, loading that QPY file with 0.18.0 is not supported and may not
+work.
+
 **********
 QPY Format
 **********


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The current QPY documentation doesn't actual mention the version
compatibility of the format. While we do mention it in the release notes
for QPY it would be good to make sure we're documenting what users can
expect for compatibility between qiskit versions for QPY. This commit
adds a new section to the QPY module documentation outlining the
compatibility guarantees with the format.

### Details and comments