### PR TITLE
demote noisy warning to the debug logger

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -14,7 +14,6 @@
 
 import copy
 import logging
-import warnings
 
 import numpy as np
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The warning in `Optimize1qGatesDecomposition` has served its purpose by generating several open issues (#7033, #7042; #7121, #7106) . Some of these are handled by an open PR, #7084, which needs more consideration before merging; the fate of the other issues is less clear. In either case, the warning is now generating more user strife than developer info, and this PR proposes to mute it.

Happy to add a `reno` tag if y'all want. I don't think it merits the attention.
