### PR TITLE
Add cross-build wheel jobs for ppc64le and s390x

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,76 @@ on:
     tags:
       - '*'
 jobs:
+  build_wheels_s390x:
+    name: Build wheels on s390x
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        env:
+          CIBW_ARCHS_LINUX: s390x
+          CIBW_TEST_SKIP: "cp*"
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Install twine
+        run: python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
+  build_wheels_ppc64le:
+    name: Build wheels on s390x
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        env:
+          CIBW_ARCHS_LINUX: ppc64le
+          CIBW_TEST_SKIP: "cp*"
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Install twine
+        run: python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -25,17 +95,15 @@ jobs:
         uses: docker/setup-qemu-action@v1
         with:
           platforms: all
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.2.2 twine
       - name: Build wheels
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_ARCHS_LINUX: aarch64
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Install twine
+        run: python -m pip install twine
       - name: Upload to PyPI
         run: twine upload ./wheelhouse/*.whl
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install twine
         run: python -m pip install twine
   build_wheels_ppc64le:
-    name: Build wheels on s390x
+    name: Build wheels on ppc64le
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,9 +1,8 @@
 ---
 name: Wheel Builds
 on:
-  push:
-    tags:
-      - '*'
+  pull_request:
+    branches: ['main']
 jobs:
   build_wheels_s390x:
     name: Build wheels on s390x
@@ -35,11 +34,6 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
   build_wheels_ppc64le:
     name: Build wheels on s390x
     runs-on: ${{ matrix.os }}
@@ -70,11 +64,6 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -104,8 +93,3 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
-      - name: Upload to PyPI
-        run: twine upload ./wheelhouse/*.whl
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: qiskit

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,8 +1,9 @@
 ---
 name: Wheel Builds
 on:
-  pull_request:
-    branches: ['main']
+  push:
+    tags:
+      - '*'
 jobs:
   build_wheels_s390x:
     name: Build wheels on s390x
@@ -34,6 +35,11 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
   build_wheels_ppc64le:
     name: Build wheels on ppc64le
     runs-on: ${{ matrix.os }}
@@ -64,6 +70,11 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit
   build_wheels_aarch64:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -93,3 +104,8 @@ jobs:
           path: ./wheelhouse/*.whl
       - name: Install twine
         run: python -m pip install twine
+      - name: Upload to PyPI
+        run: twine upload ./wheelhouse/*.whl
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: qiskit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,5 @@ target-version = ['py36', 'py37', 'py38', 'py39']
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
-skip = "pp* cp36-*"
+skip = "pp* cp36-* *musllinux*"
 test-command = "python {project}/examples/python/stochastic_swap.py"

--- a/releasenotes/notes/ibm-cpu-arch-support-3289377f3834f29e.yaml
+++ b/releasenotes/notes/ibm-cpu-arch-support-3289377f3834f29e.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Added partial support for running on ppc64le and s390x Linux platforms.
+    This release will start publishing pre-compiled binaries for ppc64le and
+    s390x Linux platforms on all Python versions. However, unlike other
+    supported platforms not all of Qiskit's upstream dependencies support these
+    platforms yet. So a C/C++ compiler may be required to build and install
+    these dependencies and a simple ``pip install qiskit-terra`` with just a
+    working Python environment will not be sufficient to install Qiskit.
+    Additionally, these same constraints prevent us from testing the
+    pre-compiled before publishing them so the same guarantees around platform
+    support that exist for the other platforms don't apply here.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new CI job at release time to build precompiled
binaries for s390x and ppc64le linux platforms.  These platforms do not
have precompiled wheels for any upstream dependencies (except for
retworkx and tweedledum, which both publish binaries for both platforms).
Since the only publically available CI service that has native s390x and
ppc64le environments available is travis which doesn't provide
sufficient quota to open source projects anymore to make it usable we
have to rely on either cross compilation or emulation. Cross compiling
with python wheels while possible is quite tricky to setup and configure
in practice so emulation is used here. This is a much simpler path
configure, especially because cibuildwheel has support for emulating
non-x86 architectures via QEMU to build wheels. While QEMU emulation of
other architectures is exceedingly slow, we have a 6 hour job time limit
with github actions which should hopefully be sufficient to compile the
binary and build wheels for all our supported python versions.

This was previously attempted in #5844 but we hit a timout issue
reliably every time trying to build scipy from source. Compiling scipy
is slow on a native system and it's an order of magnitude slower under
qemu emulation. In #5844 we exceeded the 6 hour job time limit just
compiling scipy once for testing. To avoid this issue (since scipy
doesn't publish s390x or ppc64le wheels) this commit skips the test
runs on these jobs. This means we're solely building the wheels and not
testing if they're valid. This also means installing scipy and other
dependencies is still an exercise for the s390x and ppc64le users. But,
if this works it will mean that at least for Qiskit there will not be a
need to compile anything from source.

### Details and comments