### PR TITLE
Support target and basis gates in Unroll3qOrMore transpiler pass

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -108,7 +108,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             plugin_config=unitary_synthesis_plugin_config,
             target=target,
         ),
-        Unroll3qOrMore(),
+        Unroll3qOrMore(target=target, basis_gates=basis_gates),
     ]
 
     # 2. Choose an initial layout if not set by user (default: trivial layout)
@@ -190,7 +190,7 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 plugin_config=unitary_synthesis_plugin_config,
                 target=target,
             ),
-            Unroll3qOrMore(),
+            Unroll3qOrMore(target=target, basis_gates=basis_gates),
             Collect2qBlocks(),
             Collect1qRuns(),
             ConsolidateBlocks(basis_gates=basis_gates, target=target),

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -173,7 +173,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             plugin_config=unitary_synthesis_plugin_config,
             target=target,
         ),
-        Unroll3qOrMore(),
+        Unroll3qOrMore(target=target, basis_gates=basis_gates),
     ]
 
     # 3. Use a better layout on densely connected qubits, if circuit needs swaps
@@ -253,7 +253,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 min_qubits=3,
                 target=target,
             ),
-            Unroll3qOrMore(),
+            Unroll3qOrMore(target=target, basis_gates=basis_gates),
             Collect2qBlocks(),
             ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -122,7 +122,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             plugin_config=unitary_synthesis_plugin_config,
             target=target,
         ),
-        Unroll3qOrMore(),
+        Unroll3qOrMore(target=target, basis_gates=basis_gates),
     ]
 
     # 2. Search for a perfect layout, or choose a dense layout, if no layout given
@@ -238,7 +238,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 min_qubits=3,
                 target=target,
             ),
-            Unroll3qOrMore(),
+            Unroll3qOrMore(target=target, basis_gates=basis_gates),
             Collect2qBlocks(),
             ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -125,7 +125,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
             min_qubits=3,
             target=target,
         ),
-        Unroll3qOrMore(),
+        Unroll3qOrMore(target=target, basis_gates=basis_gates),
     ]
 
     # 2. Layout on good qubits if calibration info available, otherwise on dense links
@@ -236,7 +236,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> PassManager:
                 min_qubits=3,
                 target=target,
             ),
-            Unroll3qOrMore(),
+            Unroll3qOrMore(target=target, basis_gates=basis_gates),
             Collect2qBlocks(),
             ConsolidateBlocks(basis_gates=basis_gates, target=target),
             UnitarySynthesis(

--- a/releasenotes/notes/unroll3q-target-bf57cc4365808862.yaml
+++ b/releasenotes/notes/unroll3q-target-bf57cc4365808862.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    The constructor for the :class:`~.Unroll3qOrMore` transpiler pass has
+    two new optional keyword arguments, ``target`` and ``basis`` gates. These
+    options enable you to specify the :class:`~.Target` or supported basis
+    gates respectively to describe the target backend. If any of the operations
+    in the circuit are in the ``target`` or ``basis_gates`` those will not
+    be unrolled by the pass as the target device has native support for the
+    operation.

--- a/test/python/transpiler/test_unroll_3q_or_more.py
+++ b/test/python/transpiler/test_unroll_3q_or_more.py
@@ -12,13 +12,16 @@
 
 """Test the Unroll3qOrMore pass"""
 import numpy as np
+
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.circuit.library import CCXGate, RCCXGate
 from qiskit.transpiler.passes import Unroll3qOrMore
 from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.random import random_unitary
 from qiskit.test import QiskitTestCase
 from qiskit.extensions import UnitaryGate
+from qiskit.transpiler import Target
 
 
 class TestUnroll3qOrMore(QiskitTestCase):
@@ -91,3 +94,39 @@ class TestUnroll3qOrMore(QiskitTestCase):
         after_dag = pass_.run(dag)
         after_circ = dag_to_circuit(after_dag)
         self.assertTrue(Operator(circuit).equiv(Operator(after_circ)))
+
+    def test_target(self):
+        """Test target is respected by the unroll 3q or more pass."""
+        target = Target(num_qubits=3)
+        target.add_instruction(CCXGate())
+        qc = QuantumCircuit(3)
+        qc.ccx(0, 1, 2)
+        qc.append(RCCXGate(), [0, 1, 2])
+        unroll_pass = Unroll3qOrMore(target=target)
+        res = unroll_pass(qc)
+        self.assertIn('ccx', res.count_ops())
+        self.assertNotIn('rccx', res.count_ops())
+
+    def test_basis_gates(self):
+        """Test basis_gates are respected by the unroll 3q or more pass."""
+        basis_gates = ["rccx"]
+        qc = QuantumCircuit(3)
+        qc.ccx(0, 1, 2)
+        qc.append(RCCXGate(), [0, 1, 2])
+        unroll_pass = Unroll3qOrMore(basis_gates=basis_gates)
+        res = unroll_pass(qc)
+        self.assertNotIn('ccx', res.count_ops())
+        self.assertIn('rccx', res.count_ops())
+
+    def test_target_over_basis_gates(self):
+        """Test target is respected over basis_gates  by the unroll 3q or more pass."""
+        target = Target(num_qubits=3)
+        basis_gates = ['rccx']
+        target.add_instruction(CCXGate())
+        qc = QuantumCircuit(3)
+        qc.ccx(0, 1, 2)
+        qc.append(RCCXGate(), [0, 1, 2])
+        unroll_pass = Unroll3qOrMore(target=target, basis_gates=basis_gates)
+        res = unroll_pass(qc)
+        self.assertIn('ccx', res.count_ops())
+        self.assertNotIn('rccx', res.count_ops())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds two new constructor arguments to the Unroll3qOrMore
transpiler pass, target and basis_gates, which are used to specify a
backend target and basis gate list respectively. If these are specified
the pass will not decompose any multiqubit operations present in the
circuit if they are in the target or basis_gates list.

### Details and comments

Fixes #5518
Related to #7812
Part of #7113
