### PR TITLE
Add a decompose() call to circuit library table in docs

### DIFF
--- a/qiskit/tools/jupyter/library.py
+++ b/qiskit/tools/jupyter/library.py
@@ -39,8 +39,8 @@ def circuit_data_table(circuit: QuantumCircuit) -> wid.HTML:
         Output widget.
     """
 
+    circuit = circuit.decompose()
     ops = circuit.count_ops()
-
     num_nl = circuit.num_nonlocal_gates()
 
     html = "<table>"
@@ -214,6 +214,6 @@ def circuit_library_widget(circuit: QuantumCircuit) -> None:
     top = circuit_diagram_widget()
 
     with top.children[0]:
-        display(circuit.draw(output="mpl"))
+        display(circuit.decompose().draw(output="mpl"))
 
     display(wid.VBox(children=[top, bottom], layout=wid.Layout(width="100%", height="auto")))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For the purpose of documentation many of the circuit library classes
were using the circuit_library_widget to provide a visualization of
the circuit, a QASM definition, and some basic high level statistics
about the circuit. However, since #6634 and #6659 all the circuit
library elements are wrapped in an outer Instruction object. This
makes the top level object appear as a logical block in the circuit.
This has the unintended side effect of causing the widget output to not
be super useful, primarily it would should a single logical block for
each element and the circuit statistics would be for the single element
as opposed to its implementation. This commit address this by adding a
single decompose() call around all the statistics and drawing calls
inside the widget code. Since we're consistently wrapping every circuit
library element the widget will always need to do this now, so instead
of calling it directly in the library docstring it's better to just do
this in the widget itself.

### Details and comments