### PR TITLE
Fix double matrix computation in numpy eigensolver

### DIFF
--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -132,13 +132,9 @@ class NumPyEigensolver(Eigensolver):
                     eigval, eigvec = np.linalg.eig(operator.to_matrix())
             else:
                 if operator.is_hermitian():
-                    eigval, eigvec = scisparse.linalg.eigsh(
-                        sp_mat, k=self._k, which="SA"
-                    )
+                    eigval, eigvec = scisparse.linalg.eigsh(sp_mat, k=self._k, which="SA")
                 else:
-                    eigval, eigvec = scisparse.linalg.eigs(
-                        sp_mat, k=self._k, which="SR"
-                    )
+                    eigval, eigvec = scisparse.linalg.eigs(sp_mat, k=self._k, which="SR")
             indices = np.argsort(eigval)[: self._k]
             eigval = eigval[indices]
             eigvec = eigvec[:, indices]

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -133,11 +133,11 @@ class NumPyEigensolver(Eigensolver):
             else:
                 if operator.is_hermitian():
                     eigval, eigvec = scisparse.linalg.eigsh(
-                        operator.to_spmatrix(), k=self._k, which="SA"
+                        sp_mat, k=self._k, which="SA"
                     )
                 else:
                     eigval, eigvec = scisparse.linalg.eigs(
-                        operator.to_spmatrix(), k=self._k, which="SR"
+                        sp_mat, k=self._k, which="SR"
                     )
             indices = np.argsort(eigval)[: self._k]
             eigval = eigval[indices]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the CONTRIBUTING document.
-->

### Summary

Trivial perf bugfix in NumpyEigensolver (to_spmatrix() was called twice on some paths, instead of first resullt being reused.

### Details and comments

In the code of _solve(), `sp_mat `is assigned the result of `operator.to_spmatrix()`.  Later, on two code-paths, that expression is recomputed, instead of `sp_mat` being reused.  That's it.  A trivial performance fix (b/c `to_spmatrix()` can be very, very expensive for large operators.
