### PR TITLE
Clean up strings

### DIFF
--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -83,8 +83,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
 
         if confint_method not in {"chernoff", "beta"}:
             raise ValueError(
-                "The confidence interval method must be chernoff or beta, but "
-                f"is {confint_method}."
+                f"The confidence interval method must be chernoff or beta, but is {confint_method}."
             )
 
         super().__init__()

--- a/qiskit/algorithms/linear_solvers/hhl.py
+++ b/qiskit/algorithms/linear_solvers/hhl.py
@@ -519,8 +519,7 @@ class HHL(LinearSolver):
         if observable is not None:
             if observable_circuit is not None or post_processing is not None:
                 raise ValueError(
-                    "If observable is passed, observable_circuit and post_processing "
-                    "cannot be set."
+                    "If observable is passed, observable_circuit and post_processing cannot be set."
                 )
 
         solution = LinearSolverResult()

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -681,8 +681,7 @@ queried as VQEResult.ansatz.bind_parameters(VQEResult.optimal_point)."""
         """Get the circuit with the optimal parameters."""
         if self._ret.optimal_point is None:
             raise AlgorithmError(
-                "Cannot find optimal circuit before running the "
-                "algorithm to find optimal params."
+                "Cannot find optimal circuit before running the algorithm to find optimal params."
             )
         return self.ansatz.assign_parameters(self._ret.optimal_parameters)
 
@@ -697,8 +696,7 @@ queried as VQEResult.eigenvector."""
         """Get the simulation outcome of the optimal circuit."""
         if self._ret.optimal_parameters is None:
             raise AlgorithmError(
-                "Cannot find optimal circuit before running the "
-                "algorithm to find optimal vector."
+                "Cannot find optimal circuit before running the algorithm to find optimal vector."
             )
         return self._get_eigenstate(self._ret.optimal_parameters)
 

--- a/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
+++ b/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
@@ -65,9 +65,10 @@ class NLoptOptimizer(Optimizer):
             raise MissingOptionalLibraryError(
                 libname="nlopt",
                 name="NLoptOptimizer",
-                msg="See https://qiskit.org/documentation/apidoc/"
-                "qiskit.algorithms.optimizers.nlopts.html"
-                " for installation information",
+                msg=(
+                    "See https://qiskit.org/documentation/apidoc/"
+                    "qiskit.algorithms.optimizers.nlopts.html for installation information"
+                ),
             )
 
         super().__init__()

