### PR TITLE
Fix registerless bit conditions in circuit_to_instruction

### DIFF
--- a/qiskit/converters/circuit_to_instruction.py
+++ b/qiskit/converters/circuit_to_instruction.py
@@ -113,14 +113,7 @@ def circuit_to_instruction(circuit, parameter_map=None, equivalence_library=None
         if condition:
             reg, val = condition
             if isinstance(reg, Clbit):
-                idx = 0
-                for creg in circuit.cregs:
-                    if reg not in creg:
-                        idx += creg.size
-                    else:
-                        cond_reg = creg
-                        break
-                rule[0].condition = (c[idx + list(cond_reg).index(reg)], val)
+                rule[0].condition = (clbit_map[reg], val)
             elif reg.size == c.size:
                 rule[0].condition = (c, val)
             else:

--- a/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
+++ b/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     Fixed conversion of :class:`.QuantumCircuit`\ s with classical conditions on
-    single, registerless :class:`.Clbit` \s to :class:`.Instruction`\ s when
+    single, registerless :class:`.Clbit` \s to :class:`~.circuit.Instruction`\ s when
     using the :func:`.circuit_to_instruction` function or the
     :meth:`.QuantumCircuit.to_instruction` method.  For example, the following
     will now work::

--- a/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
+++ b/releasenotes/notes/fix-circuit_to_instruction_single-bit-condition-db75291ce921001a.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixed conversion of :class:`.QuantumCircuit`\ s with classical conditions on
+    single, registerless :class:`.Clbit` \s to :class:`.Instruction`\ s when
+    using the :func:`.circuit_to_instruction` function or the
+    :meth:`.QuantumCircuit.to_instruction` method.  For example, the following
+    will now work::
+
+        from qiskit.circuit import QuantumCircuit, Qubit, Clbit
+
+        qc = QuantumCircuit([Qubit(), Clbit()])
+        qc.h(0).c_if(qc.clbits[0], 0)
+        qc.to_instruction()

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -16,7 +16,7 @@ import unittest
 
 from qiskit.converters import circuit_to_instruction
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
-from qiskit.circuit import Qubit, Clbit
+from qiskit.circuit import Qubit, Clbit, Instruction
 from qiskit.circuit import Parameter
 from qiskit.test import QiskitTestCase
 from qiskit.exceptions import QiskitError
@@ -185,6 +185,23 @@ class TestCircuitToInstruction(QiskitTestCase):
         self.assertEqual(inst.definition[1][0].params, [phi])
         self.assertEqual(inst.definition[2][0].params, [gamma, phi, 0])
         self.assertEqual(str(inst.definition[3][0].params[0]), "gamma + phi")
+
+    def test_registerless_classical_bits(self):
+        """Test that conditions on registerless classical bits can be handled during the conversion.
+
+        Regression test of gh-7394."""
+        expected = QuantumCircuit([Qubit(), Clbit()])
+        expected.h(0).c_if(expected.clbits[0], 0)
+        test = circuit_to_instruction(expected)
+
+        self.assertIsInstance(test, Instruction)
+        self.assertIsInstance(test.definition, QuantumCircuit)
+
+        self.assertEqual(len(test.definition.data), 1)
+        test_instruction, _, _ = test.definition.data[0]
+        expected_instruction, _, _ = expected.data[0]
+        self.assertIs(type(test_instruction), type(expected_instruction))
+        self.assertEqual(test_instruction.condition, (test.definition.clbits[0], False))
 
 
 if __name__ == "__main__":

--- a/test/python/converters/test_circuit_to_instruction.py
+++ b/test/python/converters/test_circuit_to_instruction.py
@@ -201,7 +201,7 @@ class TestCircuitToInstruction(QiskitTestCase):
         test_instruction, _, _ = test.definition.data[0]
         expected_instruction, _, _ = expected.data[0]
         self.assertIs(type(test_instruction), type(expected_instruction))
-        self.assertEqual(test_instruction.condition, (test.definition.clbits[0], False))
+        self.assertEqual(test_instruction.condition, (test.definition.clbits[0], 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

This version of the change is stable for backports, but a more thorough
refactor of `circuit_to_instruction` is in order to support multiple
registers, overlapping registers and remove the creation of unnecessary
registers.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This is the minimal change needed to fix #7394.  There's unnecessary registers being created in `circuit_to_instruction`, in a manner that is limiting its ability to handle conditions on registers not containing _all_ the clbits in the instruction, but this is part of a larger issue (see #5529 and #6496, for example).

I've tagged this for 0.19.2, because I want to consider 0.19.1 closed now pending release.
