### PR TITLE
Enable proper iteration over `Statevector`

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -218,6 +218,9 @@ class Statevector(QuantumState, TolerancesMixin):
         else:
             raise QiskitError("Key must be int or a valid binary string.")
 
+    def __iter__(self):
+        yield from self._data
+
     @property
     def data(self):
         """Return data."""

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -221,6 +221,9 @@ class Statevector(QuantumState, TolerancesMixin):
     def __iter__(self):
         yield from self._data
 
+    def __len__(self):
+        return len(self._data)
+
     @property
     def data(self):
         """Return data."""

--- a/releasenotes/notes/statevector-enable-iter-4652d7ce87f4d459.yaml
+++ b/releasenotes/notes/statevector-enable-iter-4652d7ce87f4d459.yaml
@@ -1,0 +1,24 @@
+---
+features:
+  - |
+    :func:`~qiskit.quantum_info.states.Statevector.__iter__` and 
+    :func:`~qiskit.quantum_info.states.Statevector.__len__` have been 
+    added to facilitate iteration over and referencing the length of 
+    a state vector, correspondingly.
+fixes:
+  - |
+    :class:`~qiskit.quantum_info.states.Statevector` objects raised an 
+    ``qiskit.exceptions.QiskitError`` upon being iterated over, in 
+    certain circumstances, due to the fact that no explicit iteration 
+    mechanism had been implemented, as it hadn't been within the original 
+    design scope. Instead, Python, as a fallback, relied in an ad-hoc manner on 
+    :func:`~qiskit.quantum_info.states.Statevector.__getitem__` to provide 
+    iteration functionality. If a key, that is being iterated over in such 
+    manner, gets referenced and its value is outside of the range of values, 
+    corresponding to valid ``dim`` dimensionality, then an error of 
+    the aforementioned type occurred. Refer to 
+    `#8039 <https://github.com/Qiskit/qiskit-terra/issues/8039>` for more
+    details.
+    This issue has been addressed by introducing 
+    :func:`~qiskit.quantum_info.states.Statevector.__iter__`, which enables 
+    correct behavior.

--- a/releasenotes/notes/statevector-enable-iter-4652d7ce87f4d459.yaml
+++ b/releasenotes/notes/statevector-enable-iter-4652d7ce87f4d459.yaml
@@ -1,24 +1,8 @@
 ---
-features:
-  - |
-    :func:`~qiskit.quantum_info.states.Statevector.__iter__` and 
-    :func:`~qiskit.quantum_info.states.Statevector.__len__` have been 
-    added to facilitate iteration over and referencing the length of 
-    a state vector, correspondingly.
 fixes:
   - |
-    :class:`~qiskit.quantum_info.states.Statevector` objects raised an 
-    ``qiskit.exceptions.QiskitError`` upon being iterated over, in 
-    certain circumstances, due to the fact that no explicit iteration 
-    mechanism had been implemented, as it hadn't been within the original 
-    design scope. Instead, Python, as a fallback, relied in an ad-hoc manner on 
-    :func:`~qiskit.quantum_info.states.Statevector.__getitem__` to provide 
-    iteration functionality. If a key, that is being iterated over in such 
-    manner, gets referenced and its value is outside of the range of values, 
-    corresponding to valid ``dim`` dimensionality, then an error of 
-    the aforementioned type occurred. Refer to 
-    `#8039 <https://github.com/Qiskit/qiskit-terra/issues/8039>` for more
-    details.
-    This issue has been addressed by introducing 
-    :func:`~qiskit.quantum_info.states.Statevector.__iter__`, which enables 
-    correct behavior.
+    :class:`.Statevector` will now allow direct iteration through its values
+    (such as ``for coefficient in statevector``) and
+    correctly report its length under ``len``.  Previously it would try and
+    and access out-of-bounds data and raise a :class:`.QiskitError`.  See
+    `#8039 <https://github.com/Qiskit/qiskit-terra/issues/8039>`__.

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1175,8 +1175,8 @@ class TestStatevector(QiskitTestCase):
         # iterator is reset upon each exhaustion of the corresponding
         # collection of elements.
         for _ in range(2):
-            self.assertEqual(empty_vector, [x for x in empty_sv])
-            self.assertEqual(dummy_vector, [x for x in sv])
+            self.assertEqual(empty_vector, list(empty_sv))
+            self.assertEqual(dummy_vector, list(sv))
 
     def test_statevector_len(self):
         """Test state vector length"""

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1178,5 +1178,15 @@ class TestStatevector(QiskitTestCase):
             self.assertEqual(empty_vector, [x for x in empty_sv])
             self.assertEqual(dummy_vector, [x for x in sv])
 
+    def test_statevector_len(self):
+        """Test state vector length"""
+        empty_vector = []
+        dummy_vector = [1, 2, 3]
+        empty_sv = Statevector([])
+        sv = Statevector(dummy_vector)
+        self.assertEqual(len(empty_vector), len(empty_sv))
+        self.assertEqual(len(dummy_vector), len(sv))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1164,6 +1164,19 @@ class TestStatevector(QiskitTestCase):
         self.assertTrue(latex_string.startswith(" |0\\rangle"))
         self.assertNotIn("|1\\rangle", latex_string)
 
+    def test_statevctor_iter(self):
+        """Test iteration over a state vector"""
+        empty_vector = []
+        dummy_vector = [1, 2, 3]
+        empty_sv = Statevector([])
+        sv = Statevector(dummy_vector)
+
+        # Assert that successive iterations behave as expected, i.e., the
+        # iterator is reset upon each exhaustion of the corresponding
+        # collection of elements.
+        for _ in range(2):
+            self.assertEqual(empty_vector, [x for x in empty_sv])
+            self.assertEqual(dummy_vector, [x for x in sv])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Fixes https://github.com/Qiskit/qiskit-terra/issues/8039.
This is achieved by enabling proper iteration over `Statevector`.

### Details and comments
I've opted to not add a docstring to the newly-added `__iter__` method, as I believe it's quite straightforward. Please, let me know if documentation should be added there and/or elsewhere.

I am new to the project, so if you could please suggest whether a release note needs to be added in the case of this PR.

Thanks!