### PR TITLE
Uniformly allow abstract numeric types

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
+++ b/qiskit/algorithms/amplitude_amplifiers/amplification_problem.py
@@ -12,6 +12,7 @@
 
 """The Amplification problem class."""
 
+import numbers
 from typing import Optional, Callable, Any, Union, List
 
 from qiskit.circuit import QuantumCircuit
@@ -142,7 +143,7 @@ class AmplificationProblem:
         if self._objective_qubits is None:
             return list(range(self.oracle.num_qubits))
 
-        if isinstance(self._objective_qubits, int):
+        if isinstance(self._objective_qubits, numbers.Integral):
             return [self._objective_qubits]
 
         return self._objective_qubits

--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -13,6 +13,7 @@
 """Grover's search algorithm."""
 
 import itertools
+import numbers
 import operator
 from typing import Iterator, List, Optional, Union
 
@@ -142,7 +143,7 @@ class Grover(AmplitudeAmplifier):
         if growth_rate is not None:
             # yield iterations ** 1, iterations ** 2, etc. and casts to int
             self._iterations = map(lambda x: int(growth_rate ** x), itertools.count(1))
-        elif isinstance(iterations, int):
+        elif isinstance(iterations, numbers.Integral):
             self._iterations = [iterations]
         else:
             self._iterations = iterations

--- a/qiskit/algorithms/amplitude_estimators/estimation_problem.py
+++ b/qiskit/algorithms/amplitude_estimators/estimation_problem.py
@@ -12,6 +12,7 @@
 
 """The Estimation problem class."""
 
+import numbers
 import warnings
 from typing import Optional, List, Callable, Union
 import numpy
@@ -83,7 +84,7 @@ class EstimationProblem:
         Returns:
             The criterion as list of qubit indices.
         """
-        if isinstance(self._objective_qubits, int):
+        if isinstance(self._objective_qubits, numbers.Integral):
             return [self._objective_qubits]
 
         return self._objective_qubits

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -12,6 +12,7 @@
 
 """The Maximum Likelihood Amplitude Estimation algorithm."""
 
+import numbers
 from typing import Optional, List, Union, Tuple, Dict, Callable
 import numpy as np
 from scipy.optimize import brute
@@ -77,7 +78,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         self.quantum_instance = quantum_instance
 
         # get parameters
-        if isinstance(evaluation_schedule, int):
+        if isinstance(evaluation_schedule, numbers.Integral):
             if evaluation_schedule < 0:
                 raise ValueError("The evaluation schedule cannot be < 0.")
 

--- a/qiskit/algorithms/optimizers/aqgd.py
+++ b/qiskit/algorithms/optimizers/aqgd.py
@@ -13,6 +13,7 @@
 """Analytical Quantum Gradient Descent (AQGD) optimizer."""
 
 import logging
+import numbers
 from typing import Callable, Tuple, List, Dict, Union, Any
 
 import numpy as np
@@ -75,11 +76,11 @@ class AQGD(Optimizer):
             AlgorithmError: If the length of ``maxiter``, `momentum``, and ``eta`` is not the same.
         """
         super().__init__()
-        if isinstance(maxiter, int):
+        if isinstance(maxiter, numbers.Integral):
             maxiter = [maxiter]
-        if isinstance(eta, (int, float)):
+        if isinstance(eta, numbers.Real):
             eta = [eta]
