### PR TITLE
Speed up passmanager if it is empty

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -214,12 +214,11 @@ class PassManager:
         """
         if not self._pass_sets and output_name is None and callback is None:
             return circuits
-        elif isinstance(circuits, QuantumCircuit):
+        if isinstance(circuits, QuantumCircuit):
             return self._run_single_circuit(circuits, output_name, callback)
-        elif len(circuits) == 1:
+        if len(circuits) == 1:
             return self._run_single_circuit(circuits[0], output_name, callback)
-        else:
-            return self._run_several_circuits(circuits, output_name, callback)
+        return self._run_several_circuits(circuits, output_name, callback)
 
     def _create_running_passmanager(self) -> RunningPassManager:
         running_passmanager = RunningPassManager(self.max_iteration)

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -212,7 +212,9 @@ class PassManager:
         Returns:
             The transformed circuit(s).
         """
-        if isinstance(circuits, QuantumCircuit):
+        if not self._pass_sets and output_name is None and callback is None:
+            return circuits
+        elif isinstance(circuits, QuantumCircuit):
             return self._run_single_circuit(circuits, output_name, callback)
         elif len(circuits) == 1:
             return self._run_single_circuit(circuits[0], output_name, callback)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Calling `pm.run(circuits)` with an empty pass manager is slow since it uses parallel map and does dag-circuit conversions which aren't necessary if there are no passes to run. This changes the pass manager to return the input circuits for these cases.

### Details and comments

Here is a trivial case showing the slow performance

```python
from qiskit.transpiler import PassManager
from qiskit import QuantumCircuit

pm = PassManager()
circuits = [QuantumCircuit(2) for _ in range(100)]
%timeit pm.run(circuits)
```
Before change
```
69.5 ms ± 2.13 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

After this change:
```
164 ns ± 3.58 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```