### PR TITLE
Check the existence of AncillaQubits before adding

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1352,7 +1352,9 @@ class QuantumCircuit:
                 raise CircuitError('register name "%s" already exists' % register.name)
 
             if isinstance(register, AncillaRegister):
-                self._ancillas.extend(register)
+                for bit in register:
+                    if bit not in self._qubit_indices:
+                        self._ancillas.append(bit)
 
             if isinstance(register, QuantumRegister):
                 self.qregs.append(register)

--- a/test/python/circuit/test_circuit_operations.py
+++ b/test/python/circuit/test_circuit_operations.py
@@ -22,6 +22,7 @@ from qiskit.circuit import Gate, Instruction, Parameter
 from qiskit.circuit.classicalregister import Clbit
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumcircuit import BitLocations
+from qiskit.circuit.quantumregister import AncillaQubit, AncillaRegister, Qubit
 from qiskit.test import QiskitTestCase
 from qiskit.circuit.library.standard_gates import SGate
 from qiskit.quantum_info import Operator
@@ -947,6 +948,23 @@ class TestCircuitOperations(QiskitTestCase):
         qc2 = None
 
         self.assertFalse(qc1 == qc2)
+
+    def test_add_existing_bits(self):
+        """Test add registers whose bits have already been added."""
+        qc = QuantumCircuit()
+        for bit_type, reg_type in (
+            [Qubit, QuantumRegister],
+            [Clbit, ClassicalRegister],
+            [AncillaQubit, AncillaRegister],
+        ):
+            bits = [bit_type() for _ in range(10)]
+            reg = reg_type(bits=bits)
+            qc.add_bits(bits)
+            qc.add_register(reg)
+
+        self.assertEqual(qc.num_qubits, 20)
+        self.assertEqual(qc.num_clbits, 10)
+        self.assertEqual(qc.num_ancillas, 10)
 
     def test_deprecated_measure_function(self):
         """Test that the deprecated version of the loose 'measure' function works correctly."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
The bits in an `AncillaRegister` are appended to `QuantumCircuit._ancilla` without checking:

https://github.com/Qiskit/qiskit-terra/blob/9cc9225f249d3a895d9f3944175ea7b681d248c0/qiskit/circuit/quantumcircuit.py#L1354-L1355

This caused the issue described in #7445.
### Details and comments
I fix this problem by checking the existence of `AncillaQubit` before the appending, which is similar to the operation regarding `QuantumRegister`. A test case is added to demonstrate the change. The test failed without the modification.

close #7445