### PR TITLE
Add param to qpy load for custom definitions fixing #7454

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -1547,7 +1547,7 @@ def load(file_obj, custom_gate_dict=None):
 
         class Gate1(QiskitGate):
             def validate_parameter(self, single_param):
-                if not isinstance(single_param,(int, float, str, bool, dict, qiskit.circuit.ParameterExpression)):
+                if not isinstance(single_param,(int, float, str, bool, dict)):
                     raise Exception(f"parameter of type {type(single_param)} not supported")
                 return single_param
 

--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -1540,21 +1540,21 @@ def load(file_obj, custom_gate_dict=None):
     :class:`~qiskit.circuit.QuantumCircuit` objects from the file.
 
     With custom gate definitions containing overidden methods such as :
+
     .. code-block:: python
+
         from qiskit.circuit import Gate as QiskitGate
 
         class Gate1(QiskitGate):
             def validate_parameter(self, single_param):
-                if not isinstance(
-                    single_param,
-                    (int, float, str, bool, dict, qiskit.circuit.ParameterExpression),
-                ):
+                if not isinstance(single_param,(int, float, str, bool, dict, qiskit.circuit.ParameterExpression)):
                     raise Exception(f"parameter of type {type(single_param)} not supported")
                 return single_param
 
     use custom_dict parameter to pass this definition to the load method :
 
     .. code-block:: python
+
         from qiskit.circuit import qpy_serialization
         #let the circuit with the custom gate be saved in a file circ
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adding parameter for qpy `load` method to support custom quantum `Gate` definitions


### Details and comments
- In response to issue #7454 , an optional parameter called `custom_gate_dict` was added to the qpy `load` method. 
- The reason was that in `_parse_custom_instruction` method in `qiskit.circuit.qpy_serialization.py`, a definition for the gate used in the original circuit is needed. The original method does not have access to the definitions made by the user
- The optional parameter `custom_gate_dict` is a mapping of the name and the definitions of custom gates defined by the user
- A unit test is also added

- Example of resolved issue : 
```
import io
import qiskit
import numpy as np
from qiskit.circuit import QuantumCircuit
from qiskit.circuit import qpy_serialization
from qiskit.circuit import Gate as QiskitGate
from qiskit.circuit.exceptions import CircuitError


class Gate1(QiskitGate):
    def validate_parameter(self, single_param):
        if not isinstance(
            single_param,
            (int, float, str, bool, dict, qiskit.circuit.ParameterExpression),
        ):
            raise CircuitError(f"parameter of type {type(single_param)} not supported")
        return single_param


class Gate2(QiskitGate):
    def validate_parameter(self, single_param):
        if not isinstance(
            single_param,
            (int, float, str, bool, dict, qiskit.circuit.ParameterExpression),
        ):
            raise CircuitError(f"parameter of type {type(single_param)} not supported")
        return single_param


ramsey = QuantumCircuit(2, 2)
ramsey.rx(np.pi / 2, 0)

gate1 = Gate1(name="wait", num_qubits=1, params=[10, "special"])
gate2 = Gate2(name="forward", num_qubits=1, params=[10, "unique"])

ramsey.append(gate1, [0])
ramsey.append(gate2, [1])
ramsey.rx(np.pi / 2, 0)

print("Original :\n", ramsey.draw())

with io.BytesIO() as fid:
    qpy_serialization.dump([ramsey], fid)
    b = fid.getvalue()

# the gates should be ordered by their names, as the gates may be multiple
with io.BytesIO(initial_bytes=b) as fid:
    circuits = qpy_serialization.load(
        fid, custom_gate_dict={"wait": Gate1, "forward": Gate2}
    )
    print("Reloaded :\n", circuits[0].draw())




```