--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -379,8 +379,7 @@ def execute(
             if not hasattr(backend.options, key):
                 if run_kwargs[key] is not None:
                     logger.info(
-                        "%s backend doesn't support option %s so not "
-                        "passing that kwarg to run()",
+                        "%s backend doesn't support option %s so not passing that kwarg to run()",
                         backend.name,
                         key,
                     )

--- a/qiskit/opflow/converters/two_qubit_reduction.py
+++ b/qiskit/opflow/converters/two_qubit_reduction.py
@@ -68,8 +68,7 @@ class TwoQubitReduction(ConverterBase):
 
         if operator.is_zero():
             logger.info(
-                "Operator is empty, can not do two qubit reduction. "
-                "Return the empty operator back."
+                "Operator is empty, can not do two qubit reduction. Return the empty operator back."
             )
             return PauliSumOp.from_list([("I" * (operator.num_qubits - 2), 0)])
 

--- a/qiskit/opflow/gradients/gradient.py
+++ b/qiskit/opflow/gradients/gradient.py
@@ -206,9 +206,11 @@ class Gradient(GradientBase):
                     raise MissingOptionalLibraryError(
                         libname="jax",
                         name="get_gradient",
-                        msg="This automatic differentiation function is based on JAX. "
-                        "Please install jax and use `import jax.numpy as jnp` instead "
-                        "of `import numpy as np` when defining a combo_fn.",
+                        msg=(
+                            "This automatic differentiation function is based on JAX. "
+                            "Please install jax and use `import jax.numpy as jnp` instead "
+                            "of `import numpy as np` when defining a combo_fn."
+                        ),
                     )
 
             def chain_rule_combo_fn(x):

--- a/qiskit/opflow/gradients/hessian.py
+++ b/qiskit/opflow/gradients/hessian.py
@@ -253,9 +253,11 @@ class Hessian(HessianBase):
                     raise MissingOptionalLibraryError(
                         libname="jax",
                         name="get_hessian",
-                        msg="This automatic differentiation function is based on JAX. Please "
-                        "install jax and use `import jax.numpy as jnp` instead of "
-                        "`import numpy as np` when defining a combo_fn.",
+                        msg=(
+                            "This automatic differentiation function is based on JAX. Please "
+                            "install jax and use `import jax.numpy as jnp` instead of "
+                            "`import numpy as np` when defining a combo_fn."
+                        ),
                     )
             else:
                 if _HAS_JAX:
@@ -267,9 +269,11 @@ class Hessian(HessianBase):
                     raise MissingOptionalLibraryError(
                         libname="jax",
                         name="get_hessian",
-                        msg="This automatic differentiation function is based on JAX. "
-                        "Please install jax and use `import jax.numpy as jnp` instead "
-                        "of `import numpy as np` when defining a combo_fn.",
+                        msg=(
+                            "This automatic differentiation function is based on JAX. "
+                            "Please install jax and use `import jax.numpy as jnp` instead "
+                            "of `import numpy as np` when defining a combo_fn."
+                        ),
                     )
 
             # For a general combo_fn F(g_0, g_1, ..., g_k)

--- a/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
@@ -52,8 +52,7 @@ class TaperedPauliSumOp(PauliSumOp):
         super().__init__(primitive, coeff)
         if not isinstance(z2_symmetries, Z2Symmetries):
             raise TypeError(
-                "Argument parameter z2_symmetries must be Z2Symmetries, "
-                f"not {type(z2_symmetries)}"
+                f"Argument parameter z2_symmetries must be Z2Symmetries, not {type(z2_symmetries)}"
             )
         self._z2_symmetries = z2_symmetries
 
@@ -109,8 +108,7 @@ class Z2Symmetries:
 
         if len(sq_paulis) != len(sq_list):
             raise OpflowError(
-                "Number of single-qubit pauli x has to be the same "
-                "as length of single-qubit list."
+                "Number of single-qubit pauli x has to be the same as length of single-qubit list."
             )
 
         if tapering_values is not None:

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -728,8 +728,7 @@ class Schedule:
                 return new_sched
             except PulseError as err:
                 raise PulseError(
-                    "Replacement of {old} with {new} results in "
-                    "overlapping instructions.".format(old=old, new=new)
+                    f"Replacement of {old} with {new} results in overlapping instructions."
                 ) from err
 
     def is_parameterized(self) -> bool:

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -96,8 +96,7 @@ def instruction_duration_validation(duration: int):
 
     if not isinstance(duration, (int, np.integer)) or duration < 0:
         raise QiskitError(
-            "Instruction duration must be a non-negative integer, "
-            "got {} instead.".format(duration)
+            f"Instruction duration must be a non-negative integer, got {duration} instead."
         )
 
 

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -343,8 +343,7 @@ def _cvxpy_check(name):
     # Check if CVXPY package is installed
     if not _HAS_CVX:
         raise QiskitError(
-            "CVXPY backage is requried for {}. Install"
-            " with `pip install cvxpy` to use.".format(name)
+            f"CVXPY backage is requried for {name}. Install with `pip install cvxpy` to use."
         )
     # Check CVXPY version
     version = cvxpy.__version__

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -178,8 +178,7 @@ class Pauli(BasePauli):
         elif isinstance(data, tuple):
             if len(data) not in [2, 3]:
                 raise QiskitError(
-                    "Invalid input tuple for Pauli, input tuple must be"
-                    " `(z, x, phase)` or `(z, x)`"
+                    "Invalid input tuple for Pauli, input tuple must be `(z, x, phase)` or `(z, x)`"
                 )
             base_z, base_x, base_phase = self._from_array(*data)
         elif isinstance(data, str):

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -292,8 +292,9 @@ class StabilizerTable(PauliTable, AdjointMixin):
             ind = [ind]
         if max(ind) >= self.size:
             raise QiskitError(
-                "Indices {} are not all less than the size"
-                " of the SatbilizerTable ({})".format(ind, self.size)
+                "Indices {} are not all less than the size of the StabilizerTable ({})".format(
+                    ind, self.size
+                )
             )
         return StabilizerTable(
             np.delete(self._array, ind, axis=0), np.delete(self._phase, ind, axis=0)

--- a/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
@@ -180,8 +180,8 @@ def xx_circuit_step(source, strength, target, embodiment):
                 continue
 
             # pick out the other coordinates
-            source_first, source_second = [x for x in [0, 1, 2] if x != source_shared]
-            target_first, target_second = [x for x in [0, 1, 2] if x != target_shared]
+            source_first, source_second = (x for x in [0, 1, 2] if x != source_shared)
+            target_first, target_second = (x for x in [0, 1, 2] if x != target_shared)
 
             # check for arccos validity
             r, s, u, v, x, y = decompose_xxyy_into_xxyy_xx(

--- a/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
@@ -205,7 +205,7 @@ def xx_circuit_step(source, strength, target, embodiment):
 
     if permute_source_for_overlap is None:
         raise QiskitError(
-            f"Error during RZX decomposition: Could not find a suitable Weyl "
+            "Error during RZX decomposition: Could not find a suitable Weyl "
             f"reflection to match {source} to {target} along {strength}."
         )
 

--- a/qiskit/quantum_info/synthesis/xx_decompose/paths.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/paths.py
@@ -135,8 +135,10 @@ xx_region_polytope = PolytopeData(
                 [0, 0, 0, 0, 0, 0, 0, 1],
             ],
             equalities=[],
-            name="I ∩ A alcove ∩ "
-            "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -157,8 +159,10 @@ xx_region_polytope = PolytopeData(
                 [0, 0, 0, 0, 0, 0, 0, 1],
             ],
             equalities=[],
-            name="I ∩ A alcove ∩ "
-            "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -180,8 +184,10 @@ xx_region_polytope = PolytopeData(
                 [0, 0, 0, 0, 0, 0, 0, 1],
             ],
             equalities=[],
-            name="I ∩ A alcove ∩ "
-            "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -203,8 +209,10 @@ xx_region_polytope = PolytopeData(
                 [0, 0, 0, 0, 0, 0, 0, 1],
             ],
             equalities=[],
