### PR TITLE
Pin Aer to 0.9.1 in CI

### DIFF
--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -19,7 +19,7 @@ jobs:
           pip install -U -r requirements-dev.txt coveralls -c constraints.txt
           pip install -c constraints.txt -e .
           pip install "qiskit-ibmq-provider" -c constraints.txt
-          pip install "qiskit-aer"
+          pip install "qiskit-aer==0.9.1"
       - name: Run randomized tests
         run: make test_randomized
       - name: Create comment on failed test run

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -187,7 +187,7 @@ stages:
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             python setup.py sdist
             pip install -U -c constraints.txt dist/qiskit-terra*.tar.gz
-            pip install -U "cplex" "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U "cplex" "qiskit-aer==0.9.1" "z3-solver" -c constraints.txt
             mkdir -p /tmp/terra-tests
             cp -r test /tmp/terra-tests/.
             cp .stestr.conf /tmp/terra-tests/.
@@ -283,7 +283,7 @@ stages:
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -U -c constraints.txt -e .
-            pip install -U "qiskit-aer" -c constraints.txt
+            pip install -U "qiskit-aer==0.9.1" -c constraints.txt
             python setup.py build_ext --inplace
           displayName: 'Install dependencies'
         - bash: |
@@ -381,7 +381,7 @@ stages:
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -U -c constraints.txt -e .
-            pip install -U "qiskit-aer" -c constraints.txt
+            pip install -U "qiskit-aer==0.9.1" -c constraints.txt
             python setup.py build_ext --inplace
             pip check
           displayName: 'Install dependencies'
@@ -621,7 +621,7 @@ stages:
             source test-job/bin/activate
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -U -c constraints.txt -e .
-            pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
+            pip install -U "qiskit-aer==0.9.1" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz
             pip check
@@ -770,7 +770,7 @@ stages:
             python -m pip install --upgrade pip
             pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
             pip install -c constraints.txt -e .
-            pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "matplotlib>=3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
+            pip install "qiskit-ibmq-provider" "qiskit-aer==0.9.1" "z3-solver" "qiskit-ignis" "matplotlib>=3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
             python setup.py build_ext --inplace
             sudo apt install -y graphviz pandoc
             pip check

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ setenv =
   PYTHON=coverage3 run --source qiskit --parallel-mode
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
-       qiskit-aer
+       qiskit-aer==0.9.1
 commands =
   stestr run {posargs}
   coverage3 combine


### PR DESCRIPTION
### Summary

The recent release of Aer 0.10 has major performance regressions, and
appears to be causing Terra's CI to fail with timeouts on Mac and Linux.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

@chriseclectic, @hhorii I guess we've got more impetus to get a new patch release fixing this now.
