### PR TITLE
Drop support for 32bit py310 wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ target-version = ['py36', 'py37', 'py38', 'py39']
 manylinux-x86_64-image = "manylinux2010"
 manylinux-i686-image = "manylinux2010"
 skip = "pp* cp36-*"
+test-skip = "cp310-win32 cp310-manylinux_i686"
 test-command = "python {project}/examples/python/stochastic_swap.py"

--- a/releasenotes/notes/py310-support-869d47583c976eef.yaml
+++ b/releasenotes/notes/py310-support-869d47583c976eef.yaml
@@ -1,0 +1,17 @@
+---
+features:
+  - |
+    Added support for running with Python 3.10. This includes publishing
+    precompiled binaries to PyPI for Python 3.10 on supported platforms.
+upgrade:
+  - |
+    Qiskit no longer fully supports 32 bit platforms, Linux i686 and Windows
+    32bit, on Python >= 3.10. This is because the upstream dependencies Numpy
+    and Scipy do not support these platforms on Python 3.10 and we're unable to
+    reliably test on these platforms anymore. Qiskit will still publish
+    precompiled binaries for these platforms but we're unable to test them
+    prior to publishing and you will need a C/C++ compiler to install them
+    as numpy, scipy, and potentially other dependencies will need to be built
+    from source when installing qiskit-terra on Python 3.10 on linux i686 or
+    win32. If you're running on i686 or win32 platforms it is recommended that
+    you use Python 3.7, 3.8, or 3.9.

--- a/releasenotes/notes/py310-support-869d47583c976eef.yaml
+++ b/releasenotes/notes/py310-support-869d47583c976eef.yaml
@@ -5,13 +5,13 @@ features:
     precompiled binaries to PyPI for Python 3.10 on supported platforms.
 upgrade:
   - |
-    Qiskit no longer fully supports 32 bit platforms, Linux i686 and Windows
-    32bit, on Python >= 3.10. This is because the upstream dependencies Numpy
-    and Scipy do not support these platforms on Python 3.10 and we're unable to
-    reliably test on these platforms anymore. Qiskit will still publish
-    precompiled binaries for these platforms but we're unable to test them
-    prior to publishing and you will need a C/C++ compiler to install them
-    as numpy, scipy, and potentially other dependencies will need to be built
-    from source when installing qiskit-terra on Python 3.10 on linux i686 or
-    win32. If you're running on i686 or win32 platforms it is recommended that
+    Qiskit Terra no longer fully supports 32 bit platforms on Python >= 3.10.
+    These are Linux i686 and 32-bit Windows. These platforms with Python 3.10
+    are now at Tier 3 instead of Tier 2 support (per the tiers defined in:
+    https://qiskit.org/documentation/getting_started.html#platform-support)
+    This is because the upstream dependencies Numpy and Scipy have dropped
+    support for them. Qiskit will still publish precompiled binaries for these
+    platforms, but we're unable to test the packages prior to publishing, and
+    you will need a C/C++ compiler so that ``pip`` can build their dependencies
+    from source. If you're using one of these platforms, we recommended that
     you use Python 3.7, 3.8, or 3.9.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #7102 we added support for Python 3.10 to Qiskit. However, numpy and
scipy stopped publishing wheels for 32bit platforms in Python 3.10. This
means that to test Python 3.10 32bit wheels we will have to compile
numpy and scipy from source (which for scipy is prohibitively slow).
In response this commit updates our cibuildwheel configuration to skip
tests on 32bit Python 3.10 wheels since we can't reliably test the built
wheels in CI and it would require users to build them from source.
This is the same approach taken in PR #7549 for ppc64le and s390x. For
32 bit platform users on python 3.10 this means they'll need to locally
build numpy, scipy, and potentially other depencies from source to use
Qiskit Terra with Python 3.10, but for the Qiskit components at least
precompiled binaries will be available.

### Details and comments