### PR TITLE
Swap old networkx usage to retworkx

### DIFF
--- a/qiskit/circuit/library/graph_state.py
+++ b/qiskit/circuit/library/graph_state.py
@@ -44,11 +44,9 @@ class GraphState(QuantumCircuit):
 
         from qiskit.circuit.library import GraphState
         import qiskit.tools.jupyter
-        import networkx as nx
-        G = nx.Graph()
-        G.add_edges_from([(1, 2), (2, 3), (3, 4), (4, 5), (5, 1)])
-        adjmat = nx.adjacency_matrix(G)
-        circuit = GraphState(adjmat.toarray())
+        import retworkx as rx
+        G = rx.generators.cycle_graph(5)
+        circuit = GraphState(rx.adjacency_matrix(G))
         %circuit_library_info circuit
 
     **References:**


### PR DESCRIPTION
### Summary

Since NetworkX 2.8, calling `networkx.adjacency_matrix` issues a
FutureWarning that causes the documentation build to fail.  There's no
reason for us to be using `networkx` since we have `retworkx` now.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

NetworkX 2.8 released on the 9th of April and started emitted this `FutureWarning`, but we've fortunately not had any CI failures with this yet because our `pip` cache is still valid and pulling version 2.6.3.  Kevin's `tox` environment for the docs pulled the new version in and caused a failure, though.