### PR TITLE
CSPLayout is being deprecated in favor of VF2Layout

### DIFF
--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -17,6 +17,7 @@ found, no ``property_set['layout']`` is set.
 """
 import random
 from time import time
+from warnings import warn
 from constraint import Problem, RecursiveBacktrackingSolver, AllDifferentConstraint
 
 from qiskit.transpiler.layout import Layout
@@ -63,7 +64,7 @@ class CustomSolver(RecursiveBacktrackingSolver):
 
 
 class CSPLayout(AnalysisPass):
-    """If possible, chooses a Layout as a CSP, using backtracking."""
+    """Deprecated: use :class:`qiskit.transpiler.passes.VF2Layout` pass instead."""
 
     def __init__(
         self, coupling_map, strict_direction=False, seed=None, call_limit=1000, time_limit=10
@@ -96,6 +97,12 @@ class CSPLayout(AnalysisPass):
         self.call_limit = call_limit
         self.time_limit = time_limit
         self.seed = seed
+        warn(
+            "The CSPLayout pass has been deprecated "
+            "and replaced by a more generic and faster VF2Layout pass.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def run(self, dag):
         """run the layout method"""

--- a/releasenotes/notes/deprecate_csp-61623bc5005a34a4.yaml
+++ b/releasenotes/notes/deprecate_csp-61623bc5005a34a4.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    The pass :class:`~.CSPLayout` is been deprecated in favor of :class:`~.VF2Layout`.
+    Both passes work under the same principle of subgraph isomorphism and :class:`~.VF2Layout` is not only faster, but also noise-aware.

--- a/test/python/transpiler/test_csp_layout.py
+++ b/test/python/transpiler/test_csp_layout.py
@@ -38,7 +38,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[1], qr[0])  # qr1 -> qr0
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap([[0, 1]]), strict_direction=False, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap([[0, 1]]), strict_direction=False, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -63,7 +64,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[1], qr[2])  # qr1 -> qr2
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap(cmap5), strict_direction=False, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap(cmap5), strict_direction=False, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -88,7 +90,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr1[4], qr0[2])  # q1[4] -> q0[2]
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap(cmap16), strict_direction=False, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap(cmap16), strict_direction=False, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -113,7 +116,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[1], qr[0])  # qr1 -> qr0
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap([[0, 1]]), strict_direction=True, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap([[0, 1]]), strict_direction=True, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -138,7 +142,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[1], qr[2])  # qr1 -> qr2
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap(cmap5), strict_direction=True, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap(cmap5), strict_direction=True, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -163,7 +168,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr1[4], qr0[2])  # q1[4] -> q0[2]
 
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap(cmap16), strict_direction=True, seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap(cmap16), strict_direction=True, seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
 
@@ -194,7 +200,8 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[0], qr[3])
         circuit.cx(qr[0], qr[4])
         dag = circuit_to_dag(circuit)
-        pass_ = CSPLayout(CouplingMap(cmap16), seed=self.seed)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(CouplingMap(cmap16), seed=self.seed)
         pass_.run(dag)
         layout = pass_.property_set["layout"]
         self.assertIsNone(layout)
@@ -242,7 +249,8 @@ class TestCSPLayout(QiskitTestCase):
         """Hard to solve situations hit the time limit"""
         dag = TestCSPLayout.create_hard_dag()
         coupling_map = CouplingMap(FakeTokyo().configuration().coupling_map)
-        pass_ = CSPLayout(coupling_map, call_limit=None, time_limit=1)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(coupling_map, call_limit=None, time_limit=1)
 
         start = process_time()
         pass_.run(dag)
@@ -255,7 +263,8 @@ class TestCSPLayout(QiskitTestCase):
         """Hard to solve situations hit the call limit"""
         dag = TestCSPLayout.create_hard_dag()
         coupling_map = CouplingMap(FakeTokyo().configuration().coupling_map)
-        pass_ = CSPLayout(coupling_map, call_limit=1, time_limit=None)
+        with self.assertWarns(DeprecationWarning):
+            pass_ = CSPLayout(coupling_map, call_limit=1, time_limit=None)
 
         start = process_time()
         pass_.run(dag)
@@ -278,11 +287,13 @@ class TestCSPLayout(QiskitTestCase):
         circuit.cx(qr[1], qr[2])  # qr1 -> qr2
         dag = circuit_to_dag(circuit)
 
-        pass_1 = CSPLayout(CouplingMap(cmap5), seed=seed_1)
+        with self.assertWarns(DeprecationWarning):
+            pass_1 = CSPLayout(CouplingMap(cmap5), seed=seed_1)
         pass_1.run(dag)
         layout_1 = pass_1.property_set["layout"]
 
-        pass_2 = CSPLayout(CouplingMap(cmap5), seed=seed_2)
+        with self.assertWarns(DeprecationWarning):
+            pass_2 = CSPLayout(CouplingMap(cmap5), seed=seed_2)
         pass_2.run(dag)
         layout_2 = pass_2.property_set["layout"]
 


### PR DESCRIPTION
In https://github.com/Qiskit/qiskit-terra/issues/4443 we replaced `CSPLayout` with `VF2Layout`. Since the are functionally equivalent, I suggest to remove `CSPLayout`.