### PR TITLE
Fix broken f-string in qasm3 exporter error message

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -465,7 +465,8 @@ class QASM3Builder:
             # the definition.
             raise QASM3ExporterError(
                 "Exporting subroutines with parameters is not yet supported by the OpenQASM 3"
-                " exporter. Received this instruction, which appears parameterized:\n{instruction}"
+                " exporter. Received this instruction, which appears parameterized:"
+                f"\n{instruction}"
             )
         name = self.global_namespace[instruction]
         self.push_context(instruction.definition)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->
Fixes #7611
- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.


### Summary

fixes f-sting where `f` was missing at the start of the string



### Details and comments

```diff
-                " exporter. Received this instruction, which appears parameterized:\n{instruction}"
+                " exporter. Received this instruction, which appears parameterized:"
+                f"\n{instruction}"
```

Separated `f"\n{instruction}"` from `" exporter. Received this instruction, which appears parameterized:"` to keep it consistent with https://github.com/Qiskit/qiskit-terra/blob/74014e6adbeb9e4e794403bcec6dd221c2045371/qiskit/qasm3/exporter.py#L455-L457