### PR TITLE
Improve efficiency of RemoveFinalMeasurement transpiler pass

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -788,19 +788,18 @@ class DAGCircuit:
             Bit: Bit in idle wire.
         """
         if ignore is None:
-            ignore = []
+            ignore = set()
+        ignore_set = set(ignore)
         for wire in self._wires:
             if not ignore:
                 if isinstance(self.successors(self.input_map[wire]), DAGOutNode):
                     yield wire
             else:
-                count = 0
                 for node in self.nodes_on_wire(wire, only_ops=True):
-                    if node.op.name not in ignore:
-                        count += 1
+                    if node.op.name not in ignore_set:
                         # If we found an op node outside of ignore we can stop iterating over the wire
                         break
-                if count == 0:
+                else:
                     yield wire
 
     def size(self):

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -798,6 +798,8 @@ class DAGCircuit:
                 for node in self.nodes_on_wire(wire, only_ops=True):
                     if node.op.name not in ignore:
                         count += 1
+                        # If we found an op node outside of ignore we can stop iterating over the wire
+                        break
                 if count == 0:
                     yield wire
 

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -786,13 +786,22 @@ class DAGCircuit:
 
         Yields:
             Bit: Bit in idle wire.
+
+        Raises:
+            DAGCircuitError: If the DAG is invalid
         """
         if ignore is None:
             ignore = set()
         ignore_set = set(ignore)
         for wire in self._wires:
             if not ignore:
-                if isinstance(self.successors(self.input_map[wire]), DAGOutNode):
+                try:
+                    child = next(self.successors(self.input_map[wire]))
+                except StopIteration as e:
+                    raise DAGCircuitError(
+                        "Invalid dagcircuit input node %s has no output" % self.input_map[wire]
+                    ) from e
+                if isinstance(child, DAGOutNode):
                     yield wire
             else:
                 for node in self.nodes_on_wire(wire, only_ops=True):

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -790,13 +790,16 @@ class DAGCircuit:
         if ignore is None:
             ignore = []
         for wire in self._wires:
-            nodes = [
-                node
-                for node in self.nodes_on_wire(wire, only_ops=True)
-                if node.op.name not in ignore
-            ]
-            if len(nodes) == 0:
-                yield wire
+            if not ignore:
+                if isinstance(self.successors(self.input_map[wire]), DAGOutNode):
+                    yield wire
+            else:
+                count = 0
+                for node in self.nodes_on_wire(wire, only_ops=True):
+                    if node.op.name not in ignore:
+                        count += 1
+                if count == 0:
+                    yield wire
 
     def size(self):
         """Return the number of operations."""


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The RemoveFinalMeasurement was determining which operations were at the
end of a circuit quite inefficiently. It was searching over the entire
DAG to find barrier and measurement instructions and then checking any
that were found if they're children were output nodes. While instead
it'd be much more efficient to chack the parent of each output node for
whether it's a barrier or a measurement. Additionally, the output dag
was being needless rebuilt by modifying the input and then looping over
all nodes in the dag again and copy the node to a new dag. While instead
we can just return the modified input graph. This commit makes those
changes to improve the efficiency of the pass.

### Details and comments

Fixes #7038