### PR TITLE
Enable to schedule circuits with any directives

### DIFF
--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -14,7 +14,7 @@
 import warnings
 from typing import Optional, List, Tuple, Union, Iterable, Set
 
-from qiskit.circuit import Barrier, Delay
+from qiskit.circuit import Delay
 from qiskit.circuit import Instruction, Qubit, ParameterExpression
 from qiskit.circuit.duration import duration_in_dt
 from qiskit.providers import BaseBackend
@@ -137,6 +137,8 @@ class InstructionDurations:
         unit: str = "dt",
     ) -> float:
         """Get the duration of the instruction with the name and the qubits.
+        If the instruction is a directive, e.g. barrier, return 0.
+        If the instruction is a delay, return its own duration stored in it (not asking the self).
 
         Args:
             inst: An instruction or its name to be queried.
@@ -149,9 +151,10 @@ class InstructionDurations:
         Raises:
             TranspilerError: No duration is defined for the instruction.
         """
-        if isinstance(inst, Barrier):
+        if isinstance(inst, Instruction) and inst._directive:
             return 0
-        elif isinstance(inst, Delay):
+
+        if isinstance(inst, Delay):
             return self._convert_unit(inst.duration, inst.unit, unit)
 
         if isinstance(inst, Instruction):

--- a/test/python/transpiler/test_instruction_durations.py
+++ b/test/python/transpiler/test_instruction_durations.py
@@ -14,7 +14,7 @@
 
 """Test InstructionDurations class."""
 
-from qiskit.circuit import Delay, Parameter
+from qiskit.circuit import Delay, Parameter, Barrier
 from qiskit.test.mock.backends import FakeParis, FakeTokyo
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
@@ -30,6 +30,10 @@ class TestInstructionDurationsClass(QiskitTestCase):
         self.assertEqual(durations.dt, None)
         with self.assertRaises(TranspilerError):
             durations.get("cx", [0, 1], "dt")
+
+    def test_get_duration_of_barrier(self):
+        durations = InstructionDurations()
+        self.assertEqual(durations.get(Barrier(1), 0), 0)
 
     def test_fail_if_invalid_dict_is_supplied_when_construction(self):
         invalid_dic = [("cx", [0, 1])]  # no duration


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Enable to schedule circuits containing other directives as well as barriers.

### Details and comments
Previously, the following code fails
```
from qiskit import QuantumCircuit, transpile
from qiskit.test.mock import FakeLagos
from qiskit.providers.aer import AerSimulator

circ = QuantumCircuit(2)
circ.x(0)
circ.cx(0, 1)
circ.save_density_matrix([0, 1])

noisy_sim = AerSimulator.from_backend(FakeLagos())
qc = transpile(circ, backend=noisy_sim, scheduling_method="alap")
```
raising
```
qiskit.transpiler.exceptions.TranspilerError: 'Duration of save_density_matrix on qubits [0, 1] is not found.'
```

This commit updates `InstructionDuration.get` function to return 0 for all directives (previously, it returns 0 only for `Barrier` instruction`) so that transpiler can schedule circuits with any directive.