### PR TITLE
rename XYGate to XXPlusYYGate

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -60,7 +60,7 @@ Standard Gates
    RZGate
    RZZGate
    RZXGate
-   XYGate
+   XXPlusYYGate
    ECRGate
    SGate
    SdgGate

--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -49,7 +49,7 @@ Standard gates (:mod:`qiskit.circuit.library.standard_gates`)
    RZGate
    RZZGate
    RZXGate
-   XYGate
+   XXPlusYYGate
    ECRGate
    SGate
    SdgGate
@@ -80,7 +80,7 @@ from .ryy import RYYGate
 from .rz import RZGate, CRZGate
 from .rzz import RZZGate
 from .rzx import RZXGate
-from .xy import XYGate
+from .xy import XXPlusYYGate
 from .ecr import ECRGate
 from .s import SGate, SdgGate
 from .swap import SwapGate, CSwapGate

--- a/qiskit/circuit/library/standard_gates/xy.py
+++ b/qiskit/circuit/library/standard_gates/xy.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Two-qubit XY gate."""
+"""Two-qubit XX+YY gate."""
 
 from typing import Optional
 from qiskit.qasm import pi
@@ -19,8 +19,8 @@ from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.parameterexpression import ParameterValueType
 
 
-class XYGate(Gate):
-    r"""XY gate.
+class XXPlusYYGate(Gate):
+    r"""XX+YY interaction gate.
 
     A 2-qubit parameterized XX+YY interaction. Its action is to induce
     a coherent rotation by some angle between :math:`|01\rangle` and :math:`|10\rangle`.
@@ -61,11 +61,11 @@ class XYGate(Gate):
 
         .. parsed-literal::
 
-                ┌──────────┐
+                 ┌──────────┐
             q_0: ┤1         ├
-                │  Xy(θ,β) │
+                 │  Xy(θ,β) │
             q_1: ┤0         ├
-                └──────────┘
+                 └──────────┘
 
         .. math::
 
@@ -84,7 +84,7 @@ class XYGate(Gate):
     def __init__(
         self, theta: ParameterValueType, beta: ParameterValueType = 0, label: Optional[str] = None
     ):
-        """Create new XY gate."""
+        """Create new XX+YY gate."""
         super().__init__("xy", 2, [theta, beta], label=label)
 
     def _define(self):
@@ -140,11 +140,11 @@ class XYGate(Gate):
         self.definition = qc
 
     def inverse(self):
-        """Return inverse XY gate (i.e. with the negative rotation angle and same phase angle)."""
-        return XYGate(-self.params[0], self.params[1])
+        """Return inverse XX+YY gate (i.e. with the negative rotation angle and same phase angle)."""
+        return XXPlusYYGate(-self.params[0], self.params[1])
 
     def __array__(self, dtype=None):
-        """Return a numpy.array for the XY gate."""
+        """Return a numpy.array for the XX+YY gate."""
         import numpy
 
         half_theta = float(self.params[0]) / 2

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -3195,7 +3195,7 @@ class QuantumCircuit:
         qubit2: QubitSpecifier,
         beta: Optional[ParameterValueType] = 0,
     ) -> InstructionSet:
-        """Apply :class:`~qiskit.circuit.library.XYGate`.
+        """Apply :class:`~qiskit.circuit.library.XXPlusYYGate`.
 
         For the full matrix form of this gate, see the underlying gate documentation.
 
@@ -3208,9 +3208,9 @@ class QuantumCircuit:
         Returns:
             A handle to the instructions created.
         """
-        from .library.standard_gates.xy import XYGate
+        from .library.standard_gates.xy import XXPlusYYGate
 
-        return self.append(XYGate(theta, beta), [qubit1, qubit2], [])
+        return self.append(XXPlusYYGate(theta, beta), [qubit1, qubit2], [])
 
     def ecr(self, qubit1: QubitSpecifier, qubit2: QubitSpecifier) -> InstructionSet:
         """Apply :class:`~qiskit.circuit.library.ECRGate`.

--- a/releasenotes/notes/add-xy-gate-e3ac32084273136a.yaml
+++ b/releasenotes/notes/add-xy-gate-e3ac32084273136a.yaml
@@ -2,6 +2,6 @@
 
 features:
   - |
-    Added new gate, :class:`~qiskit.circuit.library.standard_gates.XYGate` to
+    Added new gate, :class:`~qiskit.circuit.library.standard_gates.XXPlusYYGate` to
     the standard library and as a function for the :class:`~qiskit.circuit.QuantumCircuit`
     class. Refer to the discussion in `#7164 <https://github.com/Qiskit/qiskit-terra/issues/7164>`__.

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1681,7 +1681,7 @@ class TestParameterExpressions(QiskitTestCase):
         circlib.CRXGate,
         circlib.CRYGate,
         circlib.CRZGate,
-        circlib.XYGate,
+        circlib.XXPlusYYGate,
     )
     def test_bound_gate_to_matrix(self, gate_class):
         """Test to_matrix works if previously free parameters are bound.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Renames XYGate to XXPlusYYGate. This was decided at #7635 .


### Details and comments
I only changed the name of the class, and not other names like `QuantumCircuit.xy` or the name of the gate's circuit diagram. Let me know if I should change those too.

