### PR TITLE
Add `SwapCXSwapToBridge` transpiler pass.

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -99,6 +99,7 @@ Generalized Gates
    GRZ
    RVGate
    PauliGate
+   BridgeGate
 
 Boolean Logic Circuits
 ======================
@@ -368,6 +369,7 @@ from .generalized_gates import (
     GRZ,
     RVGate,
     PauliGate,
+    BridgeGate,
 )
 from .pauli_evolution import PauliEvolutionGate
 from .boolean_logic import (

--- a/qiskit/circuit/library/generalized_gates/__init__.py
+++ b/qiskit/circuit/library/generalized_gates/__init__.py
@@ -19,3 +19,4 @@ from .gms import GMS, MSGate
 from .gr import GR, GRX, GRY, GRZ
 from .pauli import PauliGate
 from .rv import RVGate
+from .bridge import BridgeGate

--- a/qiskit/circuit/library/generalized_gates/bridge.py
+++ b/qiskit/circuit/library/generalized_gates/bridge.py
@@ -1,0 +1,77 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Bridge gate."""
+
+from typing import Optional
+from itertools import chain
+
+from qiskit.circuit.gate import Gate
+from qiskit.circuit.library.standard_gates import CXGate
+
+
+class BridgeGate(Gate):
+    r"""The Bridge gate.
+
+    For n = 3, the Bridge gate allows executing a CNOT between two qubits
+    that share a common neighbor.
+
+    **Circuit symbol:**
+
+    .. parsed-literal::
+
+             ┌─────────┐
+        q_0: ┤0        ├
+             │         │
+        q_1: ┤1 bridge ├
+             │         │
+        q_2: ┤2        ├
+             └─────────┘
+
+        q_0: ──■──              q_0: ──■─────────■───────
+               │                     ┌─┴─┐     ┌─┴─┐
+        q_1: ──┼──      =       q_1: ┤ X ├──■──┤ X ├──■──
+             ┌─┴─┐                   └───┘┌─┴─┐└───┘┌─┴─┐
+        q_2: ┤ X ├              q_2: ─────┤ X ├─────┤ X ├
+             └───┘                        └───┘     └───┘
+
+    For n > 3, the Bridge gate allows executing a CNOT between the first and
+    last qubit assuming they are connected by a line path that passes through
+    the intermediate qubits in the quantum device.
+    """
+
+    def __init__(self, num_qubits: int, label: Optional[str] = None):
+        """Create a new Bridge gate."""
+        super().__init__("bridge", num_qubits, [], label=label)
+
+    def _define(self):
+        # pylint: disable=cyclic-import
+        from qiskit.circuit import QuantumCircuit, QuantumRegister
+
+        n = self.num_qubits
+        qr = QuantumRegister(n, name="q")
+        qc = QuantumCircuit(qr, name=self.name)
+
+        rules = []
+        for _ in range(2):
+            rules.extend(
+                (CXGate(), [qr[i], qr[i + 1]], ()) for i in chain(range(n - 2), range(n - 2, 0, -1))
+            )
+
+        for instr, qargs, cargs in rules:
+            qc._append(instr, qargs, cargs)
+
+        self.definition = qc
+
+    def inverse(self):
+        """Return inverse Bridge gate (itself)."""
+        return BridgeGate(self.num_qubits)  # self-inverse

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1252,28 +1252,33 @@ class DAGCircuit:
         """
         yield from self._multi_graph.nodes()
 
-    def edges(self, nodes=None):
+    def edges(self, nodes=None, incoming=False):
         """Iterator for edge values and source and dest node
 
-        This works by returning the output edges from the specified nodes. If
+        This works by returning the outgoing (or incoming) edges from the specified nodes. If
         no nodes are specified all edges from the graph are returned.
 
         Args:
             nodes(DAGOpNode, DAGInNode, or DAGOutNode|list(DAGOpNode, DAGInNode, or DAGOutNode):
                 Either a list of nodes or a single input node. If none is specified,
                 all edges are returned from the graph.
+            incoming (bool): Optional, default False. If True, the output edges will be
+                the incoming edges of the nodes, or else it'll be the outgoing edges.
 
         Yield:
             edge: the edge in the same format as out_edges the tuple
                 (source node, destination node, edge data)
         """
+        collect_edges_fn = self._multi_graph.out_edges
+        if incoming:
+            collect_edges_fn = self._multi_graph.in_edges
         if nodes is None:
             nodes = self._multi_graph.nodes()
 
         elif isinstance(nodes, (DAGOpNode, DAGInNode, DAGOutNode)):
             nodes = [nodes]
         for node in nodes:
-            raw_nodes = self._multi_graph.out_edges(node._node_id)
+            raw_nodes = collect_edges_fn(node._node_id)
             for source, dest, edge in raw_nodes:
                 yield (self._multi_graph[source], self._multi_graph[dest], edge)
 

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -78,6 +78,7 @@ Optimizations
    RemoveResetInZeroState
    CrosstalkAdaptiveSchedule
    TemplateOptimization
+   SwapCXSwapToBridge
 
 Calibration
 =============
@@ -191,6 +192,7 @@ from .optimization import CrosstalkAdaptiveSchedule
 from .optimization import HoareOptimizer
 from .optimization import TemplateOptimization
 from .optimization import InverseCancellation
+from .optimization import SwapCXSwapToBridge
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -29,3 +29,4 @@ from .hoare_opt import HoareOptimizer
 from .template_optimization import TemplateOptimization
 from .inverse_cancellation import InverseCancellation
 from .collect_1q_runs import Collect1qRuns
+from .swap_cx_swap_to_bridge import SwapCXSwapToBridge

--- a/qiskit/transpiler/passes/optimization/swap_cx_swap_to_bridge.py
+++ b/qiskit/transpiler/passes/optimization/swap_cx_swap_to_bridge.py
@@ -1,0 +1,138 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Replace each SWAP-CX-SWAP sequence by a single Bridge gate."""
+
+from qiskit.dagcircuit.dagnode import DAGOpNode
+from qiskit.circuit.library.standard_gates import CXGate, SwapGate
+from qiskit.circuit.library.generalized_gates import BridgeGate
+from qiskit.transpiler.basepasses import TransformationPass
+
+
+class SwapCXSwapToBridge(TransformationPass):
+    """Replace each SWAP-CX-SWAP sequence by a single Bridge gate.
+
+    This pass finds CX gates surrounded by SWAP compute/uncompute pairs
+    that act on either the control or target qubit of CX and replaces them
+    by a Bridge Gate which has fewer CNOTs. Note that it's able to handle
+    any sequence of such SWAP pairs, not just one pair. For example, the
+    following subcircuit will be collected:
+
+                                                           ┌─────────┐
+        q_0: ─X─────────────X─                        q_0: ┤0        ├
+              │             │                              │         │
+        q_1: ─X──X───────X──X─                        q_1: ┤1        ├
+                 │       │             =>                  │  Bridge │
+        q_2: ────X───■───X────                        q_2: ┤2        ├
+                   ┌─┴─┐                                   │         │
+        q_3: ──────┤ X ├──────                        q_3: ┤3        ├
+                   └───┘                                   └─────────┘
+
+    This transpiler pass is particularly useful since routing passes may
+    insert such subcircuits and hence it should be run after routing.
+    """
+
+    def run(self, dag):
+        """Run the SwapCXSwapToBridge pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+        marked = set()
+        qubit_indices = {qb: ix for ix, qb in enumerate(dag.qubits)}
+
+        def is_pred_unmarked_and_on_qubit(edge, qubit):
+            pred, _, edge_qb = edge
+            return isinstance(pred, DAGOpNode) and edge_qb == qubit and pred not in marked
+
+        def is_succ_unmarked_and_on_qubit(edge, qubit):
+            _, succ, edge_qb = edge
+            return isinstance(succ, DAGOpNode) and edge_qb == qubit and succ not in marked
+
+        def is_swap_pair(nd_a, nd_b):
+            return (
+                isinstance(nd_a.op, SwapGate)
+                and nd_a.op.condition is None
+                and isinstance(nd_b.op, SwapGate)
+                and nd_b.op.condition is None
+                and sorted(nd_a.qargs, key=lambda q: qubit_indices[q])
+                == sorted(nd_b.qargs, key=lambda q: qubit_indices[q])
+                and dag.is_successor(nd_a, nd_b)
+            )
+
+        blocks = []
+        for node in dag.topological_op_nodes():
+            if not isinstance(node.op, CXGate):
+                continue
+
+            def follow_qubit_through_swap_pairs(qubit):
+                block_nd = []
+                wires = [qubit]
+
+                pred, succ = node, node
+                while True:
+                    try:
+                        pred, _, _ = next(
+                            filter(
+                                lambda raw: is_pred_unmarked_and_on_qubit(raw, qubit),
+                                dag.edges(pred, incoming=True),
+                            )
+                        )
+                        _, succ, _ = next(
+                            filter(
+                                lambda raw: is_succ_unmarked_and_on_qubit(raw, qubit),
+                                dag.edges(succ, incoming=False),
+                            )
+                        )
+
+                        if not is_swap_pair(pred, succ):
+                            break
+
+                        qubits = pred.qargs
+                        # move now to the qubit of this swap pair that we have not yet "explored".
+                        qubit = qubits[1 - qubits.index(qubit)]
+
+                        block_nd.extend([pred, succ])
+                        wires.append(qubit)
+                    except StopIteration:
+                        break
+
+                return block_nd, wires
+
+            # follow control qubit
+            c_qubit = node.qargs[0]
+            c_block, c_wires = follow_qubit_through_swap_pairs(c_qubit)
+            marked.update(c_block)
+
+            # follow target qubit
+            t_qubit = node.qargs[1]
+            t_block, t_wires = follow_qubit_through_swap_pairs(t_qubit)
+            marked.update(t_block)
+
+            if not (c_block or t_block):
+                continue
+
+            block_tot = c_block + [node] + t_block
+            wires = c_wires[::-1] + t_wires
+            wire_pos_map = dict((qb, ix) for ix, qb in enumerate(wires))
+            blocks.append((block_tot, wire_pos_map, node.op.condition))
+
+        # now replace the collected blocks with a Bridge gate.
+        for block, wire_pos_map, cx_node_condition in blocks:
+            op = BridgeGate(len(wire_pos_map))
+            op.condition = cx_node_condition
+            dag.replace_block_with_op(block, op, wire_pos_map, cycle_check=False)
+
+        return dag

--- a/releasenotes/notes/swap-cx-swap-8422538ecab51f77.yaml
+++ b/releasenotes/notes/swap-cx-swap-8422538ecab51f77.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Adds a new gate :class:`~qiskit.circuit.library.BridgeGate` which allows
+    executing a CNOT between two qubits that are connected by a path of length
+    greater than 1 in a quantum device.
+  - |
+    Adds a new transpiler pass :class:`~qiskit.transpiler.passes.SwapCXSwapToBridge`
+    which runs post-routing to find instances where a routing pass inserted a SWAP-CX-SWAP
+    and replaces it with a :class:`~qiskit.circuit.library.BridgeGate`. 

--- a/test/python/circuit/library/test_bridge.py
+++ b/test/python/circuit/library/test_bridge.py
@@ -1,0 +1,67 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test library of Bridge gate."""
+
+import unittest
+from ddt import ddt, data
+
+from qiskit.test.base import QiskitTestCase
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import BridgeGate, CXGate
+from qiskit.quantum_info import Operator
+
+
+@ddt
+class TestBridgeGate(QiskitTestCase):
+    """Test of Bridge gate."""
+
+    def test_threeq_decomposition(self):
+        bridge = BridgeGate(3)
+        circuit = bridge.definition
+
+        expected = QuantumCircuit(3)
+        expected.cx(0, 1)
+        expected.cx(1, 2)
+        expected.cx(0, 1)
+        expected.cx(1, 2)
+        self.assertEqual(circuit, expected)
+
+    @data(3, 4, 5)
+    def test_equivalence(self, n):
+        """Test Bridge on `n` qubits is same as CX_0,{n-1}."""
+        circuit = BridgeGate(n)
+
+        expected = QuantumCircuit(n)
+        expected.cx(0, n - 1)
+        expected = Operator(expected)
+
+        simulated = Operator(circuit)
+        self.assertTrue(expected.equiv(simulated))
+
+    @data(3, 4, 5)
+    def test_cnots_between_neighbors(self, n):
+        """Test Bridge gate decomposition has CNOTs only between neighbors in a line topology."""
+        bridge = BridgeGate(n)
+        circuit = bridge.definition
+        indices = {qb: ix for ix, qb in enumerate(circuit.qubits)}
+        for gate, qargs, _ in circuit:
+            self.assertTrue(isinstance(gate, CXGate))
+            self.assertEqual(indices[qargs[1]] - indices[qargs[0]], 1)
+
+    def test_self_inverse(self):
+        """Test Bridge gate is self-inverse."""
+        self.assertEqual(BridgeGate(3), BridgeGate(3).inverse())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/transpiler/test_swap_cx_swap_to_bridge.py
+++ b/test/python/transpiler/test_swap_cx_swap_to_bridge.py
@@ -1,0 +1,269 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Tests for the SwapCXSwapToBridge transpiler pass.
+"""
+
+import unittest
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.classicalregister import ClassicalRegister
+from qiskit.circuit.library import BridgeGate
+from qiskit.circuit.library.standard_gates import CXGate, SwapGate
+from qiskit.circuit.quantumregister import QuantumRegister
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes.optimization import SwapCXSwapToBridge
+from qiskit.test import QiskitTestCase
+
+
+class TestSwapCXSwapToBridge(QiskitTestCase):
+    """
+    Tests to verify that blocks of Swap-CX-Swap are found and replaced correctly.
+    """
+
+    def test_one_occurence(self):
+        """Test with input circuit:
+        q_0: ─X───────X─
+              │       │
+        q_1: ─X───■───X─
+                ┌─┴─┐
+        q_2: ───┤ X ├───
+                └───┘
+        """
+        qc = QuantumCircuit(3)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.append(BridgeGate(3), [0, 1, 2])
+        self.assertEqual(circuit, expected)
+
+    def test_one_occurence_cx_reversed_direction(self):
+        """Test with input circuit:
+        q_0: ─X───────X─
+              │ ┌───┐ │
+        q_1: ─X─┤ X ├─X─
+                └─┬─┘
+        q_2: ─────■─────
+        """
+        qc = QuantumCircuit(3)
+        qc.swap(0, 1)
+        qc.cx(2, 1)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.append(BridgeGate(3), [2, 1, 0])
+        self.assertEqual(circuit, expected)
+
+    def test_cx_with_single_qubit_adjacent_gates(self):
+        """Test with input circuit:
+        q_0: ──X─────────X──
+               │         │
+        q_1: ──X────■────X──
+             ┌───┐┌─┴─┐┌───┐
+        q_2: ┤ Z ├┤ X ├┤ H ├
+             └───┘└───┘└───┘
+        """
+        qc = QuantumCircuit(3)
+        qc.z(2)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.h(2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.z(2)
+        expected.append(BridgeGate(3), [0, 1, 2])
+        expected.h(2)
+        self.assertEqual(circuit, expected)
+
+    def test_multiple_occurences(self):
+        """Test with input circuit:
+        q_0: ─X───────X──────■─────
+              │       │    ┌─┴─┐
+        q_1: ─X───■───X──X─┤ X ├─X─
+                ┌─┴─┐    │ └───┘ │
+        q_2: ───┤ X ├────X───────X─
+                └───┘
+        """
+        qc = QuantumCircuit(3)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+        qc.swap(1, 2)
+        qc.cx(0, 1)
+        qc.swap(1, 2)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.append(BridgeGate(3), [0, 1, 2])
+        expected.append(BridgeGate(3), [0, 1, 2])
+        self.assertEqual(circuit, expected)
+
+    def test_with_more_swap_pairs(self):
+        """Test with input circuit:
+        q_0: ─X─────────────X─
+              │             │
+        q_1: ─X──X───────X──X─
+                 │       │
+        q_2: ────X───■───X────
+                   ┌─┴─┐
+        q_3: ──────┤ X ├──────
+                   └───┘
+        """
+        qc = QuantumCircuit(4)
+        qc.swap(0, 1)
+        qc.swap(1, 2)
+        qc.cx(2, 3)
+        qc.swap(1, 2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(4)
+        expected.append(BridgeGate(4), [0, 1, 2, 3])
+        self.assertEqual(circuit, expected)
+
+    def test_with_swap_pairs_in_both_control_and_target_qubits(self):
+        """Test with input circuit:
+        q_0: ─X───────X─
+              │       │
+        q_1: ─X───■───X─
+                ┌─┴─┐
+        q_2: ─X─┤ X ├─X─
+              │ └───┘ │
+        q_3: ─X───────X─
+        """
+        qc = QuantumCircuit(4)
+        qc.swap(0, 1)
+        qc.swap(2, 3)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+        qc.swap(2, 3)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(4)
+        expected.append(BridgeGate(4), [0, 1, 2, 3])
+        self.assertEqual(circuit, expected)
+
+    def test_swap_is_not_collected_twice(self):
+        """Test with input circuit:
+        q_0: ─X───────X───────X─
+              │       │       │
+        q_1: ─X───■───X───■───X─
+                ┌─┴─┐   ┌─┴─┐
+        q_2: ───┤ X ├───┤ X ├───
+                └───┘   └───┘
+        """
+        qc = QuantumCircuit(3)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(3)
+        expected.append(BridgeGate(3), [0, 1, 2])
+        expected.cx(1, 2)
+        expected.swap(0, 1)
+        self.assertEqual(circuit, expected)
+
+    def test_not_replace_if_gate_between_swaps(self):
+        """Test with input circuit:
+                ┌───┐
+        q_0: ─X─┤ X ├─X─
+              │ └───┘ │
+        q_1: ─X───■───X─
+                ┌─┴─┐
+        q_2: ───┤ X ├───
+                └───┘
+        """
+        qc = QuantumCircuit(3)
+        qc.swap(0, 1)
+        qc.x(0)
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+        self.assertEqual(circuit, qc)
+
+    def test_with_classical_bit_in_cx(self):
+        """Test with input circuit:
+        q_0: ─X─────────X─
+              │         │
+        q_1: ─X────■────X─
+                 ┌─┴─┐
+        q_2: ────┤ X ├────
+                 └─╥─┘
+                ┌──╨──┐
+        c: 1/═══╡ 0x1 ╞═══
+                └─────┘
+        """
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(1)
+        qc = QuantumCircuit(qr, cr)
+        qc.swap(0, 1)
+        qc.append(CXGate().c_if(cr, 1), (1, 2))
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+
+        expected = QuantumCircuit(qr, cr)
+        expected.append(BridgeGate(3).c_if(cr, 1), [0, 1, 2])
+        self.assertEqual(circuit, expected)
+
+    def test_not_replace_with_classical_bit_in_swap(self):
+        """Test with input circuit:
+        q_0: ───X─────────X─
+                │         │
+        q_1: ───X─────■───X─
+                ║   ┌─┴─┐
+        q_2: ───╫───┤ X ├───
+             ┌──╨──┐└───┘
+        c: 1/╡ 0x1 ╞════════
+             └─────┘
+        """
+        qr = QuantumRegister(3)
+        cr = ClassicalRegister(1)
+        qc = QuantumCircuit(qr, cr)
+        qc.append(SwapGate().c_if(cr, 1), (0, 1))
+        qc.cx(1, 2)
+        qc.swap(0, 1)
+
+        pm = PassManager(SwapCXSwapToBridge())
+        circuit = pm.run(qc)
+        self.assertEqual(circuit, qc)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This commits implements a new transpiler optimization
pass that finds sub-circuits of the form:
sequence of SWAPS - CX - reversed sequence of SWAPS
and replaces them with a bridge gate which has fewer CNOT gates.
Sub-circuits of this form might be inserted by a routing pass and
hence this pass should run post-routing. At the same time,
this commit adds the bridge gate which was missing from the qiskit
circuit library.

Closes #6656
