### PR TITLE
[WIP] Adding Cliffords to QuantumCircuits as Operations

### DIFF
--- a/qiskit/circuit/__init__.py
+++ b/qiskit/circuit/__init__.py
@@ -192,6 +192,7 @@ Gates and Instructions
    Reset
    Instruction
    InstructionSet
+   Operation
    EquivalenceLibrary
 
 Control Flow Operations
@@ -234,6 +235,7 @@ from .gate import Gate
 from .controlledgate import ControlledGate
 from .instruction import Instruction
 from .instructionset import InstructionSet
+from .operation import Operation
 from .barrier import Barrier
 from .delay import Delay
 from .measure import Measure

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -42,12 +42,13 @@ from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.qobj.qasm_qobj import QasmQobjInstruction
 from qiskit.circuit.parameter import ParameterExpression
+from qiskit.circuit.operation import Operation
 from .tools import pi_check
 
 _CUTOFF_PRECISION = 1e-10
 
 
-class Instruction:
+class Instruction(Operation):
     """Generic quantum instruction."""
 
     # Class attribute to treat like barrier for transpiler, unroller, drawer

--- a/qiskit/circuit/instructionset.py
+++ b/qiskit/circuit/instructionset.py
@@ -19,8 +19,8 @@ import warnings
 from typing import Callable, Optional, Tuple, Union
 
 from qiskit.circuit.exceptions import CircuitError
-from .instruction import Instruction
 from .classicalregister import Clbit, ClassicalRegister
+from .operation import Operation
 
 
 # ClassicalRegister is hashable, and generally the registers in a circuit are completely fixed after
@@ -150,8 +150,8 @@ class InstructionSet:
 
     def add(self, gate, qargs, cargs):
         """Add an instruction and its context (where it is attached)."""
-        if not isinstance(gate, Instruction):
-            raise CircuitError("attempt to add non-Instruction" + " to InstructionSet")
+        if not isinstance(gate, Operation):
+            raise CircuitError("attempt to add non-Operation" + " to InstructionSet")
         self.instructions.append(gate)
         self.qargs.append(qargs)
         self.cargs.append(cargs)

--- a/qiskit/circuit/operation.py
+++ b/qiskit/circuit/operation.py
@@ -59,3 +59,26 @@ class Operation(ABC):
     def num_clbits(self):
         """Number of classical bits."""
         raise NotImplementedError
+
+    @abstractmethod
+    def broadcast_arguments(self, qargs, cargs):
+        """Expanding (broadcasting) arguments."""
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def _directive(self):
+        """Class attribute to treat like barrier for transpiler, unroller, drawer."""
+        raise NotImplementedError
+
+    # @property
+    # @abstractmethod
+    # def condition(self):
+    #    """Condition for when the instruction has a conditional if."""
+    #    raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def definition(self):
+        """Definition of the operation in terms of more basic gates."""
+        raise NotImplementedError

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -21,7 +21,7 @@ from numbers import Number
 import numpy as np
 
 from qiskit.circuit.quantumcircuit import QuantumCircuit
-from qiskit.circuit.instruction import Instruction
+from qiskit.circuit.operation import Operation
 from qiskit.circuit.library.standard_gates import IGate, XGate, YGate, ZGate, HGate, SGate, TGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.predicates import is_unitary_matrix, matrix_equal
@@ -53,7 +53,7 @@ class Operator(LinearOp):
 
         Args:
             data (QuantumCircuit or
-                  Instruction or
+                  Operation or
                   BaseOperator or
                   matrix): data to initialize operator.
             input_dims (tuple): the input subsystem dimensions.
@@ -75,7 +75,7 @@ class Operator(LinearOp):
         if isinstance(data, (list, np.ndarray)):
             # Default initialization from list or numpy array matrix
             self._data = np.asarray(data, dtype=complex)
-        elif isinstance(data, (QuantumCircuit, Instruction)):
+        elif isinstance(data, (QuantumCircuit, Operation)):
             # If the input is a Terra QuantumCircuit or Instruction we
             # perform a simulation to construct the unitary operator.
             # This will only work if the circuit or instruction can be
