### PR TITLE
Add hexagonal lattice CouplingMap

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -369,7 +369,7 @@ class CouplingMap:
             distance, bidirectional=bidirectional
         )
         return cmap
-    
+
     @classmethod
     def from_hexagonal_lattice(cls, rows, cols, bidirectional=True):
         """Return a hexagonal lattice graph coupling map.

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -369,6 +369,25 @@ class CouplingMap:
             distance, bidirectional=bidirectional
         )
         return cmap
+    
+    @classmethod
+    def from_hexagonal_lattice(cls, rows, cols, bidirectional=True):
+        """Return a hexagonal lattice graph coupling map.
+
+        Args:
+            rows (int): The number of rows to generate the graph with.
+            cols (int): The number of columns to generate the graph with.
+            bidirectional (bool): Whether the edges in the output coupling
+                graph are bidirectional or not. By default this is set to
+                ``True``
+        Returns:
+            CouplingMap: A hexagonal lattice coupling graph
+        """
+        cmap = cls(description="hexagonal-lattice")
+        cmap.graph = rx.generators.directed_hexagonal_lattice_graph(
+            rows, cols, bidirectional=bidirectional
+        )
+        return cmap
 
     def largest_connected_component(self):
         """Return a set of qubits in the largest connected component."""

--- a/releasenotes/notes/add-hexagonal-lattice-couplingmap-d3b65b146b6cd1d1.yaml
+++ b/releasenotes/notes/add-hexagonal-lattice-couplingmap-d3b65b146b6cd1d1.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Add a new constructor method, :meth: `~qiskit.transpiler.CouplingMap.from_hexagonal_lattice`, to
+    the :class:`~qiskit.transpiler.CouplingMap` class.
+
+    For example:
+
+    .. jupyter-execute::
+      from qiskit.transpiler import CouplingMap
+      cmap = CouplingMap.from_hexagonal_lattice(2, 2)
+      cmap.draw()

--- a/releasenotes/notes/add-hexagonal-lattice-couplingmap-d3b65b146b6cd1d1.yaml
+++ b/releasenotes/notes/add-hexagonal-lattice-couplingmap-d3b65b146b6cd1d1.yaml
@@ -7,6 +7,7 @@ features:
     For example:
 
     .. jupyter-execute::
+
       from qiskit.transpiler import CouplingMap
       cmap = CouplingMap.from_hexagonal_lattice(2, 2)
       cmap.draw()

--- a/test/python/transpiler/test_coupling.py
+++ b/test/python/transpiler/test_coupling.py
@@ -356,6 +356,77 @@ class CouplingTest(QiskitTestCase):
         ]
         self.assertEqual(set(edges), set(expected))
 
+    def test_hexagonal_lattice_2_2_factory(self):
+        coupling = CouplingMap.from_hexagonal_lattice(2, 2, bidirectional=False)
+        edges = coupling.get_edges()
+        expected = [
+            (0, 1),
+            (1, 2),
+            (2, 3),
+            (3, 4),
+            (5, 6),
+            (6, 7),
+            (7, 8),
+            (8, 9),
+            (9, 10),
+            (11, 12),
+            (12, 13),
+            (13, 14),
+            (14, 15),
+            (0, 5),
+            (2, 7),
+            (4, 9),
+            (6, 11),
+            (8, 13),
+            (10, 15),
+        ]
+        self.assertEqual(set(edges), set(expected))
+
+    def test_hexagonal_lattice_2_2_factory_bidirectional(self):
+        coupling = CouplingMap.from_hexagonal_lattice(2, 2, bidirectional=True)
+        edges = coupling.get_edges()
+        expected = [
+            (0, 1),
+            (1, 0),
+            (1, 2),
+            (2, 1),
+            (2, 3),
+            (3, 2),
+            (3, 4),
+            (4, 3),
+            (5, 6),
+            (6, 5),
+            (6, 7),
+            (7, 6),
+            (7, 8),
+            (8, 7),
+            (8, 9),
+            (9, 8),
+            (9, 10),
+            (10, 9),
+            (11, 12),
+            (12, 11),
+            (12, 13),
+            (13, 12),
+            (13, 14),
+            (14, 13),
+            (14, 15),
+            (15, 14),
+            (0, 5),
+            (5, 0),
+            (2, 7),
+            (7, 2),
+            (4, 9),
+            (9, 4),
+            (6, 11),
+            (11, 6),
+            (8, 13),
+            (13, 8),
+            (10, 15),
+            (15, 10),
+        ]
+        self.assertEqual(set(edges), set(expected))
+
     def test_subgraph(self):
         coupling = CouplingMap.from_line(6, bidirectional=False)
         with self.assertWarns(DeprecationWarning):


### PR DESCRIPTION
### Summary

Adds `qiskit.transpiler.CouplingMap.from_hexagonal_lattice`.

### Details and comments

Add `qiskit.transpiler.CouplingMap.from_hexagonal_lattice`, which generates a hexagonal lattice as a coupling map.
