### PR TITLE
allow sympy deprecations

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -203,6 +203,7 @@ class QiskitTestCase(BaseQiskitTestCase):
             "qiskit.quantum_info.operators.pauli",
             "pybobyqa",
             "numba",
+            "sympy",
             "qiskit.utils.measurement_error_mitigation",
             "qiskit.circuit.library.standard_gates.x",
             "qiskit.pulse.schedule",


### PR DESCRIPTION
The following Sympy deprecation is stopping CI.

```
    sympy.utilities.exceptions.SymPyDeprecationWarning: 

expr_free_symbols method has been deprecated since SymPy 1.9. See
https://github.com/sympy/sympy/issues/21494 for more info.`
```

This PR adds sympy in the list of modules allowed to raise deprecation warnings.