### PR TITLE
Fix return type of get_counts() for one-element circuit list

### DIFF
--- a/qiskit/result/result.py
+++ b/qiskit/result/result.py
@@ -69,6 +69,7 @@ class Result:
         if header is not None:
             self.header = header
         self._metadata.update(kwargs)
+        self.get_counts_type = None
 
     def __repr__(self):
         out = (
@@ -300,7 +301,7 @@ class Result:
                 raise QiskitError(f'No counts for experiment "{repr(key)}"')
 
         # Return first item of dict_list if size is 1
-        if len(dict_list) == 1:
+        if experiment is not None or self.get_counts_type != list and len(dict_list) == 1:
             return dict_list[0]
         else:
             return dict_list

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -493,6 +493,7 @@ class QuantumInstance:
             build_measurement_error_mitigation_circuits,
         )
 
+        circuits_type = type(circuits)
         if had_transpiled:
             # Convert to a list or make a copy.
             # The measurement mitigation logic expects a list and
@@ -720,6 +721,7 @@ class QuantumInstance:
         if self._circuit_summary:
             self._circuit_summary = False
 
+        result.get_counts_type = circuits_type
         return result
 
     def set_config(self, **kwargs):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #8103 and `get_counts()` return type depends only on what is passed to execute


### Details and comments
Need some feedback on where to add tests. 

