### PR TITLE
Fix performance regression of VQE by #7217

### DIFF
--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -329,7 +329,7 @@ class CircuitSampler(ConverterBase):
             ready_circs = self._transpiled_circ_cache
 
         # run transpiler passes on bound circuits
-        if self._transpile_before_bind:
+        if self._transpile_before_bind and self.quantum_instance.bound_pass_manager:
             ready_circs = self.quantum_instance.transpile(
                 ready_circs, pass_manager=self.quantum_instance.bound_pass_manager
             )

--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -329,7 +329,7 @@ class CircuitSampler(ConverterBase):
             ready_circs = self._transpiled_circ_cache
 
         # run transpiler passes on bound circuits
-        if self._transpile_before_bind and self.quantum_instance.bound_pass_manager:
+        if self._transpile_before_bind and self.quantum_instance.bound_pass_manager is not None:
             ready_circs = self.quantum_instance.transpile(
                 ready_circs, pass_manager=self.quantum_instance.bound_pass_manager
             )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

#7217 calls transpilation two times: 1) transpile of parameterized circuits and 2) transpile of bound circuits.
Unless users define their pass for the second pass, we don't need to call the transpile again.

Fixes #7337 

### Details and comments

```
from timeit import timeit

from qiskit import Aer
from qiskit.algorithms import VQE
from qiskit.algorithms.optimizers import COBYLA
from qiskit.circuit.library import RealAmplitudes
from qiskit.opflow import PauliSumOp
from qiskit.utils import QuantumInstance

quantum_instance = QuantumInstance(backend=Aer.get_backend('aer_simulator'), shots=1)
vqe = VQE(ansatz=RealAmplitudes(), optimizer=COBYLA(maxiter=1), quantum_instance=quantum_instance)
op = PauliSumOp.from_list([("ZZ"*5, 1), ("IX"*5, 2)])
print(f'{timeit(lambda: vqe.compute_minimum_eigenvalue(op), number=10)} sec')
```

main c95ec3712
```
4.612741603000359 sec
```

this PR
```
1.943418126999859 sec
```
