### PR TITLE
Remove Cython as a build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["Cython>=0.27.1", "setuptools", "wheel", "setuptools-rust"]
+requires = ["setuptools", "wheel", "setuptools-rust"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,6 @@ pylint==2.8.3
 stestr>=2.0.0
 PyGithub
 wheel
-cython>=0.27.1
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This follows up on #7702, which removed the last of the Cython code. The current change was was presumably intended to be part of that PR, I think, based on the release note added there:

> Cython is no longer a build dependency of Qiskit Terra and is no longer required to be installed when building Qiskit Terra from source.

@mtreinish 

### Details and comments


