### PR TITLE
Add option to unitary synthesis plugin interface for user config

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -66,6 +66,7 @@ def transpile(
     callback: Optional[Callable[[BasePass, DAGCircuit, float, PropertySet, int], Any]] = None,
     output_name: Optional[Union[str, List[str]]] = None,
     unitary_synthesis_method: str = "default",
+    unitary_synthesis_plugin_config: dict = None,
 ) -> Union[QuantumCircuit, List[QuantumCircuit]]:
     """Transpile one or more circuits, according to some desired transpilation targets.
 
@@ -220,6 +221,14 @@ def transpile(
             method to use. By default 'default' is used, which is the only
             method included with qiskit. If you have installed any unitary
             synthesis plugins you can use the name exported by the plugin.
+        unitary_synthesis_plugin_config: An optional configuration dictionary
+            that will be passed directly to the unitary synthesis plugin. By
+            default this setting will have no effect as the default unitary
+            synthesis method does not take custom configuration. This should
+            only be necessary when a unitary synthesis plugin is specified with
+            the ``unitary_synthesis`` argument. As this is custom for each
+            unitary synthesis plugin refer to the plugin documentation for how
+            to use this option.
 
     Returns:
         The transpiled circuit(s).
@@ -301,6 +310,7 @@ def transpile(
         output_name,
         timing_constraints,
         unitary_synthesis_method,
+        unitary_synthesis_plugin_config,
     )
 
     _check_circuits_coupling_map(circuits, transpile_args, backend)
@@ -484,6 +494,7 @@ def _parse_transpile_args(
     output_name,
     timing_constraints,
     unitary_synthesis_method,
+    unitary_synthesis_plugin_config,
 ) -> List[Dict]:
     """Resolve the various types of args allowed to the transpile() function through
     duck typing, overriding args, etc. Refer to the transpile() docstring for details on
@@ -518,6 +529,9 @@ def _parse_transpile_args(
     approximation_degree = _parse_approximation_degree(approximation_degree, num_circuits)
     unitary_synthesis_method = _parse_unitary_synthesis_method(
         unitary_synthesis_method, num_circuits
+    )
+    unitary_synthesis_plugin_config = _parse_unitary_plugin_config(
+        unitary_synthesis_plugin_config, num_circuits
     )
     seed_transpiler = _parse_seed_transpiler(seed_transpiler, num_circuits)
     optimization_level = _parse_optimization_level(optimization_level, num_circuits)
@@ -554,6 +568,7 @@ def _parse_transpile_args(
             "backend_num_qubits": backend_num_qubits,
             "faulty_qubits_map": faulty_qubits_map,
             "unitary_synthesis_method": unitary_synthesis_method,
+            "unitary_synthesis_plugin_config": unitary_synthesis_plugin_config,
         }
     ):
         transpile_args = {
@@ -572,6 +587,7 @@ def _parse_transpile_args(
                 timing_constraints=kwargs["timing_constraints"],
                 seed_transpiler=kwargs["seed_transpiler"],
                 unitary_synthesis_method=kwargs["unitary_synthesis_method"],
+                unitary_synthesis_plugin_config=kwargs["unitary_synthesis_plugin_config"],
             ),
             "optimization_level": kwargs["optimization_level"],
             "output_name": kwargs["output_name"],
@@ -835,6 +851,12 @@ def _parse_unitary_synthesis_method(unitary_synthesis_method, num_circuits):
     if not isinstance(unitary_synthesis_method, list):
         unitary_synthesis_method = [unitary_synthesis_method] * num_circuits
     return unitary_synthesis_method
+
+
+def _parse_unitary_plugin_config(unitary_synthesis_plugin_config, num_circuits):
+    if not isinstance(unitary_synthesis_plugin_config, list):
+        unitary_synthesis_plugin_config = [unitary_synthesis_plugin_config] * num_circuits
+    return unitary_synthesis_plugin_config
 
 
 def _parse_seed_transpiler(seed_transpiler, num_circuits):

--- a/qiskit/transpiler/passes/synthesis/plugin.py
+++ b/qiskit/transpiler/passes/synthesis/plugin.py
@@ -134,6 +134,16 @@ include as long as each plugin has a unique name. So a single package can
 expose multiple plugins if necessary. The name ``default`` is used by Qiskit
 itself and can't be used in a plugin.
 
+Unitary Synthesis Plugin Configuration
+''''''''''''''''''''''''''''''''''''''
+
+For some unitary synthesis plugins that expose multiple options and tunables
+the plugin interface has an option for users to provide a free form
+configuration dictionary. This will be passed through to the ``run()`` method
+as the ``config`` kwarg. If your plugin has these configuration options you
+should clearly document how a user should specify these configuration options
+and how they're used as it's a free form field.
+
 Using Plugins
 =============
 

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -118,6 +118,7 @@ class UnitarySynthesis(TransformationPass):
         synth_gates: Union[List[str], None] = None,
         method: str = "default",
         min_qubits: int = None,
+        plugin_config: dict = None,
     ):
         """Synthesize unitaries over some basis gates.
 
@@ -161,6 +162,11 @@ class UnitarySynthesis(TransformationPass):
             min_qubits: The minimum number of qubits in the unitary to synthesize. If this is set
                 and the unitary is less than the specified number of qubits it will not be
                 synthesized.
+            plugin_config: Optional extra configuration arguments (as a dict)
+                which are passed directly to the specified unitary synthesis
+                plugin. By default this will have no effect as the default
+                plugin has no extra arguments. Refer to the documentation of
+                your unitary synthesis plugin on how to use this.
         """
         super().__init__()
         self._basis_gates = set(basis_gates or ())
