### PR TITLE
Fix typo at line 262 of qiskit.circuit.quantumcircuit.py in a #comment

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -259,7 +259,7 @@ class QuantumCircuit:
         self._qubits = []
         self._clbits = []
 
-        # Dict mapping Qubt or Clbit instances to tuple comprised of 0) the
+        # Dict mapping Qubit or Clbit instances to tuple comprised of 0) the
         # corresponding index in circuit.{qubits,clbits} and 1) a list of
         # Register-int pairs for each Register containing the Bit and its index
         # within that register.


### PR DESCRIPTION
**Summary**
There was a spelling mistake in a comment at line 262 of qiskit.circuit.quantumcircuit.py

**Details and comments**
I replaced "Qubt" with "Qubit" at line 262 of a #comment
