### PR TITLE
Fix calling convention of `PulseSimulator.run`

### DIFF
--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -140,7 +140,7 @@ class FakeBackend(BackendV1):
 
                 system_model = PulseSystemModel.from_backend(self)
                 sim = aer.Aer.get_backend("pulse_simulator")
-                job = sim.run(circuits, system_model, **kwargs)
+                job = sim.run(circuits, system_model=system_model, **kwargs)
             else:
                 sim = aer.Aer.get_backend("qasm_simulator")
                 if self.properties():


### PR DESCRIPTION
### Summary

Previously the `system_model` parameter was being passed positionally,
but this was filling in the `validate` parameter in Aer's
`PulseSimulator`, rather than the intended slot.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #7059.
