### PR TITLE
Add concurrency limit on github actions coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
     branches: ['main']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 jobs:
   coverage:
     name: Coverage


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a concurrency limit for jobs running from a single PR.
This means that on PR updates github actions will cancel any currently
running job for that because they exceed the concurrency limit on the
PR. Without this we end up running duplicate jobs when there are
frequent pushes to an open pull request.

### Details and comments


