### PR TITLE
``PauliEvolution``: Fix backward compatibility with application modules

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -138,7 +138,9 @@ def _to_sparse_pauli_op(operator):
     else:
         raise ValueError(f"Unsupported operator type for evolution: {type(operator)}.")
 
-    if any(np.iscomplex(sparse_pauli.coeffs)):
-        raise ValueError("Operator contains complex coefficients, which are not supported.")
+    # TODO Enable this check for Qiskit Terra 0.20.0. It cannot be included in a 0.19.x release
+    # since it breaks already released application modules.
+    # if any(np.iscomplex(sparse_pauli.coeffs)):
+    #     raise ValueError("Operator contains complex coefficients, which are not supported.")
 
     return sparse_pauli

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -13,7 +13,6 @@
 """A gate to implement time-evolution of operators."""
 
 from typing import Union, Optional
-import numpy as np
 
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterExpression


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Alternative to #7593.

Fix the compatibility by restoring the release behavior of 0.19 and not checking if the coefficients of the operator in the ``PauliEvolution`` are complex.


