### PR TITLE
Return fast from transpile with empty input

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -240,6 +240,9 @@ def transpile(
     arg_circuits_list = isinstance(circuits, list)
     circuits = circuits if arg_circuits_list else [circuits]
 
+    if not circuits:
+        return []
+
     # transpiling schedules is not supported yet.
     start_time = time()
     if all(isinstance(c, Schedule) for c in circuits):

--- a/releasenotes/notes/fix-transpile-empty-list-c93a41d4145a01c3.yaml
+++ b/releasenotes/notes/fix-transpile-empty-list-c93a41d4145a01c3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Calling :obj:`~qiskit.compiler.transpile` on an empty list will now correctly return an empty list without issuing a warning.
+    Fix of `#7287 <https://github.com/Qiskit/qiskit-terra/issues/7287>`__.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -48,6 +48,10 @@ from qiskit.transpiler.preset_passmanagers import level_0_pass_manager
 class TestTranspile(QiskitTestCase):
     """Test transpile function."""
 
+    def test_empty_transpilation(self):
+        """Test that transpiling an empty list is a no-op.  Regression test of gh-7287."""
+        self.assertEqual(transpile([]), [])
+
     def test_pass_manager_none(self):
         """Test passing the default (None) pass manager to the transpiler.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously `transpile([])` raised a warning.  Now we just return quickly without further tests, similarly to how we return early if we're asked to transpile a list of `Schedule`s.


### Details and comments

Fix #7287.

