### PR TITLE
Avoid UnitarySynthesis plugin discovery overhead with no method set

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -211,7 +211,9 @@ class UnitarySynthesis(TransformationPass):
         self._approximation_degree = approximation_degree
         self._min_qubits = min_qubits
         self.method = method
-        self.plugins = plugin.UnitarySynthesisPluginManager()
+        self.plugins = None
+        if method != "default":
+            self.plugins = plugin.UnitarySynthesisPluginManager()
         self._coupling_map = coupling_map
         self._backend_props = backend_props
         self._pulse_optimize = pulse_optimize
@@ -245,14 +247,16 @@ class UnitarySynthesis(TransformationPass):
                 plugins can be queried with
                 :func:`~qiskit.transpiler.passes.synthesis.plugin.unitary_synthesis_plugin_names`
         """
-        if self.method not in self.plugins.ext_plugins:
+        if self.method != "default" and self.method not in self.plugins.ext_plugins:
             raise TranspilerError("Specified method: %s not found in plugin list" % self.method)
         # Return fast if we have no synth gates (ie user specified an empty
         # list or the synth gates are all in the basis
         if not self._synth_gates:
             return dag
-
-        plugin_method = self.plugins.ext_plugins[self.method].obj
+        if self.plugins:
+            plugin_method = self.plugins.ext_plugins[self.method].obj
+        else:
+            plugin_method = DefaultUnitarySynthesis()
         plugin_kwargs = {"config": self._plugin_config}
         _gate_lengths = _gate_errors = None
         dag_bit_indices = {}

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -302,8 +302,10 @@ class UnitarySynthesis(TransformationPass):
         # Handle approximation degree as a special case for backwards compatibility, it's
         # not part of the plugin interface and only something needed for the default
         # pass.
+        # pylint: disable=attribute-defined-outside-init
         default_method._approximation_degree = self._approximation_degree
         if self.method == "default":
+            # pylint: disable=attribute-defined-outside-init
             plugin_method._approximation_degree = self._approximation_degree
 
         for node in dag.named_nodes(*self._synth_gates):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit tweaks the logic around loading plugins in the
UnitarySynthesis transpiler pass. Previously we would unconditionally
perform plugin discovery in all cases even if no custom plugin was
specified. This added some overhead the first time we initialize a
UnitarySynthesis pass object to do the initial discovery, import, and
initialization of any installed plugins. While typically this is fast
(locally just with the 2 plugins including in terra this takes ~.04
seconds) it does depend on the performance of all the installed plugins.
However, this overhead is not necessary if there is not a custom
synthesis method requested by a user. If the default method is being
used we can just directly instatiate the plugin and avoid the discovery
process. This commit changes the UnitarySynthesis pass to only run
discovery if the method argument is set to something other than
"default".

### Details and comments