### PR TITLE
Bump black version and relax constraint

### DIFF
--- a/examples/python/initialize.py
+++ b/examples/python/initialize.py
@@ -64,6 +64,6 @@ result = job.result()
 
 counts = result.get_counts(circuit)
 
-qubit_strings = [format(i, "0%sb" % 4) for i in range(2 ** 4)]
+qubit_strings = [format(i, "0%sb" % 4) for i in range(2**4)]
 print("Probabilities from simulator: ")
 print([format(counts.get(s, 0) / shots, ".3f") for s in qubit_strings])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["Cython>=0.27.1", "setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux2014"

--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -143,7 +143,7 @@ class Grover(AmplitudeAmplifier):
 
         if growth_rate is not None:
             # yield iterations ** 1, iterations ** 2, etc. and casts to int
-            self._iterations = map(lambda x: int(growth_rate ** x), itertools.count(1))
+            self._iterations = map(lambda x: int(growth_rate**x), itertools.count(1))
         elif isinstance(iterations, int):
             self._iterations = [iterations]
         else:
@@ -195,7 +195,7 @@ class Grover(AmplitudeAmplifier):
             max_power = np.inf  # no cap on the power
             iterator = iter(self._iterations)
         else:
-            max_iterations = max(10, 2 ** amplification_problem.oracle.num_qubits)
+            max_iterations = max(10, 2**amplification_problem.oracle.num_qubits)
             max_power = np.ceil(
                 2 ** (len(amplification_problem.grover_operator.reflection_qubits) / 2)
             )
@@ -292,7 +292,7 @@ class Grover(AmplitudeAmplifier):
         Returns:
             The optimal number of iterations for Grover's algorithm to succeed.
         """
-        amplitude = np.sqrt(num_solutions / 2 ** num_qubits)
+        amplitude = np.sqrt(num_solutions / 2**num_qubits)
         return round(np.arccos(amplitude) / (2 * np.arcsin(amplitude)))
 
     def construct_circuit(

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -83,7 +83,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
 
         # get parameters
         self._m = num_eval_qubits  # pylint: disable=invalid-name
-        self._M = 2 ** num_eval_qubits  # pylint: disable=invalid-name
+        self._M = 2**num_eval_qubits  # pylint: disable=invalid-name
 
         self._iqft = iqft
         self._pec = phase_estimation_circuit
@@ -194,7 +194,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
             if y >= int(self._M / 2):
                 y = self._M - y
             # due to the finite accuracy of the sine, we round the result to 7 decimals
-            a = np.round(np.power(np.sin(y * np.pi / 2 ** self._m), 2), decimals=7)
+            a = np.round(np.power(np.sin(y * np.pi / 2**self._m), 2), decimals=7)
             samples[a] = samples.get(a, 0) + probability
 
         return samples, measurements
@@ -209,7 +209,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
             y = int(state.replace(" ", "")[: self._m][::-1], 2)
             probability = count / shots
             measurements[y] = probability
-            a = np.round(np.power(np.sin(y * np.pi / 2 ** self._m), 2), decimals=7)
+            a = np.round(np.power(np.sin(y * np.pi / 2**self._m), 2), decimals=7)
             samples[a] = samples.get(a, 0.0) + probability
 
         return samples, measurements
@@ -229,7 +229,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
             The MLE for the provided result object.
         """
         m = result.num_evaluation_qubits
-        M = 2 ** m  # pylint: disable=invalid-name
+        M = 2**m  # pylint: disable=invalid-name
         qae = result.estimation
 
         # likelihood function
@@ -481,7 +481,7 @@ def _compute_fisher_information(result: AmplitudeEstimationResult, observed: boo
     fisher_information = None
     mlv = result.mle  # MLE in [0,1]
     m = result.num_evaluation_qubits
-    M = 2 ** m  # pylint: disable=invalid-name
+    M = 2**m  # pylint: disable=invalid-name
 
     if observed:
         a_i = np.asarray(list(result.samples.keys()))
@@ -535,7 +535,7 @@ def _likelihood_ratio_confint(result: AmplitudeEstimationResult, alpha: float) -
     # Compute the two intervals in which we the look for values above
     # the likelihood ratio: the two bubbles next to the QAE estimate
     m = result.num_evaluation_qubits
-    M = 2 ** m  # pylint: disable=invalid-name
+    M = 2**m  # pylint: disable=invalid-name
     qae = result.estimation
 
     y = int(np.round(M * np.arcsin(np.sqrt(qae)) / np.pi))

--- a/qiskit/algorithms/amplitude_estimators/ae_utils.py
+++ b/qiskit/algorithms/amplitude_estimators/ae_utils.py
@@ -171,7 +171,7 @@ def _derivative_beta(x, p):
 
 def _pdf_a_single_angle(x, p, m, pi_delta):
     """Helper function for `pdf_a`."""
-    M = 2 ** m
+    M = 2**m
 
     d = pi_delta(x, p)
     res = np.sin(M * d) ** 2 / (M * np.sin(d)) ** 2 if d != 0 else 1
@@ -226,7 +226,7 @@ def derivative_log_pdf_a(x, p, m):
     Returns:
         float: d/dp log(PDF(x|p))
     """
-    M = 2 ** m
+    M = 2**m
 
     if x not in [0, 1]:
         num_p1 = 0

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -218,7 +218,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
 
                     if 2 ** (j + 1) * theta_ci[1] >= 3 * np.pi / 8 and j < self._maxiter:
                         j_0 = j
-                        v = 2 ** j * np.sum(theta_ci)
+                        v = 2**j * np.sum(theta_ci)
                         first_stage = False
                 else:
                     cos = cos_estimate(2 ** (j - 1), self._shots[1])

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -81,7 +81,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
             if evaluation_schedule < 0:
                 raise ValueError("The evaluation schedule cannot be < 0.")
 
-            self._evaluation_schedule = [0] + [2 ** j for j in range(evaluation_schedule)]
+            self._evaluation_schedule = [0] + [2**j for j in range(evaluation_schedule)]
         else:
             if any(value < 0 for value in evaluation_schedule):
                 raise ValueError("The elements of the evaluation schedule cannot be < 0.")
@@ -445,7 +445,7 @@ def _compute_fisher_information(
             d_loglik += (2 * m_k + 1) * (h_k / tan + (shots_k - h_k) * tan)
 
         d_loglik /= np.sqrt(a * (1 - a))
-        fisher_information = d_loglik ** 2 / len(all_hits)
+        fisher_information = d_loglik**2 / len(all_hits)
 
     else:
         fisher_information = sum(

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -104,8 +104,8 @@ class NumPyEigensolver(Eigensolver):
 
     def _check_set_k(self, operator: OperatorBase) -> None:
         if operator is not None:
-            if self._in_k > 2 ** operator.num_qubits:
-                self._k = 2 ** operator.num_qubits
+            if self._in_k > 2**operator.num_qubits:
+                self._k = 2**operator.num_qubits
                 logger.debug(
                     "WARNING: Asked for %s eigenvalues but max possible is %s.", self._in_k, self._k
                 )
@@ -123,7 +123,7 @@ class NumPyEigensolver(Eigensolver):
             for i, idx in enumerate(indices):
                 eigvec[idx, i] = 1.0
         else:
-            if self._k >= 2 ** operator.num_qubits - 1:
+            if self._k >= 2**operator.num_qubits - 1:
                 logger.debug("SciPy doesn't support to get all eigenvalues, using NumPy instead.")
                 if operator.is_hermitian():
                     eigval, eigvec = np.linalg.eigh(operator.to_matrix())
@@ -221,7 +221,7 @@ class NumPyEigensolver(Eigensolver):
         k_orig = self._k
         if self._filter_criterion:
             # need to consider all elements if a filter is set
-            self._k = 2 ** operator.num_qubits
+            self._k = 2**operator.num_qubits
 
         self._ret = EigensolverResult()
         self._solve(operator)

--- a/qiskit/algorithms/factorizers/shor.py
+++ b/qiskit/algorithms/factorizers/shor.py
@@ -461,7 +461,7 @@ class Shor:
                 counts = {}
                 for i, v in enumerate(up_qreg_density_mat_diag):
                     if not v == 0:
-                        counts[bin(int(i))[2:].zfill(2 * n)] = v ** 2
+                        counts[bin(int(i))[2:].zfill(2 * n)] = v**2
             else:
                 circuit = self.construct_circuit(N=N, a=a, measurement=True)
                 counts = self._quantum_instance.execute(circuit).get_counts(circuit)

--- a/qiskit/algorithms/linear_solvers/hhl.py
+++ b/qiskit/algorithms/linear_solvers/hhl.py
@@ -189,7 +189,7 @@ class HHL(LinearSolver):
             The value of the scaling factor.
         """
         formatstr = "#0" + str(n_l + 2) + "b"
-        lambda_min_tilde = np.abs(lambda_min * (2 ** n_l - 1) / lambda_max)
+        lambda_min_tilde = np.abs(lambda_min * (2**n_l - 1) / lambda_max)
         # floating point precision can cause problems
         if np.abs(lambda_min_tilde - 1) < 1e-7:
             lambda_min_tilde = 1
@@ -356,7 +356,7 @@ class HHL(LinearSolver):
                 raise ValueError("Input matrix dimension must be 2^n!")
             if not np.allclose(matrix, matrix.conj().T):
                 raise ValueError("Input matrix must be hermitian!")
-            if matrix.shape[0] != 2 ** vector_circuit.num_qubits:
+            if matrix.shape[0] != 2**vector_circuit.num_qubits:
                 raise ValueError(
                     "Input vector dimension does not match input "
                     "matrix dimension! Vector dimension: "
@@ -392,11 +392,11 @@ class HHL(LinearSolver):
             # the most to the solution of the system. -1 to take into account the sign qubit
             delta = self._get_delta(nl - neg_vals, lambda_min, lambda_max)
             # Update evolution time
-            matrix_circuit.evolution_time = 2 * np.pi * delta / lambda_min / (2 ** neg_vals)
+            matrix_circuit.evolution_time = 2 * np.pi * delta / lambda_min / (2**neg_vals)
             # Update the scaling of the solution
             self.scaling = lambda_min
         else:
-            delta = 1 / (2 ** nl)
+            delta = 1 / (2**nl)
             print("The solution will be calculated up to a scaling factor.")
 
         if self._exact_reciprocal:
@@ -405,7 +405,7 @@ class HHL(LinearSolver):
             na = matrix_circuit.num_ancillas
         else:
             # Calculate breakpoints for the reciprocal approximation
-            num_values = 2 ** nl
+            num_values = 2**nl
             constant = delta
             a = int(round(num_values ** (2 / 3)))
 
@@ -432,7 +432,7 @@ class HHL(LinearSolver):
             breakpoints = []
             for i in range(0, num_intervals):
                 # Add the breakpoint to the list
-                breakpoints.append(a * (5 ** i))
+                breakpoints.append(a * (5**i))
 
                 # Define the right breakpoint of the interval
                 if i == num_intervals - 1:

--- a/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
+++ b/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
@@ -197,13 +197,13 @@ class TridiagonalToeplitz(LinearSystemMatrix):
         matrix = diags(
             [self.off_diag, self.main_diag, self.off_diag],
             [-1, 0, 1],
-            shape=(2 ** self.num_state_qubits, 2 ** self.num_state_qubits),
+            shape=(2**self.num_state_qubits, 2**self.num_state_qubits),
         ).toarray()
         return matrix
 
     def eigs_bounds(self) -> Tuple[float, float]:
         """Return lower and upper bounds on the eigenvalues of the matrix."""
-        n_b = 2 ** self.num_state_qubits
+        n_b = 2**self.num_state_qubits
         # Calculate the eigenvalues according to the formula for Toeplitz matrices
         eig_1 = np.abs(self.main_diag - 2 * self.off_diag * np.cos(n_b * np.pi / (n_b + 1)))
         eig_2 = np.abs(self.main_diag - 2 * self.off_diag * np.cos(np.pi / (n_b + 1)))

--- a/qiskit/algorithms/linear_solvers/observables/absolute_average.py
+++ b/qiskit/algorithms/linear_solvers/observables/absolute_average.py
@@ -106,7 +106,7 @@ class AbsoluteAverage(LinearSystemObservable):
             else:
                 raise ValueError("Solution probability must be given as a single value.")
 
-        return np.real(np.sqrt(solution / (2 ** num_qubits)) / scaling)
+        return np.real(np.sqrt(solution / (2**num_qubits)) / scaling)
 
     def evaluate_classically(self, solution: Union[np.array, QuantumCircuit]) -> float:
         """Evaluates the given observable on the solution to the linear system.

--- a/qiskit/algorithms/linear_solvers/observables/matrix_functional.py
+++ b/qiskit/algorithms/linear_solvers/observables/matrix_functional.py
@@ -153,8 +153,8 @@ class MatrixFunctional(LinearSystemObservable):
         # Calculate the value from the off-diagonal elements
         off_val = 0
         for i in range(1, len(solution), 2):
-            off_val += (solution[i] - solution[i + 1]) / (scaling ** 2)
-        main_val = solution[0] / (scaling ** 2)
+            off_val += (solution[i] - solution[i + 1]) / (scaling**2)
+        main_val = solution[0] / (scaling**2)
         return np.real(self._main_diag * main_val + self._off_diag * off_val)
 
     def evaluate_classically(self, solution: Union[np.array, QuantumCircuit]) -> float:

--- a/qiskit/algorithms/optimizers/adam_amsgrad.py
+++ b/qiskit/algorithms/optimizers/adam_amsgrad.py
@@ -247,7 +247,7 @@ class ADAM(Optimizer):
             self._t += 1
             self._m = self._beta_1 * self._m + (1 - self._beta_1) * derivative
             self._v = self._beta_2 * self._v + (1 - self._beta_2) * derivative * derivative
-            lr_eff = self._lr * np.sqrt(1 - self._beta_2 ** self._t) / (1 - self._beta_1 ** self._t)
+            lr_eff = self._lr * np.sqrt(1 - self._beta_2**self._t) / (1 - self._beta_1**self._t)
             if not self._amsgrad:
                 params_new = params - lr_eff * self._m.flatten() / (
                     np.sqrt(self._v.flatten()) + self._noise_factor

--- a/qiskit/algorithms/optimizers/qnspsa.py
+++ b/qiskit/algorithms/optimizers/qnspsa.py
@@ -195,7 +195,7 @@ class QNSPSA(SPSA):
         # compute the preconditioner point estimate
         diff = fidelity_values[2] - fidelity_values[0]
         diff -= fidelity_values[3] - fidelity_values[1]
-        diff /= 2 * eps ** 2
+        diff /= 2 * eps**2
 
         rank_one = np.outer(delta1, delta2)
         # -0.5 factor comes from the fact that we need -0.5 * fidelity

--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -339,7 +339,7 @@ class SPSA(Optimizer):
         avg_magnitudes /= steps
 
         if modelspace:
-            a = target_magnitude / (avg_magnitudes ** 2)
+            a = target_magnitude / (avg_magnitudes**2)
         else:
             a = target_magnitude / avg_magnitudes
 
@@ -430,7 +430,7 @@ class SPSA(Optimizer):
         hessian_sample = None
         if self.second_order:
             diff = (values[2] - plus) - (values[3] - minus)
-            diff /= 2 * eps ** 2
+            diff /= 2 * eps**2
 
             rank_one = np.outer(delta1, delta2)
             hessian_sample = diff * (rank_one + rank_one.T) / 2

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -160,7 +160,7 @@ def _bit_string_to_phase(binary_string: str) -> float:
         A phase scaled to :math:`[0,1)`.
     """
     n_qubits = len(binary_string)
-    return int(binary_string, 2) / (2 ** n_qubits)
+    return int(binary_string, 2) / (2**n_qubits)
 
 
 def _sort_phases(phases: Dict) -> Dict:

--- a/qiskit/circuit/_utils.py
+++ b/qiskit/circuit/_utils.py
@@ -44,7 +44,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
         QiskitError: unrecognized mode or invalid ctrl_state
     """
     num_target = int(numpy.log2(base_mat.shape[0]))
-    ctrl_dim = 2 ** num_ctrl_qubits
+    ctrl_dim = 2**num_ctrl_qubits
     ctrl_grnd = numpy.repeat([[1], [0]], [1, ctrl_dim - 1])
     if ctrl_state is None:
         ctrl_state = ctrl_dim - 1
@@ -56,7 +56,7 @@ def _compute_control_matrix(base_mat, num_ctrl_qubits, ctrl_state=None):
     else:
         raise QiskitError("Invalid control state type specified.")
     ctrl_proj = numpy.diag(numpy.roll(ctrl_grnd, ctrl_state))
-    full_mat = numpy.kron(numpy.eye(2 ** num_target), numpy.eye(ctrl_dim) - ctrl_proj) + numpy.kron(
+    full_mat = numpy.kron(numpy.eye(2**num_target), numpy.eye(ctrl_dim) - ctrl_proj) + numpy.kron(
         base_mat, ctrl_proj
     )
     return full_mat
@@ -86,12 +86,12 @@ def _ctrl_state_to_int(ctrl_state, num_ctrl_qubits):
         except AssertionError as ex:
             raise CircuitError("invalid control bit string: length != num_ctrl_qubits") from ex
     if isinstance(ctrl_state, int):
-        if 0 <= ctrl_state < 2 ** num_ctrl_qubits:
+        if 0 <= ctrl_state < 2**num_ctrl_qubits:
             ctrl_state_std = ctrl_state
         else:
             raise CircuitError("invalid control state specification")
     elif ctrl_state is None:
-        ctrl_state_std = 2 ** num_ctrl_qubits - 1
+        ctrl_state_std = 2**num_ctrl_qubits - 1
     else:
         raise CircuitError(f"invalid control state specification: {repr(ctrl_state)}")
     return ctrl_state_std

--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -52,7 +52,7 @@ def add_control(
 
     """
     if ctrl_state is None:
-        ctrl_state = 2 ** num_ctrl_qubits - 1
+        ctrl_state = 2**num_ctrl_qubits - 1
     if isinstance(operation, UnitaryGate):
         # attempt decomposition
         operation._define()

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -236,7 +236,7 @@ class ControlledGate(Gate):
     @property
     def _open_ctrl(self) -> bool:
         """Return whether gate has any open controls"""
-        return self.ctrl_state < 2 ** self.num_ctrl_qubits - 1
+        return self.ctrl_state < 2**self.num_ctrl_qubits - 1
 
     def __eq__(self, other) -> bool:
         return (

--- a/qiskit/circuit/library/arithmetic/adders/draper_qft_adder.py
+++ b/qiskit/circuit/library/arithmetic/adders/draper_qft_adder.py
@@ -103,7 +103,7 @@ class DraperQFTAdder(Adder):
 
         for j in range(num_state_qubits):
             for k in range(num_state_qubits - j):
-                lam = np.pi / (2 ** k)
+                lam = np.pi / (2**k)
                 circuit.cp(lam, qr_a[j], qr_b[j + k])
 
         if kind == "half":

--- a/qiskit/circuit/library/arithmetic/exact_reciprocal.py
+++ b/qiskit/circuit/library/arithmetic/exact_reciprocal.py
@@ -49,7 +49,7 @@ class ExactReciprocal(QuantumCircuit):
         circuit = QuantumCircuit(qr_state, qr_flag, name=name)
 
         angles = [0.0]
-        nl = 2 ** (num_state_qubits - 1) if neg_vals else 2 ** num_state_qubits
+        nl = 2 ** (num_state_qubits - 1) if neg_vals else 2**num_state_qubits
 
         # Angles to rotate by scaling / x, where x = i / nl
         for i in range(1, nl):

--- a/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
+++ b/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
@@ -127,13 +127,13 @@ class LinearAmplitudeFunction(QuantumCircuit):
         mapped_slope = []
         mapped_offset = []
         for i, point in enumerate(breakpoints):
-            mapped_breakpoint = (point - a) / (b - a) * (2 ** num_state_qubits - 1)
+            mapped_breakpoint = (point - a) / (b - a) * (2**num_state_qubits - 1)
             mapped_breakpoints += [mapped_breakpoint]
 
             # factor (upper - lower) / (2^n - 1) is for the scaling of x to [l,u]
             # note that the +l for mapping to [l,u] is already included in
             # the offsets given as parameters
-            mapped_slope += [slope[i] * (b - a) / (2 ** num_state_qubits - 1)]
+            mapped_slope += [slope[i] * (b - a) / (2**num_state_qubits - 1)]
             mapped_offset += [offset[i]]
 
         # approximate linear behavior by scaling and contracting around pi/4

--- a/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_chebyshev.py
@@ -181,7 +181,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
 
         # it the state qubits are set ensure that the breakpoints match beginning and end
         if self.num_state_qubits is not None:
-            num_states = 2 ** self.num_state_qubits
+            num_states = 2**self.num_state_qubits
 
             # If the last breakpoint is < num_states, add the identity polynomial
             if breakpoints[-1] < num_states:
@@ -228,7 +228,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
         breakpoints = self._breakpoints
         # Need to take into account the case in which no breakpoints were provided in first place
         if breakpoints == [0]:
-            breakpoints = [0, 2 ** self.num_state_qubits]
+            breakpoints = [0, 2**self.num_state_qubits]
 
         num_intervals = len(breakpoints)
 
@@ -258,7 +258,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
                 ) from err
 
         # If the last breakpoint is < 2 ** num_qubits, add the identity polynomial
-        if breakpoints[-1] < 2 ** self.num_state_qubits:
+        if breakpoints[-1] < 2**self.num_state_qubits:
             polynomials = polynomials + [[2 * np.arcsin(1)]]
 
         # If the first breakpoint is > 0, add the identity polynomial
@@ -308,7 +308,7 @@ class PiecewiseChebyshev(BlueprintCircuit):
 
             # Set breakpoints if they haven't been set
             if num_state_qubits is not None and self._breakpoints is None:
-                self.breakpoints = [0, 2 ** num_state_qubits]
+                self.breakpoints = [0, 2**num_state_qubits]
 
             self._reset_registers(num_state_qubits)
 

--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -131,9 +131,9 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
         if (
             self.num_state_qubits is not None
             and len(self._breakpoints) == len(self.coeffs)
-            and self._breakpoints[-1] < 2 ** self.num_state_qubits
+            and self._breakpoints[-1] < 2**self.num_state_qubits
         ):
-            return self._breakpoints + [2 ** self.num_state_qubits]
+            return self._breakpoints + [2**self.num_state_qubits]
 
         return self._breakpoints
 

--- a/qiskit/circuit/library/arithmetic/quadratic_form.py
+++ b/qiskit/circuit/library/arithmetic/quadratic_form.py
@@ -135,7 +135,7 @@ class QuadraticForm(QuantumCircuit):
         # constant coefficient
         if offset != 0:
             for i, q_i in enumerate(qr_result):
-                circuit.p(scaling * 2 ** i * offset, q_i)
+                circuit.p(scaling * 2**i * offset, q_i)
 
         # the linear part consists of the vector and the diagonal of the
         # matrix, since x_i * x_i = x_i, as x_i is a binary variable
@@ -144,7 +144,7 @@ class QuadraticForm(QuantumCircuit):
             value += quadratic[j][j] if quadratic is not None else 0
             if value != 0:
                 for i, q_i in enumerate(qr_result):
-                    circuit.cp(scaling * 2 ** i * value, qr_input[j], q_i)
+                    circuit.cp(scaling * 2**i * value, qr_input[j], q_i)
 
         # the quadratic part adds A_ij and A_ji as x_i x_j == x_j x_i
         if quadratic is not None:
@@ -153,7 +153,7 @@ class QuadraticForm(QuantumCircuit):
                     value = quadratic[j][k] + quadratic[k][j]
                     if value != 0:
                         for i, q_i in enumerate(qr_result):
-                            circuit.mcp(scaling * 2 ** i * value, [qr_input[j], qr_input[k]], q_i)
+                            circuit.mcp(scaling * 2**i * value, [qr_input[j], qr_input[k]], q_i)
 
         # add the inverse QFT
         iqft = QFT(num_result_qubits, do_swaps=False).inverse().reverse_bits()

--- a/qiskit/circuit/library/boolean_logic/quantum_xor.py
+++ b/qiskit/circuit/library/boolean_logic/quantum_xor.py
@@ -60,7 +60,7 @@ class XOR(QuantumCircuit):
                 raise CircuitError("Bits in 'amount' exceed circuit width")
         else:
             rng = np.random.default_rng(seed)
-            amount = rng.integers(0, 2 ** num_qubits)
+            amount = rng.integers(0, 2**num_qubits)
 
         for i in range(num_qubits):
             bit = amount & 1

--- a/qiskit/circuit/library/generalized_gates/gms.py
+++ b/qiskit/circuit/library/generalized_gates/gms.py
@@ -86,7 +86,7 @@ class GMS(QuantumCircuit):
         """
         super().__init__(num_qubits, name="gms")
         if not isinstance(theta, list):
-            theta = [theta] * int((num_qubits ** 2 - 1) / 2)
+            theta = [theta] * int((num_qubits**2 - 1) / 2)
         gms = QuantumCircuit(num_qubits, name="gms")
         for i in range(self.num_qubits):
             for j in range(i + 1, self.num_qubits):

--- a/qiskit/circuit/library/phase_estimation.py
+++ b/qiskit/circuit/library/phase_estimation.py
@@ -91,7 +91,7 @@ class PhaseEstimation(QuantumCircuit):
         circuit.h(qr_eval)  # hadamards on evaluation qubits
 
         for j in range(num_evaluation_qubits):  # controlled powers
-            circuit.compose(unitary.power(2 ** j).control(), qubits=[j] + qr_state[:], inplace=True)
+            circuit.compose(unitary.power(2**j).control(), qubits=[j] + qr_state[:], inplace=True)
 
         circuit.compose(iqft, qubits=qr_eval[:], inplace=True)  # final QFT
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -275,7 +275,7 @@ def _generate_gray_code(num_bits):
         raise ValueError("Cannot generate the gray code for less than 1 bit.")
     result = [0]
     for i in range(num_bits):
-        result += [x + 2 ** i for x in reversed(result)]
+        result += [x + 2**i for x in reversed(result)]
     return [format(x, "0%sb" % num_bits) for x in result]
 
 

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -612,7 +612,7 @@ def _does_commute(node1, node2):
     qarg1 = [qarg.index(q) for q in node1.qargs]
     qarg2 = [qarg.index(q) for q in node2.qargs]
 
-    dim = 2 ** qbit_num
+    dim = 2**qbit_num
     id_op = np.reshape(np.eye(dim), (2, 2) * qbit_num)
 
     op1 = np.reshape(node1.op.to_matrix(), (2, 2) * len(qarg1))

--- a/qiskit/extensions/hamiltonian_gate.py
+++ b/qiskit/extensions/hamiltonian_gate.py
@@ -61,7 +61,7 @@ class HamiltonianGate(Gate):
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
         num_qubits = int(numpy.log2(input_dim))
-        if input_dim != output_dim or 2 ** num_qubits != input_dim:
+        if input_dim != output_dim or 2**num_qubits != input_dim:
             raise ExtensionError("Input matrix is not an N-qubit operator.")
 
         # Store instruction params

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -259,7 +259,7 @@ class Initialize(Instruction, Operation):
         a_complex = complex(a_complex)
         b_complex = complex(b_complex)
         mag_a = np.absolute(a_complex)
-        final_r = float(np.sqrt(mag_a ** 2 + np.absolute(b_complex) ** 2))
+        final_r = float(np.sqrt(mag_a**2 + np.absolute(b_complex) ** 2))
         if final_r < _EPS:
             theta = 0
             phi = 0
@@ -341,7 +341,7 @@ class Initialize(Instruction, Operation):
             raise QiskitError(
                 "Initialize parameter vector has %d elements, therefore expects %s "
                 "qubits. However, %s were provided."
-                % (2 ** self.num_qubits, self.num_qubits, len(flat_qargs))
+                % (2**self.num_qubits, self.num_qubits, len(flat_qargs))
             )
         yield flat_qargs, []
 

--- a/qiskit/extensions/quantum_initializer/isometry.py
+++ b/qiskit/extensions/quantum_initializer/isometry.py
@@ -135,7 +135,7 @@ class Isometry(Instruction, Operation):
         # Return the isometry that is left to decompose, where the columns up to index column_index
         # correspond to the firstfew columns of the identity matrix up to diag, and hence we only
         # have to save a list containing them.
-        for column_index in range(2 ** m):
+        for column_index in range(2**m):
             self._decompose_column(circuit, q, diag, remaining_isometry, column_index)
             # extract phase of the state that was sent to the basis state ket(column_index)
             diag.append(remaining_isometry[column_index, 0])
@@ -167,8 +167,8 @@ class Isometry(Instruction, Operation):
         n = int(np.log2(self.params[0].shape[0]))
 
         # MCG to set one entry to zero (preparation for disentangling with UCGate):
-        index1 = 2 * _a(k, s + 1) * 2 ** s + _b(k, s + 1)
-        index2 = (2 * _a(k, s + 1) + 1) * 2 ** s + _b(k, s + 1)
+        index1 = 2 * _a(k, s + 1) * 2**s + _b(k, s + 1)
+        index2 = (2 * _a(k, s + 1) + 1) * 2**s + _b(k, s + 1)
         target_label = n - s - 1
         # Check if a MCG is required
         if _k_s(k, s) == 0 and _b(k, s + 1) != 0 and np.abs(v[index2, k_prime]) > self._epsilon:
@@ -225,8 +225,8 @@ class Isometry(Instruction, Operation):
         squs = [
             _reverse_qubit_state(
                 [
-                    v[2 * i * 2 ** s + _b(k, s), k_prime],
-                    v[(2 * i + 1) * 2 ** s + _b(k, s), k_prime],
+                    v[2 * i * 2**s + _b(k, s), k_prime],
+                    v[(2 * i + 1) * 2**s + _b(k, s), k_prime],
                 ],
                 _k_s(k, s),
                 self._epsilon,
@@ -504,11 +504,11 @@ def _merge_UCGate_and_diag(single_qubit_gates, diag):
 
 
 def _a(k, s):
-    return k // 2 ** s
+    return k // 2**s
 
 
 def _b(k, s):
-    return k - (_a(k, s) * 2 ** s)
+    return k - (_a(k, s) * 2**s)
 
 
 # given a binary representation of k with binary digits [k_{n-1},..,k_1,k_0],

--- a/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
+++ b/qiskit/extensions/quantum_initializer/mcg_up_to_diagonal.py
@@ -112,7 +112,7 @@ class MCGupDiag(Gate):
         threshold = float("inf")
         if self.num_controls < threshold:
             # Implement the MCG as a UCGate (up to diagonal)
-            gate_list = [np.eye(2, 2) for i in range(2 ** self.num_controls)]
+            gate_list = [np.eye(2, 2) for i in range(2**self.num_controls)]
             gate_list[-1] = self.params[0]
             ucg = UCGate(gate_list, up_to_diagonal=True)
             circuit.append(ucg, [q_target] + q_controls)

--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -132,7 +132,7 @@ class UCGate(Gate):
         up_to_diagonal=True, the circuit implements the gate up to a diagonal gate and
         the diagonal gate is also returned.
         """
-        diag = np.ones(2 ** self.num_qubits).tolist()
+        diag = np.ones(2**self.num_qubits).tolist()
         q = QuantumRegister(self.num_qubits)
         q_controls = q[1:]
         q_target = q[0]
@@ -183,10 +183,10 @@ class UCGate(Gate):
         https://arxiv.org/pdf/quant-ph/0410066.pdf.
         """
         single_qubit_gates = [gate.astype(complex) for gate in self.params]
-        diag = np.ones(2 ** self.num_qubits, dtype=complex)
+        diag = np.ones(2**self.num_qubits, dtype=complex)
         num_contr = self.num_qubits - 1
         for dec_step in range(num_contr):
-            num_ucgs = 2 ** dec_step
+            num_ucgs = 2**dec_step
             # The decomposition works recursively and the following loop goes over the different
             # UCGates that arise in the decomposition
             for ucg_index in range(num_ucgs):

--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -64,7 +64,7 @@ class UnitaryGate(Gate):
         # Check input is N-qubit matrix
         input_dim, output_dim = data.shape
         num_qubits = int(numpy.log2(input_dim))
-        if input_dim != output_dim or 2 ** num_qubits != input_dim:
+        if input_dim != output_dim or 2**num_qubits != input_dim:
             raise ExtensionError("Input matrix is not an N-qubit operator.")
 
         self._qasm_name = None

--- a/qiskit/opflow/evolutions/trotterizations/qdrift.py
+++ b/qiskit/opflow/evolutions/trotterizations/qdrift.py
@@ -67,7 +67,7 @@ class QDrift(TrotterizationBase):
         weights = np.abs(coeffs)
         lambd = np.sum(weights)
 
-        N = 2 * (lambd ** 2) * (coeff ** 2)
+        N = 2 * (lambd**2) * (coeff**2)
         factor = lambd * coeff / (N * self.reps)
         # The protocol calls for the removal of the individual coefficients,
         # and multiplication by a constant factor.

--- a/qiskit/opflow/expectations/expectation_factory.py
+++ b/qiskit/opflow/expectations/expectation_factory.py
@@ -85,8 +85,8 @@ class ExpectationFactory:
                             "the BasicAer qasm backend for this expectation to avoid having to "
                             "construct the %dx%d operator matrix.",
                             operator.num_qubits,
-                            2 ** operator.num_qubits,
-                            2 ** operator.num_qubits,
+                            2**operator.num_qubits,
+                            2**operator.num_qubits,
                         )
                         backend_to_check = BasicAer.get_backend("qasm_simulator")
 

--- a/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
@@ -423,7 +423,7 @@ class LinComb(CircuitGradient):
             return [([-0.5j], [czx])]
         if isinstance(gate, ControlledGate):
             # TODO support arbitrary control states
-            if gate.ctrl_state != 2 ** gate.num_ctrl_qubits - 1:
+            if gate.ctrl_state != 2**gate.num_ctrl_qubits - 1:
                 raise OpflowError(
                     "Function only support controlled gates with control state `1` on all control "
                     "qubits."
@@ -443,7 +443,7 @@ class LinComb(CircuitGradient):
                 coeffs = []
                 gates = []
                 for phase, proj_gates in proj_gates_controlled:
-                    coeffs.extend([phase * c / (2 ** gate.num_ctrl_qubits) for c in base_coeffs])
+                    coeffs.extend([phase * c / (2**gate.num_ctrl_qubits) for c in base_coeffs])
                     for base_gate in base_gates:
                         controlled_circ = QuantumCircuit(gate.num_ctrl_qubits + gate.num_qubits)
                         for i, proj_gate in enumerate(proj_gates):

--- a/qiskit/opflow/gradients/circuit_qfis/overlap_diag.py
+++ b/qiskit/opflow/gradients/circuit_qfis/overlap_diag.py
@@ -141,7 +141,7 @@ class OverlapDiag(CircuitQFI):
             rotated_op = PauliExpectation().convert(op)
             diag.append(rotated_op)
 
-        grad_op = ListOp(diag, combo_fn=lambda x: np.diag(np.real([1 - y ** 2 for y in x])))
+        grad_op = ListOp(diag, combo_fn=lambda x: np.diag(np.real([1 - y**2 for y in x])))
         return grad_op
 
 

--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -487,7 +487,7 @@ class OperatorBase(StarAlgebraMixin, TensorMixin, ABC):
             ValueError: Massive is False and number of qubits is greater than 16
         """
         if num_qubits > 16 and not massive and not algorithm_globals.massive:
-            dim = 2 ** num_qubits
+            dim = 2**num_qubits
             if matrix:
                 obj_type = "matrix"
                 dimensions = f"{dim}x{dim}"

--- a/qiskit/opflow/primitive_ops/matrix_op.py
+++ b/qiskit/opflow/primitive_ops/matrix_op.py
@@ -114,7 +114,7 @@ class MatrixOp(PrimitiveOp):
         return self.coeff * self.primitive == other.coeff * other.primitive
 
     def _expand_dim(self, num_qubits: int) -> "MatrixOp":
-        identity = np.identity(2 ** num_qubits, dtype=complex)
+        identity = np.identity(2**num_qubits, dtype=complex)
         return MatrixOp(self.primitive.tensor(Operator(identity)), coeff=self.coeff)
 
     def tensor(self, other: OperatorBase) -> Union["MatrixOp", TensoredOp]:

--- a/qiskit/opflow/state_fns/cvar_measurement.py
+++ b/qiskit/opflow/state_fns/cvar_measurement.py
@@ -198,7 +198,7 @@ class CVaRMeasurement(OperatorStateFn):
                 is computed as H_j^2 + 1/α*(sum_i<j p_i*(H_i^2 - H_j^2))
         """
         energies, probabilities = self.get_outcome_energies_probabilities(front)
-        sq_energies = [energy ** 2 for energy in energies]
+        sq_energies = [energy**2 for energy in energies]
         return self.compute_cvar(sq_energies, probabilities) - self.eval(front) ** 2
 
     def get_outcome_energies_probabilities(

--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -182,12 +182,12 @@ class DictStateFn(StateFn):
 
     def to_density_matrix(self, massive: bool = False) -> np.ndarray:
         OperatorBase._check_massive("to_density_matrix", True, self.num_qubits, massive)
-        states = int(2 ** self.num_qubits)
+        states = int(2**self.num_qubits)
         return self.to_matrix(massive=massive) * np.eye(states) * self.coeff
 
     def to_matrix(self, massive: bool = False) -> np.ndarray:
         OperatorBase._check_massive("to_matrix", False, self.num_qubits, massive)
-        states = int(2 ** self.num_qubits)
+        states = int(2**self.num_qubits)
         probs = np.zeros(states) + 0.0j
         for k, v in self.primitive.items():
             probs[int(k, 2)] = v
@@ -209,7 +209,7 @@ class DictStateFn(StateFn):
         indices = [int(v, 2) for v in self.primitive.keys()]
         vals = np.array(list(self.primitive.values())) * self.coeff
         spvec = sparse.csr_matrix(
-            (vals, (np.zeros(len(indices), dtype=int), indices)), shape=(1, 2 ** self.num_qubits)
+            (vals, (np.zeros(len(indices), dtype=int), indices)), shape=(1, 2**self.num_qubits)
         )
         return spvec if not self.is_measurement else spvec.transpose()
 

--- a/qiskit/opflow/state_fns/vector_state_fn.py
+++ b/qiskit/opflow/state_fns/vector_state_fn.py
@@ -130,7 +130,7 @@ class VectorStateFn(StateFn):
         return DictStateFn(new_dict, coeff=self.coeff, is_measurement=self.is_measurement)
 
     def _expand_dim(self, num_qubits: int) -> "VectorStateFn":
-        primitive = np.zeros(2 ** num_qubits, dtype=complex)
+        primitive = np.zeros(2**num_qubits, dtype=complex)
         return VectorStateFn(
             self.primitive.tensor(primitive), coeff=self.coeff, is_measurement=self.is_measurement
         )

--- a/qiskit/providers/basicaer/qasm_simulator.py
+++ b/qiskit/providers/basicaer/qasm_simulator.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 class QasmSimulatorPy(BackendV1):
     """Python implementation of a qasm simulator."""
 
-    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()["memory"] * (1024 ** 3) / 16))
+    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()["memory"] * (1024**3) / 16))
 
     DEFAULT_CONFIGURATION = {
         "backend_name": "qasm_simulator",
@@ -205,12 +205,12 @@ class QasmSimulatorPy(BackendV1):
             # with respect to position from end of the list
             axis.remove(self._number_of_qubits - 1 - qubit)
         probabilities = np.reshape(
-            np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis)), 2 ** num_measured
+            np.sum(np.abs(self._statevector) ** 2, axis=tuple(axis)), 2**num_measured
         )
         # Generate samples on measured qubits as ints with qubit
         # position in the bit-string for each int given by the qubit
         # position in the sorted measured_qubits list
-        samples = self._local_random.choice(range(2 ** num_measured), num_samples, p=probabilities)
+        samples = self._local_random.choice(range(2**num_measured), num_samples, p=probabilities)
         # Convert the ints to bitstrings
         memory = []
         for sample in samples:
@@ -279,7 +279,7 @@ class QasmSimulatorPy(BackendV1):
             return
         # Check statevector is correct length for number of qubits
         length = len(self._initial_statevector)
-        required_dim = 2 ** self._number_of_qubits
+        required_dim = 2**self._number_of_qubits
         if length != required_dim:
             raise BasicAerError(
                 f"initial statevector is incorrect length: {length} != {required_dim}"
@@ -317,7 +317,7 @@ class QasmSimulatorPy(BackendV1):
         """Set the initial statevector for simulation"""
         if self._initial_statevector is None:
             # Set to default state of all qubits in |0>
-            self._statevector = np.zeros(2 ** self._number_of_qubits, dtype=complex)
+            self._statevector = np.zeros(2**self._number_of_qubits, dtype=complex)
             self._statevector[0] = 1
         else:
             self._statevector = self._initial_statevector.copy()
@@ -326,7 +326,7 @@ class QasmSimulatorPy(BackendV1):
 
     def _get_statevector(self):
         """Return the current statevector"""
-        vec = np.reshape(self._statevector, 2 ** self._number_of_qubits)
+        vec = np.reshape(self._statevector, 2**self._number_of_qubits)
         vec[abs(vec) < self._chop_threshold] = 0.0
         return vec
 

--- a/qiskit/providers/basicaer/statevector_simulator.py
+++ b/qiskit/providers/basicaer/statevector_simulator.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class StatevectorSimulatorPy(QasmSimulatorPy):
     """Python statevector simulator."""
 
-    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()["memory"] * (1024 ** 3) / 16))
+    MAX_QUBITS_MEMORY = int(log2(local_hardware_info()["memory"] * (1024**3) / 16))
 
     DEFAULT_CONFIGURATION = {
         "backend_name": "statevector_simulator",

--- a/qiskit/providers/basicaer/unitary_simulator.py
+++ b/qiskit/providers/basicaer/unitary_simulator.py
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 class UnitarySimulatorPy(BackendV1):
     """Python implementation of a unitary simulator."""
 
-    MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()["memory"] * (1024 ** 3) / 16)))
+    MAX_QUBITS_MEMORY = int(log2(sqrt(local_hardware_info()["memory"] * (1024**3) / 16)))
 
     DEFAULT_CONFIGURATION = {
         "backend_name": "unitary_simulator",
@@ -147,7 +147,7 @@ class UnitarySimulatorPy(BackendV1):
             return
         # Check unitary is correct length for number of qubits
         shape = np.shape(self._initial_unitary)
-        required_shape = (2 ** self._number_of_qubits, 2 ** self._number_of_qubits)
+        required_shape = (2**self._number_of_qubits, 2**self._number_of_qubits)
         if shape != required_shape:
             raise BasicAerError(
                 f"initial unitary is incorrect shape: {shape} != 2 ** {required_shape}"
@@ -191,7 +191,7 @@ class UnitarySimulatorPy(BackendV1):
         self._validate_initial_unitary()
         if self._initial_unitary is None:
             # Set to identity matrix
-            self._unitary = np.eye(2 ** self._number_of_qubits, dtype=complex)
+            self._unitary = np.eye(2**self._number_of_qubits, dtype=complex)
         else:
             self._unitary = self._initial_unitary.copy()
         # Reshape to rank-N tensor
@@ -199,7 +199,7 @@ class UnitarySimulatorPy(BackendV1):
 
     def _get_unitary(self):
         """Return the current unitary"""
-        unitary = np.reshape(self._unitary, 2 * [2 ** self._number_of_qubits])
+        unitary = np.reshape(self._unitary, 2 * [2**self._number_of_qubits])
         if self._global_phase:
             unitary *= np.exp(1j * float(self._global_phase))
         unitary[abs(unitary) < self._chop_threshold] = 0.0

--- a/qiskit/pulse/library/continuous.py
+++ b/qiskit/pulse/library/continuous.py
@@ -173,7 +173,7 @@ def gaussian(
     """
     times = np.asarray(times, dtype=np.complex_)
     x = (times - center) / sigma
-    gauss = amp * np.exp(-(x ** 2) / 2).astype(np.complex_)
+    gauss = amp * np.exp(-(x**2) / 2).astype(np.complex_)
 
     if zeroed_width is not None:
         gauss = _fix_gaussian_width(

--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -450,7 +450,7 @@ class Drag(ParametricPulse):
             #    There is a second maxima mirrored around the center of the pulse with the same
             #    norm as the first, so checking the value at the first x maxima is sufficient.
             argmax_x = self.duration / 2 - (self.sigma / self.beta) * math.sqrt(
-                self.beta ** 2 - self.sigma ** 2
+                self.beta**2 - self.sigma**2
             )
             # If the max point is out of range, either end of the pulse will do
             argmax_x = max(argmax_x, 0)

--- a/qiskit/quantum_info/analysis/distance.py
+++ b/qiskit/quantum_info/analysis/distance.py
@@ -97,4 +97,4 @@ def hellinger_fidelity(dist_p, dist_q):
         `Hellinger Distance @ wikipedia <https://en.wikipedia.org/wiki/Hellinger_distance>`_
     """
     dist = hellinger_distance(dist_p, dist_q)
-    return (1 - dist ** 2) ** 2
+    return (1 - dist**2) ** 2

--- a/qiskit/quantum_info/operators/channel/chi.py
+++ b/qiskit/quantum_info/operators/channel/chi.py
@@ -117,7 +117,7 @@ class Chi(QuantumChannel):
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
         num_qubits = int(np.log2(input_dim))
-        if 2 ** num_qubits != input_dim or input_dim != output_dim:
+        if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Chi matrix.")
         super().__init__(chi_mat, num_qubits=num_qubits)
 

--- a/qiskit/quantum_info/operators/channel/ptm.py
+++ b/qiskit/quantum_info/operators/channel/ptm.py
@@ -98,7 +98,7 @@ class PTM(QuantumChannel):
                 output_dim = np.product(input_dims)
             else:
                 output_dim = int(np.sqrt(dout))
-            if output_dim ** 2 != dout or input_dim ** 2 != din or input_dim != output_dim:
+            if output_dim**2 != dout or input_dim**2 != din or input_dim != output_dim:
                 raise QiskitError("Invalid shape for PTM matrix.")
         else:
             # Otherwise we initialize by conversion from another Qiskit
@@ -121,7 +121,7 @@ class PTM(QuantumChannel):
                 output_dims = data.output_dims()
         # Check input is N-qubit channel
         num_qubits = int(np.log2(input_dim))
-        if 2 ** num_qubits != input_dim or input_dim != output_dim:
+        if 2**num_qubits != input_dim or input_dim != output_dim:
             raise QiskitError("Input is not an n-qubit Pauli transfer matrix.")
         super().__init__(ptm, num_qubits=num_qubits)
 

--- a/qiskit/quantum_info/operators/channel/quantum_channel.py
+++ b/qiskit/quantum_info/operators/channel/quantum_channel.py
@@ -236,7 +236,7 @@ class QuantumChannel(LinearOp):
 
         # Check if input is an N-qubit CPTP channel.
         num_qubits = int(np.log2(self._input_dim))
-        if self._input_dim != self._output_dim or 2 ** num_qubits != self._input_dim:
+        if self._input_dim != self._output_dim or 2**num_qubits != self._input_dim:
             raise QiskitError(
                 "Cannot convert QuantumChannel to Instruction: channel is not an N-qubit channel."
             )

--- a/qiskit/quantum_info/operators/channel/superop.py
+++ b/qiskit/quantum_info/operators/channel/superop.py
@@ -83,7 +83,7 @@ class SuperOp(QuantumChannel):
             dout, din = super_mat.shape
             input_dim = int(np.sqrt(din))
             output_dim = int(np.sqrt(dout))
-            if output_dim ** 2 != dout or input_dim ** 2 != din:
+            if output_dim**2 != dout or input_dim**2 != din:
                 raise QiskitError("Invalid shape for SuperOp matrix.")
             op_shape = OpShape.auto(
                 dims_l=output_dims, dims_r=input_dims, shape=(output_dim, input_dim)
@@ -292,7 +292,7 @@ class SuperOp(QuantumChannel):
             instruction = instruction.to_instruction()
         # Initialize an identity superoperator of the correct size
         # of the circuit
-        op = SuperOp(np.eye(4 ** instruction.num_qubits))
+        op = SuperOp(np.eye(4**instruction.num_qubits))
         op._append_instruction(instruction)
         return op
 

--- a/qiskit/quantum_info/operators/channel/transformations.py
+++ b/qiskit/quantum_info/operators/channel/transformations.py
@@ -423,7 +423,7 @@ def _transform_to_pauli(data, num_qubits):
             ),
             (4 * dim * dim, 4 * dim * dim),
         )
-    return np.dot(np.dot(cob, data), cob.conj().T) / 2 ** num_qubits
+    return np.dot(np.dot(cob, data), cob.conj().T) / 2**num_qubits
 
 
 def _transform_from_pauli(data, num_qubits):
@@ -444,7 +444,7 @@ def _transform_from_pauli(data, num_qubits):
             ),
             (4 * dim * dim, 4 * dim * dim),
         )
-    return np.dot(np.dot(cob, data), cob.conj().T) / 2 ** num_qubits
+    return np.dot(np.dot(cob, data), cob.conj().T) / 2**num_qubits
 
 
 def _reshuffle(mat, shape):
@@ -462,5 +462,5 @@ def _check_nqubit_dim(input_dim, output_dim):
             f"Not an n-qubit channel: input_dim ({input_dim}) != output_dim ({output_dim})"
         )
     num_qubits = int(np.log2(input_dim))
-    if 2 ** num_qubits != input_dim:
+    if 2**num_qubits != input_dim:
         raise QiskitError("Not an n-qubit channel: input_dim != 2 ** n")

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -126,7 +126,7 @@ def process_fidelity(channel, target=None, require_cp=True, require_tp=True):
             fid = np.abs(np.trace(channel.data) / input_dim) ** 2
         else:
             # Tr[S] / (dim ** 2)
-            fid = np.trace(SuperOp(channel).data) / (input_dim ** 2)
+            fid = np.trace(SuperOp(channel).data) / (input_dim**2)
         return float(np.real(fid))
 
     # For comparing two non-unitary channels we compute the state fidelity of

--- a/qiskit/quantum_info/operators/op_shape.py
+++ b/qiskit/quantum_info/operators/op_shape.py
@@ -162,14 +162,14 @@ class OpShape:
         """Return the total input dimension."""
         if self._dims_r:
             return reduce(mul, self._dims_r)
-        return 2 ** self._num_qargs_r
+        return 2**self._num_qargs_r
 
     @property
     def _dim_l(self):
         """Return the total input dimension."""
         if self._dims_l:
             return reduce(mul, self._dims_l)
-        return 2 ** self._num_qargs_l
+        return 2**self._num_qargs_l
 
     def validate_shape(self, shape):
         """Raise an exception if shape is not valid for the OpShape"""
@@ -192,7 +192,7 @@ class OpShape:
                         "({} != {})".format(reduce(mul, self._dims_l), shape[0])
                     )
                 return False
-        elif shape[0] != 2 ** self._num_qargs_l:
+        elif shape[0] != 2**self._num_qargs_l:
             if raise_exception:
                 raise QiskitError("Number of left qubits does not match matrix shape")
             return False
@@ -206,7 +206,7 @@ class OpShape:
                             "({} != {})".format(reduce(mul, self._dims_r), shape[1])
                         )
                     return False
-            elif shape[1] != 2 ** self._num_qargs_r:
+            elif shape[1] != 2**self._num_qargs_r:
                 if raise_exception:
                     raise QiskitError("Number of right qubits does not match matrix shape")
                 return False

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -193,7 +193,7 @@ class Operator(LinearOp):
             raise QiskitError("Label contains invalid characters.")
         # Initialize an identity matrix and apply each gate
         num_qubits = len(label)
-        op = Operator(np.eye(2 ** num_qubits, dtype=complex))
+        op = Operator(np.eye(2**num_qubits, dtype=complex))
         for qubit, char in enumerate(reversed(label)):
             if char != "I":
                 op = op.compose(label_mats[char], qargs=[qubit])
@@ -226,7 +226,7 @@ class Operator(LinearOp):
         Returns:
             Operator: An operator representing the input circuit
         """
-        dimension = 2 ** circuit.num_qubits
+        dimension = 2**circuit.num_qubits
         op = cls(np.eye(dimension))
         if layout is None:
             if not ignore_set_layout:
@@ -503,7 +503,7 @@ class Operator(LinearOp):
         if hasattr(instruction, "__array__"):
             return Operator(np.array(instruction, dtype=complex))
 
-        dimension = 2 ** instruction.num_qubits
+        dimension = 2**instruction.num_qubits
         op = Operator(np.eye(dimension))
         # Convert circuit to an instruction
         if isinstance(instruction, QuantumCircuit):
@@ -553,7 +553,7 @@ class Operator(LinearOp):
                     )
                 )
             if obj.definition.global_phase:
-                dimension = 2 ** obj.num_qubits
+                dimension = 2**obj.num_qubits
                 op = self.compose(
                     ScalarOp(dimension, np.exp(1j * float(obj.definition.global_phase))),
                     qargs=qargs,

--- a/qiskit/quantum_info/operators/pauli.py
+++ b/qiskit/quantum_info/operators/pauli.py
@@ -60,14 +60,14 @@ def pauli_group(number_of_qubits, case="weight"):
             return sorted(tmp, key=lambda x: -np.count_nonzero(np.array(x.to_label(), "c") == b"I"))
         elif case == "tensor":
             # the Pauli set is in tensor order II IX IY IZ XI ...
-            for k in range(4 ** number_of_qubits):
+            for k in range(4**number_of_qubits):
                 z = np.zeros(number_of_qubits, dtype=bool)
                 x = np.zeros(number_of_qubits, dtype=bool)
                 # looping over all the qubits
                 for j in range(number_of_qubits):
                     # making the Pauli for each j fill it in from the
                     # end first
-                    element = (k // (4 ** j)) % 4
+                    element = (k // (4**j)) % 4
                     if element == 1:
                         x[j] = True
                     elif element == 2:

--- a/qiskit/quantum_info/operators/scalar_op.py
+++ b/qiskit/quantum_info/operators/scalar_op.py
@@ -139,7 +139,7 @@ class ScalarOp(LinearOp):
             ScalarOp: the ``coeff ** n`` ScalarOp.
         """
         ret = self.copy()
-        ret._coeff = self.coeff ** n
+        ret._coeff = self.coeff**n
         return ret
 
     def tensor(self, other):

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -408,7 +408,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
             phase += np.sum(x & z)
             phase %= 4
 
-        dim = 2 ** num_qubits
+        dim = 2**num_qubits
         twos_array = 1 << np.arange(num_qubits)
         x_indices = np.asarray(x).dot(twos_array)
         z_indices = np.asarray(z).dot(twos_array)

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -141,7 +141,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
     def __array__(self, dtype=None):
         """Convert to numpy array"""
         # pylint: disable=unused-argument
-        shape = (len(self),) + 2 * (2 ** self.num_qubits,)
+        shape = (len(self),) + 2 * (2**self.num_qubits,)
         ret = np.zeros(shape, dtype=complex)
         for i, mat in enumerate(self.matrix_iter()):
             ret[i] = mat
@@ -985,7 +985,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         # For efficiency we also allow returning a single rank-3
         # array where first index is the Pauli row, and second two
         # indices are the matrix indices
-        dim = 2 ** self.num_qubits
+        dim = 2**self.num_qubits
         ret = np.zeros((self.size, dim, dim), dtype=complex)
         iterator = self.matrix_iter(sparse=sparse)
         for i in range(self.size):

--- a/qiskit/quantum_info/operators/symplectic/pauli_table.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_table.py
@@ -935,7 +935,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         # For efficiency we also allow returning a single rank-3
         # array where first index is the Pauli row, and second two
         # indices are the matrix indices
-        dim = 2 ** self.num_qubits
+        dim = 2**self.num_qubits
         ret = np.zeros((self.size, dim, dim), dtype=complex)
         for i in range(self.size):
             ret[i] = self._to_matrix(self._array[i])
@@ -1013,7 +1013,7 @@ class PauliTable(BaseOperator, AdjointMixin):
         x = symp[0:num_qubits]
         z = symp[num_qubits : 2 * num_qubits]
 
-        dim = 2 ** num_qubits
+        dim = 2**num_qubits
         twos_array = 1 << np.arange(num_qubits)
         x_indices = np.array(x).dot(twos_array)
         z_indices = np.array(z).dot(twos_array)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -484,7 +484,7 @@ class SparsePauliOp(LinearOp):
         # Non-zero coefficients
         coeffs = []
         # Non-normalized basis factor
-        denom = 2 ** num_qubits
+        denom = 2**num_qubits
         # Compute coefficients from basis
         basis = pauli_basis(num_qubits, pauli_list=True)
         for i, mat in enumerate(basis.matrix_iter()):

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -948,7 +948,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
         # For efficiency we also allow returning a single rank-3
         # array where first index is the Pauli row, and second two
         # indices are the matrix indices
-        dim = 2 ** self.num_qubits
+        dim = 2**self.num_qubits
         ret = np.zeros((self.size, dim, dim), dtype=float)
         for i in range(self.size):
             ret[i] = self._to_matrix(self._array[i], self._phase[i])

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -592,7 +592,7 @@ class DensityMatrix(QuantumState, TolerancesMixin):
             instruction = instruction.to_instruction()
         # Initialize an the statevector in the all |0> state
         num_qubits = instruction.num_qubits
-        init = np.zeros((2 ** num_qubits, 2 ** num_qubits), dtype=complex)
+        init = np.zeros((2**num_qubits, 2**num_qubits), dtype=complex)
         init[0, 0] = 1
         vec = DensityMatrix(init, dims=num_qubits * (2,))
         vec._append_instruction(instruction)

--- a/qiskit/quantum_info/states/measures.py
+++ b/qiskit/quantum_info/states/measures.py
@@ -250,5 +250,5 @@ def entanglement_of_formation(state):
     if state.dim != 4:
         raise QiskitError("Input density matrix must be a 2-qubit state.")
     conc = concurrence(state)
-    val = (1 + np.sqrt(1 - (conc ** 2))) / 2
+    val = (1 + np.sqrt(1 - (conc**2))) / 2
     return shannon_entropy([val, 1 - val])

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -723,7 +723,7 @@ class Statevector(QuantumState, TolerancesMixin):
         if isinstance(instruction, QuantumCircuit):
             instruction = instruction.to_instruction()
         # Initialize an the statevector in the all |0> state
-        init = np.zeros(2 ** instruction.num_qubits, dtype=complex)
+        init = np.zeros(2**instruction.num_qubits, dtype=complex)
         init[0] = 1.0
         vec = Statevector(init, dims=instruction.num_qubits * (2,))
         return Statevector._evolve_instruction(vec, instruction)

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -66,7 +66,7 @@ def partial_trace(state, qargs):
     ret = state.evolve(tr_op, [qargs[0]])
     # Trace over remaining subsystems
     for qarg, dim in zip(qargs[1:], dims[1:]):
-        tr_op = SuperOp(np.eye(dim).reshape(1, dim ** 2), input_dims=[dim], output_dims=[1])
+        tr_op = SuperOp(np.eye(dim).reshape(1, dim**2), input_dims=[dim], output_dims=[1])
         ret = ret.evolve(tr_op, [qarg])
     # Remove traced over subsystems which are listed as dimension 1
     ret._op_shape = traced_shape

--- a/qiskit/quantum_info/synthesis/quaternion.py
+++ b/qiskit/quantum_info/synthesis/quaternion.py
@@ -78,9 +78,9 @@ class Quaternion:
         w, x, y, z = self.normalize().data
         mat = np.array(
             [
-                [1 - 2 * y ** 2 - 2 * z ** 2, 2 * x * y - 2 * z * w, 2 * x * z + 2 * y * w],
-                [2 * x * y + 2 * z * w, 1 - 2 * x ** 2 - 2 * z ** 2, 2 * y * z - 2 * x * w],
-                [2 * x * z - 2 * y * w, 2 * y * z + 2 * x * w, 1 - 2 * x ** 2 - 2 * y ** 2],
+                [1 - 2 * y**2 - 2 * z**2, 2 * x * y - 2 * z * w, 2 * x * z + 2 * y * w],
+                [2 * x * y + 2 * z * w, 1 - 2 * x**2 - 2 * z**2, 2 * y * z - 2 * x * w],
+                [2 * x * z - 2 * y * w, 2 * y * z + 2 * x * w, 1 - 2 * x**2 - 2 * y**2],
             ],
             dtype=float,
         )

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -1089,7 +1089,7 @@ class TwoQubitBasisDecomposer:
 
         target_decomposed = TwoQubitWeylDecomposition(target)
         traces = self.traces(target_decomposed)
-        expected_fidelities = [trace_to_fid(traces[i]) * basis_fidelity ** i for i in range(4)]
+        expected_fidelities = [trace_to_fid(traces[i]) * basis_fidelity**i for i in range(4)]
 
         best_nbasis = int(np.argmax(expected_fidelities))
         if _num_basis_uses is not None:
@@ -1400,7 +1400,7 @@ class TwoQubitBasisDecomposer:
             4 * math.cos(c),
             4,
         ]
-        return np.argmax([trace_to_fid(traces[i]) * self.basis_fidelity ** i for i in range(4)])
+        return np.argmax([trace_to_fid(traces[i]) * self.basis_fidelity**i for i in range(4)])
 
 
 # This weird duplicated lazy structure is for backwards compatibility; Qiskit has historically

--- a/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/circuits.py
@@ -62,7 +62,7 @@ def decompose_xxyy_into_xxyy_xx(a_target, b_target, a_source, b_source, interact
         1
         / 2
         * safe_arccos(
-            cminus ** 2 * ca ** 2 + sminus ** 2 * sa ** 2 - np.cos(a_target - b_target) ** 2,
+            cminus**2 * ca**2 + sminus**2 * sa**2 - np.cos(a_target - b_target) ** 2,
             2 * cminus * ca * sminus * sa,
         )
     )
@@ -70,7 +70,7 @@ def decompose_xxyy_into_xxyy_xx(a_target, b_target, a_source, b_source, interact
         1
         / 2
         * safe_arccos(
-            cplus ** 2 * ca ** 2 + splus ** 2 * sa ** 2 - np.cos(a_target + b_target) ** 2,
+            cplus**2 * ca**2 + splus**2 * sa**2 - np.cos(a_target + b_target) ** 2,
             2 * cplus * ca * splus * sa,
         )
     )

--- a/qiskit/result/mitigation/correlated_readout_mitigator.py
+++ b/qiskit/result/mitigation/correlated_readout_mitigator.py
@@ -112,7 +112,7 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
 
         # Get operator coeffs
         if diagonal is None:
-            diagonal = z_diagonal(2 ** self._num_qubits)
+            diagonal = z_diagonal(2**self._num_qubits)
         elif isinstance(diagonal, str):
             diagonal = str2diag(diagonal)
 
@@ -222,10 +222,10 @@ class CorrelatedReadoutMitigator(BaseReadoutMitigator):
         )
         num_qubits = len(qubits)
 
-        new_amat = np.zeros(2 * [2 ** num_qubits], dtype=float)
+        new_amat = np.zeros(2 * [2**num_qubits], dtype=float)
         for i, col in enumerate(self._assignment_mat.T[self._keep_indexes(qubit_indices)]):
             new_amat[i] = (
-                np.reshape(col, self._num_qubits * [2]).sum(axis=axis).reshape([2 ** num_qubits])
+                np.reshape(col, self._num_qubits * [2]).sum(axis=axis).reshape([2**num_qubits])
             )
         new_amat = new_amat.T
         return new_amat

--- a/qiskit/result/mitigation/local_readout_mitigator.py
+++ b/qiskit/result/mitigation/local_readout_mitigator.py
@@ -142,7 +142,7 @@ class LocalReadoutMitigator(BaseReadoutMitigator):
 
         # Get operator coeffs
         if diagonal is None:
-            diagonal = z_diagonal(2 ** num_qubits)
+            diagonal = z_diagonal(2**num_qubits)
         elif isinstance(diagonal, str):
             diagonal = str2diag(diagonal)
 

--- a/qiskit/result/mitigation/utils.py
+++ b/qiskit/result/mitigation/utils.py
@@ -45,8 +45,8 @@ def expval_with_stddev(coeffs: np.ndarray, probs: np.ndarray, shots: int) -> Tup
     expval = coeffs.dot(probs)
 
     # Compute variance
-    sq_expval = (coeffs ** 2).dot(probs)
-    variance = (sq_expval - expval ** 2) / shots
+    sq_expval = (coeffs**2).dot(probs)
+    variance = (sq_expval - expval**2) / shots
 
     # Compute standard deviation
     if variance < 0 and not np.isclose(variance, 0):
@@ -86,7 +86,7 @@ def str2diag(string):
 
 def counts_to_vector(counts: Counts, num_qubits: int) -> Tuple[np.ndarray, int]:
     """Transforms Counts to a probability vector"""
-    vec = np.zeros(2 ** num_qubits, dtype=float)
+    vec = np.zeros(2**num_qubits, dtype=float)
     shots = 0
     for key, val in counts.items():
         shots += val

--- a/qiskit/synthesis/evolution/qdrift.py
+++ b/qiskit/synthesis/evolution/qdrift.py
@@ -71,7 +71,7 @@ class QDrift(ProductFormula):
         weights = np.abs(coeffs)
         lambd = np.sum(weights)
 
-        num_gates = int(np.ceil(2 * (lambd ** 2) * (time ** 2) * self.reps))
+        num_gates = int(np.ceil(2 * (lambd**2) * (time**2) * self.reps))
         # The protocol calls for the removal of the individual coefficients,
         # and multiplication by a constant evolution time.
         evolution_time = lambd * time / num_gates

--- a/qiskit/transpiler/passes/optimization/commutation_analysis.py
+++ b/qiskit/transpiler/passes/optimization/commutation_analysis.py
@@ -162,7 +162,7 @@ def _commute(node1, node2, cache):
                 id_op = _COMMUTE_ID_OP[extra_qarg2]
             except KeyError:
                 id_op = _COMMUTE_ID_OP[extra_qarg2] = Operator(
-                    np.eye(2 ** extra_qarg2),
+                    np.eye(2**extra_qarg2),
                     input_dims=(2,) * extra_qarg2,
                     output_dims=(2,) * extra_qarg2,
                 )

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -149,19 +149,19 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
         """
         backend_prop = self.backend_prop
         for qid in range(len(backend_prop.qubits)):
-            self.bp_t1_time[qid] = int(backend_prop.t1(qid) * 10 ** 9)
-            self.bp_t2_time[qid] = int(backend_prop.t2(qid) * 10 ** 9)
-            self.bp_u1_dur[qid] = int(backend_prop.gate_length("u1", qid)) * 10 ** 9
+            self.bp_t1_time[qid] = int(backend_prop.t1(qid) * 10**9)
+            self.bp_t2_time[qid] = int(backend_prop.t2(qid) * 10**9)
+            self.bp_u1_dur[qid] = int(backend_prop.gate_length("u1", qid)) * 10**9
             u1_err = backend_prop.gate_error("u1", qid)
             if u1_err == 1.0:
                 u1_err = 0.9999
             self.bp_u1_err = round(u1_err, NUM_PREC)
-            self.bp_u2_dur[qid] = int(backend_prop.gate_length("u2", qid)) * 10 ** 9
+            self.bp_u2_dur[qid] = int(backend_prop.gate_length("u2", qid)) * 10**9
             u2_err = backend_prop.gate_error("u2", qid)
             if u2_err == 1.0:
                 u2_err = 0.9999
             self.bp_u2_err = round(u2_err, NUM_PREC)
-            self.bp_u3_dur[qid] = int(backend_prop.gate_length("u3", qid)) * 10 ** 9
+            self.bp_u3_dur[qid] = int(backend_prop.gate_length("u3", qid)) * 10**9
             u3_err = backend_prop.gate_error("u3", qid)
             if u3_err == 1.0:
                 u3_err = 0.9999
@@ -171,7 +171,7 @@ class CrosstalkAdaptiveSchedule(TransformationPass):
                 q_0 = ginfo.qubits[0]
                 q_1 = ginfo.qubits[1]
                 cx_tup = (min(q_0, q_1), max(q_0, q_1))
-                self.bp_cx_dur[cx_tup] = int(backend_prop.gate_length("cx", cx_tup)) * 10 ** 9
+                self.bp_cx_dur[cx_tup] = int(backend_prop.gate_length("cx", cx_tup)) * 10**9
                 cx_err = backend_prop.gate_error("cx", cx_tup)
                 if cx_err == 1.0:
                     cx_err = 0.9999

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -176,7 +176,7 @@ class StochasticSwap(TransformationPass):
         best_circuit = None  # initialize best swap circuit
         best_layout = None  # initialize best final layout
 
-        cdist2 = coupling._dist_matrix ** 2
+        cdist2 = coupling._dist_matrix**2
         # Scaling matrix
         scale = np.zeros((num_qubits, num_qubits))
 

--- a/qiskit/transpiler/synthesis/aqc/cnot_structures.py
+++ b/qiskit/transpiler/synthesis/aqc/cnot_structures.py
@@ -34,7 +34,7 @@ def _lower_limit(num_qubits: int) -> int:
     Returns:
         lower limit on the number of CNOT units.
     """
-    num_cnots = round(np.ceil((4 ** num_qubits - 3 * num_qubits - 1) / 4.0))
+    num_cnots = round(np.ceil((4**num_qubits - 3 * num_qubits - 1) / 4.0))
     return num_cnots
 
 

--- a/qiskit/transpiler/synthesis/aqc/cnot_unit_objective.py
+++ b/qiskit/transpiler/synthesis/aqc/cnot_unit_objective.py
@@ -78,7 +78,7 @@ class DefaultCNOTUnitObjective(CNOTUnitObjective):
         # rename parameters just to make shorter and make use of our dictionary
         thetas = param_values
         n = self._num_qubits
-        d = int(2 ** n)
+        d = int(2**n)
         cnots = self._cnots
         num_cnots = self.num_cnots
 
@@ -183,7 +183,7 @@ class DefaultCNOTUnitObjective(CNOTUnitObjective):
         pauli_z = np.multiply(-1j / 2, np.array([[1, 0], [0, -1]]))
 
         n = self._num_qubits
-        d = int(2 ** n)
+        d = int(2**n)
         cnots = self._cnots
         num_cnots = self.num_cnots
 

--- a/qiskit/transpiler/synthesis/aqc/elementary_operations.py
+++ b/qiskit/transpiler/synthesis/aqc/elementary_operations.py
@@ -31,7 +31,7 @@ def place_unitary(unitary: np.ndarray, n: int, j: int) -> np.ndarray:
     Returns:
         a unitary of n qubits with u in position j.
     """
-    return np.kron(np.kron(np.eye(2 ** j), unitary), np.eye(2 ** (n - 1 - j)))
+    return np.kron(np.kron(np.eye(2**j), unitary), np.eye(2 ** (n - 1 - j)))
 
 
 def place_cnot(n: int, j: int, k: int) -> np.ndarray:
@@ -48,20 +48,20 @@ def place_cnot(n: int, j: int, k: int) -> np.ndarray:
     """
     if j < k:
         unitary = np.kron(
-            np.kron(np.eye(2 ** j), [[1, 0], [0, 0]]), np.eye(2 ** (n - 1 - j))
+            np.kron(np.eye(2**j), [[1, 0], [0, 0]]), np.eye(2 ** (n - 1 - j))
         ) + np.kron(
             np.kron(
-                np.kron(np.kron(np.eye(2 ** j), [[0, 0], [0, 1]]), np.eye(2 ** (k - j - 1))),
+                np.kron(np.kron(np.eye(2**j), [[0, 0], [0, 1]]), np.eye(2 ** (k - j - 1))),
                 [[0, 1], [1, 0]],
             ),
             np.eye(2 ** (n - 1 - k)),
         )
     else:
         unitary = np.kron(
-            np.kron(np.eye(2 ** j), [[1, 0], [0, 0]]), np.eye(2 ** (n - 1 - j))
+            np.kron(np.eye(2**j), [[1, 0], [0, 0]]), np.eye(2 ** (n - 1 - j))
         ) + np.kron(
             np.kron(
-                np.kron(np.kron(np.eye(2 ** k), [[0, 1], [1, 0]]), np.eye(2 ** (j - k - 1))),
+                np.kron(np.kron(np.eye(2**k), [[0, 1], [1, 0]]), np.eye(2 ** (j - k - 1))),
                 [[0, 0], [0, 1]],
             ),
             np.eye(2 ** (n - 1 - j)),

--- a/qiskit/utils/arithmetic.py
+++ b/qiskit/utils/arithmetic.py
@@ -52,14 +52,14 @@ def is_power(num, return_decomposition=False):
     Check if num is a perfect power in O(n^3) time, n=ceil(logN)
     """
     b = 2
-    while (2 ** b) <= num:
+    while (2**b) <= num:
         a = 1
         c = num
         while (c - a) >= 2:
             m = int((a + c) / 2)
 
-            if (m ** b) < (num + 1):
-                p = int(m ** b)
+            if (m**b) < (num + 1):
+                p = int(m**b)
             else:
                 p = int(num + 1)
 

--- a/qiskit/utils/mitigation/_filters.py
+++ b/qiskit/utils/mitigation/_filters.py
@@ -356,7 +356,7 @@ class TensoredFilter:
         from scipy import linalg as la
 
         all_states = count_keys(self.nqubits)
-        num_of_states = 2 ** self.nqubits
+        num_of_states = 2**self.nqubits
 
         if meas_layout is None:
             meas_layout = []

--- a/qiskit/utils/mitigation/circuits.py
+++ b/qiskit/utils/mitigation/circuits.py
@@ -32,7 +32,7 @@ def count_keys(num_qubits: int) -> List[str]:
         >>> count_keys(3)
         ['000', '001', '010', '011', '100', '101', '110', '111']
     """
-    return [bin(j)[2:].zfill(num_qubits) for j in range(2 ** num_qubits)]
+    return [bin(j)[2:].zfill(num_qubits) for j in range(2**num_qubits)]
 
 
 def complete_meas_cal(

--- a/qiskit/utils/mitigation/fitters.py
+++ b/qiskit/utils/mitigation/fitters.py
@@ -391,7 +391,7 @@ class TensoredMeasFitter:
         # initialize the set of empty calibration matrices
         self._cal_matrices = []
         for list_size in self._qubit_list_sizes:
-            self._cal_matrices.append(np.zeros([2 ** list_size, 2 ** list_size], dtype=float))
+            self._cal_matrices.append(np.zeros([2**list_size, 2**list_size], dtype=float))
 
         # go through for each calibration experiment
         for result in self._result_list:

--- a/qiskit/utils/multiprocessing.py
+++ b/qiskit/utils/multiprocessing.py
@@ -33,7 +33,7 @@ def local_hardware_info():
         "python_build": ", ".join(platform.python_build()),
         "python_version": platform.python_version(),
         "os": platform.system(),
-        "memory": psutil.virtual_memory().total / (1024 ** 3),
+        "memory": psutil.virtual_memory().total / (1024**3),
         "cpus": psutil.cpu_count(logical=False) or 1,
     }
     return results

--- a/qiskit/visualization/pulse_v2/generators/frame.py
+++ b/qiskit/visualization/pulse_v2/generators/frame.py
@@ -95,7 +95,7 @@ def gen_formatted_phase(
         xvals=[data.t0],
         yvals=[formatter["label_offset.frame_change"]],
         text=f"VZ({plain_phase})",
-        latex=fr"{{\rm VZ}}({latex_phase})",
+        latex=rf"{{\rm VZ}}({latex_phase})",
         ignore_scaling=True,
         styles=style,
     )
@@ -143,7 +143,7 @@ def gen_formatted_freq_mhz(
         xvals=[data.t0],
         yvals=[formatter["label_offset.frame_change"]],
         text=f"\u0394f = {plain_freq}",
-        latex=fr"\Delta f = {latex_freq}",
+        latex=rf"\Delta f = {latex_freq}",
         ignore_scaling=True,
         styles=style,
     )
@@ -198,7 +198,7 @@ def gen_formatted_frame_values(
             xvals=[data.t0],
             yvals=[formatter["label_offset.frame_change"]],
             text=f"VZ({plain_phase})",
-            latex=fr"{{\rm VZ}}({latex_phase})",
+            latex=rf"{{\rm VZ}}({latex_phase})",
             ignore_scaling=True,
             styles=phase_style,
         )
@@ -218,7 +218,7 @@ def gen_formatted_frame_values(
             xvals=[data.t0],
             yvals=[2 * formatter["label_offset.frame_change"]],
             text=f"\u0394f = {plain_freq}",
-            latex=fr"\Delta f = {latex_freq}",
+            latex=rf"\Delta f = {latex_freq}",
             ignore_scaling=True,
             styles=freq_style,
         )
@@ -382,7 +382,7 @@ def _phase_to_text(
     denom = frac.denominator
     if denom > max_denom:
         # denominator is too large
-        latex = fr"{np.abs(phase):.2f}"
+        latex = rf"{np.abs(phase):.2f}"
         plain = f"{np.abs(phase):.2f}"
     else:
         if num == 1:
@@ -390,10 +390,10 @@ def _phase_to_text(
                 latex = r"\pi"
                 plain = "pi"
             else:
-                latex = fr"\pi/{denom:d}"
+                latex = rf"\pi/{denom:d}"
                 plain = f"pi/{denom:d}"
         else:
-            latex = fr"{num:d}/{denom:d} \pi"
+            latex = rf"{num:d}/{denom:d} \pi"
             plain = f"{num:d}/{denom:d} pi"
 
     if flip:
@@ -431,7 +431,7 @@ def _freq_to_text(formatter: Dict[str, Any], freq: float, unit: str = "MHz") -> 
     except KeyError as ex:
         raise VisualizationError(f"Unit {unit} is not supported.") from ex
 
-    latex = fr"{value:.2f}~{{\rm {unit}}}"
+    latex = rf"{value:.2f}~{{\rm {unit}}}"
     plain = f"{value:.2f} {unit}"
 
     return plain, latex

--- a/qiskit/visualization/pulse_v2/generators/waveform.py
+++ b/qiskit/visualization/pulse_v2/generators/waveform.py
@@ -186,7 +186,7 @@ def gen_ibmq_latex_waveform_name(
                 angle_val = match_dict["angle"]
                 frac = Fraction(int(int(angle_val) / 2), 180)
                 if frac.numerator == 1:
-                    angle = fr"\pi/{frac.denominator:d}"
+                    angle = rf"\pi/{frac.denominator:d}"
                 else:
                     angle = r"{num:d}/{denom:d} \pi".format(
                         num=frac.numerator, denom=frac.denominator
@@ -200,12 +200,12 @@ def gen_ibmq_latex_waveform_name(
                 else:
                     frac = Fraction(int(angle_val), 180)
                     if frac.numerator == 1:
-                        angle = fr"\pi/{frac.denominator:d}"
+                        angle = rf"\pi/{frac.denominator:d}"
                     else:
                         angle = r"{num:d}/{denom:d} \pi".format(
                             num=frac.numerator, denom=frac.denominator
                         )
-            latex_name = fr"{op_name}({sign}{angle})"
+            latex_name = rf"{op_name}({sign}{angle})"
         else:
             latex_name = None
 

--- a/qiskit/visualization/pulse_v2/plotters/matplotlib.py
+++ b/qiskit/visualization/pulse_v2/plotters/matplotlib.py
@@ -109,7 +109,7 @@ class Mpl2DPlotter(BasePlotter):
                         self.ax.plot(x, y, **data.styles)
                 elif isinstance(data, drawings.TextData):
                     # text object
-                    text = fr"${data.latex}$" if data.latex else data.text
+                    text = rf"${data.latex}$" if data.latex else data.text
                     # replace dynamic text
                     text = text.replace(types.DynamicString.SCALE, f"{chart.scale:.1f}")
                     self.ax.text(x=x[0], y=y[0], s=text, **data.styles)

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -107,8 +107,8 @@ def plot_state_hinton(
             fig = ax_imag.get_figure()
         ax1 = ax_real
         ax2 = ax_imag
-    column_names = [bin(i)[2:].zfill(num) for i in range(2 ** num)]
-    row_names = [bin(i)[2:].zfill(num) for i in range(2 ** num)]
+    column_names = [bin(i)[2:].zfill(num) for i in range(2**num)]
+    row_names = [bin(i)[2:].zfill(num) for i in range(2**num)]
     ly, lx = datareal.shape
     # Real
     if ax1:
@@ -363,8 +363,8 @@ def plot_state_city(
     dataimag = np.imag(rho.data)
 
     # get the labels
-    column_names = [bin(i)[2:].zfill(num) for i in range(2 ** num)]
-    row_names = [bin(i)[2:].zfill(num) for i in range(2 ** num)]
+    column_names = [bin(i)[2:].zfill(num) for i in range(2**num)]
+    row_names = [bin(i)[2:].zfill(num) for i in range(2**num)]
 
     lx = len(datareal[0])  # Work out matrix dimensions
     ly = len(datareal[:, 0])
@@ -789,7 +789,7 @@ def plot_state_qsphere(
             state = angleset * state
 
             d = num
-            for i in range(2 ** num):
+            for i in range(2**num):
                 # get x,y,z points
                 element = bin(i)[2:].zfill(num)
                 weight = element.count("1")
@@ -805,8 +805,8 @@ def plot_state_qsphere(
                 ):
                     angle = np.pi - angle - (2 * np.pi / number_of_divisions)
 
-                xvalue = np.sqrt(1 - zvalue ** 2) * np.cos(angle)
-                yvalue = np.sqrt(1 - zvalue ** 2) * np.sin(angle)
+                xvalue = np.sqrt(1 - zvalue**2) * np.cos(angle)
+                yvalue = np.sqrt(1 - zvalue**2) * np.sin(angle)
 
                 # get prob and angle - prob will be shade and angle color
                 prob = np.real(np.dot(state[i], state[i].conj()))
@@ -819,7 +819,7 @@ def plot_state_qsphere(
 
                 if not np.isclose(prob, 0) and show_state_labels:
                     rprime = 1.3
-                    angle_theta = np.arctan2(np.sqrt(1 - zvalue ** 2), zvalue)
+                    angle_theta = np.arctan2(np.sqrt(1 - zvalue**2), zvalue)
                     xvalue_text = rprime * np.sin(angle_theta) * np.cos(angle)
                     yvalue_text = rprime * np.sin(angle_theta) * np.sin(angle)
                     zvalue_text = rprime * np.cos(angle_theta)
@@ -868,7 +868,7 @@ def plot_state_qsphere(
             for weight in range(d + 1):
                 theta = np.linspace(-2 * np.pi, 2 * np.pi, 100)
                 z = -2 * weight / d + 1
-                r = np.sqrt(1 - z ** 2)
+                r = np.sqrt(1 - z**2)
                 x = r * np.cos(theta)
                 y = r * np.sin(theta)
                 ax.plot(x, y, z, color=(0.5, 0.5, 0.5), lw=1, ls=":", alpha=0.5)

--- a/qiskit/visualization/timeline/generators.py
+++ b/qiskit/visualization/timeline/generators.py
@@ -227,11 +227,11 @@ def gen_full_gate_name(
         "ha": "center",
     }
     # find latex representation
-    default_name = fr"{{\rm {gate.operand.name}}}"
+    default_name = rf"{{\rm {gate.operand.name}}}"
     latex_name = formatter["latex_symbol.gates"].get(gate.operand.name, default_name)
 
     label_plain = f"{gate.operand.name}"
-    label_latex = fr"{latex_name}"
+    label_latex = rf"{latex_name}"
 
     # bit index
     with warnings.catch_warnings():
@@ -313,7 +313,7 @@ def gen_short_gate_name(
         "ha": "center",
     }
     # find latex representation
-    default_name = fr"{{\rm {gate.operand.name}}}"
+    default_name = rf"{{\rm {gate.operand.name}}}"
     latex_name = formatter["latex_symbol.gates"].get(gate.operand.name, default_name)
 
     label_plain = f"{gate.operand.name}"

--- a/qiskit/visualization/timeline/plotters/matplotlib.py
+++ b/qiskit/visualization/timeline/plotters/matplotlib.py
@@ -120,7 +120,7 @@ class MplPlotter(BasePlotter):
             elif isinstance(data, drawings.TextData):
                 # text data
                 if data.latex is not None:
-                    s = fr"${data.latex}$"
+                    s = rf"${data.latex}$"
                 else:
                     s = data.text
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ ipywidgets>=7.3.0
 jupyter
 matplotlib>=3.3
 pillow>=4.2.1
-black[jupyter]==21.12b0
+black[jupyter]~=22.0
 pydot
 astroid==2.5.6
 pylint==2.8.3

--- a/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -490,7 +490,7 @@ class TestMatplotlibDrawer(QiskitTestCase):
         """Tests scale
         See: https://github.com/Qiskit/qiskit-terra/issues/4179"""
         circuit = QuantumCircuit(5)
-        circuit.unitary(random_unitary(2 ** 5), circuit.qubits)
+        circuit.unitary(random_unitary(2**5), circuit.qubits)
 
         self.circuit_drawer(circuit, filename="scale_default.png")
         self.circuit_drawer(circuit, filename="scale_half.png", scale=0.5)
@@ -754,7 +754,7 @@ class TestMatplotlibDrawer(QiskitTestCase):
     def test_overwide_gates(self):
         """Test gates don't exceed width of default fold"""
         circuit = QuantumCircuit(5)
-        initial_state = np.zeros(2 ** 5)
+        initial_state = np.zeros(2**5)
         initial_state[5] = 1
         circuit.initialize(initial_state)
         self.circuit_drawer(circuit, filename="wide_params.png")

--- a/test/python/algorithms/optimizers/test_gradient_descent.py
+++ b/test/python/algorithms/optimizers/test_gradient_descent.py
@@ -95,7 +95,7 @@ class TestGradientDescent(QiskitAlgorithmsTestCase):
             def powerlaw():
                 n = 0
                 while True:
-                    yield constant_coeff * (n ** power)
+                    yield constant_coeff * (n**power)
                     n += 1
 
             return powerlaw()

--- a/test/python/algorithms/optimizers/test_optimizers.py
+++ b/test/python/algorithms/optimizers/test_optimizers.py
@@ -328,7 +328,7 @@ class TestOptimizerSerialization(QiskitAlgorithmsTestCase):
         def powerlaw():
             n = 0
             while True:
-                yield rate ** n
+                yield rate**n
                 n += 1
 
         def steps():

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -81,7 +81,7 @@ class TestSPSA(QiskitAlgorithmsTestCase):
         """Test SPSA calibrates anew upon each optimization run, if no autocalibration is set."""
 
         def objective(x):
-            return -(x ** 2)
+            return -(x**2)
 
         spsa = SPSA(maxiter=1)
         _ = spsa.optimize(1, objective, initial_point=np.array([0.5]))

--- a/test/python/algorithms/test_amplitude_estimators.py
+++ b/test/python/algorithms/test_amplitude_estimators.py
@@ -72,9 +72,9 @@ class SineIntegral(QuantumCircuit):
         self.h(qr_state)
 
         # apply the sine/cosine term
-        self.ry(2 * 1 / 2 / 2 ** num_qubits, qr_objective[0])
+        self.ry(2 * 1 / 2 / 2**num_qubits, qr_objective[0])
         for i, qubit in enumerate(qr_state):
-            self.cry(2 * 2 ** i / 2 ** num_qubits, qubit, qr_objective[0])
+            self.cry(2 * 2**i / 2**num_qubits, qubit, qr_objective[0])
 
 
 @ddt
@@ -197,7 +197,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
             if efficient_circuit:
                 qae.grover_operator = BernoulliGrover(prob)
                 for power in range(m):
-                    circuit.cry(2 * 2 ** power * angle, qr_eval[power], qr_objective[0])
+                    circuit.cry(2 * 2**power * angle, qr_eval[power], qr_objective[0])
             else:
                 oracle = QuantumCircuit(1)
                 oracle.z(0)
@@ -207,7 +207,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
                 grover_op = GroverOperator(oracle, state_preparation)
                 for power in range(m):
                     circuit.compose(
-                        grover_op.power(2 ** power).control(),
+                        grover_op.power(2**power).control(),
                         qubits=[qr_eval[power], qr_objective[0]],
                         inplace=True,
                     )
@@ -286,7 +286,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
                 # Q^(2^j) operator
                 if efficient_circuit:
                     qae.grover_operator = BernoulliGrover(prob)
-                    circuit.ry(2 * 2 ** power * angle, q_objective[0])
+                    circuit.ry(2 * 2**power * angle, q_objective[0])
 
                 else:
                     oracle = QuantumCircuit(1)
@@ -294,7 +294,7 @@ class TestBernoulli(QiskitAlgorithmsTestCase):
                     state_preparation = QuantumCircuit(1)
                     state_preparation.ry(angle, 0)
                     grover_op = GroverOperator(oracle, state_preparation)
-                    for _ in range(2 ** power):
+                    for _ in range(2**power):
                         circuit.compose(grover_op, inplace=True)
                 circuits += [circuit]
 

--- a/test/python/algorithms/test_grover.py
+++ b/test/python/algorithms/test_grover.py
@@ -164,7 +164,7 @@ class TestGrover(QiskitAlgorithmsTestCase):
         n = 5
         problem = AmplificationProblem(Statevector.from_label("1" * n), is_good_state=["1" * n])
         result = grover.amplify(problem)
-        self.assertEqual(len(result.iterations), 2 ** n)
+        self.assertEqual(len(result.iterations), 2**n)
 
     def test_max_power(self):
         """Test the iteration stops when the maximum power is reached."""
@@ -209,8 +209,8 @@ class TestGrover(QiskitAlgorithmsTestCase):
     def test_optimal_num_iterations(self):
         """Test optimal_num_iterations"""
         num_qubits = 7
-        for num_solutions in range(1, 2 ** num_qubits):
-            amplitude = np.sqrt(num_solutions / 2 ** num_qubits)
+        for num_solutions in range(1, 2**num_qubits):
+            amplitude = np.sqrt(num_solutions / 2**num_qubits)
             expected = round(np.arccos(amplitude) / (2 * np.arcsin(amplitude)))
             actual = Grover.optimal_num_iterations(num_solutions, num_qubits)
         self.assertEqual(actual, expected)

--- a/test/python/algorithms/test_linear_solvers.py
+++ b/test/python/algorithms/test_linear_solvers.py
@@ -185,21 +185,21 @@ class TestReciprocal(QiskitAlgorithmsTestCase):
         qc.append(reciprocal, list(range(num_qubits + 1 + neg_vals)))
 
         # Create the operator 0
-        state_vec = quantum_info.Statevector.from_instruction(qc).data[-(2 ** num_qubits) :]
+        state_vec = quantum_info.Statevector.from_instruction(qc).data[-(2**num_qubits) :]
 
         # Remove the factor from the hadamards
         state_vec *= np.sqrt(2) ** num_qubits
 
         # Analytic value
         exact = []
-        for i in range(0, 2 ** num_qubits):
+        for i in range(0, 2**num_qubits):
             if i == 0:
                 exact.append(0)
             else:
                 if neg_vals:
-                    exact.append(-scaling / (1 - i / (2 ** num_qubits)))
+                    exact.append(-scaling / (1 - i / (2**num_qubits)))
                 else:
-                    exact.append(scaling * (2 ** num_qubits) / i)
+                    exact.append(scaling * (2**num_qubits) / i)
 
         np.testing.assert_array_almost_equal(state_vec, exact, decimal=2)
 

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -226,7 +226,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.assertWarns(DeprecationWarning):
             optimal_vector = vqe.get_optimal_vector()
 
-        self.assertAlmostEqual(sum(v ** 2 for v in optimal_vector.values()), 1.0, places=4)
+        self.assertAlmostEqual(sum(v**2 for v in optimal_vector.values()), 1.0, places=4)
 
     @unittest.skipUnless(has_aer(), "qiskit-aer doesn't appear to be installed.")
     def test_with_aer_statevector(self):

--- a/test/python/basicaer/test_statevector_simulator.py
+++ b/test/python/basicaer/test_statevector_simulator.py
@@ -65,12 +65,12 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         # Test 1 to max_qubits for random n-qubit unitary gate
         for i in range(max_qubits):
             num_qubits = i + 1
-            psi_init = np.zeros(2 ** num_qubits)
+            psi_init = np.zeros(2**num_qubits)
             psi_init[0] = 1.0
             qr = QuantumRegister(num_qubits, "qr")
             for _ in range(num_trials):
                 # Create random unitary
-                unitary = random_unitary(2 ** num_qubits)
+                unitary = random_unitary(2**num_qubits)
                 # Compute expected output state
                 psi_target = unitary.data.dot(psi_init)
                 # Simulate output on circuit
@@ -92,7 +92,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.circuit = circ
         result = super().test_run_circuit()
         actual = result.get_statevector(self.circuit)
-        expected = np.exp(1j * circ.global_phase) * np.repeat([[0], [1]], [n_qubits ** 2 - 1, 1])
+        expected = np.exp(1j * circ.global_phase) * np.repeat([[0], [1]], [n_qubits**2 - 1, 1])
         self.assertTrue(np.allclose(actual, expected))
 
     def test_global_phase_composite(self):
@@ -110,7 +110,7 @@ class StatevectorSimulatorTest(providers.BackendTestCase):
         self.circuit = comp
         result = super().test_run_circuit()
         actual = result.get_statevector(self.circuit)
-        expected = np.exp(1j * 0.6) * np.repeat([[0], [1]], [n_qubits ** 2 - 1, 1])
+        expected = np.exp(1j * 0.6) * np.repeat([[0], [1]], [n_qubits**2 - 1, 1])
         self.assertTrue(np.allclose(actual, expected))
 
 

--- a/test/python/basicaer/test_unitary_simulator.py
+++ b/test/python/basicaer/test_unitary_simulator.py
@@ -98,11 +98,11 @@ class BasicAerUnitarySimulatorPyTest(providers.BackendTestCase):
         # Test 1 to max_qubits for random n-qubit unitary gate
         for i in range(max_qubits):
             num_qubits = i + 1
-            unitary_init = Operator(np.eye(2 ** num_qubits))
+            unitary_init = Operator(np.eye(2**num_qubits))
             qr = QuantumRegister(num_qubits, "qr")
             for _ in range(num_trials):
                 # Create random unitary
-                unitary = random_unitary(2 ** num_qubits)
+                unitary = random_unitary(2**num_qubits)
                 # Compute expected output state
                 unitary_target = unitary.dot(unitary_init)
                 # Simulate output on circuit

--- a/test/python/circuit/library/test_adders.py
+++ b/test/python/circuit/library/test_adders.py
@@ -66,15 +66,15 @@ class TestAdder(QiskitTestCase):
         expectations = np.zeros_like(probabilities)
         num_bits_sum = num_state_qubits + 1
         # iterate over all possible inputs
-        for x in range(2 ** num_state_qubits):
-            for y in range(2 ** num_state_qubits):
+        for x in range(2**num_state_qubits):
+            for y in range(2**num_state_qubits):
                 # compute the sum
                 if kind == "full":
                     additions = [x + y, 1 + x + y]
                 elif kind == "half":
                     additions = [x + y]
                 else:
-                    additions = [(x + y) % (2 ** num_state_qubits)]
+                    additions = [(x + y) % (2**num_state_qubits)]
 
                 # compute correct index in statevector
                 bin_x = bin(x)[2:].zfill(num_state_qubits)
@@ -95,7 +95,7 @@ class TestAdder(QiskitTestCase):
                         )
 
                     index = int(bin_index, 2)
-                    expectations[index] += 1 / 2 ** num_superpos_qubits
+                    expectations[index] += 1 / 2**num_superpos_qubits
 
         np.testing.assert_array_almost_equal(expectations, probabilities)
 

--- a/test/python/circuit/library/test_boolean_logic.py
+++ b/test/python/circuit/library/test_boolean_logic.py
@@ -44,12 +44,12 @@ class TestBooleanLogicLibrary(QiskitTestCase):
         # compute the expected outcome by computing the entries of the statevector that should
         # have a 1 / sqrt(2**n) factor
         expectations = np.zeros_like(probabilities)
-        for x in range(2 ** boolean_circuit.num_variable_qubits):
+        for x in range(2**boolean_circuit.num_variable_qubits):
             bits = np.array(list(bin(x)[2:].zfill(boolean_circuit.num_variable_qubits)), dtype=int)
             result = reference(bits[::-1])
 
             entry = int(str(int(result)) + bin(x)[2:].zfill(boolean_circuit.num_variable_qubits), 2)
-            expectations[entry] = 1 / 2 ** boolean_circuit.num_variable_qubits
+            expectations[entry] = 1 / 2**boolean_circuit.num_variable_qubits
 
         np.testing.assert_array_almost_equal(probabilities, expectations)
 

--- a/test/python/circuit/library/test_diagonal.py
+++ b/test/python/circuit/library/test_diagonal.py
@@ -31,9 +31,9 @@ class TestDiagonalGate(QiskitTestCase):
         [0, 0.8],
         [0, 0, 1, 1],
         [0, 1, 0.5, 1],
-        (2 * np.pi * np.random.rand(2 ** 3)),
-        (2 * np.pi * np.random.rand(2 ** 4)),
-        (2 * np.pi * np.random.rand(2 ** 5)),
+        (2 * np.pi * np.random.rand(2**3)),
+        (2 * np.pi * np.random.rand(2**4)),
+        (2 * np.pi * np.random.rand(2**5)),
     )
     def test_diag_gate(self, phases):
         """Test correctness of diagonal decomposition."""

--- a/test/python/circuit/library/test_evolution_gate.py
+++ b/test/python/circuit/library/test_evolution_gate.py
@@ -290,4 +290,4 @@ class TestEvolutionGate(QiskitTestCase):
         circuit.append(evo, circuit.qubits)
         circuit.append(evo.inverse(), circuit.qubits)
 
-        self.assertTrue(Operator(circuit).equiv(np.identity(2 ** circuit.num_qubits)))
+        self.assertTrue(Operator(circuit).equiv(np.identity(2**circuit.num_qubits)))

--- a/test/python/circuit/library/test_functional_pauli_rotations.py
+++ b/test/python/circuit/library/test_functional_pauli_rotations.py
@@ -52,9 +52,9 @@ class TestFunctionalPauliRotations(QiskitTestCase):
         for i, probability in probabilities.items():
             x, last_qubit = int(i[1:], 2), i[0]
             if last_qubit == "0":
-                expected_amplitude = np.cos(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.cos(reference(x)) / np.sqrt(2**num_state_qubits)
             else:
-                expected_amplitude = np.sin(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.sin(reference(x)) / np.sqrt(2**num_state_qubits)
 
             unrolled_probabilities += [probability]
             unrolled_expectations += [np.real(np.abs(expected_amplitude) ** 2)]
@@ -71,7 +71,7 @@ class TestFunctionalPauliRotations(QiskitTestCase):
         """Test the polynomial rotation."""
 
         def poly(x):
-            res = sum(coeff * x ** i for i, coeff in enumerate(coeffs))
+            res = sum(coeff * x**i for i, coeff in enumerate(coeffs))
             return res
 
         polynome = PolynomialPauliRotations(num_state_qubits, [2 * coeff for coeff in coeffs])
@@ -92,12 +92,12 @@ class TestFunctionalPauliRotations(QiskitTestCase):
 
         with self.subTest(msg="setting non-default values"):
             polynomial_rotations.coeffs = [0, 1.2 * 2, 0.4 * 2]
-            self.assertFunctionIsCorrect(polynomial_rotations, lambda x: 1.2 * x + 0.4 * x ** 2)
+            self.assertFunctionIsCorrect(polynomial_rotations, lambda x: 1.2 * x + 0.4 * x**2)
 
         with self.subTest(msg="changing of all values"):
             polynomial_rotations.num_state_qubits = 4
             polynomial_rotations.coeffs = [1 * 2, 0, 0, -0.5 * 2]
-            self.assertFunctionIsCorrect(polynomial_rotations, lambda x: 1 - 0.5 * x ** 3)
+            self.assertFunctionIsCorrect(polynomial_rotations, lambda x: 1 - 0.5 * x**3)
 
     @data(
         (2, 0.1, 0),

--- a/test/python/circuit/library/test_grover_operator.py
+++ b/test/python/circuit/library/test_grover_operator.py
@@ -36,7 +36,7 @@ class TestGroverOperator(QiskitTestCase):
         state_in = Operator(state_in)
 
         if zero_reflection is None:
-            zero_reflection = np.eye(2 ** oracle.num_qubits)
+            zero_reflection = np.eye(2**oracle.num_qubits)
             zero_reflection[0][0] = -1
         zero_reflection = Operator(zero_reflection)
 

--- a/test/python/circuit/library/test_hidden_linear_function.py
+++ b/test/python/circuit/library/test_hidden_linear_function.py
@@ -35,8 +35,8 @@ class TestHiddenLinearFunctionLibrary(QiskitTestCase):
         hidden_function = np.asarray(hidden_function)
         simulated = Operator(hlf)
 
-        expected = np.zeros((2 ** num_qubits, 2 ** num_qubits), dtype=complex)
-        for i in range(2 ** num_qubits):
+        expected = np.zeros((2**num_qubits, 2**num_qubits), dtype=complex)
+        for i in range(2**num_qubits):
             i_qiskit = int(bin(i)[2:].zfill(num_qubits)[::-1], 2)
             x_vec = np.asarray(list(map(int, bin(i)[2:].zfill(num_qubits)[::-1])))
             expected[i_qiskit, i_qiskit] = 1j ** (

--- a/test/python/circuit/library/test_integer_comparator.py
+++ b/test/python/circuit/library/test_integer_comparator.py
@@ -39,7 +39,7 @@ class TestIntegerComparator(QiskitTestCase):
             prob = np.abs(amplitude) ** 2
             if prob > 1e-6:
                 # equal superposition
-                self.assertEqual(True, np.isclose(1.0, prob * 2.0 ** num_state_qubits))
+                self.assertEqual(True, np.isclose(1.0, prob * 2.0**num_state_qubits))
                 b_value = f"{i:b}".rjust(qc.width(), "0")
                 x = int(b_value[(-num_state_qubits):], 2)
                 comp_result = int(b_value[-num_state_qubits - 1], 2)

--- a/test/python/circuit/library/test_linear_amplitude_function.py
+++ b/test/python/circuit/library/test_linear_amplitude_function.py
@@ -50,9 +50,9 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
         for i, probability in probabilities.items():
             x, last_qubit = int(i[1:], 2), i[0]
             if last_qubit == "0":
-                expected_amplitude = np.cos(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.cos(reference(x)) / np.sqrt(2**num_state_qubits)
             else:
-                expected_amplitude = np.sin(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.sin(reference(x)) / np.sqrt(2**num_state_qubits)
 
             unrolled_probabilities += [probability]
             unrolled_expectations += [np.real(np.abs(expected_amplitude) ** 2)]
@@ -67,7 +67,7 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
         c, d = image
 
         # map integer x to the domain of the function
-        x = a + (b - a) / (2 ** num_qubits - 1) * x_int
+        x = a + (b - a) / (2**num_qubits - 1) * x_int
 
         # apply the function
         if breakpoints is None:

--- a/test/python/circuit/library/test_multipliers.py
+++ b/test/python/circuit/library/test_multipliers.py
@@ -61,10 +61,10 @@ class TestMultiplier(QiskitTestCase):
         expectations = np.zeros_like(probabilities)
         num_bits_product = num_state_qubits * 2
         # iterate over all possible inputs
-        for x in range(2 ** num_state_qubits):
-            for y in range(2 ** num_state_qubits):
+        for x in range(2**num_state_qubits):
+            for y in range(2**num_state_qubits):
                 # compute the product
-                product = x * y % (2 ** num_result_qubits)
+                product = x * y % (2**num_result_qubits)
                 # compute correct index in statevector
                 bin_x = bin(x)[2:].zfill(num_state_qubits)
                 bin_y = bin(y)[2:].zfill(num_state_qubits)

--- a/test/python/circuit/library/test_phase_oracle.py
+++ b/test/python/circuit/library/test_phase_oracle.py
@@ -55,10 +55,10 @@ class TestPhaseOracle(QiskitTestCase):
         circuit.compose(oracle, inplace=True)
         statevector = Statevector.from_instruction(circuit)
 
-        valid_state = -1 / sqrt(2 ** num_qubits)
-        invalid_state = 1 / sqrt(2 ** num_qubits)
+        valid_state = -1 / sqrt(2**num_qubits)
+        invalid_state = 1 / sqrt(2**num_qubits)
 
-        states = list(range(2 ** num_qubits))
+        states = list(range(2**num_qubits))
         expected_valid = [state in good_states for state in states]
         result_valid = [isclose(statevector.data[state], valid_state) for state in states]
 

--- a/test/python/circuit/library/test_piecewise_chebyshev.py
+++ b/test/python/circuit/library/test_piecewise_chebyshev.py
@@ -49,9 +49,9 @@ class TestPiecewiseChebyshev(QiskitTestCase):
         for i, probability in probabilities.items():
             x, last_qubit = int(i[1:], 2), i[0]
             if last_qubit == "0":
-                expected_amplitude = np.cos(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.cos(reference(x)) / np.sqrt(2**num_state_qubits)
             else:
-                expected_amplitude = np.sin(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.sin(reference(x)) / np.sqrt(2**num_state_qubits)
 
             unrolled_probabilities += [probability]
             unrolled_expectations += [np.real(np.abs(expected_amplitude) ** 2)]
@@ -76,10 +76,10 @@ class TestPiecewiseChebyshev(QiskitTestCase):
                     end = breakpoints[-1]
                 else:
                     start = breakpoints[0]
-                    end = 2 ** num_state_qubits
+                    end = 2**num_state_qubits
             else:
                 start = 0
-                end = 2 ** num_state_qubits
+                end = 2**num_state_qubits
             if start <= x < end:
                 return f_x(x)
             return np.arcsin(1)
@@ -125,7 +125,7 @@ class TestPiecewiseChebyshev(QiskitTestCase):
             self.assertFunctionIsCorrect(pw_approximation, lambda x: pw_poly(x, f_x_2))
 
         def f_x_3(x):
-            return x ** 2
+            return x**2
 
         with self.subTest(msg="changing all values"):
             pw_approximation.num_state_qubits = 4

--- a/test/python/circuit/library/test_qft.py
+++ b/test/python/circuit/library/test_qft.py
@@ -44,11 +44,11 @@ class TestQFT(QiskitTestCase):
         simulated = Operator(qft)
 
         num_qubits = num_qubits or qft.num_qubits
-        expected = np.empty((2 ** num_qubits, 2 ** num_qubits), dtype=complex)
-        for i in range(2 ** num_qubits):
+        expected = np.empty((2**num_qubits, 2**num_qubits), dtype=complex)
+        for i in range(2**num_qubits):
             i_index = int(bin(i)[2:].zfill(num_qubits), 2)
-            for j in range(i, 2 ** num_qubits):
-                entry = np.exp(2 * np.pi * 1j * i * j / 2 ** num_qubits) / 2 ** (num_qubits / 2)
+            for j in range(i, 2**num_qubits):
+                entry = np.exp(2 * np.pi * 1j * i * j / 2**num_qubits) / 2 ** (num_qubits / 2)
                 j_index = int(bin(j)[2:].zfill(num_qubits), 2)
                 expected[i_index, j_index] = entry
                 if i != j:

--- a/test/python/circuit/library/test_quadratic_form.py
+++ b/test/python/circuit/library/test_quadratic_form.py
@@ -33,17 +33,17 @@ class TestQuadraticForm(QiskitTestCase):
             x = np.array([int(val) for val in reversed(x)])
             res = x.T.dot(quadratic).dot(x) + x.T.dot(linear) + offset
             # compute 2s complement
-            res = (2 ** num_bits + int(res)) % 2 ** num_bits
+            res = (2**num_bits + int(res)) % 2**num_bits
             twos = bin(res)[2:].zfill(num_bits)
             return twos
 
         n = len(quadratic)  # number of value qubits
         ref = np.zeros(2 ** (n + m), dtype=complex)
-        for x in range(2 ** n):
+        for x in range(2**n):
             x_bin = bin(x)[2:].zfill(n)
             index = q_form(x_bin, m) + x_bin
             index = int(index, 2)
-            ref[index] = 1 / np.sqrt(2 ** n)
+            ref[index] = 1 / np.sqrt(2**n)
 
         actual = QuantumCircuit(circuit.num_qubits)
         actual.h(list(range(n)))
@@ -63,7 +63,7 @@ class TestQuadraticForm(QiskitTestCase):
 
         # the state is encoded as |q(x)>|x>, |x> = |x_1 x_0> = |10>
         index = (result if little_endian else result[::-1]) + "10"
-        ref = np.zeros(2 ** 4, dtype=complex)
+        ref = np.zeros(2**4, dtype=complex)
         ref[int(index, 2)] = 1
 
         self.assertTrue(Statevector.from_instruction(circuit).equiv(ref))

--- a/test/python/circuit/library/test_weighted_adder.py
+++ b/test/python/circuit/library/test_weighted_adder.py
@@ -43,14 +43,14 @@ class TestWeightedAdder(QiskitTestCase):
             probabilities[i] += np.real(np.abs(statevector_amplitude) ** 2)
 
         expectations = defaultdict(float)
-        for x in range(2 ** adder.num_state_qubits):
+        for x in range(2**adder.num_state_qubits):
             bits = np.array(list(bin(x)[2:].zfill(adder.num_state_qubits)), dtype=int)
             summation = bits.dot(adder.weights[::-1])
 
             entry = bin(summation)[2:].zfill(adder.num_sum_qubits) + bin(x)[2:].zfill(
                 adder.num_state_qubits
             )
-            expectations[entry] = 1 / 2 ** adder.num_state_qubits
+            expectations[entry] = 1 / 2**adder.num_state_qubits
 
         for state, probability in probabilities.items():
             self.assertAlmostEqual(probability, expectations[state])

--- a/test/python/circuit/test_circuit_registers.py
+++ b/test/python/circuit/test_circuit_registers.py
@@ -487,7 +487,7 @@ class TestCircuitRegisters(QiskitTestCase):
         See https://github.com/Qiskit/qiskit-terra/issues/2508"""
         qr = QuantumRegister(4)
         circ = QuantumCircuit(qr)
-        circ.unitary(np.eye(2 ** 4), [qr[0], qr[1], qr[2], qr[3]])
+        circ.unitary(np.eye(2**4), [qr[0], qr[1], qr[2], qr[3]])
 
         self.assertEqual(len(circ.data), 1)
         (gate, qargs, _) = circ.data[0]
@@ -503,7 +503,7 @@ class TestCircuitRegisters(QiskitTestCase):
         qr4 = QuantumRegister(4)
 
         circ = QuantumCircuit(qr1, qr2, qr3, qr4)
-        circ.unitary(np.eye(2 ** 4), [qr1, qr2, qr3, qr4])
+        circ.unitary(np.eye(2**4), [qr1, qr2, qr3, qr4])
 
         self.assertEqual(len(circ.data), 4)
         for (gate, qargs, _) in circ.data:

--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -443,7 +443,7 @@ class TestControlledGate(QiskitTestCase):
         q_target = QuantumRegister(1)
 
         # iterate over all possible combinations of control qubits
-        for ctrl_state in range(2 ** num_controls):
+        for ctrl_state in range(2**num_controls):
             bitstr = bin(ctrl_state)[2:].zfill(num_controls)[::-1]
             lam = 0.3165354 * pi
             qc = QuantumCircuit(q_controls, q_target)
@@ -591,7 +591,7 @@ class TestControlledGate(QiskitTestCase):
         q_target = QuantumRegister(1)
 
         # iterate over all possible combinations of control qubits
-        for ctrl_state in range(2 ** num_controls):
+        for ctrl_state in range(2**num_controls):
             bitstr = bin(ctrl_state)[2:].zfill(num_controls)[::-1]
             theta = 0.871236 * pi
             qc = QuantumCircuit(q_controls, q_target)
@@ -649,7 +649,7 @@ class TestControlledGate(QiskitTestCase):
         q_controls = QuantumRegister(num_controls)
         q_target = QuantumRegister(1)
 
-        for ctrl_state in range(2 ** num_controls):
+        for ctrl_state in range(2**num_controls):
             bitstr = bin(ctrl_state)[2:].zfill(num_controls)[::-1]
             theta = 0.871236 * pi
             if num_ancillas > 0:
@@ -803,7 +803,7 @@ class TestControlledGate(QiskitTestCase):
     def test_controlled_random_unitary(self, num_ctrl_qubits):
         """Test the matrix data of an Operator based on a random UnitaryGate."""
         num_target = 2
-        base_gate = random_unitary(2 ** num_target).to_instruction()
+        base_gate = random_unitary(2**num_target).to_instruction()
         base_mat = base_gate.to_matrix()
         cgate = base_gate.control(num_ctrl_qubits)
         test_op = Operator(cgate)
@@ -849,7 +849,7 @@ class TestControlledGate(QiskitTestCase):
         for i in range(num_target_qubits - 1):
             target_op = target_op.tensor(XGate())
 
-        for i in range(2 ** num_qubits):
+        for i in range(2**num_qubits):
             input_bitstring = bin(i)[2:].zfill(num_qubits)
             input_target = input_bitstring[0:num_target_qubits]
             input_ctrl = input_bitstring[-num_ctrl_qubits:]
@@ -857,7 +857,7 @@ class TestControlledGate(QiskitTestCase):
             cop = Operator(
                 _compute_control_matrix(target_op.data, num_ctrl_qubits, ctrl_state=input_ctrl)
             )
-            for j in range(2 ** num_qubits):
+            for j in range(2**num_qubits):
                 output_bitstring = bin(j)[2:].zfill(num_qubits)
                 output_target = output_bitstring[0:num_target_qubits]
                 output_ctrl = output_bitstring[-num_ctrl_qubits:]
@@ -1080,7 +1080,7 @@ class TestControlledGate(QiskitTestCase):
         with self.assertRaises(CircuitError):
             base_gate.control(num_ctrl_qubits, ctrl_state=-1)
         with self.assertRaises(CircuitError):
-            base_gate.control(num_ctrl_qubits, ctrl_state=2 ** num_ctrl_qubits)
+            base_gate.control(num_ctrl_qubits, ctrl_state=2**num_ctrl_qubits)
         with self.assertRaises(CircuitError):
             base_gate.control(num_ctrl_qubits, ctrl_state="201")
 
@@ -1324,7 +1324,7 @@ class TestControlledStandardGates(QiskitTestCase):
     def test_controlled_standard_gates(self, num_ctrl_qubits, gate_class):
         """Test controlled versions of all standard gates."""
         theta = pi / 2
-        ctrl_state_ones = 2 ** num_ctrl_qubits - 1
+        ctrl_state_ones = 2**num_ctrl_qubits - 1
         ctrl_state_zeros = 0
         ctrl_state_mixed = ctrl_state_ones >> int(num_ctrl_qubits / 2)
 

--- a/test/python/circuit/test_diagonal_gate.py
+++ b/test/python/circuit/test_diagonal_gate.py
@@ -35,9 +35,9 @@ class TestDiagonalGate(QiskitTestCase):
             [0, 0.8],
             [0, 0, 1, 1],
             [0, 1, 0.5, 1],
-            (2 * np.pi * np.random.rand(2 ** 3)).tolist(),
-            (2 * np.pi * np.random.rand(2 ** 4)).tolist(),
-            (2 * np.pi * np.random.rand(2 ** 5)).tolist(),
+            (2 * np.pi * np.random.rand(2**3)).tolist(),
+            (2 * np.pi * np.random.rand(2**4)).tolist(),
+            (2 * np.pi * np.random.rand(2**5)).tolist(),
         ]:
             with self.subTest(phases=phases):
                 diag = [np.exp(1j * ph) for ph in phases]

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -416,7 +416,7 @@ class TestInitialize(QiskitTestCase):
         for n_qubits in [1, 2, 4]:
             for irep in range(repeats):
                 with self.subTest(i=f"{n_qubits}_{irep}"):
-                    dim = 2 ** n_qubits
+                    dim = 2**n_qubits
                     qr = QuantumRegister(n_qubits)
                     initializer = QuantumCircuit(qr)
                     target = random_statevector(dim)
@@ -434,7 +434,7 @@ class TestInitialize(QiskitTestCase):
             Statevector([1j / np.sqrt(2), 1j / np.sqrt(2)]),
         ]
         n_qubits = 1
-        dim = 2 ** n_qubits
+        dim = 2**n_qubits
         qr = QuantumRegister(n_qubits)
         for target in target_list:
             with self.subTest(i=target):

--- a/test/python/circuit/test_isometry.py
+++ b/test/python/circuit/test_isometry.py
@@ -67,7 +67,7 @@ class TestIsometry(QiskitTestCase):
         simulator = BasicAer.get_backend("unitary_simulator")
         result = execute(qc, simulator).result()
         unitary = result.get_unitary(qc)
-        iso_from_circuit = unitary[::, 0 : 2 ** num_q_input]
+        iso_from_circuit = unitary[::, 0 : 2**num_q_input]
         iso_desired = iso
         self.assertTrue(matrix_equal(iso_from_circuit, iso_desired, ignore_phase=True))
 
@@ -107,7 +107,7 @@ class TestIsometry(QiskitTestCase):
         simulator = BasicAer.get_backend("unitary_simulator")
         result = execute(qc, simulator).result()
         unitary = result.get_unitary(qc)
-        iso_from_circuit = unitary[::, 0 : 2 ** num_q_input]
+        iso_from_circuit = unitary[::, 0 : 2**num_q_input]
         self.assertTrue(matrix_equal(iso_from_circuit, iso, ignore_phase=True))
 
     @data(

--- a/test/python/circuit/test_piecewise_polynomial.py
+++ b/test/python/circuit/test_piecewise_polynomial.py
@@ -50,9 +50,9 @@ class TestPiecewisePolynomialRotations(QiskitTestCase):
         for i, probability in probabilities.items():
             x, last_qubit = int(i[1:], 2), i[0]
             if last_qubit == "0":
-                expected_amplitude = np.cos(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.cos(reference(x)) / np.sqrt(2**num_state_qubits)
             else:
-                expected_amplitude = np.sin(reference(x)) / np.sqrt(2 ** num_state_qubits)
+                expected_amplitude = np.sin(reference(x)) / np.sqrt(2**num_state_qubits)
 
             unrolled_probabilities += [probability]
             unrolled_expectations += [np.real(np.abs(expected_amplitude) ** 2)]

--- a/test/python/circuit/test_templates.py
+++ b/test/python/circuit/test_templates.py
@@ -40,7 +40,7 @@ class TestTemplates(QiskitTestCase):
         """test to verify that all templates are equivalent to the identity"""
 
         target = Operator(template_circuit)
-        value = Operator(np.eye(2 ** template_circuit.num_qubits))
+        value = Operator(np.eye(2**template_circuit.num_qubits))
         self.assertTrue(target.equiv(value))
 
 

--- a/test/python/circuit/test_tools.py
+++ b/test/python/circuit/test_tools.py
@@ -42,8 +42,8 @@ class TestPiCheck(QiskitTestCase):
             (-pi / 35, "-π/35"),
             (3 * pi / 35, "0.26928"),
             (-3 * pi / 35, "-0.26928"),
-            (pi ** 2, "π**2"),
-            (-(pi ** 2), "-π**2"),
+            (pi**2, "π**2"),
+            (-(pi**2), "-π**2"),
             (1e9, "1e+09"),
             (-1e9, "-1e+09"),
             (1e-9, "1e-09"),
@@ -80,7 +80,7 @@ class TestPiCheck(QiskitTestCase):
         x = Parameter("x")
         y = Parameter("y")
         z = Parameter("z")
-        pcase = (pi ** 3 * x + 3 / (4 * pi) * y - 13 * pi / 2 * z, "π**3*x + 3/4π*y - 13π/2*z")
+        pcase = (pi**3 * x + 3 / (4 * pi) * y - 13 * pi / 2 * z, "π**3*x + 3/4π*y - 13π/2*z")
         input_number = pcase[0]
         expected_string = pcase[1]
         result = pi_check(input_number)

--- a/test/python/circuit/test_uc.py
+++ b/test/python/circuit/test_uc.py
@@ -39,9 +39,9 @@ squs_list = [
     [_id, _id],
     [_id, 1j * _id],
     [_id, _not, _id, _not],
-    [random_unitary(2).data for i in range(2 ** 2)],
-    [random_unitary(2).data for i in range(2 ** 3)],
-    [random_unitary(2).data for i in range(2 ** 4)],
+    [random_unitary(2).data for i in range(2**2)],
+    [random_unitary(2).data for i in range(2**3)],
+    [random_unitary(2).data for i in range(2**4)],
 ]
 
 up_to_diagonal_list = [True, False]

--- a/test/python/circuit/test_ucx_y_z.py
+++ b/test/python/circuit/test_ucx_y_z.py
@@ -31,9 +31,9 @@ angles_list = [
     [0, 0.8],
     [0, 0, 1, 1],
     [0, 1, 0.5, 1],
-    (2 * np.pi * np.random.rand(2 ** 3)).tolist(),
-    (2 * np.pi * np.random.rand(2 ** 4)).tolist(),
-    (2 * np.pi * np.random.rand(2 ** 5)).tolist(),
+    (2 * np.pi * np.random.rand(2**3)).tolist(),
+    (2 * np.pi * np.random.rand(2**4)).tolist(),
+    (2 * np.pi * np.random.rand(2**5)).tolist(),
 ]
 
 rot_axis_list = ["X", "Y", "Z"]

--- a/test/python/classical_function_compiler/utils.py
+++ b/test/python/classical_function_compiler/utils.py
@@ -20,7 +20,7 @@ def get_truthtable_from_function(function):
     """Runs an classicalfunction function (on python) and generates a truthtable from it."""
     amount_bit_input = len(getfullargspec(function).args)
     result = ""
-    for decimal in range(2 ** amount_bit_input):
+    for decimal in range(2**amount_bit_input):
         entry = bin(decimal)[2:].rjust(amount_bit_input, "0")
         result += str(int(function(*(i == "1" for i in entry[::-1]))))
     return result[::-1]

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -98,7 +98,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
         sampled_zero = self.sampler.convert(zero_mean)
         np.testing.assert_array_almost_equal(sampled_zero.eval(), [0, 0, 1, 1], decimal=1)
 
-        sum_zero = (Plus + Minus) * (0.5 ** 0.5)
+        sum_zero = (Plus + Minus) * (0.5**0.5)
         sum_zero_mean = converted_meas @ sum_zero
         sampled_zero_mean = self.sampler.convert(sum_zero_mean)
         # !!NOTE!!: Depolarizing channel (Sampling) means interference
@@ -143,7 +143,7 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
         plus_mean = converted_meas @ Plus
         sampled_plus = self.sampler.convert(plus_mean)
         np.testing.assert_array_almost_equal(
-            sampled_plus.eval(), [1, 0.5 ** 0.5, (1 + 0.5 ** 0.5), 1], decimal=1
+            sampled_plus.eval(), [1, 0.5**0.5, (1 + 0.5**0.5), 1], decimal=1
         )
 
     @unittest.skip("Skip until https://github.com/Qiskit/qiskit-aer/issues/1249 is closed.")

--- a/test/python/opflow/test_matrix_expectation.py
+++ b/test/python/opflow/test_matrix_expectation.py
@@ -92,7 +92,7 @@ class TestMatrixExpectation(QiskitOpflowTestCase):
         sampled_zero = self.sampler.convert(zero_mean)
         np.testing.assert_array_almost_equal(sampled_zero.eval(), [0, 0, 1, 1], decimal=1)
 
-        sum_zero = (Plus + Minus) * (0.5 ** 0.5)
+        sum_zero = (Plus + Minus) * (0.5**0.5)
         sum_zero_mean = converted_meas @ sum_zero
         np.testing.assert_array_almost_equal(sum_zero_mean.eval(), [0, 0, 1, 1], decimal=1)
         sampled_zero = self.sampler.convert(sum_zero)
@@ -153,7 +153,7 @@ class TestMatrixExpectation(QiskitOpflowTestCase):
         plus_mean = converted_meas @ Plus
         sampled_plus = self.sampler.convert(plus_mean)
         np.testing.assert_array_almost_equal(
-            sampled_plus.eval(), [1, 0.5 ** 0.5, (1 + 0.5 ** 0.5), 1], decimal=1
+            sampled_plus.eval(), [1, 0.5**0.5, (1 + 0.5**0.5), 1], decimal=1
         )
 
     def test_matrix_expectation_non_hermite_op(self):

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -89,7 +89,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
 
     def test_composed_eval(self):
         """Test eval of ComposedOp"""
-        self.assertAlmostEqual(Minus.eval("1"), -(0.5 ** 0.5))
+        self.assertAlmostEqual(Minus.eval("1"), -(0.5**0.5))
 
     def test_xz_compose_phase(self):
         """Test phase composition"""
@@ -613,7 +613,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
         self.assertEqual(dsfn_exp.num_qubits, num_qubits + add_qubits)
 
         # case VectorStateFn
-        vsfn = VectorStateFn(np.ones(2 ** num_qubits, dtype=complex))
+        vsfn = VectorStateFn(np.ones(2**num_qubits, dtype=complex))
         self.assertEqual(vsfn.num_qubits, num_qubits)
 
         vsfn_exp = vsfn._expand_dim(add_qubits)
@@ -623,7 +623,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
         """Test if StateFns permute are consistent."""
 
         num_qubits = 4
-        dim = 2 ** num_qubits
+        dim = 2**num_qubits
         primitive_list = [1.0 / (i + 1) for i in range(dim)]
         primitive_dict = {format(i, "b").zfill(num_qubits): 1.0 / (i + 1) for i in range(dim)}
 
@@ -724,7 +724,7 @@ class TestOpConstruction(QiskitOpflowTestCase):
 
         # StateFn
         num_qubits = 3
-        dim = 2 ** num_qubits
+        dim = 2**num_qubits
         vec = [1.0 / (i + 1) for i in range(dim)]
         dic = {format(i, "b").zfill(num_qubits): 1.0 / (i + 1) for i in range(dim)}
 
@@ -1160,7 +1160,7 @@ class TestListOpComboFn(QiskitOpflowTestCase):
 
     def setUp(self):
         super().setUp()
-        self.combo_fn = lambda x: [x_i ** 2 for x_i in x]
+        self.combo_fn = lambda x: [x_i**2 for x_i in x]
         self.listop = ListOp([X], combo_fn=self.combo_fn)
 
     def assertComboFnPreserved(self, processed_op):

--- a/test/python/opflow/test_pauli_expectation.py
+++ b/test/python/opflow/test_pauli_expectation.py
@@ -97,7 +97,7 @@ class TestPauliExpectation(QiskitOpflowTestCase):
         sampled_zero = self.sampler.convert(zero_mean)
         np.testing.assert_array_almost_equal(sampled_zero.eval(), [0, 0, 1, 1], decimal=1)
 
-        sum_zero = (Plus + Minus) * (0.5 ** 0.5)
+        sum_zero = (Plus + Minus) * (0.5**0.5)
         sum_zero_mean = converted_meas @ sum_zero
         np.testing.assert_array_almost_equal(sum_zero_mean.eval(), [0, 0, 1, 1], decimal=1)
         sampled_zero_mean = self.sampler.convert(sum_zero_mean)
@@ -238,7 +238,7 @@ class TestPauliExpectation(QiskitOpflowTestCase):
         plus_mean = converted_meas @ Plus
         sampled_plus = self.sampler.convert(plus_mean)
         np.testing.assert_array_almost_equal(
-            sampled_plus.eval(), [1, 0.5 ** 0.5, (1 + 0.5 ** 0.5), 1], decimal=1
+            sampled_plus.eval(), [1, 0.5**0.5, (1 + 0.5**0.5), 1], decimal=1
         )
 
     def test_pauli_expectation_non_hermite_op(self):

--- a/test/python/opflow/test_state_construction.py
+++ b/test/python/opflow/test_state_construction.py
@@ -94,20 +94,20 @@ class TestStateConstruction(QiskitOpflowTestCase):
         ).result()
 
         np.testing.assert_array_almost_equal(
-            StateFn(sv_res).to_matrix(), [0.5 ** 0.5, 0.5 ** 0.5, 0, 0, 0, 0, 0, 0]
+            StateFn(sv_res).to_matrix(), [0.5**0.5, 0.5**0.5, 0, 0, 0, 0, 0, 0]
         )
         np.testing.assert_array_almost_equal(
-            StateFn(sv_vector).to_matrix(), [0.5 ** 0.5, 0.5 ** 0.5, 0, 0, 0, 0, 0, 0]
+            StateFn(sv_vector).to_matrix(), [0.5**0.5, 0.5**0.5, 0, 0, 0, 0, 0, 0]
         )
         np.testing.assert_array_almost_equal(
-            StateFn(qasm_res).to_matrix(), [0.5 ** 0.5, 0.5 ** 0.5, 0, 0, 0, 0, 0, 0], decimal=1
+            StateFn(qasm_res).to_matrix(), [0.5**0.5, 0.5**0.5, 0, 0, 0, 0, 0, 0], decimal=1
         )
 
         np.testing.assert_array_almost_equal(
-            ((I ^ I ^ H) @ Zero).to_matrix(), [0.5 ** 0.5, 0.5 ** 0.5, 0, 0, 0, 0, 0, 0]
+            ((I ^ I ^ H) @ Zero).to_matrix(), [0.5**0.5, 0.5**0.5, 0, 0, 0, 0, 0, 0]
         )
         np.testing.assert_array_almost_equal(
-            qc_op.to_matrix(), [0.5 ** 0.5, 0.5 ** 0.5, 0, 0, 0, 0, 0, 0]
+            qc_op.to_matrix(), [0.5**0.5, 0.5**0.5, 0, 0, 0, 0, 0, 0]
         )
 
     def test_state_meas_composition(self):

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -42,7 +42,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_wf_evals_x(self):
         """wf evals x test"""
         qbits = 4
-        wf = ((Zero ^ qbits) + (One ^ qbits)) * (1 / 2 ** 0.5)
+        wf = ((Zero ^ qbits) + (One ^ qbits)) * (1 / 2**0.5)
         # Note: wf = Plus^qbits fails because TensoredOp can't handle it.
         wf_vec = StateFn(wf.to_matrix())
         op = X ^ qbits
@@ -54,7 +54,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
 
         # op = (H^X^Y)^2
         op = H ^ 6
-        wf = ((Zero ^ 6) + (One ^ 6)) * (1 / 2 ** 0.5)
+        wf = ((Zero ^ 6) + (One ^ 6)) * (1 / 2**0.5)
         wf_vec = StateFn(wf.to_matrix())
         # print(wf.adjoint().to_matrix() @ op.to_matrix() @ wf.to_matrix())
         self.assertAlmostEqual(wf.adjoint().eval(op.eval(wf)), 0.25)

--- a/test/python/pulse/test_continuous_pulses.py
+++ b/test/python/pulse/test_continuous_pulses.py
@@ -182,7 +182,7 @@ class TestContinuousPulses(QiskitTestCase):
         self.assertAlmostEqual(gaussian_arr_zeroed[1], amp)
         self.assertAlmostEqual(gaussian_arr_zeroed[2], 0.0, places=6)
         self.assertAlmostEqual(
-            np.sum(gaussian_arr * dt), amp * np.sqrt(2 * np.pi * sigma ** 2), places=3
+            np.sum(gaussian_arr * dt), amp * np.sqrt(2 * np.pi * sigma**2), places=3
         )
 
     def test_gaussian_deriv(self):
@@ -191,7 +191,7 @@ class TestContinuousPulses(QiskitTestCase):
         center = 10
         sigma = 2
         times, dt = np.linspace(0, 20, 1000, retstep=True)
-        deriv_prefactor = -(sigma ** 2) / (times - center)
+        deriv_prefactor = -(sigma**2) / (times - center)
 
         gaussian_deriv_arr = continuous.gaussian_deriv(times, amp, center, sigma)
         gaussian_arr = gaussian_deriv_arr * deriv_prefactor
@@ -202,7 +202,7 @@ class TestContinuousPulses(QiskitTestCase):
             continuous.gaussian_deriv(np.array([0]), amp, center, sigma)[0], 0, places=5
         )
         self.assertAlmostEqual(
-            np.sum(gaussian_arr * dt), amp * np.sqrt(2 * np.pi * sigma ** 2), places=3
+            np.sum(gaussian_arr * dt), amp * np.sqrt(2 * np.pi * sigma**2), places=3
         )
 
     def test_sech(self):
@@ -255,12 +255,12 @@ class TestContinuousPulses(QiskitTestCase):
         # test half gaussian rise/fall
         self.assertAlmostEqual(
             np.sum(gaussian_square_arr[:900] * dt) * 2,
-            amp * np.sqrt(2 * np.pi * sigma ** 2),
+            amp * np.sqrt(2 * np.pi * sigma**2),
             places=2,
         )
         self.assertAlmostEqual(
             np.sum(gaussian_square_arr[1100:] * dt) * 2,
-            amp * np.sqrt(2 * np.pi * sigma ** 2),
+            amp * np.sqrt(2 * np.pi * sigma**2),
             places=2,
         )
         # test for continuity at gaussian/square boundaries
@@ -278,11 +278,11 @@ class TestContinuousPulses(QiskitTestCase):
 
         # should be locally approximated by amp*dt^2/(2*sigma^2)
         self.assertAlmostEqual(
-            amp * dt_rise ** 2 / (2 * sigma ** 2),
+            amp * dt_rise**2 / (2 * sigma**2),
             gaussian_square_rise_arr[500] - gaussian_square_rise_arr[499],
         )
         self.assertAlmostEqual(
-            amp * dt_fall ** 2 / (2 * sigma ** 2),
+            amp * dt_fall**2 / (2 * sigma**2),
             gaussian_square_fall_arr[501] - gaussian_square_fall_arr[500],
         )
 

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -179,7 +179,7 @@ class TestParametricPulses(QiskitTestCase):
         wf = Drag(duration=duration, sigma=sigma, amp=amp, beta=beta)
         samples = wf.get_waveform().samples
         self.assertTrue(max(np.abs(samples)) <= 1)
-        beta = sigma ** 2
+        beta = sigma**2
         with self.assertRaises(PulseError):
             wf = Drag(duration=duration, sigma=sigma, amp=amp, beta=beta)
         # If sigma is high enough, side peaks fall out of range and norm restriction is met
@@ -325,10 +325,10 @@ class TestFunctionalPulse(QiskitTestCase):
         @functional_pulse
         def local_gaussian(duration, amp, t0, sig):
             x = np.linspace(0, duration - 1, duration)
-            return amp * np.exp(-((x - t0) ** 2) / sig ** 2)
+            return amp * np.exp(-((x - t0) ** 2) / sig**2)
 
         pulse_wf_inst = local_gaussian(duration=10, amp=1, t0=5, sig=1, name="test_pulse")
-        _y = 1 * np.exp(-((np.linspace(0, 9, 10) - 5) ** 2) / 1 ** 2)
+        _y = 1 * np.exp(-((np.linspace(0, 9, 10) - 5) ** 2) / 1**2)
 
         self.assertListEqual(list(pulse_wf_inst.samples), list(_y))
 
@@ -344,7 +344,7 @@ class TestFunctionalPulse(QiskitTestCase):
         @functional_pulse
         def local_gaussian(duration, amp, t0, sig):
             x = np.linspace(0, duration - 1, duration)
-            return amp * np.exp(-((x - t0) ** 2) / sig ** 2)
+            return amp * np.exp(-((x - t0) ** 2) / sig**2)
 
         _durations = np.arange(10, 15, 1)
 

--- a/test/python/quantum_info/operators/channel/test_chi.py
+++ b/test/python/quantum_info/operators/channel/test_chi.py
@@ -232,7 +232,7 @@ class TestChi(ChannelTestCase):
         depol = Chi(self.depol_chi(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan3 = depol.power(3)
         targ3 = Chi(self.depol_chi(1 - p_id3))
         self.assertEqual(chan3, targ3)
@@ -253,7 +253,7 @@ class TestChi(ChannelTestCase):
 
     def test_add_qargs(self):
         """Test add method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 
@@ -300,7 +300,7 @@ class TestChi(ChannelTestCase):
 
     def test_sub_qargs(self):
         """Test subtract method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 

--- a/test/python/quantum_info/operators/channel/test_choi.py
+++ b/test/python/quantum_info/operators/channel/test_choi.py
@@ -317,7 +317,7 @@ class TestChoi(ChannelTestCase):
         depol = Choi(self.depol_choi(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan3 = depol.power(3)
         targ3 = Choi(self.depol_choi(1 - p_id3))
         self.assertEqual(chan3, targ3)
@@ -336,7 +336,7 @@ class TestChoi(ChannelTestCase):
 
     def test_add_qargs(self):
         """Test add method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 
@@ -383,7 +383,7 @@ class TestChoi(ChannelTestCase):
 
     def test_sub_qargs(self):
         """Test subtract method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 

--- a/test/python/quantum_info/operators/channel/test_evolve.py
+++ b/test/python/quantum_info/operators/channel/test_evolve.py
@@ -35,7 +35,7 @@ class TestEvolve(ChannelTestCase):
     def _unitary_to_other(self, rep, qubits_test_cases, repetitions):
         """Test Operator to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim, dim)
@@ -47,7 +47,7 @@ class TestEvolve(ChannelTestCase):
     def _other_to_operator(self, rep, qubits_test_cases, repetitions):
         """Test Other to Operator evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
                 mat = self.rand_matrix(dim, dim)
@@ -59,10 +59,10 @@ class TestEvolve(ChannelTestCase):
     def _choi_to_other_cp(self, rep, qubits_test_cases, repetitions):
         """Test CP Choi to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = dim * self.rand_rho(dim ** 2)
+                mat = dim * self.rand_rho(dim**2)
                 chan = Choi(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -71,10 +71,10 @@ class TestEvolve(ChannelTestCase):
     def _choi_to_other_noncp(self, rep, qubits_test_cases, repetitions):
         """Test CP Choi to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = self.rand_matrix(dim ** 2, dim ** 2)
+                mat = self.rand_matrix(dim**2, dim**2)
                 chan = Choi(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -83,10 +83,10 @@ class TestEvolve(ChannelTestCase):
     def _superop_to_other(self, rep, qubits_test_cases, repetitions):
         """Test SuperOp to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = self.rand_matrix(dim ** 2, dim ** 2)
+                mat = self.rand_matrix(dim**2, dim**2)
                 chan = SuperOp(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -95,10 +95,10 @@ class TestEvolve(ChannelTestCase):
     def _kraus_to_other_single(self, rep, qubits_test_cases, repetitions):
         """Test single Kraus to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                kraus = self.rand_kraus(dim, dim, dim ** 2)
+                kraus = self.rand_kraus(dim, dim, dim**2)
                 chan = Kraus(kraus)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -107,11 +107,11 @@ class TestEvolve(ChannelTestCase):
     def _kraus_to_other_double(self, rep, qubits_test_cases, repetitions):
         """Test double Kraus to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                kraus_l = self.rand_kraus(dim, dim, dim ** 2)
-                kraus_r = self.rand_kraus(dim, dim, dim ** 2)
+                kraus_l = self.rand_kraus(dim, dim, dim**2)
+                kraus_r = self.rand_kraus(dim, dim, dim**2)
                 chan = Kraus((kraus_l, kraus_r))
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -120,10 +120,10 @@ class TestEvolve(ChannelTestCase):
     def _stinespring_to_other_single(self, rep, qubits_test_cases, repetitions):
         """Test single Stinespring to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = self.rand_matrix(dim ** 2, dim)
+                mat = self.rand_matrix(dim**2, dim)
                 chan = Stinespring(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -132,11 +132,11 @@ class TestEvolve(ChannelTestCase):
     def _stinespring_to_other_double(self, rep, qubits_test_cases, repetitions):
         """Test double Stinespring to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat_l = self.rand_matrix(dim ** 2, dim)
-                mat_r = self.rand_matrix(dim ** 2, dim)
+                mat_l = self.rand_matrix(dim**2, dim)
+                mat_r = self.rand_matrix(dim**2, dim)
                 chan = Stinespring((mat_l, mat_r))
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -145,10 +145,10 @@ class TestEvolve(ChannelTestCase):
     def _chi_to_other(self, rep, qubits_test_cases, repetitions):
         """Test Chi to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
+                mat = self.rand_matrix(dim**2, dim**2, real=True)
                 chan = Chi(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data
@@ -157,10 +157,10 @@ class TestEvolve(ChannelTestCase):
     def _ptm_to_other(self, rep, qubits_test_cases, repetitions):
         """Test PTM to Other evolution."""
         for nq in qubits_test_cases:
-            dim = 2 ** nq
+            dim = 2**nq
             for _ in range(repetitions):
                 rho = self.rand_rho(dim)
-                mat = self.rand_matrix(dim ** 2, dim ** 2, real=True)
+                mat = self.rand_matrix(dim**2, dim**2, real=True)
                 chan = PTM(mat)
                 rho1 = DensityMatrix(rho).evolve(chan).data
                 rho2 = DensityMatrix(rho).evolve(rep(chan)).data

--- a/test/python/quantum_info/operators/channel/test_kraus.py
+++ b/test/python/quantum_info/operators/channel/test_kraus.py
@@ -305,7 +305,7 @@ class TestKraus(ChannelTestCase):
         chan = Kraus(self.depol_kraus(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan3 = chan.power(3)
         targ3a = rho & chan & chan & chan
         self.assertEqual(rho & chan3, targ3a)

--- a/test/python/quantum_info/operators/channel/test_ptm.py
+++ b/test/python/quantum_info/operators/channel/test_ptm.py
@@ -227,7 +227,7 @@ class TestPTM(ChannelTestCase):
         depol = PTM(self.depol_ptm(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan3 = depol.power(3)
         targ3 = PTM(self.depol_ptm(1 - p_id3))
         self.assertEqual(chan3, targ3)
@@ -248,7 +248,7 @@ class TestPTM(ChannelTestCase):
 
     def test_add_qargs(self):
         """Test add method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 
@@ -295,7 +295,7 @@ class TestPTM(ChannelTestCase):
 
     def test_sub_qargs(self):
         """Test subtract method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 

--- a/test/python/quantum_info/operators/channel/test_stinespring.py
+++ b/test/python/quantum_info/operators/channel/test_stinespring.py
@@ -297,7 +297,7 @@ class TestStinespring(ChannelTestCase):
         chan1 = Stinespring(self.depol_stine(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan = chan1.power(3)
         rho_targ = rho_init & chan1 & chan1 & chan1
         self.assertEqual(rho_init & chan, rho_targ)

--- a/test/python/quantum_info/operators/channel/test_superop.py
+++ b/test/python/quantum_info/operators/channel/test_superop.py
@@ -516,7 +516,7 @@ class TestSuperOp(ChannelTestCase):
         depol = SuperOp(self.depol_sop(1 - p_id))
 
         # Compose 3 times
-        p_id3 = p_id ** 3
+        p_id3 = p_id**3
         chan3 = depol.power(3)
         targ3 = SuperOp(self.depol_sop(1 - p_id3))
         self.assertEqual(chan3, targ3)
@@ -535,7 +535,7 @@ class TestSuperOp(ChannelTestCase):
 
     def test_add_qargs(self):
         """Test add method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 
@@ -582,7 +582,7 @@ class TestSuperOp(ChannelTestCase):
 
     def test_sub_qargs(self):
         """Test subtract method with qargs."""
-        mat = self.rand_matrix(8 ** 2, 8 ** 2)
+        mat = self.rand_matrix(8**2, 8**2)
         mat0 = self.rand_matrix(4, 4)
         mat1 = self.rand_matrix(4, 4)
 

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -539,7 +539,7 @@ class TestCliffordDecomposition(QiskitTestCase):
             circ = random_clifford_circuit(num_qubits, num_gates, gates=gates, seed=seed + i)
             mat = Clifford(circ).to_matrix()
             self.assertIsInstance(mat, np.ndarray)
-            self.assertEqual(mat.shape, 2 * (2 ** num_qubits,))
+            self.assertEqual(mat.shape, 2 * (2**num_qubits,))
             value = Operator(mat)
             target = Operator(circ)
             self.assertTrue(value.equiv(target))

--- a/test/python/quantum_info/operators/symplectic/test_legacy_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_legacy_pauli.py
@@ -386,7 +386,7 @@ class TestPauli(QiskitTestCase):
         self.assertEqual(len(q.z), length)
         self.assertEqual(len(q.x), length)
         self.assertEqual(len(q.to_label()), length)
-        self.assertEqual(len(q.to_matrix()), 2 ** length)
+        self.assertEqual(len(q.to_matrix()), 2**length)
 
     def test_mul(self):
         """Test multiplication."""

--- a/test/python/quantum_info/operators/symplectic/test_pauli.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli.py
@@ -325,7 +325,7 @@ class TestPauli(QiskitTestCase):
         """Test power method."""
         iden = Pauli("II")
         op = Pauli(label)
-        self.assertTrue(op ** 2, iden)
+        self.assertTrue(op**2, iden)
 
     @data(1, 1.0, -1, -1.0, 1j, -1j)
     def test_multiply(self, val):

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -262,7 +262,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_conjugate(self, num_qubits):
         """Test conjugate method for {num_qubits}-qubits."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op).conjugate()
         op = spp_op.conjugate()
         value = op.to_operator()
@@ -272,7 +272,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_transpose(self, num_qubits):
         """Test transpose method for {num_qubits}-qubits."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op).transpose()
         op = spp_op.transpose()
         value = op.to_operator()
@@ -282,7 +282,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_adjoint(self, num_qubits):
         """Test adjoint method for {num_qubits}-qubits."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op).adjoint()
         op = spp_op.adjoint()
         value = op.to_operator()
@@ -292,8 +292,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_compose(self, num_qubits):
         """Test {num_qubits}-qubit compose methods."""
-        spp_op1 = self.random_spp_op(num_qubits, 2 ** num_qubits)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(num_qubits, 2**num_qubits)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op1).compose(Operator(spp_op2))
 
         op = spp_op1.compose(spp_op2)
@@ -309,8 +309,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_dot(self, num_qubits):
         """Test {num_qubits}-qubit compose methods."""
-        spp_op1 = self.random_spp_op(num_qubits, 2 ** num_qubits)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(num_qubits, 2**num_qubits)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op1).dot(Operator(spp_op2))
 
         op = spp_op1.dot(spp_op2)
@@ -321,8 +321,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3])
     def test_qargs_compose(self, num_qubits):
         """Test 3-qubit compose method with {num_qubits}-qubit qargs."""
-        spp_op1 = self.random_spp_op(3, 2 ** 3)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(3, 2**3)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         qargs = self.RNG.choice(3, size=num_qubits, replace=False).tolist()
         target = Operator(spp_op1).compose(Operator(spp_op2), qargs=qargs)
 
@@ -339,8 +339,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3])
     def test_qargs_dot(self, num_qubits):
         """Test 3-qubit dot method with {num_qubits}-qubit qargs."""
-        spp_op1 = self.random_spp_op(3, 2 ** 3)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(3, 2**3)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         qargs = self.RNG.choice(3, size=num_qubits, replace=False).tolist()
         target = Operator(spp_op1).dot(Operator(spp_op2), qargs=qargs)
 
@@ -352,8 +352,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits1=[1, 2, 3], num_qubits2=[1, 2, 3])
     def test_tensor(self, num_qubits1, num_qubits2):
         """Test tensor method for {num_qubits1} and {num_qubits2} qubits."""
-        spp_op1 = self.random_spp_op(num_qubits1, 2 ** num_qubits1)
-        spp_op2 = self.random_spp_op(num_qubits2, 2 ** num_qubits2)
+        spp_op1 = self.random_spp_op(num_qubits1, 2**num_qubits1)
+        spp_op2 = self.random_spp_op(num_qubits2, 2**num_qubits2)
         target = Operator(spp_op1).tensor(Operator(spp_op2))
         op = spp_op1.tensor(spp_op2)
         value = op.to_operator()
@@ -363,8 +363,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits1=[1, 2, 3], num_qubits2=[1, 2, 3])
     def test_expand(self, num_qubits1, num_qubits2):
         """Test expand method for {num_qubits1} and {num_qubits2} qubits."""
-        spp_op1 = self.random_spp_op(num_qubits1, 2 ** num_qubits1)
-        spp_op2 = self.random_spp_op(num_qubits2, 2 ** num_qubits2)
+        spp_op1 = self.random_spp_op(num_qubits1, 2**num_qubits1)
+        spp_op2 = self.random_spp_op(num_qubits2, 2**num_qubits2)
         target = Operator(spp_op1).expand(Operator(spp_op2))
         op = spp_op1.expand(spp_op2)
         value = op.to_operator()
@@ -374,8 +374,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_add(self, num_qubits):
         """Test + method for {num_qubits} qubits."""
-        spp_op1 = self.random_spp_op(num_qubits, 2 ** num_qubits)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(num_qubits, 2**num_qubits)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op1) + Operator(spp_op2)
         op = spp_op1 + spp_op2
         value = op.to_operator()
@@ -385,8 +385,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4])
     def test_sub(self, num_qubits):
         """Test + method for {num_qubits} qubits."""
-        spp_op1 = self.random_spp_op(num_qubits, 2 ** num_qubits)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(num_qubits, 2**num_qubits)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op1) - Operator(spp_op2)
         op = spp_op1 - spp_op2
         value = op.to_operator()
@@ -396,8 +396,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3])
     def test_add_qargs(self, num_qubits):
         """Test + method for 3 qubits with {num_qubits} qubit qargs."""
-        spp_op1 = self.random_spp_op(3, 2 ** 3)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(3, 2**3)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         qargs = self.RNG.choice(3, size=num_qubits, replace=False).tolist()
         target = Operator(spp_op1) + Operator(spp_op2)(qargs)
         op = spp_op1 + spp_op2(qargs)
@@ -408,8 +408,8 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3])
     def test_sub_qargs(self, num_qubits):
         """Test - method for 3 qubits with {num_qubits} qubit qargs."""
-        spp_op1 = self.random_spp_op(3, 2 ** 3)
-        spp_op2 = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op1 = self.random_spp_op(3, 2**3)
+        spp_op2 = self.random_spp_op(num_qubits, 2**num_qubits)
         qargs = self.RNG.choice(3, size=num_qubits, replace=False).tolist()
         target = Operator(spp_op1) - Operator(spp_op2)(qargs)
         op = spp_op1 - spp_op2(qargs)
@@ -420,7 +420,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3], value=[0, 1, 1j, -3 + 4.4j, np.int64(2)])
     def test_mul(self, num_qubits, value):
         """Test * method for {num_qubits} qubits and value {value}."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         target = value * Operator(spp_op)
         op = value * spp_op
         value = op.to_operator()
@@ -430,7 +430,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3], value=[1, 1j, -3 + 4.4j])
     def test_div(self, num_qubits, value):
         """Test / method for {num_qubits} qubits and value {value}."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         target = Operator(spp_op) / value
         op = spp_op / value
         value = op.to_operator()
@@ -452,7 +452,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4], num_adds=[0, 1, 2, 3])
     def test_simplify2(self, num_qubits, num_adds):
         """Test simplify method for {num_qubits} qubits with {num_adds} `add` calls."""
-        spp_op = self.random_spp_op(num_qubits, 2 ** num_qubits)
+        spp_op = self.random_spp_op(num_qubits, 2**num_qubits)
         for _ in range(num_adds):
             spp_op += spp_op
         simplified_op = spp_op.simplify()
@@ -465,7 +465,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
     @combine(num_qubits=[1, 2, 3, 4], num_ops=[1, 2, 3, 4])
     def test_sum(self, num_qubits, num_ops):
         """Test sum method for {num_qubits} qubits with {num_ops} operators."""
-        ops = [self.random_spp_op(num_qubits, 2 ** num_qubits) for _ in range(num_ops)]
+        ops = [self.random_spp_op(num_qubits, 2**num_qubits) for _ in range(num_ops)]
         sum_op = SparsePauliOp.sum(ops)
         value = Operator(sum_op)
         target_operator = sum((Operator(op) for op in ops[1:]), Operator(ops[0]))
@@ -479,7 +479,7 @@ class TestSparsePauliOpMethods(QiskitTestCase):
         with self.assertRaises(QiskitError):
             SparsePauliOp.sum([])
         with self.assertRaises(QiskitError):
-            ops = [self.random_spp_op(num_qubits, 2 ** num_qubits) for num_qubits in [1, 2]]
+            ops = [self.random_spp_op(num_qubits, 2**num_qubits) for num_qubits in [1, 2]]
             SparsePauliOp.sum(ops)
         with self.assertRaises(QiskitError):
             SparsePauliOp.sum([1, 2])

--- a/test/python/quantum_info/operators/test_dihedral.py
+++ b/test/python/quantum_info/operators/test_dihedral.py
@@ -592,7 +592,7 @@ class TestCNOTDihedral(unittest.TestCase):
                 elem = CNOTDihedral(circ)
                 mat = elem.to_matrix()
                 self.assertIsInstance(mat, np.ndarray)
-                self.assertEqual(mat.shape, 2 * (2 ** num_qubits,))
+                self.assertEqual(mat.shape, 2 * (2**num_qubits,))
                 value = Operator(mat)
                 target = Operator(circ)
                 self.assertTrue(value.equiv(target), "Error: matrix of the circuit is not the same")

--- a/test/python/quantum_info/operators/test_measures.py
+++ b/test/python/quantum_info/operators/test_measures.py
@@ -171,7 +171,7 @@ class TestOperatorMeasures(QiskitTestCase):
 
         # Pauli channels have an analytic expression for the
         # diamond norm so we can easily test it
-        op = Choi(np.zeros((4 ** num_qubits, 4 ** num_qubits)))
+        op = Choi(np.zeros((4**num_qubits, 4**num_qubits)))
         labels = [num_qubits * i for i in ["I", "X", "Y", "Z"]]
         coeffs = [-1.0, 0.5, 2.5, -0.1]
         for coeff, label in zip(coeffs, labels):

--- a/test/python/quantum_info/operators/test_scalar_op.py
+++ b/test/python/quantum_info/operators/test_scalar_op.py
@@ -47,7 +47,7 @@ class TestScalarOpInit(ScalarOpTestCase):
     @combine(j=range(1, 5))
     def test_init(self, j):
         """Test {j}-qubit automatic dims."""
-        dim = 2 ** j
+        dim = 2**j
         op = ScalarOp(dim)
         self.assertEqual(op.dim, (dim, dim))
         self.assertEqual(op.input_dims(), j * (2,))
@@ -128,7 +128,7 @@ class TestScalarOpMethods(ScalarOpTestCase):
     def test_base_operator_power_exp(self, coeff, exp):
         """Test basic class power method (** {exp}, coeff={coeff})"""
         op = ScalarOp(4, coeff=coeff).power(exp)
-        target = coeff ** exp
+        target = coeff**exp
         self.assertTrue(isinstance(op, ScalarOp))
         self.assertAlmostEqual(op.coeff, target)
 

--- a/test/python/quantum_info/states/test_densitymatrix.py
+++ b/test/python/quantum_info/states/test_densitymatrix.py
@@ -1016,7 +1016,7 @@ class TestDensityMatrix(QiskitTestCase):
         """Test expectation_value method for Pauli op"""
         seed = 1020
         op = Pauli(pauli)
-        rho = random_density_matrix(2 ** op.num_qubits, seed=seed)
+        rho = random_density_matrix(2**op.num_qubits, seed=seed)
         rho._data = np.reshape(rho.data.flatten(order="F"), rho.data.shape, order="F")
         target = rho.expectation_value(op.to_matrix())
         expval = rho.expectation_value(op)
@@ -1092,7 +1092,7 @@ class TestDensityMatrix(QiskitTestCase):
         """Test expectation_value method for Pauli op"""
         seed = 1020
         op = Pauli(pauli)
-        rho = random_density_matrix(2 ** op.num_qubits, seed=seed)
+        rho = random_density_matrix(2**op.num_qubits, seed=seed)
         rho._data = np.reshape(rho.data.flatten(order="C"), rho.data.shape, order="C")
         target = rho.expectation_value(op.to_matrix())
         expval = rho.expectation_value(op)
@@ -1103,7 +1103,7 @@ class TestDensityMatrix(QiskitTestCase):
         """Test expectation_value method for Pauli op"""
         seed = 1020
         op = random_pauli(2, seed=seed)
-        state = random_density_matrix(2 ** 3, seed=seed)
+        state = random_density_matrix(2**3, seed=seed)
         target = state.expectation_value(op.to_matrix(), qubits)
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)

--- a/test/python/quantum_info/states/test_measures.py
+++ b/test/python/quantum_info/states/test_measures.py
@@ -135,7 +135,7 @@ class TestStateMeasures(QiskitTestCase):
             (0.75, 0.25),
             (0, 0.75),
         ]:
