### PR TITLE
Make `Optimize1qGatesSimpleCommuation` and `Optimize1qGatesDecomposition` passes `Target` aware

### DIFF
--- a/qiskit/transpiler/passes/basis/decompose.py
+++ b/qiskit/transpiler/passes/basis/decompose.py
@@ -78,7 +78,7 @@ class Decompose(TransformationPass):
         self._make_gate_lists()
 
     def _make_gate_lists(self):
-        """Make comparison lists for the gates"""
+        """Make comparison lists for the gate list"""
         if not isinstance(self.gates_to_decompose, list):
             gates = [self.gates_to_decompose]
         else:

--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -101,7 +101,7 @@ class MergeAdjacentBarriers(TransformationPass):
         # Start from the first barrier
         current_barrier = barriers[0]
         end_of_barrier = current_barrier
-        current_barrier_nodes = set([current_barrier])
+        current_barrier_nodes = [current_barrier]
 
         current_qubits = set(current_barrier.qargs)
         current_ancestors = dag.ancestors(current_barrier)
@@ -140,7 +140,7 @@ class MergeAdjacentBarriers(TransformationPass):
                     barrier_to_add = Barrier(len(current_qubits))
 
                     end_of_barrier = next_barrier
-                    current_barrier_nodes.add(end_of_barrier)
+                    current_barrier_nodes.append(end_of_barrier)
 
                     continue
 
@@ -156,10 +156,10 @@ class MergeAdjacentBarriers(TransformationPass):
             current_descendants = dag.descendants(next_barrier)
 
             barrier_to_add = Barrier(len(current_qubits))
-            current_barrier_nodes = set()
+            current_barrier_nodes = []
 
             end_of_barrier = next_barrier
-            current_barrier_nodes.add(end_of_barrier)
+            current_barrier_nodes.append(end_of_barrier)
 
         if barrier_to_add:
             node_to_barrier_qubits[end_of_barrier] = current_qubits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Make `Optimize1qGatesSimpleCommuation` (O1QC) and `Optimize1qGatesDecomposition` (O1QD) passes `Target` aware, in continuation of #7113 


### Details and comments
- This PR tries to make the above passes target aware by introducing `target` as a parameter

### `Optimize1qGatesSimpleCommuation`
- *O1QC* did not have any direct dependence to the target (as far as I could figure out) but depended indirectly through *O1QD*

### `Optimize1qGatesDecomposition`
- In *O1QD*, three major changes were introduced - 
    - In the constructor, decomposers were checked for the `target.operation_names` instead of the `basis_set`. This is beacuse if target was provided, then decomposition was required for the operations supported by it. 
    - In `_substitution_checks`, gates were checked for whether they were supported by `target` or not as `target` support should supersede the `basis_set`
    - In `run` method, again check for the optimization of `u3` gate was changed. It included check for whether the qubit on which `u3` was being performed, whether it was supported by `target` or not. If it was, then relevant optimization was done including some additional checks for `u1` and `u2` gates. 

#### Note
- The test for the changes hasn't been added yet as I wasn't exactly sure if this was the correct way to do the `target` introduction. Would love to know if this was somewhat correct or not!


