### PR TITLE
Pin jsonschema==3.2.0 in constraints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,3 +4,6 @@ decorator==4.4.2
 jax==0.2.13
 jaxlib==0.1.67
 networkx==2.5
+# jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
+# 4.0+. The pin can be removed after nbformat is updated.
+jsonschema==3.2.0


### PR DESCRIPTION
This dependency is used transitively by jupyter via nbformat.  In the
new 4.0 release of jsonscheme, nbformat uses deprecated behaviour,
triggering CI failures, so we pin jsonschema to a known-good version.
The pin can be removed once nbformat is updated.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments

Fix #7090.

See jupyter/nbformat#232 for the tracking issue.