### PR TITLE
Allow anybody to approve release notes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,6 +31,6 @@ quantum_info/         @Qiskit/terra-core @ikkoham
 pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli
 scheduler/            @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli
 visualization/        @Qiskit/terra-core @nonhermitian @nkanazawa1989
-# All codeowners have permission on release notes since most PRs include
-# release notes
-/releasenotes/notes   @Qiskit/terra-core @manoelmarques @woodsp-ibm @ikkoham @jyu00 @eggerdj @nkanazawa1989 @danpuzzuoli @nonhermitian
+# Override the release notes directories to have _no_ code owners, so any review
+# from somebody with write access is acceptable.
+/releasenotes/notes


### PR DESCRIPTION
### Summary

This explicitly overrides the release notes directory to have no code
owner, so anybody with write access can give an approving review to
changes within, without GitHub requesting review from everyone.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

@mtreinish and I tried this on a separate repository, and it seemed to do the right thing, as best I could tell.
