### PR TITLE
Fix size-1 Numpy array qubit and clbit specifiers

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1081,7 +1081,7 @@ class QuantumCircuit:
                 ret = bit_representation[:]
             elif isinstance(QuantumCircuit.cast(bit_representation, int), int):
                 # circuit.h(0) -> circuit.h([qr[0]])
-                ret = [in_array[bit_representation]]
+                ret = [in_array[int(bit_representation)]]
             elif isinstance(bit_representation, slice):
                 # circuit.h(slice(0,2)) -> circuit.h([qr[0], qr[1]])
                 ret = in_array[bit_representation]

--- a/releasenotes/notes/fix-circuit-resources-scalar-array-22b907b159d4a388.yaml
+++ b/releasenotes/notes/fix-circuit-resources-scalar-array-22b907b159d4a388.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`.QuantumCircuit` will no longer raise an ``IndexError`` when trying
+    to use a size-1 Numpy array of integers as the specifier for the qubits or
+    clbits of an operation.

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -12,6 +12,7 @@
 
 """Test Qiskit's QuantumCircuit class."""
 
+import ddt
 import numpy as np
 
 from qiskit.circuit import (
@@ -28,6 +29,7 @@ from qiskit.circuit.exceptions import CircuitError
 from qiskit.test import QiskitTestCase
 
 
+@ddt.ddt
 class TestCircuitRegisters(QiskitTestCase):
     """QuantumCircuit Registers tests."""
 
@@ -469,6 +471,19 @@ class TestCircuitRegisters(QiskitTestCase):
 
         qc.h([qr[0], 1])
         self.assertEqual(qc, expected)
+
+    @ddt.data(np.array(0), np.array([0]))
+    def test_index_scalar_numpy_array(self, index):
+        """Test that size-1 Numpy arrays with various numbers of dimensions can be used to index
+        arguments.  These arrays can be passed to ``int``, which means they sometimes might be
+        involved in spurious casts."""
+        test = QuantumCircuit(1, 1)
+        test.measure(index, index)
+
+        expected = QuantumCircuit(1, 1)
+        expected.measure(0, 0)
+
+        self.assertEqual(test, expected)
 
     def test_4_args_custom_gate_trivial_expansion(self):
         """test 'expansion' of 4 args in custom gate.


### PR DESCRIPTION
### Summary

Size-1 Numpy arrays declare themselves as scalar-like, notably allowing
them to be the argument to `int` (or `float`, etc).  The type casting
within `QuantumCircuit.append` tries various casts to convert its input,
but assumed that if it _could_ be cast to the type, it was already valid
to use the object in a duck-typed manner.  This isn't always true, so
instead we have to make sure we actually use the cast form.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #7600.
