### PR TITLE
Make docplex and cplex imports for BIP mapper runtime imports

### DIFF
--- a/qiskit/transpiler/passes/routing/bip_mapping.py
+++ b/qiskit/transpiler/passes/routing/bip_mapping.py
@@ -23,11 +23,7 @@ from qiskit.dagcircuit import DAGCircuit, DAGOpNode
 from qiskit.exceptions import MissingOptionalLibraryError
 from qiskit.transpiler import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
-from qiskit.transpiler.passes.routing.algorithms.bip_model import (
-    BIPMappingModel,
-    HAS_CPLEX,
-    HAS_DOCPLEX,
-)
+from qiskit.transpiler.passes.routing.algorithms.bip_model import BIPMappingModel
 
 logger = logging.getLogger(__name__)
 
@@ -115,13 +111,16 @@ class BIPMapping(TransformationPass):
             MissingOptionalLibraryError: if cplex or docplex are not installed.
             TranspilerError: if invalid options are specified.
         """
-        if not HAS_DOCPLEX or not HAS_CPLEX:
+        try:
+            import docplex  # pylint: disable=unused-import
+            import cplex  # pylint: disable=unused-import
+        except ImportError as error:
             raise MissingOptionalLibraryError(
                 libname="bip-mapper",
                 name="BIP-based mapping pass",
                 pip_install="pip install 'qiskit-terra[bip-mapper]'",
                 msg="This may not be possible for all Python versions and OSes",
-            )
+            ) from error
         super().__init__()
         self.coupling_map = coupling_map
         self.qubit_subset = qubit_subset

--- a/test/python/transpiler/test_bip_mapping.py
+++ b/test/python/transpiler/test_bip_mapping.py
@@ -24,7 +24,21 @@ from qiskit.transpiler import CouplingMap, Layout, PassManager
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import BIPMapping
 from qiskit.transpiler.passes import CheckMap, Collect2qBlocks, ConsolidateBlocks, UnitarySynthesis
-from qiskit.transpiler.passes.routing.algorithms.bip_model import HAS_CPLEX, HAS_DOCPLEX
+
+
+try:
+    import cplex  # pylint: disable=unused-import
+
+    HAS_CPLEX = True
+except ImportError:
+    HAS_CPLEX = False
+
+try:
+    import docplex  # pylint: disable=unused-import
+
+    HAS_DOCPLEX = True
+except ImportError:
+    HAS_DOCPLEX = False
 
 
 @unittest.skipUnless(HAS_CPLEX, "cplex is required to run the BIPMapping tests")

--- a/tools/find_optional_imports.py
+++ b/tools/find_optional_imports.py
@@ -32,6 +32,7 @@ def _main():
         "qiskit.providers.ibmq",
         "qiskit.ignis",
         "qiskit.aqua",
+        "docplex",
     ]
 
     modules_imported = []


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The docplex and cplex optional dependencies which are used for the BIP
mapper routing transpiler pass are quite heavy weight and pull in a lot
of extra libraries to the import tree slowing down the overall import of
qiskit when installed. For example, just importing docplex also imports
pandas, jedi, and ipython. We don't want this overhead for importing
qiskit because docplex and cplex are only used by a small part of qiskit
which is not widely used (and not even available to all users). To avoid
this overhead when docplex and cplex are installed this commit moves the
docplex and cplex imports to be runtime during the execution of the pass
which uses them. This is necessary because the pass gets re-exported to
the root qiskit.transpiler.passes which gets imported as part of the
root 'import qiskit'.

### Details and comments