### PR TITLE
Pin pyparsing<3 in constraints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,10 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
+
+# pyparsing restrictions are needed because pyparsing 3.0.0 and 3.0.1 break
+# matplotlib's mathtex extensions.  At the time of writing (2021-10-25), the
+# docs build is pinned to matplotlib<3.4 (current) because of deprecations, so
+# as we won't get matplotlib upgrades by default, this constraint likely can't
+# be removed until we can unpin matplotlib.
+pyparsing<3.0.0


### PR DESCRIPTION
Matplotlib's LaTeX handling is broken by the new release of pyparsing
3.0.  We are already restricting matplotlib<3.4 in CI due to
deprecations, so we are unlikely to get updated versions of matplotlib
any time soon, which we will likely need to lift the pin.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


