### PR TITLE
Improve parenthesis in circuit library equations 

### DIFF
--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -48,8 +48,8 @@ class iSwapGate(Gate):
 
     .. math::
 
-        iSWAP = R_{XX+YY}(-\frac{\pi}{2})
-          = exp(i \frac{\pi}{4} (X{\otimes}X+Y{\otimes}Y)) =
+        iSWAP = R_{XX+YY}\left(-\frac{\pi}{2}\right)
+          = \exp\left(i \frac{\pi}{4} \left(X{\otimes}X+Y{\otimes}Y\right)\right) =
             \begin{pmatrix}
                 1 & 0 & 0 & 0 \\
                 0 & 0 & i & 0 \\

--- a/qiskit/circuit/library/standard_gates/r.py
+++ b/qiskit/circuit/library/standard_gates/r.py
@@ -38,7 +38,7 @@ class RGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        R(\theta, \phi) = e^{-i \th (\cos{\phi} x + \sin{\phi} y)} =
+        R(\theta, \phi) = e^{-i \th \left(\cos{\phi} x + \sin{\phi} y\right)} =
             \begin{pmatrix}
                 \cos{\th} & -i e^{-i \phi} \sin{\th} \\
                 -i e^{i \phi} \sin{\th} & \cos{\th}

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -122,7 +122,7 @@ class CRXGate(ControlledGate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        CRX(\lambda)\ q_0, q_1 =
+        CRX(\theta)\ q_0, q_1 =
             I \otimes |0\rangle\langle 0| + RX(\theta) \otimes |1\rangle\langle 1| =
             \begin{pmatrix}
                 1 & 0 & 0 & 0 \\

--- a/qiskit/circuit/library/standard_gates/rx.py
+++ b/qiskit/circuit/library/standard_gates/rx.py
@@ -40,7 +40,7 @@ class RXGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        RX(\theta) = exp(-i \th X) =
+        RX(\theta) = \exp\left(-i \th X\right) =
             \begin{pmatrix}
                 \cos{\th}   & -i\sin{\th} \\
                 -i\sin{\th} & \cos{\th}

--- a/qiskit/circuit/library/standard_gates/rxx.py
+++ b/qiskit/circuit/library/standard_gates/rxx.py
@@ -39,12 +39,12 @@ class RXXGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        R_{XX}(\theta) = exp(-i \th X{\otimes}X) =
+        R_{XX}(\theta) = \exp\left(-i \th X{\otimes}X\right) =
             \begin{pmatrix}
-                \cos(\th)   & 0           & 0           & -i\sin(\th) \\
-                0           & \cos(\th)   & -i\sin(\th) & 0 \\
-                0           & -i\sin(\th) & \cos(\th)   & 0 \\
-                -i\sin(\th) & 0           & 0           & \cos(\th)
+                \cos\left(\th\right)   & 0           & 0           & -i\sin\left(\th\right) \\
+                0           & \cos\left(\th\right)   & -i\sin\left(\th\right) & 0 \\
+                0           & -i\sin\left(\th\right) & \cos\left(\th\right)   & 0 \\
+                -i\sin\left(\th\right) & 0           & 0           & \cos\left(\th\right)
             \end{pmatrix}
 
     **Examples:**
@@ -59,7 +59,7 @@ class RXXGate(Gate):
 
         .. math::
 
-            R_{XX}(\theta = \frac{\pi}{2}) = \frac{1}{\sqrt{2}}
+            R_{XX}\left(\theta = \frac{\pi}{2}\right) = \frac{1}{\sqrt{2}}
                                     \begin{pmatrix}
                                         1  & 0  & 0  & -i \\
                                         0  & 1  & -i & 0 \\

--- a/qiskit/circuit/library/standard_gates/ry.py
+++ b/qiskit/circuit/library/standard_gates/ry.py
@@ -39,7 +39,7 @@ class RYGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        RY(\theta) = exp(-i \th Y) =
+        RY(\theta) = \exp\left(-i \th Y\right) =
             \begin{pmatrix}
                 \cos{\th} & -\sin{\th} \\
                 \sin{\th} & \cos{\th}

--- a/qiskit/circuit/library/standard_gates/ryy.py
+++ b/qiskit/circuit/library/standard_gates/ryy.py
@@ -40,12 +40,12 @@ class RYYGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        R_{YY}(\theta) = exp(-i \th Y{\otimes}Y) =
+        R_{YY}(\theta) = \exp\left(-i \th Y{\otimes}Y\right) =
             \begin{pmatrix}
-                \cos(\th)   & 0           & 0           & i\sin(\th) \\
-                0           & \cos(\th)   & -i\sin(\th) & 0 \\
-                0           & -i\sin(\th) & \cos(\th)   & 0 \\
-                i\sin(\th)  & 0           & 0           & \cos(\th)
+                \cos\left(\th\right)   & 0           & 0           & i\sin\left(\th\right) \\
+                0           & \cos\left(\th\right)   & -i\sin\left(\th\right) & 0 \\
+                0           & -i\sin\left(\th\right) & \cos\left(\th\right)   & 0 \\
+                i\sin\left(\th\right)  & 0           & 0           & \cos\left(\th\right)
             \end{pmatrix}
 
     **Examples:**
@@ -60,7 +60,7 @@ class RYYGate(Gate):
 
         .. math::
 
-            R_{YY}(\theta = \frac{\pi}{2}) = \frac{1}{\sqrt{2}}
+            R_{YY}\left(\theta = \frac{\pi}{2}\right) = \frac{1}{\sqrt{2}}
                                     \begin{pmatrix}
                                         1 & 0 & 0 & i \\
                                         0 & 1 & -i & 0 \\

--- a/qiskit/circuit/library/standard_gates/rz.py
+++ b/qiskit/circuit/library/standard_gates/rz.py
@@ -37,7 +37,7 @@ class RZGate(Gate):
 
     .. math::
 
-        RZ(\lambda) = exp(-i\frac{\lambda}{2}Z) =
+        RZ(\lambda) = \exp\left(-i\frac{\lambda}{2}Z\right) =
             \begin{pmatrix}
                 e^{-i\frac{\lambda}{2}} & 0 \\
                 0 & e^{i\frac{\lambda}{2}}

--- a/qiskit/circuit/library/standard_gates/rzx.py
+++ b/qiskit/circuit/library/standard_gates/rzx.py
@@ -42,12 +42,12 @@ class RZXGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        R_{ZX}(\theta)\ q_0, q_1 = exp(-i \frac{\theta}{2} X{\otimes}Z) =
+        R_{ZX}(\theta)\ q_0, q_1 = \exp\left(-i \frac{\theta}{2} X{\otimes}Z\right) =
             \begin{pmatrix}
-                \cos(\th)   & 0          & -i\sin(\th)  & 0          \\
-                0           & \cos(\th)  & 0            & i\sin(\th) \\
-                -i\sin(\th) & 0          & \cos(\th)    & 0          \\
-                0           & i\sin(\th) & 0            & \cos(\th)
+                \cos\left(\th\right)   & 0          & -i\sin\left(\th\right)  & 0          \\
+                0           & \cos\left(\th\right)  & 0            & i\sin\left(\th\right) \\
+                -i\sin\left(\th\right) & 0          & \cos\left(\th\right)    & 0          \\
+                0           & i\sin\left(\th\right) & 0            & \cos\left(\th\right)
             \end{pmatrix}
 
     .. note::

--- a/qiskit/circuit/library/standard_gates/rzz.py
+++ b/qiskit/circuit/library/standard_gates/rzz.py
@@ -37,7 +37,7 @@ class RZZGate(Gate):
 
         \newcommand{\th}{\frac{\theta}{2}}
 
-        R_{ZZ}(\theta) = exp(-i \th Z{\otimes}Z) =
+        R_{ZZ}(\theta) = \exp\left(-i \th Z{\otimes}Z\right) =
             \begin{pmatrix}
                 e^{-i \th} & 0 & 0 & 0 \\
                 0 & e^{i \th} & 0 & 0 \\
@@ -72,7 +72,7 @@ class RZZGate(Gate):
 
         .. math::
 
-            R_{ZZ}(\theta = \frac{\pi}{2}) = \frac{1}{\sqrt{2}}
+            R_{ZZ}\left(\theta = \frac{\pi}{2}\right) = \frac{1}{\sqrt{2}}
                                     \begin{pmatrix}
                                         1-i & 0 & 0 & 0 \\
                                         0 & 1+i & 0 & 0 \\

--- a/qiskit/circuit/library/standard_gates/u.py
+++ b/qiskit/circuit/library/standard_gates/u.py
@@ -52,8 +52,8 @@ class UGate(Gate):
 
         U(\theta, \phi, \lambda) =
             \begin{pmatrix}
-                \cos(\th)          & -e^{i\lambda}\sin(\th) \\
-                e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)}\cos(\th)
+                \cos\left(\th\right)          & -e^{i\lambda}\sin\left(\th\right) \\
+                e^{i\phi}\sin\left(\th\right) & e^{i(\phi+\lambda)}\cos\left(\th\right)
             \end{pmatrix}
 
     **Examples:**