-            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha ** 2 - beta ** 2)])
+            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(purity(psi), purity(rho))
 
@@ -184,7 +184,7 @@ class TestStateMeasures(QiskitTestCase):
             (0.75, 0.25),
             (0, 0.75),
         ]:
-            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha ** 2 - beta ** 2)])
+            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(entropy(psi), entropy(rho))
 
@@ -235,7 +235,7 @@ class TestStateMeasures(QiskitTestCase):
             (0.75, 0.25),
             (0, 0.75),
         ]:
-            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha ** 2 - beta ** 2)])
+            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(concurrence(psi), concurrence(rho))
 
@@ -288,7 +288,7 @@ class TestStateMeasures(QiskitTestCase):
             (0.75, 0.25),
             (0, 0.75),
         ]:
-            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha ** 2 - beta ** 2)])
+            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(entanglement_of_formation(psi), entanglement_of_formation(rho))
 
@@ -337,7 +337,7 @@ class TestStateMeasures(QiskitTestCase):
             (0.75, 0.25),
             (0, 0.75),
         ]:
-            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha ** 2 - beta ** 2)])
+            psi = Statevector([alpha, beta, 0, 1j * np.sqrt(1 - alpha**2 - beta**2)])
             rho = DensityMatrix(psi)
             self.assertAlmostEqual(mutual_information(psi), mutual_information(rho))
 

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -220,8 +220,8 @@ class TestStatevector(QiskitTestCase):
     def test_getitem_except(self):
         """Test __getitem__ method raises exceptions."""
         for i in range(1, 4):
