### PR TITLE
Fix documentation for Sphinx 4

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -187,6 +187,7 @@ Gates and Instructions
    Gate
    ControlledGate
    Delay
+   Barrier
    Measure
    Reset
    Instruction

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -24,7 +24,6 @@ Standard Gates
    :toctree: ../stubs/
    :template: autosummary/class_no_inherited_members.rst
 
-   Barrier
    C3XGate
    C3SXGate
    C4XGate
@@ -50,12 +49,10 @@ Standard Gates
    MCXGrayCode
    MCXRecursive
    MCXVChain
-   Measure
    MSGate
    PhaseGate
    RCCXGate
    RC3XGate
-   Reset
    RGate
    RXGate
    RXXGate
@@ -81,6 +78,19 @@ Standard Gates
    XGate
    YGate
    ZGate
+
+Standard Directives
+===================
+
+..
+    This summary table deliberately does not generate toctree entries; these directives are "owned"
+    by ``qiskit.circuit``.
+
+.. autosummary::
+
+   ~qiskit.circuit.Barrier
+   ~qiskit.circuit.Measure
+   ~qiskit.circuit.Reset
 
 Generalized Gates
 =================

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,11 +18,11 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0
 reno>=3.4.0
-Sphinx>=3.0.0,<4.0.0
+Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
 sphinx-autodoc-typehints
 jupyter-sphinx
-sphinx-panels<0.6.0
+sphinx-panels
 pygments>=2.4
 networkx>=2.2
 scikit-learn>=0.20.0


### PR DESCRIPTION
### Summary

Sphinx 4 is more particular about disallowing the same Python object to
be documented in multiple toctree entries.  The culprits were `Barrier`,
`Reset` and `Measure` in the circuit library; the library re-exports
them from their canonical locations, and used `autosummary` to generate
extra links to them.  We still re-export them, but change the
`autosummary` tables to link to the existing definitions.

This then builds the documentation without errors on Sphinx 4, and
consequently the pin on `sphinx-panels` can be removed.  Previously the
pin was applied because an update to that package caused the
documentation build to break; in reality, it's just that
`sphinx-panels<0.6` pinned itself to `Sphinx<4`, whereas version 0.6
allowed Sphinx 4 - there were no breaking changes for us.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This currently doesn't add any behaviour that _requires_ Sphinx 4.
