### PR TITLE
Fix wrong qubit order for ``ZX`` evolution in ``PauliEvolutionGate``

### DIFF
--- a/qiskit/synthesis/evolution/product_formula.py
+++ b/qiskit/synthesis/evolution/product_formula.py
@@ -138,9 +138,9 @@ def _two_qubit_evolution(pauli, time, cx_structure):
     elif all(labels == "Z"):  # RZZ
         definition.rzz(2 * time, qubits[0], qubits[1])
     elif labels[0] == "Z" and labels[1] == "X":  # RZX
-        definition.rzx(2 * time, qubits[0], qubits[1])
-    elif labels[0] == "X" and labels[1] == "Z":  # RXZ
         definition.rzx(2 * time, qubits[1], qubits[0])
+    elif labels[0] == "X" and labels[1] == "Z":  # RXZ
+        definition.rzx(2 * time, qubits[0], qubits[1])
     else:  # all the others are not native in Qiskit, so use default the decomposition
         definition = _multi_qubit_evolution(pauli, time, cx_structure)
 

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -49,6 +49,21 @@ class TestEvolutionGate(QiskitTestCase):
         decomposed = evo_gate.definition.decompose()
         self.assertEqual(decomposed.count_ops()["cx"], reps * 3 * 4)
 
+    def test_rzx_order(self):
+        """Test ZX is mapped onto the correct qubits."""
+        evo_gate = PauliEvolutionGate(X ^ Z)
+        decomposed = evo_gate.definition.decompose()
+
+        ref = QuantumCircuit(2)
+        ref.h(1)
+        ref.cx(1, 0)
+        ref.rz(2.0, 0)
+        ref.cx(1, 0)
+        ref.h(1)
+
+        # don't use circuit equality since RZX here decomposes with RZ on the bottom
+        self.assertTrue(Operator(decomposed).equiv(ref))
+
     def test_suzuki_trotter(self):
         """Test constructing the circuit with Lie Trotter decomposition."""
         op = (X ^ 3) + (Y ^ 3) + (Z ^ 3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For 1 and 2 qubit evolutions we return the according standard gate (if we have it in the library), so that e.g. the time evolution `exp(it XX)` uses the `RXX` gate. For the `exp(it XZ)` evolution the qubit order in applying the RZX gate is reversed, since the X term should act on qubit 1 and Z on qubit 0. The same happens analogously for `exp(it ZX)`.

### Details and comments

This was realized since prior to #6975, the `PauliTrotterEvolution` returned 
```
          ┌───┐┌───────┐┌───┐┌──────────────┐
q_0: ─────┤ X ├┤ Rz(2) ├┤ X ├┤ circuit-7_dg ├
     ┌───┐└─┬─┘└───────┘└─┬─┘└────┬───┬─────┘
q_1: ┤ H ├──■─────────────■───────┤ H ├──────
     └───┘                        └───┘
```
(where `circuit-7_dg` is empty)
and after that PR was merged it returned 
```
     ┌───┐┌───┐┌─────────┐┌───┐┌───┐
q_0: ┤ H ├┤ X ├┤ Rz(2.0) ├┤ X ├┤ H ├
     └───┘└─┬─┘└─────────┘└─┬─┘└───┘
q_1: ───────■───────────────■───────
```
With this PR it now correctly returns
```
          ┌───┐┌───────┐┌───┐
q_0: ─────┤ X ├┤ Rz(2) ├┤ X ├─────
     ┌───┐└─┬─┘└───────┘└─┬─┘┌───┐
q_1: ┤ H ├──■─────────────■──┤ H ├
     └───┘                   └───┘
```

I'm adding "no changelog" since the `PauliEvolutionGate` PR was not yet released.
