### PR TITLE
Add `SparsePauliOp.sum`

### DIFF
--- a/releasenotes/notes/add-sparsepauliop-sum-d55fc817c9fded82.yaml
+++ b/releasenotes/notes/add-sparsepauliop-sum-d55fc817c9fded82.yaml
@@ -2,6 +2,5 @@
 features:
   - |
     Added :meth:`~qiskit.quantum_info.SparsePauliOp.sum` as a specialized function of the builtin
-    function ``sum`` for a list of :class:`:meth:`~qiskit.quantum_info.SparsePauliOp`.
-    This method has less overhead of the array stacking of
-    :meth:`~qiskit.quantum_info.SparsePauliOp._add`.
+    function ``sum`` for a list of :class:`~qiskit.quantum_info.SparsePauliOp`.
+    This method has better scaling than repeated calls to :meth:`~qiskit.quantum_info.SparsePauliOp._add`.

--- a/releasenotes/notes/add-sparsepauliop-sum-d55fc817c9fded82.yaml
+++ b/releasenotes/notes/add-sparsepauliop-sum-d55fc817c9fded82.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added :meth:`~qiskit.quantum_info.SparsePauliOp.sum` as a specialized function of the builtin
+    function ``sum`` for a list of :class:`:meth:`~qiskit.quantum_info.SparsePauliOp`.
+    This method has less overhead of the array stacking of
+    :meth:`~qiskit.quantum_info.SparsePauliOp._add`.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -476,6 +476,28 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         np.testing.assert_array_equal(spp_op.paulis.phase, np.zeros(spp_op.size))
         np.testing.assert_array_equal(simplified_op.paulis.phase, np.zeros(simplified_op.size))
 
+    @combine(num_qubits=[1, 2, 3, 4], num_ops=[1, 2, 3, 4])
+    def test_sum(self, num_qubits, num_ops):
+        """Test sum method for {num_qubits} qubits with {num_ops} operators."""
+        ops = [self.random_spp_op(num_qubits, 2 ** num_qubits) for _ in range(num_ops)]
+        sum_op = SparsePauliOp.sum(ops)
+        value = Operator(sum_op)
+        target_operator = sum((Operator(op) for op in ops[1:]), Operator(ops[0]))
+        self.assertEqual(value, target_operator)
+        target_spp_op = sum((op for op in ops[1:]), ops[0])
+        self.assertEqual(sum_op, target_spp_op)
+        np.testing.assert_array_equal(sum_op.paulis.phase, np.zeros(sum_op.size))
+
+    def test_sum_error(self):
+        """Test sum method with invalid cases."""
+        with self.assertRaises(QiskitError):
+            SparsePauliOp.sum([])
+        with self.assertRaises(QiskitError):
+            ops = [self.random_spp_op(num_qubits, 2 ** num_qubits) for num_qubits in [1, 2]]
+            SparsePauliOp.sum(ops)
+        with self.assertRaises(QiskitError):
+            SparsePauliOp.sum([1, 2])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Adds `SparsePauliOp.sum` as a specialized version the builtin `sum` for a list of `SparsePauliOp`.
The builtin `sum` calls `SparsePauliOp._add` N-1 times if there are N items in the list.
Each `SparsePauliOp._add` stacks arrays of z, x, phase and coeffs and it is carried out N-1 times.
On the other hand, the new method `SparsePauliOp.sum` stacks all arrays at once. So, it can reduce the overhead.

### Details and comments

Jordan Wigner transformation takes a sum of a list of `SparsePauliOp` and it is one of the bottlenecks.
I proposed a [workaround](https://github.com/Qiskit/qiskit-nature/blob/cf6511578d39a2ed2a3b6a2db2aff9c194ba72e4/qiskit_nature/mappers/second_quantization/qubit_mapper.py#L146
) to reduce the overhead in this PR https://github.com/Qiskit/qiskit-nature/pull/397;
but, it is not intuitive.
The specialized method of this PR is more intuitive and more efficient than the workaround.
```python
# workaround 
        def _sum(ops: List[SparsePauliOp]) -> SparsePauliOp:
            while len(ops) > 1:
                ops.append(ops[0] + ops[1])
                ops = ops[2:]
            return ops[0]
```

Microbenchmark of JW transformation with Qiskit nature. (same as one in https://github.com/Qiskit/qiskit-nature/pull/397)
```python
import random
from timeit import timeit

from qiskit_nature.converters.second_quantization import QubitConverter
from qiskit_nature.mappers.second_quantization import JordanWignerMapper
from qiskit_nature.operators.second_quantization import FermionicOp

random.seed(123)
k = 10
n = 100

op = sum(
    (FermionicOp(''.join(random.choices('+-ENI', k=k)), display_format="dense") * random.random())
    for _ in range(n))
mapper = JordanWignerMapper()
qubit_conv = QubitConverter(mapper)
print(f"{timeit(lambda: qubit_conv.convert(op), number=1)} sec")
```

nature main (https://github.com/Qiskit/qiskit-nature/commit/7d12a134afc050aebe4389502c61df4cfd13c6e9) + terra main
```
2.446942435002711 sec
```

nature https://github.com/Qiskit/qiskit-nature/pull/397 + terra main
```
1.5037378649976745 sec
```

nature https://github.com/Qiskit/qiskit-nature/pull/397 + this PR (replace `_sum` with `SparsePauliOp.sum`)
```
1.4083706309975241 sec
```