### PR TITLE
[WIP] Gradient Framework Update - Lin. Comb. for Imag Parts

### DIFF
--- a/qiskit/opflow/gradients/circuit_gradients/param_shift.py
+++ b/qiskit/opflow/gradients/circuit_gradients/param_shift.py
@@ -53,7 +53,6 @@ class ParamShift(CircuitGradient):
                       else use a finite difference approach
             epsilon: The offset size to use when computing finite difference gradients.
                      Ignored if analytic == True
-
         Raises:
             ValueError: If method != ``fin_diff`` and ``epsilon`` is not None.
         """
@@ -64,20 +63,16 @@ class ParamShift(CircuitGradient):
     @property
     def analytic(self) -> bool:
         """Returns ``analytic`` flag.
-
         Returns:
              ``analytic`` flag.
-
         """
         return self._analytic
 
     @property
     def epsilon(self) -> float:
         """Returns ``epsilon``.
-
         Returns:
             ``epsilon``.
-
         """
         return self._epsilon
 
@@ -103,13 +98,11 @@ class ParamShift(CircuitGradient):
                     If a Tuple[ParameterExpression, ParameterExpression] or
                     List[Tuple[ParameterExpression, ParameterExpression]]
                     is given, then the 2nd order derivative of the operator is calculated.
-
         Returns:
             An operator corresponding to the gradient resp. Hessian. The order is in accordance with
             the order of the given parameters.
         Raises:
             OpflowError: If the parameters are given in an invalid format.
-
         """
         if isinstance(params, (ParameterExpression, ParameterVector)):
             return self._parameter_shift(operator, params)
@@ -148,7 +141,6 @@ class ParamShift(CircuitGradient):
                     a ParameterVector is provided, each parameter will be shifted.
         Returns:
             param_shifted_op: An operator object which evaluates to the respective gradients.
-
         Raises:
             ValueError: If the given parameters do not occur in the provided operator
             TypeError: If the operator has more than one circuit representing the quantum state
@@ -273,17 +265,13 @@ class ParamShift(CircuitGradient):
         shift_constant: float,
     ) -> Union[Dict, np.ndarray]:
         """Implement the combo_fn used to evaluate probability gradients
-
         Args:
             x: Output of an operator evaluation
             shift_constant: Shifting constant factor needed for proper rescaling
-
         Returns:
             Array representing the probability gradients w.r.t. the given operator and parameters
-
         Raises:
             TypeError: if ``x`` is not DictStateFn, VectorStateFn or their list.
-
         """
         # In the probability gradient case, the amplitudes still need to be converted
         # into sampling probabilities.
@@ -348,15 +336,12 @@ class ParamShift(CircuitGradient):
     @staticmethod
     def _replace_operator_circuit(operator: OperatorBase, circuit: QuantumCircuit) -> OperatorBase:
         """Replace a circuit element in an operator with a single element given as circuit
-
         Args:
             operator: Operator for which the circuit representing the quantum state shall be
                       replaced
             circuit: Circuit which shall replace the circuit in the given operator
-
         Returns:
             Operator with replaced circuit quantum state function
-
         """
         if isinstance(operator, CircuitStateFn):
             return CircuitStateFn(circuit, coeff=operator.coeff)
@@ -370,13 +355,10 @@ class ParamShift(CircuitGradient):
     @classmethod
     def get_unique_circuits(cls, operator: OperatorBase) -> List[QuantumCircuit]:
         """Traverse the operator and return all unique circuits
-
         Args:
             operator: An operator that potentially includes QuantumCircuits
-
         Returns:
             A list of all unique quantum circuits that appear in the operator
-
         """
         if isinstance(operator, CircuitStateFn):
             return [operator.primitive]
@@ -401,14 +383,11 @@ class ParamShift(CircuitGradient):
         """Traverse the operator and return all OperatorBase objects flattened
            into a single list. This is used as a subroutine to extract all
            circuits within a large composite operator.
-
         Args:
             operator: An OperatorBase type object
-
         Returns:
             A single flattened list of all OperatorBase objects within the
             input operator
-
         """
         if isinstance(operator, ListOp):
             return [cls.unroll_operator(op) for op in operator]

--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -18,6 +18,7 @@ import numpy as np
 from qiskit.circuit import QuantumCircuit, QuantumRegister, ParameterVector, ParameterExpression
 from qiskit.utils.arithmetic import triu_to_dense
 
+from ...operator_base import OperatorBase
 from ...list_ops.list_op import ListOp
 from ...list_ops.summed_op import SummedOp
 from ...operator_globals import I, Z, Y
