### PR TITLE
Pin importlib-metadata in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,4 @@ decorator==4.4.2
 jax==0.2.13
 jaxlib==0.1.67
 networkx==2.5
+importlib-metadata==4.7.1


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of importlib-metadata has broken an interface that
stevedore uses when looking for entrypoints (see
https://github.com/python/importlib_metadata/issues/348 ). Several of
our test/ci dependecies use stevedore for their plugin interfaces
including stestr which is causing CI failures. To unblock CI this commit
pins the importlib metadata version in our constraints file while the
upstream issue is resolved.

### Details and comments