### PR TITLE
documentation update: c_if needs val

### DIFF
--- a/qiskit/circuit/controlflow/for_loop.py
+++ b/qiskit/circuit/controlflow/for_loop.py
@@ -142,7 +142,7 @@ class ForLoopContext:
             qc.rx(i * math.pi/4, 0)
             qc.cx(0, 1)
             qc.measure(0, 0)
-            qc.break_loop().c_if(0)
+            qc.break_loop().c_if(0, True)
 
     This context should almost invariably be created by a :meth:`.QuantumCircuit.for_loop` call, and
     the resulting instance is a "friend" of the calling circuit.  The context will manipulate the

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4277,7 +4277,7 @@ class QuantumCircuit:
                 qc.h(0)
                 qc.cx(0, 1)
                 qc.measure(0, 0)
-                qc.break_loop().c_if(0)
+                qc.break_loop().c_if(0, True)
 
         Args:
             indexset (Iterable[int]): A collection of integers to loop over.  Always necessary.


### PR DESCRIPTION
Some docstring have examples on how to use `c_if` without a `val` parameter, which is required.