### PR TITLE
Initialize mixer terms of `QAOAAnsatz` with `PauliSumOp.from_list` (performance improvement)

### DIFF
--- a/qiskit/circuit/library/n_local/qaoa_ansatz.py
+++ b/qiskit/circuit/library/n_local/qaoa_ansatz.py
@@ -220,16 +220,16 @@ class QAOAAnsatz(EvolvedOperatorAnsatz):
         # if no mixer is passed and we know the number of qubits, then initialize it.
         if self.cost_operator is not None:
             # local imports to avoid circular imports
-            from qiskit.opflow import I, X
+            from qiskit.opflow import PauliSumOp
 
             num_qubits = self.cost_operator.num_qubits
 
             # Mixer is just a sum of single qubit X's on each qubit. Evolving by this operator
             # will simply produce rx's on each qubit.
             mixer_terms = [
-                (I ^ left) ^ X ^ (I ^ (num_qubits - left - 1)) for left in range(num_qubits)
+                ("I" * left + "X" + "I" * (num_qubits - left - 1), 1) for left in range(num_qubits)
             ]
-            mixer = sum(mixer_terms)
+            mixer = PauliSumOp.from_list(mixer_terms)
             return mixer
 
         # otherwise we cannot provide a default


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Improve performance of `QAOAAnsatz` by initializing mixer terms directly with `PauliSumOp.from_list`

```python
from timeit import timeit
from qiskit.circuit.library import QAOAAnsatz
from qiskit.opflow import PauliSumOp

n = 50
lst = []
for i in range(n - 1):
    v = ["I"] * n
    v[i] = v[i + 1] = "Z"
    lst.append(("".join(v), 1))

op = PauliSumOp.from_list(lst)
qaoa = QAOAAnsatz(cost_operator=op, reps=5)
print(f'{timeit(lambda: qaoa.assign_parameters([0] * qaoa.num_parameters), number=1)} sec')
```

main
```
4.2214362309998705 sec
```

this PR (13% improvement)
```
3.6385711119999087 sec
```

### Details and comments


