### PR TITLE
[WIP] Add qpy serialization for PauliEvolutionGate

### DIFF
--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -536,8 +536,8 @@ class TestLoadFromQPY(QiskitTestCase):
 
     def test_evolutiongate(self):
         """Test loading a circuit with evolution gate works."""
-        synthesis = LieTrotter(reps=2)
-        evo = PauliEvolutionGate((Z ^ I) + (I ^ Z), time=0.2, synthesis=synthesis)
+#        synthesis = LieTrotter(reps=2)
+        evo = PauliEvolutionGate((Z ^ I) + (I ^ Z), time=0.2, synthesis=None)
         qc = QuantumCircuit(2)
         qc.append(evo, range(2))
         qpy_file = io.BytesIO()
@@ -546,17 +546,16 @@ class TestLoadFromQPY(QiskitTestCase):
         new_circ = load(qpy_file)[0]
 
         # remove wrapping of instructions
-        qc = qc.decompose().decompose()
-        new_circ = new_circ.decompose().decompose()
+#        qc = qc.decompose().decompose()
+#        new_circ = new_circ.decompose().decompose()
 
         self.assertEqual(qc, new_circ)
         self.assertEqual([x[0].label for x in qc.data], [x[0].label for x in new_circ.data])
 
-        # enable these tests once we can can serialize allPauliEvolutionGate parameters such as
-        # new_evo = new_circ.data[0][0]
+        new_evo = new_circ.data[0][0]
         # SparsePauliOp and EvolutionSynthesis
-        # self.assertIsInstance(new_evo,PauliEvolutionGate)
-        # self.assertIsInstance(new_evo.synthesis, LieTrotter)
+        self.assertIsInstance(new_evo,PauliEvolutionGate)
+#        self.assertIsInstance(new_evo.synthesis, LieTrotter)
 
     def test_parameter_expression_global_phase(self):
         """Test a circuit with a parameter expression global_phase."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds serialization for the PauliEvolutionGate class so that
we can exactly reproduce a PauliEvolutionGate over QPY. This works by
bumping the qpy format version and adding new structs to represent the
PauliEvolutionGate and all it's child attribute types.


### Details and comments

If this can be finished and thoroughly tested in time for 0.19.1 we can include this. Otherwise we can come up with a faster workaround and then just save this for 0.20.0 (and probably QPY v4 assuming #7372 is included in 0.19.1 with a format bump to represent `ParameterVectorElement`s).

TODO:

- [ ] release notes
- [ ] add support for synthesis class
- [ ] fix `PauliEvolutionGate.operator` to not use `PauliSumOp` (which is incorrect and use `SparsePauliOp` directly
- [ ] Add more test coverage
- [ ] Add qpy compat tests