### PR TITLE
Add function to easily generate preset pass managers

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -11,7 +11,6 @@
 # that they have been altered from the originals.
 
 """Circuit transpile function"""
-import datetime
 import logging
 import warnings
 from time import time
@@ -40,7 +39,7 @@ from qiskit.transpiler.preset_passmanagers import (
     level_3_pass_manager,
 )
 from qiskit.transpiler.timing_constraints import TimingConstraints
-from qiskit.transpiler.target import Target
+from qiskit.transpiler.target import Target, target_to_backend_properties
 
 logger = logging.getLogger(__name__)
 
@@ -515,7 +514,7 @@ def _parse_transpile_args(
         if timing_constraints is None:
             timing_constraints = target.timing_constraints()
         if backend_properties is None:
-            backend_properties = _target_to_backend_properties(target)
+            backend_properties = target_to_backend_properties(target)
 
     basis_gates = _parse_basis_gates(basis_gates, backend, circuits)
     inst_map = _parse_inst_map(inst_map, backend, num_circuits)
@@ -717,86 +716,6 @@ def _parse_coupling_map(coupling_map, backend, num_circuits):
     return coupling_map
 
 
-def _target_to_backend_properties(target: Target):
-    properties_dict = {
-        "backend_name": "",
-        "backend_version": "",
-        "last_update_date": None,
-        "general": [],
-    }
-    gates = []
-    qubits = []
-    for gate, qargs_list in target.items():
-        if gate != "measure":
-            for qargs, props in qargs_list.items():
-                property_list = []
-                if props is not None:
-                    if props.duration is not None:
-                        property_list.append(
-                            {
-                                "date": datetime.datetime.utcnow(),
-                                "name": "gate_length",
-                                "unit": "s",
-                                "value": props.duration,
-                            }
-                        )
-                    if props.error is not None:
-                        property_list.append(
-                            {
-                                "date": datetime.datetime.utcnow(),
-                                "name": "gate_error",
-                                "unit": "",
-                                "value": props.error,
-                            }
-                        )
-                if property_list:
-                    gates.append(
-                        {
-                            "gate": gate,
-                            "qubits": list(qargs),
-                            "parameters": property_list,
-                            "name": gate + "_".join([str(x) for x in qargs]),
-                        }
-                    )
-        else:
-            qubit_props = {x: None for x in range(target.num_qubits)}
-            for qargs, props in qargs_list.items():
-                if qargs is None:
-                    continue
-                qubit = qargs[0]
-                props_list = []
-                if props.error is not None:
-                    props_list.append(
-                        {
-                            "date": datetime.datetime.utcnow(),
-                            "name": "readout_error",
-                            "unit": "",
-                            "value": props.error,
-                        }
-                    )
-                if props.duration is not None:
-                    props_list.append(
-                        {
-                            "date": datetime.datetime.utcnow(),
-                            "name": "readout_length",
-                            "unit": "s",
-                            "value": props.duration,
-                        }
-                    )
-                if not props_list:
-                    qubit_props = {}
-                    break
-                qubit_props[qubit] = props_list
-            if qubit_props and all(x is not None for x in qubit_props.values()):
-                qubits = [qubit_props[i] for i in range(target.num_qubits)]
-    if gates or qubits:
-        properties_dict["gates"] = gates
-        properties_dict["qubits"] = qubits
-        return BackendProperties.from_dict(properties_dict)
-    else:
-        return None
-
-
 def _parse_backend_properties(backend_properties, backend, num_circuits):
     # try getting backend_properties from user, else backend
     if backend_properties is None:
@@ -832,7 +751,7 @@ def _parse_backend_properties(backend_properties, backend, num_circuits):
 
                     backend_properties.gates = gates
         else:
-            backend_properties = _target_to_backend_properties(backend.target)
+            backend_properties = target_to_backend_properties(backend.target)
     if not isinstance(backend_properties, list):
         backend_properties = [backend_properties] * num_circuits
     return backend_properties

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -612,6 +612,7 @@ Pass Manager Construction
 .. autosummary::
    :toctree: ../stubs/
 
+   generate_preset_pass_manager
    PassManager
    PassManagerConfig
    PropertySet
@@ -677,3 +678,4 @@ from .instruction_durations import InstructionDurations
 from .target import Target
 from .target import InstructionProperties
 from .target import QubitProperties
+from .preset_passmanagers import generate_preset_pass_manager

--- a/qiskit/transpiler/__init__.py
+++ b/qiskit/transpiler/__init__.py
@@ -612,7 +612,6 @@ Pass Manager Construction
 .. autosummary::
    :toctree: ../stubs/
 
-   generate_preset_pass_manager
    PassManager
    PassManagerConfig
    PropertySet
@@ -678,4 +677,3 @@ from .instruction_durations import InstructionDurations
 from .target import Target
 from .target import InstructionProperties
 from .target import QubitProperties
-from .preset_passmanagers import generate_preset_pass_manager

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -20,13 +20,180 @@ Preset Passmanagers (:mod:`qiskit.transpiler.preset_passmanagers`)
 .. autosummary::
    :toctree: ../stubs/
 
+   generate_preset_pass_manager
    level_0_pass_manager
    level_1_pass_manager
    level_2_pass_manager
    level_3_pass_manager
 """
 
+from qiskit.transpiler.passmanager_config import PassManagerConfig
+
 from .level0 import level_0_pass_manager
 from .level1 import level_1_pass_manager
 from .level2 import level_2_pass_manager
 from .level3 import level_3_pass_manager
+
+
+def generate_preset_pass_manager(
+    optimization_level,
+    backend=None,
+    target=None,
+    basis_gates=None,
+    inst_map=None,
+    coupling_map=None,
+    instruction_durations=None,
+    backend_properties=None,
+    timing_constraints=None,
+    initial_layout=None,
+    layout_method=None,
+    routing_method=None,
+    translation_method=None,
+    scheduling_method=None,
+    approximation_degree=None,
+    seed_transpiler=None,
+    unitary_synthesis_method="default",
+    unitary_synthesis_plugin_config=None,
+):
+    """Generate a preset :class:`~.PassManager`
+
+    This function is used to quickly generate a preset pass manager. A preset pass
+    manager are the default pass managers used by the :func:`~.transpile`
+    function. This function provides a convenient and simple method to construct
+    a standalone :class:`~.PassManager` object that mirrors what the transpile
+
+
+    Args:
+        optimization_level (int): The optimization level to generate a
+            :class:`~.PassManager` for. This can be 0, 1, 2, or 3. Higher
+            levels generate more optimized circuits, at the expense of
+            longer transpilation time:
+
+                * 0: no optimization
+                * 1: light optimization
+                * 2: heavy optimization
+                * 3: even heavier optimization
+
+        backend (Backend): An optional backend object which can be used as the
+            source of the default values for the ``basis_gates``, ``inst_map``,
+            ``couplig_map``, ``backend_properties``, ``instruction_durations``,
+            ``timing_constraints``, and ``target``. If any of those other arguments
+            are specified in addition to ``backend`` they will take precedence
+            over the value contained in the backend.
+        target (Target): The :class:`~.Target` representing a backend compilation
+            target
+        basis_gates (list): List of basis gate names to unroll to
+            (e.g: ``['u1', 'u2', 'u3', 'cx']``).
+        inst_map (InstructionScheduleMap): Mapping object that maps gate to schedules.
+            If any user defined calibration is found in the map and this is used in a
+            circuit, transpiler attaches the custom gate definition to the circuit.
+            This enables one to flexibly override the low-level instruction
+            implementation.
+        coupling_map (CouplingMap): Directed graph represented a coupling
+            map.
+        instruction_durations (InstructionDurations): Dictionary of duration
+            (in dt) for each instruction.
+        timing_constraints (TimingConstraints): Hardware time alignment restrictions.
+        initial_layout (Layout): Initial position of virtual qubits on
+            physical qubits.
+        layout_method (str): the :class:`~.Pass` to use for choosing initial qubit
+            placement. Valid choices are ``'trivial'``, ``'dense'``, ``'noise_adaptive'``,
+            and, ``'sabre'`` repsenting :class:`~.TrivialLayout`, :class:`~DenseLayout`,
+            :class:`~.NoiseAdaptiveLayout`, :class:`~.SabreLayout` respectively.
+        routing_method (str): the pass to use for routing qubits on the
+            architecture. Valid choices are ``'basic'``, ``'lookahead'``, ``'stochastic'``,
+            ``'sabre'``, and ``'none'`` representing :class:`~.BasicSwap`,
+            :class:`~.LookaheadSwap`, :class:`~.StochasticSwap`, :class:`~.SabreSwap`, and
+            erroring if routing is required respectively.
+        translation_method (str): the method to use for translating gates to
+            basis_gates. Valid choices ``'unroller'``, ``'translator'``, ``'synthesis'``
+            representing :class:`~.Unroller`, :class:`~.BasisTranslator`, and
+            :class:`~.UnitarySynthesis` respectively.
+        scheduling_method (str): the pass to use for scheduling instructions. Valid choices
+            are ``'alap'`` and ``'asap``.
+        backend_properties (BackendProperties): Properties returned by a
+            backend, including information on gate errors, readout errors,
+            qubit coherence times, etc.
+        approximation_degree (float): heuristic dial used for circuit approximation
+            (1.0=no approximation, 0.0=maximal approximation)
+        seed_transpiler (int): Sets random seed for the stochastic parts of
+            the transpiler.
+        unitary_synthesis_method (str): The name of the unitary synthesis
+            method to use. By default 'default' is used, which is the only
+            method included with qiskit. If you have installed any unitary
+            synthesis plugins you can use the name exported by the plugin.
+        unitary_synthesis_plugin_config (dict): An optional configuration dictionary
+            that will be passed directly to the unitary synthesis plugin. By
+            default this setting will have no effect as the default unitary
+            synthesis method does not take custom configuration. This should
+            only be necessary when a unitary synthesis plugin is specified with
+            the ``unitary_synthesis`` argument. As this is custom for each
+            unitary synthesis plugin refer to the plugin documentation for how
+            to use this option.
+
+    Returns:
+        PassManager: The preset pass manager for the given options
+
+    Raises:
+        ValueError: if an invalid value for ``optimization_level`` is passed in.
+    """
+
+    if backend is not None:
+        pm_config = PassManagerConfig.from_backend(
+            backend,
+            target=target,
+            basis_gates=basis_gates,
+            inst_map=inst_map,
+            coupling_map=coupling_map,
+            instruction_durations=instruction_durations,
+            backend_properties=backend_properties,
+            timing_constraints=timing_constraints,
+            layout_method=layout_method,
+            routing_method=routing_method,
+            translation_method=translation_method,
+            scheduling_method=scheduling_method,
+            approximation_degree=approximation_degree,
+            seed_transpiler=seed_transpiler,
+            unitary_synthesis_method=unitary_synthesis_method,
+            unitary_synthesis_plugin_config=unitary_synthesis_plugin_config,
+            initial_layout=initial_layout,
+        )
+    else:
+        pm_config = PassManagerConfig(
+            target=target,
+            basis_gates=basis_gates,
+            inst_map=inst_map,
+            coupling_map=coupling_map,
+            instruction_durations=instruction_durations,
+            backend_properties=backend_properties,
+            timing_constraints=timing_constraints,
+            layout_method=layout_method,
+            routing_method=routing_method,
+            translation_method=translation_method,
+            scheduling_method=scheduling_method,
+            approximation_degree=approximation_degree,
+            seed_transpiler=seed_transpiler,
+            unitary_synthesis_method=unitary_synthesis_method,
+            unitary_synthesis_plugin_config=unitary_synthesis_plugin_config,
+            initial_layout=initial_layout,
+        )
+    if optimization_level == 0:
+        pm = level_0_pass_manager(pm_config)
+    elif optimization_level == 1:
+        pm = level_1_pass_manager(pm_config)
+    elif optimization_level == 2:
+        pm = level_2_pass_manager(pm_config)
+    elif optimization_level == 3:
+        pm = level_3_pass_manager(pm_config)
+    else:
+        raise ValueError(f"Invalid optimization level {optimization_level}")
+    return pm
+
+
+__all__ = [
+    "level_0_pass_manager",
+    "level_1_pass_manager",
+    "level_2_pass_manager",
+    "level_3_pass_manager",
+    "generate_preset_pass_manager",
+]

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -28,6 +28,7 @@ Preset Passmanagers (:mod:`qiskit.transpiler.preset_passmanagers`)
 """
 
 from qiskit.transpiler.passmanager_config import PassManagerConfig
+from qiskit.transpiler.target import target_to_backend_properties
 
 from .level0 import level_0_pass_manager
 from .level1 import level_1_pass_manager
@@ -137,6 +138,21 @@ def generate_preset_pass_manager(
     Raises:
         ValueError: if an invalid value for ``optimization_level`` is passed in.
     """
+    if target is not None:
+        if coupling_map is None:
+            coupling_map = target.build_coupling_map()
+        if basis_gates is None:
+            basis_gates = target.operation_names
+        if instruction_durations is None:
+            instruction_durations = target.durations()
+        if inst_map is None:
+            inst_map = target.instruction_schedule_map()
+        if dt is None:
+            dt = target.dt
+        if timing_constraints is None:
+            timing_constraints = target.timing_constraints()
+        if backend_properties is None:
+            backend_properties = target_to_backend_properties(target)
 
     if backend is not None:
         pm_config = PassManagerConfig.from_backend(

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -154,45 +154,30 @@ def generate_preset_pass_manager(
         if backend_properties is None:
             backend_properties = target_to_backend_properties(target)
 
+    pm_options = dict(
+        target=target,
+        basis_gates=basis_gates,
+        inst_map=inst_map,
+        coupling_map=coupling_map,
+        instruction_durations=instruction_durations,
+        backend_properties=backend_properties,
+        timing_constraints=timing_constraints,
+        layout_method=layout_method,
+        routing_method=routing_method,
+        translation_method=translation_method,
+        scheduling_method=scheduling_method,
+        approximation_degree=approximation_degree,
+        seed_transpiler=seed_transpiler,
+        unitary_synthesis_method=unitary_synthesis_method,
+        unitary_synthesis_plugin_config=unitary_synthesis_plugin_config,
+        initial_layout=initial_layout,
+    )
+
     if backend is not None:
-        pm_config = PassManagerConfig.from_backend(
-            backend,
-            target=target,
-            basis_gates=basis_gates,
-            inst_map=inst_map,
-            coupling_map=coupling_map,
-            instruction_durations=instruction_durations,
-            backend_properties=backend_properties,
-            timing_constraints=timing_constraints,
-            layout_method=layout_method,
-            routing_method=routing_method,
-            translation_method=translation_method,
-            scheduling_method=scheduling_method,
-            approximation_degree=approximation_degree,
-            seed_transpiler=seed_transpiler,
-            unitary_synthesis_method=unitary_synthesis_method,
-            unitary_synthesis_plugin_config=unitary_synthesis_plugin_config,
-            initial_layout=initial_layout,
-        )
+        pm_config = PassManagerConfig.from_backend(backend, **pm_options)
     else:
-        pm_config = PassManagerConfig(
-            target=target,
-            basis_gates=basis_gates,
-            inst_map=inst_map,
-            coupling_map=coupling_map,
-            instruction_durations=instruction_durations,
-            backend_properties=backend_properties,
-            timing_constraints=timing_constraints,
-            layout_method=layout_method,
-            routing_method=routing_method,
-            translation_method=translation_method,
-            scheduling_method=scheduling_method,
-            approximation_degree=approximation_degree,
-            seed_transpiler=seed_transpiler,
-            unitary_synthesis_method=unitary_synthesis_method,
-            unitary_synthesis_plugin_config=unitary_synthesis_plugin_config,
-            initial_layout=initial_layout,
-        )
+        pm_config = PassManagerConfig(**pm_options)
+
     if optimization_level == 0:
         pm = level_0_pass_manager(pm_config)
     elif optimization_level == 1:

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -147,8 +147,6 @@ def generate_preset_pass_manager(
             instruction_durations = target.durations()
         if inst_map is None:
             inst_map = target.instruction_schedule_map()
-        if dt is None:
-            dt = target.dt
         if timing_constraints is None:
             timing_constraints = target.timing_constraints()
         if backend_properties is None:

--- a/qiskit/transpiler/preset_passmanagers/__init__.py
+++ b/qiskit/transpiler/preset_passmanagers/__init__.py
@@ -82,7 +82,10 @@ def generate_preset_pass_manager(
             are specified in addition to ``backend`` they will take precedence
             over the value contained in the backend.
         target (Target): The :class:`~.Target` representing a backend compilation
-            target
+            target. The following attributes will be inferred from this
+            argument if they are not set: ``coupling_map``, ``basis_gates``,
+            ``instruction_durations``, ``inst_map``, ``timing_constraints``
+            and ``backend_properties``.
         basis_gates (list): List of basis gate names to unroll to
             (e.g: ``['u1', 'u2', 'u3', 'cx']``).
         inst_map (InstructionScheduleMap): Mapping object that maps gate to schedules.
@@ -97,26 +100,26 @@ def generate_preset_pass_manager(
         timing_constraints (TimingConstraints): Hardware time alignment restrictions.
         initial_layout (Layout): Initial position of virtual qubits on
             physical qubits.
-        layout_method (str): the :class:`~.Pass` to use for choosing initial qubit
+        layout_method (str): The :class:`~.Pass` to use for choosing initial qubit
             placement. Valid choices are ``'trivial'``, ``'dense'``, ``'noise_adaptive'``,
             and, ``'sabre'`` repsenting :class:`~.TrivialLayout`, :class:`~DenseLayout`,
             :class:`~.NoiseAdaptiveLayout`, :class:`~.SabreLayout` respectively.
-        routing_method (str): the pass to use for routing qubits on the
+        routing_method (str): The pass to use for routing qubits on the
             architecture. Valid choices are ``'basic'``, ``'lookahead'``, ``'stochastic'``,
             ``'sabre'``, and ``'none'`` representing :class:`~.BasicSwap`,
             :class:`~.LookaheadSwap`, :class:`~.StochasticSwap`, :class:`~.SabreSwap`, and
             erroring if routing is required respectively.
-        translation_method (str): the method to use for translating gates to
-            basis_gates. Valid choices ``'unroller'``, ``'translator'``, ``'synthesis'``
+        translation_method (str): The method to use for translating gates to
+            basis gates. Valid choices ``'unroller'``, ``'translator'``, ``'synthesis'``
             representing :class:`~.Unroller`, :class:`~.BasisTranslator`, and
             :class:`~.UnitarySynthesis` respectively.
-        scheduling_method (str): the pass to use for scheduling instructions. Valid choices
-            are ``'alap'`` and ``'asap``.
+        scheduling_method (str): The pass to use for scheduling instructions. Valid choices
+            are ``'alap'`` and ``'asap'``.
         backend_properties (BackendProperties): Properties returned by a
             backend, including information on gate errors, readout errors,
             qubit coherence times, etc.
-        approximation_degree (float): heuristic dial used for circuit approximation
-            (1.0=no approximation, 0.0=maximal approximation)
+        approximation_degree (float): Heuristic dial used for circuit approximation
+            (1.0=no approximation, 0.0=maximal approximation).
         seed_transpiler (int): Sets random seed for the stochastic parts of
             the transpiler.
         unitary_synthesis_method (str): The name of the unitary synthesis

--- a/releasenotes/notes/generate_pass_manager_preset-1e6c9641accd5d60.yaml
+++ b/releasenotes/notes/generate_pass_manager_preset-1e6c9641accd5d60.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    Added a new function :func:`qiskit.transpiler.generate_preset_pass_manager` which can
+    be used to quickly generate a preset :class:`~.PassManager` object that mirrors the
+    :class:`~.PassManager` used internally by the :func:`~.transpile` function. For example::
+
+      from qiskit.transpiler import generate_preset_pass_manager
+      from qiskit.providers.fake_provider import FakeWashingtonV2
+
+      # Generate an optimization level 3 pass manager targeting FakeWashingtonV2
+      pass_manager = generate_preset_pass_manager(3, FakeWashingtonV2())

--- a/releasenotes/notes/generate_pass_manager_preset-1e6c9641accd5d60.yaml
+++ b/releasenotes/notes/generate_pass_manager_preset-1e6c9641accd5d60.yaml
@@ -1,11 +1,11 @@
 ---
 features:
   - |
-    Added a new function :func:`qiskit.transpiler.generate_preset_pass_manager` which can
+    Added a new function :func:`~.generate_preset_pass_manager` which can
     be used to quickly generate a preset :class:`~.PassManager` object that mirrors the
     :class:`~.PassManager` used internally by the :func:`~.transpile` function. For example::
 
-      from qiskit.transpiler import generate_preset_pass_manager
+      from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
       from qiskit.providers.fake_provider import FakeWashingtonV2
 
       # Generate an optimization level 3 pass manager targeting FakeWashingtonV2

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -22,7 +22,7 @@ import numpy as np
 from qiskit import QuantumCircuit, ClassicalRegister, QuantumRegister
 from qiskit.circuit import Qubit
 from qiskit.compiler import transpile, assemble
-from qiskit.transpiler import CouplingMap, Layout
+from qiskit.transpiler import CouplingMap, Layout, PassManager
 from qiskit.circuit.library import U2Gate, U3Gate
 from qiskit.test import QiskitTestCase
 from qiskit.test.mock import (
@@ -36,6 +36,7 @@ from qiskit.test.mock import (
 from qiskit.converters import circuit_to_dag
 from qiskit.circuit.library import GraphState
 from qiskit.quantum_info import random_unitary
+from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 
 
 def emptycircuit():
@@ -940,3 +941,15 @@ class TestOptimizationOnSize(QiskitTestCase):
 
         self.assertLess(circ.size(), qc.size())
         self.assertLessEqual(circ.depth(), qc.depth())
+
+
+@ddt
+class TestGeenratePresetPassManagers(QiskitTestCase):
+    """Test generate_preset_pass_manager function."""
+
+    @data(0, 1, 2, 3)
+    def test_with_backend(self, optimization_level):
+        """Test a passmanager is constructed when only a backend and optimization level."""
+        target = FakeTokyo()
+        pm = generate_preset_pass_manager(optimization_level, target)
+        self.assertIsInstance(pm, PassManager)

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -32,6 +32,7 @@ from qiskit.test.mock import (
     FakeRueschlikon,
     FakeTokyo,
     FakePoughkeepsie,
+    FakeLagosV2,
 )
 from qiskit.converters import circuit_to_dag
 from qiskit.circuit.library import GraphState
@@ -953,3 +954,30 @@ class TestGeenratePresetPassManagers(QiskitTestCase):
         target = FakeTokyo()
         pm = generate_preset_pass_manager(optimization_level, target)
         self.assertIsInstance(pm, PassManager)
+
+    @data(0, 1, 2, 3)
+    def test_with_no_backend(self, optimization_level):
+        """Test a passmanager is constructed with no backend and optimization level."""
+        target = FakeLagosV2()
+        pm = generate_preset_pass_manager(
+            optimization_level,
+            coupling_map=target.coupling_map,
+            basis_gates=target.operation_names,
+            inst_map=target.instruction_schedule_map,
+            instruction_durations=target.instruction_durations,
+            timing_constraints=target.target.timing_constraints(),
+            target=target.target,
+        )
+        self.assertIsInstance(pm, PassManager)
+
+    @data(0, 1, 2, 3)
+    def test_with_no_backend_only_target(self, optimization_level):
+        """Test a passmanager is constructed with a manual target and optimization level."""
+        target = FakeLagosV2()
+        pm = generate_preset_pass_manager(optimization_level, target=target.target)
+        self.assertIsInstance(pm, PassManager)
+
+    def test_invalid_optimization_level(self):
+        """Assert we fail with an invalid optimization_level."""
+        with self.assertRaises(ValueError):
+            generate_preset_pass_manager(42)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new function, `generate_preset_pass_managers()`, which
is used to quickly generate the preset pass manager for manual
interaction. Prior to this new function there were lower level functions
which are used to generate the individual pass manager objects for each
optimization level but they are hidden behind an abstraction object,
`PassManagerConfig` which is the only input. This makes it harder to work
with because the user has to manually remember to generate the config
object prior to creating the pass manager. Similarly this new function
simplifies the creation of preset pass managers by having a single entry
point instead of 4 for each optimization level.

### Details and comments