### PR TITLE
Fix decomposition of C3SXGate

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -511,19 +511,19 @@ class C3SXGate(ControlledGate):
         """
         gate c3sqrtx a,b,c,d
         {
-            h d; cu1(-pi/8) a,d; h d;
-            cx a,b;
-            h d; cu1(pi/8) b,d; h d;
+            h d; cu1(pi/8) a,d; h d;
             cx a,b;
             h d; cu1(-pi/8) b,d; h d;
+            cx a,b;
+            h d; cu1(pi/8) b,d; h d;
             cx b,c;
-            h d; cu1(pi/8) c,d; h d;
-            cx a,c;
             h d; cu1(-pi/8) c,d; h d;
+            cx a,c;
+            h d; cu1(pi/8) c,d; h d;
             cx b,c;
-            h d; cu1(pi/8) c,d; h d;
-            cx a,c;
             h d; cu1(-pi/8) c,d; h d;
+            cx a,c;
+            h d; cu1(pi/8) c,d; h d;
         }
         """
         # pylint: disable=cyclic-import
@@ -534,31 +534,31 @@ class C3SXGate(ControlledGate):
         # pylint: disable=invalid-unary-operand-type
         rules = [
             (HGate(), [q[3]], []),
-            (CU1Gate(-self._angle), [q[0], q[3]], []),
-            (HGate(), [q[3]], []),
-            (CXGate(), [q[0], q[1]], []),
-            (HGate(), [q[3]], []),
-            (CU1Gate(self._angle), [q[1], q[3]], []),
+            (CU1Gate(self._angle), [q[0], q[3]], []),
             (HGate(), [q[3]], []),
             (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[3]], []),
             (CU1Gate(-self._angle), [q[1], q[3]], []),
             (HGate(), [q[3]], []),
-            (CXGate(), [q[1], q[2]], []),
+            (CXGate(), [q[0], q[1]], []),
             (HGate(), [q[3]], []),
-            (CU1Gate(self._angle), [q[2], q[3]], []),
-            (HGate(), [q[3]], []),
-            (CXGate(), [q[0], q[2]], []),
-            (HGate(), [q[3]], []),
-            (CU1Gate(-self._angle), [q[2], q[3]], []),
+            (CU1Gate(self._angle), [q[1], q[3]], []),
             (HGate(), [q[3]], []),
             (CXGate(), [q[1], q[2]], []),
             (HGate(), [q[3]], []),
-            (CU1Gate(self._angle), [q[2], q[3]], []),
+            (CU1Gate(-self._angle), [q[2], q[3]], []),
             (HGate(), [q[3]], []),
             (CXGate(), [q[0], q[2]], []),
             (HGate(), [q[3]], []),
+            (CU1Gate(self._angle), [q[2], q[3]], []),
+            (HGate(), [q[3]], []),
+            (CXGate(), [q[1], q[2]], []),
+            (HGate(), [q[3]], []),
             (CU1Gate(-self._angle), [q[2], q[3]], []),
+            (HGate(), [q[3]], []),
+            (CXGate(), [q[0], q[2]], []),
+            (HGate(), [q[3]], []),
+            (CU1Gate(self._angle), [q[2], q[3]], []),
             (HGate(), [q[3]], []),
         ]
         qc = QuantumCircuit(q)
