### PR TITLE
Unify and simplify some Weyl decomposition code

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -165,7 +165,7 @@ class TwoQubitWeylDecomposition:
         # eigenvectors.  Instead, since `M2` is complex-symmetric,
         #   M2 = A + iB
         # for real-symmetric `A` and `B`, and as
-        #   M2^+ @ M2 = A^2 + B^2 - 2 i [A, B] = 1
+        #   M2^+ @ M2 = A^2 + B^2 + i [A, B] = 1
         # we must have `A` and `B` commute, and consequently they are simultaneously diagonalizable.
         # Mixing them together _should_ account for any degeneracy problems, but it's not
         # guaranteed, so we repeat it a little bit.  The fixed seed is to make failures

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -40,7 +40,7 @@ from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import CXGate, RXGate, RYGate, RZGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators import Operator
-from qiskit.quantum_info.synthesis.weyl import weyl_coordinates
+from qiskit.quantum_info.synthesis.weyl import weyl_coordinates, transform_to_magic_basis
 from qiskit.quantum_info.synthesis.one_qubit_decompose import (
     OneQubitEulerDecomposer,
     DEFAULT_ATOL,
@@ -85,10 +85,6 @@ def decompose_two_qubit_product_gate(special_unitary_matrix):
     return L, R, phase
 
 
-_B = (1.0 / math.sqrt(2)) * np.array(
-    [[1, 1j, 0, 0], [0, 0, 1j, 1], [0, 0, 1j, -1], [1, -1j, 0, 0]], dtype=complex
-)
-_Bd = _B.T.conj()
 _ipx = np.array([[0, 1j], [1j, 0]], dtype=complex)
 _ipy = np.array([[0, 1], [-1, 0]], dtype=complex)
 _ipz = np.array([[1j, 0], [0, -1j]], dtype=complex)
@@ -159,12 +155,21 @@ class TwoQubitWeylDecomposition:
         U *= detU ** (-0.25)
         global_phase = cmath.phase(detU) / 4
 
-        Up = _Bd.dot(U).dot(_B)
+        Up = transform_to_magic_basis(U, reverse=True)
         M2 = Up.T.dot(Up)
 
         # M2 is a symmetric complex matrix. We need to decompose it as M2 = P D P^T where
         # P ∈ SO(4), D is diagonal with unit-magnitude elements.
-        # D, P = la.eig(M2)  # this can fail for certain kinds of degeneracy
+        #
+        # We can't use raw `eig` directly because it isn't guaranteed to give us real or othogonal
+        # eigenvectors.  Instead, since `M2` is complex-symmetric,
+        #   M2 = A + iB
+        # for real-symmetric `A` and `B`, and as
+        #   M2^+ @ M2 = A^2 + B^2 - 2 i [A, B] = 1
+        # we must have `A` and `B` commute, and consequently they are simultaneously diagonalizable.
+        # Mixing them together _should_ account for any degeneracy problems, but it's not
+        # guaranteed, so we repeat it a little bit.  The fixed seed is to make failures
+        # deterministic; the value is not important.
         state = np.random.default_rng(2020)
         for _ in range(100):  # FIXME: this randomized algorithm is horrendous
             M2real = state.normal() * M2.real + state.normal() * M2.imag
@@ -173,7 +178,11 @@ class TwoQubitWeylDecomposition:
             if np.allclose(P.dot(np.diag(D)).dot(P.T), M2, rtol=0, atol=1.0e-13):
                 break
         else:
-            raise QiskitError("TwoQubitWeylDecomposition: failed to diagonalize M2")
+            raise QiskitError(
+                "TwoQubitWeylDecomposition: failed to diagonalize M2."
+                " Please report this at https://github.com/Qiskit/qiskit-terra/issues/4159."
+                f" Input: {U.tolist()}"
+            )
 
         d = -np.angle(D) / 2
         d[3] = -d[0] - d[1] - d[2]
@@ -192,8 +201,8 @@ class TwoQubitWeylDecomposition:
             P[:, -1] = -P[:, -1]
 
         # Find K1, K2 so that U = K1.A.K2, with K being product of single-qubit unitaries
-        K1 = _B.dot(Up).dot(P).dot(np.diag(np.exp(1j * d))).dot(_Bd)
-        K2 = _B.dot(P.T).dot(_Bd)
+        K1 = transform_to_magic_basis(Up @ P @ np.diag(np.exp(1j * d)))
+        K2 = transform_to_magic_basis(P.T)
 
         K1l, K1r, phase_l = decompose_two_qubit_product_gate(K1)
         K2l, K2r, phase_r = decompose_two_qubit_product_gate(K2)

--- a/qiskit/quantum_info/synthesis/weyl.py
+++ b/qiskit/quantum_info/synthesis/weyl.py
@@ -16,50 +16,52 @@
 
 import numpy as np
 import scipy.linalg as la
-from qiskit.exceptions import QiskitError
 
-_B = (1.0 / np.sqrt(2)) * np.array(
-    [[1, 1j, 0, 0], [0, 0, 1j, 1], [0, 0, 1j, -1], [1, -1j, 0, 0]], dtype=complex
-)
-_Bd = _B.T.conj()
+# "Magic" basis used for the Weyl decomposition. The basis and its adjoint are stored individually
+# unnormalized, but such that their matrix multiplication is still the identity.  This is because
+# they are only used in unitary transformations (so it's safe to do so), and `sqrt(0.5)` is not
+# exactly representable in floating point.  Doing it this way means that every element of the matrix
+# is stored exactly correctly, and the multiplication is _exactly_ the identity rather than
+# differing by 1ULP.
+_B_nonnormalized = np.array([[1, 1j, 0, 0], [0, 0, 1j, 1], [0, 0, 1j, -1], [1, -1j, 0, 0]])
+_B_nonnormalized_dagger = 0.5 * _B_nonnormalized.conj().T
+
+
+def transform_to_magic_basis(U, reverse=False):
+    """Transform the 4-by-4 matrix ``U`` into the magic basis.
+
+    This method internally uses non-normalized versions of the basis to minimize the floating-point
+    errors that arise during the transformation.
+
+    Args:
+        U (np.ndarray): 4-by-4 matrix to transform.
+        reverse (bool): Whether to do the transformation forwards (``B @ U @ B.conj().T``, the
+        default) or backwards (``B.conj().T @ U @ B``).
+
+    Returns:
+        np.ndarray: The transformed 4-by-4 matrix.
+    """
+    if reverse:
+        return _B_nonnormalized_dagger @ U @ _B_nonnormalized
+    return _B_nonnormalized @ U @ _B_nonnormalized_dagger
 
 
 def weyl_coordinates(U):
-    """Computes the Weyl coordinates for
-    a given two-qubit unitary matrix.
+    """Computes the Weyl coordinates for a given two-qubit unitary matrix.
 
     Args:
-        U (ndarray): Input two-qubit unitary.
+        U (np.ndarray): Input two-qubit unitary.
 
     Returns:
-        ndarray: Array of Weyl coordinates.
-
-    Raises:
-        QiskitError: Computed coordinates not in Weyl chamber.
+        np.ndarray: Array of the 3 Weyl coordinates.
     """
     pi2 = np.pi / 2
     pi4 = np.pi / 4
 
     U = U / la.det(U) ** (0.25)
-    Up = _Bd.dot(U).dot(_B)
-    M2 = Up.T.dot(Up)
-
-    # M2 is a symmetric complex matrix. We need to decompose it as M2 = P D P^T where
-    # P ∈ SO(4), D is diagonal with unit-magnitude elements.
-    # D, P = la.eig(M2)  # this can fail for certain kinds of degeneracy
-    for _ in range(3):  # FIXME: this randomized algorithm is horrendous
-        M2real = np.random.normal() * M2.real + np.random.normal() * M2.imag
-        _, P = la.eigh(M2real)
-        D = P.T.dot(M2).dot(P).diagonal()
-        if np.allclose(P.dot(np.diag(D)).dot(P.T), M2, rtol=1.0e-10, atol=1.0e-10):
-            break
-    else:
-        raise QiskitError(
-            "TwoQubitWeylDecomposition: failed to diagonalize M2. "
-            "Please submit this output to "
-            "https://github.com/Qiskit/qiskit-terra/issues/4159 "
-            "Input %s" % U.tolist()
-        )
+    Up = transform_to_magic_basis(U, reverse=True)
+    # We only need the eigenvalues of `M2 = Up.T @ Up` here, not the full diagonalization.
+    D = la.eigvals(Up.T @ Up)
 
     d = -np.angle(D) / 2
     d[3] = -d[0] - d[1] - d[2]


### PR DESCRIPTION
### Summary

`weyl_coordinates` was unnecessarily computing the entire
diagonalisation of the M2 matrix, even though it only needed the
diagonal.  The diagonal is just the eigenvalues (no matter the
degeneracy pattern), so this can be computed directly without the random
algorithm used to find the diagonalising SO(4) element.

The transformation to the magic basis is factored out into one place, so
only one location is responsible for it.  Factoring it out into a black
box also lets us store the basis and its adjoint with unusual
normalisations, to minimise floating-point errors when applying it.  By
storing one matrix directly as
    B = np.array([[1, 1j, 0, 0], ..., [1, -1j, 0, 0]])
and the other as
    B_dagger = 0.5 * B.conj().T
the normalisation of the _transformation_ is maintained, but the two
individual matrices are not.  This is better because now all the
elements of `B` and `B_dagger` are exactly representable in
double-precision floating point, so `B @ B_dagger` is now _exactly_ the
identity, rather than differing by 1ULP in all elements of the diagonal.

This commit does not change the random algorithm used in the
diagonalisation, though it does significantly reduce the number of times
it will be called.  It is possible to do by calculating the eigenvectors
of `M2` with a general-purpose routine, then manually orthonormalising
degenerate subspaces and finding real spanning vectors, but it generally
takes 1.3x to 2x as long to do this, with no meaningful improvement in
accuracy.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