-            name="I ∩ A alcove ∩ "
-            "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1"
+            ),
         ),
     ]
 )
@@ -256,8 +264,10 @@ xx_lift_polytope = PolytopeData(
                 [0, 1, -1, 0, 1, -1, 0, 0, 0, 0, -1],
             ],
             equalities=[[0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0]],
-            name="I ∩ A alcove ∩ "
-            "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A unreflected ∩ ah slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B3"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -292,8 +302,10 @@ xx_lift_polytope = PolytopeData(
                 [0, 1, -1, 0, 0, 1, -1, 0, 0, 0, -1],
             ],
             equalities=[[0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0]],
-            name="I ∩ A alcove ∩ "
-            "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A unreflected ∩ af slant ∩ al frustrum ∩ B alcove ∩ B unreflected ∩ AF=B1"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -328,8 +340,10 @@ xx_lift_polytope = PolytopeData(
                 [0, 1, -1, 0, 0, 1, -1, 0, 0, 0, -1],
             ],
             equalities=[[0, 0, 0, 1, -1, 0, 0, 0, 0, 0, 0]],
-            name="I ∩ A alcove ∩ "
-            "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A reflected ∩ af strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B1"
+            ),
         ),
         ConvexPolytopeData(
             inequalities=[
@@ -364,8 +378,10 @@ xx_lift_polytope = PolytopeData(
                 [0, 1, -1, 0, 1, -1, 0, 0, 0, 0, -1],
             ],
             equalities=[[0, 0, 0, 1, 0, 0, -1, 0, 0, 0, 0]],
-            name="I ∩ A alcove ∩ "
-            "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3",
+            name=(
+                "I ∩ A alcove ∩ "
+                "A reflected ∩ ah strength ∩ al frustrum ∩ B alcove ∩ B reflected ∩ AF=B3"
+            ),
         ),
     ]
 )

