### PR TITLE
granularity aware symbolic pulse

### DIFF
--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -387,6 +387,7 @@ class SymbolicPulse(Pulse):
         "_envelope",
         "_constraints",
         "_valid_amp_conditions",
+        "_granularity",
     )
 
     # Lambdify caches keyed on sympy expressions. Returns the corresponding callable.
@@ -404,6 +405,7 @@ class SymbolicPulse(Pulse):
         envelope: Optional[sym.Expr] = None,
         constraints: Optional[sym.Expr] = None,
         valid_amp_conditions: Optional[sym.Expr] = None,
+        granularity: Optional[int] = 1,
     ):
         """Create a parametric pulse.
 
@@ -421,10 +423,15 @@ class SymbolicPulse(Pulse):
                 will investigate the full-waveform and raise an error when the amplitude norm
                 of any data point exceeds 1.0. If not provided, the validation always
                 creates a full-waveform.
+            granularity: Pulse granularity constraint on backend hardware. Duration value is
+                always truncated to nearest multiple of this value.
 
         Raises:
             PulseError: When not all parameters are listed in the attribute :attr:`PARAM_DEF`.
         """
+        if not isinstance(duration, ParameterExpression):
+            duration = granularity * int(duration / granularity)
+
         super().__init__(
             duration=duration,
             name=name,
@@ -442,6 +449,7 @@ class SymbolicPulse(Pulse):
 
         self._pulse_type = pulse_type
         self._params = parameters
+        self._granularity = granularity
 
         self._envelope = envelope
         self._constraints = constraints
@@ -558,6 +566,9 @@ class SymbolicPulse(Pulse):
         if self._envelope != other._envelope:
             return False
 
+        if self._granularity != other._granularity:
+            return False
+
         if self.parameters != other.parameters:
             return False
 
@@ -598,6 +609,7 @@ class Gaussian(SymbolicPulse):
         sigma: Union[float, ParameterExpression],
         name: Optional[str] = None,
         limit_amplitude: Optional[bool] = None,
+        granularity: Optional[int] = 1,
     ):
         """Create new pulse instance.
 
@@ -609,7 +621,8 @@ class Gaussian(SymbolicPulse):
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the
                 waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
-
+            granularity: Pulse granularity constraint on backend hardware. Duration value is
+                always truncated to nearest multiple of this value.
         """
         parameters = {"amp": amp, "sigma": sigma}
 
@@ -630,6 +643,7 @@ class Gaussian(SymbolicPulse):
             envelope=envelope_expr,
             constraints=consts_expr,
             valid_amp_conditions=valid_amp_conditions_expr,
+            granularity=granularity,
         )
         self.validate_parameters()
 
@@ -681,6 +695,7 @@ class GaussianSquare(SymbolicPulse):
         risefall_sigma_ratio: Optional[Union[float, ParameterExpression]] = None,
         name: Optional[str] = None,
         limit_amplitude: Optional[bool] = None,
+        granularity: Optional[int] = 1,
     ):
         """Create new pulse instance.
 
@@ -694,6 +709,8 @@ class GaussianSquare(SymbolicPulse):
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the
                 waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
+            granularity: Pulse granularity constraint on backend hardware. Duration value is
+                always truncated to nearest multiple of this value.
 
         Raises:
             PulseError: When width and risefall_sigma_ratio are both empty or both non-empty.
@@ -738,6 +755,7 @@ class GaussianSquare(SymbolicPulse):
             envelope=envelope_expr,
             constraints=consts_expr,
             valid_amp_conditions=valid_amp_conditions_expr,
+            granularity=granularity,
         )
         self.validate_parameters()
 
@@ -792,6 +810,7 @@ class Drag(SymbolicPulse):
         beta: Union[float, ParameterExpression],
         name: Optional[str] = None,
         limit_amplitude: Optional[bool] = None,
+        granularity: Optional[int] = 1,
     ):
         """Create new pulse instance.
 
@@ -804,6 +823,8 @@ class Drag(SymbolicPulse):
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the
                 waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
