### PR TITLE
Ensure algorithms correctly handle `Statevector` results

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -225,7 +225,7 @@ class Grover(AmplitudeAmplifier):
             # Run a grover experiment for a given power of the Grover operator.
             if self._quantum_instance.is_statevector:
                 qc = self.construct_circuit(amplification_problem, power, measurement=False)
-                circuit_results = self._quantum_instance.execute(qc).get_statevector()
+                circuit_results = np.asarray(self._quantum_instance.execute(qc).get_statevector())
                 num_bits = len(amplification_problem.objective_qubits)
 
                 # trace out work qubits

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -20,6 +20,7 @@ from scipy.optimize import bisect
 
 from qiskit import QuantumCircuit, ClassicalRegister
 from qiskit.providers import BaseBackend, Backend
+from qiskit.quantum_info import Statevector
 from qiskit.utils import QuantumInstance
 from .amplitude_estimator import AmplitudeEstimator, AmplitudeEstimatorResult
 from .ae_utils import pdf_a, derivative_log_pdf_a, bisect_max
@@ -368,7 +369,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
             NotImplementedError: If the confidence interval method `kind` is not implemented.
         """
         # if statevector simulator the estimate is exact
-        if isinstance(result.circuit_results, (list, np.ndarray)):
+        if isinstance(result.circuit_results, (list, np.ndarray, Statevector)):
             return (result.mle, result.mle)
 
         if kind in ["likelihood_ratio", "lr"]:

--- a/releasenotes/notes/fix-grover-get_statevector-cc2102741c6aca42.yaml
+++ b/releasenotes/notes/fix-grover-get_statevector-cc2102741c6aca42.yaml
@@ -1,0 +1,22 @@
+---
+fixes:
+  - |
+    :class:`.Grover` amplification problems will no longer error when run on Aer
+    simulators with Qiskit Aer versions 0.10 and above.  Previously the code::
+
+        from qiskit import Aer
+        from qiskit.algorithms import AmplificationProblem, Grover
+        from qiskit.circuit.library import PhaseOracle
+
+        backend = Aer.get_backend("aer_simulator_statevector")
+
+        oracle = PhaseOracle("x1 & x2 & (not x3)")
+        problem = AmplificationProblem(oracle, is_good_state=oracle.evaluate_bitstring)
+        grover = Grover(quantum_instance=backend, iterations=2)
+        result = grover.amplify(problem)
+
+    would fail with::
+
+        IndexError: index 0 is out of bounds for axis 0 with size 0
+
+    but will now run as expected.


### PR DESCRIPTION
### Summary

Aer 0.10 swapped the output of `get_statevector` in results objects to
the `quantum_info` module `Statevector` class, with a compatibility
wrapper to make Numpy array methods work automatically on it.  The
exceptions are instance checks and `__eq__`; the former because the
objects are not actually Numpy arrays, and the latter because the
semantics of `Statevector.__eq__` are scalar, not broadcasting.

In places in algorithms where a Numpy array is required (as in Grover),
or the result is being type-checked (as in amplitude estimation), we
make sure that the new form is handled correctly.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #7558.
