### PR TITLE
Fix the inverse method of ``PauliEvolutionGate``

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -104,9 +104,6 @@ class PauliEvolutionGate(Gate):
         """Unroll, where the default synthesis is matrix based."""
         self.definition = self.synthesis.synthesize(self)
 
-    def inverse(self) -> "PauliEvolutionGate":
-        return PauliEvolutionGate(operator=self.operator, time=-self.time, synthesis=self.synthesis)
-
     def validate_parameter(
         self, parameter: Union[int, float, ParameterExpression]
     ) -> Union[float, ParameterExpression]:

--- a/releasenotes/notes/fix-paulievo-inverse-b53a6ecd0ff9a313.yaml
+++ b/releasenotes/notes/fix-paulievo-inverse-b53a6ecd0ff9a313.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fix :meth:`~qiskit.circuit.library.PauliEvolutionGate.inverse` which previously computed the
+    inverse by inverting the evolution time, which is only the correct inverse if the operator
+    was involved correctly. In particular, this led to the inverse of Trotterization-based time
+    evolutions being incorrect.

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -261,3 +261,14 @@ class TestEvolutionGate(QiskitTestCase):
             circuit.data[2][0].params[0],  # Z
         ]
         self.assertListEqual(rz_angles, [20, 30, -10])
+
+    @data(LieTrotter, MatrixExponential)
+    def test_inverse(self, synth_cls):
+        """Test calculating the inverse is correct."""
+        evo = PauliEvolutionGate(X + Y, time=0.12, synthesis=synth_cls())
+
+        circuit = QuantumCircuit(1)
+        circuit.append(evo, circuit.qubits)
+        circuit.append(evo.inverse(), circuit.qubits)
+
+        self.assertTrue(Operator(circuit).equiv(np.identity(2 ** circuit.num_qubits)))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix `PauliEvolutionGate.inverse` which previously computed the
inverse by inverting the evolution time, which is only the correct inverse if the operator
was involved correctly. In particular, this led to the inverse of Trotterization-based time
evolutions being incorrect

### Details and comments

By removing the inverse method, the code will rely on the standard inversion of circuits. That's arguably less elegant than inverting the time, but correct 🙂 