+            granularity: Pulse granularity constraint on backend hardware. Duration value is
+                always truncated to nearest multiple of this value.
         """
         parameters = {"amp": amp, "sigma": sigma, "beta": beta}
 
@@ -828,6 +849,7 @@ class Drag(SymbolicPulse):
             envelope=envelope_expr,
             constraints=consts_expr,
             valid_amp_conditions=valid_amp_conditions_expr,
+            granularity=granularity,
         )
         self.validate_parameters()
 
@@ -847,6 +869,7 @@ class Constant(SymbolicPulse):
         amp: Union[complex, ParameterExpression],
         name: Optional[str] = None,
         limit_amplitude: Optional[bool] = None,
+        granularity: Optional[int] = 1,
     ):
         """Create new pulse instance.
 
@@ -856,6 +879,8 @@ class Constant(SymbolicPulse):
             name: Display name for this pulse envelope.
             limit_amplitude: If ``True``, then limit the amplitude of the
                 waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
+            granularity: Pulse granularity constraint on backend hardware. Duration value is
+                always truncated to nearest multiple of this value.
         """
         parameters = {"amp": amp}
 
@@ -880,5 +905,6 @@ class Constant(SymbolicPulse):
             limit_amplitude=limit_amplitude,
             envelope=envelope_expr,
             valid_amp_conditions=valid_amp_conditions_expr,
+            granularity=granularity,
         )
         self.validate_parameters()

--- a/qiskit/pulse/parameter_manager.py
+++ b/qiskit/pulse/parameter_manager.py
@@ -225,7 +225,11 @@ class ParameterSetter(NodeVisitor):
         if node.is_parameterized():
             # Assign duration
             if isinstance(node.duration, ParameterExpression):
-                node.duration = self._assign_parameter_expression(node.duration)
+                assigned_dur = self._assign_parameter_expression(node.duration)
+                if not isinstance(assigned_dur, ParameterExpression):
+                    node.duration = node._granularity * int(assigned_dur / node._granularity)
+                else:
+                    node.duration = assigned_dur
             # Assign other parameters
             for name in node._params:
                 pval = node._params[name]

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -21,7 +21,7 @@ import struct
 
 from qiskit.qpy import formats
 
-QPY_VERSION = 5
+QPY_VERSION = 6
 ENCODE = "utf8"
 
 

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -195,6 +195,21 @@ SYMBOLIC_PULSE = namedtuple(
 SYMBOLIC_PULSE_PACK = "!HHHH?"
 SYMBOLIC_PULSE_SIZE = struct.calcsize(SYMBOLIC_PULSE_PACK)
 
+# SYMBOLIC_PULSE_V6
+SYMBOLIC_PULSE_V6 = namedtuple(
+    "SYMBOLIC_PULSE",
+    [
+        "type_size",
+        "envelope_size",
+        "constraints_size",
+        "valid_amp_conditions_size",
+        "amp_limited",
+        "granularity",
+    ],
+)
+SYMBOLIC_PULSE_V6_PACK = "!HHHH?H"
+SYMBOLIC_PULSE_V6_SIZE = struct.calcsize(SYMBOLIC_PULSE_V6_PACK)
+
 # INSTRUCTION_PARAM
 INSTRUCTION_PARAM = namedtuple("INSTRUCTION_PARAM", ["type", "size"])
 INSTRUCTION_PARAM_PACK = "!1cQ"

--- a/releasenotes/notes/upgrade_symbolic_pulse_with_granularity-65e57cd68fb9c981.yaml
+++ b/releasenotes/notes/upgrade_symbolic_pulse_with_granularity-65e57cd68fb9c981.yaml
@@ -1,0 +1,25 @@
+---
+upgrade:
+  - |
+    :class:`.SymbolicPulse` and its subclass can be instantiated with ``granularity``.
+    This allows a user to parameterize ``duration`` and sweep it
+    without seriously concerning about hardware constraints.
+
+    .. code-block:: python
+
+      from qiskit import pulse, circuit
+      import numpy as np
+
+      sigma = circuit.Parameter("sigma")
+      with pulse.build() as sched:
+        pulse.play(
+          pulse.Gaussian(duration=4 * sigma, amp=0.1, sigma=sigma, granularity=16),
+          pulse.DriveChannel(0),
+        )
+
+      sigmas = np.linspace(40, 100, 10)
+      scheds = [sched.assign_parameters({sigma: s}, inplace=False) for s in sigmas]
+
+    Assigned ``scheds`` are guaranteed to be executable on a real hardware with
+    the pulse granularity constraints of 16, though one doesn't carefully manage
+    parameter values to assign.

--- a/test/python/qpy/test_block_load_from_qpy.py
+++ b/test/python/qpy/test_block_load_from_qpy.py
@@ -192,6 +192,15 @@ class TestLoadFromQPY(QpyScheduleTestCase):
 
         self.assert_roundtrip_equal(test_sched)
 
+    def test_constrained_pulse(self):
+        """Test pulse with granularity constraint."""
+        with builder.build() as test_sched:
+            builder.play(
+                Gaussian(120, 0.1, 30, granularity=16),
+                DriveChannel(0),
+            )
+        self.assert_roundtrip_equal(test_sched)
+
 
 class TestPulseGate(QpyScheduleTestCase):
     """Test loading and saving pulse gate attached circuit to qpy file."""

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -438,6 +438,16 @@ def generate_schedule_blocks():
     return schedule_blocks
 
 
+def generate_pulse_with_constraint():
+    """QPY schedule with pulse knowing constraint."""
+    from qiskit.pulse import builder, channels, library
+
+    # Pulse with granularity constraint
+    with builder.build() as block:
+        builder.play(library.Gaussian(120, 0.1, 30, granularity=16), channels.DriveChannel(0))
+    return [block]
+
+
 def generate_calibrated_circuits():
     """Test for QPY serialization with calibrations."""
     from qiskit.pulse import builder, Constant, DriveChannel
@@ -525,6 +535,8 @@ def generate_circuits(version_str=None):
         output_circuits["controlled_gates.qpy"] = generate_controlled_gates()
         output_circuits["schedule_blocks.qpy"] = generate_schedule_blocks()
         output_circuits["pulse_gates.qpy"] = generate_calibrated_circuits()
+    if version_parts >= (0, 22, 0):
+        output_circuits["constrained_pulse.qpy"] = generate_pulse_with_constraint()
 
     return output_circuits
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR updates `SymbolicPulse` instance to be aware of `granularity` constraints. This is particularly convenient when we scan parameterized duration. For example, so far we often write

```python
      # Scan area under curve, i.e. sigma, of Gaussian pulse. Fix duration to be 4 sigma.
      from qiskit import pulse, circuit
      import numpy as np

      duration = circuit.Parameter("duration")  # redundant because this is 4 sigma, but cannot be removed
      sigma = circuit.Parameter("sigma")
      with pulse.build() as sched:
        pulse.play(
          pulse.Gaussian(duration=duration, amp=0.1, sigma=sigma),
          pulse.DriveChannel(0),
        )

      sigmas = np.linspace(40, 100, 10)
      scheds = []
      for sigma_val in sigmas:
          duration_val = 16 * int(sigma_val * 4 / 16)  # duration should be multiple of 16
          sched_assigned = sched.assign_parameters({duration: duration_val, sigma_val: sigma}, inplace=False)
          scheds.append(sched_assigned)
```
with this PR, we can simply write the identical code:
```python
      sigma = circuit.Parameter("sigma")
      with pulse.build() as sched:
        pulse.play(
          pulse.Gaussian(duration=4 * sigma, amp=0.1, sigma=sigma, granularity=16),  # pulse knows constraints
          pulse.DriveChannel(0),
        )

      sigmas = np.linspace(40, 100, 10)
      scheds = [sched.assign_parameters({sigma: s}, inplace=False) for s in sigmas]
```


### Details and comments

This updates QPY version with `SYMBOLIC_PULSE_V6_PACK`. This format will be further updated with #8232 

