### PR TITLE
Remove leftover debug prints in unit tests

### DIFF
--- a/test/python/quantum_info/xx_decompose/test_polytopes.py
+++ b/test/python/quantum_info/xx_decompose/test_polytopes.py
@@ -46,7 +46,6 @@ class TestMonodromyXXPolytope(unittest.TestCase):
         """Check that the nearest point calculator recovers some known cases."""
         polytope = XXPolytope.from_strengths(pi / 6, pi / 8, pi / 10)
         result = polytope.nearest(np.array(offbody))
-        print(offbody, result)
         self.assertTrue(np.all(np.abs(np.array(expected) - result) < EPSILON))
 
     def test_add_strengths(self):

--- a/test/python/quantum_info/xx_decompose/test_weyl.py
+++ b/test/python/quantum_info/xx_decompose/test_weyl.py
@@ -52,10 +52,6 @@ class TestMonodromyWeyl(unittest.TestCase):
             original_matrix = canonical_matrix(*coordinate)
             reflected_matrix = canonical_matrix(*reflected_coordinate)
             reflect_matrix = Operator(reflection_circuit).data
-            with np.printoptions(precision=3, suppress=True):
-                print(name)
-                print(reflect_matrix.conjugate().transpose(1, 0) @ original_matrix @ reflect_matrix)
-                print(reflected_matrix * reflection_phase)
             self.assertTrue(
                 np.all(
                     np.abs(
@@ -76,10 +72,6 @@ class TestMonodromyWeyl(unittest.TestCase):
             original_matrix = canonical_matrix(*coordinate)
             shifted_matrix = canonical_matrix(*shifted_coordinate)
             shift_matrix = Operator(shift_circuit).data
-            with np.printoptions(precision=3, suppress=True):
-                print(name)
-                print(original_matrix @ shift_matrix)
-                print(shifted_matrix * shift_phase)
             self.assertTrue(
                 np.all(
                     np.abs(original_matrix @ shift_matrix - shifted_matrix * shift_phase) < EPSILON


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #6551 a few debug prints slipped into the unittests which are dumping
arrays to stdout during unit test runs. This commit just cleans those up
and removes the stray prints.

### Details and comments