### PR TITLE
Fix a performance regression in `Optimize1qGatesSimpleCommutation`

### DIFF
--- a/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_commutation.py
@@ -14,9 +14,6 @@
 
 from copy import copy
 import logging
-from collections import deque
-
-from more_itertools import first
 
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import CXGate, RZXGate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR tries to fix a performance regression caused due to [PR 7913](https://github.com/Qiskit/qiskit-terra/pull/7913).


### Details and comments
- The performance regression was detected in the qiskit benchmarks [here](https://qiskit.github.io/qiskit/#passes.MultipleBasisPassBenchmarks.time_optimize_1q_commutation?cpu=Intel(R)%20Xeon(R)%20E-2174G%20CPU%20%40%203.80GHz&machine=qiskit-benchmarking01&num_cpu=8&os=Ubuntu%2020.04&ram=64GB&python=3.8&p-n_qubits=20&p-depth=1024&p-basis_gates=%5B'u'%2C%20'cx'%2C%20'id'%5D&commits=74e07119) 
- Essentially `deque` may have had a constant time overhead in its operations which is showing up in the benchmarks
- This PR tries to eliminate any need to modify the single qubit runs and tries to find indices of the ending and the starting subarrays of commuting gates in the `_commute_through` function

