### PR TITLE
Make ConsolidateBlocks transpiler pass target aware

### DIFF
--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -69,13 +69,18 @@ class ConsolidateBlocks(TransformationPass):
         if self.decomposer is None:
             return dag
 
+        dag_qubits = None
+        if self.target is not None:
+            dag_qubits = {bit: index for index, bit in enumerate(dag.qubits)}
         # compute ordered indices for the global circuit wires
         global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
         blocks = self.property_set["block_list"]
         basis_gate_name = self.decomposer.gate.name
         all_block_gates = set()
         for block in blocks:
-            if len(block) == 1 and self._check_not_in_basis(block[0].name, block[0].qargs):
+            if len(block) == 1 and self._check_not_in_basis(
+                block[0].name, block[0].qargs, dag_qubits
+            ):
                 all_block_gates.add(block[0])
                 dag.substitute_node(block[0], UnitaryGate(block[0].op.to_matrix()))
             else:
@@ -97,7 +102,7 @@ class ConsolidateBlocks(TransformationPass):
                 for nd in block:
                     if nd.op.name == basis_gate_name:
                         basis_count += 1
-                    if self._check_not_in_basis(nd.op.name, nd.qargs):
+                    if self._check_not_in_basis(nd.op.name, nd.qargs, dag_qubits):
                         outside_basis = True
                     qc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
                 unitary = UnitaryGate(Operator(qc))
@@ -109,6 +114,7 @@ class ConsolidateBlocks(TransformationPass):
                     or self.decomposer.num_basis_gates(unitary) < basis_count
                     or len(block) > max_2q_depth
                     or ((self.basis_gates is not None) and outside_basis)
+                    or ((self.target is not None) and outside_basis)
                 ):
                     dag.replace_block_with_op(block, unitary, block_index_map, cycle_check=False)
         # If 1q runs are collected before consolidate those too
@@ -116,7 +122,9 @@ class ConsolidateBlocks(TransformationPass):
         for run in runs:
             if run[0] in all_block_gates:
                 continue
-            if len(run) == 1 and not self._check_not_in_basis(run[0].name, run[0].qargs):
+            if len(run) == 1 and not self._check_not_in_basis(
+                run[0].name, run[0].qargs, dag_qubits
+            ):
                 dag.substitute_node(run[0], UnitaryGate(run[0].op.to_matrix()))
             else:
                 qubit = run[0].qargs[0]
@@ -132,9 +140,11 @@ class ConsolidateBlocks(TransformationPass):
                 dag.replace_block_with_op(run, unitary, {qubit: 0}, cycle_check=False)
         return dag
 
-    def _check_not_in_basis(self, gate_name, qargs):
+    def _check_not_in_basis(self, gate_name, qargs, dag_qubits):
         if self.target is not None:
-            return not self.target.instruction_supported(gate_name, tuple(qargs))
+            return not self.target.instruction_supported(
+                gate_name, tuple(dag_qubits[qubit] for qubit in qargs)
+            )
         else:
             return self.basis_gates and gate_name not in self.basis_gates
 

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -116,7 +116,7 @@ class ConsolidateBlocks(TransformationPass):
         for run in runs:
             if run[0] in all_block_gates:
                 continue
-            if len(run) == 1 and not self._check_in_basis(run[0].name, run[0].qargs):
+            if len(run) == 1 and not self._check_not_in_basis(run[0].name, run[0].qargs):
                 dag.substitute_node(run[0], UnitaryGate(run[0].op.to_matrix()))
             else:
                 qubit = run[0].qargs[0]

--- a/qiskit/transpiler/passes/optimization/consolidate_blocks.py
+++ b/qiskit/transpiler/passes/optimization/consolidate_blocks.py
@@ -37,16 +37,18 @@ class ConsolidateBlocks(TransformationPass):
         collected by a previous pass, such as `Collect2qBlocks`.
     """
 
-    def __init__(self, kak_basis_gate=None, force_consolidate=False, basis_gates=None):
+    def __init__(self, kak_basis_gate=None, force_consolidate=False, basis_gates=None, target=None):
         """ConsolidateBlocks initializer.
 
         Args:
             kak_basis_gate (Gate): Basis gate for KAK decomposition.
             force_consolidate (bool): Force block consolidation
             basis_gates (List(str)): Basis gates from which to choose a KAK gate.
