### PR TITLE
Fix matrix representation of ``ExcitationPreserving`` circuit

### DIFF
--- a/qiskit/circuit/library/n_local/excitation_preserving.py
+++ b/qiskit/circuit/library/n_local/excitation_preserving.py
@@ -24,8 +24,8 @@ class ExcitationPreserving(TwoLocal):
     r"""The heuristic excitation-preserving wave function ansatz.
 
     The ``ExcitationPreserving`` circuit preserves the ratio of :math:`|00\rangle`,
-    :math:`|01\rangle + |10\rangle` and :math:`|11\rangle` states. The matrix representing
-    the operation is
+    :math:`|01\rangle + |10\rangle` and :math:`|11\rangle` states. To this end, this circuit
+    uses two-qubit interactions of the form
 
     .. math::
 
@@ -33,8 +33,8 @@ class ExcitationPreserving(TwoLocal):
 
         \begin{pmatrix}
         1 & 0 & 0 & 0 \\
-        0 & \cos(\th) & -\sin(\th) & 0 \\
-        0 & \sin(\th) & \cos(\th) & 0 \\
+        0 & \cos(\th) & -i\sin(\th) & 0 \\
+        0 & -i\sin(\th) & \cos(\th) & 0 \\
         0 & 0 & 0 & e^{-i\phi}
         \end{pmatrix}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix the matrix of the two-qubit interaction the ``qiskit.circuit.library.ExcitationPreserving`` circuit is using.

### Details and comments

The middle 2x2 block should have `-i sin(theta / 2)` on the antidiagonal instead of what the documentation currently states. This can also be seen if the circuit is instantiated:
```python
>>> from qiskit.circuit.library import ExcitationPreserving
>>> circuit = ExcitationPreserving(2, reps=1)
>>> circuit.decompose().draw()
     ┌──────────┐┌────────────┐┌────────────┐┌──────────┐
q_0: ┤ Rz(θ[0]) ├┤0           ├┤0           ├┤ Rz(θ[3]) ├
     ├──────────┤│  Rxx(θ[2]) ││  Ryy(θ[2]) │├──────────┤
q_1: ┤ Rz(θ[1]) ├┤1           ├┤1           ├┤ Rz(θ[4]) ├
     └──────────┘└────────────┘└────────────┘└──────────┘
>>> bound = circuit.bind_parameters([0, 0, np.pi / 4, 0, 0])
>>> Operator(bound)
Operator([[1.  +0.j  , 0.  +0.j  , 0.  +0.j  , 0.  +0.j  ],
          [0.  +0.j  , 0.71+0.j  , 0.  -0.71j, 0.  +0.j  ],  
          [0.  +0.j  , 0.  -0.71j, 0.71+0.j  , 0.  +0.j  ],
          [0.  +0.j  , 0.  +0.j  , 0.  +0.j  , 1.  +0.j  ]],
         input_dims=(2, 2), output_dims=(2, 2))
```
