### PR TITLE
[WIP] Add quantum phase-estimation simulator

### DIFF
--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -167,6 +167,7 @@ Algorithms that estimate the phases of eigenstates of a unitary.
    PhaseEstimation
    PhaseEstimationResult
    IterativePhaseEstimation
+   PhaseEstimationSimulator
 
 Exceptions
 ==========
@@ -211,6 +212,7 @@ from .phase_estimators import (
     PhaseEstimation,
     PhaseEstimationResult,
     IterativePhaseEstimation,
+    PhaseEstimationSimulator
 )
 from .exceptions import AlgorithmError
 
@@ -253,5 +255,6 @@ __all__ = [
     "PhaseEstimation",
     "PhaseEstimationResult",
     "IterativePhaseEstimation",
+    "PhaseEstimationSimulator",
     "AlgorithmError",
 ]

--- a/qiskit/algorithms/phase_estimators/__init__.py
+++ b/qiskit/algorithms/phase_estimators/__init__.py
@@ -19,7 +19,7 @@ from .phase_estimation_scale import PhaseEstimationScale
 from .hamiltonian_phase_estimation import HamiltonianPhaseEstimation
 from .hamiltonian_phase_estimation_result import HamiltonianPhaseEstimationResult
 from .ipe import IterativePhaseEstimation
-from .phase_estimation_simulator import PhaseEstimationSimulator
+from .phase_estimation_emulator import PhaseEstimationEmulator
 
 __all__ = [
     "PhaseEstimator",
@@ -29,5 +29,5 @@ __all__ = [
     "HamiltonianPhaseEstimation",
     "HamiltonianPhaseEstimationResult",
     "IterativePhaseEstimation",
-    "PhaseEstimationSimulator"
+    "PhaseEstimationEmulator"
 ]

--- a/qiskit/algorithms/phase_estimators/__init__.py
+++ b/qiskit/algorithms/phase_estimators/__init__.py
@@ -19,6 +19,7 @@ from .phase_estimation_scale import PhaseEstimationScale
 from .hamiltonian_phase_estimation import HamiltonianPhaseEstimation
 from .hamiltonian_phase_estimation_result import HamiltonianPhaseEstimationResult
 from .ipe import IterativePhaseEstimation
+from .phase_estimation_simulator import PhaseEstimationSimulator
 
 __all__ = [
     "PhaseEstimator",
@@ -28,4 +29,5 @@ __all__ = [
     "HamiltonianPhaseEstimation",
     "HamiltonianPhaseEstimationResult",
     "IterativePhaseEstimation",
+    "PhaseEstimationSimulator"
 ]

--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation.py
@@ -28,7 +28,7 @@ from qiskit.opflow import (
 from qiskit.providers import BaseBackend
 from .phase_estimation import PhaseEstimation
 from .phase_estimator import PhaseEstimator
-from .phase_estimation_simulator import PhaseEstimationSimulator
+from .phase_estimation_emulator import PhaseEstimationEmulator
 from .hamiltonian_phase_estimation_result import HamiltonianPhaseEstimationResult
 from .phase_estimation_scale import PhaseEstimationScale
 
@@ -194,9 +194,9 @@ class HamiltonianPhaseEstimation:
         # 3. Tighten the bound on the eigenvalues so that the spectrum is better resolved, i.e.
         #   occupies more of the range of values representable by the qubit register.
         # The coefficient of this term will be added to the eigenvalues.
-        # The simulator does not need to remove the identity terms.
+        # The emulator does not need to remove the identity terms.
         if subtract_identity is None:
-            if isinstance(hamiltonian, SummedOp) and not isinstance(self._phase_estimation, PhaseEstimationSimulator):
+            if isinstance(hamiltonian, SummedOp) and not isinstance(self._phase_estimation, PhaseEstimationEmulator):
                 subtract_identity = True
             else:
                 subtract_identity = False

--- a/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation.py
+++ b/qiskit/algorithms/phase_estimators/hamiltonian_phase_estimation.py
@@ -27,6 +27,7 @@ from qiskit.opflow import (
 )
 from qiskit.providers import BaseBackend
 from .phase_estimation import PhaseEstimation
+from .phase_estimation_simulator import PhaseEstimationSimulator
 from .hamiltonian_phase_estimation_result import HamiltonianPhaseEstimationResult
 from .phase_estimation_scale import PhaseEstimationScale
 
@@ -89,6 +90,7 @@ class HamiltonianPhaseEstimation:
         self,
         num_evaluation_qubits: int,
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend]] = None,
+        phase_estimator = PhaseEstimation,
     ) -> None:
         """
         Args:
@@ -96,7 +98,7 @@ class HamiltonianPhaseEstimation:
                 be estimated as a binary string with this many bits.
             quantum_instance: The quantum instance on which the circuit will be run.
         """
