### PR TITLE
Fix init_observable for Pauli

### DIFF
--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -20,6 +20,7 @@ from qiskit.extensions.quantum_initializer.initializer import Initialize
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info import SparsePauliOp, Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.quantum_info.operators.symplectic.base_pauli import BasePauli
 
 
 def init_circuit(state: QuantumCircuit | Statevector) -> QuantumCircuit:
@@ -37,15 +38,18 @@ def init_observable(observable: BaseOperator | PauliSumOp) -> SparsePauliOp:
     """Initialize observable"""
     if isinstance(observable, SparsePauliOp):
         return observable
-    if isinstance(observable, PauliSumOp):
+    elif isinstance(observable, PauliSumOp):
         if isinstance(observable.coeff, ParameterExpression):
             raise TypeError(
                 f"observable must have numerical coefficient, not {type(observable.coeff)}"
             )
         return observable.coeff * observable.primitive
-    if isinstance(observable, BaseOperator):
+    elif isinstance(observable, BasePauli):
+        return SparsePauliOp(observable)
+    elif isinstance(observable, BaseOperator):
         return SparsePauliOp.from_operator(observable)
-    return SparsePauliOp(observable)
+    else:
+        return SparsePauliOp(observable)
 
 
 def final_measurement_mapping(circuit: QuantumCircuit) -> dict[int, int]:

--- a/releasenotes/notes/fix-primitive-init-observable-pauli-e312c05d1c3bd804.yaml
+++ b/releasenotes/notes/fix-primitive-init-observable-pauli-e312c05d1c3bd804.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes the bug that take exponential time and does not terminate when
+    :class:`~qiskit.quantum_info.Pauli` is input to
+    :meth:`~qiskit.primitives.utils.init_observables`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes https://github.com/Qiskit/qiskit-ibm-runtime/issues/262.

<img width="493" alt="image" src="https://user-images.githubusercontent.com/6814928/161994270-865322ce-abab-4fcc-9dd7-233a228ecfb8.png">



### Details and comments


