### PR TITLE
Set sphinx-build --keep-going by default

### DIFF
--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -43,7 +43,7 @@ jobs:
       - bash: |
           set -e
           cd qiskit-tutorials
-          sphinx-build -b html . _build/html
+          sphinx-build -W -T --keep-going -b html . _build/html
         env:
           QISKIT_PARALLEL: False
 

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -43,7 +43,7 @@ jobs:
       - bash: |
           set -e
           cd qiskit-tutorials
-          sphinx-build -W -T --keep-going -b html . _build/html
+          sphinx-build -b html . _build/html
         env:
           QISKIT_PARALLEL: False
 

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ setenv =
 deps =
   -r{toxinidir}/requirements-dev.txt
 commands =
-  sphinx-build -W --keep-going -b html docs/ docs/_build/html {posargs}
+  sphinx-build -W -T --keep-going -b html docs/ docs/_build/html {posargs}
 
 [pycodestyle]
 max-line-length = 105

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,7 @@ setenv =
 deps =
   -r{toxinidir}/requirements-dev.txt
 commands =
-  sphinx-build -W -b html docs/ docs/_build/html {posargs}
+  sphinx-build -W --keep-going -b html docs/ docs/_build/html {posargs}
 
 [pycodestyle]
 max-line-length = 105


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For sphinx builds we set the -W flag to treat warnings as errors. This
however, has the unfortunate side-effect of exiting the sphinx build
on the first warning and in the typical documentation debugging
workflow multiple iterations are required to debug all the issues. This
commit adds the --keep-going sphinx-build flag [1] to the default build
options. The --keep-going flag will still treat warnings as errors, but
not exit the build early. This should hopefully improve the
debuggability of the documentation as we'll get a complete picture of
what's wrong with a build instead of having to deal with it one warning
at a time.

### Details and comments

[1] https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going