### PR TITLE
Fix `c3sx` gate definition (`c3sqrtx`->`c3sx`)

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -509,7 +509,7 @@ class C3SXGate(ControlledGate):
 
     def _define(self):
         """
-        gate c3sqrtx a,b,c,d
+        gate c3sx a,b,c,d
         {
             h d; cu1(pi/8) a,d; h d;
             cx a,b;
@@ -832,7 +832,7 @@ class C4XGate(ControlledGate):
     # seems like open controls not hapening?
     def _define(self):
         """
-        gate c3sqrtx a,b,c,d
+        gate c3sx a,b,c,d
         {
             h d; cu1(pi/8) a,d; h d;
             cx a,b;
@@ -854,7 +854,7 @@ class C4XGate(ControlledGate):
             rc3x a,b,c,d;
             h e; cu1(-pi/2) d,e; h e;
             rc3x a,b,c,d;
-            c3sqrtx a,b,c,e;
+            c3sx a,b,c,e;
         }
         """
         # pylint: disable=cyclic-import

--- a/qiskit/qasm/libs/qelib1.inc
+++ b/qiskit/qasm/libs/qelib1.inc
@@ -239,7 +239,7 @@ gate c3x a,b,c,d
     h d;
 }
 // 3-controlled sqrt(X) gate, this equals the C3X gate where the CU1 rotations are -pi/8 not -pi/4
-gate c3sqrtx a,b,c,d
+gate c3sx a,b,c,d
 {
     h d; cu1(pi/8) a,d; h d;
     cx a,b;
@@ -260,7 +260,5 @@ gate c4x a,b,c,d,e
 {
     h e; cu1(pi/2) d,e; h e;
     c3x a,b,c,d;
-    h e; cu1(-pi/2) d,e; h e;
-    c3x a,b,c,d;
-    c3sqrtx a,b,c,e;
+    c3sx a,b,c,e;
 }

--- a/qiskit/qasm/pygments/lexer.py
+++ b/qiskit/qasm/pygments/lexer.py
@@ -73,7 +73,7 @@ class OpenQASMLexer(RegexLexer):
         "ccx",
         "c3x",
         "c4x",
-        "c3sqrtx",
+        "c3sx",
         "rx",
         "ry",
         "rz",

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -66,7 +66,15 @@ class LoadFromQasmTest(QiskitTestCase):
         Test setting up a circuit with all gates defined in qiskit/qasm/libs/qelib1.inc
         """
         from qiskit.circuit.library import (
-            U1Gate, U2Gate, U3Gate, CU1Gate, CU3Gate, UGate, C3XGate, C4XGate, C3SXGate,
+            U1Gate,
+            U2Gate,
+            U3Gate,
+            CU1Gate,
+            CU3Gate,
+            UGate,
+            C3XGate,
+            C4XGate,
+            C3SXGate,
         )
 
         all_gates_qasm = self.qasm_dir / "all_gates.qasm"
@@ -135,10 +143,10 @@ class LoadFromQasmTest(QiskitTestCase):
 
         # check that all qelib1.inc gates are in ref_circuit
         qelib1_gates = self.get_qelib1_gates()
-        qelib1_gates -= {"u0"}    # u0 is not supported outside of qelib1
+        qelib1_gates -= {"u0"}  # u0 is not supported outside of qelib1
         qelib1_gates -= {"rc3x"}  # rc3x is defined as rcccx in RC3XGate class
-        qelib1_gates -= {"c3x"}   # c3x is defined as mcx in C3XGate class
-        qelib1_gates -= {"c4x"}   # c4x is defined as mcx in C4XGate class
+        qelib1_gates -= {"c3x"}  # c3x is defined as mcx in C3XGate class
+        qelib1_gates -= {"c4x"}  # c4x is defined as mcx in C4XGate class
 
         self.assertTrue(qelib1_gates <= ref_ops, msg=qelib1_gates - ref_ops)
 

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -13,7 +13,7 @@
 
 """Test cases for the circuit qasm_file and qasm_string method."""
 
-import os
+from pathlib import Path
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit import Gate, Parameter
@@ -29,10 +29,8 @@ class LoadFromQasmTest(QiskitTestCase):
     def setUp(self):
         super().setUp()
         self.qasm_file_name = "entangled_registers.qasm"