+            target (Target): The target object for the compilation target backend
         """
         super().__init__()
         self.basis_gates = None
+        self.target = target
         if basis_gates is not None:
             self.basis_gates = set(basis_gates)
         self.force_consolidate = force_consolidate
@@ -73,7 +75,7 @@ class ConsolidateBlocks(TransformationPass):
         basis_gate_name = self.decomposer.gate.name
         all_block_gates = set()
         for block in blocks:
-            if len(block) == 1 and (self.basis_gates and block[0].name not in self.basis_gates):
+            if len(block) == 1 and self._check_not_in_basis(block[0].name, block[0].qargs):
                 all_block_gates.add(block[0])
                 dag.substitute_node(block[0], UnitaryGate(block[0].op.to_matrix()))
             else:
@@ -95,7 +97,7 @@ class ConsolidateBlocks(TransformationPass):
                 for nd in block:
                     if nd.op.name == basis_gate_name:
                         basis_count += 1
-                    if self.basis_gates and nd.op.name not in self.basis_gates:
+                    if self._check_not_in_basis(nd.op.name, nd.qargs):
                         outside_basis = True
                     qc.append(nd.op, [q[block_index_map[i]] for i in nd.qargs])
                 unitary = UnitaryGate(Operator(qc))
@@ -106,7 +108,7 @@ class ConsolidateBlocks(TransformationPass):
                     or unitary.num_qubits > 2
                     or self.decomposer.num_basis_gates(unitary) < basis_count
                     or len(block) > max_2q_depth
-                    or (self.basis_gates is not None and outside_basis)
+                    or ((self.basis_gates is not None) and outside_basis)
                 ):
                     dag.replace_block_with_op(block, unitary, block_index_map, cycle_check=False)
         # If 1q runs are collected before consolidate those too
@@ -114,7 +116,7 @@ class ConsolidateBlocks(TransformationPass):
         for run in runs:
             if run[0] in all_block_gates:
                 continue
-            if len(run) == 1 and self.basis_gates and run[0].name not in self.basis_gates:
+            if len(run) == 1 and not self._check_in_basis(run[0].name, run[0].qargs):
                 dag.substitute_node(run[0], UnitaryGate(run[0].op.to_matrix()))
             else:
                 qubit = run[0].qargs[0]
@@ -129,6 +131,12 @@ class ConsolidateBlocks(TransformationPass):
                 unitary = UnitaryGate(operator)
                 dag.replace_block_with_op(run, unitary, {qubit: 0}, cycle_check=False)
         return dag
+
+    def _check_not_in_basis(self, gate_name, qargs):
+        if self.target is not None:
+            return not self.target.instruction_supported(gate_name, tuple(qargs))
+        else:
+            return self.basis_gates and gate_name not in self.basis_gates
 
     def _block_qargs_to_indices(self, block_qargs, global_index_map):
         """Map each qubit in block_qargs to its wire position among the block's wires.

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -189,7 +189,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             Unroll3qOrMore(),
             Collect2qBlocks(),
             Collect1qRuns(),
-            ConsolidateBlocks(basis_gates=basis_gates),
+            ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(
                 basis_gates,
                 approximation_degree=approximation_degree,

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -247,7 +247,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             ),
             Unroll3qOrMore(),
             Collect2qBlocks(),
-            ConsolidateBlocks(basis_gates=basis_gates),
+            ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(
                 basis_gates,
                 approximation_degree=approximation_degree,

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -232,7 +232,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             ),
             Unroll3qOrMore(),
             Collect2qBlocks(),
-            ConsolidateBlocks(basis_gates=basis_gates),
+            ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(
                 basis_gates,
                 approximation_degree=approximation_degree,

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -230,7 +230,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             ),
             Unroll3qOrMore(),
             Collect2qBlocks(),
