### PR TITLE
Small speedup to construct DagDependency

### DIFF
--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -608,6 +608,10 @@ def _does_commute(node1, node2):
         intersection_c = set(carg1).intersection(set(carg2))
         return not (intersection_q or intersection_c)
 
+    # Gates over disjoint sets of qubits commute
+    if not set(qarg1).intersection(set(qarg2)):
+        return True
+
     # Known non-commuting gates (TODO: add more).
     non_commute_gates = [{"x", "y"}, {"x", "z"}]
     if qarg1 == qarg2 and ({node1.name, node2.name} in non_commute_gates):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Checking whether gates are over disjoint sets of qubits: if so, they commute, and the more expensive check using matrix multiplication is not necessary. 

This is just a quick optimization. See also #8020.

### Details and comments

A few experiments on random clifford circuits: 

```
    gates = ["i", "x", "y", "z", "h", "s", "sdg", "cx", "cz", "swap"]
    qc = random_clifford_circuit(num_qubits, num_gates, gates=gates, seed=0)
```

```
#qubits = 5,  #gates =  100  : size = 100,  depth = 26,   #edges = 138,  previous time = 0.29,    new time = 0.07
#qubits = 5,  #gates =  500  : size = 500,  depth = 146,  #edges = 722,  previous time = 3.51,    new time = 1.49
#qubits = 5,  #gates =  1000 : size = 1000, depth = 294,  #edges = 1500, previous time = 11.41,   new time = 4.32
#qubits = 5,  #gates =  5000 : size = 5000, depth = 1478, #edges = 7144, previous time = 250.84,  new time = 95.89
#qubits = 10, #gates =  100  : size = 100,  depth = 13,   #edges = 131,  previous time = 0.40,    new time = 0.06
#qubits = 10, #gates =  500  : size = 500,  depth = 91,   #edges = 741,  previous time = 4.57,    new time = 0.87
#qubits = 10, #gates =  1000 : size = 1000, depth = 182,  #edges = 1535, previous time = 12.10,   new time = 2.77
#qubits = 10, #gates =  5000 : size = 5000, depth = 868,  #edges = 7358, previous time = 292.63,  new time = 64.49
#qubits = 20, #gates =  100  : size = 100,  depth = 9,    #edges = 100,  previous time = 0.49,    new time = 0.05
#qubits = 20, #gates =  500  : size = 500,  depth = 52,   #edges = 714,  previous time = 6.88,    new time = 0.83
#qubits = 20, #gates =  1000 : size = 1000, depth = 99,   #edges = 1564, previous time = 21.00,   new time = 2.67
#qubits = 20, #gates =  5000 : size = 5000, depth = 475,  #edges = 7617, previous time = 339.75,  new time = 55.36
#qubits = 50, #gates =  100  : size = 100,  depth = 4,    #edges = 55,   previous time = 0.56,    new time = 0.06
#qubits = 50, #gates =  500  : size = 500,  depth = 26,   #edges = 659,  previous time = 12.40,   new time = 1.01
#qubits = 50, #gates =  1000 : size = 1000, depth = 44,   #edges = 1464, previous time = 37.57,   new time = 2.77
#qubits = 50, #gates =  5000 : size = 5000, depth = 219,  #edges = 7741, previous time = 456.01,  new time = 50.24
```

