### PR TITLE
Revert "Pin retworkx dependency version to 0.9.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 contextvars>=2.4;python_version<'3.7'
-retworkx==0.9.0
+retworkx>=0.9.0
 numpy>=1.17
 ply>=3.10
 psutil>=5


### PR DESCRIPTION
The cause of the issue in retworkx 0.10.0 was worked around in
https://github.com/Qiskit/retworkx/pull/422 and released as retworkx
0.10.1 so we no longer need to pin retworkx.

Reverts Qiskit/qiskit-terra#6945