### PR TITLE
Add copy method to Options

### DIFF
--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -99,6 +99,15 @@ class Options:
             return self._fields == other._fields
         return NotImplemented
 
+    def copy(self):
+        """Return a copy of the Options.
+
+        The returned option and validator values are shallow copies of the originals.
+        """
+        out = Options()
+        out.__setstate__((self._fields.copy(), self.validator.copy()))
+        return out
+
     def set_validator(self, field, validator_value):
         """Set an optional validator for a field in the options
 

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -80,6 +80,15 @@ class Options:
         super().__setattr__("_fields", _fields)
         super().__setattr__("validator", validator)
 
+    def __copy__(self):
+        """Return a copy of the Options.
+
+        The returned option and validator values are shallow copies of the originals.
+        """
+        out = self.__new__(type(self))
+        out.__setstate__((self._fields.copy(), self.validator.copy()))
+        return out
+
     def __init__(self, **kwargs):
         super().__setattr__("_fields", kwargs)
         super().__setattr__("validator", {})
@@ -98,15 +107,6 @@ class Options:
         if isinstance(self, Options) and isinstance(other, Options):
             return self._fields == other._fields
         return NotImplemented
-
-    def copy(self):
-        """Return a copy of the Options.
-
-        The returned option and validator values are shallow copies of the originals.
-        """
-        out = Options()
-        out.__setstate__((self._fields.copy(), self.validator.copy()))
-        return out
 
     def set_validator(self, field, validator_value):
         """Set an optional validator for a field in the options

--- a/releasenotes/notes/add-backend-v2-ce84c976fb13b038.yaml
+++ b/releasenotes/notes/add-backend-v2-ce84c976fb13b038.yaml
@@ -85,3 +85,8 @@ features:
     :meth:`~qiskit.providers.Options.update_options` method will check that
     if ``shots`` is being updated the proposed new value is within the valid
     range.
+  - |
+    Adds a :meth:`~qiskit.providers.Options.copy` method to the
+    :class:`~qiskit.providers.Options` class which returns a shallow copy
+    of the option where updates to the copies fields or validator will
+    not change the originals values.

--- a/releasenotes/notes/add-backend-v2-ce84c976fb13b038.yaml
+++ b/releasenotes/notes/add-backend-v2-ce84c976fb13b038.yaml
@@ -85,8 +85,3 @@ features:
     :meth:`~qiskit.providers.Options.update_options` method will check that
     if ``shots`` is being updated the proposed new value is within the valid
     range.
-  - |
-    Adds a :meth:`~qiskit.providers.Options.copy` method to the
-    :class:`~qiskit.providers.Options` class which returns a shallow copy
-    of the option where updates to the copies fields or validator will
-    not change the originals values.

--- a/test/python/providers/test_options.py
+++ b/test/python/providers/test_options.py
@@ -115,7 +115,7 @@ Where:
         cpy.update_options(opt1=10, opt3=20)
         self.assertEqual(options.opt1, 1)
         self.assertEqual(options.opt2, 2)
-        self.assertNotIn('opt3', options)
+        self.assertNotIn("opt3", options)
         self.assertEqual(cpy.opt1, 10)
         self.assertEqual(cpy.opt2, 2)
         self.assertEqual(cpy.opt3, 20)

--- a/test/python/providers/test_options.py
+++ b/test/python/providers/test_options.py
@@ -111,7 +111,7 @@ Where:
 
     def test_copy(self):
         options = Options(opt1=1, opt2=2)
-        cpy = options.copy()
+        cpy = copy.copy(options)
         cpy.update_options(opt1=10, opt3=20)
         self.assertEqual(options.opt1, 1)
         self.assertEqual(options.opt2, 2)

--- a/test/python/providers/test_options.py
+++ b/test/python/providers/test_options.py
@@ -109,6 +109,17 @@ Where:
         self.assertTrue(hasattr(options, "shots"))
         self.assertFalse(hasattr(options, "method"))
 
+    def test_copy(self):
+        options = Options(opt1=1, opt2=2)
+        cpy = options.copy()
+        cpy.update_options(opt1=10, opt3=20)
+        self.assertEqual(options.opt1, 1)
+        self.assertEqual(options.opt2, 2)
+        self.assertNotIn('opt3', options)
+        self.assertEqual(cpy.opt1, 10)
+        self.assertEqual(cpy.opt2, 2)
+        self.assertEqual(cpy.opt3, 20)
+
 
 class TestOptionsSimpleNamespaceBackwardCompatibility(QiskitTestCase):
     """Tests that SimpleNamespace-like functionality that qiskit-experiments relies on for Options


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds copy method to the `Option` class.

### Details and comments

The option refactor changes the behaviour of `copy.copy(opts)` compared to the original class so that changing option values of the copy also change the original.

This adds a `copy` method for returning a shallow copy of option values where changes of the copy do not change the values of the original.

This copy functionality is used in qiskit-experiments.
