### PR TITLE
Fix Bloch sphere with Matplotlib 3.3 and 3.4

### DIFF
--- a/qiskit/visualization/bloch.py
+++ b/qiskit/visualization/bloch.py
@@ -81,10 +81,12 @@ class Arrow3D(Patch3D, FancyArrowPatch):
         # pylint: disable=super-init-not-called
         FancyArrowPatch.__init__(self, (0, 0), (0, 0), **kwargs)
         self.set_3d_properties(tuple(zip(xs, ys)), zs, zdir)
+        self._path2d = None
 
     def draw(self, renderer):
         xs3d, ys3d, zs3d = zip(*self._segment3d)
         x_s, y_s, _ = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        self._path2d = matplotlib.path.Path(np.column_stack([x_s, y_s]))
         self.set_positions((x_s[0], y_s[0]), (x_s[1], y_s[1]))
         FancyArrowPatch.draw(self, renderer)
 

--- a/releasenotes/notes/fix-path2d-mpl3.4-b1af3a23b408d30a.yaml
+++ b/releasenotes/notes/fix-path2d-mpl3.4-b1af3a23b408d30a.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixed an issue where plotting Bloch spheres could cause an ``AttributeError``
+    to be raised in Jupyter or when trying to crop figures down to size with
+    Matplotlib 3.4.  For example, the following code would previously crash with a
+    message::
+
+      AttributeError: 'Arrow3D' object has no attribute '_path2d'
+
+    but will now succeed with both Matplotlib 3.4 and 3.5::
+
+      from qiskit.visualization import plot_bloch_vector
+      plot_bloch_vector([0, 1, 0]).savefig("tmp.png", bbox_inches='tight')

--- a/releasenotes/notes/fix-path2d-mpl3.4-b1af3a23b408d30a.yaml
+++ b/releasenotes/notes/fix-path2d-mpl3.4-b1af3a23b408d30a.yaml
@@ -3,12 +3,12 @@ fixes:
   - |
     Fixed an issue where plotting Bloch spheres could cause an ``AttributeError``
     to be raised in Jupyter or when trying to crop figures down to size with
-    Matplotlib 3.4.  For example, the following code would previously crash with a
-    message::
+    Matplotlib 3.3 or 3.4 (but not 3.5).  For example, the following code would
+    previously crash with a message::
 
       AttributeError: 'Arrow3D' object has no attribute '_path2d'
 
-    but will now succeed with both Matplotlib 3.4 and 3.5::
+    but will now succeed with all current supported versions of Matplotlib::
 
       from qiskit.visualization import plot_bloch_vector
       plot_bloch_vector([0, 1, 0]).savefig("tmp.png", bbox_inches='tight')


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In Matplotlib 3.4, the paths for cropping the figure down to its bounding box attempted to access `Arrow3D._path3d` without it being set.  This just ensures it is set as soon as the patch is drawn onto a figure.

### Details and comments

Fix #7488