@@ -172,6 +178,7 @@ class UnitarySynthesis(TransformationPass):
         self._backend_props = backend_props
         self._pulse_optimize = pulse_optimize
         self._natural_direction = natural_direction
+        self._plugin_config = plugin_config
         if synth_gates:
             self._synth_gates = synth_gates
         else:
@@ -267,7 +274,7 @@ class UnitarySynthesis(TransformationPass):
                     self._coupling_map,
                     [dag_bit_indices[x] for x in node.qargs],
                 )
-            synth_dag = method.run(unitary, **kwargs)
+            synth_dag = method.run(unitary, config=self._plugin_config, **kwargs)
             if synth_dag is not None:
                 if isinstance(synth_dag, tuple):
                     dag.substitute_node_with_dag(node, synth_dag[0], wires=synth_dag[1])

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -212,7 +212,7 @@ class UnitarySynthesis(TransformationPass):
             return dag
 
         plugin_method = self.plugins.ext_plugins[self.method].obj
-        plugin_kwargs = {}
+        plugin_kwargs = {"config": self._plugin_config}
         _gate_lengths = _gate_errors = None
         dag_bit_indices = {}
 
@@ -274,7 +274,7 @@ class UnitarySynthesis(TransformationPass):
                     self._coupling_map,
                     [dag_bit_indices[x] for x in node.qargs],
                 )
-            synth_dag = method.run(unitary, config=self._plugin_config, **kwargs)
+            synth_dag = method.run(unitary, **kwargs)
             if synth_dag is not None:
                 if isinstance(synth_dag, tuple):
                     dag.substitute_node_with_dag(node, synth_dag[0], wires=synth_dag[1])

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -35,6 +35,7 @@ class PassManagerConfig:
         seed_transpiler=None,
         timing_constraints=None,
         unitary_synthesis_method="default",
