### PR TITLE
Add ikkoham as code owner for quantum_info and opflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,10 @@
 
 # Qiskit folders (also their corresponding tests)
 algorithms/           @Qiskit/terra-core @manoelmarques @woodsp-ibm
-opflow/               @Qiskit/terra-core @manoelmarques @woodsp-ibm
+opflow/               @Qiskit/terra-core @manoelmarques @woodsp-ibm @ikkoham
 qiskit/utils/         @Qiskit/terra-core @manoelmarques @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00 @chriseclectic
-quantum_info/         @Qiskit/terra-core @chriseclectic
+quantum_info/         @Qiskit/terra-core @chriseclectic @ikkoham
 pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli @taalexander @lcapelluto
 scheduler/            @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli @taalexander @lcapelluto
 visualization/        @Qiskit/terra-core @nonhermitian @maddy-tod @nkanazawa1989


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Ikko has been doing great work maintaining the opflow and quantum_info
code bases. The optimization and improvements he's made there have
greatly improved performance and he has shown an understanding and
respect for the code contribution guidelines and review process.
This commit adds him as a codeowner of those submodules which gives him
merge permission on PRs that touch either submodule and a formal
responsibility to review and maintain both submodules.

### Details and comments