### PR TITLE
[WIP] Enable parameterization of Qobj in CircuitSampler

### DIFF
--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -82,8 +82,6 @@ class CircuitSampler(ConverterBase):
         self._statevector = (
             statevector if statevector is not None else self.quantum_instance.is_statevector
         )
-        # Set to False until https://github.com/Qiskit/qiskit-aer/issues/1249 is closed.
-        param_qobj = False
         self._param_qobj = param_qobj
         self._attach_results = attach_results
 

--- a/releasenotes/notes/enable-param-qobj-02eb71f81a88860a.yaml
+++ b/releasenotes/notes/enable-param-qobj-02eb71f81a88860a.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Previously, any value passed to the parameter `param_qobj` of the constructor of
+    :class:`~.CircuitSampler` was ignored due to a bug in Qiskit Aer:
+    https://github.com/Qiskit/qiskit-aer/issues/1249. Now this parameter is enabled back and can be
+    used to parameterized Qobj.

--- a/releasenotes/notes/enable-param-qobj-02eb71f81a88860a.yaml
+++ b/releasenotes/notes/enable-param-qobj-02eb71f81a88860a.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Previously, any value passed to the parameter `param_qobj` of the constructor of
-    :class:`~.CircuitSampler` was ignored due to a bug in Qiskit Aer:
+    Previously, any value passed in the `param_qobj` parameter of the :class:`~.CircuitSampler`
+    constructor was ignored due to a bug in Qiskit Aer, see
     https://github.com/Qiskit/qiskit-aer/issues/1249. Now this parameter is enabled back and can be
-    used to parameterized Qobj.
+    used to parameterize Qobj.

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -170,7 +170,6 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
             sampled_plus.eval(), [1, 0.5**0.5, (1 + 0.5**0.5), 1], decimal=1
         )
 
-    @unittest.skip("Skip until https://github.com/Qiskit/qiskit-aer/issues/1249 is closed.")
     def test_parameterized_qobj(self):
         """grouped pauli expectation test"""
         two_qubit_h2 = (


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Previously, any value passed in the `param_qobj` parameter of the `CircuitSampler` constructor was ignored due to a bug in Qiskit Aer, see https://github.com/Qiskit/qiskit-aer/issues/1249. Now this parameter is enabled back and can be used to parameterize Qobj.
