### PR TITLE
Merge u1, u2 and p gate together if they contain parameters.

### DIFF
--- a/test/python/transpiler/test_optimize_1q_gates.py
+++ b/test/python/transpiler/test_optimize_1q_gates.py
@@ -231,9 +231,7 @@ class TestOptimize1qGates(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         expected = QuantumCircuit(qr)
-        expected.append(U1Gate(0.7), [qr])
-        expected.append(U1Gate(theta), [qr])
-        expected.append(U1Gate(0.3), [qr])
+        expected.append(U1Gate(theta + 1.0), [qr])
 
         after = Optimize1qGates().run(dag)
 
@@ -257,11 +255,7 @@ class TestOptimize1qGates(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         expected = QuantumCircuit(qr)
-        expected.append(U1Gate(0.7), [qr])
-        expected.append(U1Gate(theta), [qr])
-        expected.append(U1Gate(0.3), [qr])
-        expected.append(U1Gate(theta), [qr])
-        expected.append(U1Gate(0.5), [qr])
+        expected.append(U1Gate(2*theta + 1.5), [qr])
 
         after = Optimize1qGates().run(dag)
 
@@ -288,12 +282,7 @@ class TestOptimize1qGates(QiskitTestCase):
         dag = circuit_to_dag(qc)
 
         expected = QuantumCircuit(qr)
-        expected.append(U1Gate(0.7), [qr])
-        expected.append(U1Gate(theta), [qr])
-        expected.append(U1Gate(phi), [qr])
-        expected.append(U1Gate(sum_), [qr])
-        expected.append(U1Gate(product_), [qr])
-        expected.append(U1Gate(0.5), [qr])
+        expected.append(U1Gate(2*theta + 2*phi + product_ + 1.2), [qr])
 
         after = Optimize1qGates().run(dag)
 
@@ -647,6 +636,27 @@ class TestOptimize1qGatesBasis(QiskitTestCase):
 
         self.assertEqual(expected, result)
 
+    def test_optimize_u3_with_parameters(self):
+        phi = Parameter('φ')
+        alpha = Parameter('α')
+        qr = QuantumRegister(1, 'qr')
 
-if __name__ == "__main__":
+        qc = QuantumCircuit(qr)
+        qc.ry(2 * phi, qr[0])
+        qc.ry(alpha, qr[0])
+        qc.ry(0.1, qr[0])
+        qc.ry(0.2, qr[0])
+
+        passmanager = PassManager([Unroller(['u3']), Optimize1qGates()])
+        result = passmanager.run(qc)
+
+        expected = QuantumCircuit(qr)
+        expected.append(U3Gate(2 * phi, 0, 0), [qr[0]])
+        expected.append(U3Gate(alpha, 0, 0), [qr[0]])
+        expected.append(U3Gate(0.3, 0, 0), [qr[0]])
+
+        self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Before the fix, the 'Optimize1qGates' transpiler optimization join together the gate only when the parameter was bounded (or when there was no parameter at all). After the fix, the u1, u2, and p gates will be combined even when the parameter is unbounded.

from qiskit import QuantumCircuit
from qiskit.circuit import Parameter
from qiskit.transpiler import PassManager
from qiskit.transpiler.passes import Optimize1qGates, Unroller

phi = Parameter('φ')
alpha = Parameter('α')

qc = QuantumCircuit(1)
qc.u1(2*phi, 0)
qc.u1(alpha, 0)
qc.u1(0.1, 0)
qc.u1(0.2, 0)
qc.draw(output='mpl')

![image](https://user-images.githubusercontent.com/55279376/143238619-fdc83421-7a6e-4c3f-bf8a-f4f486ecf03e.png)

pm = PassManager([Unroller(['u1', 'cx']), Optimize1qGates()])
nqc = pm.run(qc)
nqc.draw(output='mpl')

This change is a part of the advocate project done under @nbronn.

![image](https://user-images.githubusercontent.com/55279376/143238723-ae949bbd-1660-48e1-83ab-a78f31cf2907.png)



