### PR TITLE
Performance improvement of `SparsePauliOp.compose`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2020.
+# (C) Copyright IBM 2017, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -286,7 +286,9 @@ class SparsePauliOp(LinearOp):
             z4[:, qargs] = z3
             pauli_list = PauliList(BasePauli(z4, x4, phase))
 
-        coeffs = np.kron(self.coeffs, other.coeffs)
+        # note: equivalent to `coeffs = np.kron(self.coeffs, other.coeffs)`
+        # since `self.coeffs` and `other.coeffs` are both 1d arrays.
+        coeffs = np.ravel(self.coeffs[:, np.newaxis] @ other.coeffs[np.newaxis])
         return SparsePauliOp(pauli_list, coeffs, copy=False)
 
     def tensor(self, other):

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -286,9 +286,10 @@ class SparsePauliOp(LinearOp):
             z4[:, qargs] = z3
             pauli_list = PauliList(BasePauli(z4, x4, phase))
 
-        # note: equivalent to `coeffs = np.kron(self.coeffs, other.coeffs)`
+        # note: the following is a faster code equivalent to
+        # `coeffs = np.kron(self.coeffs, other.coeffs)`
         # since `self.coeffs` and `other.coeffs` are both 1d arrays.
-        coeffs = np.ravel(self.coeffs[:, np.newaxis] @ other.coeffs[np.newaxis])
+        coeffs = np.multiply.outer(self.coeffs, other.coeffs).ravel()
         return SparsePauliOp(pauli_list, coeffs, copy=False)
 
     def tensor(self, other):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Improves the performance of `SparsePauliOp.compose` by replacing `np.kron` with a specialized operation for 1d arrays.


### Details and comments

This PR replaces `np.kron` of 1d arrays with a faster alternative.
`np.kron` seems slow due to `concatenate` inside.

```python
import random
from timeit import timeit

from qiskit.quantum_info import SparsePauliOp

def bench(k, n):
    random.seed(123)
    op = SparsePauliOp.from_list([(''.join(random.choices('IXYZ', k=k)), 1) for _ in range(n)])
    op2 = SparsePauliOp.from_list([(''.join(random.choices('IXYZ', k=k)), 1) for _ in range(2)])

    print(f'{k}, {n}: {timeit(lambda: op.compose(op2), number=1000)} sec')

bench(20, 2000)
```
cProfile call graph
![image](https://user-images.githubusercontent.com/31178928/156876570-19e46298-8e18-4003-bbbb-2d757861077f.png)

main
```
20, 2000: 1.7031413420008903 sec
```

this PR
```
20, 2000: 0.73382812699856 sec
```

### JW transformation

This PR has an impact on qubit converter of Qiskit nature as follows.

```python
import random
from timeit import timeit

from qiskit_nature.converters.second_quantization import QubitConverter
from qiskit_nature.mappers.second_quantization import JordanWignerMapper
from qiskit_nature.operators.second_quantization import FermionicOp


def random_op(k, n):
    random.seed(123)
    op = sum(
        (
            FermionicOp("".join(random.choices("+-ENI", k=k)), display_format="dense")
            * random.random()
        )
        for _ in range(n)
    )
    return op


def bench(op):
    mapper = JordanWignerMapper()
    qubit_conv = QubitConverter(mapper)
    print(f"{timeit(lambda: qubit_conv.convert(op), number=1)} sec")


op = random_op(15, 200)
bench(op)
```

nature main + terra main
```
2.443965930999184 sec
```

nature main + terra this PR
```
1.695774731999336 sec
```