--- a/qiskit/circuit/library/standard_gates/u1.py
+++ b/qiskit/circuit/library/standard_gates/u1.py
@@ -151,7 +151,7 @@ class CU1Gate(ControlledGate):
 
     .. math::
 
-        CU1 =
+        CU1(\lambda) =
             |0\rangle\langle 0| \otimes I + |1\rangle\langle 1| \otimes U1 =
             \begin{pmatrix}
                 1 & 0 & 0 & 0 \\

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -45,15 +45,15 @@ class U3Gate(Gate):
 
         U3(\theta, \phi, \lambda) =
             \begin{pmatrix}
-                \cos(\th)          & -e^{i\lambda}\sin(\th) \\
-                e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)}\cos(\th)
+                \cos\left(\th\right)          & -e^{i\lambda}\sin\left(\th\right) \\
+                e^{i\phi}\sin\left(\th\right) & e^{i(\phi+\lambda)}\cos\left(\th\right)
             \end{pmatrix}
 
     **Examples:**
 
     .. math::
 
-        U3(\theta, -\frac{\pi}{2}, \frac{\pi}{2}) = RX(\theta)
+        U3\left(\theta, -\frac{\pi}{2}, \frac{\pi}{2}\right) = RX(\theta)
 
     .. math::
 

--- a/qiskit/circuit/library/standard_gates/xx_minus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_minus_yy.py
@@ -51,12 +51,12 @@ class XXMinusYYGate(Gate):
         \newcommand{\th}{\frac{\theta}{2}}
 
         R_{XX-YY}(\theta, \beta) q_0, q_1 =
