### PR TITLE
Document that ParametricPulse.validate_parameters is for internal use only.

### DIFF
--- a/qiskit/pulse/library/parametric_pulses.py
+++ b/qiskit/pulse/library/parametric_pulses.py
@@ -82,7 +82,8 @@ class ParametricPulse(Pulse):
     @abstractmethod
     def validate_parameters(self) -> None:
         """
-        Validate parameters.
+        Validate parameters. This is an internal check for subclasses and should
+        not be interpreted or used as part of the user-facing API.
 
         Raises:
             PulseError: If the parameters passed are not valid.

--- a/releasenotes/notes/update-parametric-pulse-documentation-b1fd3c39064aabe5.yaml
+++ b/releasenotes/notes/update-parametric-pulse-documentation-b1fd3c39064aabe5.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Additional documentation has been added to
+    :method:`~.pulse.library.ParametricPulse.validate_parameters`
+    which clarifies that this method serves only as an internal check for subclasses
+    and should not be interpreted or used as a part of the user-facing API. Refer to
+    `#7882 <https://github.com/Qiskit/qiskit-terra/issues/7882>` for more details.


### PR DESCRIPTION
### Summary

Fixes #7882 by updating the documentation of `qiskit.pulse.library.ParametricPulse.validate_parameters` to note that this method is an internal check for subclasses and should not be interpreted or used as a part of the user-facing API.
