### PR TITLE
Remove erroneous LaTeX alignment character

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -105,7 +105,7 @@ class Pauli(BasePauli):
 
     .. math::
 
-        P &= (-i)^{q + z\cdot x} Z^z \cdot X^x.
+        P = (-i)^{q + z\cdot x} Z^z \cdot X^x
 
     The :math:`k`th qubit corresponds to the :math:`k`th entry in the
     :math:`z` and :math:`x` arrays

--- a/qiskit/quantum_info/operators/symplectic/pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli.py
@@ -105,7 +105,7 @@ class Pauli(BasePauli):
 
     .. math::
 
-        P = (-i)^{q + z\cdot x} Z^z \cdot X^x
+        P = (-i)^{q + z\cdot x} Z^z \cdot X^x.
 
     The :math:`k`th qubit corresponds to the :math:`k`th entry in the
     :math:`z` and :math:`x` arrays


### PR DESCRIPTION
@mberna found a MathJax syntax problem in https://qiskit.org/documentation/stubs/qiskit.quantum_info.Pauli.html
<img width="801" alt="image (14)" src="https://user-images.githubusercontent.com/766693/170113370-eff630c3-c207-4908-a300-86f2dfd2c10b.png">

The problem is that that there is an amp alignment in a single equation.

I dont think the fix needs reno nor changelog entry.