### PR TITLE
Speed up `Optimize1qGatesSimpleCommutation`

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -942,6 +942,9 @@ class DAGCircuit:
                 in the input circuit. This order gets matched to the node wires
                 by qargs first, then cargs, then conditions.
 
+        Returns:
+            dict: maps node IDs from `input_dag` to their new node incarnations in `self`.
+
         Raises:
             DAGCircuitError: if met with unexpected predecessor/successors
         """
@@ -1074,7 +1077,7 @@ class DAGCircuit:
             node._node_id, in_dag._multi_graph, edge_map_fn, filter_fn, edge_weight_map
         )
 
-        # Iterate over nodes of input_circuit and update wiires in node objects migrated
+        # Iterate over nodes of input_circuit and update wires in node objects migrated
         # from in_dag
         for old_node_index, new_node_index in node_map.items():
             # update node attributes
@@ -1086,6 +1089,8 @@ class DAGCircuit:
             new_node._node_id = new_node_index
             new_node.op.condition = condition
             self._multi_graph[new_node_index] = new_node
+
+        return {k: self._multi_graph[v] for k, v in node_map.items()}
 
     def substitute_node(self, node, op, inplace=False):
         """Replace an DAGOpNode with a single instruction. qargs, cargs and

--- a/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
@@ -144,16 +144,16 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
             assert run_clone + commuted == run
             return run_clone, commuted
 
-    def _resynthesize(self, dag, new_run):
+    def _resynthesize(self, new_run):
         """
         Synthesizes an efficient circuit from a sequence `new_run` of `DAGOpNode`s.
 
         NOTE: Returns None when resynthesis is not possible.
         """
-        if 0 == len(new_run):
+        if len(new_run) == 0:
             return (), QuantumCircuit(1)
 
-        return self._optimize1q._resynthesize_run(dag, new_run)
+        return self._optimize1q._resynthesize_run(new_run)
 
     @staticmethod
     def _replace_subdag(dag, old_run, new_circ):
@@ -205,12 +205,12 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
 
             # re-synthesize
             new_preceding_basis, new_preceding_run = self._resynthesize(
-                dag, preceding_run + commuted_preceding
+                preceding_run + commuted_preceding
             )
             new_succeeding_basis, new_succeeding_run = self._resynthesize(
-                dag, commuted_succeeding + succeeding_run
+                commuted_succeeding + succeeding_run
             )
-            new_basis, new_run = self._resynthesize(dag, run_clone)
+            new_basis, new_run = self._resynthesize(run_clone)
 
             # perform the replacement if it was indeed a good idea
             if self._optimize1q._substitution_checks(

--- a/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
@@ -144,15 +144,16 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
             assert run_clone + commuted == run
             return run_clone, commuted
 
-    def _resynthesize(self, new_run):
+    def _resynthesize(self, dag, new_run):
         """
         Synthesizes an efficient circuit from a sequence `new_run` of `DAGOpNode`s.
-        """
 
-        new_circuit = QuantumCircuit(1)
-        for gate in new_run:
-            new_circuit.append(gate.op, [0])
-        return self._optimize1q(new_circuit)
+        NOTE: Returns None when resynthesis is not possible.
+        """
+        if 0 == len(new_run):
+            return (), QuantumCircuit(1)
+
+        return self._optimize1q._resynthesize_run(dag, new_run)
 
     @staticmethod
     def _replace_subdag(dag, old_run, new_circ):
@@ -162,20 +163,24 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
         """
 
         new_dag = circuit_to_dag(new_circ)
-        dag.substitute_node_with_dag(old_run[0], new_dag)
+        node_map = dag.substitute_node_with_dag(old_run[0], new_dag)
+
         for node in old_run[1:]:
             dag.remove_op_node(node)
 
+        spliced_run = [node_map[node._node_id] for node in new_dag.topological_op_nodes()]
+        mov_list(old_run, spliced_run)
+
     def _step(self, dag):
         """
-        Performs one unit of optimization work.
+        Performs one full pass of optimization work.
 
         Returns True if `dag` changed, False if no work on `dag` was possible.
         """
 
-        # NOTE: This next call is somewhat expensive, and it could be improved if
-        #       `dag.substitute_node_with_dag` returned the new (ordered) replacement node list.
         runs = dag.collect_1q_runs()
+        did_work = False
+
         for run in runs:
             # identify the preceding blocking gates
             run_clone = copy(run)
@@ -199,24 +204,34 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
                 )
 
             # re-synthesize
