### PR TITLE
Guard against floating-point errors resulting from np.abs

### DIFF
--- a/qiskit/pulse/library/waveform.py
+++ b/qiskit/pulse/library/waveform.py
@@ -12,6 +12,7 @@
 
 """A pulse that is described by complex-valued sample points."""
 from __future__ import annotations
+from sys import float_info
 from typing import Any
 
 import numpy as np
@@ -72,8 +73,11 @@ class Waveform(Pulse):
         Raises:
             PulseError: If there exists a pulse sample with a norm greater than 1+epsilon.
         """
+        # On some architectures `np.abs` results in floating-point errors
+        # of 1ULP, and the discrepancy needs to be accounted for.
+        ulp = float_info.epsilon
         samples_norm = np.abs(samples)
-        to_clip = (samples_norm > 1.0) & (samples_norm <= 1.0 + epsilon)
+        to_clip = (samples_norm > 1.0) & (samples_norm <= 1.0 + epsilon + ulp)
 
         if np.any(to_clip):
             # first try normalizing by the abs value
@@ -94,9 +98,15 @@ class Waveform(Pulse):
 
             # update samples with clipped values
             samples[clip_where] = clipped_samples
-            samples_norm[clip_where] = np.abs(clipped_samples)
 
-        if np.any(samples_norm > 1.0) and self._limit_amplitude:
+            # If we're within an epsilon from 1, then the normalized norms
+            # are expected to be strictly capped at 1.0.
+            # However, this needs to be enforced via `np.clip` due to the
+            # aforementioned floating-point errors resulting from the
+            # application of `np.abs`.
+            samples_norm[clip_where] = np.clip(np.abs(clipped_samples), 0.0, 1.0)
+
+        if self.limit_amplitude and np.any(samples_norm > 1.0):
             amp = np.max(samples_norm)
             raise PulseError(
                 f"Pulse contains sample with norm {amp} greater than 1+epsilon."


### PR DESCRIPTION
Fixes #8163.

### Summary
As discussed in issue #8163, due to floating-point errors, resulting from the application of `np.abs`, `Waveform` - upon initialization - may throw a `PulseError`, incorrectly suggesting that there is at least one sample with a norm greater than the sum of unity and arbitrary tolerance.

This adds a guard, which - via `np.clip` - ensures that in the corresponding cases, the norm will be strictly bounded between 0.0 and 1.0, inclusive, as it is logically expected to be.

### Details and comments

The solution is my own interpretation of @jakelishman's [suggestion](https://github.com/Qiskit/qiskit-terra/issues/7235#issuecomment-1148504161). Any errors and mistakes would be solely due to myself.

I would like to invite the reviewers for a discussion on what kind of unit tests could be added to the PR (given that the issue is not reproducible on all platforms), so that our confidence can be further increased that the proposed functionality is behaving as it should be.
Even though [the current set of unit tests](https://github.com/Qiskit/qiskit-terra/blob/a18df1456c79dbbd52dae1bd1185c68a0b3e891a/test/python/pulse/test_pulse_lib.py#L69) is good, I would like for the unit-test set to be further enriched, as part of this PR.

P.S.: Ideally, I would like to mark this PR as WIP, but I'm afraid I don't see this functionality on the qiskit-terra project.
