### PR TITLE
Fix bug in TridiagonalToeplitz.eigs_bounds() method

### DIFF
--- a/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
+++ b/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
@@ -202,13 +202,32 @@ class TridiagonalToeplitz(LinearSystemMatrix):
         return matrix
 
     def eigs_bounds(self) -> Tuple[float, float]:
-        """Return lower and upper bounds on the eigenvalues of the matrix."""
+        """Return lower and upper bounds on the absolute eigenvalues of the matrix."""
         n_b = 2**self.num_state_qubits
-        # Calculate the eigenvalues according to the formula for Toeplitz matrices
-        eig_1 = np.abs(self.main_diag - 2 * self.off_diag * np.cos(n_b * np.pi / (n_b + 1)))
-        eig_2 = np.abs(self.main_diag - 2 * self.off_diag * np.cos(np.pi / (n_b + 1)))
-        lambda_min = min(eig_1, eig_2)
-        lambda_max = max(eig_1, eig_2)
+        
+        # Calculate minimum and maximum of absolute value of eigenvalues 
+        # according to the formula for Toeplitz 3-diagonal matrices 
+
+        # For maximum it's enough to check border points of segment [1, n_b]
+        candidate_eig_ids = [1, n_b]
+
+        # Trying to add candidates near the minimum value of absolute eigenvalues 
+        # function abs(main_diag - 2 * off_diag * cos(i * pi / (nb + 1))
+        if abs(self.main_diag) < 2 * abs(self.off_diag):
+            optimal_index = int(np.arccos(self.main_diag / 2 / self.off_diag) / np.pi * (n_b + 1))
+
+            def add_candidate_index_if_valid(index_to_add: int) -> None:
+                if (index_to_add >= 1) and (index_to_add <= n_b):
+                    candidate_eig_ids.append(index_to_add)
+
+            add_candidate_index_if_valid(optimal_index - 1)
+            add_candidate_index_if_valid(optimal_index)
+            add_candidate_index_if_valid(optimal_index + 1)
+
+        candidate_abs_eigs = np.abs([self.main_diag - 2 * self.off_diag * np.cos(eig_id * np.pi / (n_b + 1)) for eig_id in candidate_eig_ids])
+
+        lambda_min = np.min(candidate_abs_eigs)
+        lambda_max = np.max(candidate_abs_eigs)
         return lambda_min, lambda_max
 
     def condition_bounds(self) -> Tuple[float, float]:

--- a/test/python/algorithms/test_linear_solvers.py
+++ b/test/python/algorithms/test_linear_solvers.py
@@ -79,6 +79,28 @@ class TestMatrices(QiskitAlgorithmsTestCase):
         np.testing.assert_array_almost_equal(approx_exp, exact_exp, decimal=2)
 
 
+    @idata(
+        [
+            [TridiagonalToeplitz(2, 1.5, 2.5)],
+            [TridiagonalToeplitz(4, -1, 1.6)],
+        ]
+    )
+    @unpack
+    def test_eigs_bounds(self, matrix):
+        """Test the capability of TridiagonalToeplitz matrix class to find accurate absolute eigenvalues bounds."""
+
+        matrix_lambda_min, matrix_lambda_max = matrix.eigs_bounds()
+
+        numpy_matrix = matrix.matrix
+        eigenvalues, _ = np.linalg.eig(numpy_matrix)
+        abs_eigenvalues = np.abs(eigenvalues)
+        exact_lambda_min = np.min(abs_eigenvalues)
+        exact_lambda_max = np.max(abs_eigenvalues)
+
+        np.testing.assert_almost_equal(matrix_lambda_min, exact_lambda_min, decimal=6)
+        np.testing.assert_almost_equal(matrix_lambda_max, exact_lambda_max, decimal=6)
+
+
 @ddt
 class TestObservables(QiskitAlgorithmsTestCase):
     """Tests based on the observables classes.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [+] I have added the tests to cover my changes.
- [+] I have updated the documentation accordingly.
- [+] I have read the CONTRIBUTING document.
-->

### Summary
This PR solve issue https://github.com/Qiskit/qiskit-terra/issues/7939

Fix a bug in TridiagonalToeplitz.eigs_bounds() method, which caused 
a returning of wrong eigenvalues bounds in some cases with negative
eigenvalues.

### Details and comments

Previous version returned just absolute values of minimal and maximal eigenvalues. In case of having negative and positive eigenvalues simultaneously it isn't equal to minimal and maximal value among absolute values of all eigenvalues.

A simple way of fixing this is to obtain all eigenvalues and take minimal and maximal absolute values. However, it requires O(N) classical operations, which mitigates any possible quantum advantage. Fortunately, due to special structure of eigenvalues of 3-diagonal Toeplitz matrix we are able to calculate it much faster, using O(1) operations.