-            new_preceding_run = self._resynthesize(preceding_run + commuted_preceding)
-            new_succeeding_run = self._resynthesize(commuted_succeeding + succeeding_run)
-            new_run = self._resynthesize(run_clone)
-
-            # check whether this was actually a good idea
-            original_depth = len(run) + len(preceding_run) + len(succeeding_run)
-            new_depth = len(new_run) + len(new_preceding_run) + len(new_succeeding_run)
+            new_preceding_basis, new_preceding_run = self._resynthesize(
+                dag, preceding_run + commuted_preceding
+            )
+            new_succeeding_basis, new_succeeding_run = self._resynthesize(
+                dag, commuted_succeeding + succeeding_run
+            )
+            new_basis, new_run = self._resynthesize(dag, run_clone)
 
             # perform the replacement if it was indeed a good idea
-            if original_depth > new_depth:
-                if preceding_run != []:
+            if self._optimize1q._substitution_checks(
+                dag,
+                (preceding_run or []) + run + (succeeding_run or []),
+                (
+                    (new_preceding_run or QuantumCircuit(1)).data
+                    + (new_run or QuantumCircuit(1)).data
+                    + (new_succeeding_run or QuantumCircuit(1)).data
+                ),
+                new_basis + new_preceding_basis + new_succeeding_basis,
+            ):
+                if preceding_run and new_preceding_run is not None:
                     self._replace_subdag(dag, preceding_run, new_preceding_run)
-                if succeeding_run != []:
+                if succeeding_run and new_succeeding_run is not None:
                     self._replace_subdag(dag, succeeding_run, new_succeeding_run)
-                self._replace_subdag(dag, run, new_run)
-                return True
+                if new_run is not None:
+                    self._replace_subdag(dag, run, new_run)
+                did_work = True
 
-        return False
+        return did_work
 
     def run(self, dag):
         """
@@ -234,3 +249,13 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
                 break
 
         return dag
+
+
+def mov_list(destination, source):
+    """
+    Replace `destination` in-place with `source`.
+    """
+
+    while destination:
+        del destination[0]
+    destination += source

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -64,13 +64,12 @@ class Optimize1qGatesDecomposition(TransformationPass):
                             tuple(gates)
                         ] = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis_name)
 
-    def _resynthesize_run(self, dag, run):
+    def _resynthesize_run(self, run):
         """
-        Resynthesizes one `run` from `dag`, typically extracted via `dag.collect_1q_runs`.
+        Resynthesizes one `run`, typically extracted via `dag.collect_1q_runs`.
 
