### PR TITLE
Fix order of do-while loop in transpile optimisation

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -337,7 +337,8 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         pm1.append(_direction_check)
         pm1.append(_direction, condition=_direction_condition)
     pm1.append(_reset)
-    pm1.append(_depth_check + _size_check + _opt + _unroll, do_while=_opt_control)
+    pm1.append(_depth_check + _size_check)
+    pm1.append(_opt + _unroll + _depth_check + _size_check, do_while=_opt_control)
     if inst_map and inst_map.has_custom_gate():
         pm1.append(PulseGates(inst_map=inst_map))
     if scheduling_method:

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -325,7 +325,8 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         pm2.append(_direction, condition=_direction_condition)
     pm2.append(_reset)
 
-    pm2.append(_depth_check + _size_check + _opt + _unroll, do_while=_opt_control)
+    pm2.append(_depth_check + _size_check)
+    pm2.append(_opt + _unroll + _depth_check + _size_check, do_while=_opt_control)
 
     if inst_map and inst_map.has_custom_gate():
         pm2.append(PulseGates(inst_map=inst_map))

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -335,19 +335,21 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
         pm3.append(_direction_check)
         pm3.append(_direction, condition=_direction_condition)
         pm3.append(_reset)
+        pm3.append(_depth_check + _size_check)
         # For transpiling to a target we need to run GateDirection in the
         # optimization loop to correct for incorrect directions that might be
         # inserted by UnitarySynthesis which is direction aware but only via
         # the coupling map which with a target doesn't give a full picture
         if target is not None:
             pm3.append(
-                _depth_check + _size_check + _opt + _unroll + _direction, do_while=_opt_control
+                _opt + _unroll + _depth_check + _size_check + _direction, do_while=_opt_control
             )
         else:
-            pm3.append(_depth_check + _size_check + _opt + _unroll, do_while=_opt_control)
+            pm3.append(_opt + _unroll + _depth_check + _size_check, do_while=_opt_control)
     else:
         pm3.append(_reset)
-        pm3.append(_depth_check + _size_check + _opt + _unroll, do_while=_opt_control)
+        pm3.append(_depth_check + _size_check)
+        pm3.append(_opt + _unroll + _depth_check + _size_check, do_while=_opt_control)
     if inst_map and inst_map.has_custom_gate():
         pm3.append(PulseGates(inst_map=inst_map))
     if scheduling_method:


### PR DESCRIPTION
### Summary

The previous check would always run the body of the optimisation loop
once after the fixed point had been achieved.  As well as being
unnecessary, this also made it possible in theory for the optimisation
loop to "unfix" the point, although hopefully our optimisations on that
front would never increase the number of operations.

Instead, we now do the depth/size scans ahead of the loop, then move the
checking condition to the end.  In the best-case scenario for
optimisation (the circuit is already optimised) this would be a 2x
speedup of the optimisation loop for free, but more likely it will
manifest itself as a ~20% or so speedup.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

A smallish subset of the transpiler benchmarks:
```text
       before           after         ratio
     [592b9acb]       [4977c3a7]
     <main>           <fix-optimisation-condition>
-      2.78±0.03s          2.28±0s     0.82  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_qv_14_x_14(3)
-         519±5ms         426±10ms     0.82  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_from_large_qasm(1)
-      1.67±0.03s        1.36±0.1s     0.81  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_qv_14_x_14(2)
-       1.20±0.4s          947±2ms     0.79  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_qv_14_x_14(1)
-        659±20ms         517±20ms     0.78  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_from_large_qasm(2)
-         840±3ms          653±8ms     0.78  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_from_large_qasm_backend_with_prop(1)
-         663±8ms          494±5ms     0.75  transpiler_levels.TranspilerLevelBenchmarks.time_transpile_from_large_qasm_backend_with_prop(2)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

This should ameliorate the performance regressions caused by #7542.  Note though that performance regressions there were expected and should have come with an accompanying improvement in circuit size, which unfortunately wasn't added to the benchmark suite ahead of time.