### PR TITLE
[WIP] Reimplement SabreSwap heuristic scoring in multithreaded Rust

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -25,6 +25,7 @@ import qiskit._accelerate
 # manually define them on import so people can directly import
 # qiskit._accelerate.* submodules and not have to rely on attribute access
 sys.modules["qiskit._accelerate.stochastic_swap"] = qiskit._accelerate.stochastic_swap
+sys.modules["qiskit._accelerate.sabre_swap"] = qiskit._accelerate.sabre_swap
 sys.modules["qiskit._accelerate.pauli_expval"] = qiskit._accelerate.pauli_expval
 sys.modules["qiskit._accelerate.dense_layout"] = qiskit._accelerate.dense_layout
 sys.modules["qiskit._accelerate.sparse_pauli_op"] = qiskit._accelerate.sparse_pauli_op

--- a/src/edge_list.rs
+++ b/src/edge_list.rs
@@ -1,0 +1,101 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2022
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::exceptions::PyIndexError;
+use pyo3::prelude::*;
+
+/// A simple container that contains a vector representing edges in the
+/// coupling map that are found to be optimal by the swap mapper.
+#[pyclass(module = "qiskit._accelerate.stochastic_swap")]
+#[pyo3(text_signature = "(/)")]
+#[derive(Clone, Debug)]
+pub struct EdgeList {
+    pub edges: Vec<[usize; 2]>,
+}
+
+impl Default for EdgeList {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+#[pymethods]
+impl EdgeList {
+    #[new]
+    pub fn new(capacity: Option<usize>) -> Self {
+        match capacity {
+            Some(size) => EdgeList {
+                edges: Vec::with_capacity(size),
+            },
+            None => EdgeList { edges: Vec::new() },
+        }
+    }
+
+    /// Append an edge to the list.
+    ///
+    /// Args:
+    ///     edge_start (int): The start qubit of the edge.
+    ///     edge_end (int): The end qubit of the edge.
+    #[pyo3(text_signature = "(self, edge_start, edge_end, /)")]
+    pub fn append(&mut self, edge_start: usize, edge_end: usize) {
+        self.edges.push([edge_start, edge_end]);
+    }
+
+    pub fn __iter__(slf: PyRef<Self>) -> PyResult<Py<EdgeListIter>> {
+        let iter = EdgeListIter {
+            inner: slf.edges.clone().into_iter(),
+        };
+        Py::new(slf.py(), iter)
+    }
+
+    pub fn __len__(&self) -> usize {
+        self.edges.len()
+    }
+
+    pub fn __contains__(&self, object: [usize; 2]) -> bool {
+        self.edges.contains(&object)
+    }
+
+    pub fn __getitem__(&self, object: usize) -> PyResult<[usize; 2]> {
+        if object > self.edges.len() {
+            return Err(PyIndexError::new_err(format!(
+                "Index {} out of range for this EdgeList",
+                object
+            )));
+        }
+        Ok(self.edges[object])
+    }
+
+    fn __getstate__(&self) -> Vec<[usize; 2]> {
+        self.edges.clone()
+    }
+
+    fn __setstate__(&mut self, state: Vec<[usize; 2]>) {
+        self.edges = state
+    }
+}
+
+#[pyclass]
+pub struct EdgeListIter {
+    inner: std::vec::IntoIter<[usize; 2]>,
+}
+
+#[pymethods]
+impl EdgeListIter {
+    fn __iter__(slf: PyRef<Self>) -> PyRef<Self> {
+        slf
+    }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> Option<[usize; 2]> {
+        slf.inner.next()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,14 @@ use pyo3::Python;
 
 mod dense_layout;
 mod edge_collections;
+mod edge_list;
 mod nlayout;
 mod pauli_exp_val;
+mod qubits_decay;
+mod sabre_swap;
 mod sparse_pauli_op;
 mod stochastic_swap;
+mod swap_scores;
 
 #[inline]
 pub fn getenv_use_multiple_threads() -> bool {
@@ -39,6 +43,7 @@ pub fn getenv_use_multiple_threads() -> bool {
 #[pymodule]
 fn _accelerate(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pymodule!(stochastic_swap::stochastic_swap))?;
+    m.add_wrapped(wrap_pymodule!(sabre_swap::sabre_swap))?;
     m.add_wrapped(wrap_pymodule!(pauli_exp_val::pauli_expval))?;
     m.add_wrapped(wrap_pymodule!(dense_layout::dense_layout))?;
     m.add_wrapped(wrap_pymodule!(sparse_pauli_op::sparse_pauli_op))?;

--- a/src/nlayout.rs
+++ b/src/nlayout.rs
@@ -86,4 +86,28 @@ impl NLayout {
             .map(|i| [i, self.logic_to_phys[i]])
             .collect()
     }
+
+    /// Get physical bit from logical bit
+    fn get_item_logic(&self, logical_bit: usize) -> usize {
+        self.logic_to_phys[logical_bit]
+    }
+
+    /// Get logical bit from physical bit
+    pub fn get_item_phys(&self, physical_bit: usize) -> usize {
+        self.phys_to_logic[physical_bit]
+    }
+
+    /// Swap the specified virtual qubits
+    pub fn swap_logic(&mut self, bit_a: usize, bit_b: usize) {
+        self.phys_to_logic
+            .swap(self.logic_to_phys[bit_a], self.logic_to_phys[bit_b]);
+        self.logic_to_phys.swap(bit_a, bit_b);
+    }
+
+    /// Swap the specified physical qubits
+    pub fn swap_phys(&mut self, bit_a: usize, bit_b: usize) {
+        self.logic_to_phys
+            .swap(self.phys_to_logic[bit_a], self.phys_to_logic[bit_b]);
+        self.phys_to_logic.swap(bit_a, bit_b);
+    }
 }

--- a/src/qubits_decay.rs
+++ b/src/qubits_decay.rs
@@ -1,0 +1,83 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2022
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use numpy::IntoPyArray;
+use pyo3::exceptions::PyIndexError;
+use pyo3::prelude::*;
+use pyo3::Python;
+
+/// An unsigned integer Vector based layout class
+///
+/// This class tracks the layout (or mapping between virtual qubits in the the
+/// circuit and physical qubits on the physical device) efficiently
+///
+/// Args:
+///     qubit_indices (dict): A dictionary mapping the virtual qubit index in the circuit to the
+///         physical qubit index on the coupling graph.
+///     logical_qubits (int): The number of logical qubits in the layout
+///     physical_qubits (int): The number of physical qubits in the layout
+#[pyclass(module = "qiskit._accelerate.sabre_swap")]
+#[pyo3(text_signature = "(qubit_indices, logical_qubits, physical_qubits, /)")]
+#[derive(Clone, Debug)]
+pub struct QubitsDecay {
+    pub decay: Vec<f64>,
+}
+
+#[pymethods]
+impl QubitsDecay {
+    #[new]
+    pub fn new(qubit_count: usize) -> Self {
+        QubitsDecay {
+            decay: vec![1.; qubit_count],
+        }
+    }
+
+    // Mapping Protocol
+    pub fn __len__(&self) -> usize {
+        self.decay.len()
+    }
+
+    pub fn __contains__(&self, object: f64) -> bool {
+        self.decay.contains(&object)
+    }
+
+    pub fn __getitem__(&self, object: usize) -> PyResult<f64> {
+        match self.decay.get(object) {
+            Some(val) => Ok(*val),
+            None => Err(PyIndexError::new_err(format!(
+                "Index {} out of range for this EdgeList",
+                object
+            ))),
+        }
+    }
+
+    pub fn __setitem__(mut slf: PyRefMut<Self>, object: usize, value: f64) -> PyResult<()> {
+        if object > slf.decay.len() {
+            return Err(PyIndexError::new_err(format!(
+                "Index {} out of range for this EdgeList",
+                object
+            )));
+        }
+        slf.decay[object] = value;
+        Ok(())
+    }
+
+    pub fn __array__(&self, py: Python) -> PyObject {
+        self.decay.clone().into_pyarray(py).into()
+    }
+
+    pub fn reset(mut slf: PyRefMut<Self>) {
+        for v in &mut slf.decay {
+            *v = 1.;
+        }
+    }
+}

--- a/src/sabre_swap.rs
+++ b/src/sabre_swap.rs
@@ -1,0 +1,138 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2022
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use ndarray::prelude::*;
+use numpy::PyReadonlyArray2;
+use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
+use pyo3::Python;
+
+use rayon::prelude::*;
+
+use crate::edge_list::EdgeList;
+use crate::nlayout::NLayout;
+use crate::qubits_decay::QubitsDecay;
+use crate::swap_scores::SwapScores;
+
+const EXTENDED_SET_WEIGHT: f64 = 0.5;
+
+#[pyclass]
+pub enum Heuristic {
+    Basic,
+    Lookahead,
+    Decay,
+}
+
+#[pyfunction]
+pub fn sabre_score_heuristic(
+    layer: EdgeList,
+    layout: &NLayout,
+    swap_scores: &mut SwapScores,
+    extended_set: EdgeList,
+    distance_matrix: PyReadonlyArray2<f64>,
+    qubits_decay: QubitsDecay,
+    heuristic: &Heuristic,
+) -> Vec<[usize; 2]> {
+    let dist = distance_matrix.as_array();
+    swap_scores
+        .scores
+        .par_iter_mut()
+        .for_each(|(swap_qubits, score)| {
+            let mut trial_layout = layout.clone();
+            trial_layout.swap_logic(swap_qubits[0], swap_qubits[1]);
+            *score = score_heuristic(
+                heuristic,
+                &layer.edges,
+                &extended_set.edges,
+                &trial_layout,
+                swap_qubits,
+                &dist,
+                &qubits_decay.decay,
+            );
+        });
+    let min_score = swap_scores
+        .scores
+        .par_values()
+        .min_by(|a, b| a.partial_cmp(b).unwrap())
+        .unwrap();
+    let mut best_swaps: Vec<[usize; 2]> = swap_scores
+        .scores
+        .iter()
+        .filter_map(|(k, v)| if v == min_score { Some(*k) } else { None })
+        .collect();
+    best_swaps.par_sort();
+    best_swaps
+}
+
+#[inline]
+fn compute_cost(layer: &[[usize; 2]], layout: &NLayout, dist: &ArrayView2<f64>) -> f64 {
+    layer
+        .iter()
+        .map(|gate| dist[[layout.logic_to_phys[gate[0]], layout.logic_to_phys[gate[1]]]])
+        .sum()
+}
+
+fn score_lookahead(
+    layer: &[[usize; 2]],
+    extended_set: &[[usize; 2]],
+    layout: &NLayout,
+    dist: &ArrayView2<f64>,
+) -> f64 {
+    let mut first_cost = compute_cost(layer, layout, dist);
+    first_cost /= layer.len() as f64;
+    let second_cost = if !extended_set.is_empty() {
+        compute_cost(extended_set, layout, dist)
+    } else {
+        0.
+    };
+    first_cost + EXTENDED_SET_WEIGHT * second_cost
+}
+
+fn score_decay(
+    layer: &[[usize; 2]],
+    extended_set: &[[usize; 2]],
+    layout: &NLayout,
+    dist: &ArrayView2<f64>,
+    swap_qubits: &[usize; 2],
+    qubits_decay: &[f64],
+) -> f64 {
+    let total_cost = score_lookahead(layer, extended_set, layout, dist);
+    qubits_decay[swap_qubits[0]].max(qubits_decay[swap_qubits[1]]) * total_cost
+}
+
+fn score_heuristic(
+    heuristic: &Heuristic,
+    layer: &[[usize; 2]],
+    extended_set: &[[usize; 2]],
+    layout: &NLayout,
+    swap_qubits: &[usize; 2],
+    dist: &ArrayView2<f64>,
+    qubits_decay: &[f64],
+) -> f64 {
+    match heuristic {
+        Heuristic::Basic => compute_cost(layer, layout, dist),
+        Heuristic::Lookahead => score_lookahead(layer, extended_set, layout, dist),
+        Heuristic::Decay => {
+            score_decay(layer, extended_set, layout, dist, swap_qubits, qubits_decay)
+        }
+    }
+}
+
+#[pymodule]
+pub fn sabre_swap(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(sabre_score_heuristic))?;
+    m.add_class::<SwapScores>()?;
+    m.add_class::<Heuristic>()?;
+    m.add_class::<EdgeList>()?;
+    m.add_class::<QubitsDecay>()?;
+    Ok(())
+}

--- a/src/swap_scores.rs
+++ b/src/swap_scores.rs
@@ -1,0 +1,58 @@
+// This code is part of Qiskit.
+//
+// (C) Copyright IBM 2022
+//
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
+use pyo3::prelude::*;
+
+use hashbrown::HashMap;
+
+/// An unsigned integer Vector based layout class
+///
+/// This class tracks the layout (or mapping between virtual qubits in the the
+/// circuit and physical qubits on the physical device) efficiently
+///
+/// Args:
+///     qubit_indices (dict): A dictionary mapping the virtual qubit index in the circuit to the
+///         physical qubit index on the coupling graph.
+///     logical_qubits (int): The number of logical qubits in the layout
+///     physical_qubits (int): The number of physical qubits in the layout
+#[pyclass(module = "qiskit._accelerate.sabre_swap")]
+#[pyo3(text_signature = "(qubit_indices, logical_qubits, physical_qubits, /)")]
+#[derive(Clone, Debug)]
+pub struct SwapScores {
+    pub scores: HashMap<[usize; 2], f64>,
+}
+
+#[pymethods]
+impl SwapScores {
+    #[new]
+    pub fn new(swap_candidates: Vec<[usize; 2]>) -> Self {
+        SwapScores {
+            scores: swap_candidates
+                .into_iter()
+                .map(|candiate| (candiate, std::f64::INFINITY))
+                .collect(),
+        }
+    }
+
+    // Mapping Protocol
+    pub fn __len__(&self) -> usize {
+        self.scores.len()
+    }
+
+    pub fn __contains__(&self, object: [usize; 2]) -> bool {
+        self.scores.contains_key(&object)
+    }
+
+    pub fn __getitem__(&self, object: [usize; 2]) -> f64 {
+        self.scores[&object]
+    }
+}

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -659,19 +659,19 @@ class TestFinalLayouts(QiskitTestCase):
             4: ancilla[4],
             5: ancilla[5],
             6: ancilla[6],
-            7: qr[4],
-            8: qr[1],
+            7: qr[3],
+            8: qr[0],
             9: ancilla[7],
             10: ancilla[8],
             11: ancilla[9],
             12: qr[2],
-            13: qr[0],
+            13: qr[1],
             14: ancilla[10],
             15: ancilla[11],
             16: ancilla[12],
             17: ancilla[13],
             18: ancilla[14],
-            19: qr[3],
+            19: qr[4],
         }
 
         expected_layout_level0 = trivial_layout


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit re-implements the core heuristic scoring of swap candidates
in the `SabreSwap` pass as a multithread Rust routine. The heuristic
scoring in sabre previously looped over all potential swap candidates
serially in Python and applied a computed a heuristic score on which to
candidate to pick. This can easily be done in parallel as there is no
data dependency between scoring the different candidates. By performing
this in Rust not only is the scoring operation done more quickly for
each candidate but we can also leverage multithreading to do this
efficiently in parallel.

### Details and comments

TODO:

- [ ] Benchmarking and tuning
- [ ] Organize rust sabre code into module
- [ ] Add release note
