### PR TITLE
Add Operator.from_circuit constructor method

### DIFF
--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -200,11 +200,14 @@ class Operator(LinearOp):
         return op
 
     @classmethod
-    def from_circuit(cls, circuit, use_layout=True, layout=None):
+    def from_circuit(cls, circuit, ignore_set_layout=False, layout=None):
         """Create a new Operator object from a :class`.QuantumCircuit`
 
         While a :class:`.QuantumCircuit` object can passed directly as ``data``
-        to the class constructor
+        to the class constructor this provides no options on how the circuit
+        is used to create an :class:`.Operator`. This constructor method lets
+        you control how the :class:`.Operator` is created so it can be adjusted
+        for a particular use case.
 
         By default this constructor method will permute the qubits based on a
         configured initial layout (i.e. after it was transpiled). It also
@@ -214,7 +217,7 @@ class Operator(LinearOp):
         Args:
             circuit (QuantumCircuit): The :class:`.QuantumCircuit` to create an Operator
                 object from.
-            use_layout (bool): When set to ``False`` if the input ``circuit``
+            ignore_set_layout (bool): When set to ``True`` if the input ``circuit``
                 has a layout set it will be ignored
             layout (Layout): If specified this kwarg can be used to specify a
                 particular layout to use to permute the qubits in the created
@@ -226,7 +229,7 @@ class Operator(LinearOp):
         dimension = 2 ** circuit.num_qubits
         op = cls(np.eye(dimension))
         if layout is None:
-            if use_layout:
+            if not ignore_set_layout:
                 layout = getattr(circuit, "_layout", None)
         qargs = None
         # If there was a layout specified (either from the circuit

--- a/releasenotes/notes/Operator-from_circuit-25b20d4b3ad5c398.yaml
+++ b/releasenotes/notes/Operator-from_circuit-25b20d4b3ad5c398.yaml
@@ -1,0 +1,28 @@
+---
+features:
+  - |
+    Added a new constructor method for the :class:`.Operator` class,
+    :meth:`.Operator.from_circuit` for creating a new :class`.Operator`
+    object from a :class:`.QuantumCircuit`. While this was possible normally
+    using the default constructor, the :meth:`.Operator.from_circuit` method
+    provide additional options to adjust how the operator is created. Primarily
+    this lets you permute the qubit order based on a set :class:`.Layout`. For,
+    example::
+
+      from qiskit.circuit import QuantumCircuit
+      from qiskit import transpile
+      from qiskit.transpiler import CouplingMap
+      from qiskit.quantum_info import Operator
+
+      circuit = QuantumCircuit(3)
+      circuit.h(0)
+      circuit.cx(0, 1)
+      circuit.cx(1, 2)
+
+      cmap = CouplingMap.from_line(3)
+      out_circuit = transpile(circuit, initial_layout=[2, 1, 0], coupling_map=cmap)
+      operator = Operator.from_circuit(out_circuit)
+
+    the ``operator`` variable will have the qubits permuted based on the
+    layout so that it is identical to what is returned by ``Operator(circuit)``
+    before transpilation.

--- a/releasenotes/notes/Operator-from_circuit-25b20d4b3ad5c398.yaml
+++ b/releasenotes/notes/Operator-from_circuit-25b20d4b3ad5c398.yaml
@@ -5,7 +5,7 @@ features:
     :meth:`.Operator.from_circuit` for creating a new :class`.Operator`
     object from a :class:`.QuantumCircuit`. While this was possible normally
     using the default constructor, the :meth:`.Operator.from_circuit` method
-    provide additional options to adjust how the operator is created. Primarily
+    provides additional options to adjust how the operator is created. Primarily
     this lets you permute the qubit order based on a set :class:`.Layout`. For,
     example::
 

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -25,6 +25,7 @@ from qiskit import QiskitError
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.circuit.library import HGate, CHGate, CXGate, QFT
 from qiskit.test import QiskitTestCase
+from qiskit.transpiler.layout import Layout
 from qiskit.quantum_info.operators.operator import Operator
 from qiskit.quantum_info.operators.predicates import matrix_equal
 
@@ -664,6 +665,145 @@ class TestOperator(OperatorTestCase):
         state1 = Operator(circ1)
         state2 = Operator(circ2)
         self.assertEqual(state1.reverse_qargs(), state2)
+
+    def test_from_circuit_constructor_no_layout(self):
+        """Test initialization from a circuit using the from_circuit constructor."""
+        # Test tensor product of 1-qubit gates
+        circuit = QuantumCircuit(3)
+        circuit.h(0)
+        circuit.x(1)
+        circuit.ry(np.pi / 2, 2)
+        op = Operator.from_circuit(circuit)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = np.kron(y90, np.kron(self.UX, self.UH))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of Controlled-Phase gate
+        lam = np.pi / 4
+        circuit = QuantumCircuit(2)
+        circuit.cp(lam, 0, 1)
+        op = Operator.from_circuit(circuit)
+        target = np.diag([1, 1, 1, np.exp(1j * lam)])
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of controlled-H gate
+        circuit = QuantumCircuit(2)
+        circuit.ch(0, 1)
+        op = Operator.from_circuit(circuit)
+        target = np.kron(self.UI, np.diag([1, 0])) + np.kron(self.UH, np.diag([0, 1]))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+    def test_from_circuit_constructor_reverse_embedded_layout(self):
+        """Test initialization from a circuit with an embedded reverse layout."""
+        # Test tensor product of 1-qubit gates
+        circuit = QuantumCircuit(3)
+        circuit.h(2)
+        circuit.x(1)
+        circuit.ry(np.pi / 2, 0)
+        circuit._layout = Layout({circuit.qubits[2]: 0, circuit.qubits[1]: 1, circuit.qubits[0]: 2})
+        op = Operator.from_circuit(circuit)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = np.kron(y90, np.kron(self.UX, self.UH))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of Controlled-Phase gate
+        lam = np.pi / 4
+        circuit = QuantumCircuit(2)
+        circuit.cp(lam, 1, 0)
+        circuit._layout = Layout({circuit.qubits[1]: 0, circuit.qubits[0]: 1})
+        op = Operator.from_circuit(circuit)
+        target = np.diag([1, 1, 1, np.exp(1j * lam)])
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of controlled-H gate
+        circuit = QuantumCircuit(2)
+        circuit.ch(1, 0)
+        circuit._layout = Layout({circuit.qubits[1]: 0, circuit.qubits[0]: 1})
+        op = Operator.from_circuit(circuit)
+        target = np.kron(self.UI, np.diag([1, 0])) + np.kron(self.UH, np.diag([0, 1]))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+    def test_from_circuit_constructor_reverse_user_specified_layout(self):
+        """Test initialization from a circuit with a user specified reverse layout."""
+        # Test tensor product of 1-qubit gates
+        circuit = QuantumCircuit(3)
+        circuit.h(2)
+        circuit.x(1)
+        circuit.ry(np.pi / 2, 0)
+        layout = Layout({circuit.qubits[2]: 0, circuit.qubits[1]: 1, circuit.qubits[0]: 2})
+        op = Operator.from_circuit(circuit, layout=layout)
+        y90 = (1 / np.sqrt(2)) * np.array([[1, -1], [1, 1]])
+        target = np.kron(y90, np.kron(self.UX, self.UH))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of Controlled-Phase gate
+        lam = np.pi / 4
+        circuit = QuantumCircuit(2)
+        circuit.cp(lam, 1, 0)
+        layout = Layout({circuit.qubits[1]: 0, circuit.qubits[0]: 1})
+        op = Operator.from_circuit(circuit, layout=layout)
+        target = np.diag([1, 1, 1, np.exp(1j * lam)])
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+        # Test decomposition of controlled-H gate
+        circuit = QuantumCircuit(2)
+        circuit.ch(1, 0)
+        layout = Layout({circuit.qubits[1]: 0, circuit.qubits[0]: 1})
+        op = Operator.from_circuit(circuit, layout=layout)
+        target = np.kron(self.UI, np.diag([1, 0])) + np.kron(self.UH, np.diag([0, 1]))
+        global_phase_equivalent = matrix_equal(op.data, target, ignore_phase=True)
+        self.assertTrue(global_phase_equivalent)
+
+    def test_from_circuit_constructor_ghz_out_of_order_layout(self):
+        """Test an out of order ghz state with a layout set."""
+        circuit = QuantumCircuit(5)
+        circuit.h(3)
+        circuit.cx(3, 4)
+        circuit.cx(3, 2)
+        circuit.cx(3, 0)
+        circuit.cx(3, 1)
+        circuit._layout = Layout(
+            {
+                circuit.qubits[3]: 0,
+                circuit.qubits[4]: 1,
+                circuit.qubits[2]: 2,
+                circuit.qubits[0]: 3,
+                circuit.qubits[1]: 4,
+            }
+        )
+        result = Operator.from_circuit(circuit)
+        expected = QuantumCircuit(5)
+        expected.h(0)
+        expected.cx(0, 1)
+        expected.cx(0, 2)
+        expected.cx(0, 3)
+        expected.cx(0, 4)
+        expected_op = Operator(expected)
+        self.assertTrue(expected_op.equiv(result))
+
+    def test_from_circuit_empty_circuit_empty_layout(self):
+        """Test an out of order ghz state with a layout set."""
+        circuit = QuantumCircuit()
+        circuit._layout = Layout()
+        op = Operator.from_circuit(circuit)
+        self.assertEqual(Operator([1]), op)
+
+    def test_from_circuit_constructor_empty_layout(self):
+        """Test an out of order ghz state with a layout set."""
+        circuit = QuantumCircuit(2)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        layout = Layout()
+        with self.assertRaises(KeyError):
+            Operator.from_circuit(circuit, layout=layout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new constructor method .from_circuit() to the
Operator class. This allows users to construct Operator objects from
QuantumCircuits and have additional features than the default __init__
constructor allows. To start this just involves permuting the qubit
order based on the specified layout. The permutation based on layout has
come before, especially in testing with transpilation (see #7213 for
where equivalent functionality was done inline in the unittests).
Exposing this as an api will provide a single place to build an Operator
with a layout. It also will provide us a dedicated location if we need
to offer additional options to the construction of Operators from
circuits.

### Details and comments