### PR TITLE
Fix sdist build and deployment

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -240,11 +240,13 @@ stages:
             - bash: |
                 set -e
                 python -m pip install --upgrade pip
+                python -m pip install --upgrade setuptools_rust
                 python setup.py sdist
             - task: PublishBuildArtifacts@1
               inputs: {pathtoPublish: 'dist'}
               condition: succeededOrFailed()
             - bash: |
+                python -m pip install --upgrade twine
                 twine upload dist/*
               env:
                 TWINE_USERNAME: "qiskit"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds the missing lines to install `setuptools_rust` (and `twine`, which somehow got dropped during #7698).


### Details and comments

Perhaps the "proper" way to do this is to use a PEP-517 builder (e.g. https://pypi.org/project/build/), but this PR is more about getting things working again before we forget.