### PR TITLE
Fix `dt` units in test util function `convert_to_target`

### DIFF
--- a/qiskit/test/mock/utils/backend_converter.py
+++ b/qiskit/test/mock/utils/backend_converter.py
@@ -99,7 +99,7 @@ def convert_to_target(conf_dict: dict, props_dict: dict = None, defs_dict: dict 
     # parse global configuration properties
     dt = conf_dict.get("dt")
     if dt:
-        target.dt = dt
+        target.dt = dt * 1e-9
     if "timing_constraints" in conf_dict:
         target.granularity = conf_dict["timing_constraints"].get("granularity")
         target.min_length = conf_dict["timing_constraints"].get("min_length")

--- a/releasenotes/notes/fix-target-dt-4d306f1e9b07f819.yaml
+++ b/releasenotes/notes/fix-target-dt-4d306f1e9b07f819.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue with test util :func:`~qiskit.test.mock.utils.convert_to_target`
+    in which ``dt`` was not being converted to seconds when reading from parameter
+    ``conf_dict``.

--- a/releasenotes/notes/fix-target-dt-4d306f1e9b07f819.yaml
+++ b/releasenotes/notes/fix-target-dt-4d306f1e9b07f819.yaml
@@ -1,6 +1,8 @@
 ---
 fixes:
   - |
-    Fixed an issue with test util :func:`~qiskit.test.mock.utils.convert_to_target`
-    in which ``dt`` was not being converted to seconds when reading from parameter
-    ``conf_dict``.
+    Fixed an issue with :class:`~.BackendV2` based fake backend classes from the 
+    ``qiskit.providers.fake_provider`` module such as ``FakeMontrealV2`` where the
+    value for the :attr:`~.BackendV2.dt` attribute (and the :attr:`.Target.dt` attribute) 
+    were not properly being converted to seconds. This would cause issues when
+    using these fake backends with scheduling.

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -103,6 +103,12 @@ class TestFakeBackends(QiskitTestCase):
         else:
             self.assertTrue(backend.configuration().simulator)
 
+    @data(*FAKE_PROVIDER_FOR_BACKEND_V2.backends())
+    def test_convert_to_target(self, backend):
+        target = backend.target
+        if target.dt is not None:
+            self.assertLess(target.dt, 1e-6)
+
     @data(*FAKE_PROVIDER.backends())
     def test_to_dict_configuration(self, backend):
         configuration = backend.configuration()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Previously, `convert_to_target` was reading `dt` from the configuration/conf file, expecting it to be in seconds, when it is actually in nanoseconds.

The effect of this was that `FakeBackendV2` targets would return a `InstructionDurations` with all durations as `0`, since all durations round to `0` when divided by the erroneously large `dt` and converted to an integer.
