### PR TITLE
Fix InverseCancellation pass to handle gates of different names.

### DIFF
--- a/qiskit/transpiler/passes/optimization/inverse_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/inverse_cancellation.py
@@ -124,7 +124,7 @@ class InverseCancellation(TransformationPass):
             DAGCircuit: Transformed DAG.
         """
         for pair in inverse_gate_pairs:
-            gate_cancel_runs = dag.collect_runs([pair[0].name])
+            gate_cancel_runs = dag.collect_runs([pair[0].name, pair[1].name])
             for dag_nodes in gate_cancel_runs:
                 for i in range(len(dag_nodes) - 1):
                     if dag_nodes[i].op == pair[0] and dag_nodes[i + 1].op == pair[1]:

--- a/test/python/transpiler/test_inverse_cancellation.py
+++ b/test/python/transpiler/test_inverse_cancellation.py
@@ -21,7 +21,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import InverseCancellation
 from qiskit.transpiler import PassManager
 from qiskit.test import QiskitTestCase
-from qiskit.circuit.library import RXGate, HGate, CXGate, PhaseGate, XGate
+from qiskit.circuit.library import RXGate, HGate, CXGate, PhaseGate, XGate, TGate, TdgGate
 
 
 class TestInverseCancellation(QiskitTestCase):
@@ -164,3 +164,15 @@ class TestInverseCancellation(QiskitTestCase):
         gates_after = new_circ.count_ops()
         self.assertNotIn("x", gates_after)
         self.assertEqual(gates_after["h"], 2)
+
+    def test_inverse_with_different_names(self):
+        """Test that inverse gates that have different names."""
+        qc = QuantumCircuit(2, 2)
+        qc.t(0)
+        qc.tdg(0)
+        pass_ = InverseCancellation([(TGate(), TdgGate())])
+        pm = PassManager(pass_)
+        new_circ = pm.run(qc)
+        gates_after = new_circ.count_ops()
+        self.assertNotIn("t", gates_after)
+        self.assertNotIn("tdg", gates_after)


### PR DESCRIPTION
As reported in GH-7378, the InverseCancellation optimization pass
previously assumed that inverse gate pairs would always share a
common name, but this is not universally true. This commit updates
the pass to search for runs containing any of the gate names in the
gates_to_cancel list, instead of only the first.

Co-authored-by: Bruno Schmitt <bruno.schmitt@epfl.ch>

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


