### PR TITLE
Fix `UnitaryGate.qasm()` with unused qubits

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -191,22 +191,13 @@ class UnitaryGate(Gate):
             _qasm_escape_gate_name(self.label) if self.label else "unitary" + str(id(self))
         )
 
-        # map from gates in the definition to params in the method
-        bit_to_qasm = OrderedDict()
-        current_bit = 0
-
+        qubit_to_qasm = {bit: f"p{i}" for i, bit in enumerate(self.definition.qubits)}
         gates_def = ""
         for instruction in self.definition.data:
 
-            # add bits from this gate to the overall set of params
-            for bit in instruction.qubits + instruction.clbits:
-                if bit not in bit_to_qasm:
-                    bit_to_qasm[bit] = "p" + str(current_bit)
-                    current_bit += 1
-
             curr_gate = "\t{} {};\n".format(
                 instruction.operation.qasm(),
-                ",".join([bit_to_qasm[j] for j in instruction.qubits + instruction.clbits]),
+                ",".join(qubit_to_qasm[qubit] for qubit in instruction.qubits),
             )
             gates_def += curr_gate
 
@@ -215,7 +206,7 @@ class UnitaryGate(Gate):
             "gate "
             + self._qasm_name
             + " "
-            + ",".join(bit_to_qasm.values())
+            + ",".join(qubit_to_qasm[qubit] for qubit in self.definition.qubits)
             + " {\n"
             + gates_def
             + "}"

--- a/releasenotes/notes/fix-qasm2-identity-as-unitary-aa2feeb05707a597.yaml
+++ b/releasenotes/notes/fix-qasm2-identity-as-unitary-aa2feeb05707a597.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The OpenQASM 2 exporter (:meth:`.QuantumCircuit.qasm`) will now correctly
+    define the qubit parameters for :class:`.UnitaryGate` operations that do
+    not affect all the qubits they are defined over.
+    Fixed `#8224 <https://github.com/Qiskit/qiskit-terra/issues/8224>`__.

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -281,6 +281,20 @@ class TestUnitaryCircuit(QiskitTestCase):
         )
         self.assertEqual(expected_qasm, qc.qasm())
 
+    def test_qasm_unitary_noop(self):
+        """Test that an identifier unitary can be converted to OpenQASM 2"""
+        qc = QuantumCircuit(QuantumRegister(3, "q0"))
+        qc.unitary(numpy.eye(8), qc.qubits, label="unitary_identity")
+        expected_qasm = (
+            "OPENQASM 2.0;\n"
+            'include "qelib1.inc";\n'
+            "gate unitary_identity p0,p1,p2 {\n"
+            "}\n"
+            "qreg q0[3];\n"
+            "unitary_identity q0[0],q0[1],q0[2];\n"
+        )
+        self.assertEqual(expected_qasm, qc.qasm())
+
     def test_unitary_decomposition(self):
         """Test decomposition for unitary gates over 2 qubits."""
         qc = QuantumCircuit(3)


### PR DESCRIPTION
The OpenQASM 2 exporter has a special case for providing `gate`
definitions, which was implemented purely for `UnitaryGate`.  This is
stateful per instruction, and does not generally behave well with the
rest of the exporter.  This commit fixes one misbehaviour: the way the
qubit operands for the definition was calculated was unreliable in both
order and number of qubits, if any of the qubits were unaffected by
the gate operation.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

There are general problems with the special-case approach to defining the definition like this (see also #8222), which this commit does not fix, and the whole OpenQASM 2 exporter is known to be pretty questionable with custom and parameterised gates still.

Fix #8224.