-            ConsolidateBlocks(basis_gates=basis_gates),
+            ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(
                 basis_gates,
                 approximation_degree=approximation_degree,
@@ -264,7 +264,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
 
     _opt = [
         Collect2qBlocks(),
-        ConsolidateBlocks(basis_gates=basis_gates),
+        ConsolidateBlocks(basis_gates=basis_gates, target=target),
         UnitarySynthesis(
             basis_gates,
             approximation_degree=approximation_degree,

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -495,17 +495,12 @@ class Target(Mapping):
             bool: Returns ``True`` if the instruction is supported and ``False`` if it isn't.
 
         """
-        return_value = False
         if operation_name in self._gate_map:
             if qargs in self._gate_map[operation_name]:
-                return_value = True
-            elif self._gate_map[operation_name] is None:
-                if all(x < self.num_qubits for x in qargs):
-                    return_value = True
-            elif None in self._gate_map[operation_name]:
-                if all(x < self.num_qubits for x in qargs):
-                    return_value = True
-        return return_value
+                return True
+            if self._gate_map[operation_name] is None or None in self._gate_map[operation_name]:
+                return all(x < self.num_qubits for x in qargs)
+        return False
 
     @property
     def operation_names(self):

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -495,14 +495,17 @@ class Target(Mapping):
             bool: Returns ``True`` if the instruction is supported and ``False`` if it isn't.
 
         """
+        return_value = False
         if operation_name in self._gate_map:
-            if (
-                qargs not in self._gate_map[operation_name]
-                or self._gate_map[operation_name] is None
-                or None in self._gate_map[operation_name]
-            ):
-                return True
-        return False
+            if qargs in self._gate_map[operation_name]:
+                return_value = True
+            elif self._gate_map[operation_name] is None:
+                if all(x < self.num_qubits for x in qargs):
+                    return_value = True
+            elif None in self._gate_map[operation_name]:
+                if all(x < self.num_qubits for x in qargs):
+                    return_value = True
+        return return_value
 
     @property
     def operation_names(self):

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -499,7 +499,9 @@ class Target(Mapping):
             if qargs in self._gate_map[operation_name]:
                 return True
             if self._gate_map[operation_name] is None or None in self._gate_map[operation_name]:
-                return all(x < self.num_qubits for x in qargs)
+                return self._gate_name_map[operation_name].num_qubits == len(qargs) and all(
+                    x < self.num_qubits for x in qargs
+                )
         return False
 
     @property

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -495,6 +495,8 @@ class Target(Mapping):
             bool: Returns ``True`` if the instruction is supported and ``False`` if it isn't.
 
         """
+        # Case a list if passed in by mistake
+        qargs = tuple(qargs)
         if operation_name in self._gate_map:
             if qargs in self._gate_map[operation_name]:
                 return True

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -484,6 +484,26 @@ class Target(Mapping):
             raise KeyError(f"{qargs} not in target.")
         return [self._gate_name_map[x] for x in self._qarg_gate_map[qargs]]
 
+    def instruction_supported(self, operation_name, qargs):
+        """Return whether the instruction (operation + qubits) is supported by the target
+
+        Args:
+            operation_name (str): The name of the operation for the instruction
+            qargs (tuple): The tuple of qubit indices for the instruction
+
+        Returns:
+            bool: Returns ``True`` if the instruction is supported and ``False`` if it isn't.
+
+        """
+        if operation_name in self._gate_map:
+            if (
+                qargs not in self._gate_map[operation_name]
+                or self._gate_map[operation_name] is None
+                or None in self._gate_map[operation_name]
+            ):
+                return True
+        return False
+
     @property
     def operation_names(self):
         """Get the operation names in the target."""

--- a/releasenotes/notes/consolidate-blocks-target-aware-6482e65d6ee2d18c.yaml
+++ b/releasenotes/notes/consolidate-blocks-target-aware-6482e65d6ee2d18c.yaml
@@ -1,0 +1,16 @@
+---
+
+features:
+  - |
+    The :class:`~qiskit.transpiler.ConsolidateBlocks` pass has a new keyword
+    argument on it's constructor, ``target``. This argument is used to specify a
+    :class:`~qiskit.transpiler.Target` object representing the compilation
+    target for the pass. If it is specified it supersedes the ``basis_gates``
+    kwarg. If a target is specified the pass will respect the gates and qubits
+    when deciding which gates to consolidate into a unitary.
+  - |
+    The :class:`~qiskit.transpiler.Target` class has a new method,
+    :meth:`~qiskit.transpiler.Target.instruction_supported` which is used
+    to query the target to see if an instruction (the combination of an
+    operation and the qubit(s) it is executed on) is supported on the backend
+    modelled by the :class:`~qiskit.transpiler.Target`.

--- a/releasenotes/notes/consolidate-blocks-target-aware-6482e65d6ee2d18c.yaml
+++ b/releasenotes/notes/consolidate-blocks-target-aware-6482e65d6ee2d18c.yaml
@@ -3,7 +3,7 @@
 features:
   - |
     The :class:`~qiskit.transpiler.ConsolidateBlocks` pass has a new keyword
-    argument on it's constructor, ``target``. This argument is used to specify a
+    argument on its constructor, ``target``. This argument is used to specify a
     :class:`~qiskit.transpiler.Target` object representing the compilation
     target for the pass. If it is specified it supersedes the ``basis_gates``
     kwarg. If a target is specified the pass will respect the gates and qubits

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -904,6 +904,14 @@ Instructions:
             self.fake_backend_target.get_non_global_operation_names(True), ["cx", "ecr"]
         )
 
+    def test_instruction_supported(self):
+        self.assertTrue(self.aqt_target.instruction_supported("r", (0,)))
+        self.assertFalse(self.aqt_target.instruction_supported("cx", (0, 1)))
+        self.assertTrue(self.ideal_sim_target.instruction_supported("cx", (0, 1)))
+        self.assertFalse(self.ideal_sim_target.instruction_supported("cx", (0, 524)))
+        self.assertTrue(self.fake_backend_target.instruction_supported("cx", (0, 1)))
+        self.assertFalse(self.fake_backend_target.instruction_supported("cx", (1, 0)))
+
 
 class TestPulseTarget(QiskitTestCase):
     def setUp(self):

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -911,6 +911,7 @@ Instructions:
         self.assertFalse(self.ideal_sim_target.instruction_supported("cx", (0, 524)))
         self.assertTrue(self.fake_backend_target.instruction_supported("cx", (0, 1)))
         self.assertFalse(self.fake_backend_target.instruction_supported("cx", (1, 0)))
+        self.assertFalse(self.ideal_sim_target.instruction_supported("cx", (0, 1, 2)))
 
 
 class TestPulseTarget(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the consolidate blocks pass target aware so that at
its instantiation a Target object can be specified to define the target
device for compilation. When specified this target will be used for
all device aware operations in the pass. When a target is specified the
consolidate blocks pass will only consolidate blocks with instructions
outside the target (both operation and qubits).

### Details and comments

Part of #7113

TODO:

- [x] Add release note
- [x] Add tests for new target method
- [x] Add tests for consolidate block with target