### PR TITLE
Rename old FakeMumbaiV2 to avoid name conflict with new FakeMumbaiV2

### DIFF
--- a/qiskit/providers/fake_provider/__init__.py
+++ b/qiskit/providers/fake_provider/__init__.py
@@ -27,7 +27,7 @@ from qiskit.test.mock.fake_pulse_backend import FakePulseBackend, FakePulseLegac
 from qiskit.test.mock.fake_qasm_backend import FakeQasmBackend, FakeQasmLegacyBackend
 from qiskit.test.mock.utils.configurable_backend import ConfigurableFakeBackend
 from qiskit.test.mock.fake_backend_v2 import FakeBackendV2, FakeBackend5QV2
-from qiskit.test.mock.fake_mumbai_v2 import FakeMumbaiV2
+from qiskit.test.mock.fake_mumbai_v2 import FakeMumbaiFractionalCX
 from qiskit.test.mock.fake_job import FakeJob, FakeLegacyJob
 from qiskit.test.mock.fake_qobj import FakeQobj
 

--- a/qiskit/test/mock/__init__.py
+++ b/qiskit/test/mock/__init__.py
@@ -24,7 +24,7 @@ from .fake_provider import FakeProvider, FakeLegacyProvider
 from .fake_provider import FakeProviderFactory
 from .fake_backend import FakeBackend, FakeLegacyBackend
 from .fake_backend_v2 import FakeBackendV2, FakeBackend5QV2
-from .fake_mumbai_v2 import FakeMumbaiV2
+from .fake_mumbai_v2 import FakeMumbaiFractionalCX
 from .fake_job import FakeJob, FakeLegacyJob
 from .fake_qobj import FakeQobj
 

--- a/qiskit/test/mock/fake_mumbai_v2.py
+++ b/qiskit/test/mock/fake_mumbai_v2.py
@@ -33,12 +33,12 @@ from qiskit.providers.options import Options
 from qiskit.transpiler import Target, InstructionProperties
 
 
-class FakeMumbaiV2(BackendV2):
+class FakeMumbaiFractionalCX(BackendV2):
     """A fake mumbai backend."""
 
     def __init__(self):
         super().__init__(
-            name="FakeMumbaiV2",
+            name="FakeMumbaiFractionalCX",
             description="A fake BackendV2 example based on IBM Mumbai",
             online_date=datetime.datetime.utcnow(),
             backend_version="0.0.1",

--- a/releasenotes/notes/rename-fake-mumbai-v2-2a4b4ead7360eab5.yaml
+++ b/releasenotes/notes/rename-fake-mumbai-v2-2a4b4ead7360eab5.yaml
@@ -2,6 +2,8 @@
 upgrade:
   - |
     :class:`~qiskit.test.mock.fake_mumbai_v2.FakeMumbaiV2` has been renamed to
-    `FakeMumbaiFractionalCX`. to avoid name conflict with the newer
+    `FakeMumbaiFractionalCX` to avoid name conflict with the newer
     :class:`~qiskit.test.mock.backends.FakeMumbaiV2` inherited from
-    :class:`~qiskit.test.fake_backend.FakeBackendV2`.
+    :class:`~qiskit.test.fake_backend.FakeBackendV2` which creates fake backend
+    based on device snapshot payload files instead of hardcoded instruction
+    properties.

--- a/releasenotes/notes/rename-fake-mumbai-v2-2a4b4ead7360eab5.yaml
+++ b/releasenotes/notes/rename-fake-mumbai-v2-2a4b4ead7360eab5.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    :class:`~qiskit.test.mock.fake_mumbai_v2.FakeMumbaiV2` has been renamed to
+    `FakeMumbaiFractionalCX`. to avoid name conflict with the newer
+    :class:`~qiskit.test.mock.backends.FakeMumbaiV2` inherited from
+    :class:`~qiskit.test.fake_backend.FakeBackendV2`.

--- a/test/python/providers/test_backend_v2.py
+++ b/test/python/providers/test_backend_v2.py
@@ -25,7 +25,7 @@ from qiskit.compiler.transpiler import _parse_inst_map
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
 from qiskit.test.base import QiskitTestCase
 from qiskit.test.mock.fake_backend_v2 import FakeBackendV2, FakeBackend5QV2
-from qiskit.test.mock.fake_mumbai_v2 import FakeMumbaiV2
+from qiskit.test.mock.fake_mumbai_v2 import FakeMumbaiFractionalCX
 from qiskit.quantum_info import Operator
 
 
@@ -150,7 +150,7 @@ class TestBackendV2(QiskitTestCase):
 
     def test_transpile_mumbai_target(self):
         """Test that transpile respects a more involved target for a fake mumbai."""
-        backend = FakeMumbaiV2()
+        backend = FakeMumbaiFractionalCX()
         qc = QuantumCircuit(2)
         qc.h(0)
         qc.cx(1, 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

https://github.com/Qiskit/qiskit-terra/pull/7643 implemented mocked IBM Quantum Systems backends using the new BackendV2 interface. FakeMumbaiV2 in https://github.com/Qiskit/qiskit-terra/blob/8105a80c84ce2447a1e224b85f4f56e98f074763/qiskit/test/mock/fake_mumbai_v2.py was created earlier for testing new V2 interface. This PR fix the name conflict between the old FakeMumbaiV2 (with hard coded instruction properties) and new FakeMumbaiV2 (built with device snapshots payloads) based on the new FakeBackendV2 class.

### Details and comments

Partial fixes #7838

