### PR TITLE
Remove out of date constraints from constraints.txt

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,10 +1,3 @@
-appnope==0.1.0
-numpy>=1.20.0 ; python_version>'3.6'
-decorator==4.4.2
-jax==0.2.13
-jaxlib==0.1.67
-networkx==2.5
-importlib-metadata==4.6.4
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The constraints.txt file is used to pin specific versions of packages in
the dependency tree when we can't (typically for dependencies of
dependencies) modify the requirements list to workaround temporary
packaging issues. With the recent release of stevedore 3.5.0 [1] the
importlib-metadata pin in the constraints.txt file was no longer needed.
However, looking at the git log for other pinned dependencies only 1
package being pinned is still required, jsonschema, because nbformat
hasn't been updated to fix the incompatibility with the latest version
yet. This commit removes all the out of date entries from the
constraints.txt file leaving only the pin for jsonschema so we're
testing the latest versions of everything in CI, so that our CI
environment is closer to what users will typically install.

### Details and comments

[1] https://pypi.org/project/stevedore/3.5.0/