### PR TITLE
Remove parameter broadcasting in Primitives

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -70,15 +70,6 @@ class Estimator(BaseEstimator):
         if parameter_values and not isinstance(parameter_values[0], Sequence):
             parameter_values = cast("Sequence[float]", parameter_values)
             parameter_values = [parameter_values]
-        if (
-            circuit_indices is None
-            and len(self._circuits) == 1
-            and observable_indices is None
-            and len(self._observables) == 1
-            and parameter_values is not None
-        ):
-            circuit_indices = [0] * len(parameter_values)
-            observable_indices = [0] * len(parameter_values)
         if circuit_indices is None:
             circuit_indices = list(range(len(self._circuits)))
         if observable_indices is None:

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -71,8 +71,6 @@ class Sampler(BaseSampler):
         if self._is_closed:
             raise QiskitError("The primitive has been closed.")
 
-        if circuit_indices is None and parameter_values is not None and len(self._circuits) == 1:
-            circuit_indices = [0] * len(parameter_values)
         if circuit_indices is None:
             circuit_indices = list(range(len(self._circuits)))
         if parameter_values is None:

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -105,7 +105,9 @@ class TestEstimator(QiskitTestCase):
     def test_evaluate_multi_params(self):
         """test for evaluate with multiple parameters"""
         with Estimator([self.ansatz], [self.observable]) as est:
-            result = est(parameter_values=[[0, 1, 1, 2, 3, 5], [1, 1, 2, 3, 5, 8]])
+            result = est(
+                [0] * 2, [0] * 2, parameter_values=[[0, 1, 1, 2, 3, 5], [1, 1, 2, 3, 5, 8]]
+            )
         self.assertIsInstance(result, EstimatorResult)
         np.testing.assert_allclose(result.values, [-1.284366511861733, -1.3187526349078742])
 

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -92,7 +92,7 @@ class TestSampler(QiskitTestCase):
         """test for sampler with a parametrized circuit"""
         params, target = self._generate_params_target(indices)
         with Sampler(circuits=self._pqc) as sampler:
-            result = sampler(parameter_values=params)
+            result = sampler([0] * len(params), params)
             self._compare_probs(result.quasi_dists, target)
 
     @combine(indices=[[0, 0], [0, 1], [1, 1]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Remove parameter broadcasting that can be applied only for 1 circuit case.

Addresses part of #7836 (see this issue for details)

### Details and comments


