### PR TITLE
Rework `QuantumCircuit._append` and bit resolver

### DIFF
--- a/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
+++ b/qiskit/circuit/library/standard_gates/multi_control_rotation_gates.py
@@ -96,26 +96,12 @@ def mcrx(
     Raises:
         QiskitError: parameter errors
     """
-
-    # check controls
-    if isinstance(q_controls, QuantumRegister):
-        control_qubits = list(q_controls)
-    elif isinstance(q_controls, list):
-        control_qubits = q_controls
-    else:
-        raise QiskitError(
-            "The mcrx gate needs a list of qubits or a quantum register for controls."
-        )
-
-    # check target
-    if isinstance(q_target, Qubit):
-        target_qubit = q_target
-    else:
-        raise QiskitError("The mcrx gate needs a single qubit as target.")
-
-    all_qubits = control_qubits + [target_qubit]
-
-    self._check_qargs(all_qubits)
+    control_qubits = self.qbit_argument_conversion(q_controls)
+    target_qubit = self.qbit_argument_conversion(q_target)
+    if len(target_qubit) != 1:
+        raise QiskitError("The mcrz gate needs a single qubit as target.")
+    all_qubits = control_qubits + target_qubit
+    target_qubit = target_qubit[0]
     self._check_dups(all_qubits)
 
     n_c = len(control_qubits)
@@ -166,38 +152,13 @@ def mcry(
     Raises:
         QiskitError: parameter errors
     """
-
-    # check controls
-    if isinstance(q_controls, QuantumRegister):
-        control_qubits = list(q_controls)
-    elif isinstance(q_controls, list):
-        control_qubits = q_controls
-    else:
-        raise QiskitError(
-            "The mcry gate needs a list of qubits or a quantum register for controls."
-        )
-
-    # check target
-    if isinstance(q_target, Qubit):
-        target_qubit = q_target
-    else:
-        raise QiskitError("The mcry gate needs a single qubit as target.")
-
-    # check ancilla
-    if q_ancillae is None:
-        ancillary_qubits = []
-    elif isinstance(q_ancillae, QuantumRegister):
-        ancillary_qubits = list(q_ancillae)
-    elif isinstance(q_ancillae, list):
-        ancillary_qubits = q_ancillae
-    else:
-        raise QiskitError(
-            "The mcry gate needs None or a list of qubits or a quantum register for ancilla."
-        )
-
-    all_qubits = control_qubits + [target_qubit] + ancillary_qubits
-
-    self._check_qargs(all_qubits)
+    control_qubits = self.qbit_argument_conversion(q_controls)
+    target_qubit = self.qbit_argument_conversion(q_target)
+    if len(target_qubit) != 1:
+        raise QiskitError("The mcrz gate needs a single qubit as target.")
+    ancillary_qubits = [] if q_ancillae is None else self.qbit_argument_conversion(q_ancillae)
+    all_qubits = control_qubits + target_qubit + ancillary_qubits
+    target_qubit = target_qubit[0]
     self._check_dups(all_qubits)
 
     # auto-select the best mode
@@ -255,26 +216,12 @@ def mcrz(
     Raises:
         QiskitError: parameter errors
     """
-
-    # check controls
-    if isinstance(q_controls, QuantumRegister):
-        control_qubits = list(q_controls)
-    elif isinstance(q_controls, list):
-        control_qubits = q_controls
-    else:
-        raise QiskitError(
-            "The mcrz gate needs a list of qubits or a quantum register for controls."
-        )
-
-    # check target
-    if isinstance(q_target, Qubit):
-        target_qubit = q_target
-    else:
+    control_qubits = self.qbit_argument_conversion(q_controls)
+    target_qubit = self.qbit_argument_conversion(q_target)
+    if len(target_qubit) != 1:
         raise QiskitError("The mcrz gate needs a single qubit as target.")
-
-    all_qubits = control_qubits + [target_qubit]
-
-    self._check_qargs(all_qubits)
+    all_qubits = control_qubits + target_qubit
+    target_qubit = target_qubit[0]
     self._check_dups(all_qubits)
 
     n_c = len(control_qubits)

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1070,46 +1070,6 @@ class QuantumCircuit:
         except (ValueError, TypeError):
             return value
 
-    @staticmethod
-    def _bit_argument_conversion(bit_representation, in_array: Sequence[BitType]) -> List[BitType]:
-        try:
-            if isinstance(bit_representation, Bit):
-                # circuit.h(qr[0]) -> circuit.h([qr[0]])
-                ret = [bit_representation]
-            elif isinstance(bit_representation, Register):
-                # circuit.h(qr) -> circuit.h([qr[0], qr[1]])
-                ret = bit_representation[:]
-            elif isinstance(QuantumCircuit.cast(bit_representation, int), int):
-                # circuit.h(0) -> circuit.h([qr[0]])
-                ret = [in_array[bit_representation]]
-            elif isinstance(bit_representation, slice):
-                # circuit.h(slice(0,2)) -> circuit.h([qr[0], qr[1]])
-                ret = in_array[bit_representation]
-            elif isinstance(bit_representation, list) and all(
-                isinstance(bit, Bit) for bit in bit_representation
-            ):
-                # circuit.h([qr[0], qr[1]]) -> circuit.h([qr[0], qr[1]])
-                ret = bit_representation
-            elif isinstance(QuantumCircuit.cast(bit_representation, list), (range, list)):
-                # circuit.h([0, 1])     -> circuit.h([qr[0], qr[1]])
-                # circuit.h(range(0,2)) -> circuit.h([qr[0], qr[1]])
-                # circuit.h([qr[0],1])  -> circuit.h([qr[0], qr[1]])
-                ret = [
-                    index if isinstance(index, Bit) else in_array[index]
-                    for index in bit_representation
-                ]
-            else:
-                raise CircuitError(
-                    f"Not able to expand a {bit_representation} ({type(bit_representation)})"
-                )
-        except IndexError as ex:
-            raise CircuitError("Index out of range.") from ex
-        except TypeError as ex:
-            raise CircuitError(
-                f"Type error handling {bit_representation} ({type(bit_representation)})"
-            ) from ex
-        return ret
-
     def qbit_argument_conversion(self, qubit_representation: QubitSpecifier) -> List[Qubit]:
         """
         Converts several qubit representations (such as indexes, range, etc.)
@@ -1121,7 +1081,9 @@ class QuantumCircuit:
         Returns:
             List(Qubit): the resolved instances of the qubits.
         """
-        return QuantumCircuit._bit_argument_conversion(qubit_representation, self.qubits)
+        return _bit_argument_conversion(
+            qubit_representation, self.qubits, self._qubit_indices, Qubit
+        )
 
     def cbit_argument_conversion(self, clbit_representation: ClbitSpecifier) -> List[Clbit]:
         """
@@ -1134,7 +1096,9 @@ class QuantumCircuit:
         Returns:
             List(tuple): Where each tuple is a classical bit.
         """
-        return QuantumCircuit._bit_argument_conversion(clbit_representation, self.clbits)
+        return _bit_argument_conversion(
+            clbit_representation, self.clbits, self._clbit_indices, Clbit
+        )
 
     def _resolve_classical_resource(self, specifier):
         """Resolve a single classical resource specifier into a concrete resource, raising an error
@@ -1210,6 +1174,8 @@ class QuantumCircuit:
             )
         if not isinstance(instruction, Instruction) and hasattr(instruction, "to_instruction"):
             instruction = instruction.to_instruction()
+        if not isinstance(instruction, Instruction):
+            raise CircuitError("object is not an Instruction.")
 
         # Make copy of parameterized gate instances
         if hasattr(instruction, "params"):
@@ -1228,14 +1194,24 @@ class QuantumCircuit:
             requester = self._resolve_classical_resource
         instructions = InstructionSet(resource_requester=requester)
         for qarg, carg in instruction.broadcast_arguments(expanded_qargs, expanded_cargs):
+            self._check_dups(qarg)
             instructions.add(appender(instruction, qarg, carg), qarg, carg)
         return instructions
 
     def _append(
-        self, instruction: Instruction, qargs: Sequence[Qubit], cargs: Sequence[Clbit]
+        self,
+        instruction: Instruction,
+        qargs: Sequence[Qubit],
+        cargs: Sequence[Clbit],
     ) -> Instruction:
-        """Append an instruction to the end of the circuit, modifying
-        the circuit in place.
+        """Append an instruction to the end of the circuit, modifying the circuit in place.
+
+        .. warning::
+
+            This is an internal fast-path function, and it is the responsibility of the caller to
+            ensure that all the arguments are valid; there is no error checking here.  In
+            particular, all the qubits and clbits must already exist in the circuit and there can be
+            no duplicates in the list.
 
         .. note::
 
@@ -1249,28 +1225,16 @@ class QuantumCircuit:
 
         Args:
             instruction: Instruction instance to append
-            qargs: qubits to attach instruction to
-            cargs: clbits to attach instruction to
+            qargs: Qubits to attach the instruction to.
+            cargs: Clbits to attach the instruction to.
 
         Returns:
             Instruction: a handle to the instruction that was just added
 
-        Raises:
-            CircuitError: if the gate is of a different shape than the wires
-                it is being attached to.
+        :meta public:
         """
-        if not isinstance(instruction, Instruction):
-            raise CircuitError("object is not an Instruction.")
 
-        # do some compatibility checks
-        self._check_dups(qargs)
-        self._check_qargs(qargs)
-        self._check_cargs(cargs)
-
-        # add the instruction onto the given wires
-        instruction_context = instruction, qargs, cargs
-        self._data.append(instruction_context)
-
+        self._data.append((instruction, qargs, cargs))
         self._update_parameter_table(instruction)
 
         # mark as normal circuit if a new instruction is added
@@ -1446,20 +1410,6 @@ class QuantumCircuit:
         squbits = set(qubits)
         if len(squbits) != len(qubits):
             raise CircuitError("duplicate qubit arguments")
-
-    def _check_qargs(self, qargs: Sequence[Qubit]) -> None:
-        """Raise exception if a qarg is not in this circuit or bad format."""
-        if not all(isinstance(i, Qubit) for i in qargs):
-            raise CircuitError("qarg is not a Qubit")
-        if not set(qargs) <= self._qubit_indices.keys():
-            raise CircuitError("qargs not in this circuit")
-
-    def _check_cargs(self, cargs: Sequence[Clbit]) -> None:
-        """Raise exception if clbit is not in this circuit or bad format."""
-        if not all(isinstance(i, Clbit) for i in cargs):
-            raise CircuitError("carg is not a Clbit")
-        if not set(cargs) <= self._clbit_indices.keys():
-            raise CircuitError("cargs not in this circuit")
 
     def to_instruction(
         self,
@@ -4841,3 +4791,69 @@ def _insert_composite_gate_definition_qasm(
 
     string_temp = string_temp.replace(extension_lib, f"{extension_lib}{gate_definition_string}")
     return string_temp
+
+
+def _bit_argument_conversion(specifier, bit_sequence, bit_set, type_):
+    """Get the list of bits referred to by the specifier ``specifier``.
+
+    Valid types for ``specifier`` are integers, bits of the correct type (as given in ``type_``), or
+    iterables of one of those two scalar types.  Integers are interpreted as indices into the
+    sequence ``bit_sequence``.  All allowed bits must be in ``bit_set`` (which should implement
+    fast lookup), which is assumed to contain the same bits as ``bit_sequence``.
+
+    Returns:
+        List[Bit]: a list of the specified bits from ``bits``.
+
+    Raises:
+        CircuitError: if an incorrect type or index is encountered, if the same bit is specified
+            more than once, or if the specifier is to a bit not in the ``bit_set``.
+    """
+    # The duplication between this function and `_bit_argument_conversion_scalar` is so that fast
+    # paths return as quickly as possible, and all valid specifiers will resolve without needing to
+    # try/catch exceptions (which is too slow for inner-loop code).
+    if isinstance(specifier, type_):
+        if specifier in bit_set:
+            return [specifier]
+        raise CircuitError(f"Bit '{specifier}' is not in the circuit.")
+    if isinstance(specifier, (int, np.integer)):
+        try:
+            return [bit_sequence[specifier]]
+        except IndexError as ex:
+            raise CircuitError(
+                f"Index {specifier} out of range for size {len(bit_sequence)}."
+            ) from ex
+    # Slices can't raise IndexError - they just return an empty list.
+    if isinstance(specifier, slice):
+        return bit_sequence[specifier]
+    try:
+        return [
+            _bit_argument_conversion_scalar(index, bit_sequence, bit_set, type_)
+            for index in specifier
+        ]
+    except TypeError as ex:
+        message = (
+            f"Incorrect bit type: expected '{type_.__name__}' but got '{type(specifier).__name__}'"
+            if isinstance(specifier, Bit)
+            else f"Invalid bit index: '{specifier}' of type '{type(specifier)}'"
+        )
+        raise CircuitError(message) from ex
+
+
+def _bit_argument_conversion_scalar(specifier, bit_sequence, bit_set, type_):
+    if isinstance(specifier, type_):
+        if specifier in bit_set:
+            return specifier
+        raise CircuitError(f"Bit '{specifier}' is not in the circuit.")
+    if isinstance(specifier, (int, np.integer)):
+        try:
+            return bit_sequence[specifier]
+        except IndexError as ex:
+            raise CircuitError(
+                f"Index {specifier} out of range for size {len(bit_sequence)}."
+            ) from ex
+    message = (
+        f"Incorrect bit type: expected '{type_.__name__}' but got '{type(specifier).__name__}'"
+        if isinstance(specifier, Bit)
+        else f"Invalid bit index: '{specifier}' of type '{type(specifier)}'"
+    )
+    raise CircuitError(message)

--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -34,6 +34,8 @@ class QuantumCircuitData(MutableSequence):
 
         if not isinstance(instruction, Instruction) and hasattr(instruction, "to_instruction"):
             instruction = instruction.to_instruction()
+        if not isinstance(instruction, Instruction):
+            raise CircuitError("object is not an Instruction.")
 
         expanded_qargs = [self._circuit.qbit_argument_conversion(qarg) for qarg in qargs or []]
         expanded_cargs = [self._circuit.cbit_argument_conversion(carg) for carg in cargs or []]
@@ -47,15 +49,8 @@ class QuantumCircuitData(MutableSequence):
 
         qargs, cargs = broadcast_args[0]
 
-        if not isinstance(instruction, Instruction):
-            raise CircuitError("object is not an Instruction.")
-
         self._circuit._check_dups(qargs)
-        self._circuit._check_qargs(qargs)
-        self._circuit._check_cargs(cargs)
-
         self._circuit._data[key] = (instruction, qargs, cargs)
-
         self._circuit._update_parameter_table(instruction)
 
     def insert(self, index, value):

--- a/qiskit/extensions/quantum_initializer/initializer.py
+++ b/qiskit/extensions/quantum_initializer/initializer.py
@@ -450,12 +450,9 @@ def initialize(self, params, qubits=None):
     """
     if qubits is None:
         qubits = self.qubits
-    else:
-        if isinstance(qubits, int):
-            qubits = [qubits]
-        qubits = self._bit_argument_conversion(qubits, self.qubits)
-
-    num_qubits = None if not isinstance(params, int) else len(qubits)
+    elif isinstance(qubits, (int, np.integer, slice)):
+        qubits = [qubits]
+    num_qubits = len(qubits) if isinstance(params, int) else None
     return self.append(Initialize(params, num_qubits), qubits)
 
 

--- a/releasenotes/notes/rework-circuit-argument-resolver-780091cd6f97f872.yaml
+++ b/releasenotes/notes/rework-circuit-argument-resolver-780091cd6f97f872.yaml
@@ -1,0 +1,33 @@
+---
+upgrade:
+  - |
+    The resolver used by :meth:`.QuantumCircuit.append` (and consequently all
+    methods that add an instruction onto a :class:`.QuantumCircuit`) to convert
+    bit specifiers has changed to make it faster and more reliable.  Certain
+    constructs like::
+
+        import numpy as np
+        from qiskit import QuantumCircuit
+
+        qc = QuantumCircuit(1, 1)
+        qc.measure(np.array([0]), np.array([0]))
+
+    will now work where they previously would incorrectly raise an error, but
+    certain pathological inputs such as::
+
+        from sympy import E, I, pi
+        qc.x(E ** (I * pi))
+
+    will now raise errors where they may have occasionally (erroneously)
+    succeeded before.  For almost all correct uses, there should be no
+    noticeable change except for a general speed-up.
+  - |
+    The semi-public internal method :meth:`.QuantumCircuit._append` no longer
+    checks the types of its inputs, and assumes that there are no invalid
+    duplicates in its argument lists.  This function is used by certain internal
+    parts of Qiskit and other libraries to build up :class:`.QuantumCircuit`
+    instances as quickly as possible by skipping the error checking when the
+    data is already *known* to be correct.  In general, users or functions
+    taking in user data should use the public :meth:`.QuantumCircuit.append`
+    method, which resolves integer bit specifiers, broadcasts its arguments and
+    checks the inputs for correctness.


### PR DESCRIPTION
### Summary

The previous resolver of indices for bits involved catching several
exceptions even when resolving a valid specifier.  This is comparatively
slow for inner-loop code.  The implementation also assumed that if a
type could be cast to an integer, the only way it could be a valid
specifier was as an index.  This broke for size-1 Numpy arrays, which
can be cast to `int`, but should be treated as iterables.

Since `QuantumCircuit.append` necessarily checks the types of all its
arguments, it is unnecessary for `QuantumCircuit._append` to do so as
well.  This also allows anywhere that is constructing a `QuantumCircuit`
from known-safe data (such as copying from an existing circuit, or
building templates) to do so without the checks.  This is now
documented as its contract.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #7600.

This should have a noticeable impact on performance for even normal circuit construction, due to slightly faster conversions, and no duplicated type checks.  I see ~10-15% improvements in the circuit construction benchmark locally:
```text
       before           after         ratio
     [7af16a3d]       [0c89cc50]
     <main>           <rework-circuit-argument-resolver>
-      2.15±0.02s       1.94±0.01s     0.90  time_circuit_construction(14, 131072)
-      2.14±0.01s       1.93±0.02s     0.90  time_circuit_construction(20, 131072)
-         325±5ms          292±3ms     0.90  time_circuit_construction(1, 32768)
-      2.14±0.01s       1.92±0.02s     0.89  time_circuit_construction(8, 131072)
-         505±3ms          451±4ms     0.89  time_circuit_construction(2, 32768)
-      33.7±0.9ms       29.9±0.3ms     0.89  time_circuit_construction(8, 2048)
-      2.16±0.03s       1.91±0.04s     0.88  time_circuit_construction(5, 131072)
-       107±0.9μs         94.3±2μs     0.88  time_circuit_construction(1, 8)
-         539±6ms          474±6ms     0.88  time_circuit_construction(5, 32768)
-      2.04±0.01s       1.79±0.02s     0.88  time_circuit_construction(2, 131072)
-         185±4μs          162±2μs     0.88  time_circuit_construction(5, 8)
-         172±2μs          150±3μs     0.88  time_circuit_construction(2, 8)
-      1.30±0.01s       1.14±0.01s     0.87  time_circuit_construction(1, 131072)
-         135±4ms          118±2ms     0.87  time_circuit_construction(8, 8192)
-        295±10μs          256±7μs     0.87  time_circuit_construction(8, 8)
-        82.6±1ms         71.6±1ms     0.87  time_circuit_construction(1, 8192)
-     2.24±0.06ms      1.93±0.04ms     0.86  time_circuit_construction(8, 128)
-        35.5±1ms       30.4±0.4ms     0.85  time_circuit_construction(14, 2048)
-     1.35±0.07ms      1.15±0.02ms     0.85  time_circuit_construction(1, 128)
```

Strictly, there are some specifiers that were previously legal, but are now not.  This is anything that implements `__index__` but is neither an `int` nor a Numpy integer - I couldn't think of any useful cases for those (they're pretty weird types like sympy's integers), and the user always has an alternative (manually cast to `int`).