### PR TITLE
Correct output format for matplotlib in `QuantumCircuit.draw` docstrings

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1736,7 +1736,7 @@ class QuantumCircuit:
 
         **text**: ASCII art TextDrawing that can be printed in the console.
 
-        **matplotlib**: images with color rendered purely in Python.
+        **mpl**: images with color rendered purely in Python using matplotlib.
 
         **latex**: high-quality images compiled via latex.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR changes the misleading line
https://github.com/Qiskit/qiskit-terra/blob/56b0de6822dec3fe1d97c05f4a5ddf3c3f4d4174/qiskit/circuit/quantumcircuit.py#L1739
to be 
```
**mpl**: images with color rendered purely in Python using matplotlib.
```
as a new user most likely would try `output='matplotlib'` whereas the correct param is `output='mpl'`.

### Details and comments

The other output formats given in the docstring reflect the correct params, see https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.draw.html.


Closes #8119