### PR TITLE
Fix issue 7500 by setting a copy of the fake backend options to all i…

### DIFF
--- a/qiskit/test/mock/fake_backend.py
+++ b/qiskit/test/mock/fake_backend.py
@@ -119,6 +119,7 @@ class FakeBackend(BackendV1):
         """Main job in simulator"""
         circuits = run_input
         pulse_job = None
+        options_copy = dict(self.options.__dict__)
         if isinstance(circuits, (pulse.Schedule, pulse.ScheduleBlock)):
             pulse_job = True
         elif isinstance(circuits, circuit.QuantumCircuit):
@@ -140,9 +141,11 @@ class FakeBackend(BackendV1):
 
                 system_model = PulseSystemModel.from_backend(self)
                 sim = aer.Aer.get_backend("pulse_simulator")
+                sim.set_options(**options_copy)
                 job = sim.run(circuits, system_model=system_model, **kwargs)
             else:
                 sim = aer.Aer.get_backend("qasm_simulator")
+                sim.set_options(**options_copy)
                 if self.properties():
                     from qiskit.providers.aer.noise import NoiseModel
 
@@ -155,6 +158,7 @@ class FakeBackend(BackendV1):
                 raise QiskitError("Unable to run pulse schedules without qiskit-aer installed")
             warnings.warn("Aer not found using BasicAer and no noise", RuntimeWarning)
             sim = basicaer.BasicAer.get_backend("qasm_simulator")
+            sim.set_options(**options_copy)
             job = sim.run(circuits, **kwargs)
         return job
 


### PR DESCRIPTION
…nternal simulator options

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #7500 


### Details and comments
Created a copy of the options dictionary at the top of the run function for Fake Backends. Then this copy is set as the argument for the set_options in the internal simulators. This will allow the set_options for fake backends to work as intended.