-        if isinstance(momentum, (int, float)):
+        if isinstance(momentum, numbers.Real):
             momentum = [momentum]
         if len(maxiter) != len(eta) or len(maxiter) != len(momentum):
             raise AlgorithmError(

--- a/qiskit/algorithms/optimizers/gradient_descent.py
+++ b/qiskit/algorithms/optimizers/gradient_descent.py
@@ -12,6 +12,7 @@
 
 """A standard gradient descent optimizer."""
 
+import numbers
 from typing import Iterator, Optional, Union, Callable, Dict, Any
 from functools import partial
 
@@ -151,7 +152,7 @@ class GradientDescent(Optimizer):
 
     def _minimize(self, loss, grad, initial_point):
         # set learning rate
-        if isinstance(self.learning_rate, float):
+        if isinstance(self.learning_rate, numbers.Real):
             eta = constant(self.learning_rate)
         else:
             eta = self.learning_rate()

--- a/qiskit/algorithms/optimizers/optimizer.py
+++ b/qiskit/algorithms/optimizers/optimizer.py
@@ -12,6 +12,7 @@
 
 """Optimizer interface"""
 
+import numbers
 from typing import Dict, Any
 
 from enum import IntEnum
@@ -113,7 +114,7 @@ class Optimizer(ABC):
         for chunk in chunks:  # eval the chunks in order
             parallel_parameters = np.concatenate(chunk)
             todos_results = f(parallel_parameters)  # eval the points in a chunk (order preserved)
-            if isinstance(todos_results, float):
+            if isinstance(todos_results, numbers.Real):
                 grad.append((todos_results - forig) / epsilon)
             else:
                 for todor in todos_results:

--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -17,6 +17,7 @@ This implementation allows both, standard first-order as well as second-order SP
 
 from typing import Iterator, Optional, Union, Callable, Tuple, Dict
 import logging
+import numbers
 import warnings
 from time import time
 
@@ -637,7 +638,7 @@ def _validate_pert_and_learningrate(perturbation, learning_rate):
     if learning_rate is None or perturbation is None:
         raise ValueError("If one of learning rate or perturbation is set, both must be set.")
 
-    if isinstance(perturbation, float):
+    if isinstance(perturbation, numbers.Real):
 
         def get_eps():
             return constant(perturbation)
@@ -650,7 +651,7 @@ def _validate_pert_and_learningrate(perturbation, learning_rate):
     else:
         get_eps = perturbation
 
-    if isinstance(learning_rate, float):
+    if isinstance(learning_rate, numbers.Real):
 
         def get_eta():
             return constant(learning_rate)

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -13,6 +13,7 @@
 This module contains utility functions for circuits.
 """
 
+import numbers
 import numpy
 from qiskit.exceptions import QiskitError
 from qiskit.circuit.exceptions import CircuitError
@@ -50,7 +51,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
         ctrl_state = ctrl_dim - 1
     elif isinstance(ctrl_state, str):
         ctrl_state = int(ctrl_state, 2)
-    if isinstance(ctrl_state, int):
+    if isinstance(ctrl_state, numbers.Integral):
         if not 0 <= ctrl_state < ctrl_dim:
             raise QiskitError("Invalid control state value specified.")
     else:
@@ -85,7 +86,7 @@ def _ctrl_state_to_int(ctrl_state, num_ctrl_qubits):
             raise CircuitError("invalid control bit string: " + ctrl_state) from ex
         except AssertionError as ex:
             raise CircuitError("invalid control bit string: length != " "num_ctrl_qubits") from ex
-    if isinstance(ctrl_state, int):
+    if isinstance(ctrl_state, numbers.Integral):
         if 0 <= ctrl_state < 2 ** num_ctrl_qubits:
             ctrl_state_std = ctrl_state
         else:

--- a/qiskit/circuit/delay.py
+++ b/qiskit/circuit/delay.py
@@ -13,6 +13,7 @@
 """
 Delay instruction (for circuit module).
 """
+import numbers
 import numpy as np
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.instruction import Instruction
@@ -68,13 +69,13 @@ class Delay(Instruction):
 
     def validate_parameter(self, parameter):
         """Delay parameter (i.e. duration) must be int, float or ParameterExpression."""
-        if isinstance(parameter, int):
+        if isinstance(parameter, numbers.Integral):
             if parameter < 0:
                 raise CircuitError(
                     f"Duration for Delay instruction must be positive. Found {parameter}"
                 )
-            return parameter
-        elif isinstance(parameter, float):
+            return int(parameter)
+        elif isinstance(parameter, numbers.Real):
             if parameter < 0:
                 raise CircuitError(
                     f"Duration for Delay instruction must be positive. Found {parameter}"
@@ -84,7 +85,7 @@ class Delay(Instruction):
                 if parameter != parameter_int:
                     raise CircuitError("Integer duration is expected for 'dt' unit.")
                 return parameter_int
-            return parameter
+            return float(parameter)
         elif isinstance(parameter, ParameterExpression):
             if len(parameter.parameters) > 0:
                 return parameter  # expression has free parameters, we cannot validate it

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -12,6 +12,7 @@
 
 """Unitary gate."""
 
+import numbers
 from warnings import warn
 from typing import List, Optional, Union, Tuple
 import numpy as np
@@ -223,11 +224,12 @@ class Gate(Instruction):
                 msg = f"Bound parameter expression is complex in gate {self.name}"
                 raise CircuitError(msg)
             return parameter  # per default assume parameters must be real when bound
-        if isinstance(parameter, (int, float)):
-            return parameter
-        elif isinstance(parameter, (np.integer, np.floating)):
-            return parameter.item()
-        elif isinstance(parameter, np.ndarray):
+        # Normalize to builtin Python types from (e.g.) numpy.int32 and friends.
+        if isinstance(parameter, numbers.Integral):
+            return int(parameter)
+        if isinstance(parameter, numbers.Real):
+            return float(parameter)
+        if isinstance(parameter, np.ndarray):
             warn(
                 "Gate param type %s is being deprecated as of 0.16.0, and will be removed "
                 "no earlier than 3 months after that release date. "
@@ -237,5 +239,4 @@ class Gate(Instruction):
                 3,
             )
             return parameter
-        else:
-            raise CircuitError(f"Invalid param type {type(parameter)} for gate {self.name}.")
+        raise CircuitError(f"Invalid param type {type(parameter)} for gate {self.name}.")

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -30,8 +30,9 @@ Instructions are identified by the following:
 Instructions do not have any context about where they are in a circuit (which qubits/clbits).
 The circuit itself keeps this context.
 """
-import warnings
 import copy
+import numbers
+import warnings
 from itertools import zip_longest
 
 import numpy
@@ -69,15 +70,18 @@ class Instruction:
         Raises:
             CircuitError: when the register is not in the correct format.
         """
-        if not isinstance(num_qubits, int) or not isinstance(num_clbits, int):
+        if not (
+            isinstance(num_qubits, numbers.Integral) and isinstance(num_clbits, numbers.Integral)
+        ):
             raise CircuitError("num_qubits and num_clbits must be integer.")
         if num_qubits < 0 or num_clbits < 0:
             raise CircuitError(
                 "bad instruction dimensions: %d qubits, %d clbits." % num_qubits, num_clbits
             )
         self.name = name
-        self.num_qubits = num_qubits
-        self.num_clbits = num_clbits
+        # Normalize Numpy integers to Python integers.
+        self.num_qubits = int(num_qubits)
+        self.num_clbits = int(num_clbits)
 
         self._params = []  # a list of gate params stored
         # Custom instruction label

--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -12,6 +12,7 @@
 
 """The n-local circuit class."""
 
+import numbers
 from typing import Union, Optional, List, Any, Tuple, Sequence, Set, Callable
 from itertools import combinations
 import warnings
@@ -596,7 +597,7 @@ class NLocal(BlueprintCircuit):
             return get_entangler_map(n, self.num_qubits, entanglement[i % num_i], offset=i)
 
         # entanglement is List[int]
-        if all(isinstance(en, (int, numpy.integer)) for en in entanglement):
+        if all(isinstance(en, numbers.Integral) for en in entanglement):
             return [[int(en) for en in entanglement]]
 
         # check if entanglement is List[List]
@@ -611,7 +612,7 @@ class NLocal(BlueprintCircuit):
             )
 
         # entanglement is List[List[int]]
-        if all(isinstance(e2, (int, numpy.int32, numpy.int64)) for en in entanglement for e2 in en):
+        if all(isinstance(e2, numbers.Integral) for en in entanglement for e2 in en):
             for ind, en in enumerate(entanglement):
                 entanglement[ind] = tuple(map(int, en))
             return entanglement
@@ -621,12 +622,7 @@ class NLocal(BlueprintCircuit):
             raise ValueError(f"Invalid value of entanglement: {entanglement}")
 
         # entanglement is List[List[List[int]]]
-        if all(
-            isinstance(e3, (int, numpy.int32, numpy.int64))
-            for en in entanglement
-            for e2 in en
-            for e3 in e2
-        ):
+        if all(isinstance(e3, numbers.Integral) for en in entanglement for e2 in en for e3 in e2):
             for en in entanglement:
                 for ind, e2 in enumerate(en):
                     en[ind] = tuple(map(int, e2))
@@ -638,7 +634,7 @@ class NLocal(BlueprintCircuit):
 
         # entanglement is List[List[List[List[int]]]]
         if all(
-            isinstance(e4, (int, numpy.int32, numpy.int64))
+            isinstance(e4, numbers.Integral)
             for en in entanglement
             for e2 in en
             for e3 in e2

--- a/qiskit/circuit/library/probability_distributions/lognormal.py
+++ b/qiskit/circuit/library/probability_distributions/lognormal.py
@@ -12,6 +12,7 @@
 
 """The log-normal probability distribution circuit."""
 
+import numbers
 from typing import Tuple, List, Union, Optional
 import warnings
 import numpy as np
@@ -118,7 +119,7 @@ class LogNormalDistribution(QuantumCircuit):
         _check_bounds_valid(bounds)
 
         # set default arguments
-        dim = 1 if isinstance(num_qubits, int) else len(num_qubits)
+        dim = 1 if isinstance(num_qubits, numbers.Integral) else len(num_qubits)
         if mu is None:
             mu = 0 if dim == 1 else [0] * dim
 

--- a/qiskit/circuit/library/probability_distributions/normal.py
+++ b/qiskit/circuit/library/probability_distributions/normal.py
@@ -12,6 +12,7 @@
 
 """A circuit that encodes a discretized normal probability distribution in qubit amplitudes."""
 
+import numbers
 from typing import Tuple, Union, List, Optional
 import warnings
 import numpy as np
@@ -165,7 +166,7 @@ class NormalDistribution(QuantumCircuit):
         _check_bounds_valid(bounds)
 
         # set default arguments
-        dim = 1 if isinstance(num_qubits, int) else len(num_qubits)
+        dim = 1 if isinstance(num_qubits, numbers.Integral) else len(num_qubits)
         if mu is None:
             mu = 0 if dim == 1 else [0] * dim
 

--- a/qiskit/circuit/parametertable.py
+++ b/qiskit/circuit/parametertable.py
@@ -12,8 +12,9 @@
 """
 Look-up table for variable parameters in QuantumCircuit.
 """
-import warnings
 import functools
+import numbers
+import warnings
 from collections.abc import MutableMapping, MappingView
 
 from .instruction import Instruction
@@ -43,11 +44,21 @@ class ParameterTable(MutableMapping):
             parameter (Parameter): the parameter to set
             instr_params (list): List of (Instruction, int) tuples. Int is the
               parameter index at which the parameter appears in the instruction.
+
+        Raises:
+            TypeError: if the instructions and indices in ``instr_params`` are of invalid types.
         """
 
-        for instruction, param_index in instr_params:
-            assert isinstance(instruction, Instruction)
-            assert isinstance(param_index, int)
+        for i, (instruction, param_index) in enumerate(instr_params):
+            if not isinstance(instruction, Instruction):
+                raise TypeError(
+                    f"instructions must be of type Instruction, but position {i} had"
+                    f" '{instruction}'."
+                )
+            if not isinstance(param_index, numbers.Integral):
+                raise TypeError(
+                    f"parameter indices must be integers, but position {i} had '{param_index}'."
+                )
         self._table[parameter] = instr_params
         self._keys.add(parameter)
         self._names.add(parameter.name)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -18,6 +18,7 @@ import copy
 import itertools
 import functools
 import multiprocessing as mp
+import numbers
 import string
 from collections import OrderedDict, defaultdict
 from typing import (
@@ -559,7 +560,7 @@ class QuantumCircuit:
         Returns:
             QuantumCircuit: A circuit implementing this circuit raised to the power of ``power``.
         """
-        if power >= 0 and isinstance(power, (int, np.integer)) and not matrix_power:
+        if power >= 0 and isinstance(power, numbers.Integral) and not matrix_power:
             return self.repeat(power)
 
         # attempt conversion to gate
@@ -828,7 +829,7 @@ class QuantumCircuit:
             )
         else:
             qubit_map = {
-                other.qubits[i]: (self.qubits[q] if isinstance(q, int) else q)
+                other.qubits[i]: (q if isinstance(q, Qubit) else self.qubits[q])
                 for i, q in enumerate(qubits)
             }
         if clbits is None:
@@ -840,7 +841,7 @@ class QuantumCircuit:
             )
         else:
             clbit_map = {
-                other.clbits[i]: (self.clbits[c] if isinstance(c, int) else c)
+                other.clbits[i]: (c if isinstance(c, Clbit) else self.clbits[c])
                 for i, c in enumerate(clbits)
             }
 
@@ -1246,12 +1247,12 @@ class QuantumCircuit:
         if not regs:
             return
 
-        if any(isinstance(reg, int) for reg in regs):
+        if any(isinstance(reg, numbers.Integral) for reg in regs):
             # QuantumCircuit defined without registers
-            if len(regs) == 1 and isinstance(regs[0], int):
+            if len(regs) == 1 and isinstance(regs[0], numbers.Integral):
                 # QuantumCircuit with anonymous quantum wires e.g. QuantumCircuit(2)
                 regs = (QuantumRegister(regs[0], "q"),)
-            elif len(regs) == 2 and all(isinstance(reg, int) for reg in regs):
+            elif len(regs) == 2 and all(isinstance(reg, numbers.Integral) for reg in regs):
                 # QuantumCircuit with anonymous wires e.g. QuantumCircuit(2, 3)
                 regs = (QuantumRegister(regs[0], "q"), ClassicalRegister(regs[1], "c"))
             else:
@@ -3928,7 +3929,7 @@ class QuantumCircuit:
                     )
             return 0
 
-        qubits = [self.qubits[q] if isinstance(q, int) else q for q in qubits]
+        qubits = [q if isinstance(q, Qubit) else self.qubits[q] for q in qubits]
 
         starts = {q: 0 for q in qubits}
         dones = {q: False for q in qubits}
@@ -3970,7 +3971,7 @@ class QuantumCircuit:
                     )
             return 0
 
-        qubits = [self.qubits[q] if isinstance(q, int) else q for q in qubits]
+        qubits = [q if isinstance(q, Qubit) else self.qubits[q] for q in qubits]
 
         stops = {q: self.duration for q in qubits}
         dones = {q: False for q in qubits}

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -15,9 +15,9 @@
 """
 Base register reference object.
 """
-import re
 import itertools
-import numpy as np
+import numbers
+import re
 
 from qiskit.circuit.exceptions import CircuitError
 
@@ -151,7 +151,7 @@ class Register:
         Raises:
             CircuitError: if the `key` is not an integer or not in the range `(0, self.size)`.
         """
-        if not isinstance(key, (int, np.integer, slice, list)):
+        if not isinstance(key, (numbers.Integral, slice, list)):
             raise CircuitError("expected integer or slice index into register")
         if isinstance(key, slice):
             return self._bits[key]

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -13,6 +13,7 @@
 """Assemble function for converting a list of circuits into a qobj"""
 import copy
 import logging
+import numbers
 import uuid
 import warnings
 from time import time
@@ -298,13 +299,16 @@ def _parse_common_args(
             shots = min(1024, max_shots)
         else:
             shots = 1024
-    elif not isinstance(shots, int):
+    elif not isinstance(shots, numbers.Integral):
         raise QiskitError("Argument 'shots' should be of type 'int'")
     elif max_shots and max_shots < shots:
         raise QiskitError(
             "Number of shots specified: %s exceeds max_shots property of the "
             "backend: %s." % (shots, max_shots)
         )
+    else:
+        # Unify all `numbers.Integral` types to `int`.
+        shots = int(shots)
 
     dynamic_reprate_enabled = getattr(backend_config, "dynamic_reprate_enabled", False)
     if dynamic_reprate_enabled:

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -12,6 +12,7 @@
 
 """Circuit transpile function"""
 import logging
+import numbers
 import warnings
 from time import time
 from typing import List, Union, Dict, Callable, Any, Optional, Tuple, Iterable
@@ -19,7 +20,7 @@ from typing import List, Union, Dict, Callable, Any, Optional, Tuple, Iterable
 from qiskit import user_config
 from qiskit.circuit.quantumcircuit import QuantumCircuit
 from qiskit.circuit.quantumregister import Qubit
-from qiskit.converters import isinstanceint, isinstancelist, dag_to_circuit, circuit_to_dag
+from qiskit.converters import isinstancelist, dag_to_circuit, circuit_to_dag
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend
@@ -699,7 +700,7 @@ def _parse_initial_layout(initial_layout, circuits):
         if initial_layout is None or isinstance(initial_layout, Layout):
             return initial_layout
         elif isinstancelist(initial_layout):
-            if all(isinstanceint(elem) for elem in initial_layout):
+            if all(isinstance(elem, numbers.Integral) for elem in initial_layout):
                 initial_layout = Layout.from_intlist(initial_layout, *circuit.qregs)
             elif all(elem is None or isinstance(elem, Qubit) for elem in initial_layout):
                 initial_layout = Layout.from_qubit_list(initial_layout, *circuit.qregs)

--- a/qiskit/converters/__init__.py
+++ b/qiskit/converters/__init__.py
@@ -42,17 +42,6 @@ from .dag_to_dagdependency import dag_to_dagdependency
 from .dagdependency_to_dag import dagdependency_to_dag
 
 
-def isinstanceint(obj):
-    """Like isinstance(obj,int), but with casting. Except for strings."""
-    if isinstance(obj, str):
-        return False
-    try:
-        int(obj)
-        return True
-    except TypeError:
-        return False
-
-
 def isinstancelist(obj):
     """Like isinstance(obj, list), but with casting. Except for strings and dicts."""
     if isinstance(obj, (str, dict)):

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -695,7 +695,7 @@ class DAGCircuit:
             )
         else:
             qubit_map = {
-                other.qubits[i]: (self.qubits[q] if isinstance(q, int) else q)
+                other.qubits[i]: (q if isinstance(q, Qubit) else self.qubits[q])
                 for i, q in enumerate(qubits)
             }
         if clbits is None:
@@ -707,7 +707,7 @@ class DAGCircuit:
             )
         else:
             clbit_map = {
-                other.clbits[i]: (self.clbits[c] if isinstance(c, int) else c)
+                other.clbits[i]: (c if isinstance(c, Clbit) else self.clbits[c])
                 for i, c in enumerate(clbits)
             }
         edge_map = edge_map or {**qubit_map, **clbit_map} or None

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -14,7 +14,7 @@
 Gate described by the time evolution of a Hermitian Hamiltonian operator.
 """
 
-from numbers import Number
+import numbers
 import numpy
 import scipy.linalg
 
@@ -57,7 +57,7 @@ class HamiltonianGate(Gate):
         # Check input is unitary
         if not is_hermitian_matrix(data):
             raise ExtensionError("Input matrix is not Hermitian.")
-        if isinstance(time, Number) and time != numpy.real(time):
+        if isinstance(time, numbers.Number) and time != numpy.real(time):
             raise ExtensionError("Evolution time is not real.")
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
@@ -117,7 +117,7 @@ class HamiltonianGate(Gate):
 
     def validate_parameter(self, parameter):
         """Hamiltonian parameter has to be an ndarray, operator or float."""
-        if isinstance(parameter, (float, int, numpy.ndarray)):
+        if isinstance(parameter, (numbers.Real, numpy.ndarray)):
             return parameter
         elif isinstance(parameter, ParameterExpression) and len(parameter.parameters) == 0:
             return float(parameter)

--- a/qiskit/extensions/quantum_initializer/diagonal.py
+++ b/qiskit/extensions/quantum_initializer/diagonal.py
@@ -22,6 +22,7 @@ Decomposes a diagonal matrix into elementary gates using the method described in
 """
 import cmath
 import math
+import numbers
 
 import numpy as np
 
@@ -71,7 +72,7 @@ class DiagonalGate(Gate):
     def validate_parameter(self, parameter):
         """Diagonal Gate parameter should accept complex
         (in addition to the Gate parameter types) and always return build-in complex."""
-        if isinstance(parameter, complex):
+        if isinstance(parameter, numbers.Complex):
             return complex(parameter)
         else:
             return complex(super().validate_parameter(parameter))

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -15,6 +15,7 @@ Initialize qubit registers to desired arbitrary state.
 """
 
 import math
+import numbers
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -64,7 +65,7 @@ class Initialize(Instruction):
         if isinstance(params, Statevector):
             params = params.data
 
-        if not isinstance(params, int) and num_qubits is not None:
+        if not isinstance(params, numbers.Integral) and num_qubits is not None:
             raise QiskitError(
                 "The num_qubits parameter to Initialize should only be"
                 " used when params is an integer"
@@ -75,11 +76,11 @@ class Initialize(Instruction):
         if isinstance(params, str):
             self._from_label = True
             num_qubits = len(params)
-        elif isinstance(params, int):
+        elif isinstance(params, numbers.Integral):
             self._from_int = True
             if num_qubits is None:
                 num_qubits = int(math.log2(params)) + 1
-            params = [params]
+            params = [int(params)]
         else:
             num_qubits = math.log2(len(params))
 
@@ -356,10 +357,8 @@ class Initialize(Instruction):
             )
 
         # Initialize instruction parameter can be int, float, and complex.
-        if isinstance(parameter, (int, float, complex)):
+        if isinstance(parameter, numbers.Complex):
             return complex(parameter)
-        elif isinstance(parameter, np.number):
-            return complex(parameter.item())
         else:
             raise CircuitError(
                 "invalid param type {} for instruction  " "{}".format(type(parameter), self.name)
@@ -451,11 +450,11 @@ def initialize(self, params, qubits=None):
     if qubits is None:
         qubits = self.qubits
     else:
-        if isinstance(qubits, int):
+        if isinstance(qubits, numbers.Integral):
             qubits = [qubits]
         qubits = self._bit_argument_conversion(qubits, self.qubits)
 
-    num_qubits = None if not isinstance(params, int) else len(qubits)
+    num_qubits = None if not isinstance(params, numbers.Integral) else len(qubits)
     return self.append(Initialize(params, num_qubits), qubits)
 
 

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -15,6 +15,7 @@ Arbitrary unitary circuit instruction.
 """
 
 from collections import OrderedDict
+import numbers
 import numpy
 
 from qiskit.circuit import Gate, ControlledGate
@@ -220,7 +221,7 @@ def unitary(self, obj, qubits, label=None):
         qubits = qubits[:]
     # for single qubit unitary gate, allow an 'int' or a 'list of ints' as qubits.
     if gate.num_qubits == 1:
-        if isinstance(qubits, (int, Qubit)) or len(qubits) > 1:
+        if isinstance(qubits, (numbers.Integral, Qubit)) or len(qubits) > 1:
             qubits = [qubits]
     return self.append(gate, qubits, [])
 

--- a/qiskit/opflow/evolutions/trotterizations/qdrift.py
+++ b/qiskit/opflow/evolutions/trotterizations/qdrift.py
@@ -15,6 +15,7 @@ QDrift Class
 
 """
 
+import numbers
 from typing import List, Union, cast
 
 import numpy as np
@@ -47,7 +48,7 @@ class QDrift(TrotterizationBase):
         if not isinstance(operator, (SummedOp, PauliSumOp)):
             raise TypeError("Trotterization converters can only convert SummedOp or PauliSumOp.")
 
-        if not isinstance(operator.coeff, (float, int)):
+        if not isinstance(operator.coeff, numbers.Real):
             raise TypeError(
                 "Trotterization converters can only convert operators with real coefficients."
             )

--- a/qiskit/opflow/evolutions/trotterizations/suzuki.py
+++ b/qiskit/opflow/evolutions/trotterizations/suzuki.py
@@ -12,6 +12,7 @@
 
 """ Suzuki Class """
 
+import numbers
 from typing import List, Union, cast
 
 from numpy import isreal
@@ -58,7 +59,7 @@ class Suzuki(TrotterizationBase):
         if not isinstance(operator, (SummedOp, PauliSumOp)):
             raise TypeError("Trotterization converters can only convert SummedOp or PauliSumOp.")
 
-        if isinstance(operator.coeff, (float, ParameterExpression)):
+        if isinstance(operator.coeff, (numbers.Real, ParameterExpression)):
             coeff = operator.coeff
         else:
             if isreal(operator.coeff):

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -13,7 +13,7 @@
 """ ListOp Operator Class """
 
 from functools import reduce
-from numbers import Number
+import numbers
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Sequence, Union, cast
 
 import numpy as np
@@ -250,7 +250,7 @@ class ListOp(OperatorBase):
     __array_priority__ = 10000
 
     def mul(self, scalar: Union[complex, ParameterExpression]) -> "ListOp":
-        if not isinstance(scalar, (int, float, complex, ParameterExpression)):
+        if not isinstance(scalar, (numbers.Number, ParameterExpression)):
             raise ValueError(
                 "Operators can only be scalar multiplied by float or complex, not "
                 "{} of type {}.".format(scalar, type(scalar))
@@ -270,7 +270,7 @@ class ListOp(OperatorBase):
         # Hack to make op1^(op2^0) work as intended.
         if other == 0:
             return 1
-        if not isinstance(other, int) or other <= 0:
+        if not isinstance(other, numbers.Integral) or other <= 0:
             raise TypeError("Tensorpower can only take positive int arguments")
 
         # Avoid circular dependency
@@ -344,7 +344,7 @@ class ListOp(OperatorBase):
         return ComposedOp([new_self, other])
 
     def power(self, exponent: int) -> OperatorBase:
-        if not isinstance(exponent, int) or exponent <= 0:
+        if not isinstance(exponent, numbers.Integral) or exponent <= 0:
             raise TypeError("power can only take positive int arguments")
 
         # Avoid circular dependency
@@ -367,7 +367,7 @@ class ListOp(OperatorBase):
         )
         # Note: As ComposedOp has a combo function of inner product we can end up here not with
         # a matrix (array) but a scalar. In which case we make a single element array of it.
-        if isinstance(mat, Number):
+        if isinstance(mat, numbers.Number):
             mat = [mat]
         return np.asarray(mat, dtype=complex)
 
@@ -616,7 +616,7 @@ class ListOp(OperatorBase):
             The ``OperatorBase`` at index ``offset`` of ``oplist``,
             or another ListOp with the same properties as this one if offset is a slice.
         """
-        if isinstance(offset, int):
+        if isinstance(offset, numbers.Integral):
             return self.oplist[offset]
 
         if self.__class__ == ListOp:

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -13,6 +13,7 @@
 """PauliOp Class """
 
 from math import pi
+import numbers
 from typing import Dict, List, Optional, Set, Union, cast
 
 import numpy as np
@@ -70,15 +71,15 @@ class PauliOp(PrimitiveOp):
 
         if (
             isinstance(other, PauliOp)
-            and isinstance(self.coeff, (int, float, complex))
-            and isinstance(other.coeff, (int, float, complex))
+            and isinstance(self.coeff, numbers.Complex)
+            and isinstance(other.coeff, numbers.Complex)
         ):
             return PauliSumOp(
                 SparsePauliOp(self.primitive, coeffs=[self.coeff])
                 + SparsePauliOp(other.primitive, coeffs=[other.coeff])
             )
 
-        if isinstance(other, PauliSumOp) and isinstance(self.coeff, (int, float, complex)):
+        if isinstance(other, PauliSumOp) and isinstance(self.coeff, numbers.Complex):
             return PauliSumOp(SparsePauliOp(self.primitive, coeffs=[self.coeff])) + other
 
         return SummedOp([self, other])

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -13,6 +13,7 @@
 """PauliSumOp Class """
 
 from collections import defaultdict
+import numbers
 from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
@@ -139,7 +140,7 @@ class PauliSumOp(PrimitiveOp):
         return SummedOp([self, other])
 
     def mul(self, scalar: Union[complex, ParameterExpression]) -> OperatorBase:
-        if isinstance(scalar, (int, float, complex)) and scalar != 0:
+        if isinstance(scalar, numbers.Number) and scalar != 0:
             return PauliSumOp(scalar * self.primitive, coeff=self.coeff)
 
         return PauliSumOp(self.primitive, coeff=self.coeff * scalar)
@@ -262,7 +263,7 @@ class PauliSumOp(PrimitiveOp):
 
         def format_number(x):
             x = format_sign(x)
-            if isinstance(x, (int, float)) and x < 0:
+            if isinstance(x, numbers.Real) and x < 0:
                 return f"- {-x}"
             return f"+ {x}"
 
@@ -270,7 +271,7 @@ class PauliSumOp(PrimitiveOp):
         prim_list = self.primitive.to_list()
         if prim_list:
             first = prim_list[0]
-            if isinstance(first[1], (int, float)) and first[1] < 0:
+            if isinstance(first[1], numbers.Real) and first[1] < 0:
                 main_string = indent + f"- {-first[1].real} * {first[0]}"
             else:
                 main_string = indent + f"{format_sign(first[1])} * {first[0]}"
@@ -406,7 +407,7 @@ class PauliSumOp(PrimitiveOp):
         Returns:
             The simplified ``PauliSumOp``.
         """
-        if isinstance(self.coeff, (int, float, complex)):
+        if isinstance(self.coeff, numbers.Complex):
             primitive = self.coeff * self.primitive
             return PauliSumOp(primitive.simplify(atol=atol, rtol=rtol))
         return PauliSumOp(self.primitive.simplify(atol=atol, rtol=rtol), self.coeff)

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -12,6 +12,7 @@
 
 """ PrimitiveOp Class """
 
+import numbers
 from typing import Dict, List, Optional, Set, Union, cast
 
 import numpy as np
@@ -147,7 +148,7 @@ class PrimitiveOp(OperatorBase):
         raise NotImplementedError
 
     def mul(self, scalar: Union[complex, ParameterExpression]) -> OperatorBase:
-        if not isinstance(scalar, (int, float, complex, ParameterExpression)):
+        if not isinstance(scalar, (numbers.Number, ParameterExpression)):
             raise ValueError(
                 "Operators can only be scalar multiplied by float or complex, not "
                 "{} of type {}.".format(scalar, type(scalar))
@@ -162,7 +163,7 @@ class PrimitiveOp(OperatorBase):
         # Hack to make Z^(I^0) work as intended.
         if other == 0:
             return 1
-        if not isinstance(other, int) or other < 0:
+        if not isinstance(other, numbers.Integral) or other < 0:
             raise TypeError("Tensorpower can only take positive int arguments")
         temp = PrimitiveOp(self.primitive, coeff=self.coeff)  # type: OperatorBase
         for _ in range(other - 1):

--- a/qiskit/opflow/state_fns/cvar_measurement.py
+++ b/qiskit/opflow/state_fns/cvar_measurement.py
@@ -14,6 +14,7 @@
 
 
 from typing import Callable, Optional, Tuple, Union, cast, Dict
+import numbers
 
 import numpy as np
 
@@ -111,7 +112,7 @@ class CVaRMeasurement(OperatorStateFn):
         raise OpflowError("Adjoint of a CVaR measurement not defined")
 
     def mul(self, scalar: Union[complex, ParameterExpression]) -> "CVaRMeasurement":
-        if not isinstance(scalar, (int, float, complex, ParameterExpression)):
+        if not isinstance(scalar, (numbers.Number, ParameterExpression)):
             raise ValueError(
                 "Operators can only be scalar multiplied by float or complex, not "
                 "{} of type {}.".format(scalar, type(scalar))

--- a/qiskit/opflow/state_fns/state_fn.py
+++ b/qiskit/opflow/state_fns/state_fn.py
@@ -12,6 +12,7 @@
 
 """ StateFn Class """
 
+import numbers
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -199,7 +200,7 @@ class StateFn(OperatorBase):
         # Will return NotImplementedError if not supported
 
     def mul(self, scalar: Union[complex, ParameterExpression]) -> OperatorBase:
-        if not isinstance(scalar, (int, float, complex, ParameterExpression)):
+        if not isinstance(scalar, (numbers.Number, ParameterExpression)):
             raise ValueError(
                 "Operators can only be scalar multiplied by float or complex, not "
                 "{} of type {}.".format(scalar, type(scalar))
@@ -240,7 +241,7 @@ class StateFn(OperatorBase):
         raise NotImplementedError
 
     def tensorpower(self, other: int) -> Union[OperatorBase, int]:
-        if not isinstance(other, int) or other <= 0:
+        if not isinstance(other, numbers.Integral) or other <= 0:
             raise TypeError("Tensorpower can only take positive int arguments")
         temp = StateFn(
             self.primitive, coeff=self.coeff, is_measurement=self.is_measurement

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -31,6 +31,7 @@ field, which is a result of measurements for each shot.
 import uuid
 import time
 import logging
+import numbers
 import warnings
 
 from math import log2
@@ -522,7 +523,7 @@ class QasmSimulatorPy(BackendV1):
             self._classical_register = 0
             for operation in experiment.instructions:
                 conditional = getattr(operation, "conditional", None)
-                if isinstance(conditional, int):
+                if isinstance(conditional, numbers.Integral):
                     conditional_bit_set = (self._classical_register >> conditional) & 1
                     if not conditional_bit_set:
                         continue

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -902,7 +902,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
         """
         channels = set()
         try:
-            if isinstance(qubit, int):
+            if isinstance(qubit, numbers.Integral):
                 for key in self._qubit_channel_map.keys():
                     if qubit in key:
                         channels.update(self._qubit_channel_map[key])

--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -14,6 +14,7 @@
 
 import copy
 import datetime
+import numbers
 from typing import Any, Iterable, Tuple, Union
 import dateutil.parser
 
@@ -296,7 +297,7 @@ class BackendProperties:
         try:
             result = self._gates[gate]
             if qubits is not None:
-                if isinstance(qubits, int):
+                if isinstance(qubits, numbers.Integral):
                     qubits = tuple([qubits])
                 result = result[tuple(qubits)]
                 if name:

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -196,6 +196,7 @@ import collections
 import contextvars
 import functools
 import itertools
+import numbers
 import warnings
 from contextlib import contextmanager
 from typing import (
@@ -815,7 +816,7 @@ def _qubits_to_channels(*channels_or_qubits: Union[int, chans.Channel]) -> Set[c
     """Returns the unique channels of the input qubits."""
     channels = set()
     for channel_or_qubit in channels_or_qubits:
-        if isinstance(channel_or_qubit, int):
+        if isinstance(channel_or_qubit, numbers.Integral):
             channels |= qubit_channels(channel_or_qubit)
         elif isinstance(channel_or_qubit, chans.Channel):
             channels.add(channel_or_qubit)
@@ -1517,7 +1518,7 @@ def acquire(
     Raises:
         exceptions.PulseError: If the register type is not supported.
     """
-    if isinstance(qubit_or_channel, int):
+    if isinstance(qubit_or_channel, numbers.Integral):
         qubit_or_channel = chans.AcquireChannel(qubit_or_channel)
 
     if isinstance(register, chans.MemorySlot):

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -37,6 +37,7 @@ by following the existing pattern:
         new_supported_pulse_name = library.YourPulseWaveformClass
 """
 from abc import abstractmethod
+import numbers
 from typing import Any, Dict, Optional, Union
 
 import math
@@ -427,7 +428,7 @@ class Drag(ParametricPulse):
             )
         if not _is_parameterized(self.sigma) and self.sigma <= 0:
             raise PulseError("Sigma must be greater than 0.")
-        if not _is_parameterized(self.beta) and isinstance(self.beta, complex):
+        if not _is_parameterized(self.beta) and not isinstance(self.beta, numbers.Real):
             raise PulseError("Beta must be real.")
         # Check if beta is too large: the amplitude norm must be <=1 for all points
         if (

--- a/qiskit/pulse/library/samplers/decorators.py
+++ b/qiskit/pulse/library/samplers/decorators.py
@@ -127,6 +127,7 @@ still seeing the signature for the continuous pulse function and all of its argu
 """
 
 import functools
+import numbers
 from typing import Callable
 import textwrap
 import pydoc
@@ -151,7 +152,7 @@ def functional_pulse(func: Callable) -> Callable:
     @functools.wraps(func)
     def to_pulse(duration, *args, name=None, **kwargs):
         """Return Waveform."""
-        if isinstance(duration, (int, np.integer)) and duration > 0:
+        if isinstance(duration, numbers.Integral) and duration > 0:
             samples = func(duration, *args, **kwargs)
             samples = np.asarray(samples, dtype=np.complex128)
             return Waveform(samples=samples, name=name)

--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -50,6 +50,7 @@ as the data amount scales.
 Note that we don't need to write any parameter management logic for each object,
 and thus this parameter framework gives greater scalability to the pulse module.
 """
+import numbers
 from copy import deepcopy, copy
 from typing import List, Dict, Set, Any, Union
 
@@ -199,7 +200,7 @@ class ParameterSetter(NodeVisitor):
 
             # validate
             if not isinstance(new_index, ParameterExpression):
-                if not isinstance(new_index, int) or new_index < 0:
+                if not isinstance(new_index, numbers.Integral) or new_index < 0:
                     raise PulseError("Channel index must be a nonnegative integer")
 
             # return new instance to prevent accidentally override timeslots without evaluation

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -21,6 +21,7 @@ import abc
 import copy
 import functools
 import itertools
+import numbers
 import multiprocessing as mp
 import sys
 import warnings
@@ -366,7 +367,7 @@ class Schedule:
         Raises:
             PulseError: if ``time`` is not an integer.
         """
-        if not isinstance(time, int):
+        if not isinstance(time, numbers.Integral):
             raise PulseError("Schedule start time must be an integer.")
 
         timeslots = {}
@@ -598,7 +599,7 @@ class Schedule:
         Raises:
             PulseError: If timeslots overlap or an invalid start time is provided.
         """
-        if not isinstance(time, int):
+        if not isinstance(time, numbers.Integral):
             raise PulseError("Schedule start time must be an integer.")
 
         for channel in schedule.channels:
@@ -1024,7 +1025,7 @@ class ScheduleBlock:
                 if not block.is_schedulable():
                     return False
             else:
-                if not isinstance(block.duration, int):
+                if not isinstance(block.duration, numbers.Integral):
                     return False
         return True
 

--- a/qiskit/pulse/transforms/base_transforms.py
+++ b/qiskit/pulse/transforms/base_transforms.py
@@ -13,6 +13,7 @@
 
 # TODO: replace this with proper pulse transformation passes. Qiskit-terra/#6121
 
+import numbers
 from typing import Union, Iterable, Tuple
 
 from qiskit.pulse.instructions import Instruction
@@ -62,7 +63,7 @@ def _format_schedule_component(sched: Union[InstructionSched, Iterable[Instructi
     try:
         sched = list(sched)
         # (t0, inst), or list of it
-        if isinstance(sched[0], int):
+        if isinstance(sched[0], numbers.Integral):
             # (t0, inst) tuple
             return [tuple(sched)]
         else:

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -12,6 +12,7 @@
 
 """Module for common pulse programming utilities."""
 import functools
+import numbers
 import warnings
 from typing import List, Dict, Union
 
@@ -94,7 +95,7 @@ def instruction_duration_validation(duration: int):
             "".format(repr(duration))
         )
 
-    if not isinstance(duration, (int, np.integer)) or duration < 0:
+    if not isinstance(duration, numbers.Integral) or duration < 0:
         raise QiskitError(
             "Instruction duration must be a non-negative integer, "
             "got {} instead.".format(duration)

--- a/qiskit/qasm/node/node.py
+++ b/qiskit/qasm/node/node.py
@@ -12,6 +12,8 @@
 
 """Base node object for the OPENQASM syntax tree."""
 
+import numbers
+
 
 class Node:
     """Base node object for the OPENQASM syntax tree."""
@@ -51,9 +53,7 @@ class Node:
                 print(self.children)
             if isinstance(children, str):
                 print(ind, children)
-            elif isinstance(children, int):
-                print(ind, str(children))
-            elif isinstance(children, float):
+            elif isinstance(children, numbers.Real):
                 print(ind, str(children))
             else:
                 children.to_string(indent)

--- a/qiskit/qobj/pulse_qobj.py
+++ b/qiskit/qobj/pulse_qobj.py
@@ -16,6 +16,7 @@
 """Module providing definitions of Pulse Qobj classes."""
 
 import copy
+import numbers
 import pprint
 from typing import Union, List
 
@@ -260,8 +261,8 @@ def _to_complex(value: Union[List[float], complex]) -> complex:
     """
     if isinstance(value, list) and len(value) == 2:
         return complex(value[0], value[1])
-    elif isinstance(value, complex):
-        return value
+    elif isinstance(value, numbers.Complex):
+        return complex(value)
 
     raise TypeError(f"{value} is not in a valid complex number format.")
 

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -15,7 +15,7 @@ Kraus representation of a Quantum Channel.
 """
 
 import copy
-from numbers import Number
+import numbers
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -299,13 +299,13 @@ class Kraus(QuantumChannel):
         return Kraus(Choi(self)._add(other, qargs=qargs))
 
     def _multiply(self, other):
-        if not isinstance(other, Number):
+        if not isinstance(other, numbers.Number):
             raise QiskitError("other is not a number")
 
         ret = copy.copy(self)
         # If the number is complex we need to convert to general
         # kraus channel so we multiply via Choi representation
-        if isinstance(other, complex) or other < 0:
+        if not isinstance(other, numbers.Real) or other < 0:
             # Convert to Choi-matrix
             ret._data = Kraus(Choi(self)._multiply(other))._data
             return ret

--- a/qiskit/quantum_info/operators/channel/stinespring.py
+++ b/qiskit/quantum_info/operators/channel/stinespring.py
@@ -14,7 +14,7 @@ Stinespring representation of a Quantum Channel.
 """
 
 import copy
-from numbers import Number
+import numbers
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -259,14 +259,14 @@ class Stinespring(QuantumChannel):
         return Stinespring(Choi(self)._add(other, qargs=qargs))
 
     def _multiply(self, other):
-        if not isinstance(other, Number):
+        if not isinstance(other, numbers.Number):
             raise QiskitError("other is not a number")
 
         ret = copy.copy(self)
         # If the number is complex or negative we need to convert to
         # general Stinespring representation so we first convert to
         # the Choi representation
-        if isinstance(other, complex) or other < 1:
+        if not isinstance(other, numbers.Real) or other < 1:
             # Convert to Choi-matrix
             ret._data = Stinespring(Choi(self)._multiply(other))._data
             return ret

--- a/qiskit/quantum_info/operators/dihedral/polynomial.py
+++ b/qiskit/quantum_info/operators/dihedral/polynomial.py
@@ -17,6 +17,7 @@ import itertools
 from itertools import combinations
 import copy
 from functools import reduce
+import numbers
 from operator import mul
 import numpy as np
 
@@ -78,7 +79,7 @@ class SpecialPolynomial:
         if not isinstance(other, SpecialPolynomial):
             other = int(other)
         result = SpecialPolynomial(self.n_vars)
-        if isinstance(other, int):
+        if isinstance(other, numbers.Integral):
             result.weight_0 = (self.weight_0 * other) % 8
             result.weight_1 = (self.weight_1 * other) % 8
             result.weight_2 = (self.weight_2 * other) % 8
@@ -128,7 +129,7 @@ class SpecialPolynomial:
         """
         if len(xval) != self.n_vars:
             raise QiskitError("Evaluate on wrong number of variables.")
-        check_int = list(map(lambda x: isinstance(x, int), xval))
+        check_int = list(map(lambda x: isinstance(x, numbers.Integral), xval))
         check_poly = list(map(lambda x: isinstance(x, SpecialPolynomial), xval))
         if False in check_int and False in check_poly:
             raise QiskitError("Evaluate on a wrong type.")
@@ -157,7 +158,7 @@ class SpecialPolynomial:
             if value != 0:
                 newterm = reduce(mul, [xval[j] for j in term], start)
                 result = result + value * newterm
-        if isinstance(result, int):
+        if isinstance(result, numbers.Integral):
             result = result % 8
         return result
 

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -15,6 +15,7 @@ N-qubit Pauli Operator Class
 # pylint: disable=invalid-name
 # pylint: disable=bad-docstring-quotes  # for deprecate_function decorator
 
+import numbers
 from typing import Dict
 import re
 
@@ -302,7 +303,7 @@ class Pauli(BasePauli):
     def __getitem__(self, qubits):
         """Return the unsigned Pauli group Pauli for subset of qubits."""
         # Set group phase to 0 so returned Pauli is always +1 coeff
-        if isinstance(qubits, (int, np.integer)):
+        if isinstance(qubits, numbers.Integral):
             qubits = [qubits]
         return Pauli((self.z[qubits], self.x[qubits]))
 
@@ -328,7 +329,7 @@ class Pauli(BasePauli):
             QiskitError: if ind is out of bounds for the array size or
                          number of qubits.
         """
-        if isinstance(qubits, (int, np.integer)):
+        if isinstance(qubits, numbers.Integral):
             qubits = [qubits]
         if max(qubits) > self.num_qubits - 1:
             raise QiskitError(
@@ -360,7 +361,7 @@ class Pauli(BasePauli):
         # Initialize empty operator
         ret_qubits = self.num_qubits + value.num_qubits
         ret = Pauli((np.zeros(ret_qubits, dtype=bool), np.zeros(ret_qubits, dtype=bool)))
-        if isinstance(qubits, (int, np.integer)):
+        if isinstance(qubits, numbers.Integral):
             if value.num_qubits == 1:
                 qubits = [qubits]
             else:

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -14,6 +14,7 @@ Optimized list of Pauli operators
 """
 
 from collections import defaultdict
+import numbers
 
 import numpy as np
 import retworkx as rx
@@ -290,7 +291,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
                 raise IndexError("Invalid PauliList index {}".format(index))
 
         # Row-only indexing
-        if isinstance(index, (int, np.integer)):
+        if isinstance(index, numbers.Integral):
             # Single Pauli
             return Pauli(
                 BasePauli(
@@ -346,7 +347,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
             QiskitError: if ind is out of bounds for the array size or
                          number of qubits.
         """
-        if isinstance(ind, int):
+        if isinstance(ind, numbers.Integral):
             ind = [ind]
 
         # Row deletion
@@ -392,7 +393,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         Raises:
             QiskitError: if the insertion index is invalid.
         """
-        if not isinstance(ind, int):
+        if not isinstance(ind, numbers.Integral):
             raise QiskitError("Insert index must be an integer.")
 
         if not isinstance(value, PauliList):

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -14,6 +14,7 @@ Symplectic Pauli Table Class
 """
 # pylint: disable=invalid-name
 
+import numbers
 from typing import Dict
 
 import numpy as np
@@ -248,7 +249,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         """Return a view of the PauliTable."""
         # Returns a view of specified rows of the PauliTable
         # This supports all slicing operations the underlying array supports.
-        if isinstance(key, (int, np.integer)):
+        if isinstance(key, numbers.Integral):
             key = [key]
         return PauliTable(self._array[key])
 
@@ -277,7 +278,7 @@ class PauliTable(BaseOperator, AdjointMixin):
             QiskitError: if ind is out of bounds for the array size or
                          number of qubits.
         """
-        if isinstance(ind, (int, np.integer)):
+        if isinstance(ind, numbers.Integral):
             ind = [ind]
 
         # Row deletion
@@ -316,7 +317,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         Raises:
             QiskitError: if the insertion index is invalid.
         """
-        if not isinstance(ind, (int, np.integer)):
+        if not isinstance(ind, numbers.Integral):
             raise QiskitError("Insert index must be an integer.")
 
         if not isinstance(value, PauliTable):

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -14,7 +14,7 @@ N-Qubit Sparse Pauli Operator class.
 """
 
 from typing import Dict
-from numbers import Number
+import numbers
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -139,7 +139,7 @@ class SparsePauliOp(LinearOp):
         """Return a view of the SparsePauliOp."""
         # Returns a view of specified rows of the PauliTable
         # This supports all slicing operations the underlying array supports.
-        if isinstance(key, (int, np.integer)):
+        if isinstance(key, numbers.Integral):
             key = [key]
         return SparsePauliOp(self.table[key], self.coeffs[key])
 
@@ -251,7 +251,7 @@ class SparsePauliOp(LinearOp):
         return ret
 
     def _multiply(self, other):
-        if not isinstance(other, Number):
+        if not isinstance(other, numbers.Number):
             raise QiskitError("other is not a number")
         if other == 0:
             # Check edge case that we deleted all Paulis

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -13,6 +13,8 @@
 Symplectic Stabilizer Table Class
 """
 
+import numbers
+
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -251,7 +253,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
 
     def __getitem__(self, key):
         """Return a view of StabilizerTable"""
-        if isinstance(key, (int, np.integer)):
+        if isinstance(key, numbers.Integral):
             key = [key]
         return StabilizerTable(self._array[key], self._phase[key])
 
@@ -288,7 +290,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
             table = super().delete(ind, True)
             return StabilizerTable(table, self._phase)
 
-        if isinstance(ind, (int, np.integer)):
+        if isinstance(ind, numbers.Integral):
             ind = [ind]
         if max(ind) >= self.size:
             raise QiskitError(
@@ -319,7 +321,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
         Raises:
             QiskitError: if the insertion index is invalid.
         """
-        if not isinstance(ind, (int, np.integer)):
+        if not isinstance(ind, numbers.Integral):
             raise QiskitError("Insert index must be an integer.")
         if not isinstance(value, StabilizerTable):
             value = StabilizerTable(value)

--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -12,6 +12,7 @@
 
 """A container class for counts from a circuit execution."""
 
+import numbers
 import re
 
 from qiskit.result import postprocess
@@ -68,7 +69,7 @@ class Counts(dict):
             bin_data = {}
         else:
             first_key = next(iter(data.keys()))
-            if isinstance(first_key, int):
+            if isinstance(first_key, numbers.Integral):
                 self.int_raw = data
                 self.hex_raw = {hex(key): value for key, value in self.int_raw.items()}
             elif isinstance(first_key, str):

--- a/qiskit/result/distributions/probability.py
+++ b/qiskit/result/distributions/probability.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 """Class for probability distributions."""
 
+import numbers
 import re
 
 # NOTE: A dict subclass should not overload any dunder methods like __getitem__
@@ -46,7 +47,7 @@ class ProbDistribution(dict):
         self.shots = shots
         if data:
             first_key = next(iter(data.keys()))
-            if isinstance(first_key, int):
+            if isinstance(first_key, numbers.Integral):
                 pass
             elif isinstance(first_key, str):
                 if first_key.startswith("0x"):

--- a/qiskit/result/distributions/quasi.py
+++ b/qiskit/result/distributions/quasi.py
@@ -12,6 +12,7 @@
 """Quasidistribution class"""
 
 from math import sqrt
+import numbers
 import re
 
 from .probability import ProbDistribution
@@ -50,7 +51,7 @@ class QuasiDistribution(dict):
         self.shots = shots
         if data:
             first_key = next(iter(data.keys()))
-            if isinstance(first_key, int):
+            if isinstance(first_key, numbers.Integral):
                 pass
             elif isinstance(first_key, str):
                 if first_key.startswith("0x"):

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -12,6 +12,7 @@
 
 """Post-processing of raw result."""
 
+import numbers
 import numpy as np
 
 from qiskit.exceptions import QiskitError
@@ -187,7 +188,7 @@ def format_statevector(vec, decimals=None):
             return np.around(vec, decimals=decimals)
         return vec
     num_basis = len(vec)
-    if vec and isinstance(vec[0], complex):
+    if vec and isinstance(vec[0], numbers.Complex):
         vec_complex = np.array(vec, dtype=complex)
     else:
         vec_complex = np.zeros(num_basis, dtype=complex)

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -13,6 +13,7 @@
 """Model for schema-conformant Results."""
 
 import copy
+import numbers
 import warnings
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -375,7 +376,7 @@ class Result:
         if isinstance(key, (QuantumCircuit, Schedule)):
             key = key.name
         # Key is an integer: return result by index.
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             try:
                 exp = self.results[key]
             except IndexError as ex:

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -20,6 +20,7 @@ onto a device with this coupling.
 """
 
 import io
+import numbers
 import warnings
 
 import numpy as np
@@ -86,7 +87,7 @@ class CouplingMap:
         Raises:
             CouplingError: if trying to add duplicate qubit
         """
-        if not isinstance(physical_qubit, int):
+        if not isinstance(physical_qubit, numbers.Integral):
             raise CouplingError("Physical qubits should be integers.")
         if physical_qubit in self.physical_qubits:
             raise CouplingError(

--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Durations of instructions, one of transpiler configurations."""
+import numbers
 import warnings
 from typing import Optional, List, Tuple, Union, Iterable, Set
 
@@ -120,7 +121,7 @@ class InstructionDurations:
                     )
 
             for name, qubits, duration, unit in inst_durations:
-                if isinstance(qubits, int):
+                if isinstance(qubits, numbers.Integral):
                     qubits = [qubits]
 
                 if qubits is None:
@@ -159,7 +160,7 @@ class InstructionDurations:
         else:
             inst_name = inst
 
-        if isinstance(qubits, (int, Qubit)):
+        if isinstance(qubits, (numbers.Integral, Qubit)):
             qubits = [qubits]
 
         if isinstance(qubits[0], Qubit):

--- a/qiskit/transpiler/layout.py
+++ b/qiskit/transpiler/layout.py
@@ -18,9 +18,10 @@ Virtual (qu)bits are tuples, e.g. `(QuantumRegister(3, 'qr'), 2)` or simply `qr[
 Physical (qu)bits are integers.
 """
 
+import numbers
+
 from qiskit.circuit.quantumregister import Qubit, QuantumRegister
 from qiskit.transpiler.exceptions import LayoutError
-from qiskit.converters import isinstanceint
 
 
 class Layout:
@@ -84,10 +85,10 @@ class Layout:
     @staticmethod
     def order_based_on_type(value1, value2):
         """decides which one is physical/virtual based on the type. Returns (virtual, physical)"""
-        if isinstanceint(value1) and isinstance(value2, (Qubit, type(None))):
+        if isinstance(value1, numbers.Integral) and isinstance(value2, (Qubit, type(None))):
             physical = int(value1)
             virtual = value2
-        elif isinstanceint(value2) and isinstance(value1, (Qubit, type(None))):
+        elif isinstance(value2, numbers.Integral) and isinstance(value1, (Qubit, type(None))):
             physical = int(value2)
             virtual = value1
         else:
@@ -122,7 +123,7 @@ class Layout:
             self._v2p[virtual] = physical
 
     def __delitem__(self, key):
-        if isinstance(key, int):
+        if isinstance(key, numbers.Integral):
             del self._v2p[self._p2v[key]]
             del self._p2v[key]
         elif isinstance(key, Qubit):
@@ -301,7 +302,7 @@ class Layout:
         Raises:
             LayoutError: Invalid input layout.
         """
-        if not all(isinstanceint(i) for i in int_list):
+        if not all(isinstance(i, numbers.Integral) for i in int_list):
             raise LayoutError("Expected a list of ints")
         if len(int_list) != len(set(int_list)):
             raise LayoutError("Duplicate values not permitted; Layout is bijective.")

--- a/qiskit/transpiler/timing_constraints.py
+++ b/qiskit/transpiler/timing_constraints.py
@@ -12,6 +12,8 @@
 
 """Timing Constraints class."""
 
+import numbers
+
 from qiskit.transpiler.exceptions import TranspilerError
 
 
@@ -53,7 +55,7 @@ class TimingConstraints:
         self.acquire_alignment = acquire_alignment
 
         for key, value in self.__dict__.items():
-            if not isinstance(value, int) or value < 1:
+            if not isinstance(value, numbers.Integral) or value < 1:
                 raise TranspilerError(
                     f"Timing constraint {key} should be nonzero integer. Not {value}."
                 )

--- a/qiskit/visualization/array.py
+++ b/qiskit/visualization/array.py
@@ -14,6 +14,7 @@ Tools to create LaTeX arrays.
 """
 
 import math
+import numbers
 from fractions import Fraction
 import numpy as np
 
@@ -237,7 +238,7 @@ def array_to_latex(array, precision=5, prefix="", source=False, max_size=8):
         ) from err
 
     if array.ndim <= 2:
-        if isinstance(max_size, int):
+        if isinstance(max_size, numbers.Integral):
             max_size = (max_size, max_size)
         outstr = _matrix_to_latex(array, precision=precision, prefix=prefix, max_size=max_size)
     else:

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -19,6 +19,7 @@ Visualization functions for quantum states.
 """
 
 from functools import reduce
+import numbers
 import colorsys
 import numpy as np
 from scipy import linalg
@@ -1191,7 +1192,7 @@ class TextMatrix:
         self.dims = dims
         self.prefix = prefix
         self.suffix = suffix
-        if isinstance(max_size, int):
+        if isinstance(max_size, numbers.Integral):
             self.max_size = max_size
         elif isinstance(state, DensityMatrix):
             # density matrices are square, so threshold for

--- a/qiskit/visualization/timeline/events.py
+++ b/qiskit/visualization/timeline/events.py
@@ -69,7 +69,7 @@ class BitEvents:
             VisualizationError: When the circuit is not transpiled with duration.
         """
         t0 = 0
-        tf = scheduled_circuit.qubit_stop_time(bit)
+        tf = scheduled_circuit.qubit_stop_time(bit) if isinstance(bit, circuit.Qubit) else 0
 
         instructions = []
         for inst, qargs, cargs in scheduled_circuit.data:

--- a/releasenotes/notes/numbers-checks-a3addb10f1e2376e.yaml
+++ b/releasenotes/notes/numbers-checks-a3addb10f1e2376e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Many functions across qiskit-terra will now be more permissive in the types
+    of numeric input they accept; instead of rejecting integers of type
+    ``numpy.int64`` (such as those taken from Numpy arrays), they should now
+    work as expected.


### PR DESCRIPTION
### Summary

In most cases throughout the codebase, this converts type checks of the
form
    isinstance(x, int)
or similar with `float` or `complex` with comparisons to
`numbers.Integral`, `numbers.Real` or `numbers.Complex` as appropriate.
This is because there are common types which still behave like numbers,
but do not subclass the built-in types, such as `numpy.int64` and
friends.  A few places in the code already attempted to handle these,
but it was not uniform throughout, and so using numbers taken from a
Numpy array would work with some parts of the codebase, but not others.

Very little in Qiskit relies on the underlying numbers being _exactly_
the built-in types, so allowing any type that fulfills the interface of
the relevant ABC is appropriate.  Things like equality and hash are
fixed by the specification, so all representations of the number `1`,
for example, count as the exact same object when used as a dictionary
key or whatever, no matter if they are really `int`, `np.int32` or
anything.

In general, type-validation functions are modified to return their
outputs as a built-in type, if possible, in order to be flexible in what
Qiskit functions accept, but prescriptive in what they return.  This
should make code a bit more robust for users.

There are a few places where it was not appropriate to modify the type
checks.  Of particular note is in `qpy_serialization`, where maintaining
the exact binary representation of the inputs means that the exact type
is important; numpy types have different widths, and are handled
separately.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This builds on a few far more targeted PRs (e.g. #6910), with the intent of unifying numeric handling across Terra.  The main use-case is handling numbers that are taken out of Numpy arrays, and making it so these should be more uniformly accepted, rather than only working in functions that people have previously raised issues for.