### PR TITLE
Fix permute issue in PauliSumOp

### DIFF
--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -197,6 +197,10 @@ class PauliSumOp(PrimitiveOp):
         Raises:
             OpflowError: if indices do not define a new index for each qubit.
         """
+        set_perm = set(permutation)
+        if len(set_perm) != len(permutation) or any(index < 0 for index in set_perm):
+            raise OpflowError(f"List {permutation} is not a permutation.")
+
         if len(permutation) != self.num_qubits:
             raise OpflowError(
                 "List of indices to permute must have the same size as Pauli Operator"

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -202,7 +202,12 @@ class PauliSumOp(PrimitiveOp):
                 "List of indices to permute must have the same size as Pauli Operator"
             )
         length = max(permutation) + 1
-        spop = self.primitive.tensor(SparsePauliOp(Pauli("I" * (length - self.num_qubits))))
+
+        if length > self.num_qubits:
+            spop = self.primitive.tensor(SparsePauliOp(Pauli("I" * (length - self.num_qubits))))
+        else:
+            spop = self.primitive
+
         permutation = [i for i in range(length) if i not in permutation] + permutation
         permu_arr = np.arange(length)[np.argsort(permutation)]
         spop.paulis.x = spop.paulis.x[:, permu_arr]

--- a/releasenotes/notes/pauli-op-permute-fix-d244a1145093369d.yaml
+++ b/releasenotes/notes/pauli-op-permute-fix-d244a1145093369d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    This change fixes a bug in PauliSumOp where permute would raise the error
+    QiskitError: 'Pauli string label "" is not valid.' if the permutation had
+    the same number of pauli terms. Calling permute([2, 1, 0]) on X ^ Y ^ Z
+    no longer raises an error with this fix and now returns Z ^ Y ^ X.

--- a/releasenotes/notes/pauli-op-permute-fix-d244a1145093369d.yaml
+++ b/releasenotes/notes/pauli-op-permute-fix-d244a1145093369d.yaml
@@ -1,7 +1,10 @@
 ---
 fixes:
   - |
-    This change fixes a bug in PauliSumOp where permute would raise the error
-    QiskitError: 'Pauli string label "" is not valid.' if the permutation had
-    the same number of pauli terms. Calling permute([2, 1, 0]) on X ^ Y ^ Z
-    no longer raises an error with this fix and now returns Z ^ Y ^ X.
+    Fixed a bug in :meth:`.PauliSumOp.permute` causing the error::
+
+        QiskitError: 'Pauli string label "" is not valid.'
+
+    if the permutation had the same number of Pauli terms. Calling
+    ``permute([2, 1, 0])`` on ``X ^ Y ^ Z`` no longer raises an error, and now
+    returns ``Z ^ Y ^ X``.

--- a/test/python/opflow/test_pauli_sum_op.py
+++ b/test/python/opflow/test_pauli_sum_op.py
@@ -169,6 +169,10 @@ class TestPauliSumOp(QiskitOpflowTestCase):
 
         self.assertEqual(pauli_sum.permute([1, 2, 4]), expected)
 
+        pauli_sum = PauliSumOp(SparsePauliOp((X ^ Y ^ Z).primitive))
+        expected = PauliSumOp(SparsePauliOp((Z ^ Y ^ X).primitive))
+        self.assertEqual(pauli_sum.permute([2, 1, 0]), expected)
+
     def test_compose(self):
         """compose test"""
         target = (X + Z) @ (Y + Z)

--- a/test/python/opflow/test_pauli_sum_op.py
+++ b/test/python/opflow/test_pauli_sum_op.py
@@ -36,6 +36,7 @@ from qiskit.opflow import (
     Y,
     Z,
     Zero,
+    OpflowError,
 )
 from qiskit.quantum_info import Pauli, PauliTable, SparsePauliOp
 
@@ -172,6 +173,12 @@ class TestPauliSumOp(QiskitOpflowTestCase):
         pauli_sum = PauliSumOp(SparsePauliOp((X ^ Y ^ Z).primitive))
         expected = PauliSumOp(SparsePauliOp((Z ^ Y ^ X).primitive))
         self.assertEqual(pauli_sum.permute([2, 1, 0]), expected)
+
+        with self.assertRaises(OpflowError):
+            pauli_sum.permute([1, 2, 1])
+
+        with self.assertRaises(OpflowError):
+            pauli_sum.permute([1, 2, -1])
 
     def test_compose(self):
         """compose test"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There is a bug in PauliSumOp with the permute function.

### Details and comments

Currently, the following code
```python
from qiskit.opflow import Z, I

op = (I^Z^I) + (Z^Z^I)

op.permute([1, 0, 2])
```
raises the error `QiskitError: 'Pauli string label "" is not valid.'`. This should not happen. This PR introduces a small fix to avoid such errors when the permutation does not introduce identities.
