### PR TITLE
Fix bad version test in P_BFGS

### DIFF
--- a/qiskit/algorithms/optimizers/p_bfgs.py
+++ b/qiskit/algorithms/optimizers/p_bfgs.py
@@ -15,6 +15,7 @@
 import logging
 import multiprocessing
 import platform
+import sys
 import warnings
 from typing import Optional, List, Tuple, Callable
 
@@ -144,8 +145,7 @@ class P_BFGS(SciPyOptimizer):  # pylint: disable=invalid-name
             # default. The fork start method should be considered unsafe as it can
             # lead to crashes.
             # However P_BFGS doesn't support spawn, so we revert to single process.
-            major, minor, _ = platform.python_version_tuple()
-            if major > "3" or (major == "3" and minor >= "8"):
+            if sys.version_info >= (3, 8):
                 num_procs = 0
                 logger.warning(
                     "For MacOS, python >= 3.8, using only current process. "


### PR DESCRIPTION
### Summary

Comparing the string `platform.get_version_tuple()[1] >= "8"` fails once
the minor version has two digits.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

No changelog because Python 3.10 support hasn't been released yet.
