### PR TITLE
Fix #7006 by tracking availability of clbits in scheduling

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -33,6 +33,7 @@ The circuit itself keeps this context.
 import warnings
 import copy
 from itertools import zip_longest
+from typing import Iterable
 
 import numpy
 
@@ -528,3 +529,13 @@ class Instruction:
             qc.data = [(self, qargs[:], cargs[:])] * n
         instruction.definition = qc
         return instruction
+
+    @property
+    def condition_bits(self) -> Iterable[Clbit]:
+        """Get Clbits in condition."""
+        if self.condition is None:
+            return []
+        if isinstance(self.condition[0], Clbit):
+            return [self.condition[0]]
+        else:  # ClassicalRegister
+            return self.condition[0]

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1980,12 +1980,8 @@ class QuantumCircuit:
                 num_touched = 0
                 # Controls necessarily join all the cbits in the
                 # register that they use.
-                if instr.condition and not unitary_only:
-                    if isinstance(instr.condition[0], Clbit):
-                        condition_bits = [instr.condition[0]]
-                    else:
-                        condition_bits = instr.condition[0]
-                    for bit in condition_bits:
+                if not unitary_only:
+                    for bit in instr.condition_bits:
                         idx = bit_indices[bit]
                         for k in range(num_sub_graphs):
                             if idx in sub_graphs[k]:

--- a/qiskit/transpiler/passes/scheduling/alap.py
+++ b/qiskit/transpiler/passes/scheduling/alap.py
@@ -11,14 +11,16 @@
 # that they have been altered from the originals.
 
 """ALAP Scheduling."""
+import itertools
 from collections import defaultdict
 from typing import List
-from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
-from qiskit.circuit.delay import Delay
+
+from qiskit.circuit import Delay, Measure
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
 
 
 class ALAPSchedule(TransformationPass):
@@ -58,6 +60,8 @@ class ALAPSchedule(TransformationPass):
             new_dag.add_creg(creg)
 
         qubit_time_available = defaultdict(int)
+        clbit_readable = defaultdict(int)
+        clbit_writeable = defaultdict(int)
 
         def pad_with_delays(qubits: List[int], until, unit) -> None:
             """Pad idle time-slots in ``qubits`` with delays in ``unit`` until ``until``."""
@@ -68,11 +72,6 @@ class ALAPSchedule(TransformationPass):
 
         bit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
         for node in reversed(list(dag.topological_op_nodes())):
-            start_time = max(qubit_time_available[q] for q in node.qargs)
-            pad_with_delays(node.qargs, until=start_time, unit=time_unit)
-
-            new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
-
             # validate node.op.duration
             if node.op.duration is None:
                 indices = [bit_indices[qarg] for qarg in node.qargs]
@@ -85,11 +84,30 @@ class ALAPSchedule(TransformationPass):
                     f"Parameterized duration ({node.op.duration}) "
                     f"of {node.op.name} on qubits {indices} is not bounded."
                 )
+            # choose appropriate clbit available time depending on op
+            clbit_time_available = clbit_writeable if isinstance(node.op, Measure) else clbit_readable
+            # correction to change clbit start time to qubit start time
+            start_delta = 0 if isinstance(node.op, Measure) else node.op.duration
+            # must wait for op.condition_bits as well as node.cargs
+            start_time = max(
+                itertools.chain(
+                    (qubit_time_available[q] for q in node.qargs),
+                    (clbit_time_available[c] - start_delta for c in node.cargs + node.op.condition_bits),
+                )
+            )
+
+            pad_with_delays(node.qargs, until=start_time, unit=time_unit)
+
+            new_dag.apply_operation_front(node.op, node.qargs, node.cargs)
 
             stop_time = start_time + node.op.duration
             # update time table
             for q in node.qargs:
                 qubit_time_available[q] = stop_time
+            for c in node.cargs:  # measure
+                clbit_writeable[c] = clbit_readable[c] = start_time
+            for c in node.op.condition_bits:  # conditional op
+                clbit_writeable[c] = stop_time
 
         working_qubits = qubit_time_available.keys()
         circuit_duration = max(qubit_time_available[q] for q in working_qubits)

--- a/qiskit/transpiler/passes/scheduling/asap.py
+++ b/qiskit/transpiler/passes/scheduling/asap.py
@@ -11,14 +11,16 @@
 # that they have been altered from the originals.
 
 """ASAP Scheduling."""
