### PR TITLE
Fix mypy errors (quantum_info)

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -13,7 +13,6 @@
 """
 Statevector quantum state class.
 """
-
 import copy
 import re
 from numbers import Number
@@ -225,7 +224,7 @@ class Statevector(QuantumState, TolerancesMixin):
         return len(self._data)
 
     @property
-    def data(self):
+    def data(self) -> np.ndarray:
         """Return data."""
         return self._data
 
@@ -238,7 +237,7 @@ class Statevector(QuantumState, TolerancesMixin):
         norm = np.linalg.norm(self.data)
         return np.allclose(norm, 1, rtol=rtol, atol=atol)
 
-    def to_operator(self):
+    def to_operator(self) -> Operator:
         """Convert state to a rank-1 projector operator"""
         mat = np.outer(self.data, np.conj(self.data))
         return Operator(mat, input_dims=self.dims(), output_dims=self.dims())

--- a/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
+++ b/qiskit/quantum_info/synthesis/xx_decompose/decomposer.py
@@ -13,11 +13,11 @@
 """
 Driver for a synthesis routine which emits optimal XX-based circuits.
 """
-
+from __future__ import annotations
 import heapq
 import math
 from operator import itemgetter
-from typing import Callable, Optional, Union
+from typing import Callable
 
 import numpy as np
 
@@ -78,10 +78,10 @@ class XXDecomposer:
 
     def __init__(
         self,
-        basis_fidelity: Union[dict, float] = 1.0,
+        basis_fidelity: dict | float = 1.0,
         euler_basis: str = "U",
-        embodiments: Optional[dict] = None,
-        backup_optimizer: Optional[Callable] = None,
+        embodiments: dict[float, QuantumCircuit] | None = None,
+        backup_optimizer: Callable[..., QuantumCircuit] | None = None,
     ):
         from qiskit.transpiler.passes.optimization.optimize_1q_decomposition import (
             Optimize1qGatesDecomposition,  # pylint: disable=cyclic-import
@@ -93,7 +93,9 @@ class XXDecomposer:
         self.basis_fidelity = basis_fidelity
 
         # expose one of the basis gates so others can know what this decomposer targets
-        embodiment_circuit = next(iter(self.embodiments.items()), ([], []))[1]
+        embodiment_circuit: list | QuantumCircuit = next(iter(self.embodiments.items()), ([], []))[
+            1
+        ]
         for instruction in embodiment_circuit:
             if len(instruction.qubits) == 2:
                 self.gate = instruction.operation
@@ -217,10 +219,10 @@ class XXDecomposer:
 
     def __call__(
         self,
-        unitary: Union[Operator, np.ndarray],
-        basis_fidelity: Optional[Union[dict, float]] = None,
+        unitary: Operator | np.ndarray,
+        basis_fidelity: dict | float | None = None,
         approximate: bool = True,
-    ):
+    ) -> QuantumCircuit:
         """
         Fashions a circuit which (perhaps `approximate`ly) models the special unitary operation
         `unitary`, using the circuit templates supplied at initialization as `embodiments`.  The


### PR DESCRIPTION
### Summary

Following discussion, I'm splitting https://github.com/Qiskit/qiskit-terra/pull/8187 by module.

### Details and comments

There are 8 errors left:
```
qiskit/quantum_info/synthesis/two_qubit_decompose.py:580: error: Missing positional arguments "num_qubits", "params" in call to "Gate"  [call-arg]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:580: error: Argument 1 to "Gate" has incompatible type "float"; expected "str"  [arg-type]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:583: error: Missing positional arguments "num_qubits", "params" in call to "Gate"  [call-arg]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:583: error: Argument 1 to "Gate" has incompatible type "float"; expected "str"  [arg-type]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:590: error: Missing positional arguments "num_qubits", "params" in call to "Gate"  [call-arg]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:590: error: Argument 1 to "Gate" has incompatible type "float"; expected "str"  [arg-type]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:665: error: Missing positional arguments "num_qubits", "params" in call to "Gate"  [call-arg]
qiskit/quantum_info/synthesis/two_qubit_decompose.py:665: error: Argument 1 to "Gate" has incompatible type "float"; expected "str"  [arg-type]
```
All are related to the fact that gates, even though inheriting from `Gate` have different constructor signature. Not sure what the proper fix is. 
The ignores are related to https://github.com/python/mypy/issues/1362