### PR TITLE
Do not error on complex coefficients in PauliEvolutionGate

### DIFF
--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -13,7 +13,6 @@
 """A gate to implement time-evolution of operators."""
 
 from typing import Union, Optional
-import numpy as np
 
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.parameterexpression import ParameterExpression

--- a/qiskit/circuit/library/pauli_evolution.py
+++ b/qiskit/circuit/library/pauli_evolution.py
@@ -138,7 +138,4 @@ def _to_sparse_pauli_op(operator):
     else:
         raise ValueError(f"Unsupported operator type for evolution: {type(operator)}.")
 
-    if any(np.iscomplex(sparse_pauli.coeffs)):
-        raise ValueError("Operator contains complex coefficients, which are not supported.")
-
     return sparse_pauli

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -276,11 +276,6 @@ class TestEvolutionGate(QiskitTestCase):
 
         self.assertTrue(Operator(lie_trotter).equiv(exact))
 
-    def test_complex_op_raises(self):
-        """Test an operator with complex coefficient raises an error."""
-        with self.assertRaises(ValueError):
-            _ = PauliEvolutionGate(Pauli("iZ"))
-
     @data(LieTrotter, MatrixExponential)
     def test_inverse(self, synth_cls):
         """Test calculating the inverse is correct."""


### PR DESCRIPTION
### Summary

The backported commit 6b6df5a added some additional error raising to
`PauliEvolutionGate`, which while physically correct is not stable due
to the new error.  This broke qiskit-nature downstream, and cannot be
released in a patch cycle.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Supersedes #7594 in terms of fixing the regression.
