### PR TITLE
Upgrade EstimatorResult dataclass

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -109,7 +109,7 @@ class Estimator(BaseEstimator):
                 )
             expectation_values.append(Statevector(circ).expectation_value(obs))
 
-        expectation_values = np.real_if_close(expectation_values)
+        expectation_values = np.real_if_close(expectation_values).tolist()
         variances = [0.0] * len(expectation_values)
         metadata = [{}] * len(expectation_values)
         return EstimatorResult(tuple(expectation_values), tuple(variances), tuple(metadata))

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -109,7 +109,10 @@ class Estimator(BaseEstimator):
                 )
             expectation_values.append(Statevector(circ).expectation_value(obs))
 
-        return EstimatorResult(np.real_if_close(expectation_values), [{}] * len(expectation_values))
+        expectation_values = np.real_if_close(expectation_values)
+        variances = [0.0] * len(expectation_values)
+        metadata = [{}] * len(expectation_values)
+        return EstimatorResult(tuple(expectation_values), tuple(variances), tuple(metadata))
 
     def close(self):
         self._is_closed = True

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from warnings import warn
 
-from numpy import array
+from numpy import array, ndarray
 
 
 @dataclass(frozen=True)
@@ -47,7 +47,7 @@ class EstimatorResult:
     metadata: tuple[dict[str, Any], ...]
 
     @property
-    def values(self) -> None:
+    def values(self) -> ndarray:
         warn(
             "``EstimatorResult.values`` will be deprecated,"
             "use ``EstimatorResult.expvals`` instead.",

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
+from warnings import warn
 
-if TYPE_CHECKING:
-    import numpy as np
+from numpy import array
 
 
 @dataclass(frozen=True)
@@ -45,3 +45,12 @@ class EstimatorResult:
     expvals: tuple[float, ...]
     variances: tuple[float, ...]
     metadata: tuple[dict[str, Any], ...]
+
+    @property
+    def values(self) -> None:
+        warn(
+            "``EstimatorResult.values`` will be deprecated,"
+            "use ``EstimatorResult.expvals`` instead.",
+            DeprecationWarning,
+        )
+        return array(self.expvals)

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -32,8 +32,8 @@ class EstimatorResult:
 
     where the i-th elements of ``result`` correspond to the circuit and observable given by
     ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by
-    ``params[i]``. For example, ``results.expvals[i]`` gives the expectation value, 
-    ``results.variances[i]`` the variance, and ``result.metadata[i]`` is a metadata dictionary for 
+    ``params[i]``. For example, ``results.expvals[i]`` gives the expectation value,
+    ``results.variances[i]`` the variance, and ``result.metadata[i]`` is a metadata dictionary for
     this circuit and parameters.
 
     Args:
@@ -53,4 +53,4 @@ class EstimatorResult:
             "use ``EstimatorResult.expvals`` instead.",
             DeprecationWarning,
         )
