### PR TITLE
enable rust optimization for "pip install"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ features = ["rayon"]
 [profile.release]
 lto = 'fat'
 codegen-units = 1
+
+[profile.dev]
+opt-level = 3


### PR DESCRIPTION
"pip install" uses "python setup.py develop", and that
doesn't enable rustc optimizations.

I also tried "python setup.py install", and found that that
didn't seem to properly enable rustc optimizations, but it's
possible I made a mistake in my investigation.

In any case, this is worth a 10x improvement on the rust
reimplementation of BasicPauli._to_matrix, and I suspect
that it'll improve things elsewhere.

Author: chetsky@gmail.com, Chetan.Murthy@ibm.com

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


