### PR TITLE
Update garrison's name in .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -76,6 +76,8 @@ Ismail Yunus Akhalwaya <ismaila@za.ibm.com>
 Ismail Yunus Akhalwaya <ismaila@za.ibm.com> <30803146+ismaila-at-za-ibm@users.noreply.github.com>
 Jack J. Woehr <4604036+jwoehr@users.noreply.github.com>
 Jake Lishman <jake.lishman@ibm.com> <jake@binhbar.com>
+James R. Garrison <garrison@ibm.com>
+James R. Garrison <garrison@ibm.com> <jim@garrison.cc>
 James Seaward <58116376+JamesSeaward@users.noreply.github.com>
 Jan Müggenburg <jan.mueggenburg@ibm.com>
 Jan Müggenburg <jan.mueggenburg@ibm.com> <jan@oc6058543760.ibm.com>


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This will help ensure that my name appears in `Qiskit.bib` in only one form, the one I use for academic publications.

### Details and comments

I've included my personal email address here, too, as both #7435 and #7436 were changed to that address when they were squashed & merged.  It seems that using an account's primary email address when squashing [is intended behavior](https://github.community/t/github-squash-and-merge-how-is-the-author-email-determined/156376) by GitHub, even though it seems to not *always* be changed (e.g., when https://github.com/Qiskit/qiskit-optimization/pull/296 was merged).