### PR TITLE
Add `__repr__` to DAG nodes

### DIFF
--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -341,6 +341,10 @@ class DAGOpNode(DAGNode):
         """Sets the Instruction name corresponding to the op for this node"""
         self.op.name = new_name
 
+    def __repr__(self):
+        """Returns a representation of the DAGOpNode"""
+        return f"""DAGOpNode(name : {self.name}, qargs : {self.qargs}, cargs : {self.cargs})"""
+
 
 class DAGInNode(DAGNode):
     """Object to represent an incoming wire node in the DAGCircuit."""

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -343,7 +343,7 @@ class DAGOpNode(DAGNode):
 
     def __repr__(self):
         """Returns a representation of the DAGOpNode"""
-        return f"DAGOpNode(op = {self.op}, qargs = {self.qargs}, cargs = {self.cargs})"
+        return f"DAGOpNode(op={self.op}, qargs={self.qargs}, cargs={self.cargs})"
 
 
 class DAGInNode(DAGNode):
@@ -362,7 +362,7 @@ class DAGInNode(DAGNode):
 
     def __repr__(self):
         """Returns a representation of the DAGInNode"""
-        return f"DAGInNode(wire = {self.wire})"
+        return f"DAGInNode(wire={self.wire})"
 
 
 class DAGOutNode(DAGNode):
@@ -381,4 +381,4 @@ class DAGOutNode(DAGNode):
 
     def __repr__(self):
         """Returns a representation of the DAGOutNode"""
-        return f"DAGOutNode(wire = {self.wire})"
+        return f"DAGOutNode(wire={self.wire})"

--- a/qiskit/dagcircuit/dagnode.py
+++ b/qiskit/dagcircuit/dagnode.py
@@ -343,7 +343,7 @@ class DAGOpNode(DAGNode):
 
     def __repr__(self):
         """Returns a representation of the DAGOpNode"""
-        return f"""DAGOpNode(name : {self.name}, qargs : {self.qargs}, cargs : {self.cargs})"""
+        return f"DAGOpNode(op = {self.op}, qargs = {self.qargs}, cargs = {self.cargs})"
 
 
 class DAGInNode(DAGNode):
@@ -360,6 +360,10 @@ class DAGInNode(DAGNode):
         # only works as str([]) for DAGInNodes. Need to figure out why.
         self.sort_key = str([])
 
+    def __repr__(self):
+        """Returns a representation of the DAGInNode"""
+        return f"DAGInNode(wire = {self.wire})"
+
 
 class DAGOutNode(DAGNode):
     """Object to represent an outgoing wire node in the DAGCircuit."""
@@ -374,3 +378,7 @@ class DAGOutNode(DAGNode):
         # TODO sort_key which is used in dagcircuit.topological_nodes
         # only works as str([]) for DAGOutNodes. Need to figure out why.
         self.sort_key = str([])
+
+    def __repr__(self):
+        """Returns a representation of the DAGOutNode"""
+        return f"DAGOutNode(wire = {self.wire})"

--- a/releasenotes/notes/add-repr-for-dag-nodes-2d0a95fecd3dd3db.yaml
+++ b/releasenotes/notes/add-repr-for-dag-nodes-2d0a95fecd3dd3db.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Representations for ``DAGOpNode``, ``DAGInNode`` and ``DAGOutNode``
+    which enables better print outputs.

--- a/releasenotes/notes/add-repr-for-dag-nodes-2d0a95fecd3dd3db.yaml
+++ b/releasenotes/notes/add-repr-for-dag-nodes-2d0a95fecd3dd3db.yaml
@@ -1,5 +1,6 @@
 ---
 features:
   - |
-    Representations for ``DAGOpNode``, ``DAGInNode`` and ``DAGOutNode``
-    which enables better print outputs.
+    The data elements of :class:`.DAGCircuit` (:class:`.DAGOpNode`,
+    :class:`.DAGInNode` and :class:`.DAGOutNode`) now have a more useful string
+    representation, to help debugging.

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -602,25 +602,23 @@ class TestDagNodeSelection(QiskitTestCase):
         for node in op_nodes:
             self.assertIsInstance(node.op, Instruction)
 
