### PR TITLE
set T2 with the correct value in ConfigurableFakeBackend

### DIFF
--- a/qiskit/test/mock/utils/configurable_backend.py
+++ b/qiskit/test/mock/utils/configurable_backend.py
@@ -81,7 +81,7 @@ class ConfigurableFakeBackend(FakeBackend):
             qubit_t1 = np.random.normal(loc=qubit_t1 or 113.0, scale=std, size=n_qubits).tolist()
 
         if not isinstance(qubit_t2, list):
-            qubit_t2 = np.random.normal(loc=qubit_t1 or 150.2, scale=std, size=n_qubits).tolist()
+            qubit_t2 = np.random.normal(loc=qubit_t2 or 150.2, scale=std, size=n_qubits).tolist()
 
         if not isinstance(qubit_frequency, list):
             qubit_frequency = np.random.normal(

--- a/releasenotes/notes/fix-t2-configurablefakebackend-8660ab3d7a57a824.yaml
+++ b/releasenotes/notes/fix-t2-configurablefakebackend-8660ab3d7a57a824.yaml
@@ -1,6 +1,5 @@
 ---
 fixes:
   - |
-    Fixed T2 in ConfigurableFakeBackend by setting it with the
-    correct input value
-
+    Fixed the ``t2`` attribute of ``qiskit.providers.fake_provider.ConfigurableFakeBackend``,
+    which was previously incorrectly set based on the provided ``t1``.

--- a/releasenotes/notes/fix-t2-configurablefakebackend-8660ab3d7a57a824.yaml
+++ b/releasenotes/notes/fix-t2-configurablefakebackend-8660ab3d7a57a824.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed T2 in ConfigurableFakeBackend by setting it with the
+    correct input value
+

--- a/test/python/mock/test_configurable_backend.py
+++ b/test/python/mock/test_configurable_backend.py
@@ -56,8 +56,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
                 self.assertEqual(properties.backend_name, "Tashkent")
                 self.assertEqual(len(properties.qubits), n_qubits)
                 self.assertEqual(len(properties.gates), n_qubits)
-                self.assertAlmostEqual(properties.t1(0), 9.9e-5, places=7)
-                self.assertAlmostEqual(properties.t2(0), 14.6e-5, places=7)
+                self.assertAlmostEqual(properties.t1(0), 99e-6, places=7)
+                self.assertAlmostEqual(properties.t2(0), 146e-6, places=7)
 
                 configuration = fake_backend.configuration()
                 self.assertEqual(configuration.backend_version, "0.0.1")

--- a/test/python/mock/test_configurable_backend.py
+++ b/test/python/mock/test_configurable_backend.py
@@ -56,6 +56,8 @@ class TestConfigurableFakeBackend(QiskitTestCase):
                 self.assertEqual(properties.backend_name, "Tashkent")
                 self.assertEqual(len(properties.qubits), n_qubits)
                 self.assertEqual(len(properties.gates), n_qubits)
+                self.assertAlmostEqual(properties.t1(0), 9.9e-5, places=7)
+                self.assertAlmostEqual(properties.t2(0), 14.6e-5, places=7)
 
                 configuration = fake_backend.configuration()
                 self.assertEqual(configuration.backend_version, "0.0.1")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #8112 by setting T2 in `ConfigurableFakeBackend` with the input value


### Details and comments
Unit tests added to verify it works

