### PR TITLE
Convert `operator.coeffs` to real if possible in `pauli_evolution._to_sparse_pauli_op`

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -138,6 +138,7 @@ def _to_sparse_pauli_op(operator):
     else:
         raise ValueError(f"Unsupported operator type for evolution: {type(operator)}.")
 
+    sparse_pauli.coeffs = np.real_if_close(sparse_pauli.coeffs)
     if any(np.iscomplex(sparse_pauli.coeffs)):
         raise ValueError("Operator contains complex coefficients, which are not supported.")
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Convert `operator.coeffs` to real if possible in `pauli_evolution._to_sparse_pauli_op`.
This fixes CI breakage of Nature (e.g., https://github.com/Qiskit/qiskit-nature/actions/runs/1770404994)

Since #7551 is stable backported, this might also need to be stable backported.

### Details and comments