-        return array(self.expval
+        return array(self.expvals)

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -32,13 +32,16 @@ class EstimatorResult:
 
     where the i-th elements of ``result`` correspond to the circuit and observable given by
     ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by ``params[i]``.
-    For example, ``results.values[i]`` gives the expectation value, and ``result.metadata[i]``
-    is a metadata dictionary for this circuit and parameters.
+    For example, ``results.expvals[i]`` gives the expectation value, ``results.variances[i]``
+    the variance, and ``result.metadata[i]`` is a metadata dictionary for this circuit and
+    parameters.
 
     Args:
-        values (np.ndarray): The array of the expectation values.
-        metadata (list[dict]): List of the metadata.
+        expvals (tuple[float, ...]): Tuple of expectation values.
+        variances (tuple[float, ...]): Tuple of variances associated to each expectation value.
+        metadata (tuple[dict, ...]): Tuple of metadata.
     """
 
-    values: "np.ndarray[Any, np.dtype[np.float64]]"
-    metadata: list[dict[str, Any]]
+    expvals: tuple[float, ...]
+    variances: tuple[float, ...]
+    metadata: tuple[dict[str, Any], ...]

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -32,17 +32,17 @@ class EstimatorResult:
 
     where the i-th elements of ``result`` correspond to the circuit and observable given by
     ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by
-    ``params[i]``. For example, ``results.expvals[i]`` gives the expectation value,
+    ``params[i]``. For example, ``results.expectation_values[i]`` gives the expectation value,
     ``results.variances[i]`` the variance, and ``result.metadata[i]`` is a metadata dictionary for
     this circuit and parameters.
 
     Args:
-        expvals (tuple[float, ...]): Tuple of expectation values.
+        expectation_values (tuple[float, ...]): Tuple of expectation values.
         variances (tuple[float, ...]): Tuple of variances associated to each expectation value.
         metadata (tuple[dict, ...]): Tuple of metadata.
     """
 
-    expvals: tuple[float, ...]
+    expectation_values: tuple[float, ...]
     variances: tuple[float, ...]
     metadata: tuple[dict[str, Any], ...]
 
@@ -51,8 +51,8 @@ class EstimatorResult:
         warn(
             "The EstimatorResult.values field is deprecated as of 0.21.0, and will be"
             "removed no earlier than 3 months after that release date. You should use the"
-            "EstimatorResult.expvals field instead.",
+            "EstimatorResult.expectation_values field instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return array(self.expvals)
+        return array(self.expectation_values)

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -31,10 +31,10 @@ class EstimatorResult:
         result = estimator(circuits, observables, params)
 
     where the i-th elements of ``result`` correspond to the circuit and observable given by
-    ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by ``params[i]``.
-    For example, ``results.expvals[i]`` gives the expectation value, ``results.variances[i]``
-    the variance, and ``result.metadata[i]`` is a metadata dictionary for this circuit and
-    parameters.
+    ``circuit_indices[i]``, ``observable_indices[i]``, and the parameter values bounds by
+    ``params[i]``. For example, ``results.expvals[i]`` gives the expectation value, 
+    ``results.variances[i]`` the variance, and ``result.metadata[i]`` is a metadata dictionary for 
+    this circuit and parameters.
 
     Args:
         expvals (tuple[float, ...]): Tuple of expectation values.
@@ -53,4 +53,4 @@ class EstimatorResult:
             "use ``EstimatorResult.expvals`` instead.",
             DeprecationWarning,
         )
-        return array(self.expvals)
+        return array(self.expval

--- a/qiskit/primitives/estimator_result.py
+++ b/qiskit/primitives/estimator_result.py
@@ -49,8 +49,10 @@ class EstimatorResult:
     @property
     def values(self) -> ndarray:
         warn(
-            "``EstimatorResult.values`` will be deprecated,"
-            "use ``EstimatorResult.expvals`` instead.",
+            "The EstimatorResult.values field is deprecated as of 0.21.0, and will be"
+            "removed no earlier than 3 months after that release date. You should use the"
+            "EstimatorResult.expvals field instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return array(self.expvals)

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -41,6 +41,17 @@ class TestEstimator(QiskitTestCase):
             ]
         )
 
+    def assertEstimatorResultType(self, result):
+        self.assertIsInstance(result, EstimatorResult)
+        self.assertIsInstance(result.expvals, tuple)
+        self.assertTrue(all(isinstance(ev, float) for ev in result.expvals))
+        self.assertIsInstance(result.variances, tuple)
+        self.assertTrue(all(isinstance(var, float) for var in result.variances))
+        self.assertIsInstance(result.metadata, tuple)
+        self.assertTrue(all(isinstance(md, dict) for md in result.metadata))
+        with self.assertWarns(DeprecationWarning):
+            self.assertIsInstance(result.values, np.ndarray)
+
     def test_estimator(self):
         """test for a simple use case"""
         lst = [("XX", 1), ("YY", 2), ("ZZ", 3)]
@@ -49,7 +60,7 @@ class TestEstimator(QiskitTestCase):
             ansatz = RealAmplitudes(num_qubits=2, reps=2)
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1.84209213])
 
         with self.subTest("SparsePauliOp"):
@@ -57,7 +68,7 @@ class TestEstimator(QiskitTestCase):
             ansatz = RealAmplitudes(num_qubits=2, reps=2)
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1.84209213])
 
     def test_estimator_param_reverse(self):
@@ -66,7 +77,7 @@ class TestEstimator(QiskitTestCase):
         ansatz = RealAmplitudes(num_qubits=2, reps=2)
         with Estimator([ansatz], [observable], [ansatz.parameters[::-1]]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5][::-1])
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [1.84209213])
 
     def test_init_from_statevector(self):
