### PR TITLE
Update gate_map.py to allow nonstandard coupling graph sizes

### DIFF
--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -348,6 +348,16 @@ def plot_gate_map(
     num_qubits = config.n_qubits
     coupling_map = config.coupling_map
     qubit_coordinates = qubit_coordinates_map.get(num_qubits)
+    
+    # try to adjust num_qubits to match the next highest hardcoded grid size
+    if qubit_coordinates is None:
+        if any([num_qubits < key for key in qubit_coordinates_map.keys()]):
+            num_qubits_roundup = max(qubit_coordinates_map.keys())
+            for key in qubit_coordinates_map.keys():
+                if key < num_qubits_roundup and key > num_qubits:
+                    num_qubits_roundup = key
+            qubit_coordinates = qubit_coordinates_map.get(num_qubits_roundup)
+    
     return plot_coupling_map(
         num_qubits,
         qubit_coordinates,
@@ -545,6 +555,9 @@ def plot_coupling_map(
 
     # Add circles for qubits
     for var, idx in enumerate(grid_data):
+        # add check if num_qubits had been rounded up
+        if var >= num_qubits:
+            break
         _idx = [idx[1], -idx[0]]
         ax.add_artist(
             mpatches.Ellipse(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I found this error when trying to configure my own custom coupling graphs. The gate_map plot will always be blank unless the number of qubits matches a known grid layout in visualization/gate_map.py in the qubit_coordinates_map dictionary. A suggestion to fix this is to just round up to the nearest hard-coded grid size but don't print all the qubits. See #3692. 

### Details and comments

This doesn't make the prettiest pictures but it is better than blank plots.

An example using num_qubits=5, which is normally allowed.
```
LNN4 = ConfigurableFakeBackend(name='fake_lnn4', n_qubits=5, coupling_map=cmap, basis_gates=basis_gates)
plot_gate_map(LNN4, plot_directed=True)
```
![image](https://user-images.githubusercontent.com/47376937/148450533-1bd79580-e3bb-4ed3-9a18-b5361a6ec0b7.png)

And an example using num_qubits=4, which is using the grid defintion of 5, but not including the 5th qubit in the picture.
```
LNN4 = ConfigurableFakeBackend(name='fake_lnn4', n_qubits=4, coupling_map=cmap, basis_gates=basis_gates)
plot_gate_map(LNN4, plot_directed=True)
```
![image](https://user-images.githubusercontent.com/47376937/148450674-7a44dd7d-cf44-4c6f-a1df-fef3c1429cff.png)

