### PR TITLE
Add test decorator 'gpu' for GPU unit tests

### DIFF
--- a/qiskit/test/decorators.py
+++ b/qiskit/test/decorators.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -94,6 +94,27 @@ def slow_test(func):
         skip_slow = not TEST_OPTIONS["run_slow"]
         if skip_slow:
             raise unittest.SkipTest("Skipping slow tests")
+
+        return func(*args, **kwargs)
+
+    return _wrapper
+
+
+def gpu(func):
+    """Decorator that signals that the test needs GPU to run.
+
+    Args:
+        func (callable): test function to be decorated.
+
+    Returns:
+        callable: the decorated function.
+    """
+
+    @functools.wraps(func)
+    def _wrapper(*args, **kwargs):
+        skip_gpu = not TEST_OPTIONS["gpu"]
+        if skip_gpu:
+            raise unittest.SkipTest("Skipping gpu tests")
 
         return func(*args, **kwargs)
 

--- a/qiskit/test/testing_options.py
+++ b/qiskit/test/testing_options.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -27,7 +27,13 @@ def get_test_options(option_var="QISKIT_TESTS"):
     Returns:
         dict: A dictionary with the format {<option>: (bool)<activated>}.
     """
-    tests_options = {"skip_online": False, "mock_online": False, "run_slow": False, "rec": False}
+    tests_options = {
+        "skip_online": False,
+        "mock_online": False,
+        "run_slow": False,
+        "rec": False,
+        "gpu": False,
+    }
 
     def turn_false(option):
         """Turn an option to False.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
add a `gpu` option to the env. variable `QISKIT_TESTS` and a `@gpu` decorator to be used for tests that need GPU to run


### Details and comments