+import itertools
 from collections import defaultdict
 from typing import List
-from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
-from qiskit.circuit.delay import Delay
+
+from qiskit.circuit import Delay, Measure
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.transpiler.passes.scheduling.time_unit_conversion import TimeUnitConversion
 
 
 class ASAPSchedule(TransformationPass):
@@ -59,6 +61,8 @@ class ASAPSchedule(TransformationPass):
             new_dag.add_creg(creg)
 
         qubit_time_available = defaultdict(int)
+        clbit_readable = defaultdict(int)
+        clbit_writeable = defaultdict(int)
 
         def pad_with_delays(qubits: List[int], until, unit) -> None:
             """Pad idle time-slots in ``qubits`` with delays in ``unit`` until ``until``."""
@@ -67,13 +71,8 @@ class ASAPSchedule(TransformationPass):
                     idle_duration = until - qubit_time_available[q]
                     new_dag.apply_operation_back(Delay(idle_duration, unit), [q])
 
-        bit_indices = {bit: index for index, bit in enumerate(dag.qubits)}
+        bit_indices = {q: index for index, q in enumerate(dag.qubits)}
         for node in dag.topological_op_nodes():
-            start_time = max(qubit_time_available[q] for q in node.qargs)
-            pad_with_delays(node.qargs, until=start_time, unit=time_unit)
-
-            new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
-
             # validate node.op.duration
             if node.op.duration is None:
                 indices = [bit_indices[qarg] for qarg in node.qargs]
@@ -86,11 +85,30 @@ class ASAPSchedule(TransformationPass):
                     f"Parameterized duration ({node.op.duration}) "
                     f"of {node.op.name} on qubits {indices} is not bounded."
                 )
+            # choose appropriate clbit available time depending on op
+            clbit_time_available = clbit_writeable if isinstance(node.op, Measure) else clbit_readable
+            # correction to change clbit start time to qubit start time
+            start_delta = node.op.duration if isinstance(node.op, Measure) else 0
+            # must wait for op.condition_bits as well as node.cargs
+            start_time = max(
+                itertools.chain(
+                    (qubit_time_available[q] for q in node.qargs),
+                    (clbit_time_available[c] - start_delta for c in node.cargs + node.op.condition_bits),
+                )
+            )
+
+            pad_with_delays(node.qargs, until=start_time, unit=time_unit)
+
+            new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
 
             stop_time = start_time + node.op.duration
             # update time table
             for q in node.qargs:
                 qubit_time_available[q] = stop_time
+            for c in node.cargs:  # measure
+                clbit_writeable[c] = clbit_readable[c] = stop_time
+            for c in node.op.condition_bits:  # conditional op
+                clbit_writeable[c] = start_time
 
         working_qubits = qubit_time_available.keys()
         circuit_duration = max(qubit_time_available[q] for q in working_qubits)

--- a/qiskit/transpiler/passes/scheduling/instruction_alignment.py
+++ b/qiskit/transpiler/passes/scheduling/instruction_alignment.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """Align measurement instructions."""
-
+import itertools
 import warnings
 from collections import defaultdict
 from typing import List, Union
@@ -20,8 +20,8 @@ from qiskit.circuit.delay import Delay
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.measure import Measure
 from qiskit.circuit.parameterexpression import ParameterExpression
-from qiskit.pulse import Play
 from qiskit.dagcircuit import DAGCircuit
+from qiskit.pulse import Play
 from qiskit.transpiler.basepasses import TransformationPass, AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 
@@ -133,8 +133,10 @@ class AlignMeasures(TransformationPass):
         # * pad_with_delay is called only with non-delay node to avoid consecutive delay
         new_dag = dag._copy_circuit_metadata()
 
-        qubit_time_available = defaultdict(int)
-        qubit_stop_times = defaultdict(int)
+        qubit_time_available = defaultdict(int)  # to track op start time
+        qubit_stop_times = defaultdict(int)  # to track delay start time for padding
+        clbit_readable = defaultdict(int)
+        clbit_writeable = defaultdict(int)
 
         def pad_with_delays(qubits: List[int], until, unit) -> None:
             """Pad idle time-slots in ``qubits`` with delays in ``unit`` until ``until``."""
