### PR TITLE
Pin sphinx-autodoc-typehints to unblock docs builds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints
+sphinx-autodoc-typehints<1.14.0
 jupyter-sphinx
 sphinx-panels
 pygments>=2.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

sphinx-autodoc-typehints pushed the 1.14.0 release earlier today and
ever since the docs jobs are failing to build trying failing to
resolve signatures on builtin methods to python. This commit pins the
sphinx-autodoc-typehints version to unblock this until the issue is
reported and fixed upstream.

### Details and comments


