### PR TITLE
Fix mypy errors (compiler)

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -285,7 +285,7 @@ def transpile(
             or errors in passes
     """
     arg_circuits_list = isinstance(circuits, list)
-    circuits = circuits if arg_circuits_list else [circuits]
+    circuits = circuits if arg_circuits_list else [circuits]  # type: ignore[list-item]
 
     if not circuits:
         return []


### PR DESCRIPTION
### Summary

Following discussion, I'm splitting https://github.com/Qiskit/qiskit-terra/pull/8187 by module.

### Details and comments

```

qiskit/compiler/assembler.py:209: error: Module not callable  [operator]
qiskit/compiler/assembler.py:230: error: Module not callable  [operator]
qiskit/compiler/scheduler.py:72: error: "Backend" has no attribute "instruction_schedule_map"  [attr-defined]
qiskit/compiler/scheduler.py:74: error: "Backend" has no attribute "meas_map"  [attr-defined]
qiskit/compiler/scheduler.py:76: error: "Backend" has no attribute "dt"  [attr-defined]
qiskit/compiler/scheduler.py:83: error: "Backend" has no attribute "defaults"  [attr-defined]
qiskit/compiler/scheduler.py:94: error: "Backend" has no attribute "configuration"  [attr-defined]
qiskit/compiler/scheduler.py:97: error: "Backend" has no attribute "configuration"  [attr-defined]
qiskit/compiler/sequencer.py:56: error: "Backend" has no attribute "defaults"  [attr-defined]
qiskit/compiler/sequencer.py:60: error: "Backend" has no attribute "configuration"  [attr-defined]
qiskit/compiler/sequencer.py:64: error: "Backend" has no attribute "configuration"  [attr-defined]
qiskit/compiler/transpiler.py:264: error: Item "QuantumCircuit" of "Union[QuantumCircuit, List[QuantumCircuit]]" has no attribute "__iter__" (not iterable)  [union-attr]
qiskit/compiler/transpiler.py:271: error: Incompatible return value type (got "Union[CircuitInstruction, QuantumCircuit]", expected "Union[QuantumCircuit, List[QuantumCircuit]]")  [return-value]
qiskit/compiler/transpiler.py:316: error: No overload variant of "__getitem__" of "list" matches argument type "str"  [call-overload]
qiskit/compiler/transpiler.py:316: note: Possible overload variants:
qiskit/compiler/transpiler.py:316: note:     def __getitem__(self, SupportsIndex) -> Dict[Any, Any]
qiskit/compiler/transpiler.py:316: note:     def __getitem__(self, slice) -> List[Dict[Any, Any]]
qiskit/compiler/transpiler.py:334: error: Argument 1 to "zip" has incompatible type "Union[QuantumCircuit, List[QuantumCircuit]]"; expected "Iterable[QuantumCircuit]"  [arg-type]
qiskit/compiler/transpiler.py:334: error: Argument 1 to "zip" has incompatible type "Union[QuantumCircuit, List[QuantumCircuit]]"; expected "Iterable[Any]"  [arg-type]
qiskit/compiler/transpiler.py:338: error: Argument 1 to "zip" has incompatible type "Union[QuantumCircuit, List[QuantumCircuit]]"; expected "Iterable[QuantumCircuit]"  [arg-type]
qiskit/compiler/transpiler.py:358: error: Incompatible return value type (got "Union[CircuitInstruction, QuantumCircuit]", expected "Union[QuantumCircuit, List[QuantumCircuit]]")  [return-value]
```

The first two appear to be some kind of mypy problem: it can't distinguish  between function and same named module due to import structure?
The next some are due to the fact that `Backend` class do not define any attributes, but rather its subclasses do. Finally, some errors are due to type cast mypy misses -- can be solved by explicit cast or changing variable name probably?