@@ -144,25 +146,35 @@ class AlignMeasures(TransformationPass):
                     new_dag.apply_operation_back(Delay(idle_duration, unit), [q])
 
         for node in dag.topological_op_nodes():
-            start_time = max(qubit_time_available[q] for q in node.qargs)
+            # choose appropriate clbit available time depending on op
+            clbit_time_available = clbit_writeable if isinstance(node.op, Measure) else clbit_readable
+            # correction to change clbit start time to qubit start time
+            start_delta = node.op.duration if isinstance(node.op, Measure) else 0
+            start_time = max(
+                itertools.chain(
+                    (qubit_time_available[q] for q in node.qargs),
+                    (clbit_time_available[c] - start_delta for c in node.cargs + node.op.condition_bits),
+                )
+            )
 
             if isinstance(node.op, Measure):
                 if start_time % self.alignment != 0:
                     start_time = ((start_time // self.alignment) + 1) * self.alignment
 
-            if not isinstance(node.op, Delay):
+            if not isinstance(node.op, Delay):  # exclude delays for combining consecutive delays
                 pad_with_delays(node.qargs, until=start_time, unit=time_unit)
                 new_dag.apply_operation_back(node.op, node.qargs, node.cargs)
 
-                stop_time = start_time + node.op.duration
-                # update time table
-                for q in node.qargs:
-                    qubit_time_available[q] = stop_time
+            stop_time = start_time + node.op.duration
+            # update time table
+            for q in node.qargs:
+                qubit_time_available[q] = stop_time
+                if not isinstance(node.op, Delay):
                     qubit_stop_times[q] = stop_time
-            else:
-                stop_time = start_time + node.op.duration
-                for q in node.qargs:
-                    qubit_time_available[q] = stop_time
+            for c in node.cargs:  # measure
+                clbit_writeable[c] = clbit_readable[c] = stop_time
+            for c in node.op.condition_bits:  # conditional op
+                clbit_writeable[c] = start_time
 
         working_qubits = qubit_time_available.keys()
         circuit_duration = max(qubit_time_available[q] for q in working_qubits)

--- a/test/python/transpiler/test_scheduling_pass.py
+++ b/test/python/transpiler/test_scheduling_pass.py
@@ -14,14 +14,15 @@
 
 import unittest
 
+from ddt import ddt, data
 from qiskit import QuantumCircuit
+from qiskit.test import QiskitTestCase
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.passes import ASAPSchedule, ALAPSchedule
 from qiskit.transpiler.passmanager import PassManager
 
-from qiskit.test import QiskitTestCase
 
-
+@ddt
 class TestSchedulingPass(QiskitTestCase):
     """Tests the Scheduling passes"""
 
@@ -47,6 +48,201 @@ class TestSchedulingPass(QiskitTestCase):
 
         self.assertEqual(alap_qc, new_qc)
 
+    @data(ALAPSchedule, ASAPSchedule)
+    def test_classically_controlled_gate_after_measure(self, SchedulePass):
+        """Test if ALAP/ASAP schedules circuits with c_if after measure with a common clbit.
+        See: https://github.com/Qiskit/qiskit-terra/issues/7006
+
+        (input)
+             ┌─┐
+        q_0: ┤M├───────────
+             └╥┘   ┌───┐
+        q_1: ─╫────┤ X ├───
+              ║    └─╥─┘
+              ║ ┌────╨────┐
+        c: 1/═╩═╡ c_0 = T ╞
+              0 └─────────┘
+
+        (scheduled)
+                                ┌─┐┌────────────────┐
+        q_0: ───────────────────┤M├┤ Delay(200[dt]) ├
+             ┌─────────────────┐└╥┘└─────┬───┬──────┘
+        q_1: ┤ Delay(1000[dt]) ├─╫───────┤ X ├───────
+             └─────────────────┘ ║       └─╥─┘
+                                 ║    ┌────╨────┐
+        c: 1/════════════════════╩════╡ c_0 = T ╞════
+                                 0    └─────────┘
+        """
+        qc = QuantumCircuit(2, 1)
+        qc.measure(0, 0)
+        qc.x(1).c_if(0, 1)
+
+        durations = InstructionDurations([("x", None, 200), ("measure", None, 1000)])
+        pm = PassManager(SchedulePass(durations))
+        scheduled = pm.run(qc)
+
+        self.assertEqual(1000, scheduled.qubit_start_time(1))  # x.c_if starts after measure
+
+    @data(ALAPSchedule, ASAPSchedule)
+    def test_measure_after_measure(self, SchedulePass):
+        """Test if ALAP/ASAP schedules circuits with measure after measure with a common clbit.
+        See: https://github.com/Qiskit/qiskit-terra/issues/7006
+
+        (input)
+             ┌───┐┌─┐
+        q_0: ┤ X ├┤M├───
+             └───┘└╥┘┌─┐
+        q_1: ──────╫─┤M├
+                   ║ └╥┘
+        c: 1/══════╩══╩═
+                   0  0
+
+        (scheduled)
+                    ┌───┐       ┌─┐┌─────────────────┐
+        q_0: ───────┤ X ├───────┤M├┤ Delay(1000[dt]) ├
+             ┌──────┴───┴──────┐└╥┘└───────┬─┬───────┘
+        q_1: ┤ Delay(1200[dt]) ├─╫─────────┤M├────────
+             └─────────────────┘ ║         └╥┘
+        c: 1/════════════════════╩══════════╩═════════
+                                 0          0
+        """
+        qc = QuantumCircuit(2, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        qc.measure(1, 0)
+
+        durations = InstructionDurations([("x", None, 200), ("measure", None, 1000)])
+        pm = PassManager(SchedulePass(durations))
+        scheduled = pm.run(qc)
+
+        self.assertEqual(1200, scheduled.qubit_stop_time(0))  # 1st measure (stop time)
+        self.assertEqual(
+            200, scheduled.qubit_start_time(1)
+        )  # 2nd measure starts at the same time as 1st measure starts
+
+    @data(ALAPSchedule, ASAPSchedule)
+    def test_c_if_on_different_qubits(self, SchedulePass):
+        """Test if ALAP/ASAP schedules circuits with `c_if`s on different qubits.
+
+        (input)
+             ┌─┐
+        q_0: ┤M├──────────────────────
+             └╥┘   ┌───┐
+        q_1: ─╫────┤ X ├──────────────
+              ║    └─╥─┘      ┌───┐
+        q_2: ─╫──────╫────────┤ X ├───
+              ║      ║        └─╥─┘
+              ║ ┌────╨────┐┌────╨────┐
+        c: 1/═╩═╡ c_0 = T ╞╡ c_0 = T ╞
+              0 └─────────┘└─────────┘
+
+        (scheduled)
+                                ┌─┐┌────────────────┐
+        q_0: ───────────────────┤M├┤ Delay(200[dt]) ├───────────
+             ┌─────────────────┐└╥┘└─────┬───┬──────┘
+        q_1: ┤ Delay(1000[dt]) ├─╫───────┤ X ├──────────────────
+             ├─────────────────┤ ║       └─╥─┘          ┌───┐
+        q_2: ┤ Delay(1000[dt]) ├─╫─────────╫────────────┤ X ├───
+             └─────────────────┘ ║         ║            └─╥─┘
+                                 ║    ┌────╨────┐    ┌────╨────┐
+        c: 1/════════════════════╩════╡ c_0 = T ╞════╡ c_0 = T ╞
+                                 0    └─────────┘    └─────────┘
+        """
+        qc = QuantumCircuit(3, 1)
+        qc.measure(0, 0)
+        qc.x(1).c_if(0, True)
+        qc.x(2).c_if(0, True)
+
+        durations = InstructionDurations([("x", None, 200), ("measure", None, 1000)])
+        pm = PassManager(SchedulePass(durations))
+        scheduled = pm.run(qc)
+
+        self.assertEqual(1000, scheduled.qubit_start_time(1))  # x(1).c_if (start time)
+        self.assertEqual(1000, scheduled.qubit_start_time(2))  # x(2).c_if (start time)
+
+    @data(ALAPSchedule, ASAPSchedule)
+    def test_shorter_measure_after_measure(self, SchedulePass):
+        """Test if ALAP/ASAP schedules circuits with shorter measure after measure with a common clbit.
+
+        (input)
+             ┌─┐
+        q_0: ┤M├───
+             └╥┘┌─┐
+        q_1: ─╫─┤M├
+              ║ └╥┘
+        c: 1/═╩══╩═
+              0  0
+
+        (scheduled)
+                               ┌─┐
+        q_0: ──────────────────┤M├───
+             ┌────────────────┐└╥┘┌─┐
+        q_1: ┤ Delay(300[dt]) ├─╫─┤M├
+             └────────────────┘ ║ └╥┘
+        c: 1/═══════════════════╩══╩═
+                                0  0
+        """
+        qc = QuantumCircuit(2, 1)
+        qc.measure(0, 0)
+        qc.measure(1, 0)
+
+        durations = InstructionDurations([("measure", 0, 1000), ("measure", 1, 700)])
+        pm = PassManager(SchedulePass(durations))
+        scheduled = pm.run(qc)
+
+        self.assertEqual(300, scheduled.qubit_start_time(1))  # 2nd measure (start time)
+
+    def test_measure_after_c_if(self):
+        """Test if ALAP/ASAP schedules circuits with c_if after measure with a common clbit.
+
+        (input)
+             ┌─┐
+        q_0: ┤M├──────────────
+             └╥┘   ┌───┐
+        q_1: ─╫────┤ X ├──────
+              ║    └─╥─┘   ┌─┐
+        q_2: ─╫──────╫─────┤M├
+              ║ ┌────╨────┐└╥┘
+        c: 1/═╩═╡ c_0 = T ╞═╩═
+              0 └─────────┘ 0
+
+        (scheduled - ASAP)
+                                ┌─┐┌────────────────┐
+        q_0: ───────────────────┤M├┤ Delay(200[dt]) ├─────────────────────
+             ┌─────────────────┐└╥┘└─────┬───┬──────┘
+        q_1: ┤ Delay(1000[dt]) ├─╫───────┤ X ├────────────────────────────
+             └─────────────────┘ ║       └─╥─┘       ┌─┐┌────────────────┐
+        q_2: ────────────────────╫─────────╫─────────┤M├┤ Delay(200[dt]) ├
+                                 ║    ┌────╨────┐    └╥┘└────────────────┘
+        c: 1/════════════════════╩════╡ c_0 = T ╞═════╩═══════════════════
+                                 0    └─────────┘     0
+
+        (scheduled - ALAP)
+                                ┌─┐┌────────────────┐
+        q_0: ───────────────────┤M├┤ Delay(200[dt]) ├───
+             ┌─────────────────┐└╥┘└─────┬───┬──────┘
+        q_1: ┤ Delay(1000[dt]) ├─╫───────┤ X ├──────────
+             └┬────────────────┤ ║       └─╥─┘       ┌─┐
+        q_2: ─┤ Delay(200[dt]) ├─╫─────────╫─────────┤M├
+              └────────────────┘ ║    ┌────╨────┐    └╥┘
+        c: 1/════════════════════╩════╡ c_0 = T ╞═════╩═
+                                 0    └─────────┘     0
+        """
+        qc = QuantumCircuit(3, 1)
+        qc.measure(0, 0)
+        qc.x(1).c_if(0, 1)
+        qc.measure(2, 0)
+
+        durations = InstructionDurations([("x", None, 200), ("measure", None, 1000)])
+        asap = PassManager(ASAPSchedule(durations)).run(qc)
+        alap = PassManager(ALAPSchedule(durations)).run(qc)
+
+        # start time of x.c_if is the same
+        self.assertEqual(1000, asap.qubit_start_time(1))
+        self.assertEqual(1000, alap.qubit_start_time(1))
+        # start times of 2nd measure depends on ASAP/ALAP
+        self.assertEqual(0, asap.qubit_start_time(2))
+        self.assertEqual(200, alap.qubit_start_time(2))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fix #7006  by tracking availability of clbits in scheduling passes


### Details and comments
Previously, scheduling of circuits using clbits was not correct because availability of clbits is not considered in scheduling passes. This PR updates scheduling passes (ASAP, ALAP, InstructionAlignment) so that they take clbits availability into accounts, assuming a simple I/O model where `measure` locks clbits to be written at its end and `c_if` locks clbits to be read at its beginning. That means neither of them locks clbits for entire instruction time and they lock clbits for little time. For now, it is assumed that zero time for creg I/O operations since current backends do not report I/O latencies (how much time it takes for such an I/O operation on clbits).

TODOs:
- [ ] add reno
- [ ] add disclaimer to docstring, stating ASAP/ALAP scheduler may not schedule instructions exactly the same as any real backend does (especially when the circuit has conditional instructions)