### PR TITLE
Add `__slots__` for `Bit` subclasses

### DIFF
--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -23,6 +23,8 @@ from .bit import Bit
 class Clbit(Bit):
     """Implement a classical bit."""
 
+    __slots__ = ()
+
     def __init__(self, register=None, index=None):
         """Creates a classical bit.
 

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -23,6 +23,8 @@ from .bit import Bit
 class Qubit(Bit):
     """Implement a quantum bit."""
 
+    __slots__ = ()
+
     def __init__(self, register=None, index=None):
         """Creates a qubit.
 
@@ -58,6 +60,8 @@ class QuantumRegister(Register):
 
 class AncillaQubit(Qubit):
     """A qubit used as ancillary qubit."""
+
+    __slots__ = ()
 
     pass
 

--- a/releasenotes/notes/bit-slots-17d6649872da0440.yaml
+++ b/releasenotes/notes/bit-slots-17d6649872da0440.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The classes :class:`.Qubit`, :class:`.Clbit` and :class:`.AncillaQubit` now
+    the ``__slots__`` attribute.  This is to reduce their memory usage.  As a
+    side effect, they can no longer have arbitrary data attached as attributes
+    to them.  This is very unlikely to have any effect on downstream code other
+    than performance benefits.


### PR DESCRIPTION
### Summary

Response to #7704, namely adding `__slots__` fields for the `Bit` subclasses `Clbit`, `Qubit` and `AncillaQubit`.

### Details and comments

According to [the official Python 3 docs](https://docs.python.org/3/reference/datamodel.html);

"The action of a `__slots__` declaration is not limited to the class where it is defined. `__slots__` declared in parents are available in child classes. However, child subclasses will get a [`__dict__`](https://docs.python.org/3/library/stdtypes.html#object.__dict__) and `__weakref__` unless they also define `__slots__` (which should only contain names of any additional slots)."

This PR adds `__slots__` for the `Bit` subclasses, effectively denying the creation of a `__dict__` for those instances.
