### PR TITLE
Make Counts a defaultdict

### DIFF
--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -12,6 +12,7 @@
 
 """A container class for counts from a circuit execution."""
 
+from collections import defaultdict
 import re
 
 from qiskit.result import postprocess
@@ -24,7 +25,7 @@ from qiskit import exceptions
 # methods are not always used as expected. For example, update() doesn't call
 # __setitem__ so overloading __setitem__ would not always provide the expected
 # result
-class Counts(dict):
+class Counts(defaultdict):
     """A class to store a counts result from a circuit execution."""
 
     bitstring_regex = re.compile(r"^[01\s]+$")
@@ -112,7 +113,7 @@ class Counts(dict):
             header["memory_slots"] = self.memory_slots
         if not bin_data:
             bin_data = postprocess.format_counts(self.hex_raw, header=header)
-        super().__init__(bin_data)
+        super().__init__(int, bin_data)
         self.time_taken = time_taken
 
     def most_frequent(self):

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -326,3 +326,7 @@ class TestCounts(unittest.TestCase):
         counts_obj = counts.Counts(raw_counts)
         result = counts_obj.hex_outcomes()
         self.assertEqual(expected, result)
+
+    def test_default_zero(self):
+        counts_obj = counts.Counts({})
+        self.assertEqual(counts_obj["0"], 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
With this change, querying a bitstring that is not present gives 0 instead of raising a KeyError. This is sometimes convenient and simplifies code.


### Details and comments
I haven't discussed this with anyone but since it was quick I decided to submit the PR anyway. This is just a suggestion; I understand if it's rejected.