-        self._phase_estimation = PhaseEstimation(
+        self._phase_estimation = phase_estimator(
             num_evaluation_qubits=num_evaluation_qubits, quantum_instance=quantum_instance
         )
 

--- a/qiskit/algorithms/phase_estimators/phase_estimation_emulator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_emulator.py
@@ -9,7 +9,7 @@ from .phase_estimator import PhaseEstimator
 from .phase_estimation_result import PhaseEstimationResult
 
 
-class PhaseEstimationSimulator(PhaseEstimator):
+class PhaseEstimationEmulator(PhaseEstimator):
     def __init__(
         self,
         num_evaluation_qubits: int,
@@ -29,8 +29,8 @@ class PhaseEstimationSimulator(PhaseEstimator):
         state_preparation_vector = qiskit.quantum_info.Operator(state_preparation).data
         state_preparation_vector = state_preparation_vector[:,0]
 
-        pe_simulator = PESimulator().from_eigenproblem(unitary_matrix, state_preparation_vector)
-        probs = _array_to_qiskit_endian(pe_simulator.estimate_phases(self._num_evaluation_qubits))
+        pe_emulator = PEEmulator().from_eigenproblem(unitary_matrix, state_preparation_vector)
+        probs = _array_to_qiskit_endian(pe_emulator.estimate_phases(self._num_evaluation_qubits))
         return PhaseEstimationResult(
             self._num_evaluation_qubits,
             circuit_result=None,
@@ -38,11 +38,11 @@ class PhaseEstimationSimulator(PhaseEstimator):
         )
 
 
-class PESimulator:
-    """Simulate quantum phase estimation given a list of eigenphases and
+class PEEmulator:
+    """Emulate quantum phase estimation given a list of eigenphases and
     a list of expansion coefficients.
 
-    This class simulates the parallel QPE algorithm using a classical discrete
+    This class emulates the parallel QPE algorithm using a classical discrete
     Fourier transform, but no quantum circuits.
 
     The (parallel) QPE algorithm takes as input a unitary, a vector that it
@@ -55,7 +55,7 @@ class PESimulator:
     particular, phase information in the expansion coefficients does not enter
     into the bitstring probabilities.
 
-    `PESimulator` takes as input a list of eigenphases and a
+    `PEEmulator` takes as input a list of eigenphases and a
     corresponding list of expansion coefficients, which are stored as object
     properties of the class. It is only required to supply nonzero expansion
     coefficients. The method `estimate_phases` takes as input the number of
@@ -67,7 +67,7 @@ class PESimulator:
     output probabilties to the order of amplitudes returned by the qiskit
     statevector simulator.
 
-    This simulator is faster than constructing and simulating a circuit. It is
+    This emulator is faster than constructing and simulating a circuit. It is
     far simpler, as well, and is based only on well-tested components of numpy
     and scipy.
 
@@ -136,7 +136,7 @@ def _array_to_qiskit_endian(a):
     to bit-wise reversal of their binary representation.
 
     For example, assume `a` is an array of bitstring probabilties computed by
-    QPE simulation, with bitstrings in the order "0...0", "0...1", etc.
+    QPE emulation, with bitstrings in the order "0...0", "0...1", etc.
     Then the output array corresponds to the probabilities output by a QPE
     algorithm run on the statevector simulator.
     """

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -12,7 +12,7 @@
 
 """Result of running PhaseEstimation"""
 
-from typing import Dict, Union
+from typing import Dict, Union, Optional
 import numpy
 
 from qiskit.utils.deprecation import deprecate_function
@@ -35,7 +35,7 @@ class PhaseEstimationResult(PhaseEstimatorResult):
     def __init__(
         self,
         num_evaluation_qubits: int,
-        circuit_result: Result,
+        circuit_result: Optional[Result],
         phases: Union[numpy.ndarray, Dict[str, float]],
     ) -> None:
         """

--- a/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
@@ -1,0 +1,102 @@
+import numpy
+import scipy
+
+
+class PhaseEstimationSimulator:
+    """Simulate quantum phase estimation given a list of eigenphases and
+    a list of expansion coefficients.
+
+    This class simulates the parallel QPE algorithm using a classical discrete
+    Fourier transform, but no quantum circuits.
+
+    The (parallel) QPE algorithm takes as input a unitary, a vector that it
+    operates on, and the desired number of qubits in the phase-readout register.
+    The output is an array of the probabilites of measuring each bitstring in
+    the readout register. The bitstrings are mapped to a discrete set of
+    phases. In the ideal case, the output depends on the input via the spectrum
+    of the unitary (the phases) and the moduli of the coefficients of the
+    expansion of the input vector in the corresponding eigenvectors.
+
+    `PhaseEstimationSimulator` takes as input a list of eigenphases and a
+    corresponding list of expansion coefficients, which are stored as object
+    properties of the class. It is only required to supply nonzero expansion
+    coefficients. The method `estimate_phases` takes as input the number of
+    qubits in the phase-readout register and returns an array of the bitstring
+    probabilities. Alternatively, the method `from_eigenproblem` constructs and
+    stores the arrays of phases and coeffcients from a unitary and input vector.
+
+    The module-level function `_array_to_qiskit_endian` converts the array of
+    output probabilties to the order of amplitudes returned by the qiskit
+    statevector simulator.
+
+    This simulator is faster than constructing and simulating a circuit. It is
+    far simpler, as well, and is based only on well-tested components of numpy
+    and scipy.
+    """
+
+    def __init__(self, phases=None, coeffs=None):
+        self.phases = phases
+        self.coeffs = coeffs
+
+    def from_eigenproblem(self, unitary, input_vector):
+        """Compute the phases and coefficients from a unitary and input vector.
+
+        The probabilities returned by the QPE algorithm depend only on the
+        eigen-phases and coeffcients of the input vector in the basis of the
+        unitary. This function computes and stores these phases from the input
+        unitary and vector.
+        """
+        vals, vecs = scipy.linalg.eig(unitary)
+        vecs = vecs.transpose() # put eigenvecs in columns
+        # Convert eigenvalue of unitary to a phase.
+        coeffs = [numpy.vdot(input_vector, vec) for vec in vecs]
+        norm_fac = numpy.sqrt(sum(x * x.conjugate() for x in coeffs))
+        coeffs = [x / norm_fac for x in coeffs]
+        phases = (numpy.angle(vals.astype(complex)) / (2 * numpy.pi)).real
+        self.phases = phases
+        self.coeffs = coeffs
+
+    def estimate_phases(self, num_qubits):
+        """Return an array of probabilities of measurement of each bitstring.
+
+        The probabilities are computed from eigen-phases and expansion coefficients
+        that are either set previously or computed via `from_eigenproblem`.
+        """
+        n = 2 ** num_qubits
+        prob = numpy.zeros(n)
+        for phi, c in zip(self.phases, self.coeffs):
+            if c != 0:
+                amps = _phase_estimation_amplitudes(phi, num_qubits)
+                prob += numpy.abs(c)**2 * numpy.abs(amps)**2
+        return prob
+
+
+def _intermediate_phase_vec(phi, num_qubits):
+    n = 2 ** num_qubits
+    inds = numpy.arange(n, 0, -1)
+    v = numpy.exp(2 * numpy.pi * 1.0j * phi * inds) / numpy.sqrt(n)
+    return v
+
+def _phase_estimation_amplitudes(phi, num_qubits):
+    v = _intermediate_phase_vec(phi, num_qubits)
+    return numpy.fft.ifft(v) * numpy.sqrt(len(v))
+
+def _ind_to_qiskit_endian(ind, n):
+    return int(numpy.binary_repr(ind, width=n)[::-1], base=2)
+
+def _array_to_qiskit_endian(a):
+    """Permutate array `a` to qiskit qubit register endianness.
+
+    Endian refers here to bit order, not byte order. The indices
+    into `a` are assumed to correspond to bitstrings given by their
+    binary representations. The indices of the output array correspond
+    to bit-wise reversal of their binary representation.
+
+    For example, assume `a` is an array of bitstring probabilties computed by
+    QPE simulation, with bitstrings in the order "0...0", "0...1", etc.
+    Then the output array corresponds to the probabilities output by a QPE
+    algorithm run on the statevector simulator.
+    """
+    n = int(numpy.log2(len(a)))
+    alist = [a[_ind_to_qiskit_endian(i, n)] for i in range(0, len(a))]
+    return numpy.array(alist)

--- a/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
@@ -15,7 +15,9 @@ class PhaseEstimationSimulator:
     the readout register. The bitstrings are mapped to a discrete set of
     phases. In the ideal case, the output depends on the input via the spectrum
     of the unitary (the phases) and the moduli of the coefficients of the
-    expansion of the input vector in the corresponding eigenvectors.
+    expansion of the input vector in the corresponding eigenvectors. In
+    particular, phase information in the expansion coefficients does not enter
+    into the bitstring probabilities.
 
     `PhaseEstimationSimulator` takes as input a list of eigenphases and a
     corresponding list of expansion coefficients, which are stored as object
@@ -32,6 +34,7 @@ class PhaseEstimationSimulator:
     This simulator is faster than constructing and simulating a circuit. It is
     far simpler, as well, and is based only on well-tested components of numpy
     and scipy.
+
     """
 
     def __init__(self, phases=None, coeffs=None):

--- a/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_simulator.py
@@ -51,10 +51,10 @@ class PhaseEstimationSimulator:
         """
         vals, vecs = scipy.linalg.eig(unitary)
         vecs = vecs.transpose() # put eigenvecs in columns
-        # Convert eigenvalue of unitary to a phase.
         coeffs = [numpy.vdot(input_vector, vec) for vec in vecs]
         norm_fac = numpy.sqrt(sum(x * x.conjugate() for x in coeffs))
         coeffs = [x / norm_fac for x in coeffs]
+        # Convert eigenvalue of unitary to a phase.
         phases = (numpy.angle(vals.astype(complex)) / (2 * numpy.pi)).real
         self.phases = phases
         self.coeffs = coeffs


### PR DESCRIPTION
The simulator is implemented as a class that does not depend on qiskit together with a wrapper class that implements the `PhaseEstimator` interface. The  class `PESimulator` depends only on numpy and scipy. In particular, it does not depend on Qiskit or circuits in general. The class `PhaseEstimationSimulator` is a subclass of  `PhaseEstimator` providing an alternative to the circuit-based `PhaseEstimation`. 

It is intended to be used for research and for testing. It is faster than simulating QPE with circuits and a state-vector simulator. It is much simpler, the core is only 20 lines or so, depending only on well-tested and widely used features of scipy. The rather ad-hoc tests of the QPE implementation in qiskit are augmented by comparing with the output of this simulator, which computes the probabilities of all bitstrings. It can also be used for researchers trying to debug code employing the circuit-based QPE classes.

I also have a tutorial-like text explaining the idea and math behind this simulator and the (parallel) QPE in qiskit. I'll post that somewhere after I convert it to a notebook.  This does not spend time on the things in books, rather on a few important details that the books leave out when making a working implementation.