@@ -834,25 +834,25 @@ class C4XGate(ControlledGate):
         """
         gate c3sqrtx a,b,c,d
         {
-            h d; cu1(-pi/8) a,d; h d;
-            cx a,b;
-            h d; cu1(pi/8) b,d; h d;
+            h d; cu1(pi/8) a,d; h d;
             cx a,b;
             h d; cu1(-pi/8) b,d; h d;
+            cx a,b;
+            h d; cu1(pi/8) b,d; h d;
             cx b,c;
-            h d; cu1(pi/8) c,d; h d;
-            cx a,c;
             h d; cu1(-pi/8) c,d; h d;
+            cx a,c;
+            h d; cu1(pi/8) c,d; h d;
             cx b,c;
-            h d; cu1(pi/8) c,d; h d;
-            cx a,c;
             h d; cu1(-pi/8) c,d; h d;
+            cx a,c;
+            h d; cu1(pi/8) c,d; h d;
         }
         gate c4x a,b,c,d,e
         {
-            h e; cu1(-pi/2) d,e; h e;
+            h e; cu1(pi/2) d,e; h e;
             rc3x a,b,c,d;
-            h e; cu1(pi/4) d,e; h e;
+            h e; cu1(-pi/2) d,e; h e;
             rc3x a,b,c,d;
             c3sqrtx a,b,c,e;
         }
@@ -865,11 +865,11 @@ class C4XGate(ControlledGate):
         qc = QuantumCircuit(q, name=self.name)
         rules = [
             (HGate(), [q[4]], []),
-            (CU1Gate(-numpy.pi / 2), [q[3], q[4]], []),
+            (CU1Gate(numpy.pi / 2), [q[3], q[4]], []),
             (HGate(), [q[4]], []),
             (RC3XGate(), [q[0], q[1], q[2], q[3]], []),
             (HGate(), [q[4]], []),
-            (CU1Gate(numpy.pi / 2), [q[3], q[4]], []),
+            (CU1Gate(-numpy.pi / 2), [q[3], q[4]], []),
             (HGate(), [q[4]], []),
             (RC3XGate().inverse(), [q[0], q[1], q[2], q[3]], []),
             (C3SXGate(), [q[0], q[1], q[2], q[4]], []),

--- a/qiskit/qasm/libs/qelib1.inc
+++ b/qiskit/qasm/libs/qelib1.inc
@@ -241,26 +241,26 @@ gate c3x a,b,c,d
 // 3-controlled sqrt(X) gate, this equals the C3X gate where the CU1 rotations are -pi/8 not -pi/4
 gate c3sqrtx a,b,c,d
 {
-    h d; cu1(-pi/8) a,d; h d;
-    cx a,b;
-    h d; cu1(pi/8) b,d; h d;
+    h d; cu1(pi/8) a,d; h d;
     cx a,b;
     h d; cu1(-pi/8) b,d; h d;
+    cx a,b;
+    h d; cu1(pi/8) b,d; h d;
     cx b,c;
-    h d; cu1(pi/8) c,d; h d;
-    cx a,c;
     h d; cu1(-pi/8) c,d; h d;
+    cx a,c;
+    h d; cu1(pi/8) c,d; h d;
     cx b,c;
-    h d; cu1(pi/8) c,d; h d;
-    cx a,c;
     h d; cu1(-pi/8) c,d; h d;
+    cx a,c;
+    h d; cu1(pi/8) c,d; h d;
 }
 // 4-controlled X gate
 gate c4x a,b,c,d,e
 {
-    h e; cu1(-pi/2) d,e; h e;
-    c3x a,b,c,d;
     h e; cu1(pi/2) d,e; h e;
+    c3x a,b,c,d;
+    h e; cu1(-pi/2) d,e; h e;
     c3x a,b,c,d;
     c3sqrtx a,b,c,e;
 }

--- a/releasenotes/notes/fix-c3sxgate-7138e004a2b05ca8.yaml
+++ b/releasenotes/notes/fix-c3sxgate-7138e004a2b05ca8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :obj:`~qiskit.circuit.library.C3SXGate` now has a correct decomposition and matrix representation.
+    Previously it was equivalent to ``SdgXGate().control(3)``, rather than the intended ``SXGate().control(3)``.


### PR DESCRIPTION
### Summary

The phases used in the decomposition were inverted, so that the gate was
actually equivalent to `SdgXGate().control(3)` rather than the intended
`SXGate().control(3)`.  Note that both gates are valid square roots of
`C3XGate()`, which is likely how this went undetected, but the names and
value of `ControlledGate.base_gate` did not match.

The decomposition of `C4XGate` had a similar negative-phase error, but
the prelude cancelled with the use of the inverse `C3SXGate`, resulting
in a correct gate in the end.  This commit updates `C4XGate` to work
with the new `C3SXGate`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #7209.
