### PR TITLE
Tweak apt usage in Ubuntu CI job configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,8 @@ stages:
             cp -r test /tmp/terra-tests/.
             cp .stestr.conf /tmp/terra-tests/.
             cp -r .stestr /tmp/terra-tests/. || :
-            sudo apt install -y graphviz
+            sudo apt-get update
+            sudo apt-get install -y graphviz
             pip check
           displayName: 'Install dependencies'
         - bash: |
@@ -239,7 +240,8 @@ stages:
             image_tests/bin/pip install -U -r requirements.txt -c constraints.txt
             image_tests/bin/pip install -U -c constraints.txt -e ".[visualization]"
             image_tests/bin/python setup.py build_ext --inplace
-            sudo apt install -y graphviz pandoc
+            sudo apt-get update
+            sudo apt-get install -y graphviz pandoc
             image_tests/bin/pip check
           displayName: 'Install dependencies'
         - bash: image_tests/bin/python -m unittest discover -v test/ipynb
@@ -313,7 +315,8 @@ stages:
             python -m pip install --upgrade pip setuptools wheel
             pip install -U tox
             python setup.py build_ext --inplace
-            sudo apt install -y graphviz
+            sudo apt-get update
+            sudo apt-get install -y graphviz
           displayName: 'Install dependencies'
         - bash: |
             tox -edocs
@@ -617,7 +620,8 @@ stages:
             pip install -U -c constraints.txt -e .
             pip install -U "qiskit-aer" "z3-solver" -c constraints.txt
             python setup.py build_ext --inplace
-            sudo apt install -y graphviz
+            sudo apt-get update
+            sudo apt-get install -y graphviz
             pip check
           displayName: 'Install dependencies'
         - bash: |
@@ -768,7 +772,8 @@ stages:
             pip install -c constraints.txt -e .
             pip install "qiskit-ibmq-provider" "qiskit-aer" "z3-solver" "qiskit-ignis" "matplotlib>=3.3.0" sphinx nbsphinx sphinx_rtd_theme cvxpy -c constraints.txt
             python setup.py build_ext --inplace
-            sudo apt install -y graphviz pandoc
+            sudo apt-get update
+            sudo apt-get install -y graphviz pandoc
             pip check
           displayName: 'Install dependencies'
         - bash: |


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit tweaks the apt usage in the Ubuntu CI job configuration.
Previously the Ubuntu CI jobs were using 'apt' which emits a warning
about having an unstable CLI. This commit switches to use apt-get
to avoid the warning and calls apt-get update prior to the installation
step to ensure we've synced with the mirror prior to installing.

### Details and comments