+        unitary_synthesis_plugin_config=None,
     ):
         """Initialize a PassManagerConfig object
 
@@ -80,6 +81,7 @@ class PassManagerConfig:
         self.seed_transpiler = seed_transpiler
         self.timing_constraints = timing_constraints
         self.unitary_synthesis_method = unitary_synthesis_method
+        self.unitary_synthesis_plugin_config = unitary_synthesis_plugin_config
 
     @classmethod
     def from_backend(cls, backend, **pass_manager_options):

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -92,6 +92,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     approximation_degree = pass_manager_config.approximation_degree
     timing_constraints = pass_manager_config.timing_constraints or TimingConstraints()
     unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
+    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
 
     # 1. Choose an initial layout if not set by user (default: trivial layout)
     _given_layout = SetLayout(initial_layout)
@@ -123,6 +124,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             backend_props=backend_properties,
             method=unitary_synthesis_method,
             min_qubits=3,
+            plugin_config=unitary_synthesis_plugin_config,
         ),
         Unroll3qOrMore(),
     ]
@@ -166,6 +168,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
             UnrollCustomDefinitions(sel, basis_gates),
             BasisTranslator(sel, basis_gates),
@@ -179,6 +182,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
                 min_qubits=3,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
             Unroll3qOrMore(),
             Collect2qBlocks(),
@@ -190,6 +194,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
         ]
     else:

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -98,6 +98,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     backend_properties = pass_manager_config.backend_properties
     approximation_degree = pass_manager_config.approximation_degree
     unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
+    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
     timing_constraints = pass_manager_config.timing_constraints or TimingConstraints()
 
     # 1. Use trivial layout if no layout given
@@ -142,6 +143,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             method=unitary_synthesis_method,
             backend_props=backend_properties,
             min_qubits=3,
+            plugin_config=unitary_synthesis_plugin_config,
         ),
         Unroll3qOrMore(),
     ]
@@ -187,6 +189,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 method=unitary_synthesis_method,
                 backend_props=backend_properties,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
             UnrollCustomDefinitions(sel, basis_gates),
             BasisTranslator(sel, basis_gates),
@@ -212,6 +215,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 method=unitary_synthesis_method,
                 backend_props=backend_properties,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
         ]
     else:

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -103,6 +103,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     approximation_degree = pass_manager_config.approximation_degree
     unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
     timing_constraints = pass_manager_config.timing_constraints or TimingConstraints()
+    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
 
     # 1. Search for a perfect layout, or choose a dense layout, if no layout given
     _given_layout = SetLayout(initial_layout)
@@ -176,6 +177,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             backend_props=backend_properties,
             method=unitary_synthesis_method,
             min_qubits=3,
+            plugin_config=unitary_synthesis_plugin_config,
         ),
         Unroll3qOrMore(),
     ]
@@ -221,6 +223,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
             UnrollCustomDefinitions(sel, basis_gates),
             BasisTranslator(sel, basis_gates),
@@ -235,6 +238,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
                 min_qubits=3,
             ),
             Unroll3qOrMore(),
@@ -246,6 +250,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
         ]
     else:

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -106,6 +106,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     approximation_degree = pass_manager_config.approximation_degree
     unitary_synthesis_method = pass_manager_config.unitary_synthesis_method
     timing_constraints = pass_manager_config.timing_constraints or TimingConstraints()
+    unitary_synthesis_plugin_config = pass_manager_config.unitary_synthesis_plugin_config
 
     # 1. Unroll to 1q or 2q gates
     _unroll3q = [
@@ -116,6 +117,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             coupling_map=coupling_map,
             backend_props=backend_properties,
             method=unitary_synthesis_method,
+            plugin_config=unitary_synthesis_plugin_config,
             min_qubits=3,
         ),
         Unroll3qOrMore(),
@@ -221,6 +223,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 approximation_degree=approximation_degree,
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
+                plugin_config=unitary_synthesis_plugin_config,
                 method=unitary_synthesis_method,
             ),
             UnrollCustomDefinitions(sel, basis_gates),
@@ -234,6 +237,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
                 min_qubits=3,
             ),
             Unroll3qOrMore(),
@@ -245,6 +249,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 coupling_map=coupling_map,
                 backend_props=backend_properties,
                 method=unitary_synthesis_method,
+                plugin_config=unitary_synthesis_plugin_config,
             ),
         ]
     else:
@@ -278,6 +283,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             coupling_map=coupling_map,
             backend_props=backend_properties,
             method=unitary_synthesis_method,
+            plugin_config=unitary_synthesis_plugin_config,
         ),
         Optimize1qGatesDecomposition(basis_gates),
         CommutativeCancellation(),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new option to the unitary synthesis plugin interface
for plugins to accept free form user config. Two potential synthesis
plugins both have asked for an interface where a user can pass
configuration options through to the plugin to tune how the plugin runs.
To enable this, this commit adds a new kwarg to transpile() to pass a
configuration dictionary straight through to the plugin. As this is a
custom thing for each plugin the burden is on the plugin author to
define how this dictionary is used, implement using it, and documenting
it's use.

### Details and comments