### PR TITLE
Fix Result post-processing

### DIFF
--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -182,7 +182,7 @@ def format_statevector(vec, decimals=None):
     Returns:
         list[complex]: a list of python complex numbers.
     """
-    # pylint: disable=cyclic-import,import-outside-toplevel
+    # pylint: disable=cyclic-import
     from qiskit.quantum_info.states.statevector import Statevector
 
     if isinstance(vec, Statevector):
@@ -217,7 +217,7 @@ def format_unitary(mat, decimals=None):
     Returns:
         list[list[complex]]: a matrix of complex numbers
     """
-    # pylint: disable=cyclic-import,import-outside-toplevel
+    # pylint: disable=cyclic-import
     from qiskit.quantum_info.operators.operator import Operator
 
     if isinstance(mat, Operator):

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -182,6 +182,12 @@ def format_statevector(vec, decimals=None):
     Returns:
         list[complex]: a list of python complex numbers.
     """
+    if type(vec).__name__ == "Statevector":
+        # Duck-type check since we can't import Statevector here
+        # without introducing cyclic dependencies.
+        if decimals:
+            return type(vec)(np.around(vec.data, decimals=decimals))
+        return vec
     if isinstance(vec, np.ndarray):
         if decimals:
             return np.around(vec, decimals=decimals)
@@ -210,6 +216,12 @@ def format_unitary(mat, decimals=None):
     Returns:
         list[list[complex]]: a matrix of complex numbers
     """
+    if type(mat).__name__ == "Operator":
+        # Duck-type check since we can't import Operator here
+        # without introducing cyclic dependencies.
+        if decimals:
+            return type(mat)(np.around(mat.data, decimals=decimals))
+        return mat
     if isinstance(mat, np.ndarray):
         if decimals:
             return np.around(mat, decimals=decimals)

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -182,11 +182,12 @@ def format_statevector(vec, decimals=None):
     Returns:
         list[complex]: a list of python complex numbers.
     """
-    if type(vec).__name__ == "Statevector":
-        # Duck-type check since we can't import Statevector here
-        # without introducing cyclic dependencies.
+    # pylint: disable=cyclic-import,import-outside-toplevel
+    from qiskit.quantum_info.states.statevector import Statevector
+
+    if isinstance(vec, Statevector):
         if decimals:
-            return type(vec)(np.around(vec.data, decimals=decimals))
+            return Statevector(np.around(vec.data, decimals=decimals))
         return vec
     if isinstance(vec, np.ndarray):
         if decimals:
@@ -216,11 +217,12 @@ def format_unitary(mat, decimals=None):
     Returns:
         list[list[complex]]: a matrix of complex numbers
     """
-    if type(mat).__name__ == "Operator":
-        # Duck-type check since we can't import Operator here
-        # without introducing cyclic dependencies.
+    # pylint: disable=cyclic-import,import-outside-toplevel
+    from qiskit.quantum_info.operators.operator import Operator
+
+    if isinstance(mat, Operator):
         if decimals:
-            return type(mat)(np.around(mat.data, decimals=decimals))
+            return Operator(np.around(mat.data, decimals=decimals))
         return mat
     if isinstance(mat, np.ndarray):
         if decimals:

--- a/qiskit/result/postprocess.py
+++ b/qiskit/result/postprocess.py
@@ -187,7 +187,7 @@ def format_statevector(vec, decimals=None):
 
     if isinstance(vec, Statevector):
         if decimals:
-            return Statevector(np.around(vec.data, decimals=decimals))
+            return Statevector(np.around(vec.data, decimals=decimals), dims=vec.dims())
         return vec
     if isinstance(vec, np.ndarray):
         if decimals:
@@ -222,7 +222,11 @@ def format_unitary(mat, decimals=None):
 
     if isinstance(mat, Operator):
         if decimals:
-            return Operator(np.around(mat.data, decimals=decimals))
+            return Operator(
+                np.around(mat.data, decimals=decimals),
+                input_dims=mat.input_dims(),
+                output_dims=mat.output_dims(),
+            )
         return mat
     if isinstance(mat, np.ndarray):
         if decimals:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Required for https://github.com/Qiskit/qiskit-aer/pull/1388

Fixes an issue with how the `Result` class handles post-processing for the functions `get_statevector` and `get_unitary` if the result data is already a Statevector or Operator object.

This is needed for planned feature for the next Aer release to automatically format the result data for save instructions to the corresponding terra classes (Statevector, DensityMatrix, Operator, SuperOp, Clifford, ProbDistribution).

### Details and comments

~Because of all the unexpected cyclic dependencies already in terra I couldn't import the Statevector or Operator classes for type checking in the `postprocessing` or `result` module, so had to do a duck-type check based on the class name instead.~
