### PR TITLE
Native symengine serialization for QPY generation

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -24,4 +24,5 @@ from qiskit.qpy import (
     _write_parameter_expression,
     _read_parameter_expression,
     _read_parameter_expression_v3,
+    _read_parameter_expression_v6,
 )

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -954,4 +954,5 @@ from .binary_io import (
     _write_parameter_expression,
     _read_parameter_expression,
     _read_parameter_expression_v3,
+    _read_parameter_expression_v6,
 )

--- a/qiskit/qpy/binary_io/__init__.py
+++ b/qiskit/qpy/binary_io/__init__.py
@@ -21,6 +21,7 @@ from .value import (
     _write_parameter_expression,
     _read_parameter_expression,
     _read_parameter_expression_v3,
+    _read_parameter_expression_v6,
 )
 
 from .circuits import (

--- a/qiskit/qpy/binary_io/schedules.py
+++ b/qiskit/qpy/binary_io/schedules.py
@@ -15,7 +15,6 @@
 """Read and write schedule and schedule instructions."""
 import json
 import struct
-import zlib
 
 import numpy as np
 
@@ -55,22 +54,6 @@ def _read_waveform(file_obj, version):
     )
 
 
-def _loads_symbolic_expr(expr_bytes):
-    from sympy import parse_expr
-
-    if expr_bytes == b"":
-        return None
-
-    expr_txt = zlib.decompress(expr_bytes).decode(common.ENCODE)
-    expr = parse_expr(expr_txt)
-
-    if _optional.HAS_SYMENGINE:
-        from symengine import sympify
-
-        return sympify(expr)
-    return expr
-
-
 def _read_symbolic_pulse(file_obj, version):
     header = formats.SYMBOLIC_PULSE._make(
         struct.unpack(
@@ -78,10 +61,90 @@ def _read_symbolic_pulse(file_obj, version):
             file_obj.read(formats.SYMBOLIC_PULSE_SIZE),
         )
     )
+
+    def _loads_symbolic_expr(expr_bytes):
+        from sympy import parse_expr
+        import zlib
+
+        if expr_bytes == b"":
+            return None
+
+        expr_txt = zlib.decompress(expr_bytes).decode(common.ENCODE)
+        expr = parse_expr(expr_txt)
+
+        if _optional.HAS_SYMENGINE:
+            from symengine import sympify
+
+            return sympify(expr)
+        return expr
+
     pulse_type = file_obj.read(header.type_size).decode(common.ENCODE)
     envelope = _loads_symbolic_expr(file_obj.read(header.envelope_size))
     constraints = _loads_symbolic_expr(file_obj.read(header.constraints_size))
     valid_amp_conditions = _loads_symbolic_expr(file_obj.read(header.valid_amp_conditions_size))
