### PR TITLE
fixed issue 8126 by setting coeff = 1 in suzuki.py

### DIFF
--- a/qiskit/opflow/evolutions/trotterizations/suzuki.py
+++ b/qiskit/opflow/evolutions/trotterizations/suzuki.py
@@ -60,6 +60,7 @@ class Suzuki(TrotterizationBase):
 
         if isinstance(operator.coeff, (float, ParameterExpression)):
             coeff = operator.coeff
+            coeff = 1
         else:
             if isreal(operator.coeff):
                 coeff = operator.coeff.real


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

fixes #8126 

### Details and comments
I fixed this issue by implementing the proposal on the project page by setting coef =1 in (https://github.com/Qiskit/qiskit-terra/blob/2eee56616d50a9e26756f855ef4aa0135920ad78/qiskit/opflow/evolutions/trotterizations/suzuki.py#L62)

This is fixing issue 8126
https://github.com/Qiskit/qiskit-terra/issues/8126
