### PR TITLE
fix seed in qsd test

### DIFF
--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -1371,8 +1371,7 @@ class TestQuantumShannonDecomposer(QiskitTestCase):
 
     def setUp(self):
         super().setUp()
-        seed = (hash(self.id())) % 10000
-        np.random.seed(seed)
+        np.random.seed(657)  # this seed should work for calls to scipy.stats.<method>.rvs()
         self.qsd = qsd.qs_decomposition
 
     def _get_lower_cx_bound(self, n):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Addresses issue #8233.


### Details and comments
Perhaps there was some issue with the use of `self.id` for the seed of the RNG. To check whether there was some decomposition error a ran this test with 1000 different seeds and didn't encounter any failures.

