### PR TITLE
Tests for State Visualization

### DIFF
--- a/test/python/visualization/test_plot_state_city.py
+++ b/test/python/visualization/test_plot_state_city.py
@@ -24,7 +24,7 @@ from qiskit.tools.visualization import plot_state_city
 class TestPlotStateCity(QiskitTestCase):
     """Qiskit plot_state_city tests."""
 
-    def test_different_counts_lengths(self):
+    def test_bell_state(self):
         """Test plotting Pauli vector of the bell state"""
         qc = QuantumCircuit(2)
         qc.h(0)

--- a/test/python/visualization/test_plot_state_city.py
+++ b/test/python/visualization/test_plot_state_city.py
@@ -1,0 +1,40 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for plot_state_city."""
+
+import unittest
+import matplotlib as mpl
+
+from qiskit import QuantumCircuit
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info import DensityMatrix
+from qiskit.tools.visualization import plot_state_city
+
+
+class TestPlotStateCity(QiskitTestCase):
+    """Qiskit plot_state_city tests."""
+
+    def test_different_counts_lengths(self):
+        """Test plotting Pauli vector of the bell state"""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        state = DensityMatrix.from_instruction(qc)
+        fig = plot_state_city(state,
+                              color=['midnightblue', 'midnightblue'],
+                              title="New State City")
+        self.assertIsInstance(fig, mpl.figure.Figure)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/python/visualization/test_plot_state_city.py
+++ b/test/python/visualization/test_plot_state_city.py
@@ -30,9 +30,7 @@ class TestPlotStateCity(QiskitTestCase):
         qc.h(0)
         qc.cx(0, 1)
         state = DensityMatrix.from_instruction(qc)
-        fig = plot_state_city(state,
-                              color=['midnightblue', 'midnightblue'],
-                              title="New State City")
+        fig = plot_state_city(state, color=["midnightblue", "midnightblue"], title="New State City")
         self.assertIsInstance(fig, mpl.figure.Figure)
 
 

--- a/test/python/visualization/test_plot_state_paulivec.py
+++ b/test/python/visualization/test_plot_state_paulivec.py
@@ -1,0 +1,38 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for plot_state_paulivec."""
+
+import unittest
+import matplotlib as mpl
+
+from qiskit import QuantumCircuit
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info import Statevector
+from qiskit.tools.visualization import plot_state_paulivec
+
+
+class TestPlotStatePaulivec(QiskitTestCase):
+    """Qiskit plot_state_paulivec tests."""
+
+    def test_bell_state(self):
+        """Test plotting Pauli vector of the bell state"""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        state = Statevector.from_instruction(qc)
+        fig = plot_state_paulivec(state, title="New PauliVec plot")
+        self.assertIsInstance(fig, mpl.figure.Figure)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Added a test for plot_state_city() and plot_state_paulivec(). Addressed issue https://github.com/Qiskit/qiskit-terra/issues/2306


### Details and comments
The plot_state_city creates a visual for the density matrix, showing both real and imaginary components. plot_state_paulivec  displays the pauli vector for the state. Both tests involve displaying the bell state |00>+ |11>. 
