### PR TITLE
Disallow `ddt==1.4.3`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,4 @@ decorator==4.4.2
 jax==0.2.13
 jaxlib==0.1.67
 networkx==2.5
+ddt!=1.4.3


### PR DESCRIPTION
### Summary


This version of ddt changed the signature of `ddt.idata`, to add a
second positional argument with no default.  This makes use of that
function incompatible between different versions of `ddt`, so it's no
longer safe to use in CI, and for local builds.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments


Fix #7066 by the backdoor - the best solution is probably to PR to `ddt` itself, though 1.4.3 will still be broken for us.