+    parameters = common.read_mapping(
+        file_obj,
+        deserializer=value.loads_value,
+        version=version,
+        vectors={},
+    )
+    duration = value.read_value(file_obj, version, {})
+    name = value.read_value(file_obj, version, {})
+
+    # TODO remove this and merge subclasses into a single kind of SymbolicPulse
+    #  We need some refactoring of our codebase,
+    #  mainly removal of isinstance check and name access with self.__class__.__name__.
+    if pulse_type == "Gaussian":
+        pulse_cls = library.Gaussian
+    elif pulse_type == "GaussianSquare":
+        pulse_cls = library.GaussianSquare
+    elif pulse_type == "Drag":
+        pulse_cls = library.Drag
+    elif pulse_type == "Constant":
+        pulse_cls = library.Constant
+    else:
+        pulse_cls = library.SymbolicPulse
+
+    # Skip calling constructor to absorb signature mismatch in subclass.
+    instance = object.__new__(pulse_cls)
+    instance.duration = duration
+    instance.name = name
+    instance._limit_amplitude = header.amp_limited
+    instance._pulse_type = pulse_type
+    instance._params = parameters
+    instance._envelope = envelope
+    instance._constraints = constraints
+    instance._valid_amp_conditions = valid_amp_conditions
+
+    return instance
+
+
+def _read_symbolic_pulse_v6(file_obj, version):
+    header = formats.SYMBOLIC_PULSE_V6._make(
+        struct.unpack(
+            formats.SYMBOLIC_PULSE_V6_PACK,
+            file_obj.read(formats.SYMBOLIC_PULSE_V6_SIZE),
+        )
+    )
+    pulse_type = file_obj.read(header.type_size).decode(common.ENCODE)
+    envelope = value.loads_value(
+        type_key=header.envelope_type,
+        binary_data=file_obj.read(header.envelope_size),
+        version=version,
+        vectors={},
+    )
+    constraints = value.loads_value(
+        type_key=header.constraints_type,
+        binary_data=file_obj.read(header.constraints_size),
+        version=version,
+        vectors={},
+    )
+    valid_amp_conditions = value.loads_value(
+        type_key=header.valid_amp_conditions_type,
+        binary_data=file_obj.read(header.valid_amp_conditions_size),
+        version=version,
+        vectors={},
+    )
     parameters = common.read_mapping(
         file_obj,
         deserializer=value.loads_value,
@@ -140,7 +203,9 @@ def _loads_operand(type_key, data_bytes, version):
     if type_key == type_keys.ScheduleOperand.WAVEFORM:
         return common.data_from_binary(data_bytes, _read_waveform, version=version)
     if type_key == type_keys.ScheduleOperand.SYMBOLIC_PULSE:
-        return common.data_from_binary(data_bytes, _read_symbolic_pulse, version=version)
+        if version < 6:
+            return common.data_from_binary(data_bytes, _read_symbolic_pulse, version=version)
+        return common.data_from_binary(data_bytes, _read_symbolic_pulse_v6, version=version)
     if type_key == type_keys.ScheduleOperand.CHANNEL:
         return common.data_from_binary(data_bytes, _read_channel, version=version)
 
@@ -188,35 +253,28 @@ def _write_waveform(file_obj, data):
     value.write_value(file_obj, data.name)
 
 
-def _dumps_symbolic_expr(expr):
-    from sympy import srepr, sympify
-
-    if expr is None:
-        return b""
-
-    expr_bytes = srepr(sympify(expr)).encode(common.ENCODE)
-    return zlib.compress(expr_bytes)
-
-
 def _write_symbolic_pulse(file_obj, data):
     pulse_type_bytes = data.pulse_type.encode(common.ENCODE)
-    envelope_bytes = _dumps_symbolic_expr(data.envelope)
-    constraints_bytes = _dumps_symbolic_expr(data.constraints)
-    valid_amp_conditions_bytes = _dumps_symbolic_expr(data.valid_amp_conditions)
+    envelope_type, envelope_bytes = value.dumps_value(data.envelope)
+    constraints_type, constraints_bytes = value.dumps_value(data.constraints)
+    valid_amp_conds_type, valid_amp_conds_bytes = value.dumps_value(data.valid_amp_conditions)
 
     header_bytes = struct.pack(
-        formats.SYMBOLIC_PULSE_PACK,
+        formats.SYMBOLIC_PULSE_V6_PACK,
         len(pulse_type_bytes),
+        envelope_type,
         len(envelope_bytes),
+        constraints_type,
         len(constraints_bytes),
-        len(valid_amp_conditions_bytes),
+        valid_amp_conds_type,
+        len(valid_amp_conds_bytes),
         data.limit_amplitude,
     )
     file_obj.write(header_bytes)
     file_obj.write(pulse_type_bytes)
     file_obj.write(envelope_bytes)
     file_obj.write(constraints_bytes)
-    file_obj.write(valid_amp_conditions_bytes)
+    file_obj.write(valid_amp_conds_bytes)
     common.write_mapping(
         file_obj,
         mapping=data._params,

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -21,7 +21,7 @@ import struct
 
 from qiskit.qpy import formats
 
-QPY_VERSION = 5
+QPY_VERSION = 6
 ENCODE = "utf8"
 
 

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -181,6 +181,23 @@ WAVEFORM = namedtuple("WAVEFORM", ["epsilon", "data_size", "amp_limited"])
 WAVEFORM_PACK = "!fI?"
 WAVEFORM_SIZE = struct.calcsize(WAVEFORM_PACK)
 
+# SYMBOLIC_PULSE_V6
+SYMBOLIC_PULSE_V6 = namedtuple(
+    "SYMBOLIC_PULSE",
+    [
+        "type_size",
+        "envelope_type",
+        "envelope_size",
+        "constraints_type",
+        "constraints_size",
+        "valid_amp_conditions_type",
+        "valid_amp_conditions_size",
+        "amp_limited",
+    ],
+)
+SYMBOLIC_PULSE_V6_PACK = "!H1cH1cH1cH?"
+SYMBOLIC_PULSE_V6_SIZE = struct.calcsize(SYMBOLIC_PULSE_V6_PACK)
+
 # SYMBOLIC_PULSE
 SYMBOLIC_PULSE = namedtuple(
     "SYMBOLIC_PULSE",
@@ -216,6 +233,11 @@ PARAMETER_VECTOR_ELEMENT = namedtuple(
 )
 PARAMETER_VECTOR_ELEMENT_PACK = "!HQ16sQ"
 PARAMETER_VECTOR_ELEMENT_SIZE = struct.calcsize(PARAMETER_VECTOR_ELEMENT_PACK)
+
+# PARAMETER_EXPR_V6
+PARAMETER_EXPR_V6 = namedtuple("PARAMETER_EXPR", ["map_elements", "expr_type", "expr_size"])
+PARAMETER_EXPR_V6_PACK = "!Q1cQ"
+PARAMETER_EXPR_V6_SIZE = struct.calcsize(PARAMETER_EXPR_V6_PACK)
 
 # PARAMETER_EXPR
 PARAMETER_EXPR = namedtuple("PARAMETER_EXPR", ["map_elements", "expr_size"])

--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -98,6 +98,8 @@ class Value(TypeKeyBase):
     PARAMETER_EXPRESSION = b"e"
     STRING = b"s"
     NULL = b"z"
+    SYMPY_EXPR = b"y"
+    SYMENGINE_EXPR = b"m"
 
     @classmethod
     def assign(cls, obj):
@@ -119,6 +121,18 @@ class Value(TypeKeyBase):
             return cls.STRING
         if obj is None:
             return cls.NULL
+        try:
+            import sympy
+            if isinstance(obj, sympy.Expr):
+                return cls.SYMPY_EXPR
+        except ImportError:
+            pass
+        try:
+            import symengine
+            if isinstance(obj, symengine.Expr):
+                return cls.SYMENGINE_EXPR
+        except ImportError:
+            pass
 
         raise exceptions.QpyError(
             f"Object type '{type(obj)}' is not supported in {cls.__name__} namespace."


### PR DESCRIPTION
use native symengine serializer and deserializer which is implemented in C++.
see https://github.com/symengine/symengine.py/issues/409

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In QPY version 5 and below, symengine expression is serialized through sympy string parsing mechanism. The conversion from symengine to sympy, and parsing of expression is significant overhead, especially when a program contains multiple `ParameterExpression`s, or symbolic pulses containing complicated waveform equations. 

### Details and comments

Benchmark shows significant performance improvement. Here I chose an example of schedule with `Drag` pulse, which contains the most complicated envelope equation in current pulse library. In experimental programs, this pulse instance repeatedly appears, since DRAG is the most popular implementation of single qubit gates. In addition, here the pulse parameters are also parameter expression, i.e. symengine expression.

```python
from qiskit import pulse, circuit

duration = circuit.Parameter("duration")
amp = circuit.Parameter("amp")
beta = circuit.Parameter("beta")
with pulse.build() as sched:
    pulse.play(pulse.Drag(duration, amp, duration/4, beta), pulse.DriveChannel(0))

# ---- benchmark ----

with BytesIO() as file:
    qpy.dump(sched, file)
    bout = file.getvalue()

with BytesIO(bout) as file:
    sched_load = qpy.load(file)[0]

# ---- benchmark ----

assert sched == sched_load
```

**In QPY Version 5**

![image](https://user-images.githubusercontent.com/39517270/175499166-41e81f2a-7b3d-4e4d-9120-1b67d4944009.png)

As expected, `_dumps_symbolic_expr` consumes most of the execution time.

**In this PR branch (Version 6)**

![image](https://user-images.githubusercontent.com/39517270/175499361-27034dda-c18a-4f5b-9e74-40f0ce8d0f8a.png)

Now the regex search introduced in https://github.com/Qiskit/qiskit-terra/commit/5a6ec946995ba09329e96248655096fdbb239d7e becomes a significant overhead (this pattern should be precompiled, but this is outside the scope of this PR).

Magnifying the expression generation part

![image](https://user-images.githubusercontent.com/39517270/175499781-b8a26c16-feb2-41aa-a921-7a9a1aa1044a.png)

You can see `_write_symbolic_pulse` becomes significantly faster (x290 performance gain, if I remove zlib compression this becomes more faster).

### Note

This is on hold until https://github.com/symengine/symengine.py/issues/409#issuecomment-1165320526 is closed. Currently symengine deserializer doesn't support complex double expressions, which is quite important to write pulse amplitude in the phasor representation.

```python
amp = circuit.Parameter("amp")
angle = circuit.Parameter("angle")

phasor_amp = amp * np.exp(1j * angle)
```



