### PR TITLE
Pin jinja2 in CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -8,3 +8,8 @@ jsonschema==3.2.0
 # as we won't get matplotlib upgrades by default, this constraint likely can't
 # be removed until we can unpin matplotlib.
 pyparsing<3.0.0
+
+# Jinja2 3.1.0 is incompatible with sphinx and/or jupyter until they are updated
+# to work with the new jinja version (the jinja maintainers aren't going to
+# fix things) pin to the previous working version.
+jinja2==3.0.3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent jinja2 release is breaking the tutorials ci job. This is
because something in the nbsphinx, jupyter, sphinx pipeline is
incompatible with the new version. These issues have been reported
upstream to jinja2 (and promptly closed as won't fix) so until the docs
build toolchain is upgraded to work with the new version this commit
pins the jinja2 version.

### Details and comments


