### PR TITLE
Fix register comparisons in QASM 3 exporter

### DIFF
--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -25,7 +25,8 @@ Qasm (:mod:`qiskit.qasm3`)
     dump
 """
 
-from .exporter import Exporter
+from .exceptions import QASM3Warning
+from .exporter import Exporter, QASM3ExporterWarning
 
 
 def dumps(circuit, **kwargs) -> str:

--- a/qiskit/qasm3/ast.py
+++ b/qiskit/qasm3/ast.py
@@ -114,6 +114,59 @@ class QuantumInstruction(ASTNode):
         pass
 
 
+class ClassicalType(ASTNode):
+    """Information about a classical type.  This is just an abstract base for inheritance tests."""
+
+
+class IntType(ClassicalType):
+    """Type information for a classical signed integer."""
+
+    def __init__(self, width: Optional[int]):
+        self.width = width
+
+
+class UintType(ClassicalType):
+    """Type information for a classical unsigned integer."""
+
+    def __init__(self, width: Optional[int]):
+        self.width = width
+
+
+class FloatWidth(enum.IntEnum):
+    """Allowed values for the width of floating-point types."""
+
+    HALF = 16
+    SINGLE = 32
+    DOUBLE = 64
+    QUAD = 128
+    OCT = 256
+
+
+class FloatType(ClassicalType):
+    """Type information for a classical floating-point value."""
+
+    def __init__(self, width: Optional[FloatWidth]):
+        self.width = width
+
+
+class AngleType(ClassicalType):
+    """Type information for a classical fractional angle type."""
+
+    def __init__(self, width: Optional[int]):
+        self.width = width
+
+
+class BitType(ClassicalType):
+    """Type information for the singleton ``bit`` type."""
+
+
+class BitRegisterType(ClassicalType):
+    """Type information for a sized register of classical bits."""
+
+    def __init__(self, size: int):
+        self.size = size
+
+
 class Identifier(ASTNode):
     """
     Identifier : FirstIdCharacter GeneralIdCharacter* ;
@@ -226,6 +279,14 @@ class Integer(Expression):
     """Integer : Digit+ ;"""
 
 
+class Cast(Expression):
+    """An explicit cast from one classical type to another."""
+
+    def __init__(self, type_: ClassicalType, expression: Expression):
+        self.type = type_
+        self.something = expression
+
+
 class Designator(ASTNode):
     """
     designator
@@ -236,16 +297,12 @@ class Designator(ASTNode):
         self.expression = expression
 
 
-class BitDeclaration(ASTNode):
-    """
-    bitDeclaration
-        : ( 'creg' Identifier designator? |   # NOT SUPPORTED
-            'bit' designator? Identifier ) equalsExpression?
-    """
+class ClassicalDeclaration(Statement):
+    """Declaration of a classical type, optionally initialising it to a value."""
 
-    def __init__(self, identifier: Identifier, designator=None, equalsExpression=None):
+    def __init__(self, type_: ClassicalType, identifier: Identifier, equalsExpression=None):
+        self.type = type_
         self.identifier = identifier
-        self.designator = designator
         self.equalsExpression = equalsExpression
 
 
@@ -514,10 +571,10 @@ class IOModifier(enum.Enum):
     output = enum.auto()
 
 
-class IO(ASTNode):
-    """UNDEFINED in the grammar yet"""
+class IODeclaration(Statement):
+    """A declaration of an IO variable."""
 
-    def __init__(self, modifier: IOModifier, input_type, input_variable):
+    def __init__(self, modifier: IOModifier, input_type: ClassicalType, input_variable):
         self.modifier = modifier
         self.type = input_type
         self.variable = input_variable

--- a/qiskit/qasm3/exceptions.py
+++ b/qiskit/qasm3/exceptions.py
@@ -1,0 +1,20 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Exceptions and warnings relating to QASM 3."""
+
+__all__ = ("QASM3Warning",)
+
+
+class QASM3Warning(UserWarning):
+    """A warning raised when something questionable happens while interacting with the OpenQASM 3
+    converters."""

--- a/test/python/circuit/test_circuit_qasm3.py
+++ b/test/python/circuit/test_circuit_qasm3.py
@@ -309,7 +309,7 @@ class TestCircuitQasm3(QiskitTestCase):
                 "gate custom(a) q_0 {",
                 "  rx(a) q_0;",
                 "}",
-                "input float[32] a;",
+                "input float[64] a;",
                 "qubit[1] _q;",
                 "let q = _q[0];",
                 "custom(a) q[0];",
@@ -421,7 +421,7 @@ class TestCircuitQasm3(QiskitTestCase):
             [
                 "OPENQASM 3;",
                 'include "stdgates.inc";',
-                "input float[32] θ;",
+                "input float[64] θ;",
                 "qubit[1] _q;",
                 "let q = _q[0];",
                 "rz(θ) q[0];",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously the exporter would emit code such as `if(register == 3)` to compare a register if given an instruction such as `qc.x(0).c_if(register, 3)`.  This is an implicit cast of the register to an unsigned integral type, which is likely not allowed by the language.  Now, we emit an explicit cast into an unsigned type to be sure of what we meant.

### Details and comments

First this adds more knowledge of classical types and proper declarations into the temporary AST we use for the exporter (again, this should be replaced in the future by the standardised Python interface maintained by the OpenQASM organisation), so that we don't introduce any coupling of the Terra -> AST and the AST -> string steps.  As a side-effect of this, it decouples some code which currently inserts raw strings into the AST, and replaces all classical declarations with the more general form.  I replaced the default `float[32]` for parameters with double-precision floating-point values while I was doing this decoupling, as single-precision actually just throws away some of Python's storage, and `float[64]` is (slightly) preferred in the OpenQASM 3 spec at the moment (in the sense that `const` variables are implicitly `float[64]`).

Most importantly, though, it just causes register comparisons to be emitted with the explicit cast in them.  Currently, we assume that the condition will certainly be an equality comparison to an integer (Terra currently enforces this).  We emit a warning if the integer literal cannot be represented by the amount of bits in the register (so the condition is guaranteed false).

Fix #7151.