-    def test_opnode_representation(self):
-        """Test the __repr__ method of the DAGOpNode"""
+    def test_node_representations(self):
+        """Test the __repr__ methods of the DAG Nodes"""
         self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
-
-        custom_inst = Instruction(name="my_inst", num_qubits=1, num_clbits=1, params=[0, 1])
-        self.dag.apply_operation_back(custom_inst, [self.qubit0], [self.clbit0])
-
-        op_nodes = self.dag.op_nodes()
-        cx_node = op_nodes[0]
-        my_node = op_nodes[1]
-
+        # test OpNode
+        cx_node = self.dag.named_nodes("cx")[0]
         self.assertEqual(
             repr(cx_node),
-            f"DAGOpNode(op = {cx_node.op}, qargs = {cx_node.qargs}, cargs = {cx_node.cargs})",
+            f"DAGOpNode(op={cx_node.op}, qargs={cx_node.qargs}, cargs={cx_node.cargs})",
         )
-        self.assertEqual(
-            repr(my_node),
-            f"DAGOpNode(op = {my_node.op}, qargs = {my_node.qargs}, cargs = {my_node.cargs})",
-        )
+        # test InNode
+        predecessor_cnot = self.dag.quantum_predecessors(cx_node)
+        predecessor = next(predecessor_cnot)
+        self.assertEqual(repr(predecessor), f"DAGInNode(wire={predecessor.wire})")
+        # test OutNode
+        successor_cnot = self.dag.quantum_successors(cx_node)
+        successor = next(successor_cnot)
+        self.assertEqual(repr(successor), f"DAGOutNode(wire={successor.wire})")
 
     def test_get_op_nodes_particular(self):
         """The method dag.gates_nodes(op=AGate) returns all the AGate nodes"""
@@ -674,12 +672,6 @@ class TestDagNodeSelection(QiskitTestCase):
             or (isinstance(successor2, DAGOutNode) and isinstance(successor1.op, Reset))
         )
 
-        if isinstance(successor1, DAGOutNode):
-            self.assertEqual(repr(successor1), f"DAGOutNode(wire = {successor1.wire})")
-
-        if isinstance(successor2, DAGOutNode):
-            self.assertEqual(repr(successor2), f"DAGOutNode(wire = {successor2.wire})")
-
     def test_is_successor(self):
         """The method dag.is_successor(A, B) checks if node B is a successor of A"""
         self.dag.apply_operation_back(Measure(), [self.qubit1, self.clbit1], [])
@@ -728,11 +720,6 @@ class TestDagNodeSelection(QiskitTestCase):
             (isinstance(predecessor1, DAGInNode) and isinstance(predecessor2.op, Reset))
             or (isinstance(predecessor2, DAGInNode) and isinstance(predecessor1.op, Reset))
         )
-        if isinstance(predecessor1, DAGInNode):
-            self.assertEqual(repr(predecessor1), f"DAGInNode(wire = {predecessor1.wire})")
-
-        if isinstance(predecessor2, DAGInNode):
-            self.assertEqual(repr(predecessor2), f"DAGInNode(wire = {predecessor2.wire})")
 
     def test_is_predecessor(self):
         """The method dag.is_predecessor(A, B) checks if node B is a predecessor of A"""

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -602,6 +602,26 @@ class TestDagNodeSelection(QiskitTestCase):
         for node in op_nodes:
             self.assertIsInstance(node.op, Instruction)
 
