### PR TITLE
Warn not error on overflow in QFT

### DIFF
--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -104,8 +104,6 @@ class QFT(BlueprintCircuit):
         self._insert_barriers = insert_barriers
         self._inverse = inverse
         self.num_qubits = num_qubits
-        # Warn immediately if we can detect straight away that there is a problem.
-        self._warn_if_precision_loss()
 
     @property
     def num_qubits(self) -> int:
@@ -238,8 +236,6 @@ class QFT(BlueprintCircuit):
         If we need an angle smaller than ``pi * 2**-1022``, we start to lose precision by going into
         the subnormal numbers.  We won't lose _all_ precision until an exponent of about 1075, but
         beyond 1022 we're using fractional bits to represent leading zeros."""
-        if self.num_qubits is None or self.approximation_degree is None:
-            return
         max_num_entanglements = self.num_qubits - self.approximation_degree - 1
         if max_num_entanglements > -np.finfo(float).minexp:  # > 1022 for doubles.
             warnings.warn(

--- a/qiskit/circuit/library/basis_change/qft.py
+++ b/qiskit/circuit/library/basis_change/qft.py
@@ -13,6 +13,7 @@
 """Quantum Fourier Transform Circuit."""
 
 from typing import Optional
+import warnings
 import numpy as np
 
 from qiskit.circuit import QuantumCircuit, QuantumRegister
@@ -103,6 +104,8 @@ class QFT(BlueprintCircuit):
         self._insert_barriers = insert_barriers
         self._inverse = inverse
         self.num_qubits = num_qubits
+        # Warn immediately if we can detect straight away that there is a problem.
+        self._warn_if_precision_loss()
 
     @property
     def num_qubits(self) -> int:
@@ -229,6 +232,24 @@ class QFT(BlueprintCircuit):
         inverted._inverse = not self._inverse
         return inverted
 
+    def _warn_if_precision_loss(self):
+        """Issue a warning if constructing the circuit will lose precision.
+
+        If we need an angle smaller than ``pi * 2**-1022``, we start to lose precision by going into
+        the subnormal numbers.  We won't lose _all_ precision until an exponent of about 1075, but
+        beyond 1022 we're using fractional bits to represent leading zeros."""
+        if self.num_qubits is None or self.approximation_degree is None:
+            return
+        max_num_entanglements = self.num_qubits - self.approximation_degree - 1
+        if max_num_entanglements > -np.finfo(float).minexp:  # > 1022 for doubles.
+            warnings.warn(
+                "precision loss in QFT."
+                f" The rotation needed to represent {max_num_entanglements} entanglements"
+                " is smaller than the smallest normal floating-point number.",
+                category=RuntimeWarning,
+                stacklevel=3,
+            )
+
     def _check_configuration(self, raise_on_failure: bool = True) -> bool:
         """Check if the current configuration is valid."""
         valid = True
@@ -236,7 +257,7 @@ class QFT(BlueprintCircuit):
             valid = False
             if raise_on_failure:
                 raise AttributeError("The number of qubits has not been set.")
-
+        self._warn_if_precision_loss()
         return valid
 
     def _build(self) -> None:
@@ -256,7 +277,9 @@ class QFT(BlueprintCircuit):
             circuit.h(j)
             num_entanglements = max(0, j - max(0, self.approximation_degree - (num_qubits - j - 1)))
             for k in reversed(range(j - num_entanglements, j)):
-                lam = np.pi / (2 ** (j - k))
+                # Use negative exponents so that the angle safely underflows to zero, rather than
+                # using a temporary variable that overflows to infinity in the worst case.
+                lam = np.pi * (2.0 ** (k - j))
                 circuit.cp(lam, j, k)
 
             if self.insert_barriers:

--- a/releasenotes/notes/warn-on-too-large-qft-a2dd60d4a374751a.yaml
+++ b/releasenotes/notes/warn-on-too-large-qft-a2dd60d4a374751a.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    :class:`.QFT` will now warn if it is instantiated or built with settings
+    that will cause it to lose precision, rather than raising an
+    ``OverflowError``.  This can happen if the number of qubits is very large
+    (slightly over 1000) without the approximation degree being similarly large.
+    The circuit will now build successfully, but some angles might be
+    indistinguishable from zero, due to limitations in double-precision
+    floating-point numbers.

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -13,6 +13,7 @@
 """Test library of QFT circuits."""
 
 import unittest
+import warnings
 import numpy as np
 from ddt import ddt, data, unpack
 
@@ -166,6 +167,45 @@ class TestQFT(QiskitTestCase):
 
         with self.subTest(msg="inverse as kwarg"):
             self.assertEqual(QFT(1, inverse=True).name, "IQFT")
+
+    def test_warns_if_too_large(self):
+        """Test that a warning is issued if the user tries to make a circuit that would need to
+        represent angles smaller than the smallest normal double-precision floating-point number."""
+
+        class SentinelException(Exception):
+            """It's too slow to actually let QFT construct a 1050+ qubit circuit for such a
+            simple test, so we temporarily prevent QuantumCircuits from being created in order
+            to short-circuit the QFT builder."""
+
+            def __init__(self, *_args, **_kwargs):
+                super().__init__()
+                raise self
+
+        with self.subTest("instantiation"):
+            with self.assertWarnsRegex(RuntimeWarning, "precision loss in QFT"):
+                QFT(1030)
+
+        with self.subTest("no error on mutation until build"):
+            # We don't want to issue a warning on mutation until we know that the values are
+            # finalised; this is because a user might want to mutate the number of qubits and the
+            # approximation degree.  In these cases, wait until we try to build the circuit.
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                warnings.filterwarnings(
+                    "always",
+                    category=RuntimeWarning,
+                    module=r"qiskit\..*",
+                    message=r".*precision loss in QFT.*",
+                )
+                qft = QFT()
+                # Even with the approximation this will trigger the warning.
+                qft.num_qubits = 1080
+                qft.approximation_degree = 20
+            self.assertFalse(caught_warnings)
+
+            with unittest.mock.patch("qiskit.circuit.QuantumCircuit.__new__", SentinelException):
+                with self.assertWarnsRegex(RuntimeWarning, "precision loss in QFT"):
+                    with self.assertRaises(SentinelException):
+                        qft._build()
 
 
 if __name__ == "__main__":

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -202,7 +202,7 @@ class TestQFT(QiskitTestCase):
                 qft.approximation_degree = 20
             self.assertFalse(caught_warnings)
 
-            with unittest.mock.patch("qiskit.circuit.QuantumCircuit.__new__", SentinelException):
+            with unittest.mock.patch("qiskit.circuit.QuantumCircuit.__init__", SentinelException):
                 with self.assertWarnsRegex(RuntimeWarning, "precision loss in QFT"):
                     with self.assertRaises(SentinelException):
                         qft._build()


### PR DESCRIPTION
### Summary

Previously, the rotation angles were calculated by dividing `pi` by
increasingly large numbers for large qubit counts.  This meant that the
intermediate result could overflow to infinity for large circuits,
raising an ``OverflowError``.  Instead, we do the calculation as a
multiplication with a very small number, so the intermediate values
safely underflow to zero in this case (if the intermediate value
underflows, the final value would have had precision loss anyway).

To make sure the user is aware, we raise warnings when this will happen.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #7538.

I think there's probably some speed-ups to be had in various methods called by `QFT.build` here; it takes much longer to build the circuit than I'd expect.  Probably there's some extraneous copying and binding that we can reduce.