--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -366,8 +366,7 @@ class Result:
         if key is None:
             if len(self.results) != 1:
                 raise QiskitError(
-                    "You have to select a circuit or schedule when there is more than "
-                    "one available"
+                    "You have to select a circuit or schedule when there is more than one available"
                 )
             key = 0
 

--- a/qiskit/test/decorators.py
+++ b/qiskit/test/decorators.py
@@ -136,8 +136,7 @@ def _get_credentials():
             # Use the first available credentials.
             return list(discovered_credentials.values())[0]
     raise unittest.SkipTest(
-        "No IBMQ credentials found for running the test. This is required for "
-        "running online tests."
+        "No IBMQ credentials found for running the test. This is required for running online tests."
     )
 
 

--- a/qiskit/tools/jupyter/backend_monitor.py
+++ b/qiskit/tools/jupyter/backend_monitor.py
@@ -314,8 +314,7 @@ tr:nth-child(even) {background-color: #f6f6f6;}
 
         qubit_html += f"<tr><td><font style='font-weight:bold'>{name}</font></td>"
         qubit_html += (
-            f"<td>{cal_data['frequency']}</td>"
-            f"<td>{cal_data['T1']}</td><td>{cal_data['T2']}</td>"
+            f"<td>{cal_data['frequency']}</td><td>{cal_data['T1']}</td><td>{cal_data['T2']}</td>"
         )
         for gerror in gate_error:
             qubit_html += f"<td>{gerror}</td>"

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -93,7 +93,7 @@ class Unroller(TransformationPass):
                 except (TypeError, AttributeError) as err:
                     raise QiskitError(
                         f"Error decomposing node of instruction '{node.name}': {err}. "
-                        f"Unable to define instruction '{rule[0][0].name}'in the given basis."
+                        f"Unable to define instruction '{rule[0][0].name}' in the given basis."
                     ) from err
 
             else:

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -74,9 +74,8 @@ class Unroller(TransformationPass):
                 rule = node.op.definition.data
             except (TypeError, AttributeError) as err:
                 raise QiskitError(
-                    f"Error decomposing node of instruction '{node.name}': "
-                    f"{err}. Unable to define instruction '{node.name}' in the"
-                    f" given basis."
+                    f"Error decomposing node of instruction '{node.name}': {err}. "
+                    f"Unable to define instruction '{node.name}' in the given basis."
                 ) from err
 
             # Isometry gates definitions can have widths smaller than that of the
@@ -93,9 +92,8 @@ class Unroller(TransformationPass):
                     rule = rule[0][0].definition.data
                 except (TypeError, AttributeError) as err:
                     raise QiskitError(
-                        f"Error decomposing node of instruction '{node.name}': "
-                        f"{err}. Unable to define instruction '{rule[0][0].name}'"
-                        f" in the given basis."
+                        f"Error decomposing node of instruction '{node.name}': {err}. "
+                        f"Unable to define instruction '{rule[0][0].name}'in the given basis."
                     ) from err
 
             else:

--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -40,15 +40,15 @@ class InverseCancellation(TransformationPass):
         for gates in gates_to_cancel:
             if isinstance(gates, Gate):
                 if gates != gates.inverse():
-                    raise TranspilerError("Gate {} is not self-inverse".format(gates.name))
+                    raise TranspilerError(f"Gate {gates.name} is not self-inverse")
             elif isinstance(gates, tuple):
                 if len(gates) != 2:
                     raise TranspilerError(
-                        "Too many or too few inputs: {}. Only two are allowed.".format(gates)
+                        f"Too many or too few inputs: {gates}. Only two are allowed."
                     )
                 if gates[0] != gates[1].inverse():
                     raise TranspilerError(
-                        "Gate {} and {} are not inverse.".format(gates[0].name, gates[1].name)
+                        f"Gate {gates[0].name} and {gates[1].name} are not inverse."
                     )
             else:
                 raise TranspilerError(

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -115,9 +115,9 @@ class Optimize1qGatesDecomposition(TransformationPass):
                 + "\n\nand got\n\n"
                 + "\n".join([str(node[0]) for node in new_circ])
                 + f"\n\nbut the original was native (for {self._target_basis}) and the new value "
-                f"is longer.  This indicates an efficiency bug in synthesis.  Please report it by "
-                f"opening an issue here: "
-                f"https://github.com/Qiskit/qiskit-terra/issues/new/choose",
+                "is longer.  This indicates an efficiency bug in synthesis.  Please report it by "
+                "opening an issue here: "
+                "https://github.com/Qiskit/qiskit-terra/issues/new/choose",
                 stacklevel=2,
             )
 

--- a/qiskit/transpiler/passes/routing/lookahead_swap.py
+++ b/qiskit/transpiler/passes/routing/lookahead_swap.py
@@ -121,8 +121,7 @@ class LookaheadSwap(TransformationPass):
 
             if best_step is None:
                 raise TranspilerError(
-                    "Lookahead failed to find a swap which mapped "
-                    "gates or improved layout score."
+                    "Lookahead failed to find a swap which mapped gates or improved layout score."
                 )
 
             logger.debug(

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -147,7 +147,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    f"CheckMap Error: {check_map_msg}"
+                    "CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -147,7 +147,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    "CheckMap Error: {check_map_msg}"
+                    f"CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -145,8 +145,10 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == "none":
         _swap += [
             Error(
-                msg="No routing method selected, but circuit is not routed to device. "
-                "CheckMap Error: {check_map_msg}",
+                msg=(
+                    "No routing method selected, but circuit is not routed to device. "
+                    "CheckMap Error: {check_map_msg}"
+                ),
                 action="raise",
             )
         ]

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -166,7 +166,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    "CheckMap Error: {check_map_msg}"
+                    f"CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -164,8 +164,10 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == "none":
         _swap += [
             Error(
-                msg="No routing method selected, but circuit is not routed to device. "
-                "CheckMap Error: {check_map_msg}",
+                msg=(
+                    "No routing method selected, but circuit is not routed to device. "
+                    "CheckMap Error: {check_map_msg}"
+                ),
                 action="raise",
             )
         ]

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -166,7 +166,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    f"CheckMap Error: {check_map_msg}"
+                    "CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -198,8 +198,10 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == "none":
         _swap += [
             Error(
-                msg="No routing method selected, but circuit is not routed to device. "
-                "CheckMap Error: {check_map_msg}",
+                msg=(
+                    "No routing method selected, but circuit is not routed to device. "
+                    "CheckMap Error: {check_map_msg}"
+                ),
                 action="raise",
             )
         ]

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -200,7 +200,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    "CheckMap Error: {check_map_msg}"
+                    f"CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -200,7 +200,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    f"CheckMap Error: {check_map_msg}"
+                    "CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -201,8 +201,10 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
     elif routing_method == "none":
         _swap += [
             Error(
-                msg="No routing method selected, but circuit is not routed to device. "
-                "CheckMap Error: {check_map_msg}",
+                msg=(
+                    "No routing method selected, but circuit is not routed to device. "
+                    "CheckMap Error: {check_map_msg}"
+                ),
                 action="raise",
             )
         ]

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -203,7 +203,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    "CheckMap Error: {check_map_msg}"
+                    f"CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -203,7 +203,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Error(
                 msg=(
                     "No routing method selected, but circuit is not routed to device. "
-                    f"CheckMap Error: {check_map_msg}"
+                    "CheckMap Error: {check_map_msg}"
                 ),
                 action="raise",
             )

--- a/qiskit/utils/mitigation/circuits.py
+++ b/qiskit/utils/mitigation/circuits.py
@@ -207,7 +207,7 @@ def tensored_meas_cal(
 
     cal_circuits = []
     for basis_state in state_labels:
-        qc_circuit = QuantumCircuit(qr, cr, name="%scal_%s" % (circlabel, basis_state))
+        qc_circuit = QuantumCircuit(qr, cr, name=f"{circlabel}cal_{basis_state}")
 
         end_index = nqubits
         for qubit_list, list_size in zip(mit_pattern, qubits_list_sizes):

--- a/qiskit/visualization/latex.py
+++ b/qiskit/visualization/latex.py
@@ -146,7 +146,7 @@ class QCircuitImage:
         self.cregs_bits = [self.bit_locations[bit]["register"] for bit in clbits]
         self.img_regs = {bit: ind for ind, bit in enumerate(self.ordered_bits)}
 
-        num_reg_bits = sum([reg.size for reg in self.cregs])
+        num_reg_bits = sum(reg.size for reg in self.cregs)
         if self.cregbundle:
             self.img_width = len(qubits) + len(clbits) - (num_reg_bits - len(self.cregs))
         else:

--- a/qiskit/visualization/matplotlib.py
+++ b/qiskit/visualization/matplotlib.py
@@ -886,7 +886,7 @@ class MatplotlibDrawer:
         if cond_is_bit and self._cregbundle:
             cond_reg = self._bit_locations[node.op.condition[0]]["register"]
             ctrl_bit = self._bit_locations[node.op.condition[0]]["index"]
-            label = "%s_%s=%s" % (cond_reg.name, ctrl_bit, hex(val))
+            label = f"{cond_reg.name}_{ctrl_bit}={hex(val)}"
         else:
             label = hex(val)
         if isinstance(node.op, Measure):

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -1417,8 +1417,10 @@ def state_drawer(state, output=None, **drawer_args):
             raise MissingOptionalLibraryError(
                 libname="IPython",
                 name="state_drawer",
-                pip_install="\"pip install ipython\", or set output='latex_source' "
-                "instead for an ASCII string.",
+                pip_install=(
+                    "\"pip install ipython\", or set output='latex_source' "
+                    "instead for an ASCII string."
+                ),
             ) from err
         else:
             draw_func = drawers["latex_source"]

--- a/qiskit/visualization/utils.py
+++ b/qiskit/visualization/utils.py
@@ -207,8 +207,7 @@ def get_bit_label(drawer, register, index, qubit=True, layout=None, cregbundle=T
                 bit_label = f"{virt_reg.name}_{virt_reg[:].index(virt_bit)} -> {index}"
             else:
                 bit_label = (
-                    f"{{{virt_reg.name}}}_{{{virt_reg[:].index(virt_bit)}}}"
-                    f" \\mapsto {{{index}}}"
+                    f"{{{virt_reg.name}}}_{{{virt_reg[:].index(virt_bit)}}} \\mapsto {{{index}}}"
                 )
         except StopIteration:
             if drawer == "text":

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -109,8 +109,7 @@ class TestQAOA(QiskitAlgorithmsTestCase):
     def test_qaoa_qc_mixer(self, w, prob, solutions, convert_to_matrix_op):
         """QAOA test with a mixer as a parameterized circuit"""
         self.log.debug(
-            "Testing %s-step QAOA with MaxCut on graph with "
-            "a mixer as a parameterized circuit\n%s",
+            "Testing %s-step QAOA with MaxCut on graph with a mixer as a parameterized circuit\n%s",
             prob,
             w,
         )

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -154,7 +154,7 @@ class TestEvolutionGate(QiskitTestCase):
         dag = circuit_to_dag(circuit)
 
         expected_ops = {"HGate", "CXGate", "PauliEvolutionGate"}
-        ops = set(node.op.__class__.__name__ for node in dag.op_nodes())
+        ops = {node.op.__class__.__name__ for node in dag.op_nodes()}
 
         self.assertEqual(ops, expected_ops)
 

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -523,8 +523,7 @@ class TestTranspile(QiskitTestCase):
             transpile(qc, backend, initial_layout=bad_initial_layout)
 
         self.assertEqual(
-            "FullAncillaAllocation: The layout refers to a qubit that does "
-            "not exist in circuit.",
+            "FullAncillaAllocation: The layout refers to a qubit that does not exist in circuit.",
             cm.exception.message,
         )
 

--- a/test/python/transpiler/test_full_ancilla_allocation.py
+++ b/test/python/transpiler/test_full_ancilla_allocation.py
@@ -174,8 +174,7 @@ class TestFullAncillaAllocation(QiskitTestCase):
         with self.assertRaises(TranspilerError) as cm:
             pass_.run(dag)
         self.assertEqual(
-            "FullAncillaAllocation: The layout refers to a qubit that does "
-            "not exist in circuit.",
+            "FullAncillaAllocation: The layout refers to a qubit that does not exist in circuit.",
             cm.exception.message,
         )
 

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -324,9 +324,11 @@ def _main():
     parser.add_argument(
         "--version",
         "-v",
-        help="Optionally specify the version being tested. "
-        "This will enable additional circuit features "
-        "to test generating and loading QPY.",
+        help=(
+            "Optionally specify the version being tested. "
+            "This will enable additional circuit features "
+            "to test generating and loading QPY."
+        ),
     )
     args = parser.parse_args()
     qpy_files = generate_circuits(args.version)

--- a/tools/subunit_to_junit.py
+++ b/tools/subunit_to_junit.py
@@ -122,9 +122,11 @@ def run_filter_script(
         "--forward",
         action="store_true",
         default=False,
-        help="Forward subunit stream on stdout. When set, "
-        "received non-subunit output will be encapsulated"
-        " in subunit.",
+        help=(
+            "Forward subunit stream on stdout. When set, "
+            "received non-subunit output will be encapsulated"
+            " in subunit."
+        ),
     )
     args = parser.parse_args()
     result = filter_by_result(

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ basepython = python3
 allowlist_externals = git
 commands =
   black --check {posargs} qiskit test tools examples setup.py
-	-git fetch -q https://github.com/Qiskit/qiskit-terra.git :lint_incr_latest
+  -git fetch -q https://github.com/Qiskit/qiskit-terra.git :lint_incr_latest
   {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --paths :/qiskit/*.py :/test/*.py :/tools/*.py
   {toxinidir}/tools/pylint_incr.py -rn -j4 -sn --disable='invalid-name,missing-module-docstring,redefined-outer-name' --paths :(glob,top)examples/python/*.py
   {toxinidir}/tools/verify_headers.py qiskit test tools examples


### PR DESCRIPTION
Cleaning up multiline strings.

- A few places strings were broken into more lines than necessary.
- Removed f"" from strings where no substitution is done
- ~~Added f"" to a few strings which intended to do substitution but were missing the prefix~~
- Parenthenthesized multi-line strings in the middle of function calls, for improved readabililty
- Also improved a couple python2-isms i noticed along the way