@@ -514,7 +514,7 @@ class Operator(LinearOp):
     @classmethod
     def _instruction_to_matrix(cls, obj):
         """Return Operator for instruction if defined or None otherwise."""
-        if not isinstance(obj, Instruction):
+        if not isinstance(obj, Operation):
             raise QiskitError("Input is not an instruction.")
         mat = None
         if hasattr(obj, "to_matrix"):

--- a/qiskit/transpiler/passes/optimization/optimize_cliffords.py
+++ b/qiskit/transpiler/passes/optimization/optimize_cliffords.py
@@ -1,0 +1,83 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Combine consecutive Cliffords over the same qubits."""
+
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.quantum_info.operators import Clifford
+
+
+class OptimizeCliffords(TransformationPass):
+    """Combine consecutive Cliffords over the same qubits.
+    For now, this only serves as an example of extra capabilities enabled by storing
+    Cliffords natively on the circuit.
+    """
+
+    def run(self, dag):
+        """Run the OptimizeCliffords pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+
+        blocks = []
+        prev_node = None
+        cur_block = []
+
+        # Iterate over all nodes and collect consecutive Cliffords over the
+        # same qubits. In this very first proof-of-concept implementation
+        # we require the same ordering of qubits, but this restriction will
+        # be shortly removed.
+        for node in dag.op_nodes():
+            if isinstance(node.op, Clifford):
+                if prev_node is None:
+                    blocks.append(cur_block)
+                    cur_block = [node]
+                else:
+                    if prev_node.qargs == node.qargs:
+                        cur_block.append(node)
+                    else:
+                        blocks.append(cur_block)
+                        cur_block = [node]
+
+                prev_node = node
+
+            else:
+                # not a clifford
+                blocks.append(cur_block)
+                prev_node = None
+                cur_block = []
+
+        blocks.append(cur_block)
+
+        # Replace every discovered block of cliffords by a single clifford
+        # based on the Cliffords' compose function.
+        for cur_nodes in blocks:
+            # Create clifford functions only out of blocks with at least 2 gates
+            if len(cur_nodes) <= 1:
+                continue
+
+            wire_pos_map = dict((qb, ix) for ix, qb in enumerate(cur_nodes[0].qargs))
+
+            # Construct a linear circuit
+            cliff = cur_nodes[0].op
+            for i, node in enumerate(cur_nodes):
+                if i > 0:
+                    cliff = Clifford.compose(node.op, cliff, front=True)
+
+            # Replace the block by the composed clifford
+            dag.replace_block_with_op(cur_nodes, cliff, wire_pos_map, cycle_check=False)
+
+        return dag

--- a/test/python/circuit/test_instructions.py
+++ b/test/python/circuit/test_instructions.py
@@ -400,7 +400,7 @@ class TestInstructions(QiskitTestCase):
 
         qr = QuantumRegister(2)
         qc = QuantumCircuit(qr)
-        with self.assertRaisesRegex(CircuitError, r"Object is a subclass of Instruction"):
+        with self.assertRaisesRegex(CircuitError, r"Object is a subclass of Operation"):
             qc.append(HGate, qr[:], [])
 
     def test_repr_of_instructions(self):

