### PR TITLE
Added entries for sx and sxdg in template substitution cost

### DIFF
--- a/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_matching.py
@@ -235,7 +235,7 @@ class TemplateMatching:
     def run_template_matching(self):
         """
         Run the complete algorithm for finding all maximal matches for the given template and
-        circuit. First it fixes the configuration of the the circuit due to the first match.
+        circuit. First it fixes the configuration of the circuit due to the first match.
         Then it explores all compatible qubit configurations of the circuit. For each
         qubit configurations, we apply first the Forward part of the algorithm  and then
         the Backward part of the algorithm. The longest matches for the given configuration

--- a/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
+++ b/qiskit/transpiler/passes/optimization/template_matching/template_substitution.py
@@ -94,6 +94,8 @@ class TemplateSubstitution:
                 "tdg": 1,
                 "s": 1,
                 "sdg": 1,
+                "sx": 1,
+                "sxdg": 1,
                 "u1": 1,
                 "u2": 2,
                 "u3": 2,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #7585.
Added entries for sx and sxdg in template substitution cost


### Details and comments
In `TemplateSubstitution` class (used for `TemplateOptimization` transpiler pass feature), subcircuits are compared for cost. Although it is also possible to specify a user defined cost mapping per gate, the default cost dictionary did not have entries for 'sx' and 'sxdg' gates. This led to an exception when the input circuit contained these gates. In this PR, this has been fixed by adding these keys in the default cost dictionary with the value 1 for each. This is in line with the current implementation which assigns a hardcoded default value of quantum cost.

Also added a testcase.

