### PR TITLE
Fix handling of .stestr caching for linux py37 job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -193,6 +193,7 @@ stages:
             mkdir -p /tmp/terra-tests
             cp -r test /tmp/terra-tests/.
             cp .stestr.conf /tmp/terra-tests/.
+            cp -r .stestr /tmp/terra-tests/. || :
             sudo apt install -y graphviz
             pip check
           displayName: 'Install dependencies'
@@ -225,11 +226,12 @@ stages:
             pushd /tmp/terra-tests
             mkdir -p junit
             stestr last --subunit | ./subunit_to_junit.py -o junit/test-results.xml
-            popd
-            cp -r /tmp/terra-tests/junit .
             pushd .stestr
             ls | grep -P "^\d" | xargs -d "\n" rm -f
             popd
+            popd
+            cp -r /tmp/terra-tests/junit .
+            cp -r /tmp/terra-tests/.stestr .
           condition: succeededOrFailed()
           displayName: 'Generate results'
         - task: PublishTestResults@2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the linux py37 CI job ever since #6175 we build an sdist and then
install that in a venv manually in a test /tmp directory we create for
running the tests. However, as part of that we were handling the .stestr
history caching incorrectly. We cache the .stestr directory's times.dbm
files (which contain a record of the most recent run time for each test)
to provide scheduler hints to stest in future runs. But, instead of
updating the .stestr cache with the data from the run we were just
re-populating the data we pulled from the cache. This has also been
somewhat error prone because in some cases the cache isn't downloaded
correctly and will cause an error when we try to remove unnecessary files
from the cache and the .stestr directory doesn't exist, presumably
because azure didn't pull it from the cache correctly. This commit fixes
the issue by updating the generate results post processing step to
correctly copy the most recent data to the cached path after the run.

### Details and comments