### PR TITLE
Fix cif bit bundle test

### DIFF
--- a/test/python/visualization/references/test_latex_cif_single_bit_bundle.tex
+++ b/test/python/visualization/references/test_latex_cif_single_bit_bundle.tex
@@ -6,8 +6,8 @@
 \begin{document}
 \scalebox{1.0}{
 \Qcircuit @C=1.0em @R=0.2em @!R { \\
-	 	\nghost{ {qr}_{0} :  } & \lstick{ {qr}_{0} :  } & \qw & \gate{\mathrm{H}} & \qw & \qw & \qw\\
-	 	\nghost{ {qr}_{1} :  } & \lstick{ {qr}_{1} :  } & \qw & \qw & \gate{\mathrm{X}} & \qw & \qw\\
-	 	\nghost{cr:} & \lstick{cr:} & \lstick{/_{_{2}}} \cw & \control \cw^(0.0){^{\mathtt{cr_1=F}}} \cwx[-2] & \control \cw^(0.0){^{\mathtt{cr_0=T}}} \cwx[-1] & \cw & \cw\\
+	 	\nghost{{qr}_{0} :  } & \lstick{{qr}_{0} :  } & \qw & \gate{\mathrm{H}} & \qw & \qw & \qw\\
+	 	\nghost{{qr}_{1} :  } & \lstick{{qr}_{1} :  } & \qw & \qw & \gate{\mathrm{X}} & \qw & \qw\\
+	 	\nghost{\mathrm{cr :  }} & \lstick{\mathrm{cr :  }} & \lstick{/_{_{2}}} \cw & \control \cw^(0.0){^{\mathtt{cr_1=F}}} \cwx[-2] & \control \cw^(0.0){^{\mathtt{cr_0=T}}} \cwx[-1] & \cw & \cw\\
 \\ }}
 \end{document}

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -572,6 +572,8 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         circuit.x(qr[1]).c_if(cr[0], 1)
         circuit_drawer(circuit, cregbundle=True, filename=filename, output="latex_source")
 
+        self.assertEqualToReference(filename)
+
     def test_registerless_one_bit(self):
         """Text circuit with one-bit registers and registerless bits."""
         from qiskit.circuit import Qubit, Clbit


### PR DESCRIPTION
### Summary

Add the assertion that the generated file is equal to the reference, and
correct the reference file, from its inclusion in #6248.

The extra spacing added in the identifiers is consistent with a similar
fix made to `test_latex_cif_single_bit.tex` within that PR, and the
inclusion of the additional `\mathrm` macros appears to be a deliberate
choice for bundles specifically (in `qiskit/visualization/latex.py`,
current lines 247--248).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #7063.

