### PR TITLE
Fix indent & improve consistency of primitive docs with Qiskit

### DIFF
--- a/qiskit/primitives/base_estimator.py
+++ b/qiskit/primitives/base_estimator.py
@@ -131,16 +131,15 @@ class BaseEstimator(ABC):
         holds resources until the instance is ``close()`` ed or the context is exited.
 
         Args:
-            circuits: quantum circuits that represent quantum states
-            observables: observables
-            parameters: parameters of quantum circuits, specifying the order in which values
-            will be bound.
-                Defaults to ``[circ.parameters for circ in circuits]``
+            circuits: Quantum circuits that represent quantum states.
+            observables: Observables.
+            parameters: Parameters of quantum circuits, specifying the order in which values
+                will be bound. Defaults to ``[circ.parameters for circ in circuits]``
                 The indexing is such that ``parameters[i, j]`` is the j-th formal parameter of
                 ``circuits[i]``.
 
         Raises:
-            QiskitError: for mismatch of circuits and parameters list.
+            QiskitError: For mismatch of circuits and parameters list.
         """
         self._circuits = tuple(circuits)
         self._observables = tuple(observables)
@@ -176,25 +175,25 @@ class BaseEstimator(ABC):
         """Quantum circuits that represents quantum states.
 
         Returns:
-            quantum circuits
+            The quantum circuits.
         """
         return self._circuits
 
     @property
     def observables(self) -> tuple[SparsePauliOp, ...]:
-        """Observables to be estimated
+        """Observables to be estimated.
 
         Returns:
-            observables
+            The observables.
         """
         return self._observables
 
     @property
     def parameters(self) -> tuple[ParameterView, ...]:
-        """Parameters of quantum circuits
+        """Parameters of the quantum circuits.
 
         Returns:
-            parameters, where ``parameters[i][j]`` is the j-th parameter of the i-th circuit.
+            Parameters, where ``parameters[i][j]`` is the j-th parameter of the i-th circuit.
         """
         return self._parameters
 
@@ -234,6 +233,6 @@ class BaseEstimator(ABC):
             run_options: runtime options used for circuit execution.
 
         Returns:
-            EstimatorResult: the result of Estimator.
+            EstimatorResult: The result of the estimator.
         """
         ...

--- a/qiskit/primitives/base_sampler.py
+++ b/qiskit/primitives/base_sampler.py
@@ -112,12 +112,12 @@ class BaseSampler(ABC):
     ):
         """
         Args:
-            circuits: quantum circuits to be executed
-            parameters: parameters of quantum circuits
-                Defaults to ``[circ.parameters for circ in circuits]``
+            circuits: Quantum circuits to be executed.
+            parameters: Parameters of each of the quantum circuits.
+                Defaults to ``[circ.parameters for circ in circuits]``.
 
         Raises:
-            QiskitError: for mismatch of circuits and parameters list.
+            QiskitError: For mismatch of circuits and parameters list.
         """
         self._circuits = tuple(circuits)
         if parameters is None:
@@ -143,19 +143,19 @@ class BaseSampler(ABC):
 
     @property
     def circuits(self) -> tuple[QuantumCircuit, ...]:
-        """Quantum circuits
+        """Quantum circuits to be sampled.
 
         Returns:
-            quantum circuits
+            The quantum circuits to be sampled.
         """
         return self._circuits
 
     @property
     def parameters(self) -> tuple[ParameterView, ...]:
-        """Parameters of quantum circuits
+        """Parameters of quantum circuits.
 
         Returns:
-            Parameter list of the quantum circuits
+            List of the parameters in each quantum circuit.
         """
         return self._parameters
 
@@ -169,12 +169,12 @@ class BaseSampler(ABC):
         """Run the sampling of bitstrings.
 
         Args:
-            circuit_indices: indexes of the circuits to evaluate.
-            parameter_values: parameters to be bound.
-            run_options: backend runtime options used for circuit execution.
+            circuit_indices: Indices of the circuits to evaluate.
+            parameter_values: Parameters to be bound to the circuit.
+            run_options: Backend runtime options used for circuit execution.
 
         Returns:
-            the result of Sampler. The i-th result corresponds to
+            The result of the sampler. The i-th result corresponds to
             ``self.circuits[circuit_indices[i]]`` evaluated with parameters bound as
             ``parameter_values[i]``.
         """

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -24,21 +24,20 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class EstimatorResult:
-    """
-    Result of Estimator
+    """Result of Estimator.
 
     .. code-block:: python
 
         result = estimator(circuits, observables, params)
 
     where the i-th elements of ``result`` correspond to the circuit and observable given by