@@ -77,7 +88,7 @@ class TestEstimator(QiskitTestCase):
             self.assertIsInstance(est.circuits[0], QuantumCircuit)
             np.testing.assert_allclose(est.circuits[0][0][0].params, vector)
             result = est()
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [-0.88272215])
 
     def test_init_observable_from_operator(self):
@@ -93,14 +104,14 @@ class TestEstimator(QiskitTestCase):
         )
         with Estimator([circuit], [matrix]) as est:
             result = est()
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_evaluate(self):
         """test for evaluate"""
         with Estimator([self.ansatz], [self.observable]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5])
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_evaluate_multi_params(self):
@@ -109,7 +120,7 @@ class TestEstimator(QiskitTestCase):
             result = est(
                 [0] * 2, [0] * 2, parameter_values=[[0, 1, 1, 2, 3, 5], [1, 1, 2, 3, 5, 8]]
             )
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [-1.284366511861733, -1.3187526349078742])
 
     def test_evaluate_no_params(self):
@@ -117,7 +128,7 @@ class TestEstimator(QiskitTestCase):
         circuit = self.ansatz.bind_parameters([0, 1, 1, 2, 3, 5])
         with Estimator([circuit], [self.observable]) as est:
             result = est()
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_run_with_multiple_observables_and_none_parameters(self):
@@ -128,7 +139,7 @@ class TestEstimator(QiskitTestCase):
         circuit.cx(1, 2)
         with Estimator(circuit, ["ZZZ", "III"]) as est:
             result = est(circuit_indices=[0, 0], observable_indices=[0, 1])
-        self.assertIsInstance(result, EstimatorResult)
+        self.assertEstimatorResultType(result)
         np.testing.assert_allclose(result.expvals, [0.0, 1.0])
 
     def test_estimator_example(self):
@@ -150,25 +161,25 @@ class TestEstimator(QiskitTestCase):
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)> ]
             result = est([0], [0], [theta1])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1.5555572817900956])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op2|psi1(theta1)>, <psi1(theta1)|op3|psi1(theta1)> ]
             result = est([0, 0], [1, 2], [theta1] * 2)
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [-0.5516530027638437, 0.07535238795415422])
             self.assertEqual(len(result.metadata), 2)
 
             # calculate [ <psi2(theta2)|op2|psi2(theta2)> ]
             result = est([1], [1], [theta2])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [0.17849238433885167])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)>, <psi1(theta3)|op1|psi1(theta3)> ]
             result = est([0, 0], [0, 0], [theta1, theta3])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1.5555572817900956, 1.0656325933346835])
             self.assertEqual(len(result.metadata), 2)
 
@@ -176,7 +187,7 @@ class TestEstimator(QiskitTestCase):
             #             <psi2(theta2)|op2|psi2(theta2)>,
             #             <psi1(theta3)|op3|psi1(theta3)> ]
             result = est([0, 1, 0], [0, 1, 2], [theta1, theta2, theta3])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(
                 result.expvals, [1.5555572817900956, 0.17849238433885167, -1.0876631752254926]
             )
@@ -193,19 +204,19 @@ class TestEstimator(QiskitTestCase):
 
         with Estimator([qc, qc2], [op, op2], [[]] * 2) as est:
             result = est([0], [0], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [1], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [0], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [1], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [-1])
 
     def test_2qubits(self):
@@ -220,27 +231,27 @@ class TestEstimator(QiskitTestCase):
 
         with Estimator([qc, qc2], [op, op2, op3], [[]] * 2) as est:
             result = est([0], [0], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [0], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [1], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [1], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [2], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [2], [[]])
-            self.assertIsInstance(result, EstimatorResult)
+            self.assertEstimatorResultType(result)
             np.testing.assert_allclose(result.expvals, [-1])
 
     def test_errors(self):
@@ -274,11 +285,13 @@ class TestEstimator(QiskitTestCase):
             with self.subTest("one circuit"):
                 result = estimator([0], [1], shots=1000)
                 np.testing.assert_allclose(result.expvals, [1])
+                self.assertEqual(len(result.variances), 1)
                 self.assertEqual(len(result.metadata), 1)
 
             with self.subTest("two circuits"):
                 result = estimator([2, 4], [3, 5], shots=1000)
                 np.testing.assert_allclose(result.expvals, [1, 1])
