### PR TITLE
Update data structure of acquire instruction

### DIFF
--- a/qiskit/pulse/instructions/acquire.py
+++ b/qiskit/pulse/instructions/acquire.py
@@ -90,9 +90,7 @@ class Acquire(Instruction):
     @property
     def channels(self) -> Tuple[Union[AcquireChannel, MemorySlot, RegisterSlot]]:
         """Returns the channels that this schedule uses."""
-        return tuple(
-            c for c in [self.acquire, self.mem_slot, self.reg_slot] if c is not None
-        )
+        return tuple(c for c in [self.acquire, self.mem_slot, self.reg_slot] if c is not None)
 
     @property
     def duration(self) -> Union[int, ParameterExpression]:

--- a/qiskit/pulse/instructions/acquire.py
+++ b/qiskit/pulse/instructions/acquire.py
@@ -75,10 +75,10 @@ class Acquire(Instruction):
         if not (mem_slot or reg_slot):
             raise PulseError("Neither MemorySlots nor RegisterSlots were supplied.")
 
-        self._kernel = kernel
-        self._discriminator = discriminator
-
-        super().__init__(operands=(duration, channel, mem_slot, reg_slot), name=name)
+        super().__init__(
+            operands=(duration, channel, mem_slot, reg_slot, kernel, discriminator),
+            name=name,
+        )
 
     @property
     def channel(self) -> AcquireChannel:
@@ -90,7 +90,9 @@ class Acquire(Instruction):
     @property
     def channels(self) -> Tuple[Union[AcquireChannel, MemorySlot, RegisterSlot]]:
         """Returns the channels that this schedule uses."""
-        return tuple(self.operands[ind] for ind in (1, 2, 3) if self.operands[ind] is not None)
+        return tuple(
+            c for c in [self.acquire, self.mem_slot, self.reg_slot] if c is not None
+        )
 
     @property
     def duration(self) -> Union[int, ParameterExpression]:
@@ -100,12 +102,12 @@ class Acquire(Instruction):
     @property
     def kernel(self) -> Kernel:
         """Return kernel settings."""
-        return self._kernel
+        return self.operands[4]
 
     @property
     def discriminator(self) -> Discriminator:
         """Return discrimination settings."""
-        return self._discriminator
+        return self.operands[5]
 
     @property
     def acquire(self) -> AcquireChannel:

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -55,7 +55,7 @@ class TestAcquire(QiskitTestCase):
         self.assertEqual(acq.name, "acquire")
         self.assertEqual(
             acq.operands,
-            (10, channels.AcquireChannel(0), channels.MemorySlot(0), None, kernel, discriminator)
+            (10, channels.AcquireChannel(0), channels.MemorySlot(0), None, kernel, discriminator),
         )
 
     def test_instructions_hash(self):

--- a/test/python/pulse/test_instructions.py
+++ b/test/python/pulse/test_instructions.py
@@ -54,7 +54,8 @@ class TestAcquire(QiskitTestCase):
         self.assertIsInstance(acq.id, int)
         self.assertEqual(acq.name, "acquire")
         self.assertEqual(
-            acq.operands, (10, channels.AcquireChannel(0), channels.MemorySlot(0), None)
+            acq.operands,
+            (10, channels.AcquireChannel(0), channels.MemorySlot(0), None, kernel, discriminator)
         )
 
     def test_instructions_hash(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR moves kernel and discriminator to operands of the `Acquire` instruction.

### Details and comments

These values should be a part of operands, rather than instance variables.
