### PR TITLE
Reduce Rust MSRV to 1.56

### DIFF
--- a/src/results/marginalization.rs
+++ b/src/results/marginalization.rs
@@ -18,11 +18,16 @@ fn marginalize<T: std::ops::AddAssign + Copy>(
     indices: Option<Vec<usize>>,
 ) -> HashMap<String, T> {
     let mut out_counts: HashMap<String, T> = HashMap::with_capacity(counts.len());
-    let clbit_size = counts.keys().next().unwrap().replace(&['_', ' '], "").len();
+    let clbit_size = counts
+        .keys()
+        .next()
+        .unwrap()
+        .replace(|c| c == '_' || c == ' ', "")
+        .len();
     let all_indices: Vec<usize> = (0..clbit_size).collect();
     counts
         .iter()
-        .map(|(k, v)| (k.replace(&['_', ' '], ""), *v))
+        .map(|(k, v)| (k.replace(|c| c == '_' || c == ' ', ""), *v))
         .for_each(|(k, v)| match &indices {
             Some(indices) => {
                 if all_indices == *indices {


### PR DESCRIPTION
### Summary

Commit 84cfd5c1 recently used a `&[char; 2]` as the type in the
constructor of the `std::Pattern` trait, which is a feature of Rust
unstable, and only available in newer versions of Rust.  We've not fixed
an absolute minimum supported Rust version, but have generally tried to
keep things building with at least the last six months' releases.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
---> 