### PR TITLE
Fix `NLocal.add_layer` to append layers correctly when `NLocal._data` is built already

### DIFF
--- a/qiskit/circuit/library/n_local/n_local.py
+++ b/qiskit/circuit/library/n_local/n_local.py
@@ -779,7 +779,7 @@ class NLocal(BlueprintCircuit):
             for i in entangler_map:
                 params = self.ordered_parameters[-len(get_parameters(block)) :]
                 parameterized_block = self._parameterize_block(block, params=params)
-                layer.compose(parameterized_block, i)
+                layer.compose(parameterized_block, i, inplace=True)
 
             self.compose(layer, inplace=True)
         else:

--- a/releasenotes/notes/fix-nlocal-add_layer-c3cb0b5a49c2b04e.yaml
+++ b/releasenotes/notes/fix-nlocal-add_layer-c3cb0b5a49c2b04e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix :meth:`~qiskit.circuit.library.NLocal.add_layer` to append layers correctly
+    when :obj:`~qiskit.circuit.library.NLocal._data` is built already.

--- a/test/python/circuit/library/test_nlocal.py
+++ b/test/python/circuit/library/test_nlocal.py
@@ -154,15 +154,20 @@ class TestNLocal(QiskitTestCase):
         first_circuit = random_circuit(num_qubits[0], depth, seed=4220)
         # TODO Terra bug: if this is to_gate it fails, since the QC adds an instruction not gate
         nlocal = NLocal(max(num_qubits), entanglement_blocks=first_circuit.to_instruction(), reps=1)
+        nlocal2 = nlocal.copy()
+        _ = nlocal2.data
         reference.append(first_circuit, list(range(num_qubits[0])))
 
         # append the rest
         for num in num_qubits[1:]:
             circuit = random_circuit(num, depth, seed=4220)
-            nlocal.add_layer(NLocal(num, entanglement_blocks=circuit, reps=1))
+            layer = NLocal(num, entanglement_blocks=circuit, reps=1)
+            nlocal.add_layer(layer)
+            nlocal2.add_layer(layer)
             reference.append(circuit, list(range(num)))
 
         self.assertCircuitEqual(nlocal, reference)
+        self.assertCircuitEqual(nlocal2, reference)
 
     @unittest.skip("Feature missing")
     def test_iadd_overload(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Fix `NLocal.add_layer` to append layers correctly when `NLocal._data` is built already

### Details and comments

Because `layer.compose` does not have `inplace=True`, `layer` is not modified as expected.

https://github.com/Qiskit/qiskit-terra/blob/02b49e03ef62c8297437cfa907520f1f9c14283c/qiskit/circuit/library/n_local/n_local.py#L782-L784
