### PR TITLE
Use manylinux2014 on all Linux builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
         - bash: |
             set -e
             python -m pip install --upgrade pip
-            pip install cibuildwheel==2.2.2
+            pip install cibuildwheel==2.3.1
             pip install -U twine
             cibuildwheel --output-dir wheelhouse .
         - task: PublishBuildArtifacts@1
@@ -74,7 +74,7 @@ stages:
       - bash: |
           set -e
           python -m pip install --upgrade pip
-          pip install cibuildwheel==2.2.2
+          pip install cibuildwheel==2.3.1
           pip install -U twine
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
@@ -96,7 +96,7 @@ stages:
       - bash: |
           set -e
           python -m pip install --upgrade pip
-          pip install cibuildwheel==2.2.2
+          pip install cibuildwheel==2.3.1
           pip install -U twine
           cibuildwheel --output-dir wheelhouse .
       - task: PublishBuildArtifacts@1
@@ -123,7 +123,7 @@ stages:
         - bash: |
             set -e
             python -m pip install --upgrade pip
-            pip install cibuildwheel==2.2.2
+            pip install cibuildwheel==2.3.1
             pip install -U twine
             cibuildwheel --output-dir wheelhouse
         - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,7 +107,7 @@ stages:
         env:
           TWINE_PASSWORD: $(TWINE_PASSWORD)
     - job: 'Windows'
-      pool: {vmImage: 'vs2017-win2016'}
+      pool: {vmImage: 'windows-latest'}
       condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
       variables:
         TWINE_USERNAME: qiskit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,13 @@ line-length = 100
 target-version = ['py36', 'py37', 'py38', 'py39']
 
 [tool.cibuildwheel]
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+manylinux-x86_64-image = "manylinux2014"
+manylinux-i686-image = "manylinux2014"
 skip = "pp* cp36-* *musllinux*"
 test-skip = "cp310-win32 cp310-manylinux_i686"
 test-command = "python {project}/examples/python/stochastic_swap.py"
+# We need to use pre-built versions of Numpy and Scipy in the tests; they have a
+# tendency to crash if they're installed from source by `pip install`, and since
+# Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
+# restricting any dependencies that Numpy and Scipy might have.
+before-test = "pip install --only-binary=numpy,scipy numpy scipy"

--- a/releasenotes/notes/manylinux2014-e33268fda54e12b1.yaml
+++ b/releasenotes/notes/manylinux2014-e33268fda54e12b1.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    On Linux, the minimum library support has been raised from the
+    `manylinux2010 VM <https://www.python.org/dev/peps/pep-0571/>`__ to
+    `manylinux2014 <https://www.python.org/dev/peps/pep-0599/>`__.  This mirrors
+    similar changes in Numpy and Scipy.  There should be no meaningful effect
+    for most users, unless your system still contains a very old version of
+    `glibc`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Numpy and Scipy are moving to drop manylinux2010 wheels on newer
platforms, which gives us some cover to do the same.  To test, we need
to ensure that we pull Numpy and Scipy in binary form only (forcing pip
to install slightly older versions like 1.21 instead of 1.22 on
unsupported Python versions), rather than attempting to build Numpy from
source as part of our testing process.


### Details and comments

We are going to deploy 0.19.2 with manylinux2014 for Python 3.10, since we don't have any prior commitments in the 0.19 series for Python 3.10, but we left raising the VM on other Pythons until the next minor.  Given that we really don't use much of the C API, there won't be any huge improvement from upping the VM, but it'll be easier for us to keep pace with Numpy and Scipy going forwards. 