### PR TITLE
Use `repeat` in `QuantumCircuit.power` if `power` is `numpy.integer` 

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -559,7 +559,7 @@ class QuantumCircuit:
         Returns:
             QuantumCircuit: A circuit implementing this circuit raised to the power of ``power``.
         """
-        if power >= 0 and isinstance(power, int) and not matrix_power:
+        if power >= 0 and isinstance(power, (int, np.integer)) and not matrix_power:
             return self.repeat(power)
 
         # attempt conversion to gate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Follow-up of #6831
Fixes https://github.com/Qiskit/qiskit-optimization/issues/225. Qiskit Optimization unit test of GroverOptimizer takes so long time after the merge of #6831.

This PR resolves it by applying `repeat` if `power` is `np.integer`.

### Details and comments

`GroverOptimizer` of Qiskit optimization set `power` by `numpy.random.Generator.integers`. The type is `numpy.int64`. So, it is necessary to use `np.integer` for `isintance` to catch this case.
https://github.com/Qiskit/qiskit-optimization/blob/4953e56e3c062df42e7e51fa6b89172e1f69e3c1/qiskit_optimization/algorithms/grover_optimizer.py#L220-L232

https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.integers.html

