### PR TITLE
Use round instead of ceil for GaussianSquare pulse duration in RZXCalibrationBuilder

### DIFF
--- a/qiskit/transpiler/passes/calibration/builders.py
+++ b/qiskit/transpiler/passes/calibration/builders.py
@@ -170,14 +170,14 @@ class RZXCalibrationBuilder(CalibrationBuilder):
 
             if target_area > gaussian_area:
                 width = (target_area - gaussian_area) / abs(amp)
-                duration = math.ceil((width + n_sigmas * sigma) / sample_mult) * sample_mult
+                duration = round((width + n_sigmas * sigma) / sample_mult) * sample_mult
                 return Play(
                     GaussianSquare(amp=sign * amp, width=width, sigma=sigma, duration=duration),
                     channel=instruction.channel,
                 )
             else:
                 amp_scale = sign * target_area / gaussian_area
-                duration = math.ceil(n_sigmas * sigma / sample_mult) * sample_mult
+                duration = round(n_sigmas * sigma / sample_mult) * sample_mult
                 return Play(
                     GaussianSquare(amp=amp * amp_scale, width=0, sigma=sigma, duration=duration),
                     channel=instruction.channel,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Addresses #7994 for RZXCalibrationBuilder. @nbronn @eggerdj 


### Details and comments
I didn't mark this as closing #7994 because I don't know if the issue is more widespread.

