### PR TITLE
Add missing delay instruction to fake backends

### DIFF
--- a/qiskit/test/mock/utils/backend_converter.py
+++ b/qiskit/test/mock/utils/backend_converter.py
@@ -21,6 +21,7 @@ from qiskit.utils.units import apply_prefix
 from qiskit.circuit.library.standard_gates import IGate, SXGate, XGate, CXGate, RZGate
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.gate import Gate
+from qiskit.circuit.delay import Delay
 from qiskit.circuit.measure import Measure
 from qiskit.circuit.reset import Reset
 from qiskit.providers.models.pulsedefaults import PulseDefaults
@@ -43,6 +44,7 @@ def convert_to_target(conf_dict: dict, props_dict: dict = None, defs_dict: dict 
     if props_dict:
         qubit_props = qubit_props_from_props(props_dict)
     target = Target(qubit_properties=qubit_props)
+    target.add_instruction(Delay(Parameter("t")))
     # Parse from properties if it exsits
     if props_dict is not None:
         # Parse instructions

--- a/qiskit/test/mock/utils/backend_converter.py
+++ b/qiskit/test/mock/utils/backend_converter.py
@@ -44,7 +44,6 @@ def convert_to_target(conf_dict: dict, props_dict: dict = None, defs_dict: dict 
     if props_dict:
         qubit_props = qubit_props_from_props(props_dict)
     target = Target(qubit_properties=qubit_props)
-    target.add_instruction(Delay(Parameter("t")))
     # Parse from properties if it exsits
     if props_dict is not None:
         # Parse instructions
@@ -125,6 +124,9 @@ def convert_to_target(conf_dict: dict, props_dict: dict = None, defs_dict: dict 
                             target[inst][(qubit,)].calibration = sched
                     else:
                         target[inst][qarg].calibration = sched
+    target.add_instruction(
+        Delay(Parameter("t")), {(bit,): None for bit in range(target.num_qubits)}
+    )
     return target
 
 

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -958,6 +958,8 @@ def plot_error_map(backend, figsize=(12, 9), show_title=True, qubit_coordinates=
             if prop_dict is None or None in prop_dict:
                 continue
             for qargs, inst_props in prop_dict.items():
+                if inst_props is None:
+                    continue
                 if gate == "measure":
                     if inst_props.error is not None:
                         read_err[qargs[0]] = inst_props.error

--- a/releasenotes/notes/delay-fake-backends-3f68c074e85d531f.yaml
+++ b/releasenotes/notes/delay-fake-backends-3f68c074e85d531f.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    The :class:`~.BackendV2` based fake backends in
+    the :mod:`qiskit.providers.fake_provider` module, such as
+    ``FakeMontrealV2``, previously were missing the :class:`~.Delay` operation
+    support from their :attr:`~.BackendV2.target` attribute. This prevented
+    compiling some :class:`~.QuantumCircuit` objects that contained
+    :class:`~.Delay` instructions to these backends. This has been corrected
+    by adding the :class:`~.Delay` to the :class:`~.Target` object for each
+    fake backend to ensure that the compiler knows that :class:`~.Delay` is
+    a valid operation on the fake backends.

--- a/releasenotes/notes/delay-fake-backends-3f68c074e85d531f.yaml
+++ b/releasenotes/notes/delay-fake-backends-3f68c074e85d531f.yaml
@@ -3,10 +3,10 @@ fixes:
   - |
     The :class:`~.BackendV2` based fake backends in
     the :mod:`qiskit.providers.fake_provider` module, such as
-    ``FakeMontrealV2``, previously were missing the :class:`~.Delay` operation
+    ``FakeMontrealV2``, previously were missing the :class:`~qiskit.circuit.Delay` operation
     support from their :attr:`~.BackendV2.target` attribute. This prevented
     compiling some :class:`~.QuantumCircuit` objects that contained
-    :class:`~.Delay` instructions to these backends. This has been corrected
-    by adding the :class:`~.Delay` to the :class:`~.Target` object for each
-    fake backend to ensure that the compiler knows that :class:`~.Delay` is
+    :class:`~qiskit.circuit.Delay` instructions to these backends. This has been corrected
+    by adding the :class:`~qiskit.circuit.Delay` to the :class:`~.Target` object for each
+    fake backend to ensure that the compiler knows that :class:`~qiskit.circuit.Delay` is
     a valid operation on the fake backends.

--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -25,6 +25,7 @@ from qiskit.exceptions import QiskitError
 from qiskit.execute_function import execute
 from qiskit.test.base import QiskitTestCase
 from qiskit.test.mock import FakeProviderForBackendV2, FakeProvider
+from qiskit.test.mock import FakeMumbaiV2
 from qiskit.utils import optionals
 
 FAKE_PROVIDER_FOR_BACKEND_V2 = FakeProviderForBackendV2()
@@ -140,3 +141,13 @@ class TestFakeBackends(QiskitTestCase):
                 self.assertGreater(i, 1e6)
         else:
             self.skipTest("Backend %s does not have defaults" % backend)
+
+    def test_delay_circuit(self):
+        backend = FakeMumbaiV2()
+        qc = QuantumCircuit(2)
+        qc.delay(502, 0, unit="ns")
+        qc.x(1)
+        qc.delay(250, 1, unit="ns")
+        qc.measure_all()
+        res = transpile(qc, backend)
+        self.assertIn("delay", res.count_ops())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds the delay instruction to the target for fake backends
based on BackendV2. With BackendV2 and the Target delay isn't assumed to
be present on every backend and it has to be explictly listed. This
commit fixes this so that the compiler is aware that delay is a valid
operation (without any additional constraints) on the BackendV2 based
fake backends.


### Details and comments