### PR TITLE
Use SIMD optimized sum for stochastic swap cost computation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+use std::convert::TryInto;
 use std::env;
 
 use pyo3::prelude::*;
@@ -33,6 +34,32 @@ pub fn getenv_use_multiple_threads() -> bool {
         .to_uppercase()
         == "TRUE";
     !parallel_context || force_threads
+}
+
+const LANES: usize = 8;
+
+// Based on the sum implementation in:
+// https://stackoverflow.com/a/67191480/14033130
+// and adjust for f64 usage
+#[inline]
+pub fn fast_sum(values: &[f64]) -> f64 {
+    let chunks = values.chunks_exact(LANES);
+    let remainder = chunks.remainder();
+
+    let sum = chunks.fold([0.; LANES], |mut acc, chunk| {
+        let chunk: [f64; LANES] = chunk.try_into().unwrap();
+        for i in 0..LANES {
+            acc[i] += chunk[i];
+        }
+        acc
+    });
+    let remainder: f64 = remainder.iter().copied().sum();
+
+    let mut reduced = 0.;
+    for val in sum {
+        reduced += val;
+    }
+    reduced + remainder
 }
 
 #[pymodule]

--- a/src/stochastic_swap.rs
+++ b/src/stochastic_swap.rs
@@ -32,8 +32,8 @@ use rand_distr::{Distribution, Normal};
 use rand_pcg::Pcg64Mcg;
 
 use crate::edge_collections::EdgeCollection;
-use crate::getenv_use_multiple_threads;
 use crate::nlayout::NLayout;
+use crate::{fast_sum, getenv_use_multiple_threads};
 
 #[inline]
 fn compute_cost(
@@ -42,13 +42,14 @@ fn compute_cost(
     gates: &[usize],
     num_gates: usize,
 ) -> f64 {
-    (0..num_gates)
+    let values: Vec<f64> = (0..num_gates)
         .map(|kk| {
             let ii = layout.logic_to_phys[gates[2 * kk]];
             let jj = layout.logic_to_phys[gates[2 * kk + 1]];
             dist[[ii, jj]]
         })
-        .sum()
+        .collect();
+    fast_sum(&values)
 }
 
 /// Computes the symmetric random scaling (perturbation) matrix,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As part of #7702 we added a function for performing a sum over an
array/Vec of f64 values that is optimized to let the compiler use
SIMD instructions to speed up the computation. The stochastic swap rust
module performs a very similar sum multiple times as part of each swap
trial. This commit moves the fast_sum() function used in the pauli
expectation value functions to a common location and updates stochastic
swap to use it too.

### Details and comments

TODO:

- [ ] Run benchmarks to see improvement (if any)