### PR TITLE
Fix for `None` in `state_to_latex` latex output

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -1185,19 +1185,19 @@ def num_to_latex_ket(raw_value: complex, first_term: bool) -> Optional[str]:
                 if element == "1":
                     element = ""
                 elif element == "-1":
-                    element = "-"
+                    element = "- "
             else:
 
                 if imag_value == 0 and real_value > 0:
-                    element = "+" + latex_element
+                    element = "+ " + latex_element
                 elif real_value == 0 and imag_value > 0:
-                    element = "+" + latex_element
+                    element = "+ " + latex_element
                 else:
                     element = latex_element
-                if element == "+1":
-                    element = "+"
-                elif element == "-1":
-                    element = "-"
+                if element == "+ 1":
+                    element = "+ "
+                elif element == "- 1":
+                    element = "- "
 
         return element
     else:
@@ -1242,24 +1242,29 @@ def _state_to_latex_ket(data: List[complex], max_size: int = 12) -> str:
 
     data = _round_if_close(data)
     nonzero_indices = np.where(data != 0)[0].tolist()
+    is_above_max_size = False
     if len(nonzero_indices) > max_size:
         nonzero_indices = (
             nonzero_indices[: max_size // 2] + [0] + nonzero_indices[-max_size // 2 + 1 :]
         )
         latex_terms = numbers_to_latex_terms(data[nonzero_indices])
         nonzero_indices[max_size // 2] = None
+        is_above_max_size = True
     else:
         latex_terms = numbers_to_latex_terms(data[nonzero_indices])
+        nonzero_indices = [idx for idx, term in enumerate(latex_terms) if term is not None]
 
     latex_str = ""
     for idx, ket_idx in enumerate(nonzero_indices):
-        if ket_idx is None:
-            latex_str += r" + \ldots "
-        else:
-            term = latex_terms[idx]
+        if ket_idx is not None:
+            latex_idx = idx if is_above_max_size else ket_idx
+            term = latex_terms[latex_idx]
             ket = ket_name(ket_idx)
-            latex_str += f"{term} |{ket}\\rangle"
-    return latex_str
+            latex_str += f"{term}|{ket}\\rangle "
+        else:
+            latex_str += "+ \\ldots "
+
+    return latex_str.strip()
 
 
 class TextMatrix:

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1121,6 +1121,7 @@ class TestStatevector(QiskitTestCase):
     def test_state_to_latex_for_none(self):
         """
         Test for `\rangleNone` output in latex representation
+        See https://github.com/Qiskit/qiskit-terra/issues/8169
         """
         sv = Statevector(
             [

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1118,39 +1118,62 @@ class TestStatevector(QiskitTestCase):
         with self.subTest(msg=" draw('latex', convention='vector')"):
             sv.draw("latex", convention="vector")
 
+    def test_state_to_latex_for_none(self):
+        """
+        Test for `\rangleNone` output in latex representation
+        """
+        sv = Statevector(
+            [
+                7.07106781e-01 - 8.65956056e-17j,
+                -5.55111512e-17 - 8.65956056e-17j,
+                7.85046229e-17 + 8.65956056e-17j,
+                -7.07106781e-01 + 8.65956056e-17j,
+                0.00000000e00 + 0.00000000e00j,
+                -0.00000000e00 + 0.00000000e00j,
+                -0.00000000e00 + 0.00000000e00j,
+                0.00000000e00 - 0.00000000e00j,
+            ],
+            dims=(2, 2, 2),
+        )
+        latex_representation = state_to_latex(sv)
+        self.assertEqual(
+            latex_representation,
+            "\\frac{\\sqrt{2}}{2}|000\\rangle - \\frac{\\sqrt{2}}{2}|011\\rangle",
+        )
+
     def test_state_to_latex_for_large_statevector(self):
         """Test conversion of large dense state vector"""
         sv = Statevector(np.ones((2**15, 1)))
         latex_representation = state_to_latex(sv)
         self.assertEqual(
             latex_representation,
-            " |000000000000000\\rangle+ |000000000000001\\rangle+ |000000000000010\\rangle+"
-            " |000000000000011\\rangle+ |000000000000100\\rangle+ |000000000000101\\rangle +"
-            " \\ldots + |111111111111011\\rangle+ |111111111111100\\rangle+"
-            " |111111111111101\\rangle+ |111111111111110\\rangle+ |111111111111111\\rangle",
+            "|000000000000000\\rangle + |000000000000001\\rangle + |000000000000010\\rangle +"
+            " |000000000000011\\rangle + |000000000000100\\rangle + |000000000000101\\rangle +"
+            " \\ldots + |111111111111011\\rangle + |111111111111100\\rangle +"
+            " |111111111111101\\rangle + |111111111111110\\rangle + |111111111111111\\rangle",
         )
 
     def test_state_to_latex_for_large_sparse_statevector(self):
         """Test conversion of large sparse state vector"""
         sv = Statevector(np.eye(2**15, 1))
         latex_representation = state_to_latex(sv)
-        self.assertEqual(latex_representation, " |000000000000000\\rangle")
+        self.assertEqual(latex_representation, "|000000000000000\\rangle")
 
     def test_number_to_latex_terms(self):
         """Test conversions of complex numbers to latex terms"""
 
         cases = [
             ([1 - 8e-17, 0], ["", None]),
-            ([0, -1], [None, "-"]),
+            ([0, -1], [None, "- "]),
             ([0, 1], [None, ""]),
             ([0, 1j], [None, "i"]),
-            ([-1, 1], ["-", "+"]),
+            ([-1, 1], ["- ", "+ "]),
             ([0, 1j], [None, "i"]),
-            ([-1, 1j], ["-", "+i"]),
+            ([-1, 1j], ["- ", "+ i"]),
             ([1e-16 + 1j], ["i"]),
-            ([-1 + 1e-16 * 1j], ["-"]),
-            ([-1, -1 - 1j], ["-", "+ (-1 - i)"]),
-            ([np.sqrt(2) / 2, np.sqrt(2) / 2], ["\\frac{\\sqrt{2}}{2}", "+\\frac{\\sqrt{2}}{2}"]),
+            ([-1 + 1e-16 * 1j], ["- "]),
+            ([-1, -1 - 1j], ["- ", "+ (-1 - i)"]),
+            ([np.sqrt(2) / 2, np.sqrt(2) / 2], ["\\frac{\\sqrt{2}}{2}", "+ \\frac{\\sqrt{2}}{2}"]),
             ([1 + np.sqrt(2)], ["(1 + \\sqrt{2})"]),
         ]
         for numbers, latex_terms in cases:
@@ -1161,7 +1184,7 @@ class TestStatevector(QiskitTestCase):
         """Test numerical rounding errors are not printed"""
         sv = Statevector(np.array([1 - 8e-17, 8.32667268e-17j]))
         latex_string = sv.draw(output="latex_source")
-        self.assertTrue(latex_string.startswith(" |0\\rangle"))
+        self.assertTrue(latex_string.startswith("|0\\rangle"))
         self.assertNotIn("|1\\rangle", latex_string)
 
     def test_statevctor_iter(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.
-->
- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly. No need to update the docs since this is a bug-fix
- [x] I have read the CONTRIBUTING document.
### Summary
Adds a fix to remove `\rangleNone` from latex representation given by `state_to_latex`. 

Fixes #8169 

### Details and comments

Fixed the behaviour so that there are no `None` values present