### PR TITLE
Change concatenation operator to match QASM spec

### DIFF
--- a/qiskit/qasm3/printer.py
+++ b/qiskit/qasm3/printer.py
@@ -243,7 +243,7 @@ class BasicPrinter:
         self.stream.write("let ")
         self.visit(node.identifier)
         self.stream.write(" = ")
-        self._visit_sequence(node.concatenation, separator=" || ")
+        self._visit_sequence(node.concatenation, separator=" ++ ")
         self._end_statement()
 
     def _visit_QuantumGateModifier(self, node: QuantumGateModifier) -> None:

--- a/test/python/circuit/test_circuit_qasm3.py
+++ b/test/python/circuit/test_circuit_qasm3.py
@@ -108,8 +108,8 @@ class TestCircuitQasm3(QiskitTestCase):
                 "let first_four = _q[0:3];",
                 "let last_five = _q[5:9];",
                 # The exporter does not attempt to output steps.
-                "let alternate = _q[0:0] || _q[2:2] || _q[4:4] || _q[6:6] || _q[8:8];",
-                "let sporadic = _q[4:4] || _q[2:2] || _q[9:9];",
+                "let alternate = _q[0:0] ++ _q[2:2] ++ _q[4:4] ++ _q[6:6] ++ _q[8:8];",
+                "let sporadic = _q[4:4] ++ _q[2:2] ++ _q[9:9];",
                 "",
             ]
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QASM3 concatenation operator changed to `++` in Qiskit/openqasm#303.  This brings Terra in line with the change.

### Details and comments

No changelog necessary because the exporter hasn't been released yet.