--- a/test/python/circuit/test_native_operations.py
+++ b/test/python/circuit/test_native_operations.py
@@ -1,0 +1,72 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""This is a temporary test file to experiment with natively adding operations
+to a quantum circuit."""
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.quantum_info import Clifford
+from qiskit.compiler.transpiler import circuit_to_dag, dag_to_circuit
+from qiskit.transpiler.passes import Unroll3qOrMore
+from qiskit.dagcircuit.dagnode import DAGOpNode
+
+
+def create_clifford():
+    """Comment so that pylint does not complain."""
+    qc = QuantumCircuit(3)
+    qc.cx(0, 1)
+    qc.h(0)
+    qc.s(1)
+    qc.swap(1, 2)
+    # print(qc)
+    cliff = Clifford(qc)
+    print(cliff)
+    return cliff
+
+
+def show_circuit(circ):
+    """Comment so that pylint does not complain."""
+    for inst, qargs, cargs in circ.data:
+        print(f"  {type(inst)}, {qargs}, {cargs}")
+
+
+def show_dag(dag):
+    """Comment so that pylint does not complain."""
+    for node in dag.topological_nodes():
+        print(f"-- {type(node)}")
+        if isinstance(node, DAGOpNode):
+            print(f"---{type(node.op)}, {node.op}")
+
+
+def run_test():
+    """Comment so that pylint does not complain."""
+    print("Creating Clifford")
+    cliff = create_clifford()
+    qc0 = QuantumCircuit(4)
+    print("Appending Clifford")
+    qc0.append(cliff, [0, 1, 2])
+    print(qc0)
+    show_circuit(qc0)
+    print("Converting to dag")
+    dag1 = circuit_to_dag(qc0)
+    print(dag1)
+    show_dag(dag1)
+    print("Running transpiler pass on dag")
+    dag2 = Unroll3qOrMore().run(dag1)
+    print(dag2)
+    print("Converting back to circuit")
+    qc3 = dag_to_circuit(dag2)
+    print(qc3)
+
+
+if __name__ == "__main__":
+    run_test()

--- a/test/python/transpiler/test_clifford_passes.py
+++ b/test/python/transpiler/test_clifford_passes.py
@@ -1,0 +1,152 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test transpiler passes that deal with Cliffords."""
+
+import unittest
+
+from qiskit.circuit import QuantumCircuit, Gate
+from qiskit.transpiler.passes.optimization.optimize_cliffords import OptimizeCliffords
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info.operators import Clifford
+from qiskit.transpiler import PassManager
+from qiskit.quantum_info import Operator
+
+
+class TestCliffordPasses(QiskitTestCase):
+    """Tests to verify correctness of the transpiler passes that deal with Cliffords."""
+
+    def create_cliff1(self):
+        """Creates a simple Clifford."""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.s(2)
+        return Clifford(qc)
+
+    def create_cliff2(self):
+        """Creates another simple Clifford."""
+        qc = QuantumCircuit(3)
+        qc.cx(0, 1)
+        qc.h(0)
+        qc.h(1)
+        qc.h(2)
+        qc.cx(1, 2)
+        qc.s(2)
+        return Clifford(qc)
+
+    def create_cliff3(self):
+        """Creates a third Clifford which is the composition of the previous two."""
+        qc = QuantumCircuit(3)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.cx(1, 2)
+        qc.s(2)
+        qc.cx(0, 1)
+        qc.h(0)
+        qc.h(1)
+        qc.h(2)
+        qc.cx(1, 2)
+        qc.s(2)
+        return Clifford(qc)
+
+    def test_circuit_with_cliffords(self):
+        """Test that Cliffords get stored natively on a QuantumCircuit,
+        and that QuantumCircuit's decompose() replaces Clifford with gates."""
+
+        # Create a circuit with 2 cliffords and four other gates
+        cliff1 = self.create_cliff1()
+        cliff2 = self.create_cliff2()
+        qc = QuantumCircuit(4)
+        qc.h(0)
+        qc.cx(2, 0)
+        qc.append(cliff1, [3, 0, 2])
+        qc.swap(1, 3)
+        qc.append(cliff2, [1, 2, 3])
+        qc.h(3)
+        # print(qc)
+
+        # Check that there are indeed two Clifford objects in the circuit,
+        # and that these are not gates.
+        cliffords = [inst for inst, _, _ in qc.data if isinstance(inst, Clifford)]
+        gates = [inst for inst, _, _ in qc.data if isinstance(inst, Gate)]
+        self.assertEqual(len(cliffords), 2)
+        self.assertEqual(len(gates), 4)
+
+        # Check that calling QuantumCircuit's decompose(), no Clifford objects remain
+        qc2 = qc.decompose()
+        # print(qc2)
+        cliffords2 = [inst for inst, _, _ in qc2.data if isinstance(inst, Clifford)]
+        self.assertEqual(len(cliffords2), 0)
+
+    def test_can_construct_operator(self):
+        """Test that we can construct an Operator from a circuit that
+        contains a Clifford gate."""
+
+        cliff = self.create_cliff1()
+        qc = QuantumCircuit(4)
+        qc.append(cliff, [3, 1, 2])
+
+        # Create an operator from the decomposition of qc into gates
+        op1 = Operator(qc.decompose())
+
+        # Create an operator from qc directly
+        op2 = Operator(qc)
+
+        # Check that the two operators are equal
+        self.assertTrue(op1.equiv(op2))
+
+    def test_can_combine_cliffords(self):
+        """Test that we can combine a pair of Cliffords over the same qubits
+        using OptimizeCliffords transpiler pass."""
+
+        cliff1 = self.create_cliff1()
+        cliff2 = self.create_cliff2()
+        cliff3 = self.create_cliff3()
+
+        # Create a circuit with two consective cliffords
+        qc1 = QuantumCircuit(4)
+        qc1.append(cliff1, [3, 1, 2])
+        qc1.append(cliff2, [3, 1, 2])
+        self.assertEqual(qc1.count_ops()["clifford"], 2)
+
+        # Run OptimizeCliffords pass, and check that only one Clifford remains
+        qc1opt = PassManager(OptimizeCliffords()).run(qc1)
+        self.assertEqual(qc1opt.count_ops()["clifford"], 1)
+
+        # Create the expected circuit
+        qc2 = QuantumCircuit(4)
+        qc2.append(cliff3, [3, 1, 2])
+
+        # Check that all possible operators are equal
+        self.assertTrue(Operator(qc1).equiv(Operator(qc1.decompose())))
+        self.assertTrue(Operator(qc1opt).equiv(Operator(qc1opt.decompose())))
+        self.assertTrue(Operator(qc1).equiv(Operator(qc1opt)))
+        self.assertTrue(Operator(qc2).equiv(Operator(qc2.decompose())))
+        self.assertTrue(Operator(qc1opt).equiv(Operator(qc2)))
+
+    def test_cannot_combine(self):
+        """Test that currently we cannot combine a pair of Cliffords.
+        The result will be changed after pass is updated"""
+
+        cliff1 = self.create_cliff1()
+        cliff2 = self.create_cliff2()
+        qc1 = QuantumCircuit(4)
+        qc1.append(cliff1, [3, 1, 2])
+        qc1.append(cliff2, [3, 2, 1])
+        qc1 = PassManager(OptimizeCliffords()).run(qc1)
+        self.assertEqual(qc1.count_ops()["clifford"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

In this work-in-progress issue, we are adding a `Clifford` object to a `QuantumCircuit` as an `Operation`, without first explicitly converting this `Clifford` into a `Gate`. 

An important point is that a `Clifford` is no longer _decomposed_ as soon as it is added to a `QuantumCircuit`. The procedure `decompose_clifford` only runs when the `definition` of a `Clifford` is required, which might only be during a later transpiler pass.

To illustrate an additional benefit of adding `Clifford`s natively, there is a preliminary transpiler pass `OptimizeCliffords` that uses the ability to _compose_  `Clifford`s.

In the near future, other objects will be added as `Operation`s as well.

### Details and comments

A `Clifford` object does not inherit from `Instruction`. In order to work with `Clifford`s natively, it must support the following:
- `broadcast_arguments`: this is used for expanding (aka broadcasting) arguments. Note that there is an additional PR to improve the broadcasting code. 
- `condition`: as far as I understand, this is used for _conditional if_ instructions. I don't think it applies to `Clifford`s, but is currently required by `circuit_to_dag`. I believe this is something that we can later clean up.
- `_directive`: This is a attribute to treat like barrier for transpiler, unroller, drawer. It is currently required by `DagCircuit`. Again I think that this may be something that we can later clean up.
- `definition`: This is the function that builds the definition of the `Clifford` in terms of more basic gates (i.e. the function that essentially calls `decompose_clifford`).