-        self.qasm_dir = os.path.join(
-            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "qasm"
-        )
-        self.qasm_file_path = os.path.join(self.qasm_dir, self.qasm_file_name)
+        self.qasm_dir = (Path(__file__).parent.parent / "qasm").absolute()
+        self.qasm_file_path = self.qasm_dir / self.qasm_file_name
 
     def test_qasm_file(self):
         """
@@ -58,7 +56,7 @@ class LoadFromQasmTest(QiskitTestCase):
         """Test setting up a circuit with all gates defined in qiskit/qasm/libs/qelib1.inc."""
         from qiskit.circuit.library import U1Gate, U2Gate, U3Gate, CU1Gate, CU3Gate, UGate
 
-        all_gates_qasm = os.path.join(self.qasm_dir, "all_gates.qasm")
+        all_gates_qasm = self.qasm_dir / "all_gates.qasm"
         qasm_circuit = QuantumCircuit.from_qasm_file(all_gates_qasm)
 
         ref_circuit = QuantumCircuit(3, 3)
@@ -226,7 +224,7 @@ class LoadFromQasmTest(QiskitTestCase):
 
     def test_qasm_example_file(self):
         """Loads qasm/example.qasm."""
-        qasm_filename = os.path.join(self.qasm_dir, "example.qasm")
+        qasm_filename = self.qasm_dir / "example.qasm"
         expected_circuit = QuantumCircuit.from_qasm_str(
             "\n".join(
                 [

--- a/test/python/circuit/test_circuit_load_from_qasm.py
+++ b/test/python/circuit/test_circuit_load_from_qasm.py
@@ -54,6 +54,9 @@ class LoadFromQasmTest(QiskitTestCase):
         self.assertEqual(q_circuit, q_circuit_2)
 
     def get_qelib1_gates(self):
+        """
+        Get all the gates from qelib1.inc library as a set of strings
+        """
         qelib1_path = (Path(qiskit.qasm.__file__).parent / "libs/qelib1.inc").absolute()
         self.assertTrue(qelib1_path.exists())
         parsed_qasm = qiskit.qasm.Qasm(qelib1_path).parse()

--- a/test/python/qasm/all_gates.qasm
+++ b/test/python/qasm/all_gates.qasm
@@ -1,7 +1,7 @@
 OPENQASM 2.0;
 include "qelib1.inc";
-qreg q[3];
-creg c[3];
+qreg q[5];
+creg c[5];
 
 // note that the order and where the gates are applied to is important!
 
@@ -59,8 +59,11 @@ crz(0.6) q[0], q[1];
 rxx(0.2) q[0], q[1];
 rzz(0.2) q[0], q[1];
 
+rccx q[0], q[1], q[2];
+rc3x q[0], q[1], q[2], q[3];
+c3x q[0], q[1], q[2], q[3];
+c3sx q[0], q[1], q[2], q[3];
+c4x q[0], q[1], q[2], q[3], q[4];
+
 // measure
 measure q->c;
-
-
-

--- a/test/python/qasm/all_gates.qasm
+++ b/test/python/qasm/all_gates.qasm
@@ -1,5 +1,11 @@
 OPENQASM 2.0;
 include "qelib1.inc";
+
+gate rcccx_dg q0,q1,q2,q3 { u2(-2*pi,pi) q3; u1(pi/4) q3; cx q2,q3; u1(-pi/4) q3; u2(-2*pi,pi) q3; u1(pi/4) q3; cx q1,q3; u1(-pi/4) q3; cx q0,q3; u1(pi/4) q3; cx q1,q3; u1(-pi/4) q3; cx q0,q3; u2(-2*pi,pi) q3; u1(pi/4) q3; cx q2,q3; u1(-pi/4) q3; u2(-2*pi,pi) q3; }
+gate rcccx q0,q1,q2,q3 { u2(0,pi) q3; u1(pi/4) q3; cx q2,q3; u1(-pi/4) q3; u2(0,pi) q3; cx q0,q3; u1(pi/4) q3; cx q1,q3; u1(-pi/4) q3; cx q0,q3; u1(pi/4) q3; cx q1,q3; u1(-pi/4) q3; u2(0,pi) q3; u1(pi/4) q3; cx q2,q3; u1(-pi/4) q3; u2(0,pi) q3; }
+gate mcx q0,q1,q2,q3 { h q3; p(pi/8) q0; p(pi/8) q1; p(pi/8) q2; p(pi/8) q3; cx q0,q1; p(-pi/8) q1; cx q0,q1; cx q1,q2; p(-pi/8) q2; cx q0,q2; p(pi/8) q2; cx q1,q2; p(-pi/8) q2; cx q0,q2; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q1,q3; p(pi/8) q3; cx q2,q3; p(-pi/8) q3; cx q0,q3; h q3; }
+gate mcx_5272411680 q0,q1,q2,q3,q4 { h q4; cu1(-pi/2) q3,q4; h q4; rcccx q0,q1,q2,q3; h q4; cu1(pi/2) q3,q4; h q4; rcccx_dg q0,q1,q2,q3; c3sx q0,q1,q2,q4; }
+
 qreg q[5];
 creg c[5];
 
@@ -60,10 +66,12 @@ rxx(0.2) q[0], q[1];
 rzz(0.2) q[0], q[1];
 
 rccx q[0], q[1], q[2];
-rc3x q[0], q[1], q[2], q[3];
-c3x q[0], q[1], q[2], q[3];
+rcccx q[0], q[1], q[2], q[3];
+mcx q[0], q[1], q[2], q[3];
 c3sx q[0], q[1], q[2], q[3];
-c4x q[0], q[1], q[2], q[3], q[4];
+// mcx_c4 q[0], q[1], q[2], q[3], q[4];  // no option to test this gate
+
+barrier q;
 
 // measure
 measure q->c;


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.

### Summary
Fixes #7148.
Change all the occurrences of `c3sqrtx` to `c3sx` to allow a quantum circuit with a
`C3SXGate` to be converted to qasm and back to a quantum circuit from the qasm.
Modify `test_loading_all_qelib1_gates` to truly test all `qelib1.inc` gates (except for specific ones).

### Details and comments
During working on this PR, I encountered more issues:

- Duplicate definitions and names of gates: `rcccx`, `c3x`, `c4x`, etc.
- Initial fixes for the issues should be similar to the one here.

Unfortunately, I would not be able to fix them all now.