+                self.assertEqual(len(result.variances), 2)
                 self.assertEqual(len(result.metadata), 2)
 
     def test_numpy_params(self):
@@ -295,11 +308,13 @@ class TestEstimator(QiskitTestCase):
             with self.subTest("ndarrary"):
                 result = estimator([0] * k, [0] * k, params_array)
                 self.assertEqual(len(result.metadata), k)
+                self.assertEqual(len(result.variances), k)
                 np.testing.assert_allclose(result.expvals, target.expvals)
 
             with self.subTest("list of ndarray"):
                 result = estimator([0] * k, [0] * k, params_list_array)
                 self.assertEqual(len(result.metadata), k)
+                self.assertEqual(len(result.variances), k)
                 np.testing.assert_allclose(result.expvals, target.expvals)
 
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -50,7 +50,7 @@ class TestEstimator(QiskitTestCase):
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1.84209213])
+            np.testing.assert_allclose(result.expvals, [1.84209213])
 
         with self.subTest("SparsePauliOp"):
             observable = SparsePauliOp.from_list(lst)
@@ -58,7 +58,7 @@ class TestEstimator(QiskitTestCase):
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1.84209213])
+            np.testing.assert_allclose(result.expvals, [1.84209213])
 
     def test_estimator_param_reverse(self):
         """test for the reverse parameter"""
@@ -67,7 +67,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator([ansatz], [observable], [ansatz.parameters[::-1]]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5][::-1])
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [1.84209213])
+        np.testing.assert_allclose(result.expvals, [1.84209213])
 
     def test_init_from_statevector(self):
         """test initialization from statevector"""
@@ -78,7 +78,7 @@ class TestEstimator(QiskitTestCase):
             np.testing.assert_allclose(est.circuits[0][0][0].params, vector)
             result = est()
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-0.88272215])
+        np.testing.assert_allclose(result.expvals, [-0.88272215])
 
     def test_init_observable_from_operator(self):
         """test for evaluate without parameters"""
@@ -94,14 +94,14 @@ class TestEstimator(QiskitTestCase):
         with Estimator([circuit], [matrix]) as est:
             result = est()
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-1.284366511861733])
+        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_evaluate(self):
         """test for evaluate"""
         with Estimator([self.ansatz], [self.observable]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5])
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-1.284366511861733])
+        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_evaluate_multi_params(self):
         """test for evaluate with multiple parameters"""
@@ -110,7 +110,7 @@ class TestEstimator(QiskitTestCase):
                 [0] * 2, [0] * 2, parameter_values=[[0, 1, 1, 2, 3, 5], [1, 1, 2, 3, 5, 8]]
             )
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-1.284366511861733, -1.3187526349078742])
+        np.testing.assert_allclose(result.expvals, [-1.284366511861733, -1.3187526349078742])
 
     def test_evaluate_no_params(self):
         """test for evaluate without parameters"""
@@ -118,7 +118,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator([circuit], [self.observable]) as est:
             result = est()
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-1.284366511861733])
+        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
 
     def test_run_with_multiple_observables_and_none_parameters(self):
         """test for evaluate without parameters"""
@@ -129,7 +129,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator(circuit, ["ZZZ", "III"]) as est:
             result = est(circuit_indices=[0, 0], observable_indices=[0, 1])
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [0.0, 1.0])
+        np.testing.assert_allclose(result.expvals, [0.0, 1.0])
 
     def test_estimator_example(self):
         """test for Estimator example"""
@@ -151,25 +151,25 @@ class TestEstimator(QiskitTestCase):
             # calculate [ <psi1(theta1)|op1|psi1(theta1)> ]
             result = est([0], [0], [theta1])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1.5555572817900956])
+            np.testing.assert_allclose(result.expvals, [1.5555572817900956])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op2|psi1(theta1)>, <psi1(theta1)|op3|psi1(theta1)> ]
             result = est([0, 0], [1, 2], [theta1] * 2)
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [-0.5516530027638437, 0.07535238795415422])
+            np.testing.assert_allclose(result.expvals, [-0.5516530027638437, 0.07535238795415422])
             self.assertEqual(len(result.metadata), 2)
 
             # calculate [ <psi2(theta2)|op2|psi2(theta2)> ]
             result = est([1], [1], [theta2])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [0.17849238433885167])