+    def test_opnode_representation(self):
+        """Test the __repr__ method of the DAGOpNode"""
+        self.dag.apply_operation_back(CXGate(), [self.qubit0, self.qubit1], [])
+
+        custom_inst = Instruction(name="my_inst", num_qubits=1, num_clbits=1, params=[0, 1])
+        self.dag.apply_operation_back(custom_inst, [self.qubit0], [self.clbit0])
+
+        op_nodes = self.dag.op_nodes()
+        cx_node = op_nodes[0]
+        my_node = op_nodes[1]
+        self.assertEqual(
+            repr(cx_node),
+            f"""DAGOpNode(name : {cx_node.name}, qargs : {cx_node.qargs}, cargs : {cx_node.cargs})""",
+        )
+
+        self.assertEqual(
+            repr(my_node),
+            f"""DAGOpNode(name : {my_node.name}, qargs : {my_node.qargs}, cargs : {my_node.cargs})""",
+        )
+
     def test_get_op_nodes_particular(self):
         """The method dag.gates_nodes(op=AGate) returns all the AGate nodes"""
         self.dag.apply_operation_back(HGate(), [self.qubit0], [])

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -612,14 +612,14 @@ class TestDagNodeSelection(QiskitTestCase):
         op_nodes = self.dag.op_nodes()
         cx_node = op_nodes[0]
         my_node = op_nodes[1]
-        self.assertEqual(
-            repr(cx_node),
-            f"""DAGOpNode(name : {cx_node.name}, qargs : {cx_node.qargs}, cargs : {cx_node.cargs})""",
-        )
 
         self.assertEqual(
+            repr(cx_node),
+            f"DAGOpNode(op = {cx_node.op}, qargs = {cx_node.qargs}, cargs = {cx_node.cargs})",
+        )
+        self.assertEqual(
             repr(my_node),
-            f"""DAGOpNode(name : {my_node.name}, qargs : {my_node.qargs}, cargs : {my_node.cargs})""",
+            f"DAGOpNode(op = {my_node.op}, qargs = {my_node.qargs}, cargs = {my_node.cargs})",
         )
 
     def test_get_op_nodes_particular(self):
@@ -674,6 +674,12 @@ class TestDagNodeSelection(QiskitTestCase):
             or (isinstance(successor2, DAGOutNode) and isinstance(successor1.op, Reset))
         )
 
+        if isinstance(successor1, DAGOutNode):
+            self.assertEqual(repr(successor1), f"DAGOutNode(wire = {successor1.wire})")
+
+        if isinstance(successor2, DAGOutNode):
+            self.assertEqual(repr(successor2), f"DAGOutNode(wire = {successor2.wire})")
+
     def test_is_successor(self):
         """The method dag.is_successor(A, B) checks if node B is a successor of A"""
         self.dag.apply_operation_back(Measure(), [self.qubit1, self.clbit1], [])
@@ -722,6 +728,11 @@ class TestDagNodeSelection(QiskitTestCase):
             (isinstance(predecessor1, DAGInNode) and isinstance(predecessor2.op, Reset))
             or (isinstance(predecessor2, DAGInNode) and isinstance(predecessor1.op, Reset))
         )
+        if isinstance(predecessor1, DAGInNode):
+            self.assertEqual(repr(predecessor1), f"DAGInNode(wire = {predecessor1.wire})")
+
+        if isinstance(predecessor2, DAGInNode):
+            self.assertEqual(repr(predecessor2), f"DAGInNode(wire = {predecessor2.wire})")
 
     def test_is_predecessor(self):
         """The method dag.is_predecessor(A, B) checks if node B is a predecessor of A"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
A `__repr__` method is added for the `DAGOpNode` class for better representation of op nodes in qiskit


### Details and comments
- The original issue required a `__repr__` method for the `DAGNode` but since its attributes are going to be deprecated in later versions of qiskit, it is added to the `DAGOpNode`, `DAGInNode` and `DAGOutNode` classes which inherit from `DAGNode`
- Representations are - 
```
        DAGOpNode(op = [Operation] , qargs = [List of qargs], cargs = [List of cargs])
        DAGInNode(wire = [wire of node])
        DAGOutNode(wire = [wire of node])
```
- A unit test is added for the same

Fix #7165