### PR TITLE
Fix QPY serialization of no-op instructions

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -1002,7 +1002,7 @@ def _parse_custom_instruction(custom_instructions, gate_name, params):
     (type_str, num_qubits, num_clbits, definition) = custom_instructions[gate_name]
     if type_str == "i":
         inst_obj = Instruction(gate_name, num_qubits, num_clbits, params)
-        if definition:
+        if definition is not None:
             inst_obj.definition = definition
     elif type_str == "g":
         inst_obj = Gate(gate_name, num_qubits, params)
@@ -1338,7 +1338,7 @@ def _write_custom_instruction(file_obj, name, instruction):
     data = None
     num_qubits = instruction.num_qubits
     num_clbits = instruction.num_clbits
-    if instruction.definition or type_str == b"p":
+    if instruction.definition is not None or type_str == b"p":
         has_definition = True
         definition_buffer = io.BytesIO()
         if type_str == b"p":

--- a/releasenotes/notes/fix-qpy-empty-definition-a3a24a0409377a76.yaml
+++ b/releasenotes/notes/fix-qpy-empty-definition-a3a24a0409377a76.yaml
@@ -1,0 +1,31 @@
+---
+fixes:
+  - |
+    Fixed QPY serialisation of custom instructions which had an explicit no-op
+    definition.  Previously these would be written and subsequently read the
+    same way as if they were opaque gates (with no given definition).  They will
+    now correctly round-trip an empty definition.  For example, the following
+    will now be correct::
+
+        import io
+        from qiskit.circuit import Instruction, QuantumCircuit, qpy_serialization
+
+        # This instruction is explicitly defined as a one-qubit gate with no
+        # operations.
+        empty = QuantumCircuit(1, name="empty").to_instruction()
+        # This instruction will perform some operations that are only known
+        # by the hardware backend.
+        opaque = Instruction("opaque", 1, 0, [])
+
+        circuit = QuantumCircuit(2)
+        circuit.append(empty, [0], [])
+        circuit.append(opaque, [1], [])
+
+        qpy_file = io.BytesIO()
+        qpy_serialization.dump(circuit, qpy_file)
+        qpy_file.seek(0)
+        new_circuit = qpy_serialization.load(qpy_file)[0]
+
+        # Previously both instructions in `new_circuit` would now be opaque, but
+        # there is now a correct distinction.
+        circuit == new_circuit

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -451,6 +451,50 @@ class TestLoadFromQPY(QiskitTestCase):
         self.assertEqual(qc.decompose(), new_circ.decompose())
         self.assertEqual([x[0].label for x in qc.data], [x[0].label for x in new_circ.data])
 
+    def test_custom_gate_with_noop_definition(self):
+        """Test that a custom gate whose definition contains no elements is serialized with a
+        proper definition.
+
+        Regression test of gh-7429."""
+        empty = QuantumCircuit(1, name="empty").to_gate()
+        opaque = Gate("opaque", 1, [])
+        qc = QuantumCircuit(2)
+        qc.append(empty, [0], [])
+        qc.append(opaque, [1], [])
+
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circ = load(qpy_file)[0]
+
+        self.assertEqual(qc, new_circ)
+        self.assertEqual(qc.decompose(), new_circ.decompose())
+        self.assertEqual(len(new_circ), 2)
+        self.assertIsInstance(new_circ.data[0][0].definition, QuantumCircuit)
+        self.assertIs(new_circ.data[1][0].definition, None)
+
+    def test_custom_instruction_with_noop_definition(self):
+        """Test that a custom instruction whose definition contains no elements is serialized with a
+        proper definition.
+
+        Regression test of gh-7429."""
+        empty = QuantumCircuit(1, name="empty").to_instruction()
+        opaque = Instruction("opaque", 1, 0, [])
+        qc = QuantumCircuit(2)
+        qc.append(empty, [0], [])
+        qc.append(opaque, [1], [])
+
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circ = load(qpy_file)[0]
+
+        self.assertEqual(qc, new_circ)
+        self.assertEqual(qc.decompose(), new_circ.decompose())
+        self.assertEqual(len(new_circ), 2)
+        self.assertIsInstance(new_circ.data[0][0].definition, QuantumCircuit)
+        self.assertIs(new_circ.data[1][0].definition, None)
+
     def test_standard_gate_with_label(self):
         """Test a standard gate with a label."""
         qc = QuantumCircuit(1)


### PR DESCRIPTION
### Summary

A no-op instruction is distinct from an opaque instruction: an opaque
instruction has a definition of `None`, and its operation will be filled
in by the hardware backend, whereas a no-op instruction has a
`QuantumCircuit` definition with no data in it.  Previously, the test
for whether a definition existed was `bool(instruction.definition)`,
which was false in both cases (as `QuantumCircuit` has no `__bool__` and
has a `__len__` returning its number of instructions), and consequently
both were treated as if they were opaque.  This fixes the conditionals
to distinguish them.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #7429.
