### PR TITLE
Add qiskit-neko integration test job

### DIFF
--- a/.github/workflows/neko.yml
+++ b/.github/workflows/neko.yml
@@ -1,0 +1,16 @@
+name: Qiskit Neko Integration Tests
+on:
+  push:
+  pull_request:
+    branches: ['main']
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+jobs:
+  neko:
+    name: Qiskit Neko Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Qiskit/qiskit-neko
+        with:
+          test_selection: terra


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new CI job to run the Qiskit Neko test suite. Qiskit
Neko is an integration suite that's designed to validate backwards
compatibility for end user workflows and between different components in
Qiskit. This test job will hopefully eventually replace the role that
the tutorials CI job is playing for backwards compatibility testing.
Right now the test suite is still fairly small but it covers some
examples of terra, aer, experiments, nature, and machine learning. The
test suite will continue to grow and improve our coverage for testing.

This test job will install qiskit-neko and terra from main, while the
other qiskit components (nature, aer, machine learning, and experiments)
will be installed from release. This will enable us to check that a
proposed PR does not regress compatibility on an API or an integration
point with a downstream qiskit project.

### Details and comments


