### PR TITLE
Fix QASM 3 exporter not respecting unknown `basis_gates`

### DIFF
--- a/qiskit/qasm3/exporter.py
+++ b/qiskit/qasm3/exporter.py
@@ -168,6 +168,8 @@ class Exporter:
 class GlobalNamespace:
     """Global namespace dict-like."""
 
+    BASIS_GATE = object()
+
     qiskit_gates = {
         "p": standard_gates.PhaseGate,
         "x": standard_gates.XGate,
@@ -205,7 +207,7 @@ class GlobalNamespace:
     include_paths = [abspath(join(dirname(__file__), "..", "qasm", "libs"))]
 
     def __init__(self, includelist, basis_gates=()):
-        self._data = {gate: None for gate in basis_gates}
+        self._data = {gate: self.BASIS_GATE for gate in basis_gates}
 
         for includefile in includelist:
             if includefile == "stdgates.inc":
@@ -240,13 +242,13 @@ class GlobalNamespace:
             return True
         if id(instruction) in self._data:
             return True
+        if self._data.get(instruction.name) is self.BASIS_GATE:
+            return True
         if type(instruction) in [Gate, Instruction]:  # user-defined instructions/gate
             return self._data.get(instruction.name, None) == instruction
-        if instruction.name in self._data:
-            if self._data.get(instruction.name) is None:  # it is a basis gate:
-                return True
-            if isinstance(instruction, self._data.get(instruction.name)):
-                return True
+        type_ = self._data.get(instruction.name)
+        if isinstance(type_, type) and isinstance(instruction, type_):
+            return True
         return False
 
     def register(self, instruction):

--- a/releasenotes/notes/qasm3-fix-basis-gates-c96a0b357dfdcb47.yaml
+++ b/releasenotes/notes/qasm3-fix-basis-gates-c96a0b357dfdcb47.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The OpenQASM 3 exporter (:mod:`qiskit.qasm3`) will no longer attempt to produce
+    definitions for non-standard gates in the `basis_gates` option.

--- a/test/python/circuit/test_circuit_qasm3.py
+++ b/test/python/circuit/test_circuit_qasm3.py
@@ -22,7 +22,7 @@ import unittest
 from ddt import ddt, data
 
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit, transpile
-from qiskit.circuit import Parameter, Qubit, Clbit, Instruction
+from qiskit.circuit import Parameter, Qubit, Clbit, Instruction, Gate
 from qiskit.test import QiskitTestCase
 from qiskit.qasm3 import Exporter, dumps, dump, QASM3ExporterError
 from qiskit.qasm3.exporter import QASM3Builder
@@ -733,6 +733,27 @@ class TestCircuitQASM3(QiskitTestCase):
         self.assertEqual(
             Exporter(includes=[], basis_gates=["cx", "z", "U"]).dumps(transpiled),
             expected_qasm,
+        )
+
+    def test_opaque_instruction_in_basis_gates(self):
+        """Test that an instruction that is set in the basis gates is output verbatim with no
+        definition."""
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.append(Gate("my_gate", 1, []), [0], [])
+
+        basis_gates = ["my_gate", "x"]
+        transpiled = transpile(qc, initial_layout=[0])
+        expected_qasm = "\n".join(
+            [
+                "OPENQASM 3;",
+                "x $0;",
+                "my_gate $0;",
+                "",
+            ]
+        )
+        self.assertEqual(
+            Exporter(includes=[], basis_gates=basis_gates).dumps(transpiled), expected_qasm
         )
 
     def test_reset_statement(self):


### PR DESCRIPTION
### Summary

Previously the logic in the QASM 3 exporter was out-of-order, and would
ignore non-standard names added to `basis_gates`.  This changes the
logic order to correctly assume that everything in `basis_gates` is
automatically defined.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #8159.