+            np.testing.assert_allclose(result.expvals, [0.17849238433885167])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)>, <psi1(theta3)|op1|psi1(theta3)> ]
             result = est([0, 0], [0, 0], [theta1, theta3])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1.5555572817900956, 1.0656325933346835])
+            np.testing.assert_allclose(result.expvals, [1.5555572817900956, 1.0656325933346835])
             self.assertEqual(len(result.metadata), 2)
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)>,
@@ -178,7 +178,7 @@ class TestEstimator(QiskitTestCase):
             result = est([0, 1, 0], [0, 1, 2], [theta1, theta2, theta3])
             self.assertIsInstance(result, EstimatorResult)
             np.testing.assert_allclose(
-                result.values, [1.5555572817900956, 0.17849238433885167, -1.0876631752254926]
+                result.expvals, [1.5555572817900956, 0.17849238433885167, -1.0876631752254926]
             )
             self.assertEqual(len(result.metadata), 3)
 
@@ -194,19 +194,19 @@ class TestEstimator(QiskitTestCase):
         with Estimator([qc, qc2], [op, op2], [[]] * 2) as est:
             result = est([0], [0], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [1], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [0], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [1], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [-1])
+            np.testing.assert_allclose(result.expvals, [-1])
 
     def test_2qubits(self):
         """Test for 2-qubit cases (to check endian)"""
@@ -221,27 +221,27 @@ class TestEstimator(QiskitTestCase):
         with Estimator([qc, qc2], [op, op2, op3], [[]] * 2) as est:
             result = est([0], [0], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [0], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [1], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [1], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([0], [2], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [1])
+            np.testing.assert_allclose(result.expvals, [1])
 
             result = est([1], [2], [[]])
             self.assertIsInstance(result, EstimatorResult)
-            np.testing.assert_allclose(result.values, [-1])
+            np.testing.assert_allclose(result.expvals, [-1])
 
     def test_errors(self):
         """Test for errors"""
@@ -273,12 +273,12 @@ class TestEstimator(QiskitTestCase):
         with Estimator(circuits=[qc] * 10, observables=[op] * 10) as estimator:
             with self.subTest("one circuit"):
                 result = estimator([0], [1], shots=1000)
-                np.testing.assert_allclose(result.values, [1])
+                np.testing.assert_allclose(result.expvals, [1])
                 self.assertEqual(len(result.metadata), 1)
 
             with self.subTest("two circuits"):
                 result = estimator([2, 4], [3, 5], shots=1000)
-                np.testing.assert_allclose(result.values, [1, 1])
+                np.testing.assert_allclose(result.expvals, [1, 1])
                 self.assertEqual(len(result.metadata), 2)
 
     def test_numpy_params(self):
@@ -295,12 +295,12 @@ class TestEstimator(QiskitTestCase):
             with self.subTest("ndarrary"):
                 result = estimator([0] * k, [0] * k, params_array)
                 self.assertEqual(len(result.metadata), k)
-                np.testing.assert_allclose(result.values, target.values)
+                np.testing.assert_allclose(result.expvals, target.expvals)
 
             with self.subTest("list of ndarray"):
                 result = estimator([0] * k, [0] * k, params_list_array)
                 self.assertEqual(len(result.metadata), k)
-                np.testing.assert_allclose(result.values, target.values)
+                np.testing.assert_allclose(result.expvals, target.expvals)
 
 
 if __name__ == "__main__":

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -43,8 +43,8 @@ class TestEstimator(QiskitTestCase):
 
     def assertEstimatorResultType(self, result):
         self.assertIsInstance(result, EstimatorResult)
-        self.assertIsInstance(result.expvals, tuple)
-        self.assertTrue(all(isinstance(ev, float) for ev in result.expvals))
+        self.assertIsInstance(result.expectation_values, tuple)
+        self.assertTrue(all(isinstance(ev, float) for ev in result.expectation_values))
         self.assertIsInstance(result.variances, tuple)
         self.assertTrue(all(isinstance(var, float) for var in result.variances))
         self.assertIsInstance(result.metadata, tuple)
@@ -61,7 +61,7 @@ class TestEstimator(QiskitTestCase):
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1.84209213])
+            np.testing.assert_allclose(result.expectation_values, [1.84209213])
 
         with self.subTest("SparsePauliOp"):
             observable = SparsePauliOp.from_list(lst)
