### PR TITLE
Fix copying control-flow bodies in builder interface

### DIFF
--- a/qiskit/circuit/controlflow/builder.py
+++ b/qiskit/circuit/controlflow/builder.py
@@ -368,7 +368,10 @@ class ControlFlowBuilderBlock:
             # We already did the broadcasting and checking when the first call to
             # QuantumCircuit.append happened (which the user wrote), and added the instruction into
             # this scope.  We just need to finish the job now.
-            out._append(operation, qubits, clbits)
+            #
+            # We have to convert the tuples to lists, because some parts of QuantumCircuit still
+            # expect exactly this type.
+            out._append(operation, list(qubits), list(clbits))
 
         return out
 

--- a/releasenotes/notes/0.19/fix-control-flow-builder-parameter-copy-b1f6efcc6bc283e7.yaml
+++ b/releasenotes/notes/0.19/fix-control-flow-builder-parameter-copy-b1f6efcc6bc283e7.yaml
@@ -1,0 +1,20 @@
+---
+fixes:
+  - |
+    Fixed an issue where calling :meth:`.QuantumCircuit.copy` on the "body"
+    circuits of a control-flow operation created with the builder interface
+    would raise an error.  For example, this was previously an error, but will
+    now return successfully::
+
+        from qiskit.circuit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+        qreg = QuantumRegister(4)
+        creg = ClassicalRegister(1)
+        circ = QuantumCircuit(qreg, creg)
+
+        with circ.if_test((creg, 0)):
+            circ.h(0)
+
+        if_else_instruction, _, _ = circ.data[0]
+        true_body = if_else_instruction.params[0]
+        true_body.copy()


### PR DESCRIPTION
### Summary

There are a few places where the structure of an element of
`QuantumCircuit.data` is specifically assumed to be

    Tuple[Instruction, List[Qubit], List[Clbit]]

rather than the more abstract

    Tuple[Instruction, Sequence[Qubit], Sequence[Clbit]]

For performance reasons, the control-flow builders used tuples to store
their arguments internally, because this prevents any copying being
necessary, and allows the arguments to be put in sets.  Now, in lieu of
changing the `QuantumCircuit` data structure to be more abstract, which
would have performance implications, or to require the tuples, which may
create more bugs, we just make the builder interface convert its tuples
to lists on output.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

A relatively hidden bug, but a bug nonetheless, and fixing this will make it much easier for Aer to write its test cases for 0.10.  @hhorii.

Fix #7367.