### PR TITLE
Test that circuit built from intransitive non-commutative doesn't wrongly cancels

### DIFF
--- a/qiskit/transpiler/passes/optimization/commutation_analysis.py
+++ b/qiskit/transpiler/passes/optimization/commutation_analysis.py
@@ -71,15 +71,17 @@ class CommutationAnalysis(AnalysisPass):
                     current_comm_set.append([current_gate])
 
                 if current_gate not in current_comm_set[-1]:
-                    prev_gate = current_comm_set[-1][-1]
-                    does_commute = False
+                    does_commute = True
                     try:
-                        does_commute = _commute(current_gate, prev_gate, self.cache)
+                        for prev_gate in current_comm_set[-1]:
+                            if not _commute(current_gate, prev_gate, self.cache):
+                                does_commute = False
+                                break
                     except TranspilerError:
-                        pass
+                        does_commute = False
+
                     if does_commute:
                         current_comm_set[-1].append(current_gate)
-
                     else:
                         current_comm_set.append([current_gate])
 

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -621,6 +621,22 @@ class TestCommutativeCancellation(QiskitTestCase):
         ccirc = passmanager.run(circ)
         self.assertEqual(Operator(circ), Operator(ccirc))
 
+    def test_intransitive_non_commutative_circuit1(self):
+        """Test simple intransitive non-commutative circuit on 1 qubit
+        """
+        circ = QuantumCircuit(1)
+
+        circ.x(0)
+        circ.i(0)
+        circ.h(0)
+        circ.i(0)
+        circ.x(0)
+
+        passmanager = PassManager()
+        passmanager.append(CommutativeCancellation())
+        ccirc = passmanager.run(circ)
+        self.assertEqual(Operator(circ), Operator(ccirc))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -622,8 +622,7 @@ class TestCommutativeCancellation(QiskitTestCase):
         self.assertEqual(Operator(circ), Operator(ccirc))
 
     def test_intransitive_non_commutative_circuit1(self):
-        """Test simple intransitive non-commutative circuit on 1 qubit
-        """
+        """Test simple intransitive non-commutative circuit on 1 qubit"""
         circ = QuantumCircuit(1)
 
         circ.x(0)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Following  https://github.com/Qiskit/qiskit-terra/issues/8020 I think that current implementation of `CommutationAnalysis` produces unsound optimizations. Adding test that verifies it.


### Details and comments

The simple circuit consists of Hadamard gate surrounded by X gates. Adding identity between non-commuting operators results in cancellation of X gates. In real life, though, similar cases should be very unlikely.
