### PR TITLE
Remove deprecated pass_manager arg to transpile()

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -64,7 +64,6 @@ def transpile(
     timing_constraints: Optional[Dict[str, int]] = None,
     seed_transpiler: Optional[int] = None,
     optimization_level: Optional[int] = None,
-    pass_manager: Optional[PassManager] = None,
     callback: Optional[Callable[[BasePass, DAGCircuit, float, PropertySet, int], Any]] = None,
     output_name: Optional[Union[str, List[str]]] = None,
     unitary_synthesis_method: str = "default",
@@ -190,10 +189,6 @@ def transpile(
             * 2: heavy optimization
             * 3: even heavier optimization
             If ``None``, level 1 will be chosen as default.
-        pass_manager: The pass manager to use for a custom pipeline of transpiler passes.
-            If this arg is present, all other args will be ignored and the
-            pass manager will be used directly (Qiskit will not attempt to
-            auto-select a pass manager based on transpile options).
         callback: A callback function that will be called after each
             pass execution. The function will be called with 5 keyword
             arguments,
@@ -260,32 +255,6 @@ def transpile(
         else:
             return circuits[0]
 
-    if pass_manager is not None:
-        _check_conflicting_argument(
-            optimization_level=optimization_level,
-            basis_gates=basis_gates,
-            coupling_map=coupling_map,
-            seed_transpiler=seed_transpiler,
-            backend_properties=backend_properties,
-            initial_layout=initial_layout,
-            layout_method=layout_method,
-            routing_method=routing_method,
-            translation_method=translation_method,
-            approximation_degree=approximation_degree,
-            unitary_synthesis_method=unitary_synthesis_method,
-            backend=backend,
-            target=target,
-        )
-
-        warnings.warn(
-            "The parameter pass_manager in transpile is being deprecated. "
-            "The preferred way to tranpile a circuit using a custom pass manager is"
-            " pass_manager.run(circuit)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return pass_manager.run(circuits, output_name=output_name, callback=callback)
-
     if optimization_level is None:
         # Take optimization level from the configuration or 1 as default.
         config = user_config.get_config()
@@ -341,15 +310,6 @@ def transpile(
         return circuits
     else:
         return circuits[0]
-
-
-def _check_conflicting_argument(**kargs):
-    conflicting_args = [arg for arg, value in kargs.items() if value]
-    if conflicting_args:
-        raise TranspilerError(
-            "The parameters pass_manager conflicts with the following "
-            "parameter(s): {}.".format(", ".join(conflicting_args))
-        )
 
 
 def _check_circuits_coupling_map(circuits, transpile_args, backend):
@@ -1038,12 +998,6 @@ def _parse_optimization_level(optimization_level, num_circuits):
     if not isinstance(optimization_level, list):
         optimization_level = [optimization_level] * num_circuits
     return optimization_level
-
-
-def _parse_pass_manager(pass_manager, num_circuits):
-    if not isinstance(pass_manager, list):
-        pass_manager = [pass_manager] * num_circuits
-    return pass_manager
 
 
 def _parse_callback(callback, num_circuits):

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -28,7 +28,7 @@ from qiskit.providers.models import BackendProperties
 from qiskit.providers.models.backendproperties import Gate
 from qiskit.pulse import Schedule, InstructionScheduleMap
 from qiskit.tools.parallel import parallel_map
-from qiskit.transpiler import Layout, CouplingMap, PropertySet, PassManager
+from qiskit.transpiler import Layout, CouplingMap, PropertySet
 from qiskit.transpiler.basepasses import BasePass
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations, InstructionDurationsType

--- a/releasenotes/notes/remove-deprecated-pass-manager-dc1dddbd7dcd866f.yaml
+++ b/releasenotes/notes/remove-deprecated-pass-manager-dc1dddbd7dcd866f.yaml
@@ -1,0 +1,8 @@
+upgrade:
+  - |
+    The ``pass_manager`` kwarg for the :func:`qiskit.compiler.transpile`
+    has been removed. It was originally deprecated in the 0.13.0 release.
+    The preferred way to transpile a circuit with a custom
+    :class:`~qiskit.transpiler.PassManager` object is to use the
+    :meth:`~qiskit.transpiler.PassManager.run` method of the ``PassManager``
+    object.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -79,7 +79,6 @@ class TestTranspile(QiskitTestCase):
             backend=backend,
             coupling_map=coupling_map,
             basis_gates=basis_gates,
-            pass_manager=None,
         )
 
         circuit3 = transpile(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Removes the `pass_manager` kwarg to `qiskit.compiler.transpile` per @jakelishman's suggestion on issue #7663.

### Details and comments

- The change to transpiler.py is only deletions. I removed 2 unused functions: `_check_conflicting_argument` and `_parse_pass_manager`.
- One test just needed the `pass_manager` kwarg removed.
- Reno release note added that mostly copies the [0.13 deprecation note](https://github.com/Qiskit/qiskit-terra/blob/83ac6d738641a7e00b389dbe845abe9d8492f806/releasenotes/notes/0.13/passmanager_parameter_in_transpile-9768d95afbe9127e.yaml).

Please don't hesitate to let me know if there's more I can do.