### PR TITLE
Pin CI Mac images to 10.15

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
             TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-      pool: {vmImage: 'macOS-latest'}
+      pool: {vmImage: 'macOS-10.15'}
       variables:
         python.version: '3.7'
         CIBW_BEFORE_BUILD: pip install -U Cython
@@ -92,7 +92,7 @@ stages:
           TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'macos_arm'
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
-      pool: {vmImage: 'macOS-latest'}
+      pool: {vmImage: 'macOS-10.15'}
       variables:
         python.version: '3.7'
         CIBW_BEFORE_BUILD: pip install -U Cython
@@ -344,7 +344,7 @@ stages:
             Parallel: true
             ParallelCount: 8
     - job: 'MacOS_Catalina_Tests'
-      pool: {vmImage: 'macOS-latest'}
+      pool: {vmImage: 'macOS-10.15'}
       strategy:
         matrix:
           Python37:
@@ -668,7 +668,7 @@ stages:
             testResultsFiles: '**/test-*.xml'
             testRunTitle: 'Test results for Linux Python $(python.version)'
     - job: 'MacOS_Catalina_Tests'
-      pool: {vmImage: 'macOS-latest'}
+      pool: {vmImage: 'macOS-10.15'}
       strategy:
         matrix:
           Python36:


### PR DESCRIPTION
### Summary

Currently, the images are just set to `macOS-latest`, which resolves to
10.15, so this has no immediate change in behaviour.  However, the
GitHub/Azure images will soon be moving `macOS-latest` to 11.x, and
those images do not have built-in Python 3.6 support.  Terra 0.19 will
still support Python 3.6, so we need to maintain a suitable testing
environment for it, and with Terra being (mostly) a Python-only package,
the 11.x/10.15 difference should not be as important as the different
Python versions.

See actions/virtual-environments#4060.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

FIx #7073.  I don't imagine we'll make another patch release now after 0.18.3, but it's probably best to be safe an backport this, just in case.

It would in theory be possible to get a Python 3.6 build on macOS 11, but in practice it would require fairly significant changes to how we set up our CI VMs (e.g. use conda / manually install from python.org / something), which just isn't worth it.