### PR TITLE
Fix parameter order in VQE, if the ansatz is resized

### DIFF
--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -378,8 +378,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         else:
             expectation = self.expectation
 
-        # wave_function = self.ansatz.assign_parameters(parameter)
-
         observable_meas = expectation.convert(StateFn(operator, is_measurement=True))
         ansatz_circuit_op = CircuitStateFn(self.ansatz)
         expect_op = observable_meas.compose(ansatz_circuit_op).reduce()

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -141,8 +141,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         self.expectation = expectation
         self._include_custom = include_custom
 
-        # set ansatz -- still supporting pre 0.18.0 sorting
-        self._ansatz_params = None
         self._ansatz = None
         self.ansatz = ansatz
 
@@ -186,7 +184,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             ansatz = RealAmplitudes()
 
         self._ansatz = ansatz
-        self._ansatz_params = list(ansatz.parameters)
 
     @property
     def gradient(self) -> Optional[Union[GradientBase, Callable]]:
@@ -278,7 +275,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 # try to set the number of qubits on the ansatz, if possible
                 try:
                     self.ansatz.num_qubits = operator.num_qubits
-                    self._ansatz_params = sorted(self.ansatz.parameters, key=lambda p: p.name)
                 except AttributeError as ex:
                     raise AlgorithmError(
                         "The number of qubits of the ansatz does not match the "
@@ -382,11 +378,10 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         else:
             expectation = self.expectation
 
-        param_dict = dict(zip(self._ansatz_params, parameter))  # type: Dict
-        wave_function = self.ansatz.assign_parameters(param_dict)
+        # wave_function = self.ansatz.assign_parameters(parameter)
 
         observable_meas = expectation.convert(StateFn(operator, is_measurement=True))
-        ansatz_circuit_op = CircuitStateFn(wave_function)
+        ansatz_circuit_op = CircuitStateFn(self.ansatz)
         expect_op = observable_meas.compose(ansatz_circuit_op).reduce()
 
         if return_expectation:
@@ -525,8 +520,8 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         # optimization routine.
         if isinstance(self._gradient, GradientBase):
             gradient = self._gradient.gradient_wrapper(
-                ~StateFn(operator) @ StateFn(self._ansatz),
-                bind_params=self._ansatz_params,
+                ~StateFn(operator) @ StateFn(self.ansatz),
+                bind_params=list(self.ansatz.parameters),
                 backend=self._quantum_instance,
             )
         else:
@@ -564,7 +559,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
         result = VQEResult()
         result.optimal_point = opt_result.x
-        result.optimal_parameters = dict(zip(self._ansatz_params, opt_result.x))
+        result.optimal_parameters = dict(zip(self.ansatz.parameters, opt_result.x))
         result.optimal_value = opt_result.fun
         result.cost_function_evals = opt_result.nfev
         result.optimizer_time = eval_time
@@ -615,14 +610,15 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         if num_parameters == 0:
             raise RuntimeError("The ansatz must be parameterized, but has 0 free parameters.")
 
+        ansatz_params = self.ansatz.parameters
         expect_op, expectation = self.construct_expectation(
-            self._ansatz_params, operator, return_expectation=True
+            ansatz_params, operator, return_expectation=True
         )
 
         def energy_evaluation(parameters):
             parameter_sets = np.reshape(parameters, (-1, num_parameters))
             # Create dict associating each parameter with the lists of parameterization values for it
-            param_bindings = dict(zip(self._ansatz_params, parameter_sets.transpose().tolist()))
+            param_bindings = dict(zip(ansatz_params, parameter_sets.transpose().tolist()))
 
             start_time = time()
             sampled_expect_op = self._circuit_sampler.convert(expect_op, params=param_bindings)

--- a/releasenotes/notes/fix-vqe-paramorder-if-ansatz-resized-14634a7efff7c74f.yaml
+++ b/releasenotes/notes/fix-vqe-paramorder-if-ansatz-resized-14634a7efff7c74f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fix a bug in :class:`~qiskit.algorithms.VQE` where the parameters of the ansatz were 
+    still explicitly ASCII-sorted by their name if the ansatz was resized. That led to a 
+    mismatching order of the optimized values in the ``optimal_point`` attribute of the result
+    object.
+
+    This bug did in particular occur if no ansatz was set by the user and the VQE chose 
+    a default with 11 or more free parameters.

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -46,6 +46,7 @@ from qiskit.opflow import (
     X,
     Z,
 )
+from qiskit.quantum_info import Statevector
 from qiskit.transpiler import PassManager, PassManagerConfig
 from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
 from qiskit.utils import QuantumInstance, algorithm_globals, has_aer
@@ -713,6 +714,21 @@ class TestVQE(QiskitAlgorithmsTestCase):
             "bound_pass_manager",
         ]
         self.assertEqual([record.message for record in cm.records], expected)
+
+    def test_construct_eigenstate_from_optpoint(self):
+        """Test constructing the eigenstate from the optimal point, if the default ansatz is used."""
+
+        # use Hamiltonian yielding more than 11 parameters in the default ansatz
+        hamiltonian = Z ^ Z ^ Z
+        optimizer = SPSA(maxiter=1, learning_rate=0.01, perturbation=0.01)
+        quantum_instance = QuantumInstance(
+            backend=BasicAer.get_backend("statevector_simulator"), basis_gates=["u3", "cx"]
+        )
+        vqe = VQE(optimizer=optimizer, quantum_instance=quantum_instance)
+        result = vqe.compute_minimum_eigenvalue(hamiltonian)
+
+        optimal_circuit = vqe.ansatz.bind_parameters(result.optimal_point)
+        self.assertTrue(Statevector(result.eigenstate).equiv(optimal_circuit))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix a bug in ``VQE`` where the parameters of the ansatz were 
still explicitly ASCII-sorted by their name if the ansatz was resized. That led to a 
mismatching order of the optimized values in the ``optimal_point`` attribute of the result
object.

### Details and comments

For example, this led to a wrong optimal circuit if a user tried to construct it using ``VQEResult.optimal_point``.
```python
from qiskit.algorithms import VQE
from qiskit.circuit.library import RealAmplitudes
from qiskit.opflow import Z, I
from qiskit.providers.aer import AerSimulator
from qiskit.quantum_info import Statevector

# Hamiltonian that will lead to more than 11 parameters.
# The default ansatz is RealAmplitudes with 4 rotation layers, hence this will
# produce  a 12-parameter ansatz.
hamiltonian = Z ^ Z ^ Z

sim = AerSimulator(method="statevector")
vqe = VQE(quantum_instance=sim)  # don't set the ansatz but let VQE use the default
result = vqe.compute_minimum_eigenvalue(hamiltonian)

ansatz = RealAmplitudes(hamiltonian.num_qubits)
reconstructed_state  = Statevector(ansatz.bind_parameters(result.optimal_point))
print("Reconstructed state from optimal parameters:")
print(reconstructed_state)
print("State from VQE result:")
print(result.eigenstate)
```

Instead of the same statevectors, this yields
```
Optimal circuit using optimal values as list
Statevector([ 0.64431664+0.j, -0.2110578 +0.j,  0.38441563+0.j,
             -0.17266969+0.j, -0.26513136+0.j,  0.02009964+0.j,
              0.50885393+0.j, -0.18190522+0.j],
            dims=(2, 2, 2))
[ 2.81202210e-04+0.j  2.24955744e-01+0.j -1.10683555e-01+0.j
  1.51121930e-04+0.j  7.54507043e-01+0.j  6.74747145e-05+0.j
  9.33921914e-05+0.j -6.06517165e-01+0.j]
```
With this PR, these vectors are the same.
