### PR TITLE
Fix instruction durations in transpile() with BackendV2

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -921,11 +921,15 @@ def _parse_instruction_durations(backend, inst_durations, dt, circuits):
     take precedence over backend durations, but be superceded by ``inst_duration``s.
     """
     if not inst_durations:
-        backend_durations = InstructionDurations()
-        try:
-            backend_durations = InstructionDurations.from_backend(backend)
-        except AttributeError:
-            pass
+        backend_version = getattr(backend, "version", 0)
+        if backend_version <= 1:
+            backend_durations = InstructionDurations()
+            try:
+                backend_durations = InstructionDurations.from_backend(backend)
+            except AttributeError:
+                pass
+        else:
+            backend_durations = backend.instruction_durations
 
     durations = []
     for circ in circuits:

--- a/releasenotes/notes/fix-transpile-backendv2-durations-dbc85688564cc271.yaml
+++ b/releasenotes/notes/fix-transpile-backendv2-durations-dbc85688564cc271.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~.transpile` function when run with a
+    :class:`~.BackendV2` based backend and setting the ``scheduling_method``
+    keyword argument. Previously, the function would not correctly process
+    the default durations of the instructions supported by the backend which
+    would lead to an error.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1250,7 +1250,6 @@ class TestTranspile(QiskitTestCase):
         qc.measure_all()
 
         backend = FakeMumbaiV2()
-        backend.target.dt = 1e-6
         out = transpile([qc, qc], backend, scheduling_method="alap")
         self.assertIn("delay", out[0].count_ops())
         self.assertIn("delay", out[1].count_ops())

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -35,7 +35,7 @@ from qiskit.converters import circuit_to_dag
 from qiskit.circuit.library import CXGate, U3Gate, U2Gate, U1Gate, RXGate, RYGate, RZGate, UGate
 from qiskit.circuit.measure import Measure
 from qiskit.test import QiskitTestCase
-from qiskit.test.mock import FakeMelbourne, FakeRueschlikon, FakeAlmaden
+from qiskit.test.mock import FakeMelbourne, FakeRueschlikon, FakeAlmaden, FakeMumbaiV2
 from qiskit.transpiler import Layout, CouplingMap
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.target import Target
@@ -1241,6 +1241,19 @@ class TestTranspile(QiskitTestCase):
 
         out = transpile(qc, dt=1e-9)
         self.assertEqual(out.data[0][0].unit, "dt")
+
+    def test_scheduling_backend_v2(self):
+        """Test that scheduling method works with Backendv2."""
+        qc = QuantumCircuit(2)
+        qc.h(0)
+        qc.cx(0, 1)
+        qc.measure_all()
+
+        backend = FakeMumbaiV2()
+        backend.target.dt = 1e-6
+        out = transpile([qc, qc], backend, scheduling_method="alap")
+        self.assertIn("delay", out[0].count_ops())
+        self.assertIn("delay", out[1].count_ops())
 
     @data(1, 2, 3)
     def test_no_infinite_loop(self, optimization_level):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary


When running `transpile()` with `BackendV2` based backends the instruction
durations property from the backend would not be processed correctly
resulting in the absence of the default durations for instructions
supported on the target backend. This commit fixes this by correctly
handling `BackendV2` based backends and using those instruction durations
by default for `transpile()`.

### Details and comments