-          RZ_1(\beta) \cdot exp(-i \frac{\theta}{2} \frac{XX-YY}{2}) \cdot RZ_1(-\beta) =
+          RZ_1(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_1(-\beta) =
             \begin{pmatrix}
-                \cos(\th)             & 0 & 0 & -i\sin(\th)e^{-i\beta}  \\
+                \cos\left(\th\right)             & 0 & 0 & -i\sin\left(\th\right)e^{-i\beta}  \\
                 0                     & 1 & 0 & 0  \\
                 0                     & 0 & 1 & 0  \\
-                -i\sin(\th)e^{i\beta} & 0 & 0 & \cos(\th)
+                -i\sin\left(\th\right)e^{i\beta} & 0 & 0 & \cos\left(\th\right)
             \end{pmatrix}
 
     .. note::
@@ -81,12 +81,12 @@ class XXMinusYYGate(Gate):
             \newcommand{\th}{\frac{\theta}{2}}
 
             R_{XX-YY}(\theta, \beta) q_1, q_0 =
-            RZ_0(\beta) \cdot exp(-i \frac{\theta}{2} \frac{XX-YY}{2}) \cdot RZ_0(-\beta) =
+            RZ_0(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX-YY}{2}\right) \cdot RZ_0(-\beta) =
                 \begin{pmatrix}
-                    \cos(\th)             & 0 & 0 & -i\sin(\th)e^{i\beta}  \\
+                    \cos\left(\th\right)             & 0 & 0 & -i\sin\left(\th\right)e^{i\beta}  \\
                     0                     & 1 & 0 & 0  \\
                     0                     & 0 & 1 & 0  \\
-                    -i\sin(\th)e^{-i\beta} & 0 & 0 & \cos(\th)
+                    -i\sin\left(\th\right)e^{-i\beta} & 0 & 0 & \cos\left(\th\right)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/xx_plus_yy.py
+++ b/qiskit/circuit/library/standard_gates/xx_plus_yy.py
@@ -42,11 +42,11 @@ class XXPlusYYGate(Gate):
         \newcommand{\th}{\frac{\theta}{2}}
 
         R_{XX+YY}(\theta, \beta)\ q_0, q_1 =
-          RZ_1(\beta) \cdot exp(-i \frac{\theta}{2} \frac{XX+YY}{2}) \cdot RZ_1(-\beta) =
+          RZ_1(\beta) \cdot \exp\left(-i \frac{\theta}{2} \frac{XX+YY}{2}\right) \cdot RZ_1(-\beta) =
             \begin{pmatrix}
                 1 & 0                     & 0                    & 0  \\
-                0 & \cos(\th)             & i\sin(\th)e^{i\beta} & 0  \\
-                0 & i\sin(\th)e^{-i\beta} & \cos(\th)            & 0  \\
+                0 & \cos\left(\th\right)             & i\sin\left(\th\right)e^{i\beta} & 0  \\
+                0 & i\sin\left(\th\right)e^{-i\beta} & \cos\left(\th\right)            & 0  \\
                 0 & 0                     & 0                    & 1
             \end{pmatrix}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [Yes] I have added the tests to cover my changes.
- [ Yes] I have updated the documentation accordingly.
- [ Yes] I have read the CONTRIBUTING document.
-->

### Summary
The pull request fixes issuehttps://github.com/Qiskit/qiskit-terra/issues/7800 (#7800). I have modified the docstrings of standard_gates module to fix the parenthesis size.


### Details and comments
The docstrings of some files of qiskit/circuit/library/standard_gates module were written without appropriate latex tag (\left, \right) for parenthesis (they were using default parenthesis). So, the parenthesis size was not align with other text. We can refer to https://github.com/Qiskit/qiskit-terra/issues/7800#issuecomment-1078872749 to see how modifying latex tags fixes parenthesis size.

I have edited docstrings of 13 files in the standard_gates module. Basically I adjusted the parenthesis tags to fix their size.
