### PR TITLE
Revert "Workaround Aer bug with subnormal floats in randomised tests (#7719)"

### DIFF
--- a/test/randomized/test_synthesis.py
+++ b/test/randomized/test_synthesis.py
@@ -32,9 +32,7 @@ class TestSynthesis(CheckDecompositions):
     """Test synthesis"""
 
     seed = strategies.integers(min_value=0, max_value=2**32 - 1)
-    # allow_subnormal=False should not need to be specified: remove after Aer PR #1469 is in the
-    # released version.
-    rotation = strategies.floats(min_value=-np.pi * 10, max_value=np.pi * 10, allow_subnormal=False)
+    rotation = strategies.floats(min_value=-np.pi * 10, max_value=np.pi * 10)
 
     @given(seed)
     def test_1q_random(self, seed):

--- a/test/randomized/test_transpiler_equivalence.py
+++ b/test/randomized/test_transpiler_equivalence.py
@@ -148,11 +148,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         gate=st.sampled_from(oneQ_oneP_gates),
         qarg=qubits,
         param=st.floats(
-            allow_nan=False,
-            allow_infinity=False,
-            min_value=-10 * pi,
-            max_value=10 * pi,
-            allow_subnormal=False,
+            allow_nan=False, allow_infinity=False, min_value=-10 * pi, max_value=10 * pi
         ),
     )
     def add_1q1p_gate(self, gate, qarg, param):
@@ -163,13 +159,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         gate=st.sampled_from(oneQ_twoP_gates),
         qarg=qubits,
         params=st.lists(
-            st.floats(
-                allow_nan=False,
-                allow_infinity=False,
-                min_value=-10 * pi,
-                max_value=10 * pi,
-                allow_subnormal=False,
-            ),
+            st.floats(allow_nan=False, allow_infinity=False, min_value=-10 * pi, max_value=10 * pi),
             min_size=2,
             max_size=2,
         ),
@@ -182,13 +172,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         gate=st.sampled_from(oneQ_threeP_gates),
         qarg=qubits,
         params=st.lists(
-            st.floats(
-                allow_nan=False,
-                allow_infinity=False,
-                min_value=-10 * pi,
-                max_value=10 * pi,
-                allow_subnormal=False,
-            ),
+            st.floats(allow_nan=False, allow_infinity=False, min_value=-10 * pi, max_value=10 * pi),
             min_size=3,
             max_size=3,
         ),
@@ -201,11 +185,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         gate=st.sampled_from(twoQ_oneP_gates),
         qargs=st.lists(qubits, max_size=2, min_size=2, unique=True),
         param=st.floats(
-            allow_nan=False,
-            allow_infinity=False,
-            min_value=-10 * pi,
-            max_value=10 * pi,
-            allow_subnormal=False,
+            allow_nan=False, allow_infinity=False, min_value=-10 * pi, max_value=10 * pi
         ),
     )
     def add_2q1p_gate(self, gate, qargs, param):
@@ -216,13 +196,7 @@ class QCircuitMachine(RuleBasedStateMachine):
         gate=st.sampled_from(twoQ_threeP_gates),
         qargs=st.lists(qubits, max_size=2, min_size=2, unique=True),
         params=st.lists(
-            st.floats(
-                allow_nan=False,
-                allow_infinity=False,
-                min_value=-10 * pi,
-                max_value=10 * pi,
-                allow_subnormal=False,
-            ),
+            st.floats(allow_nan=False, allow_infinity=False, min_value=-10 * pi, max_value=10 * pi),
             min_size=3,
             max_size=3,
         ),


### PR DESCRIPTION
### Summary

Since Aer 0.10.4 is now released with corrected handling of subnormal
floating-point numbers when compiled with gcc, this commit is no longer
necessary.

This reverts commit 77219b5c7b7146b1545c5e5190739b36f4064b2f.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Reverts #7719.
