### PR TITLE
Use eigh, eigsh in NumPyEigensolver

### DIFF
--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -13,15 +13,16 @@
 """The Eigensolver algorithm."""
 
 import logging
-from typing import List, Optional, Union, Tuple, Callable
+from typing import Callable, List, Optional, Tuple, Union
 
 import numpy as np
 from scipy import sparse as scisparse
 
-from qiskit.opflow import OperatorBase, I, StateFn, ListOp
+from qiskit.opflow import I, ListOp, OperatorBase, PauliSumOp, StateFn
 from qiskit.utils.validation import validate_min
-from .eigen_solver import Eigensolver, EigensolverResult
+
 from ..exceptions import AlgorithmError
+from .eigen_solver import Eigensolver, EigensolverResult
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +124,23 @@ class NumPyEigensolver(Eigensolver):
             for i, idx in enumerate(indices):
                 eigvec[idx, i] = 1.0
         else:
-            if self._k >= 2 ** operator.num_qubits - 1:
+            if (
+                isinstance(operator, PauliSumOp)
+                and np.isreal(operator.coeffs).all()
+                and np.all(operator.primitive.paulis.phase == 0)
+                and self._k >= 2 ** operator.num_qubits - 1
+            ):
+                logger.debug("SciPy doesn't support to get all eigenvalues, using NumPy instead.")
+                eigval, eigvec = np.linalg.eigh(operator.to_matrix())
+            elif (
+                isinstance(operator, PauliSumOp)
+                and np.isreal(operator.coeffs).all()
+                and np.all(operator.primitive.paulis.phase == 0)
+            ):
+                eigval, eigvec = scisparse.linalg.eigsh(
+                    operator.to_spmatrix(), k=self._k, which="SR"
+                )
+            elif self._k >= 2 ** operator.num_qubits - 1:
                 logger.debug("SciPy doesn't support to get all eigenvalues, using NumPy instead.")
                 eigval, eigvec = np.linalg.eig(operator.to_matrix())
             else:

--- a/test/python/algorithms/test_numpy_eigen_solver.py
+++ b/test/python/algorithms/test_numpy_eigen_solver.py
@@ -44,6 +44,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         result = algo.compute_eigenvalues(operator=self.qubit_op, aux_operators=[])
         self.assertEqual(len(result.eigenvalues), 1)
         self.assertEqual(len(result.eigenstates), 1)
+        self.assertEqual(result.eigenvalues.dtype, np.float64)
         self.assertAlmostEqual(result.eigenvalues[0], -1.85727503 + 0j)
 
     def test_ce_k4(self):
@@ -52,6 +53,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         result = algo.compute_eigenvalues(operator=self.qubit_op, aux_operators=[])
         self.assertEqual(len(result.eigenvalues), 4)
         self.assertEqual(len(result.eigenstates), 4)
+        self.assertEqual(result.eigenvalues.dtype, np.float64)
         np.testing.assert_array_almost_equal(
             result.eigenvalues.real, [-1.85727503, -1.24458455, -0.88272215, -0.22491125]
         )
@@ -68,6 +70,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         result = algo.compute_eigenvalues(operator=self.qubit_op, aux_operators=[])
         self.assertEqual(len(result.eigenvalues), 2)
         self.assertEqual(len(result.eigenstates), 2)
+        self.assertEqual(result.eigenvalues.dtype, np.float64)
         np.testing.assert_array_almost_equal(result.eigenvalues.real, [-0.88272215, -0.22491125])
 
     def test_ce_k4_filtered_empty(self):

--- a/test/python/algorithms/test_numpy_minimum_eigen_solver.py
+++ b/test/python/algorithms/test_numpy_minimum_eigen_solver.py
@@ -46,7 +46,8 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         """Basic test"""
         algo = NumPyMinimumEigensolver()
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=self.aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
         self.assertEqual(len(result.aux_operator_eigenvalues), 2)
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
@@ -56,24 +57,28 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         # Start with no operator or aux_operators, give via compute method
         algo = NumPyMinimumEigensolver()
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
         self.assertIsNone(result.aux_operator_eigenvalues)
 
         # Add aux_operators and go again
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=self.aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
         self.assertEqual(len(result.aux_operator_eigenvalues), 2)
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
 
         # "Remove" aux_operators and go again
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
         self.assertIsNone(result.aux_operator_eigenvalues)
 
         # Set aux_operators and go again
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=self.aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
         self.assertEqual(len(result.aux_operator_eigenvalues), 2)
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
@@ -93,7 +98,8 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
         algo = NumPyMinimumEigensolver(filter_criterion=criterion)
         result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=self.aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -0.22491125 + 0j)
+        self.assertEqual(result.eigenvalue.dtype, np.float64)
+        self.assertAlmostEqual(result.eigenvalue, -0.22491125)
         self.assertEqual(len(result.aux_operator_eigenvalues), 2)
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
         np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

If NumPyEigensSolver knows that the given operator is hermitian, we should use eigh or eigsh.
The eigenvalue becomes float from complex.

### Details and comments


<img width="462" alt="image" src="https://user-images.githubusercontent.com/6814928/132302744-2bab4c4b-1ddc-4776-92e0-b66a02120065.png">
