### PR TITLE
Add `QAOAAnsatz.num_qubits` to improve performance

### DIFF
--- a/qiskit/circuit/library/n_local/qaoa_ansatz.py
+++ b/qiskit/circuit/library/n_local/qaoa_ansatz.py
@@ -246,6 +246,10 @@ class QAOAAnsatz(EvolvedOperatorAnsatz):
         self._mixer = mixer_operator
         self._invalidate()
 
+    @property
+    def num_qubits(self) -> int:
+        return self._cost_operator.num_qubits
+
     def _build(self):
         if self._data is not None:
             return

--- a/qiskit/circuit/library/n_local/qaoa_ansatz.py
+++ b/qiskit/circuit/library/n_local/qaoa_ansatz.py
@@ -248,6 +248,8 @@ class QAOAAnsatz(EvolvedOperatorAnsatz):
 
     @property
     def num_qubits(self) -> int:
+        if self._cost_operator is None:
+            return 0
         return self._cost_operator.num_qubits
 
     def _build(self):

--- a/test/python/circuit/library/test_qaoa_ansatz.py
+++ b/test/python/circuit/library/test_qaoa_ansatz.py
@@ -13,13 +13,16 @@
 """Test QAOA ansatz from the library."""
 
 import numpy as np
+from ddt import ddt, data
+
 from qiskit.circuit import QuantumCircuit, Parameter
-from qiskit.circuit.library.n_local.qaoa_ansatz import QAOAAnsatz
 from qiskit.circuit.library import HGate, RXGate, YGate, RYGate, RZGate
+from qiskit.circuit.library.n_local.qaoa_ansatz import QAOAAnsatz
 from qiskit.opflow import I, Y, Z
 from qiskit.test import QiskitTestCase
 
 
+@ddt
 class TestQAOAAnsatz(QiskitTestCase):
     """Test QAOAAnsatz."""
 
@@ -141,3 +144,17 @@ class TestQAOAAnsatz(QiskitTestCase):
         reps = 4
         circuit = QAOAAnsatz(cost_operator=Z ^ Z, mixer_operator=mixer, reps=reps)
         self.assertEqual(circuit.num_parameters, 3 * reps)
+
+    def test_empty_op(self):
+        """Test construction without cost operator"""
+        circuit = QAOAAnsatz(reps=1)
+        self.assertEqual(circuit.num_qubits, 0)
+        with self.assertRaises(ValueError):
+            circuit.decompose()
+
+    @data(1, 2, 3, 4)
+    def test_num_qubits(self, num_qubits):
+        """Test num_qubits with {num_qubits} qubits"""
+
+        circuit = QAOAAnsatz(cost_operator=I ^ num_qubits, reps=5)
+        self.assertEqual(circuit.num_qubits, num_qubits)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Improve the performance of `QAOAAnsatz.decompose()` by adding direct access of `QAOAAnsatz.num_qubits`.

### Details and comments

The current code accesses the number of qubits `QAOAAnsatz.num_qubits` via `EvolvedOperatorAnsatz.num_qubits`.
It results in `QAOAAnsatz.operators` -> `QAOAAnsatz.mixer_operator` -> computation of mixer terms if `self._mixer` is None. But the mixer_operator is not used for num_qubits. So, we can reduce the overhead of mixer operator.

micro benchmark
```python
from timeit import timeit
from qiskit.circuit.library import QAOAAnsatz
from qiskit.opflow import PauliSumOp

n = 50
lst = []
for i in range(n - 1):
    v = ["I"] * n
    v[i] = v[i + 1] = "Z"
    lst.append(("".join(v), 1))

op = PauliSumOp.from_list(lst)
qaoa = QAOAAnsatz(cost_operator=op, reps=5)
print(f'{timeit(lambda: qaoa.decompose(), number=1)} sec')
```

main
```
13.300332591999904 sec
```

This PR
```
5.443255255995609 sec
```