### PR TITLE
Fix sdist build step on stable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
         - bash: |
             set -e
             python -m pip install --upgrade pip
-            pip install -U twine
+            pip install -U twine setuptools_rust
             python setup.py sdist
         - task: PublishBuildArtifacts@1
           inputs: {pathtoPublish: 'dist'}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds the missing install of `setuptools_rust` to the stable branch's Azure configuration, to fix the sdist build and deploy.

### Details and comments

See also #7973 for the same thing on `main`.