@@ -69,7 +69,7 @@ class TestEstimator(QiskitTestCase):
             with Estimator([ansatz], [observable]) as est:
                 result = est(parameter_values=[0, 1, 1, 2, 3, 5])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1.84209213])
+            np.testing.assert_allclose(result.expectation_values, [1.84209213])
 
     def test_estimator_param_reverse(self):
         """test for the reverse parameter"""
@@ -78,7 +78,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator([ansatz], [observable], [ansatz.parameters[::-1]]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5][::-1])
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [1.84209213])
+        np.testing.assert_allclose(result.expectation_values, [1.84209213])
 
     def test_init_from_statevector(self):
         """test initialization from statevector"""
@@ -89,7 +89,7 @@ class TestEstimator(QiskitTestCase):
             np.testing.assert_allclose(est.circuits[0][0][0].params, vector)
             result = est()
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [-0.88272215])
+        np.testing.assert_allclose(result.expectation_values, [-0.88272215])
 
     def test_init_observable_from_operator(self):
         """test for evaluate without parameters"""
@@ -105,14 +105,14 @@ class TestEstimator(QiskitTestCase):
         with Estimator([circuit], [matrix]) as est:
             result = est()
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
+        np.testing.assert_allclose(result.expectation_values, [-1.284366511861733])
 
     def test_evaluate(self):
         """test for evaluate"""
         with Estimator([self.ansatz], [self.observable]) as est:
             result = est(parameter_values=[0, 1, 1, 2, 3, 5])
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
+        np.testing.assert_allclose(result.expectation_values, [-1.284366511861733])
 
     def test_evaluate_multi_params(self):
         """test for evaluate with multiple parameters"""
@@ -121,7 +121,9 @@ class TestEstimator(QiskitTestCase):
                 [0] * 2, [0] * 2, parameter_values=[[0, 1, 1, 2, 3, 5], [1, 1, 2, 3, 5, 8]]
             )
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [-1.284366511861733, -1.3187526349078742])
+        np.testing.assert_allclose(
+            result.expectation_values, [-1.284366511861733, -1.3187526349078742]
+        )
 
     def test_evaluate_no_params(self):
         """test for evaluate without parameters"""
@@ -129,7 +131,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator([circuit], [self.observable]) as est:
             result = est()
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [-1.284366511861733])
+        np.testing.assert_allclose(result.expectation_values, [-1.284366511861733])
 
     def test_run_with_multiple_observables_and_none_parameters(self):
         """test for evaluate without parameters"""
@@ -140,7 +142,7 @@ class TestEstimator(QiskitTestCase):
         with Estimator(circuit, ["ZZZ", "III"]) as est:
             result = est(circuit_indices=[0, 0], observable_indices=[0, 1])
         self.assertEstimatorResultType(result)
-        np.testing.assert_allclose(result.expvals, [0.0, 1.0])
+        np.testing.assert_allclose(result.expectation_values, [0.0, 1.0])
 
     def test_estimator_example(self):
         """test for Estimator example"""
@@ -162,25 +164,29 @@ class TestEstimator(QiskitTestCase):
             # calculate [ <psi1(theta1)|op1|psi1(theta1)> ]
             result = est([0], [0], [theta1])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1.5555572817900956])
+            np.testing.assert_allclose(result.expectation_values, [1.5555572817900956])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op2|psi1(theta1)>, <psi1(theta1)|op3|psi1(theta1)> ]
             result = est([0, 0], [1, 2], [theta1] * 2)
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [-0.5516530027638437, 0.07535238795415422])
+            np.testing.assert_allclose(
+                result.expectation_values, [-0.5516530027638437, 0.07535238795415422]
+            )
             self.assertEqual(len(result.metadata), 2)
 
             # calculate [ <psi2(theta2)|op2|psi2(theta2)> ]
             result = est([1], [1], [theta2])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [0.17849238433885167])