-        Returns:
-            (basis, circuit) containing the newly synthesized circuit in the indicated basis.
-            (None, None) if no synthesis routine applied.
+        Returns (basis, circuit) containing the newly synthesized circuit in the indicated basis, or
+        (None, None) if no synthesis routine applied.
         """
 
         operator = run[0].op.to_matrix()
@@ -164,7 +163,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
                 if "u2" not in self._target_basis and "u1" not in self._target_basis:
                     continue
 
-            new_basis, new_circ = self._resynthesize_run(dag, run)
+            new_basis, new_circ = self._resynthesize_run(run)
 
             if new_circ is not None and self._substitution_checks(dag, run, new_circ, new_basis):
                 new_dag = circuit_to_dag(new_circ)

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -64,6 +64,80 @@ class Optimize1qGatesDecomposition(TransformationPass):
                             tuple(gates)
                         ] = one_qubit_decompose.OneQubitEulerDecomposer(euler_basis_name)
 
+    def _resynthesize_run(self, dag, run):
+        """
+        Resynthesizes one `run` from `dag`, typically extracted via `dag.collect_1q_runs`.
+
+        Returns:
+            (basis, circuit) containing the newly synthesized circuit in the indicated basis.
+            (None, None) if no synthesis routine applied.
+        """
+
+        operator = run[0].op.to_matrix()
+        for gate in run[1:]:
+            operator = gate.op.to_matrix().dot(operator)
+
+        new_circs = {k: v._decompose(operator) for k, v in self._decomposers.items()}
+
+        new_basis, new_circ = None, None
+        if len(new_circs) > 0:
+            new_basis, new_circ = min(new_circs.items(), key=lambda x: len(x[1]))
+
+        return new_basis, new_circ
+
+    def _substitution_checks(self, dag, old_run, new_circ, new_basis):
+        """
+        Returns `True` when it is recommended to replace `old_run` with `new_circ`.
+        """
+
+        if new_circ is None:
+            return False
+
+        # do we even have calibrations?
+        has_cals_p = dag.calibrations is not None and len(dag.calibrations) > 0
+        # is this run in the target set of this particular decomposer and also uncalibrated?
+        rewriteable_and_in_basis_p = all(
+            g.name in new_basis and (not has_cals_p or not dag.has_calibration_for(g))
+            for g in old_run
+        )
+        # does this run have uncalibrated gates?
+        uncalibrated_p = not has_cals_p or any(not dag.has_calibration_for(g) for g in old_run)
+        # does this run have gates not in the image of ._decomposers _and_ uncalibrated?
+        uncalibrated_and_not_basis_p = any(
+            g.name not in self._target_basis and (not has_cals_p or not dag.has_calibration_for(g))
+            for g in old_run
+        )
+
+        if rewriteable_and_in_basis_p and len(old_run) < len(new_circ):
+            # NOTE: This is short-circuited on calibrated gates, which we're timid about
+            #       reducing.
+            warnings.warn(
+                f"Resynthesized {old_run} and got {new_circ}, "
+                f"but the original was native and the new value is longer.  This "
+                f"indicates an efficiency bug in synthesis.  Please report it by "
+                f"opening an issue here: "
+                f"https://github.com/Qiskit/qiskit-terra/issues/new/choose",
+                stacklevel=2,
+            )
+
+        # if we're outside of the basis set, we're obligated to logically decompose.
+        # if we're outside of the set of gates for which we have physical definitions,
+        #    then we _try_ to decompose, using the results if we see improvement.
+        # NOTE: Here we use circuit length as a weak proxy for "improvement"; in reality,
+        #       we care about something more like fidelity at runtime, which would mean,
+        #       e.g., a preference for `RZGate`s over `RXGate`s.  In fact, users sometimes
+        #       express a preference for a "canonical form" of a circuit, which may come in
+        #       the form of some parameter values, also not visible at the level of circuit
+        #       length.  Since we don't have a framework for the caller to programmatically
+        #       express what they want here, we include some special casing for particular
+        #       gates which we've promised to normalize --- but this is fragile and should
+        #       ultimately be done away with.
+        return (
+            uncalibrated_and_not_basis_p
+            or (uncalibrated_p and len(old_run) > len(new_circ))
+            or isinstance(old_run[0].op, U3Gate)
+        )
+
     def run(self, dag):
         """Run the Optimize1qGatesDecomposition pass on `dag`.
 
@@ -76,6 +150,7 @@ class Optimize1qGatesDecomposition(TransformationPass):
         if self._decomposers is None:
             logger.info("Skipping pass because no basis is set")
             return dag
+
         runs = dag.collect_1q_runs()
         for run in runs:
             # SPECIAL CASE: Don't bother to optimize single U3 gates which are in the basis set.
@@ -89,62 +164,13 @@ class Optimize1qGatesDecomposition(TransformationPass):
                 if "u2" not in self._target_basis and "u1" not in self._target_basis:
                     continue
 
-            operator = run[0].op.to_matrix()
-            for gate in run[1:]:
-                operator = gate.op.to_matrix().dot(operator)
+            new_basis, new_circ = self._resynthesize_run(dag, run)
 