-            state = Statevector(self.rand_vec(2 ** i))
-            self.assertRaises(QiskitError, state.__getitem__, 2 ** i)
+            state = Statevector(self.rand_vec(2**i))
+            self.assertRaises(QiskitError, state.__getitem__, 2**i)
             self.assertRaises(QiskitError, state.__getitem__, -1)
 
     def test_copy(self):
@@ -1043,7 +1043,7 @@ class TestStatevector(QiskitTestCase):
         """Test expectation_value method for Pauli op"""
         seed = 1020
         op = Pauli(pauli)
-        state = random_statevector(2 ** op.num_qubits, seed=seed)
+        state = random_statevector(2**op.num_qubits, seed=seed)
         target = state.expectation_value(op.to_matrix())
         expval = state.expectation_value(op)
         self.assertAlmostEqual(expval, target)
@@ -1053,7 +1053,7 @@ class TestStatevector(QiskitTestCase):
         """Test expectation_value method for Pauli op"""
         seed = 1020
         op = random_pauli(2, seed=seed)
-        state = random_statevector(2 ** 3, seed=seed)
+        state = random_statevector(2**3, seed=seed)
         target = state.expectation_value(op.to_matrix(), qubits)
         expval = state.expectation_value(op, qubits)
         self.assertAlmostEqual(expval, target)
