### PR TITLE
Replace deprecated threading.currentThread with current_thread

### DIFF
--- a/qiskit/tools/jupyter/backend_overview.py
+++ b/qiskit/tools/jupyter/backend_overview.py
@@ -236,7 +236,7 @@ def update_backend_info(self, interval=60):
     """Updates the monitor info
     Called from another thread.
     """
-    my_thread = threading.currentThread()
+    my_thread = threading.current_thread()
     current_interval = 0
     started = False
     all_dead = False


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [n/a] I have added the tests to cover my changes.
- [n/a] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

### Details and comments

Replace with `threading.current_thread`, added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174

