### PR TITLE
Correctly handle parametric pulse assemble() kwarg if empty list

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -438,8 +438,8 @@ def _parse_pulse_args(
         if isinstance(rep_time, list):
             rep_time = rep_time[0]
         rep_time = int(rep_time * 1e6)  # convert sec to μs
-
-    parametric_pulses = parametric_pulses or getattr(backend_config, "parametric_pulses", [])
+    if parametric_pulses is None:
+        parametric_pulses = getattr(backend_config, "parametric_pulses", [])
 
     # create run configuration and populate
     run_config_dict = dict(

--- a/releasenotes/notes/fix-assemble-parametric-pulse-eea8fba73c56a69f.yaml
+++ b/releasenotes/notes/fix-assemble-parametric-pulse-eea8fba73c56a69f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~qiskit.compiler.assemble` function when
+    called with the ``backend`` kwarg set and the ``parametric_pulses`` kwarg
+    was set to an empty list the output qobj would contain the
+    ``parametric_pulses`` setting from the given backend's
+    :class:`~qiskit.providers.models.BackendConfiguration` instead of the
+    expected empty list.
+    Fixed `#6898 <https://github.com/Qiskit/qiskit-terra/issues/6898>`__

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -1318,6 +1318,36 @@ class TestPulseAssembler(QiskitTestCase):
         qobj_insts = qobj.experiments[0].instructions
         self.assertFalse(hasattr(qobj_insts[0], "pulse_shape"))
 
+    def test_assemble_parametric_pulse_kwarg_with_backend_setting(self):
+        """Test that parametric pulses respect the kwarg over backend"""
+        backend = FakeAlmaden()
+
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        with pulse.build(backend, name="x") as x_q0:
+            pulse.play(pulse.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(0))
+
+        qc.add_calibration("x", (0,), x_q0)
+
+        qobj = assemble(qc, backend, parametric_pulses=["gaussian"])
+        self.assertEqual(qobj.config.parametric_pulses, ["gaussian"])
+
+    def test_assemble_parametric_pulse_kwarg_empty_list_with_backend_setting(self):
+        """Test that parametric pulses respect the kwarg as empty list over backend"""
+        backend = FakeAlmaden()
+
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        with pulse.build(backend, name="x") as x_q0:
+            pulse.play(pulse.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(0))
+
+        qc.add_calibration("x", (0,), x_q0)
+
+        qobj = assemble(qc, backend, parametric_pulses=[])
+        self.assertEqual(qobj.config.parametric_pulses, [])
+
     def test_init_qubits_default(self):
         """Check that the init_qubits=None assemble option is passed on to the qobj."""
         qobj = assemble(self.schedule, self.backend)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue with the assemble() function. If the
parametric_pulses kwarg was set to an empty list the assemble function
was incorrectly treating this as if no parametric pulse kwarg was set.
This would result in the incorrect qobj being generated by assemble()
including any parametric pulses given for a provided backend instead of
the expected empty list. This commit fixes the issue by correcting the
logic in assemble() so we only use the backends value if the kwarg is
not set, not when the kwarg evals to False (which was the bug).

### Details and comments

Fixes #6898
