### PR TITLE
Fix performance regression of `BasePauli._to_label` by #7830

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -474,6 +474,7 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
                             for the label from the full Pauli group.
         """
         num_qubits = z.size
+        phase = int(phase)
         coeff_labels = {0: "", 1: "-i", 2: "-", 3: "i"}
         label = ""
         for i in range(num_qubits):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

I noticed that #7830 causes performance regression of `SparsePauliOp.to_list`.
Source: https://qiskit.github.io/qiskit/#quantum_info.SparsePauliOpBench.time_to_list

This PR fixes the regression.

### Details and comments

`phase` used to be np.int64 and it was fast. But, #7830 makes `phase` as small as possible such as np.uint8 or np.uint16. I observe that operations of these types are slow.

```python
import random
from timeit import timeit

from qiskit.quantum_info import SparsePauliOp

k = 10
n = 10_000
m = 3

random.seed(123)
op = SparsePauliOp.from_list([(''.join(random.choices('IXYZ', k=k)), 1) for _ in range(n)])

print(f'{timeit(lambda: op.to_list(), number=100)} sec')
```

main (794db47)
```
6.5075130869999995 sec
```

this PR
```
3.9482219790000004 sec
```

main (cbc801e, before merging #7830)
```
4.329158903 sec
```