### PR TITLE
Improve transpiler coverage of randomized equivalence test

### DIFF
--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -11,7 +11,41 @@
 # that they have been altered from the originals.
 # pylint: disable=invalid-name
 
-"""Randomized tests of transpiler circuit equivalence."""
+"""Randomized tests of transpiler circuit equivalence.
+
+This test can be optionally configured (e.g. by CI) via the
+following env vars:
+
+QISKIT_RANDOMIZED_TEST_LAYOUT_METHODS
+
+    A space-delimited list of layout method names from which the
+    randomizer should pick the layout method. Defaults to all
+    available built-in methods if unspecified.
+
+QISKIT_RANDOMIZED_TEST_ROUTING_METHODS
+
+    A space-delimited list of routing method names from which the
+    randomizer should pick the routing method. Defaults to all
+    available built-in methods if unspecified.
+
+QISKIT_RANDOMIZED_TEST_SCHEDULING_METHODS
+
+    A space-delimited list of scheduling method names from which the
+    randomizer should pick the scheduling method. Defaults to all
+    available built-in methods if unspecified.
+
+QISKIT_RANDOMIZED_TEST_BACKEND_NEEDS_DURATIONS
+
+    A boolean value (e.g. "true", "Y", etc.) which, when true, forces
+    the randomizer to pick a backend which fully supports scheduling
+    (i.e. has fully specified duration info). Defaults to False.
+
+QISKIT_RANDOMIZED_TEST_ALLOW_BARRIERS
+
+    A boolean value (e.g. "true", "Y", etc.) which, when false,
+    prevents the randomizer from emitting barrier instructions.
+    Defaults to True.
+"""
 
 import os
 from math import pi
@@ -427,9 +461,7 @@ class QCircuitMachine(RuleBasedStateMachine):
             )
             raise RuntimeError(failed_qasm) from e
 
-        xpiled_aer_counts = (
-            execute(xpiled_qc, backend=self.backend, shots=shots).result().get_counts()
-        )
+        xpiled_aer_counts = self.backend.run(xpiled_qc, shots=shots).result().get_counts()
 
         count_differences = dicts_almost_equal(aer_counts, xpiled_aer_counts, 0.05 * shots)
 


### PR DESCRIPTION
Chooses layout, routing, and scheduling methods to use when invoking
transpile. This way, preset pass manager behavior with designated
transpilation method combinations is covered.

To support scheduling method coverage, a filter list is introduced to
exclude any fake backends that do not provide the necessary information
for instruction scheduling (i.e. gate durations).

Secondarily, this test is now configurable via enviroment variables,
the intention of which is to ultimately make it easy for transpiler passes
living outside of Terra to run equivalence tests in their own CI pipelines
to ensure proper Terra integration. For now, this has limited utility,
since neither layout, routing, nor scheduling methods can be used with
`transpile` unless Terra already knows about them. In the near future,
[qiskit-toqm](https://github.com/qiskit-toqm/qiskit-toqm) is a planned
integration for Terra, but will be excluded from Terra's randomized
equivalence test CI pipeline since it lives externally. To provide
coverage, it'll use its own CI pipeline to invoke this test with
environment variables that exercise it sufficiently. This should be even
more useful in the future, should the transpiler support a more
plugin-oriented architecture.

The following changes have been made to support the above:

The hypothesis profile can now be changed via the built-in
hypothesis environment variable, HYPOTHESIS_PROFILE. Note that the
named profile must first be registered through some means
(e.g. conftest.py). See the following for details:
https://hypothesis.readthedocs.io/en/latest/settings.html#settings-profiles

This test can now be optionally configured (e.g. by CI) via the
following env vars:

QISKIT_RANDOMIZED_TEST_LAYOUT_METHODS

  A space-delimited list of layout method names from which the
  randomizer should pick the layout method. Defaults to all
  available built-in methods if unspecified.

QISKIT_RANDOMIZED_TEST_ROUTING_METHODS

  A space-delimited list of routing method names from which the
  randomizer should pick the routing method. Defaults to all
  available built-in methods if unspecified.

QISKIT_RANDOMIZED_TEST_SCHEDULING_METHODS

  A space-delimited list of scheduling method names from which the
  randomizer should pick the scheduling method. Defaults to all
  available built-in methods if unspecified.

QISKIT_RANDOMIZED_TEST_BACKEND_NEEDS_DURATIONS

  A boolean value (e.g. "true", "Y", etc.) which, when true, forces
  the randomizer to pick a backend which fully supports scheduling
  (i.e. has fully specified duration info). Defaults to False.

QISKIT_RANDOMIZED_TEST_ALLOW_BARRIERS

  A boolean value (e.g. "true", "Y", etc.) which, when false,
  prevents the randomizer from emitting barrier instructions.
  Defaults to True.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

