### PR TITLE
Refactor marginal_memory() hex to bin lookup table to be a true static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,7 +358,6 @@ dependencies = [
  "ahash",
  "hashbrown",
  "indexmap",
- "lazy_static",
  "ndarray",
  "num-bigint",
  "num-complex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ indexmap = "1.9.1"
 ahash = "0.7.6"
 num-complex = "0.4"
 num-bigint = "0.4"
-lazy_static = "1.4.0"
 
 [dependencies.pyo3]
 version = "0.16.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,6 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-#[macro_use]
-extern crate lazy_static;
-
 use std::env;
 
 use pyo3::prelude::*;

--- a/src/results/converters.rs
+++ b/src/results/converters.rs
@@ -10,34 +10,34 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-lazy_static! {
-    static ref HEX_TO_BIN_LUT: [&'static str; 256] = {
-        let mut lookup = [""; 256];
-        lookup[b'0' as usize] = "0000";
-        lookup[b'1' as usize] = "0001";
-        lookup[b'2' as usize] = "0010";
-        lookup[b'3' as usize] = "0011";
-        lookup[b'4' as usize] = "0100";
-        lookup[b'5' as usize] = "0101";
-        lookup[b'6' as usize] = "0110";
-        lookup[b'7' as usize] = "0111";
-        lookup[b'8' as usize] = "1000";
-        lookup[b'9' as usize] = "1001";
-        lookup[b'A' as usize] = "1010";
-        lookup[b'B' as usize] = "1011";
-        lookup[b'C' as usize] = "1100";
-        lookup[b'D' as usize] = "1101";
-        lookup[b'E' as usize] = "1110";
-        lookup[b'F' as usize] = "1111";
-        lookup[b'a' as usize] = "1010";
-        lookup[b'b' as usize] = "1011";
-        lookup[b'c' as usize] = "1100";
-        lookup[b'd' as usize] = "1101";
-        lookup[b'e' as usize] = "1110";
-        lookup[b'f' as usize] = "1111";
-        lookup
-    };
+const fn generate_lookup_table() -> [&'static str; 256] {
+    let mut lookup = [""; 256];
+    lookup[b'0' as usize] = "0000";
+    lookup[b'1' as usize] = "0001";
+    lookup[b'2' as usize] = "0010";
+    lookup[b'3' as usize] = "0011";
+    lookup[b'4' as usize] = "0100";
+    lookup[b'5' as usize] = "0101";
+    lookup[b'6' as usize] = "0110";
+    lookup[b'7' as usize] = "0111";
+    lookup[b'8' as usize] = "1000";
+    lookup[b'9' as usize] = "1001";
+    lookup[b'A' as usize] = "1010";
+    lookup[b'B' as usize] = "1011";
+    lookup[b'C' as usize] = "1100";
+    lookup[b'D' as usize] = "1101";
+    lookup[b'E' as usize] = "1110";
+    lookup[b'F' as usize] = "1111";
+    lookup[b'a' as usize] = "1010";
+    lookup[b'b' as usize] = "1011";
+    lookup[b'c' as usize] = "1100";
+    lookup[b'd' as usize] = "1101";
+    lookup[b'e' as usize] = "1110";
+    lookup[b'f' as usize] = "1111";
+    lookup
 }
+
+static HEX_TO_BIN_LUT: [&str; 256] = generate_lookup_table();
 
 #[inline]
 pub fn hex_to_bin(hex: &str) -> String {

--- a/src/results/converters.rs
+++ b/src/results/converters.rs
@@ -10,8 +10,8 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
-const fn generate_lookup_table() -> [&'static str; 256] {
-    let mut lookup = [""; 256];
+const fn generate_lookup_table() -> [&'static str; 103] {
+    let mut lookup = [""; 103];
     lookup[b'0' as usize] = "0000";
     lookup[b'1' as usize] = "0001";
     lookup[b'2' as usize] = "0010";
@@ -37,7 +37,7 @@ const fn generate_lookup_table() -> [&'static str; 256] {
     lookup
 }
 
-static HEX_TO_BIN_LUT: [&str; 256] = generate_lookup_table();
+static HEX_TO_BIN_LUT: [&str; 103] = generate_lookup_table();
 
 #[inline]
 pub fn hex_to_bin(hex: &str) -> String {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #8051 we create a lookup table in Rust to speed
up the hex->bin conversion used internally as part of the
marginal_memory() function. This was previously done using the
lazy_static crate which is used to lazily evaluate dynamic code to
create a static at runtime on the first access. The typical use case for
this is to create a static Vec or HashMap. However for the
marginal_counts() usage we didn't need to do this because we were
creating a fixed size array so the static can be evaulated at compile
time assuming the array is constructed with a const function. This
commit removes the lazy_static usage and switches to a true static to
further improve the performance of the lookup table by avoiding the
construction overhead.

### Details and comments