@@ -1079,7 +1079,7 @@ class TestStatevector(QiskitTestCase):
         circ = transpile(state_circ, sim)
         circ.measure(qargs, range(nc))
         result = sim.run(circ, shots=shots, seed_simulator=seed).result()
-        target = np.zeros(2 ** nc, dtype=float)
+        target = np.zeros(2**nc, dtype=float)
         for i, p in result.get_counts(0).int_outcomes().items():
             target[i] = p / shots
         # Compare
@@ -1120,7 +1120,7 @@ class TestStatevector(QiskitTestCase):
 
     def test_state_to_latex_for_large_statevector(self):
         """Test conversion of large dense state vector"""
-        sv = Statevector(np.ones((2 ** 15, 1)))
+        sv = Statevector(np.ones((2**15, 1)))
         latex_representation = state_to_latex(sv)
         self.assertEqual(
             latex_representation,
@@ -1132,7 +1132,7 @@ class TestStatevector(QiskitTestCase):
 
     def test_state_to_latex_for_large_sparse_statevector(self):
         """Test conversion of large sparse state vector"""
-        sv = Statevector(np.eye(2 ** 15, 1))
+        sv = Statevector(np.eye(2**15, 1))
         latex_representation = state_to_latex(sv)
         self.assertEqual(latex_representation, " |000000000000000\\rangle")
 

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -96,14 +96,14 @@ ONEQ_CLIFFORDS = make_oneq_cliffords()
 def make_hard_thetas_oneq(smallest=1e-18, factor=3.2, steps=22, phi=0.7, lam=0.9):
     """Make 1q gates with theta/2 close to 0, pi/2, pi, 3pi/2"""
     return (
-        [U3Gate(smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(-smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(np.pi / 2 + smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(np.pi / 2 - smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(np.pi + smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(np.pi - smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(3 * np.pi / 2 + smallest * factor ** i, phi, lam) for i in range(steps)]
-        + [U3Gate(3 * np.pi / 2 - smallest * factor ** i, phi, lam) for i in range(steps)]
+        [U3Gate(smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(-smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(np.pi / 2 + smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(np.pi / 2 - smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(np.pi + smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(np.pi - smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(3 * np.pi / 2 + smallest * factor**i, phi, lam) for i in range(steps)]
+        + [U3Gate(3 * np.pi / 2 - smallest * factor**i, phi, lam) for i in range(steps)]
     )
 
 
@@ -607,8 +607,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_a00(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,0,0)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for k1l, k1r, k2l, k2r in K1K2S:
@@ -620,8 +620,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_aa0(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,a,0)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for k1l, k1r, k2l, k2r in K1K2S:
@@ -633,8 +633,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_aaa(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,a,a)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for k1l, k1r, k2l, k2r in K1K2S:
@@ -646,8 +646,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_aama(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,a,-a)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for k1l, k1r, k2l, k2r in K1K2S:
@@ -659,8 +659,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_ab0(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,b,0)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for bbb in np.linspace(0, aaa, 10):
@@ -673,8 +673,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_abb(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,b,b)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for bbb in np.linspace(0, aaa, 6):
@@ -687,8 +687,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_abmb(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,b,-b)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for bbb in np.linspace(0, aaa, 6):
@@ -701,8 +701,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_aac(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,a,c)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for ccc in np.linspace(-aaa, aaa, 6):
@@ -715,8 +715,8 @@ class TestTwoQubitWeylDecomposition(CheckDecompositions):
     def test_two_qubit_weyl_decomposition_abc(self, smallest=1e-18, factor=9.8, steps=11):
         """Verify Weyl KAK decomposition for U~Ud(a,b,c)"""
         for aaa in (
-            [smallest * factor ** i for i in range(steps)]
-            + [np.pi / 4 - smallest * factor ** i for i in range(steps)]
+            [smallest * factor**i for i in range(steps)]
+            + [np.pi / 4 - smallest * factor**i for i in range(steps)]
             + [np.pi / 8, 0.113 * np.pi, 0.1972 * np.pi]
         ):
             for bbb in np.linspace(0, aaa, 4):

--- a/test/python/result/test_mitigators.py
+++ b/test/python/result/test_mitigators.py
@@ -222,7 +222,7 @@ class TestReadoutMitigation(QiskitTestCase):
         LRM = LocalReadoutMitigator(circuits_data["local_method_matrices"])
         num_qubits = circuits_data["num_qubits"]
         diagonals = []
-        diagonals.append(z_diagonal(2 ** num_qubits))
+        diagonals.append(z_diagonal(2**num_qubits))
         diagonals.append("IZ0")
         diagonals.append("ZZZ")
         diagonals.append("101")

--- a/test/python/transpiler/test_token_swapper.py
+++ b/test/python/transpiler/test_token_swapper.py
@@ -103,7 +103,7 @@ class TestGeneral(QiskitTestCase):
         """Test a random (partial) mapping on a large randomly generated graph"""
         size = 100
         # Note that graph may have "gaps" in the node counts, i.e. the numbering is noncontiguous.
-        graph = rx.undirected_gnm_random_graph(size, size ** 2 // 10)
+        graph = rx.undirected_gnm_random_graph(size, size**2 // 10)
         for i in graph.node_indexes():
             try:
                 graph.remove_edge(i, i)  # Remove self-loops.

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -84,7 +84,7 @@ class TestUnroll3qOrMore(QiskitTestCase):
         """Test unrolling of identity gate over 3qubits."""
         qr = QuantumRegister(3, "qr")
         circuit = QuantumCircuit(qr)
-        gate = UnitaryGate(np.eye(2 ** 3))
+        gate = UnitaryGate(np.eye(2**3))
         circuit.append(gate, range(3))
         dag = circuit_to_dag(circuit)
         pass_ = Unroll3qOrMore()

--- a/test/python/utils/mitigation/test_meas.py
+++ b/test/python/utils/mitigation/test_meas.py
@@ -260,7 +260,7 @@ class TestMeasCal(QiskitTestCase):
             result_dict[state] = #shots/len(state_labels)
         """
         results_dict = {}
-        results_list = [0] * (2 ** weight)
+        results_list = [0] * (2**weight)
         state_num = len(state_labels)
         for state in state_labels:
             shots_per_state = self.shots / state_num
@@ -273,7 +273,7 @@ class TestMeasCal(QiskitTestCase):
     def test_ideal_meas_cal(self):
         """Test ideal execution, without noise."""
         for nq in self.nq_list:
-            for pattern_type in range(1, 2 ** nq):
+            for pattern_type in range(1, 2**nq):
 
                 # Generate the quantum register according to the pattern
                 qubits, weight = self.choose_calibration(nq, pattern_type)
@@ -290,7 +290,7 @@ class TestMeasCal(QiskitTestCase):
                 meas_cal = CompleteMeasFitter(cal_results, state_labels, circlabel="test")
 
                 # Assert that the calibration matrix is equal to identity
-                IdentityMatrix = np.identity(2 ** weight)
+                IdentityMatrix = np.identity(2**weight)
                 self.assertListEqual(
                     meas_cal.cal_matrix.tolist(),
                     IdentityMatrix.tolist(),

--- a/test/python/visualization/test_circuit_latex.py
+++ b/test/python/visualization/test_circuit_latex.py
@@ -434,7 +434,7 @@ class TestLatexSourceGenerator(QiskitVisualizationTestCase):
         filename2 = self._get_resource_path("test_latex_scale_half.tex")
         filename3 = self._get_resource_path("test_latex_scale_double.tex")
         circuit = QuantumCircuit(5)
-        circuit.unitary(random_unitary(2 ** 5), circuit.qubits)
+        circuit.unitary(random_unitary(2**5), circuit.qubits)
 
         circuit_drawer(circuit, filename=filename1, output="latex_source")
 

--- a/test/randomized/test_clifford.py
+++ b/test/randomized/test_clifford.py
@@ -28,7 +28,7 @@ class TestClifford(unittest.TestCase):
         self.assertEqual(value.num_qubits, num_qubits)
 
     @given(
-        strategies.integers(min_value=0, max_value=2 ** 32 - 1),
+        strategies.integers(min_value=0, max_value=2**32 - 1),
         strategies.integers(min_value=1, max_value=211),
     )
     @settings(deadline=None)

--- a/test/randomized/test_synthesis.py
+++ b/test/randomized/test_synthesis.py
@@ -31,7 +31,7 @@ from qiskit.quantum_info.synthesis.two_qubit_decompose import (
 class TestSynthesis(CheckDecompositions):
     """Test synthesis"""
 
-    seed = strategies.integers(min_value=0, max_value=2 ** 32 - 1)
+    seed = strategies.integers(min_value=0, max_value=2**32 - 1)
     rotation = strategies.floats(min_value=-np.pi * 10, max_value=np.pi * 10)
 
     @given(seed)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This commit bumps the black version we pin to the latest release,
22.1.0. This release is also the first release not marked as beta and
with that black has introduced a stability policy where no formatting
changes will be introduced on a major version release (which is the
year). [1] With this new policy in place we no longer need to pin to a
single version and can instead constrain the requirement to just the
major version without worrying about a new release breaking ci or local
development. This commit does that and sets the black version
requirement to be any 22.x.y release so that we'll continue to get
bugfixes moving forward without having to manually bump a pinned version.

### Details and comments

[1] https://black.readthedocs.io/en/latest/the_black_code_style/index.html#stability-policy