@@ -29,35 +30,45 @@ from .circuit_qfi import CircuitQFI
 
 class LinCombFull(CircuitQFI):
     r"""Compute the full Quantum Fisher Information (QFI).
-
     Given a pure, parameterized quantum state this class uses the linear combination of unitaries
     approach, requiring one additional working qubit.
     See also :class:`~qiskit.opflow.QFI`.
     """
 
+    # pylint: disable=signature-differs
     def convert(
         self,
         operator: CircuitStateFn,
         params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]],
+        aux_meas_op: OperatorBase = Z,
+        phase_fix: bool = True,
     ) -> ListOp:
         r"""
         Args:
             operator: The operator corresponding to the quantum state :math:`|\psi(\omega)\rangle`
                 for which we compute the QFI.
             params: The parameters :math:`\omega` with respect to which we are computing the QFI.
+            aux_meas_op: The operator that the auxiliary qubit is measured with respect to.
+                         for aux_meas_op = Z we compute Re[(dω⟨<ψ(ω)|)(dω|ψ(ω)〉)]
+                         for aux_meas_op = -iY we compute Im[(dω⟨<ψ(ω)|)(dω|ψ(ω)〉)]
+            phase_fix: Whether or not to compute the additional phase fix term
+                       Re[(dω⟨<ψ(ω)|)|ψ(ω)><ψ(ω)|(dω|ψ(ω))>]
+
 
         Returns:
             A ``ListOp[ListOp]`` where the operator at position ``[k][l]`` corresponds to the matrix
             element :math:`k, l` of the QFI.
-
         Raises:
             TypeError: If ``operator`` is an unsupported type.
         """
         # QFI & phase fix observable
-        qfi_observable = ~StateFn(4 * Z ^ (I ^ operator.num_qubits))
-        phase_fix_observable = StateFn(
-            (Z + 1j * Y) ^ (I ^ operator.num_qubits), is_measurement=True
-        )
+        qfi_observable = StateFn(
+            4 * aux_meas_op ^ (I ^ operator.num_qubits), is_measurement=True
+        ).reduce()
+        if phase_fix:
+            phase_fix_observable = SummedOp(
+                [Z ^ (I ^ operator.num_qubits), -1j * Y ^ (I ^ operator.num_qubits)]
+            )
         # see https://arxiv.org/pdf/quant-ph/0108146.pdf
 
         # Check if the given operator corresponds to a quantum state given as a circuit.
@@ -73,20 +84,22 @@ class LinCombFull(CircuitQFI):
         elif isinstance(params, ParameterVector):
             params = params[:]  # unroll to list
 
-        # First, the operators are computed which can compensate for a potential phase-mismatch
-        # between target and trained state, i.e.〈ψ|∂lψ〉
-        gradient_states = LinComb()._gradient_states(
-            operator,
-            meas_op=phase_fix_observable,
-            target_params=params,
-            open_ctrl=False,
-            trim_after_grad_gate=True,
-        )
-        # if type(gradient_states) in [ListOp, SummedOp]:  # pylint: disable=unidiomatic-typecheck
-        if type(gradient_states) == ListOp:
-            phase_fix_states = gradient_states.oplist
-        else:
-            phase_fix_states = [gradient_states]
+        if phase_fix:
+            # First, the operators are computed which can compensate for a potential phase-mismatch
+            # between target and trained state, i.e.〈ψ|∂lψ〉
+            gradient_states = LinComb()._gradient_states(
+                operator,
+                meas_op=phase_fix_observable,
+                target_params=params,
+                open_ctrl=True,
+                trim_after_grad_gate=True,
+            )
+            # if type(gradient_states) in [ListOp, SummedOp]:  # pylint: disable=unidiomatic-typecheck
+
+            if type(gradient_states) == ListOp:
+                phase_fix_states = gradient_states.oplist
+            else:
+                phase_fix_states = [gradient_states]
 
         # Get  4 * Re[〈∂kψ|∂lψ]
         qfi_operators = []
@@ -179,14 +192,17 @@ class LinCombFull(CircuitQFI):
 
                 # Compute −4 * Re(〈∂kψ|ψ〉〈ψ|∂lψ〉)
                 def phase_fix_combo_fn(x):
-                    return 4 * (-0.5) * (x[0] * np.conjugate(x[1]) + x[1] * np.conjugate(x[0]))
+                    return -4 * np.real(x[0] * np.conjugate(x[1]))
 
