### PR TITLE
Add RXY gate to standard gates library (#7164)

### DIFF
--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -45,6 +45,7 @@ Standard gates (:mod:`qiskit.circuit.library.standard_gates`)
    RC3XGate
    RXGate
    RXXGate
+   RXYGate
    RYGate
    RYYGate
    RZGate
@@ -76,6 +77,7 @@ from .ms import MSGate
 from .r import RGate
 from .rx import RXGate, CRXGate
 from .rxx import RXXGate
+from .rxy import RXYGate
 from .ry import RYGate, CRYGate
 from .ryy import RYYGate
 from .rz import RZGate, CRZGate

--- a/qiskit/circuit/library/standard_gates/rxy.py
+++ b/qiskit/circuit/library/standard_gates/rxy.py
@@ -1,0 +1,65 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Two-qubit XY-rotation gate."""
+
+from typing import Optional
+from qiskit.circuit.gate import Gate
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.circuit.parameterexpression import ParameterValueType
+
+
+class RXYGate(Gate):
+    def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
+        """Create new RXY gate."""
+        super().__init__("rxy", 2, [theta], label=label)
+
+    def _define(self):
+        """
+        gate rxy(theta) a, b { h b; cx b, a; ry(theta) a; cx b, a; h b;}
+        """
+        # pylint: disable=cyclic-import
+        from qiskit.circuit.quantumcircuit import QuantumCircuit
+        from .h import HGate
+        from .x import CXGate
+        from .ry import RYGate
+
+        theta = self.params[0]
+        q = QuantumRegister(2, "q")
+        qc = QuantumCircuit(q, name=self.name)
+        rules = [
+            (HGate(), [q[1]], []),
+            (CXGate(), [q[1], q[0]], []),
+            (RYGate(theta), [q[0]], []),
+            (CXGate(), [q[1], q[0]], []),
+            (HGate(), [q[1]], []),
+        ]
+        for instr, qargs, cargs in rules:
+            qc._append(instr, qargs, cargs)
+
+        self.definition = qc
+
+    def inverse(self):
+        """Return inverse RXY gate (i.e. with the negative rotation angle)."""
+        return RXYGate(-self.params[0])
+
+    def __array__(self, dtype=None):
+        """Return a numpy.array for the RXY gate."""
+        import numpy
+
+        half_theta = float(self.params[0]) / 2
+        cos = numpy.cos(half_theta)
+        sin = numpy.sin(half_theta)
+        return numpy.array(
+            [[cos, 0, 0, -sin], [0, cos, sin, 0], [0, -sin, cos, 0], [sin, 0, 0, cos]],
+            dtype=dtype,
+        )

--- a/qiskit/circuit/library/standard_gates/rxy.py
+++ b/qiskit/circuit/library/standard_gates/rxy.py
@@ -19,13 +19,92 @@ from qiskit.circuit.parameterexpression import ParameterValueType
 
 
 class RXYGate(Gate):
+    r"""A parametric 2-qubit :math:`X \otimes Y` interaction (rotation about XY).
+
+    **Circuit Symbol:**
+
+    .. parsed-literal::
+
+             ┌─────────┐
+        q_0: ┤0        ├
+             │  Rxy(θ) │
+        q_1: ┤1        ├
+             └─────────┘
+
+    **Matrix Representation:**
+
+    .. math::
+
+        \newcommand{\th}{\frac{\theta}{2}}
+
+        R_{XY}(\theta)\ q_0, q_1 = exp(-i \frac{\theta}{2} Y{\otimes}X) =
+            \begin{pmatrix}
+                \cos(\th) & 0         & 0          & -\sin(\th)  \\
+                0         & \cos(\th) & -\sin(\th) & 0           \\
+                0         & \sin(\th) & \cos(\th)  & 0           \\
+                \sin(\th) & 0         & 0          & \cos(\th)
+            \end{pmatrix}
+
+    .. note::
+
+        In Qiskit's convention, higher qubit indices are more significant
+        (little endian convention). In the above example we apply the gate
+        on (q_0, q_1) which results in the :math:`Y \otimes X` tensor order.
+        Instead, if we apply it on (q_1, q_0), the matrix will
+        be :math:`Y \otimes X`:
+
+        .. parsed-literal::
+
+                 ┌─────────┐
+            q_0: ┤1        ├
+                 │  Rxy(θ) │
+            q_1: ┤0        ├
+                 └─────────┘
+
+        .. math::
+
+            \newcommand{\th}{\frac{\theta}{2}}
+
+            R_{XY}(\theta)\ q_1, q_0 = exp(-i \frac{\theta}{2} X{\otimes}Y) =
+                \begin{pmatrix}
+                    \cos(\th) & 0          & 0         & -\sin(\th)  \\
+                    0         & \cos(\th)  & \sin(\th) & 0           \\
+                    0         & -\sin(\th) & \cos(\th) & 0           \\
+                    \sin(\th) & 0          & 0         & \cos(\th)
+                \end{pmatrix}
+
+    **Examples:**
+
+        .. math::
+
+            R_{XY}(\theta = 0) = I
+
+        .. math::
+
+            R_{XY}(\theta = 2\pi) = -I
+
+        .. math::
+
+            R_{XY}(\theta = \pi) = -i Y \otimes X
+
+        .. math::
+
+            R_{XY}(\theta = \frac{\pi}{2}) = \frac{1}{\sqrt{2}}
+                                    \begin{pmatrix}
+                                        1 & 0 & 0  & -1 \\
+                                        0 & 1 & -1 & 0  \\
+                                        0 & 1 & 1  & 0  \\
+                                        1 & 0 & 0  & 1
+                                    \end{pmatrix}
+    """
+
     def __init__(self, theta: ParameterValueType, label: Optional[str] = None):
         """Create new RXY gate."""
         super().__init__("rxy", 2, [theta], label=label)
 
     def _define(self):
         """
-        gate rxy(theta) a, b { h b; cx b, a; ry(theta) a; cx b, a; h b;}
+        gate rxy(theta) a, b { h a; cx a, b; ry(theta) b; cx a, b; h a;}
         """
         # pylint: disable=cyclic-import
         from qiskit.circuit.quantumcircuit import QuantumCircuit
@@ -37,11 +116,11 @@ class RXYGate(Gate):
         q = QuantumRegister(2, "q")
         qc = QuantumCircuit(q, name=self.name)
         rules = [
-            (HGate(), [q[1]], []),
-            (CXGate(), [q[1], q[0]], []),
-            (RYGate(theta), [q[0]], []),
-            (CXGate(), [q[1], q[0]], []),
-            (HGate(), [q[1]], []),
+            (HGate(), [q[0]], []),
+            (CXGate(), [q[0], q[1]], []),
+            (RYGate(theta), [q[1]], []),
+            (CXGate(), [q[0], q[1]], []),
+            (HGate(), [q[0]], []),
         ]
         for instr, qargs, cargs in rules:
             qc._append(instr, qargs, cargs)
@@ -60,6 +139,6 @@ class RXYGate(Gate):
         cos = numpy.cos(half_theta)
         sin = numpy.sin(half_theta)
         return numpy.array(
-            [[cos, 0, 0, -sin], [0, cos, sin, 0], [0, -sin, cos, 0], [sin, 0, 0, cos]],
+            [[cos, 0, 0, -sin], [0, cos, -sin, 0], [0, sin, cos, 0], [sin, 0, 0, cos]],
             dtype=dtype,
         )

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1661,6 +1661,7 @@ class TestParameterExpressions(QiskitTestCase):
         circlib.RYGate,
         circlib.RZGate,
         circlib.RXXGate,
+        circlib.RXYGate,
         circlib.RYYGate,
         circlib.RZXGate,
         circlib.RZZGate,

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -39,6 +39,7 @@ from qiskit.circuit.library import (
     iSwapGate,
     SwapGate,
     RXXGate,
+    RXYGate,
     RYYGate,
     RZZGate,
     RZXGate,
@@ -1317,7 +1318,7 @@ class TestTwoQubitControlledUDecompose(CheckDecompositions):
     def test_correct_unitary(self, seed):
         """Verify unitary for different gates in the decomposition"""
         unitary = random_unitary(4, seed=seed)
-        for gate in [RXXGate, RYYGate, RZZGate, RZXGate, CPhaseGate, CRZGate]:
+        for gate in [RXXGate, RXYGate, RYYGate, RZZGate, RZXGate, CPhaseGate, CRZGate]:
             decomposer = TwoQubitControlledUDecomposer(gate)
             circ = decomposer(unitary)
             self.assertEqual(Operator(unitary), Operator(circ))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds the parameterized two-qubit XY rotation gate to the standard gates library (#7164). 


### Details and comments


