### PR TITLE
Pre-compute name dictionary in ParameterExpression._apply_operation()

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -246,6 +246,9 @@ class ParameterExpression:
         self_expr = self._symbol_expr
 
         if isinstance(other, ParameterExpression):
+            if other._names is None:
+                other._names = {p.name: p for p in other._parameters}
+
             self._raise_if_parameter_names_conflict(other._parameter_symbols.keys())
 
             parameter_symbols = {**self._parameter_symbols, **other._parameter_symbols}
@@ -261,7 +264,12 @@ class ParameterExpression:
         else:
             expr = operation(self_expr, other_expr)
 
-        return ParameterExpression(parameter_symbols, expr)
+        out_expr = ParameterExpression(parameter_symbols, expr)
+        out_expr._names = self._names
+        if isinstance(other, ParameterExpression):
+            out_expr._names.update(other._names)
+
+        return out_expr
 
     def gradient(self, param) -> Union["ParameterExpression", complex]:
         """Get the derivative of a parameter expression w.r.t. a specified parameter expression.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the performance of growing a ParameterExpression by
adding an increasing number of Parameters by pre-computing the names
cache when it generates a new output expression. The most time spent in
adding a new parameter to an expression was spent traversing the list of
parameters in the old expression and checking for used names. This is
because the cache of names stored in the ParameterExpression was empty
for each new ParameterExpression created by applying an operation. Since
applying an operation will only ever be additive we can precompute this
cache when we generate the output by just reusing it and adding any
parameters from the other expression. This saves us from having to do a
traversal and instead just do a set intersection to find potentially
conflicting Parameters.


### Details and comments

Fixes #7027