### PR TITLE
Fix the docstring of Result

### DIFF
--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -210,7 +210,7 @@ class Result:
 
         Returns:
             List[str] or np.ndarray: Either the list of each outcome, formatted according to
-                registers in circuit or a complex numpy np.ndarray with shape:
+            registers in circuit or a complex numpy np.ndarray with shape:
 
                 ============  =============  =====
                 `meas_level`  `meas_return`  shape
@@ -261,11 +261,11 @@ class Result:
                 experiment, as specified by ``data([experiment])``.
 
         Returns:
-            dict[str:int] or list[dict[str:int]]: a dictionary or a list of
-                dictionaries. A dictionary has the counts for each qubit with
-                the keys containing a string in binary format and separated
-                according to the registers in circuit (e.g. ``0100 1110``).
-                The string is little-endian (cr[0] on the right hand side).
+            dict[str, int] or list[dict[str, int]]: a dictionary or a list of
+            dictionaries. A dictionary has the counts for each qubit with
+            the keys containing a string in binary format and separated
+            according to the registers in circuit (e.g. ``0100 1110``).
+            The string is little-endian (cr[0] on the right hand side).
 
         Raises:
             QiskitError: if there are no counts for the experiment.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This fixes the broken API reference format of `Result`.
Especially, `Returns` part of `get_counts` looks broken as attached.
https://qiskit.org/documentation/stubs/qiskit.result.Result.html#qiskit.result.Result.get_counts
![image](https://user-images.githubusercontent.com/31178928/131630015-a444cd00-dbbe-4096-9522-96e14f23f7ea.png)


### Details and comments


