### PR TITLE
BackendProperties: fix docs typos

### DIFF
--- a/qiskit/providers/models/backendproperties.py
+++ b/qiskit/providers/models/backendproperties.py
@@ -220,10 +220,10 @@ class BackendProperties:
 
     @classmethod
     def from_dict(cls, data):
-        """Create a new Gate object from a dictionary.
+        """Create a new BackendProperties object from a dictionary.
 
         Args:
-            data (dict): A dictionary representing the Gate to create.
+            data (dict): A dictionary representing the BackendProperties to create.
                          It will be in the same format as output by
                          :func:`to_dict`.
 


### PR DESCRIPTION
Incorrect references to class type: Gates used instead of
BackendProperties.
