### PR TITLE
add __lt__ and friends to parameterexpression

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -471,11 +471,12 @@ class ParameterExpression:
     def __eq__(self, other):
         """Check if this parameter expression is equal to another parameter expression
            or a fixed value (only if this is a bound expression).
+
         Args:
-            other (ParameterExpression or a number):
-                Parameter expression or numeric constant used for comparison
+            other: Parameter expression or numeric constant used for comparison
+
         Returns:
-            bool: result of the comparison
+            The result of the comparison.
         """
         if isinstance(other, ParameterExpression):
             if self.parameters != other.parameters:
@@ -489,6 +490,77 @@ class ParameterExpression:
         elif isinstance(other, numbers.Number):
             return len(self.parameters) == 0 and complex(self._symbol_expr) == other
         return False
+
+    def __lt__(self, other: ParameterValueType) -> bool:
+        """Check if this parameter expression is less than another parameter expression
+           or a fixed value (only if this is a bound expression).
+
+        Args:
+            other: Parameter expression or numeric constant used for comparison
+
+        Raises:
+            TypeError:
+                - If comparison to number with unbound parameters.
+                - If comparison to type of other object unsupported.
+
+        Returns:
+            The result of the comparison.
+        """
+        if isinstance(other, ParameterExpression):
+            if HAS_SYMENGINE:
+                from sympy import sympify
+
+                return sympify(self._symbol_expr).__lt__(sympify(other._symbol_expr))
+            else:
+                return self._symbol_expr.__lt__(other._symbol_expr)
+        elif isinstance(other, numbers.Number):
+            if len(self.parameters) == 0:
+                return float(self._symbol_expr) < other
+            raise TypeError(
+                "'<' not supported between instances of {type(self)} "
+                "with unbound parameters {self.parameters} and {type(other)}."
+            )
+        else:
+            return NotImplemented
+
+    def __gt__(self, other: ParameterValueType) -> bool:
+        """Check if this parameter expression is greater than another parameter expression
+           or a fixed value (only if this is a bound expression).
+
+        Args:
+            other: Parameter expression or numeric constant used for comparison
+
+        Raises:
+            TypeError:
+                - If comparison to number with unbound parameters.
+                - If comparison to type of other object unsupported.
+
+        Returns:
+            The result of the comparison.
+        """
+        if isinstance(other, ParameterExpression):
+            if HAS_SYMENGINE:
+                from sympy import sympify
+
+                return sympify(self._symbol_expr).__gt__(sympify(other._symbol_expr))
+            else:
+                return self._symbol_expr.__gt__(other._symbol_expr)
+        elif isinstance(other, numbers.Number):
+            if len(self.parameters) == 0:
+                return float(self._symbol_expr) > other
+            else:
+                raise TypeError(
+                    "'>' not supported between instances of {type(self)} "
+                    "with unbound parameters {self.parameters} and {type(other)}."
+                )
+        else:
+            return NotImplemented
+
+    def __ge__(self, other: ParameterValueType) -> bool:
+        return not (self < other)
+
+    def __le__(self, other: ParameterValueType) -> bool:
+        return not (self > other)
 
     def __getstate__(self):
         if HAS_SYMENGINE:

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1178,7 +1178,39 @@ class TestParameterExpressions(QiskitTestCase):
 
         x = Parameter("x")
         bound_expr = x.bind({x: 2.3})
+
         self.assertEqual(bound_expr, 2.3)
+        self.assertTrue(bound_expr < 3.0)
+        self.assertTrue(bound_expr <= 3.0)
+        self.assertTrue(bound_expr > 1.0)
+        self.assertTrue(bound_expr >= 1.0)
+
+    def test_compare_to_value_not_bound(self):
+        """Verify raises if compare to value and not bound."""
+        x = Parameter("x")
+
+        with self.assertRaisesRegex(TypeError, "unbound parameters"):
+            x > 2.3
+        with self.assertRaisesRegex(TypeError, "unbound parameters"):
+            x < 2.3
+        with self.assertRaisesRegex(TypeError, "unbound parameters"):
+            x >= 2.3
+        with self.assertRaisesRegex(TypeError, "unbound parameters"):
+            x <= 2.3
+
+    def test_raise_if_compare_not_supported(self):
+        """Verify raises if compare to object."""
+        x = Parameter("x")
+        y = object()
+
+        with self.assertRaisesRegex(TypeError, "not supported"):
+            x < y
+        with self.assertRaisesRegex(TypeError, "not supported"):
+            x <= y
+        with self.assertRaisesRegex(TypeError, "not supported"):
+            x > y
+        with self.assertRaisesRegex(TypeError, "not supported"):
+            x >= y
 
     def test_cast_to_float_when_bound(self):
         """Verify expression can be cast to a float when fully bound."""


### PR DESCRIPTION
Summary
- added comparison operators `__lt__` and friends to `ParameterExpression`
- fixes failing passes that use comparison of angles when parameters are used
- results from discussion with @jakelishman at #7497

### Details and comments
- related to #7497 
- related to #5278