-    ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter_values bounds by ``params[i]``.
+    ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by ``params[i]``.
     For example, ``results.values[i]`` gives the expectation value, and ``result.metadata[i]``
     is a metadata dictionary for this circuit and parameters.
 
     Args:
-        values (np.ndarray): the array of the expectation values.
-        metadata (list[dict]): list of the metadata.
+        values (np.ndarray): The array of the expectation values.
+        metadata (list[dict]): List of the metadata.
     """
 
     values: "np.ndarray[Any, np.dtype[np.float64]]"

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -43,6 +43,8 @@ class Sampler(BaseSampler):
         """
         Args:
             circuits: circuits to be executed
+            parameters: Parameters of each of the quantum circuits.
+                Defaults to ``[circ.parameters for circ in circuits]``.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.

--- a/qiskit/primitives/sampler_result.py
+++ b/qiskit/primitives/sampler_result.py
@@ -23,21 +23,20 @@ from qiskit.result import QuasiDistribution
 
 @dataclass(frozen=True)
 class SamplerResult:
-    """
-    Result of Sampler
+    """Result of Sampler.
 
     .. code-block:: python
 
         result = sampler(circuits, params)
 
     where the i-th elements of ``result`` correspond to the circuit given by ``circuit_indices[i]``,
-    and the parameter_values bounds by ``params[i]``.
+    and the parameter values bounds by ``params[i]``.
     For example, ``results.quasi_dists[i]`` gives the quasi-probabilities of bitstrings, and
     ``result.metadata[i]`` is a metadata dictionary for this circuit and parameters.
 
     Args:
-        quasi_dists (list[QuasiDistribution]): list of the quasi-probabilities.
-        metadata (list[dict]): list of the metadata.
+        quasi_dists (list[QuasiDistribution]): List of the quasi-probabilities.
+        metadata (list[dict]): List of the metadata.
     """
 
     quasi_dists: list[QuasiDistribution]

--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -23,7 +23,14 @@ from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 
 def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
-    """Initialize state."""
+    """Initialize state by converting the input to a quantum circuit.
+
+    Args:
+        state: The state as quantum circuit or statevector.
+
+    Returns:
+        The state as quantum circuit.
+    """
     if isinstance(state, QuantumCircuit):
         return state
     if not isinstance(state, Statevector):
@@ -34,13 +41,24 @@ def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
 
 
 def init_observable(observable: BaseOperator | PauliSumOp) -> SparsePauliOp:
-    """Initialize observable"""
+    """Initialize observable by converting the input to a :class:`~qiskit.quantum_info.SparsePauliOp`.
+
+    Args:
+        observable: The observable.
+
+    Returns:
+        The observable as :class:`~qiskit.quantum_info.SparsePauliOp`.
+
+    Raises:
+        TypeError: If the observable is a :class:`~qiskit.opflow.PauliSumOp` and has a parameterized
+            coefficient.
+    """
     if isinstance(observable, SparsePauliOp):
         return observable
     if isinstance(observable, PauliSumOp):
         if isinstance(observable.coeff, ParameterExpression):
             raise TypeError(
-                f"observable must have numerical coefficient, not {type(observable.coeff)}"
+                f"Observable must have numerical coefficient, not {type(observable.coeff)}."
             )
         return observable.coeff * observable.primitive
     if isinstance(observable, BaseOperator):
@@ -59,7 +77,7 @@ def final_measurement_mapping(circuit: QuantumCircuit) -> dict[int, int]:
     `mthree <https://github.com/Qiskit-Partners/mthree>`_.
 
     Parameters:
-        circuit: Input Qiskit QuantumCircuit.
+        circuit: Input quantum circuit.
 
     Returns:
         Mapping of qubits to classical bits for final measurements.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

There was an indent missing in the `EstimatorBase`:

![image](https://user-images.githubusercontent.com/5978796/161967731-533bbbc5-2ea8-4dc2-8cba-0c8097cf996f.png)

And not all functions were fully documented (missing input args or return docs). Also I tried to improve the consistency with the rest of Qiskit whre we usually use full sentences in the docs, but feel free to reject or adjust that!

### Details and comments

Is there a reason why we use `collections.abc` for typehints instead of `typing` as in the most of the (or all?) codebase? 🙂 

