### PR TITLE
Fix imported forward references in type hints

### DIFF
--- a/qiskit/assembler/assemble_schedules.py
+++ b/qiskit/assembler/assemble_schedules.py
@@ -28,9 +28,9 @@ from qiskit.qobj.converters.pulse_instruction import ParametricPulseShapes
 def assemble_schedules(
     schedules: List[
         Union[
-            "schedule.ScheduleBlock",
-            "schedule.ScheduleComponent",
-            Tuple[int, "schedule.ScheduleComponent"],
+            schedule.ScheduleBlock,
+            schedule.ScheduleComponent,
+            Tuple[int, schedule.ScheduleComponent],
         ]
     ],
     qobj_id: int,
@@ -68,7 +68,7 @@ def assemble_schedules(
 
 
 def _assemble_experiments(
-    schedules: List[Union["schedule.ScheduleComponent", Tuple[int, "schedule.ScheduleComponent"]]],
+    schedules: List[Union[schedule.ScheduleComponent, Tuple[int, schedule.ScheduleComponent]]],
     lo_converter: converters.LoConfigConverter,
     run_config: RunConfig,
 ) -> Tuple[List[qobj.PulseQobjExperiment], Dict[str, Any]]:

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -57,12 +57,6 @@ Interval = Tuple[int, int]
 TimeSlots = Dict[Channel, List[Interval]]
 """List of timeslots occupied by instructions for each channel."""
 
-ScheduleComponent = Union["Schedule", Instruction]
-"""An element that composes a pulse schedule."""
-
-BlockComponent = Union["ScheduleBlock", Instruction]
-"""An element that composes a pulse schedule block."""
-
 
 class Schedule:
     """A quantum program *schedule* with exact time constraints for its instructions, operating
@@ -123,7 +117,7 @@ class Schedule:
 
     def __init__(
         self,
-        *schedules: Union[ScheduleComponent, Tuple[int, ScheduleComponent]],
+        *schedules: Union["ScheduleComponent", Tuple[int, "ScheduleComponent"]],
         name: Optional[str] = None,
         metadata: Optional[dict] = None,
     ):
@@ -247,7 +241,7 @@ class Schedule:
         return tuple(self._timeslots.keys())
 
     @property
-    def children(self) -> Tuple[Tuple[int, ScheduleComponent], ...]:
+    def children(self) -> Tuple[Tuple[int, "ScheduleComponent"], ...]:
         """Return the child schedule components of this ``Schedule`` in the
         order they were added to the schedule.
 
@@ -376,7 +370,7 @@ class Schedule:
     def insert(
         self,
         start_time: int,
-        schedule: ScheduleComponent,
+        schedule: "ScheduleComponent",
         name: Optional[str] = None,
         inplace: bool = False,
     ) -> "Schedule":
@@ -393,7 +387,7 @@ class Schedule:
             return self._mutable_insert(start_time, schedule)
         return self._immutable_insert(start_time, schedule, name=name)
 
-    def _mutable_insert(self, start_time: int, schedule: ScheduleComponent) -> "Schedule":
+    def _mutable_insert(self, start_time: int, schedule: "ScheduleComponent") -> "Schedule":
         """Mutably insert `schedule` into `self` at `start_time`.
 
         Args:
@@ -408,7 +402,7 @@ class Schedule:
     def _immutable_insert(
         self,
         start_time: int,
-        schedule: ScheduleComponent,
+        schedule: "ScheduleComponent",
         name: Optional[str] = None,
     ) -> "Schedule":
         """Return a new schedule with ``schedule`` inserted into ``self`` at ``start_time``.
@@ -423,7 +417,7 @@ class Schedule:
         return new_sched
 
     def append(
-        self, schedule: ScheduleComponent, name: Optional[str] = None, inplace: bool = False
+        self, schedule: "ScheduleComponent", name: Optional[str] = None, inplace: bool = False
     ) -> "Schedule":
         r"""Return a new schedule with ``schedule`` inserted at the maximum time over
         all channels shared between ``self`` and ``schedule``.
@@ -514,7 +508,7 @@ class Schedule:
             self, filters=filters, negate=True, recurse_subroutines=check_subroutine
         )
 
-    def _add_timeslots(self, time: int, schedule: ScheduleComponent) -> None:
+    def _add_timeslots(self, time: int, schedule: "ScheduleComponent") -> None:
         """Update all time tracking within this schedule based on the given schedule.
 
         Args:
@@ -569,7 +563,7 @@ class Schedule:
 
         _check_nonnegative_timeslot(self._timeslots)
 
-    def _remove_timeslots(self, time: int, schedule: ScheduleComponent):
+    def _remove_timeslots(self, time: int, schedule: "ScheduleComponent"):
         """Delete the timeslots if present for the respective schedule component.
 
         Args:
@@ -608,7 +602,7 @@ class Schedule:
             if not channel_timeslots:
                 self._timeslots.pop(channel)
 
-    def _replace_timeslots(self, time: int, old: ScheduleComponent, new: ScheduleComponent):
+    def _replace_timeslots(self, time: int, old: "ScheduleComponent", new: "ScheduleComponent"):
         """Replace the timeslots of ``old`` if present with the timeslots of ``new``.
 
         Args:
@@ -627,8 +621,8 @@ class Schedule:
 
     def replace(
         self,
-        old: ScheduleComponent,
-        new: ScheduleComponent,
+        old: "ScheduleComponent",
+        new: "ScheduleComponent",
         inplace: bool = False,
     ) -> "Schedule":
         """Return a ``Schedule`` with the ``old`` instruction replaced with a ``new``
@@ -751,11 +745,11 @@ class Schedule:
         """Return number of instructions in the schedule."""
         return len(self.instructions)
 
-    def __add__(self, other: ScheduleComponent) -> "Schedule":
+    def __add__(self, other: "ScheduleComponent") -> "Schedule":
         """Return a new schedule with ``other`` inserted within ``self`` at ``start_time``."""
         return self.append(other)
 
-    def __or__(self, other: ScheduleComponent) -> "Schedule":
+    def __or__(self, other: "ScheduleComponent") -> "Schedule":
         """Return a new schedule which is the union of `self` and `other`."""
         return self.insert(0, other)
 
@@ -763,7 +757,7 @@ class Schedule:
         """Return a new schedule which is shifted forward by ``time``."""
         return self.shift(time)
 
-    def __eq__(self, other: ScheduleComponent) -> bool:
+    def __eq__(self, other: "ScheduleComponent") -> bool:
         """Test if two Schedule are equal.
 
         Equality is checked by verifying there is an equal instruction at every time
@@ -1030,7 +1024,7 @@ class ScheduleBlock:
         return self.instructions
 
     @property
-    def blocks(self) -> Tuple[BlockComponent]:
+    def blocks(self) -> Tuple["BlockComponent", ...]:
         """Get the time-ordered instructions from self."""
         return tuple(self._blocks)
 
@@ -1049,7 +1043,7 @@ class ScheduleBlock:
         return self.ch_duration(*channels)
 
     def append(
-        self, block: BlockComponent, name: Optional[str] = None, inplace: bool = True
+        self, block: "BlockComponent", name: Optional[str] = None, inplace: bool = True
     ) -> "ScheduleBlock":
         """Return a new schedule block with ``block`` appended to the context block.
         The execution time is automatically assigned when the block is converted into schedule.
@@ -1172,8 +1166,8 @@ class ScheduleBlock:
 
     def replace(
         self,
-        old: BlockComponent,
-        new: BlockComponent,
+        old: "BlockComponent",
+        new: "BlockComponent",
         inplace: bool = True,
     ) -> "ScheduleBlock":
         """Return a ``ScheduleBlock`` with the ``old`` component replaced with a ``new``
@@ -1304,7 +1298,7 @@ class ScheduleBlock:
             self.__class__.__name__, blocks, name, repr(self.alignment_context)
         )
 
-    def __add__(self, other: BlockComponent) -> "ScheduleBlock":
+    def __add__(self, other: "BlockComponent") -> "ScheduleBlock":
         """Return a new schedule with ``other`` inserted within ``self`` at ``start_time``."""
         return self.append(other)
 
@@ -1590,7 +1584,7 @@ def _check_nonnegative_timeslot(timeslots: TimeSlots):
                 raise PulseError(f"An instruction on {chan} has a negative starting time.")
 
 
-def _get_timeslots(schedule: ScheduleComponent) -> TimeSlots:
+def _get_timeslots(schedule: "ScheduleComponent") -> TimeSlots:
     """Generate timeslots from given schedule component.
 
     Args:
@@ -1609,3 +1603,18 @@ def _get_timeslots(schedule: ScheduleComponent) -> TimeSlots:
         raise PulseError(f"Invalid schedule type {type(schedule)} is specified.")
 
     return timeslots
+
+
+# These type aliases are defined at the bottom of the file, because as of 2022-01-18 they are
+# imported into other parts of Terra.  Previously, the aliases were at the top of the file and used
+# forwards references within themselves.  This was fine within the same file, but causes scoping
+# issues when the aliases are imported into different scopes, in which the `ForwardRef` instances
+# would no longer resolve.  Instead, we only use forward references in the annotations of _this_
+# file to reference the aliases, which are guaranteed to resolve in scope, so the aliases can all be
+# concrete.
+
+ScheduleComponent = Union[Schedule, Instruction]
+"""An element that composes a pulse schedule."""
+
+BlockComponent = Union[ScheduleBlock, Instruction]
+"""An element that composes a pulse schedule block."""


### PR DESCRIPTION
### Summary

In type hints, strings are converted to `typing.ForwardRef` instances,
which only attempt to evaluate to a true reference when the are the
subject of a `typing.get_type_hints` call, which defines the scoped
names they can resolve over.  Further, the instances store their
resolved value, so they only need to be evaluated once.  Together, this
means that the evaluation order of type hints can change the result of a
program, if a `ForwardRef` is imported into a different scope.

In Terra, this happened within a type alias in the `pulse` module.  The
fix in this case is to ensure that the type aliases were concrete types
(by putting them after the definition of the classes they aliased over),
and references to the aliases _within the same file_ were done by
forward reference.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #7534.