+            np.testing.assert_allclose(result.expectation_values, [0.17849238433885167])
             self.assertEqual(len(result.metadata), 1)
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)>, <psi1(theta3)|op1|psi1(theta3)> ]
             result = est([0, 0], [0, 0], [theta1, theta3])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1.5555572817900956, 1.0656325933346835])
+            np.testing.assert_allclose(
+                result.expectation_values, [1.5555572817900956, 1.0656325933346835]
+            )
             self.assertEqual(len(result.metadata), 2)
 
             # calculate [ <psi1(theta1)|op1|psi1(theta1)>,
@@ -189,7 +195,8 @@ class TestEstimator(QiskitTestCase):
             result = est([0, 1, 0], [0, 1, 2], [theta1, theta2, theta3])
             self.assertEstimatorResultType(result)
             np.testing.assert_allclose(
-                result.expvals, [1.5555572817900956, 0.17849238433885167, -1.0876631752254926]
+                result.expectation_values,
+                [1.5555572817900956, 0.17849238433885167, -1.0876631752254926],
             )
             self.assertEqual(len(result.metadata), 3)
 
@@ -205,19 +212,19 @@ class TestEstimator(QiskitTestCase):
         with Estimator([qc, qc2], [op, op2], [[]] * 2) as est:
             result = est([0], [0], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([0], [1], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([1], [0], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([1], [1], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [-1])
+            np.testing.assert_allclose(result.expectation_values, [-1])
 
     def test_2qubits(self):
         """Test for 2-qubit cases (to check endian)"""
@@ -232,27 +239,27 @@ class TestEstimator(QiskitTestCase):
         with Estimator([qc, qc2], [op, op2, op3], [[]] * 2) as est:
             result = est([0], [0], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([1], [0], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([0], [1], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([1], [1], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([0], [2], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [1])
+            np.testing.assert_allclose(result.expectation_values, [1])
 
             result = est([1], [2], [[]])
             self.assertEstimatorResultType(result)
-            np.testing.assert_allclose(result.expvals, [-1])
+            np.testing.assert_allclose(result.expectation_values, [-1])
 
     def test_errors(self):
         """Test for errors"""
@@ -284,13 +291,13 @@ class TestEstimator(QiskitTestCase):
         with Estimator(circuits=[qc] * 10, observables=[op] * 10) as estimator:
             with self.subTest("one circuit"):
                 result = estimator([0], [1], shots=1000)
-                np.testing.assert_allclose(result.expvals, [1])
+                np.testing.assert_allclose(result.expectation_values, [1])
                 self.assertEqual(len(result.variances), 1)
                 self.assertEqual(len(result.metadata), 1)
 
             with self.subTest("two circuits"):
                 result = estimator([2, 4], [3, 5], shots=1000)
-                np.testing.assert_allclose(result.expvals, [1, 1])
+                np.testing.assert_allclose(result.expectation_values, [1, 1])
                 self.assertEqual(len(result.variances), 2)
                 self.assertEqual(len(result.metadata), 2)
 
@@ -309,13 +316,13 @@ class TestEstimator(QiskitTestCase):
                 result = estimator([0] * k, [0] * k, params_array)
                 self.assertEqual(len(result.metadata), k)
                 self.assertEqual(len(result.variances), k)
-                np.testing.assert_allclose(result.expvals, target.expvals)
+                np.testing.assert_allclose(result.expectation_values, target.expectation_values)
 
             with self.subTest("list of ndarray"):
                 result = estimator([0] * k, [0] * k, params_list_array)
                 self.assertEqual(len(result.metadata), k)
                 self.assertEqual(len(result.variances), k)
-                np.testing.assert_allclose(result.expvals, target.expvals)
+                np.testing.assert_allclose(result.expectation_values, target.expectation_values)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Upgrades the `EstimatorResult` dataclass.

Breaking change*
Closes #8100 
Changelog: New Feature

### Details and comments
- Rename `values` field to `expectation_values`.
- Add `variances` field, pulling it out of `metadata`.
- Remove numpy array type in favor of core python tuple.
- Change `metadata` list type (mutable) in favor of tuple (immutable).

*Assuming that these objects are meant to be consumed by the users, not instantiated, the only breaking change is the `metadata` type change from list to tuple; since we can alias `expectation_values` to the old name `values` with the appropriate type casting.

### To do
- [x] Update `Estimator` class.
- [x] Fix and update tests.
- [ ] Add release note.