-            new_circs = {k: v._decompose(operator) for k, v in self._decomposers.items()}
+            if new_circ is not None and self._substitution_checks(dag, run, new_circ, new_basis):
+                new_dag = circuit_to_dag(new_circ)
+                dag.substitute_node_with_dag(run[0], new_dag)
+                # Delete the other nodes in the run
+                for current_node in run[1:]:
+                    dag.remove_op_node(current_node)
 
-            if len(new_circs) > 0:
-                new_basis, new_circ = min(new_circs.items(), key=lambda x: len(x[1]))
-
-                # do we even have calibrations?
-                has_cals_p = dag.calibrations is not None and len(dag.calibrations) > 0
-                # is this run in the target set of this particular decomposer and also uncalibrated?
-                rewriteable_and_in_basis_p = all(
-                    g.name in new_basis and (not has_cals_p or not dag.has_calibration_for(g))
-                    for g in run
-                )
-                # does this run have uncalibrated gates?
-                uncalibrated_p = not has_cals_p or any(not dag.has_calibration_for(g) for g in run)
-                # does this run have gates not in the image of ._decomposers _and_ uncalibrated?
-                uncalibrated_and_not_basis_p = any(
-                    g.name not in self._target_basis
-                    and (not has_cals_p or not dag.has_calibration_for(g))
-                    for g in run
-                )
-
-                if rewriteable_and_in_basis_p and len(run) < len(new_circ):
-                    # NOTE: This is short-circuited on calibrated gates, which we're timid about
-                    #       reducing.
-                    warnings.warn(
-                        f"Resynthesized {run} and got {new_circ}, "
-                        f"but the original was native and the new value is longer.  This "
-                        f"indicates an efficiency bug in synthesis.  Please report it by "
-                        f"opening an issue here: "
-                        f"https://github.com/Qiskit/qiskit-terra/issues/new/choose",
-                        stacklevel=2,
-                    )
-                # if we're outside of the basis set, we're obligated to logically decompose.
-                # if we're outside of the set of gates for which we have physical definitions,
-                #    then we _try_ to decompose, using the results if we see improvement.
-                # NOTE: Here we use circuit length as a weak proxy for "improvement"; in reality,
-                #       we care about something more like fidelity at runtime, which would mean,
-                #       e.g., a preference for `RZGate`s over `RXGate`s.  In fact, users sometimes
-                #       express a preference for a "canonical form" of a circuit, which may come in
-                #       the form of some parameter values, also not visible at the level of circuit
-                #       length.  Since we don't have a framework for the caller to programmatically
-                #       express what they want here, we include some special casing for particular
-                #       gates which we've promised to normalize --- but this is fragile and should
-                #       ultimately be done away with.
-                if (
-                    uncalibrated_and_not_basis_p
-                    or (uncalibrated_p and len(run) > len(new_circ))
-                    or isinstance(run[0].op, U3Gate)
-                ):
-                    new_dag = circuit_to_dag(new_circ)
-                    dag.substitute_node_with_dag(run[0], new_dag)
-                    # Delete the other nodes in the run
-                    for current_node in run[1:]:
-                        dag.remove_op_node(current_node)
         return dag


### PR DESCRIPTION
### Summary

This PR follows on from #6992 , speeding it up.

### Details and comments

In #6992, we conservatively modified one 1Q run, treated the whole lot as invalidated, and re-started from scratch. This caused a lot of re-re-...-re-synthesis of 1Q runs which were analyzed early on, as well as a lot of calls to `collect_1q_runs`. Additionally, we weren't particularly careful about how frequently we converted synthesis output between its circuit and DAG representations, which added substantial overhead. This PR addresses both of these points.

Aside from the pass introduced in #6992, the main place where this PR touches existing code is in `DAGCircuit.substitute_node_with_dag`, which now returns a dictionary mapping the node IDs from the input DAG to the corresponding newly minted nodes in the target DAG. This lets us modify the standing output of `collect_1q_runs` to maintain its validity across run substitutions. I'm not _completely_ comfortable with this change: it relies on the `DAGNode._node_id` property, which is marked as private (though that same information is indirectly exposed through `DAGNode.__str__`).

Since #6992 hasn't seen release yet and this PR adds no new features + fixes no new bugs, I elected not to add a changelog entry.