-                phase_fix = ListOp(
-                    [phase_fix_states[i], phase_fix_states[j]], combo_fn=phase_fix_combo_fn
-                )
-                # Add the phase fix quantities to the entries of the QFI
-                # Get 4 * Re[〈∂kψ|∂lψ〉−〈∂kψ|ψ〉〈ψ|∂lψ〉]
-                qfi_ops += [SummedOp(qfi_op) + phase_fix]
+                if phase_fix:
+                    phase_fix_op = ListOp(
+                        [phase_fix_states[i], phase_fix_states[j]], combo_fn=phase_fix_combo_fn
+                    )
+                    # Add the phase fix quantities to the entries of the QFI
+                    # Get 4 * Re[〈∂kψ|∂lψ〉−〈∂kψ|ψ〉〈ψ|∂lψ〉]
+                    qfi_ops += [SummedOp(qfi_op) + phase_fix_op]
+                else:
+                    qfi_ops += [SummedOp(qfi_op)]
 
             qfi_operators.append(ListOp(qfi_ops))
         # Return the full QFI

--- a/qiskit/opflow/gradients/derivative_base.py
+++ b/qiskit/opflow/gradients/derivative_base.py
@@ -35,15 +35,12 @@ OperatorType = Union[StateFn, PrimitiveOp, ListOp]
 
 class DerivativeBase(ConverterBase):
     r"""Base class for differentiating opflow objects.
-
     Converter for differentiating opflow objects and handling
     things like properly differentiating combo_fn's and enforcing product rules
     when operator coefficients are parameterized.
-
     This is distinct from CircuitGradient converters which use quantum
     techniques such as parameter shifts and linear combination of unitaries
     to compute derivatives of circuits.
-
     CircuitGradient - uses quantum techniques to get derivatives of circuits
     DerivativeBase - uses classical techniques to differentiate opflow data structures
     """
@@ -61,10 +58,8 @@ class DerivativeBase(ConverterBase):
         Args:
             operator: The operator we are taking the gradient, Hessian or QFI of
             params: The parameters we are taking the gradient, Hessian or QFI with respect to.
-
         Returns:
             An operator whose evaluation yields the gradient, Hessian or QFI.
-
         Raises:
             ValueError: If ``params`` contains a parameter not present in ``operator``.
         """
@@ -130,11 +125,9 @@ class DerivativeBase(ConverterBase):
         param_expr: ParameterExpression, param: ParameterExpression
     ) -> Union[ParameterExpression, float]:
         """Get the derivative of a parameter expression w.r.t. the given parameter.
-
         Args:
             param_expr: The Parameter Expression for which we compute the derivative
             param: Parameter w.r.t. which we want to take the derivative
-
         Returns:
             ParameterExpression representing the gradient of param_expr w.r.t. param
         """
@@ -151,10 +144,8 @@ class DerivativeBase(ConverterBase):
     @classmethod
     def _erase_operator_coeffs(cls, operator: OperatorBase) -> OperatorBase:
         """This method traverses an input operator and deletes all of the coefficients
-
         Args:
             operator: An operator type object.
-
         Returns:
             An operator which is equal to the input operator but whose coefficients
             have all been set to 1.0
@@ -169,7 +160,6 @@ class DerivativeBase(ConverterBase):
     @classmethod
     def _factor_coeffs_out_of_composed_op(cls, operator: OperatorBase) -> OperatorBase:
         """Factor all coefficients of ComposedOp out into a single global coefficient.
-
         Part of the automatic differentiation logic inside of Gradient and Hessian
         counts on the fact that no product or chain rules need to be computed between
         operators or coefficients within a ComposedOp. To ensure this condition is met,
@@ -177,14 +167,11 @@ class DerivativeBase(ConverterBase):
         ComposedOp, but where all coefficients have been factored out and placed onto the
         ComposedOp. Note that this cannot be done properly if an OperatorMeasurement contains
         a SummedOp as it's primitive.
-
         Args:
             operator: The operator whose coefficients are being re-organized
-
         Returns:
             An operator equivalent to the input operator, but whose coefficients have been
             reorganized
-
         Raises:
             ValueError: If an element within a ComposedOp has a primitive of type ListOp,
                         then it is not possible to factor all coefficients out of the ComposedOp.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR enables the use of linear combination gradients to evaluate imaginary parts. To that end, we include an `aux_meas_op` parameter in `circuit_gradients/lin_comb.py` and `circuit_qfis/lin_comb_full.py`.


### Details and comments
For the gradients:
`aux_meas_op = Z` computes `Re[(dω⟨ψ(ω)|)O(θ)|ψ(ω)〉]`
`aux_meas_op = -Y` computes `Im[(dω⟨ψ(ω)|)O(θ)|ψ(ω)〉]`

For the QFIs:
`aux_meas_op = Z` computes `Re[(dω⟨<ψ(ω)|)(dω|ψ(ω)〉)]`
`aux_meas_op = -Y` computes `Im[(dω⟨<ψ(ω)|)(dω|ψ(ω)〉)]`


TODO:

- [ ] Unittests


