### PR TITLE
Pin retworkx dependency version to 0.9.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 contextvars>=2.4;python_version<'3.7'
-retworkx>=0.9.0
+retworkx==0.9.0
 numpy>=1.17
 ply>=3.10
 psutil>=5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We will release retworkx 0.10.1 to succeed with the few terra tests that currently fail with 0.10.0. Before then, this.

### Details and comments


