### PR TITLE
Leverage rust marginalization function for marginal_counts()

### DIFF
--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -68,9 +68,7 @@ def marginal_counts(
         for i, experiment_result in enumerate(result.results):
             counts = result.get_counts(i)
             new_counts = _marginalize(counts, indices)
-            new_counts_hex = {}
-            for k, v in new_counts.items():
-                new_counts_hex[_bin_to_hex(k)] = v
+            new_counts_hex = {_bin_to_hex(k): v for k, v in new_counts.items()}
             experiment_result.data.counts = new_counts_hex
 
             if indices is not None:
@@ -189,14 +187,7 @@ def _marginalize(counts, indices=None):
 
     # Sort the indices to keep in descending order
     # Since bitstrings have qubit-0 as least significant bit
-    indices = sorted(indices, reverse=True)
-
-    # Build the return list
-    new_counts = Counter()
-    for key, val in counts.items():
-        new_key = "".join([_remove_space_underscore(key)[-idx - 1] for idx in indices])
-        new_counts[new_key] += val
-    return dict(new_counts)
+    return results_rs.marginal_counts(counts, sorted(indices))
 
 
 def _format_marginal(counts, marg_counts, indices):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #8026 we added a new marginalization function marginal_distribution()
which was a standalone marginalization function for counts and
distribution dictionaries. The core of that new function was written in
rust for performance. In that PR we didn't use the rust core because
it's behavior was slightly different especially around the order of
indices. This commit reworks the internals of the marginal_counts()
function to leverage the same rust core function to ensure the ordering
is consistent after the migration the index sort is changed.

### Details and comments