### PR TITLE
Fix error in Target non-global operation method with ideal gates

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -1100,8 +1100,11 @@ def _parse_output_name(output_name, circuits):
 
 
 def _parse_timing_constraints(backend, timing_constraints, num_circuits):
-
-    if backend is not None and timing_constraints is None:
+    if isinstance(timing_constraints, TimingConstraints):
+        return [timing_constraints] * num_circuits
+    if backend is None and timing_constraints is None:
+        timing_constraints = TimingConstraints()
+    else:
         backend_version = getattr(backend, "version", 0)
         if not isinstance(backend_version, int):
             backend_version = 0
@@ -1112,8 +1115,6 @@ def _parse_timing_constraints(backend, timing_constraints, num_circuits):
             timing_constraints = TimingConstraints(**timing_constraints)
         else:
             timing_constraints = backend.target.timing_constraints()
-    elif timing_constraints is None:
-        timing_constraints = TimingConstraints()
     return [timing_constraints] * num_circuits
 
 

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -544,9 +544,9 @@ def _parse_transpile_args(
     # but if an argument is explicitly passed use that instead of the target version
     if target is not None:
         if coupling_map is None:
-            coupling_map = target.coupling_map()
+            coupling_map = target.build_coupling_map()
         if basis_gates is None:
-            basis_gates = target.operation_names()
+            basis_gates = target.operation_names
         if instruction_durations is None:
             instruction_durations = target.durations()
         if inst_map is None:
@@ -805,6 +805,8 @@ def _target_to_backend_properties(target: Target):
         else:
             qubit_props = {x: None for x in range(target.num_qubits)}
             for qargs, props in qargs_list.items():
+                if qargs is None:
+                    continue
                 qubit = qargs[0]
                 props_list = []
                 if props.error is not None:
@@ -1099,9 +1101,7 @@ def _parse_output_name(output_name, circuits):
 
 def _parse_timing_constraints(backend, timing_constraints, num_circuits):
 
-    if backend is None and timing_constraints is None:
-        timing_constraints = TimingConstraints()
-    else:
+    if backend is not None and timing_constraints is None:
         backend_version = getattr(backend, "version", 0)
         if not isinstance(backend_version, int):
             backend_version = 0
@@ -1112,6 +1112,8 @@ def _parse_timing_constraints(backend, timing_constraints, num_circuits):
             timing_constraints = TimingConstraints(**timing_constraints)
         else:
             timing_constraints = backend.target.timing_constraints()
+    elif timing_constraints is None:
+        timing_constraints = TimingConstraints()
     return [timing_constraints] * num_circuits
 
 

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -633,12 +633,16 @@ class Target(Mapping):
             if self._non_global_basis is not None:
                 return self._non_global_basis
 
-            search_set = {frozenset(qarg) for qarg in self._qarg_gate_map if len(qarg) != 1}
+            search_set = {
+                frozenset(qarg)
+                for qarg in self._qarg_gate_map
+                if qarg is not None and len(qarg) != 1
+            }
         incomplete_basis_gates = []
         size_dict = defaultdict(int)
         size_dict[1] = self.num_qubits
         for qarg in search_set:
-            if len(qarg) == 1:
+            if qarg is None or len(qarg) == 1:
                 continue
             size_dict[len(qarg)] += 1
         for inst, qargs in self._gate_map.items():

--- a/releasenotes/notes/fix-non-global-operation-name-ideal-sim-3dcbc97e29c707c7.yaml
+++ b/releasenotes/notes/fix-non-global-operation-name-ideal-sim-3dcbc97e29c707c7.yaml
@@ -6,3 +6,12 @@ fixes:
     target that contained any ideal globally defined operations, where the
     instruction properties are set to ``None``, this method would raise an
     exception instead of treating that instruction as global.
+  - |
+    Fixed an issue with the :func:`~qiskit.compiler.transpile` function where
+    it could fail when being passed a :class:`.Target` object directly with the
+    ``target`` kwarg.
+  - |
+    Fixed an issue with the :func:`~qiskit.compiler.transpile` function where
+    it could fail when the ``backend`` argument was a :class:`.BackendV2`
+    or a :class:`.Target` via the ``target`` kwarg that contained ideal
+    globally defined operations.

--- a/releasenotes/notes/fix-non-global-operation-name-ideal-sim-3dcbc97e29c707c7.yaml
+++ b/releasenotes/notes/fix-non-global-operation-name-ideal-sim-3dcbc97e29c707c7.yaml
@@ -1,0 +1,8 @@
+fixes:
+  - |
+    Fixed an issue with the :meth:`.Target.get_non_global_operation_names`
+    method when running on a target incorrectly raising an exception on targets
+    with ideal global operations. Previously, if this method was called on a
+    target that contained any ideal globally defined operations, where the
+    instruction properties are set to ``None``, this method would raise an
+    exception instead of treating that instruction as global.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -32,11 +32,13 @@ from qiskit.circuit import Parameter, Gate, Qubit, Clbit
 from qiskit.compiler import transpile
 from qiskit.dagcircuit import DAGOutNode
 from qiskit.converters import circuit_to_dag
-from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate, RZGate
+from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate, RZGate, UGate
+from qiskit.circuit.measure import Measure
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import FakeMelbourne, FakeRueschlikon, FakeAlmaden
 from qiskit.transpiler import Layout, CouplingMap
 from qiskit.transpiler import PassManager
+from qiskit.transpiler.target import Target
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements, GateDirection
 from qiskit.quantum_info import Operator, random_unitary
@@ -1376,6 +1378,29 @@ class TestTranspile(QiskitTestCase):
         else:
             # Optimization level 3 eliminates the pointless swap
             self.assertEqual(res, QuantumCircuit(2))
+
+    @data(0, 1, 2, 3)
+    def test_target_ideal_gates(self, opt_level):
+        """Test that transpile() with a custom ideal sim target works."""
+        theta = Parameter("θ")
+        phi = Parameter("ϕ")
+        lam = Parameter("λ")
+        target = Target()
+        target.add_instruction(UGate(theta, phi, lam))
+        target.add_instruction(CXGate())
+        target.add_instruction(Measure())
+        qubit_reg = QuantumRegister(2, name="q")
+        clbit_reg = ClassicalRegister(2, name="c")
+        qc = QuantumCircuit(qubit_reg, clbit_reg, name="bell")
+        qc.h(qubit_reg[0])
+        qc.cx(qubit_reg[0], qubit_reg[1])
+        qc.measure(qubit_reg, clbit_reg)
+        result = transpile(qc, target=target, optimization_level=opt_level)
+        expected = QuantumCircuit(qubit_reg, clbit_reg)
+        expected.u(np.pi / 2, 0, np.pi, qubit_reg[0])
+        expected.cx(qubit_reg[0], qubit_reg[1])
+        expected.measure(qubit_reg, clbit_reg)
+        self.assertEqual(result, expected)
 
 
 class StreamHandlerRaiseException(StreamHandler):

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -890,6 +890,20 @@ Instructions:
                 f"{getattr(generated_constraints, i)}!={getattr(expected_constraints, i)}",
             )
 
+    def test_get_non_global_operation_name_ideal_backend(self):
+        self.assertEqual(self.aqt_target.get_non_global_operation_names(), [])
+        self.assertEqual(self.ideal_sim_target.get_non_global_operation_names(), [])
+        self.assertEqual(self.ibm_target.get_non_global_operation_names(), [])
+        self.assertEqual(self.fake_backend_target.get_non_global_operation_names(), [])
+
+    def test_get_non_global_operation_name_ideal_backend_strict_direction(self):
+        self.assertEqual(self.aqt_target.get_non_global_operation_names(True), [])
+        self.assertEqual(self.ideal_sim_target.get_non_global_operation_names(True), [])
+        self.assertEqual(self.ibm_target.get_non_global_operation_names(True), [])
+        self.assertEqual(
+            self.fake_backend_target.get_non_global_operation_names(True), ["cx", "ecr"]
+        )
+
 
 class TestPulseTarget(QiskitTestCase):
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the Target
get_non_global_operation_names() method. Previously this method would
crash when you had a target with it's instruction properties set to
None (which is typically used for an ideal simulator).

### Details and comments