### PR TITLE
Deprecate `limit_amplitude` constructor argument

### DIFF
--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -13,6 +13,7 @@
 """Pulses are descriptions of waveform envelopes. They can be transmitted by control electronics
 to the device.
 """
+import warnings
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Any, Tuple, Union
 
@@ -47,6 +48,11 @@ class Pulse(ABC):
         self.duration = duration
         self.name = name
         if limit_amplitude is not None:
+            warnings.warn(
+                "Instantiating a pulse instance with 'limit_amplitude' has been deprecated. "
+                f"Please directly update class variable '{self.__class__.__name__}.limit_amplitude.'",
+                DeprecationWarning,
+            )
             self.limit_amplitude = limit_amplitude
 
     @property

--- a/qiskit/pulse/library/pulse.py
+++ b/qiskit/pulse/library/pulse.py
@@ -52,6 +52,7 @@ class Pulse(ABC):
                 "Instantiating a pulse instance with 'limit_amplitude' has been deprecated. "
                 f"Please directly update class variable '{self.__class__.__name__}.limit_amplitude.'",
                 DeprecationWarning,
+                stacklevel=4,
             )
             self.limit_amplitude = limit_amplitude
 

--- a/releasenotes/notes/deprecate_limit_amplitude-454f3ea455f3a37e.yaml
+++ b/releasenotes/notes/deprecate_limit_amplitude-454f3ea455f3a37e.yaml
@@ -1,0 +1,14 @@
+---
+deprecations:
+  - |
+    Instantiating a :class:`Pulse` subclass instance with ``limit_amplitude`` has been deprecated.
+    Though this is a constructor argument, it implicitly updates other instance settings
+    since this actually updates a class variable. To avoid confusion, user must explicitly
+    update the class variable. For example,
+
+    .. code-block:: python
+
+      from qiskit.pulse.library import Pulse, Gaussian
+
+      Pulse.limit_amplitude = False
+      waveform = Gaussian(duration=160, amp=120, sigma=40)

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -309,6 +309,12 @@ class TestParametricPulses(QiskitTestCase):
             waveform = Constant(duration=100, amp=1.1 + 0.8j)
             self.assertGreater(np.abs(waveform.amp), 1.0)
 
+    def test_deprecate_instantiating_with_limit(self):
+        """Test if deprecation warning is thrown when instance is created with limit option."""
+        with self.assertWarns(DeprecationWarning):
+            GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10, limit_amplitude=False)
+
+
 # pylint: disable=invalid-name,unexpected-keyword-arg
 
 

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -81,16 +81,9 @@ class TestWaveform(QiskitTestCase):
         with self.assertRaises(PulseError):
             Waveform(invalid_const * np.exp(1j * 2 * np.pi * np.linspace(0, 1, 1000)))
 
-        invalid_const = 1.1
-        Waveform.limit_amplitude = False
-        wave = Waveform(invalid_const * np.exp(1j * 2 * np.pi * np.linspace(0, 1, 1000)))
-        self.assertGreater(np.max(np.abs(wave.samples)), 1.0)
-        with self.assertRaises(PulseError):
-            wave = Waveform(
-                invalid_const * np.exp(1j * 2 * np.pi * np.linspace(0, 1, 1000)),
-                limit_amplitude=True,
-            )
-        Waveform.limit_amplitude = True
+        with patch("qiskit.pulse.library.pulse.Pulse.limit_amplitude", new=False):
+            wave = Waveform(invalid_const * np.exp(1j * 2 * np.pi * np.linspace(0, 1, 1000)))
+            self.assertGreater(np.max(np.abs(wave.samples)), 1.0)
 
         # Test case where data is converted to python types with complex as a list
         # with form [re, im] and back to a numpy array.
@@ -282,38 +275,39 @@ class TestParametricPulses(QiskitTestCase):
 
     def test_gaussian_limit_amplitude(self):
         """Test that the check for amplitude less than or equal to 1 can be disabled."""
-        waveform = Gaussian(duration=100, sigma=1.0, amp=1.1 + 0.8j, limit_amplitude=False)
-        self.assertGreater(np.abs(waveform.amp), 1.0)
-
         with self.assertRaises(PulseError):
-            Gaussian(duration=100, sigma=1.0, amp=1.1 + 0.8j, limit_amplitude=True)
+            GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10)
+
+        with patch("qiskit.pulse.library.pulse.Pulse.limit_amplitude", new=False):
+            waveform = GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10)
+            self.assertGreater(np.abs(waveform.amp), 1.0)
 
     def test_gaussian_square_limit_amplitude(self):
         """Test that the check for amplitude less than or equal to 1 can be disabled."""
-        waveform = GaussianSquare(
-            duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10, limit_amplitude=False
-        )
-        self.assertGreater(np.abs(waveform.amp), 1.0)
-
         with self.assertRaises(PulseError):
-            GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10, limit_amplitude=True)
+            GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10)
+
+        with patch("qiskit.pulse.library.pulse.Pulse.limit_amplitude", new=False):
+            waveform = GaussianSquare(duration=100, sigma=1.0, amp=1.1 + 0.8j, width=10)
+            self.assertGreater(np.abs(waveform.amp), 1.0)
 
     def test_drag_limit_amplitude(self):
         """Test that the check for amplitude less than or equal to 1 can be disabled."""
-        waveform = Drag(duration=100, sigma=1.0, beta=1.0, amp=1.1 + 0.8j, limit_amplitude=False)
-        self.assertGreater(np.abs(waveform.amp), 1.0)
-
         with self.assertRaises(PulseError):
-            Drag(duration=100, sigma=1.0, beta=1.0, amp=1.1 + 0.8j, limit_amplitude=True)
+            Drag(duration=100, sigma=1.0, beta=1.0, amp=1.1 + 0.8j)
+
+        with patch("qiskit.pulse.library.pulse.Pulse.limit_amplitude", new=False):
+            waveform = Drag(duration=100, sigma=1.0, beta=1.0, amp=1.1 + 0.8j)
+            self.assertGreater(np.abs(waveform.amp), 1.0)
 
     def test_constant_limit_amplitude(self):
         """Test that the check for amplitude less than or equal to 1 can be disabled."""
-        waveform = Constant(duration=100, amp=1.1 + 0.8j, limit_amplitude=False)
-        self.assertGreater(np.abs(waveform.amp), 1.0)
-
         with self.assertRaises(PulseError):
-            Constant(duration=100, amp=1.1 + 0.8j, limit_amplitude=True)
+            Constant(duration=100, amp=1.1 + 0.8j)
 
+        with patch("qiskit.pulse.library.pulse.Pulse.limit_amplitude", new=False):
+            waveform = Constant(duration=100, amp=1.1 + 0.8j)
+            self.assertGreater(np.abs(waveform.amp), 1.0)
 
 # pylint: disable=invalid-name,unexpected-keyword-arg
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR deprecates `limit_amplitude` which is a constructor argument of pulse subclass. This option is confusing because user may unintentionally update class variable, or sometime instance variable.

### Details and comments

Fix #7932 


