### PR TITLE
Fail safe in the QASM 3 exporter

### DIFF
--- a/releasenotes/notes/qasm3-limitations-ebfdedab3f4ab6e1.yaml
+++ b/releasenotes/notes/qasm3-limitations-ebfdedab3f4ab6e1.yaml
@@ -1,0 +1,8 @@
+---
+issues:
+  - |
+    The OpenQASM 3 export capabilities are in a beta state, and some features of
+    Terra's :obj:`.QuantumCircuit` are not yet supported.  In particular, you
+    may see errors if you try to export custom subroutines with classical
+    parameters, and there is no provision yet for exporting pulse-calibrated
+    operations into OpenPulse.


### PR DESCRIPTION
### Summary

There were previously parts of the QASM 3 exporter where it attempted to
do its best guess at what should happen, even when this always produced
entirely incorrect results.  These were subroutine definitions with
parameters, opaque gates (`defcal`) and non-included gates with
parameters.

We now choose to fail loudly with a message that we do not currently
support certain features, rather than outputting a meaningless
programme.  For the parameterised gates, we now force the exporter to
output a separate definition for every instance of a gate if it cannot
be sure that it has the most general form to start with.  The code it
outputs looks silly (the gates take parameters, but do not use them in
their definitions, and each gate may be defined many times), but the
semantics of the programme will actually be correct.

See gh-7335 for the parameterisation problem.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This very very lightly papers over #7335, but is not a proper solution.  The full solution will need to come after release, and may well require a proper refactor of the expectations of `Instruction.params`.
