### PR TITLE
Fix randomization in AQC plugin unit tests

### DIFF
--- a/test/python/transpiler/aqc/test_aqc_plugin.py
+++ b/test/python/transpiler/aqc/test_aqc_plugin.py
@@ -40,11 +40,12 @@ class TestAQCSynthesisPlugin(QiskitTestCase):
         )
 
         self._target_unitary = Operator(self._qc).data
+        self._seed_config = {"seed": 12345}
 
     def test_aqc_plugin(self):
         """Basic test of the plugin."""
         plugin = AQCSynthesisPlugin()
-        dag = plugin.run(self._target_unitary)
+        dag = plugin.run(self._target_unitary, config=self._seed_config)
 
         approx_circuit = dag_to_circuit(dag)
         approx_unitary = Operator(approx_circuit).data
@@ -53,7 +54,9 @@ class TestAQCSynthesisPlugin(QiskitTestCase):
 
     def test_plugin_setup(self):
         """Tests the plugin via unitary synthesis pass"""
-        transpiler_pass = UnitarySynthesis(basis_gates=["rx", "ry", "rz", "cx"], method="aqc")
+        transpiler_pass = UnitarySynthesis(
+            basis_gates=["rx", "ry", "rz", "cx"], method="aqc", plugin_config=self._seed_config
+        )
 
         dag = circuit_to_dag(self._qc)
         dag = transpiler_pass.run(dag)
@@ -91,8 +94,7 @@ class TestAQCSynthesisPlugin(QiskitTestCase):
         aqc = PassManager(
             [
                 UnitarySynthesis(
-                    basis_gates=["u", "cx"],
-                    method="aqc",
+                    basis_gates=["u", "cx"], method="aqc", plugin_config=self._seed_config
                 )
             ]
         ).run(qc)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
On rare occasions the `TestAQCSynthesisPlugin.test_with_pass_manager` may fail due to unlucky randomization of the initial parameters and the algorithm does not converge with the default number of iterations. This PR aims to fix randomization in the AQC plugin unit tests and make them fully reproducible.


### Details and comments
In the CI an error like this may be seen:
```
      File "D:\a\1\s\test\python\transpiler\aqc\test_aqc_plugin.py", line 100, in test_with_pass_manager
    np.testing.assert_array_almost_equal(np.eye(8), approx_unitary, 3)

      File "D:\a\1\s\test-job\lib\site-packages\numpy\testing\_private\utils.py", line 1046, in assert_array_almost_equal
    assert_array_compare(compare, x, y, err_msg=err_msg, verbose=verbose,

      File "D:\a\1\s\test-job\lib\site-packages\numpy\testing\_private\utils.py", line 844, in assert_array_compare
    raise AssertionError(msg)

    AssertionError: 
Arrays are not almost equal to 3 decimals

Mismatched elements: 8 / 64 (12.5%)
Max absolute difference: 0.76537652
Max relative difference: 1.
 x: array([[1., 0., 0., 0., 0., 0., 0., 0.],
       [0., 1., 0., 0., 0., 0., 0., 0.],
       [0., 0., 1., 0., 0., 0., 0., 0.],...
 y: array([[ 7.071e-01-7.071e-01j, -2.841e-06-1.166e-05j,
        -5.438e-06-7.126e-06j, -3.161e-06-4.705e-07j,
         2.074e-06+4.451e-06j, -8.117e-06+1.068e-05j,...
```

