### PR TITLE
Move QPY version regex construction to import time

### DIFF
--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -69,6 +69,7 @@ VERSION_PATTERN = (
 """
     + "$"
 )
+VERSION_PATTERN_REGEX = re.compile(VERSION_PATTERN)
 
 
 @deprecate_arguments({"circuits": "programs"})
@@ -149,7 +150,7 @@ def dump(
     else:
         raise TypeError(f"'{program_type}' is not supported data type.")
 
-    version_match = re.search(VERSION_PATTERN, __version__, re.VERBOSE | re.IGNORECASE)
+    version_match = VERSION_PATTERN_REGEX.search(__version__, re.VERBOSE | re.IGNORECASE)
     version_parts = [int(x) for x in version_match.group("release").split(".")]
     header = struct.pack(
         formats.FILE_HEADER_PACK,
@@ -226,7 +227,7 @@ def load(
     )
     if data.preface.decode(common.ENCODE) != "QISKIT":
         raise QiskitError("Input file is not a valid QPY file")
-    version_match = re.search(VERSION_PATTERN, __version__, re.VERBOSE | re.IGNORECASE)
+    version_match = VERSION_PATTERN_REGEX.search(__version__, re.VERBOSE | re.IGNORECASE)
     version_parts = [int(x) for x in version_match.group("release").split(".")]
 
     header_version_parts = [data.major_version, data.minor_version, data.patch_version]

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -69,7 +69,7 @@ VERSION_PATTERN = (
 """
     + "$"
 )
-VERSION_PATTERN_REGEX = re.compile(VERSION_PATTERN)
+VERSION_PATTERN_REGEX = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
 
 
 @deprecate_arguments({"circuits": "programs"})
@@ -150,7 +150,7 @@ def dump(
     else:
         raise TypeError(f"'{program_type}' is not supported data type.")
 
-    version_match = VERSION_PATTERN_REGEX.search(__version__, re.VERBOSE | re.IGNORECASE)
+    version_match = VERSION_PATTERN_REGEX.search(__version__)
     version_parts = [int(x) for x in version_match.group("release").split(".")]
     header = struct.pack(
         formats.FILE_HEADER_PACK,
@@ -227,7 +227,7 @@ def load(
     )
     if data.preface.decode(common.ENCODE) != "QISKIT":
         raise QiskitError("Input file is not a valid QPY file")
-    version_match = VERSION_PATTERN_REGEX.search(__version__, re.VERBOSE | re.IGNORECASE)
+    version_match = VERSION_PATTERN_REGEX.search(__version__)
     version_parts = [int(x) for x in version_match.group("release").split(".")]
 
     header_version_parts = [data.major_version, data.minor_version, data.patch_version]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As pointed out by @nkanazawa1989 in #8232 the regex construction added
to the QPY interface functions in #8200 can be a significant portion of
the overall function time especially for smaller inputs. Especially as
we're building it on every call interface function call. To ameliorate
that cost this commit compiles the version regex a single time at the
module level. This adds the overhead to import but it will only be done
once which should be a net improvement in performance.

### Details and comments