### PR TITLE
Fix the order of the Lie-Trotter formula in the documentation

### DIFF
--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -42,6 +42,9 @@ class LieTrotter(ProductFormula):
         [1]: D. Berry, G. Ahokas, R. Cleve and B. Sanders,
         "Efficient quantum algorithms for simulating sparse Hamiltonians" (2006).
         `arXiv:quant-ph/0508139 <https://arxiv.org/abs/quant-ph/0508139>`_
+        [2]: N. Hatano and M. Suzuki,
+        "Finding Exponential Product Formulas of Higher Orders" (2005).
+        `arXiv:math-ph/0506007 <https://arxiv.org/pdf/math-ph/0506007.pdf>`_
     """
 
     def __init__(

--- a/qiskit/synthesis/evolution/lie_trotter.py
+++ b/qiskit/synthesis/evolution/lie_trotter.py
@@ -24,7 +24,7 @@ class LieTrotter(ProductFormula):
     r"""The Lie-Trotter product formula.
 
     The Lie-Trotter formula approximates the exponential of two non-commuting operators
-    with products of their exponentials up to a first order error:
+    with products of their exponentials up to a second order error:
 
     .. math::
 
@@ -35,7 +35,7 @@ class LieTrotter(ProductFormula):
 
     .. math::
 
-        e^{-it(XX + ZZ)} = e^{-it XX}e^{-it ZZ} + \mathcal{O}(t).
+        e^{-it(XX + ZZ)} = e^{-it XX}e^{-it ZZ} + \mathcal{O}(t^2).
 
     References:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
The Lie-Trotter formula has a second order error [1][2].

### Details and comments
[1] https://arxiv.org/pdf/math-ph/0506007.pdf
[2] https://simons.berkeley.edu/sites/default/files/docs/15639/trottererrortheorysimons.pdf

