### PR TITLE
Add distutils warning ignore from seaborn

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -213,6 +213,8 @@ class QiskitTestCase(BaseQiskitTestCase):
             r"The QuantumCircuit.cu.",
             r"The CXDirection pass has been deprecated",
             r"The pauli_basis function with PauliTable.*",
+            # TODO: remove the following ignore after seaborn 0.12.0 releases
+            r"distutils Version classes are deprecated. Use packaging\.version",
         ]
         for msg in allow_DeprecationWarning_message:
             warnings.filterwarnings("default", category=DeprecationWarning, message=msg)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0
 reno>=3.4.0
-Sphinx>=3.0.0
+Sphinx>=3.0.0,<4.0.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -163,7 +163,10 @@ class TestGateDefinitions(QiskitTestCase):
         axis = np.array([np.cos(phi), np.sin(phi), 0])  # RGate axis
         rotvec = theta * axis
         rv = RVGate(*rotvec)
-        self.assertTrue(np.array_equal(rgate.to_matrix(), rv.to_matrix()))
+        rg_matrix = rgate.to_matrix()
+        rv_matrix = rv.to_matrix()
+        np.testing.assert_array_max_ulp(rg_matrix.real, rv_matrix.real, 4)
+        np.testing.assert_array_max_ulp(rg_matrix.imag, rv_matrix.imag, 4)
 
     def test_rv_zero(self):
         """Test R(v) gate with zero vector returns identity"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent setuptools releases, since 59.6.0 according to the release
notes: https://setuptools.pypa.io/en/latest/history.html#v59-6-0, have
been emitting a deprecation warning about the use of Version classes
from distutils. The seaborn project is still using these in the current
releases which is causing the project to emit these deprecation
warnings. Since the test suite enforces we don't emit deprecation
warnings this is causing test failures when running with newer
setuptools. The deprecated usage has already been fixed upstream in
seaborn but it hasn't been released. To fix test runs and CI while
waiting for a seaborn release this commit adds the distutils version
class deprecation message to the warning ignore list. We should remove
this once seaborn releases.

### Details and comments

Fixes #7457
