### PR TITLE
Adjust imports in aqc plugin to avoid discovery overhead

### DIFF
--- a/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
+++ b/qiskit/transpiler/synthesis/aqc/aqc_plugin.py
@@ -14,13 +14,8 @@ An AQC synthesis plugin to Qiskit's transpiler.
 """
 import numpy as np
 
-from qiskit.algorithms.optimizers import L_BFGS_B
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes.synthesis.plugin import UnitarySynthesisPlugin
-from qiskit.transpiler.synthesis.aqc.aqc import AQC
-from qiskit.transpiler.synthesis.aqc.cnot_structures import make_cnot_network
-from qiskit.transpiler.synthesis.aqc.cnot_unit_circuit import CNOTUnitCircuit
-from qiskit.transpiler.synthesis.aqc.cnot_unit_objective import DefaultCNOTUnitObjective
 
 
 class AQCSynthesisPlugin(UnitarySynthesisPlugin):
@@ -96,6 +91,15 @@ class AQCSynthesisPlugin(UnitarySynthesisPlugin):
         return False
 
     def run(self, unitary, **options):
+
+        # Runtime imports to avoid the overhead of these imports for
+        # plugin discovery and only use them if the plugin is run/used
+        from qiskit.algorithms.optimizers import L_BFGS_B
+        from qiskit.transpiler.synthesis.aqc.aqc import AQC
+        from qiskit.transpiler.synthesis.aqc.cnot_structures import make_cnot_network
+        from qiskit.transpiler.synthesis.aqc.cnot_unit_circuit import CNOTUnitCircuit
+        from qiskit.transpiler.synthesis.aqc.cnot_unit_objective import DefaultCNOTUnitObjective
+
         num_qubits = int(round(np.log2(unitary.shape[0])))
 
         config = options.get("config") or {}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit tweaks the imports for the aqc plugin to make the optimizer
and other aqc method imports occur at run time only. Previously these
were done at the module level, which is normally best practice for many
reasons, but in this specific case doing plugin discovery causes the
module to be loaded (and the plugin class instaniated) even if the
plugin is not specified by the user. The imports for aqc are fairly
heavy as both the algorithms tree and scipy can be slow to load. To
avoid the overhead on discovery these imports are moved to runtime so we
only load them if the aqc plugin is used and these imports are needed.

### Details and comments