### PR TITLE
Pass through `RAYON_NUM_THREADS` env var in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
   QISKIT_SUPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
-passenv = RAYON_NUM_THREADS
+passenv = RAYON_NUM_THREADS OMP_OMP_NUM_THREADS QISKIT_PARALLEL
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ setenv =
   QISKIT_SUPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
+passenv = RAYON_NUM_THREADS
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ setenv =
   QISKIT_SUPRESS_PACKAGING_WARNINGS=Y
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
-passenv = RAYON_NUM_THREADS OMP_OMP_NUM_THREADS QISKIT_PARALLEL
+passenv = RAYON_NUM_THREADS OMP_NUM_THREADS QISKIT_PARALLEL
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 commands =


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This change allows setting the number of rayon threads used by tox by passing through `RAYON_NUM_THREADS`, so that the user is not required to also specify `TOX_TESTENV_PASSENV=RAYON_NUM_THREADS`.

### Details and comments


