### PR TITLE
Fix ZeroDivisionError in qiskit_backend_overview

### DIFF
--- a/qiskit/tools/jupyter/backend_overview.py
+++ b/qiskit/tools/jupyter/backend_overview.py
@@ -199,7 +199,8 @@ def backend_widget(backend):
                         if param["value"] != 1.0:
                             sum_cx_err += param["value"]
                             num_cx += 1
-        avg_cx_err = round(sum_cx_err / (num_cx), 4)
+        if num_cx > 0:
+            avg_cx_err = round(sum_cx_err / num_cx, 4)
 
     cx_widget = widgets.HTML(value=f"<h5>{avg_cx_err}</h5>", layout=widgets.Layout())
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Leave `avg_cx_err` as the string "NA" if there are no `cx` gates in the map.


### Details and comments

Fix #7259.

I didn't write a unit test for it because I'm lazy, we have absolutely no testing infrastructure for testing IPython line magics at the moment, and I didn't want to play around with the mock backends, and mock out the inner calls to return dummy backends with missing `cx` gates and so forth.  We probably should, though...  It's just hard to find the time to do it.