### PR TITLE
Revert "Bump hashbrown from 0.11.2 to 0.12.0 (#7730)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "^0.15.0"
 features = ["rayon"]
 
 [dependencies.hashbrown]
-version = "0.12.0"
+version = "0.11.2"
 features = ["rayon"]
 
 [profile.release]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Hashbrown 0.12.0 bumped the MSRV (minimum support rust version) to
1.56.1 which was released on November 2021. This is causing some issues
for people building locally as that is a pretty new version of rust.
While we don't set an MSRV for terra, I think we should try to at least
support that past ~6 months of Rust releases for building just to give
people time to upgrade and not require everyone to use rustup.

As there was nothing critical in hashbrown 0.12.0 this commit just
reverts back to 0.11.2 for now. We can look at bumping that after the
0.20.0 release.

### Details and comments

This reverts commit d05931dbfac77abb0c21955b52d8ea19d5d051a3.
