### PR TITLE
Use `contract_nodes` from retworkx in `DAGCircuit`.

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1031,13 +1031,13 @@ class DAGCircuit:
                 block with
             wire_pos_map (Dict[Qubit, int]): The dictionary mapping the qarg to
                 the position. This is necessary to reconstruct the qarg order
-                over multiple gates in the combined singe op node.
+                over multiple gates in the combined single op node.
             cycle_check (bool): When set to True this method will check that
                 replacing the provided ``node_block`` with a single node
                 would introduce a a cycle (which would invalidate the
                 ``DAGCircuit``) and will raise a ``DAGCircuitError`` if a cycle
                 would be introduced. This checking comes with a run time
-                penalty, if you can guarantee that your input ``node_block`` is
+                penalty. If you can guarantee that your input ``node_block`` is
                 a contiguous block and won't introduce a cycle when it's
                 contracted to a single node, this can be set to ``False`` to
                 improve the runtime performance of this method.
@@ -1047,56 +1047,38 @@ class DAGCircuit:
                 the specified block introduces a cycle or if ``node_block`` is
                 empty.
         """
-        # TODO: Replace this with a function in retworkx to do this operation in
-        # the graph
-        block_preds = defaultdict(set)
-        block_succs = defaultdict(set)
         block_qargs = set()
         block_cargs = set()
-        block_ids = {x._node_id for x in node_block}
+        block_ids = [x._node_id for x in node_block]
 
         # If node block is empty return early
         if not node_block:
             raise DAGCircuitError("Can't replace an empty node_block")
 
         for nd in node_block:
-            for parent_id, _, edge in self._multi_graph.in_edges(nd._node_id):
-                if parent_id not in block_ids:
-                    block_preds[parent_id].add(edge)
-            for _, child_id, edge in self._multi_graph.out_edges(nd._node_id):
-                if child_id not in block_ids:
-                    block_succs[child_id].add(edge)
             block_qargs |= set(nd.qargs)
             if isinstance(nd, DAGOpNode) and nd.op.condition:
                 block_cargs |= set(nd.cargs)
-        if cycle_check:
-            # If we're cycle checking copy the graph to ensure we don't create
-            # invalid DAG when we encounter a cycle
-            backup_graph = self._multi_graph.copy()
-        # Add node and wire it into graph
-        new_index = self._add_op_node(
+
+        # Create replacement node
+        new_node = DAGOpNode(
             op,
             sorted(block_qargs, key=lambda x: wire_pos_map[x]),
             sorted(block_cargs, key=lambda x: wire_pos_map[x]),
         )
-        for node_id, edges in block_preds.items():
-            for edge in edges:
-                self._multi_graph.add_edge(node_id, new_index, edge)
-        for node_id, edges in block_succs.items():
-            for edge in edges:
-                self._multi_graph.add_edge(new_index, node_id, edge)
-        for nd in node_block:
-            self._multi_graph.remove_node(nd._node_id)
-        # If enabled ensure block won't introduce a cycle when node_block is
-        # contracted
-        if cycle_check:
-            # If a cycle was introduced remove new op node and raise error
-            if not rx.is_directed_acyclic_graph(self._multi_graph):
-                # If a cycle was encountered restore the graph to the
-                # original valid state
-                self._multi_graph = backup_graph
-                self._decrement_op(op)
-                raise DAGCircuitError("Replacing the specified node block would introduce a cycle")
+
+        try:
+            new_index = self._multi_graph.contract_nodes(
+                block_ids, new_node, check_cycle=cycle_check
+            )
+            new_node._node_id = new_index
+        except rx.DAGWouldCycle as ex:
+            raise DAGCircuitError(
+                "Replacing the specified node block would introduce a cycle"
+            ) from ex
+
+        self._increment_op(op)
+
         for nd in node_block:
             self._decrement_op(nd.op)
 

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1068,10 +1068,9 @@ class DAGCircuit:
         )
 
         try:
-            new_index = self._multi_graph.contract_nodes(
+            new_node._node_id = self._multi_graph.contract_nodes(
                 block_ids, new_node, check_cycle=cycle_check
             )
-            new_node._node_id = new_index
         except rx.DAGWouldCycle as ex:
             raise DAGCircuitError(
                 "Replacing the specified node block would introduce a cycle"

--- a/releasenotes/notes/bump-retworkx-0.11.0-97db170ae39cacf8.yaml
+++ b/releasenotes/notes/bump-retworkx-0.11.0-97db170ae39cacf8.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    The core dependency ``retworkx`` had its version requirement bumped to 0.11.0, up from 0.10.1.
+    This improves the performance of transpilation pass
+    :class:`~qiskit.transpiler.passes.ConsolidateBlocks`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-retworkx>=0.10.1
+retworkx>=0.11.0
 numpy>=1.17
 ply>=3.10
 psutil>=5

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -1605,6 +1605,7 @@ class TestReplaceBlock(QiskitTestCase):
         expected_dag.apply_operation_back(XGate(), [qr[0]])
 
         self.assertEqual(expected_dag, dag)
+        self.assertEqual(expected_dag.count_ops(), dag.count_ops())
 
 
 class TestDagProperties(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Replaces the bulk of the implementation of `DAGCircuit.replace_block_with_op` with the generic retworkx method `PyDiGraph.contract_nodes`, added in https://github.com/Qiskit/retworkx/pull/487.


### Details and comments

At a minimum, this change rids Terra of graph manipulation code that is more widely applicable in a generic graph library. For our current use cases (the `ConsolidateBlocks` pass) this change might improve performance slightly, but the primary speedup would be observed by `replace_block_with_op` callers that pass `cycle_check=True`, since retworkx's `contract_nodes` performs this check prior to modifying the DAG, and without making a backup copy.

Resolves #7418