### PR TITLE
Use algorithm_globals.random as default RNG

### DIFF
--- a/qiskit/quantum_info/operators/random.py
+++ b/qiskit/quantum_info/operators/random.py
@@ -19,6 +19,7 @@ from numpy.random import default_rng
 
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators import Operator, Stinespring
+from qiskit.utils import algorithm_globals
 
 # pylint: disable=unused-import
 from .dihedral.random import random_cnotdihedral
@@ -30,7 +31,7 @@ from .symplectic.random import (
     random_stabilizer_table,
 )
 
-DEFAULT_RNG = default_rng()
+DEFAULT_RNG = algorithm_globals.random
 
 
 def random_unitary(dims, seed=None):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
Use algorithm_globals.random as default RNG in random operator generation routines.


### Details and comments


