### PR TITLE
Make `Optimize1qGatesSimpleCommuation` and `Optimize1qGatesDecomposition` passes `Target` aware

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
@@ -60,18 +60,22 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
     # NOTE: A run from `dag.collect_1q_runs` is always nonempty, so we sometimes use an empty list
     #       to signify the absence of a run.
 
-    def __init__(self, basis=None, run_to_completion=False):
+    def __init__(self, basis=None, run_to_completion=False, target=None):
         """
         Args:
             basis (List[str]): See also `Optimize1qGatesDecomposition`.
             run_to_completion (bool): If `True`, this pass retries until it is unable to do any more
                 work.  If `False`, it finds and performs one optimization, and for full optimization
                 the user is obligated to re-call the pass until the output stabilizes.
+            target (Target): The target representing the backend. If specified
+                this will be used instead of the ``basis_gates`` parameter
+
         """
         super().__init__()
 
         self._basis = basis
-        self._optimize1q = Optimize1qGatesDecomposition(basis)
+        self._target = target
+        self._optimize1q = Optimize1qGatesDecomposition(basis, target)
         self._run_to_completion = run_to_completion
 
     @staticmethod
@@ -213,6 +217,11 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
             new_basis, new_run = self._resynthesize(run_clone)
 
             # perform the replacement if it was indeed a good idea
+            qubit_map = None
+
+            if self._target:
+                qubit_map = {qubit: index for index, qubit in enumerate(dag.qubits)}
+
             if self._optimize1q._substitution_checks(
                 dag,
                 (preceding_run or []) + run + (succeeding_run or []),
@@ -222,6 +231,7 @@ class Optimize1qGatesSimpleCommutation(TransformationPass):
                     + (new_succeeding_run or QuantumCircuit(1)).data
                 ),
                 new_basis + new_preceding_basis + new_succeeding_basis,
+                qubit_map,
             ):
                 if preceding_run and new_preceding_run is not None:
                     self._replace_subdag(dag, preceding_run, new_preceding_run)

--- a/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_decomposition.py
@@ -117,13 +117,10 @@ class Optimize1qGatesDecomposition(TransformationPass):
         uncalibrated_p = not has_cals_p or any(not dag.has_calibration_for(g) for g in old_run)
         # does this run have gates not in the image of ._decomposers _and_ uncalibrated?
         def _not_in_basis(gate):
-            """To check if gate in basis or not
+            """
+            To check if gate in basis or not
 
-            Args:
-                gate (Gate): gate to check
-
-            Returns:
-                Bool : whether Gate is supported by target or in basis set
+            Returns `True` when Gate is not supported by target or in basis set.
             """
             if self._target:
                 in_target = self._target.instruction_supported(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Make `Optimize1qGatesSimpleCommuation` (O1QC) and `Optimize1qGatesDecomposition` (O1QD) passes `Target` aware, in continuation of #7113 


### Details and comments
- This PR tries to make the above passes target aware by introducing `target` as a parameter

### `Optimize1qGatesSimpleCommuation`
- *O1QC* did not have any direct dependence to the target (as far as I could figure out) but depended indirectly through *O1QD*

### `Optimize1qGatesDecomposition`
- In *O1QD*, three major changes were introduced - 
    - In the constructor, decomposers were checked for the `target.operation_names` instead of the `basis_set`. This is beacuse if target was provided, then decomposition was required for the operations supported by it. 
    - In `_substitution_checks`, gates were checked for whether they were supported by `target` or not as `target` support should supersede the `basis_set`
    - In `run` method, again check for the optimization of `u3` gate was changed. It included check for whether the qubit on which `u3` was being performed, whether it was supported by `target` or not. If it was, then relevant optimization was done including some additional checks for `u1` and `u2` gates. 

#### Note
- The test for the changes hasn't been added yet as I wasn't exactly sure if this was the correct way to do the `target` introduction. Would love to know if this was somewhat correct or not!


