### PR TITLE
equivalence of toffoli in terms of cx and sqrt(cx)

### DIFF
--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -752,16 +752,19 @@ for inst, qargs, cargs in [
 _sel.add_equivalence(CCXGate(), def_ccx)
 
 q = QuantumRegister(3, "q")
-def_ccx_sleator_weinfurter = QuantumCircuit(q)
+ccx_to_cx_csx = QuantumCircuit(q)
 for inst, qargs, cargs in [
     (CSXGate(), [q[1], q[2]], []),
     (CXGate(), [q[0], q[1]], []),
-    (CSXGate().inverse(), [q[1], q[2]], []),
+    (ZGate(), [q[2]], []),
+    (SdgGate(), [q[1]], []),
+    (CSXGate(), [q[1], q[2]], []),
+    (ZGate(), [q[2]], []),
     (CXGate(), [q[0], q[1]], []),
     (CSXGate(), [q[0], q[2]], []),
 ]:
-    def_ccx_sleator_weinfurter.append(inst, qargs, cargs)
-_sel.add_equivalence(CCXGate(), def_ccx_sleator_weinfurter)
+    ccx_to_cx_csx.append(inst, qargs, cargs)
+_sel.add_equivalence(CCXGate(), ccx_to_cx_csx)
 
 # YGate
 

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -452,7 +452,7 @@ for inst, qargs, cargs in [
 _sel.add_equivalence(CSXGate(), def_csx)
 
 q = QuantumRegister(2, "q")
-csx_to_zx45 = QuantumCircuit(q)
+csx_to_zx45 = QuantumCircuit(q, global_phase=pi/8)
 for inst, qargs, cargs in [
     (XGate(), [q[0]], []),
     (RZXGate(pi / 4), [q[0], q[1]], []),
@@ -719,7 +719,7 @@ for inst, qargs, cargs in [
 _sel.add_equivalence(CXGate(), cx_to_ecr)
 
 q = QuantumRegister(2, "q")
-cx_to_zx90 = QuantumCircuit(q)
+cx_to_zx90 = QuantumCircuit(q, global_phase=pi/4)
 for inst, qargs, cargs in [
     (RZXGate(pi / 2), [q[0], q[1]], []),
     (SdgGate(), [q[0]], []),
@@ -727,6 +727,7 @@ for inst, qargs, cargs in [
 ]:
     cx_to_zx90.append(inst, qargs, cargs)
 _sel.add_equivalence(CXGate(), cx_to_zx90)
+
 # CCXGate
 
 q = QuantumRegister(3, "q")

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -451,6 +451,19 @@ for inst, qargs, cargs in [
     def_csx.append(inst, qargs, cargs)
 _sel.add_equivalence(CSXGate(), def_csx)
 
+q = QuantumRegister(2, "q")
+csx_to_zx45 = QuantumCircuit(q)
+for inst, qargs, cargs in [
+    (XGate(), [q[0]], []),
+    (RZXGate(pi / 4), [q[0], q[1]], []),
+    (TdgGate(), [q[0]], []),
+    (XGate(), [q[0]], []),
+    (SXGate().power(.5), [q[1]], [])
+]:
+    csx_to_zx45.append(inst, qargs, cargs)
+_sel.add_equivalence(CSXGate(), csx_to_zx45)
+
+
 # DCXGate
 
 q = QuantumRegister(2, "q")
@@ -705,6 +718,15 @@ for inst, qargs, cargs in [
     cx_to_ecr.append(inst, qargs, cargs)
 _sel.add_equivalence(CXGate(), cx_to_ecr)
 
+q = QuantumRegister(2, "q")
+cx_to_zx90 = QuantumCircuit(q)
+for inst, qargs, cargs in [
+    (RZXGate(pi / 2), [q[0], q[1]], []),
+    (SdgGate(), [q[0]], []),
+    (SXdgGate(), [q[1]], [])
+]:
+    cx_to_zx90.append(inst, qargs, cargs)
+_sel.add_equivalence(CXGate(), cx_to_zx90)
 # CCXGate
 
 q = QuantumRegister(3, "q")
@@ -728,6 +750,18 @@ for inst, qargs, cargs in [
 ]:
     def_ccx.append(inst, qargs, cargs)
 _sel.add_equivalence(CCXGate(), def_ccx)
+
+q = QuantumRegister(3, "q")
+def_ccx_sleator_weinfurter = QuantumCircuit(q)
+for inst, qargs, cargs in [
+    (CSXGate(), [q[1], q[2]], []),
+    (CXGate(), [q[0], q[1]], []),
+    (CSXGate().inverse(), [q[1], q[2]], []),
+    (CXGate(), [q[0], q[1]], []),
+    (CSXGate(), [q[0], q[2]], []),
+]:
+    def_ccx_sleator_weinfurter.append(inst, qargs, cargs)
+_sel.add_equivalence(CCXGate(), def_ccx_sleator_weinfurter)
 
 # YGate
 

--- a/qiskit/circuit/library/standard_gates/equivalence_library.py
+++ b/qiskit/circuit/library/standard_gates/equivalence_library.py
@@ -452,13 +452,13 @@ for inst, qargs, cargs in [
 _sel.add_equivalence(CSXGate(), def_csx)
 
 q = QuantumRegister(2, "q")
-csx_to_zx45 = QuantumCircuit(q, global_phase=pi/8)
+csx_to_zx45 = QuantumCircuit(q, global_phase=pi / 8)
 for inst, qargs, cargs in [
     (XGate(), [q[0]], []),
     (RZXGate(pi / 4), [q[0], q[1]], []),
     (TdgGate(), [q[0]], []),
     (XGate(), [q[0]], []),
-    (SXGate().power(.5), [q[1]], [])
+    (SXGate().power(0.5), [q[1]], []),
 ]:
     csx_to_zx45.append(inst, qargs, cargs)
 _sel.add_equivalence(CSXGate(), csx_to_zx45)
@@ -719,11 +719,11 @@ for inst, qargs, cargs in [
 _sel.add_equivalence(CXGate(), cx_to_ecr)
 
 q = QuantumRegister(2, "q")
-cx_to_zx90 = QuantumCircuit(q, global_phase=pi/4)
+cx_to_zx90 = QuantumCircuit(q, global_phase=pi / 4)
 for inst, qargs, cargs in [
     (RZXGate(pi / 2), [q[0], q[1]], []),
     (SdgGate(), [q[0]], []),
-    (SXdgGate(), [q[1]], [])
+    (SXdgGate(), [q[1]], []),
 ]:
     cx_to_zx90.append(inst, qargs, cargs)
 _sel.add_equivalence(CXGate(), cx_to_zx90)


### PR DESCRIPTION
an example that can be a use case for backendV2 and its compiler support.

ccx can be written as 2 cx and 3 csx (which is better than only if cx was available)

cx and csx can also be written as rzx(pi/2) and rzx(pi/4) respectively.

so in principle the basis translator should be able to rewrite ccx in terms of rzx(pi/2) and rzx(pi/4) if that's the instruction set that the backend has.