### PR TITLE
Fix QAOA handling of ``PauliSumOp`` identities and changing cost operators

### DIFF
--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -112,6 +112,7 @@ class QAOA(VQE):
         self._reps = reps
         self._mixer = mixer
         self._initial_state = initial_state
+        self._cost_operator = None
 
         super().__init__(
             ansatz=None,
@@ -127,7 +128,8 @@ class QAOA(VQE):
 
     def _check_operator_ansatz(self, operator: OperatorBase) -> OperatorBase:
         # Recreates a circuit based on operator parameter.
-        if operator.num_qubits != self.ansatz.num_qubits:
+        if operator != self._cost_operator:
+            self._cost_operator = operator
             self.ansatz = QAOAAnsatz(
                 operator, self._reps, initial_state=self._initial_state, mixer_operator=self._mixer
             ).decompose()  # TODO remove decompose once #6674 is fixed

--- a/qiskit/circuit/library/evolved_operator_ansatz.py
+++ b/qiskit/circuit/library/evolved_operator_ansatz.py
@@ -201,8 +201,10 @@ def _validate_prefix(parameter_prefix, operators):
 
 
 def _is_pauli_identity(operator):
-    from qiskit.opflow import PauliOp
+    from qiskit.opflow import PauliOp, PauliSumOp
 
+    if isinstance(operator, PauliSumOp):
+        operator = operator.to_pauli_op()
     if isinstance(operator, PauliOp):
         return not np.any(np.logical_or(operator.primitive.x, operator.primitive.z))
     return False

--- a/releasenotes/notes/fix-qaoa-construct-da37faf75f29fc35.yaml
+++ b/releasenotes/notes/fix-qaoa-construct-da37faf75f29fc35.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed the issue that :meth:`~qiskit.algorithms.QAOA.construct_circuit`
+    with different operators with same number of qubits generates an identical circuit.
+  - |
+    Fixed the issue that :class:`~qiskit.circuit.library.QAOAAnsatz` has
+    a wrong number of parameters if identities of :class:`~qiskit.opflow.PauliSumOp` are given,
+    e.g., ``PauliSumOp.from_list([("III", 1)])``.

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -23,7 +23,7 @@ from ddt import ddt, idata, unpack
 from qiskit.algorithms import QAOA
 from qiskit.algorithms.optimizers import COBYLA, NELDER_MEAD
 
-from qiskit.opflow import I, X, PauliSumOp
+from qiskit.opflow import I, X, Z, PauliSumOp
 
 from qiskit import BasicAer, QuantumCircuit, QuantumRegister
 
@@ -298,6 +298,17 @@ class TestQAOA(QiskitAlgorithmsTestCase):
         result = qaoa.compute_minimum_eigenvalue(operator=qubit_op)
 
         self.assertLess(result.eigenvalue, -0.97)
+
+    def test_qaoa_construct_circuit_update(self):
+        """Test updating operators with QAOA construct_circuit"""
+        qaoa = QAOA()
+        ref = qaoa.construct_circuit([0, 0], I ^ Z)[0]
+        circ2 = qaoa.construct_circuit([0, 0], I ^ Z)[0]
+        self.assertEqual(circ2, ref)
+        circ3 = qaoa.construct_circuit([0, 0], Z ^ I)[0]
+        self.assertNotEqual(circ3, ref)
+        circ4 = qaoa.construct_circuit([0, 0], I ^ Z)[0]
+        self.assertEqual(circ4, ref)
 
     def _get_operator(self, weight_matrix):
         """Generate Hamiltonian for the max-cut problem of a graph.

--- a/test/python/circuit/library/test_qaoa_ansatz.py
+++ b/test/python/circuit/library/test_qaoa_ansatz.py
@@ -18,7 +18,7 @@ from ddt import ddt, data
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.circuit.library import HGate, RXGate, YGate, RYGate, RZGate
 from qiskit.circuit.library.n_local.qaoa_ansatz import QAOAAnsatz
-from qiskit.opflow import I, Y, Z
+from qiskit.opflow import I, Y, Z, PauliSumOp
 from qiskit.test import QiskitTestCase
 
 
@@ -158,3 +158,16 @@ class TestQAOAAnsatz(QiskitTestCase):
 
         circuit = QAOAAnsatz(cost_operator=I ^ num_qubits, reps=5)
         self.assertEqual(circuit.num_qubits, num_qubits)
+
+    def test_identity(self):
+        """Test construction with identity"""
+        reps = 4
+        num_qubits = 3
+        pauli_sum_op = PauliSumOp.from_list([("I" * num_qubits, 1)])
+        pauli_op = I ^ num_qubits
+        for cost in [pauli_op, pauli_sum_op]:
+            for mixer in [None, pauli_op, pauli_sum_op]:
+                with self.subTest(f"cost: {type(cost)}, mixer:{type(mixer)}"):
+                    circuit = QAOAAnsatz(cost_operator=cost, mixer_operator=mixer, reps=reps)
+                    target = reps if mixer is None else 0
+                    self.assertEqual(circuit.num_parameters, target)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fixes following two bugs.

1. `QAOAAnsatz` cannot handle identities of `PauliSumOp` and it has a wrong number of parameters. 
2. `QAOA.construct_circuit` does not update circuits if different operators with the same number of qubits are given.

Fixes #7223

### Details and comments

I introduced `QAOA._cost_operator` to check whether `operator` is same as `_cost_operator` or not.
If we don't have to decompose `QAOA.ansatz`, we can compare `operator` with `QAOA.ansatz.cost_operator`.
Once #6674 is fixed, we need to revisit it.

https://github.com/Qiskit/qiskit-terra/blob/0a4c666ca09e129768f83f7c95ee7168455d869d/qiskit/algorithms/minimum_eigen_solvers/qaoa.py#L133