### PR TITLE
Fix mypy errors (primitives)

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -39,7 +39,7 @@ def _run_circuits(
     circuits: QuantumCircuit | list[QuantumCircuit],
     backend: BackendV1 | BackendV2,
     **run_options,
-) -> tuple[Result, list[dict]]:
+) -> tuple[list[Result], list[dict]]:
     """Remove metadata of circuits and run the circuits on a backend.
     Args:
         circuits: The circuits
@@ -70,7 +70,7 @@ def _run_circuits(
     return result, metadata
 
 
-def _prepare_counts(results):
+def _prepare_counts(results: Sequence[Result]):
     counts = []
     for res in results:
         count = res.get_counts()
@@ -351,7 +351,7 @@ class BackendEstimator(BaseEstimator):
         return preprocessed_circuits
 
     def _postprocessing(
-        self, result: Result, accum: list[int], metadata: list[dict]
+        self, result: Sequence[Result], accum: list[int], metadata: list[dict]
     ) -> EstimatorResult:
         """
         Postprocessing for evaluation of expectation value using pauli rotation gates.

--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -70,7 +70,7 @@ def _run_circuits(
     return result, metadata
 
 
-def _prepare_counts(results: Sequence[Result]):
+def _prepare_counts(results: list[Result]):
     counts = []
     for res in results:
         count = res.get_counts()
@@ -351,7 +351,7 @@ class BackendEstimator(BaseEstimator):
         return preprocessed_circuits
 
     def _postprocessing(
-        self, result: Sequence[Result], accum: list[int], metadata: list[dict]
+        self, result: list[Result], accum: list[int], metadata: list[dict]
     ) -> EstimatorResult:
         """
         Postprocessing for evaluation of expectation value using pauli rotation gates.

--- a/qiskit/primitives/backend_sampler.py
+++ b/qiskit/primitives/backend_sampler.py
@@ -159,7 +159,7 @@ class BackendSampler(BaseSampler):
         return self._postprocessing(result, bound_circuits)
 
     def _postprocessing(
-        self, result: Sequence[Result], circuits: list[QuantumCircuit]
+        self, result: list[Result], circuits: list[QuantumCircuit]
     ) -> SamplerResult:
         counts = _prepare_counts(result)
         shots = sum(counts[0].values())

--- a/qiskit/primitives/backend_sampler.py
+++ b/qiskit/primitives/backend_sampler.py
@@ -158,7 +158,9 @@ class BackendSampler(BaseSampler):
         result, _metadata = _run_circuits(bound_circuits, self._backend, **run_options)
         return self._postprocessing(result, bound_circuits)
 
-    def _postprocessing(self, result: Result, circuits: list[QuantumCircuit]) -> SamplerResult:
+    def _postprocessing(
+        self, result: Sequence[Result], circuits: list[QuantumCircuit]
+    ) -> SamplerResult:
         counts = _prepare_counts(result)
         shots = sum(counts[0].values())
 

--- a/qiskit/primitives/base/base_primitive.py
+++ b/qiskit/primitives/base/base_primitive.py
@@ -15,8 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast, Union, Sequence
 
 import numpy as np
 
@@ -84,22 +83,29 @@ class BasePrimitive(ABC):
 
         # Support numpy ndarray
         if isinstance(parameter_values, np.ndarray):
+            parameter_values = cast(np.ndarray, parameter_values)
             parameter_values = parameter_values.tolist()
         elif isinstance(parameter_values, Sequence):
+            parameter_values = cast(
+                Union[Sequence[Sequence[float]], Sequence[float]], parameter_values
+            )
             parameter_values = tuple(
-                vector.tolist() if isinstance(vector, np.ndarray) else vector
+                cast(np.ndarray, vector).tolist() if isinstance(vector, np.ndarray) else vector
                 for vector in parameter_values
             )
 
         # Allow single value
         if _isreal(parameter_values):
+            parameter_values = cast(float, parameter_values)
             parameter_values = ((parameter_values,),)
         elif isinstance(parameter_values, Sequence) and not any(
             isinstance(vector, Sequence) for vector in parameter_values
         ):
+            parameter_values = cast(Sequence[float], parameter_values)
             parameter_values = (parameter_values,)
 
         # Validation
+        parameter_values = cast(Sequence[Sequence[float]], parameter_values)
         if (
             not isinstance(parameter_values, Sequence)
             or not all(isinstance(vector, Sequence) for vector in parameter_values)
@@ -132,7 +138,7 @@ def _isint(obj: Any) -> bool:
     return isinstance(obj, int_types) and not isinstance(obj, bool)
 
 
-def _isreal(obj: Any) -> bool:
+def _isreal(obj: Any) -> bool | np.bool_:
     """Check if object is a real number: int or float except ``±Inf`` and ``NaN``."""
     float_types = (float, np.floating)
     return _isint(obj) or isinstance(obj, float_types) and float("-Inf") < obj < float("Inf")

--- a/qiskit/primitives/base/base_primitive.py
+++ b/qiskit/primitives/base/base_primitive.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, cast, Union, Sequence
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -83,29 +83,22 @@ class BasePrimitive(ABC):
 
         # Support numpy ndarray
         if isinstance(parameter_values, np.ndarray):
-            parameter_values = cast(np.ndarray, parameter_values)
             parameter_values = parameter_values.tolist()
         elif isinstance(parameter_values, Sequence):
-            parameter_values = cast(
-                Union[Sequence[Sequence[float]], Sequence[float]], parameter_values
-            )
             parameter_values = tuple(
-                cast(np.ndarray, vector).tolist() if isinstance(vector, np.ndarray) else vector
+                vector.tolist() if isinstance(vector, np.ndarray) else vector
                 for vector in parameter_values
             )
 
         # Allow single value
         if _isreal(parameter_values):
-            parameter_values = cast(float, parameter_values)
             parameter_values = ((parameter_values,),)
         elif isinstance(parameter_values, Sequence) and not any(
             isinstance(vector, Sequence) for vector in parameter_values
         ):
-            parameter_values = cast(Sequence[float], parameter_values)
             parameter_values = (parameter_values,)
 
         # Validation
-        parameter_values = cast(Sequence[Sequence[float]], parameter_values)
         if (
             not isinstance(parameter_values, Sequence)
             or not all(isinstance(vector, Sequence) for vector in parameter_values)
@@ -132,13 +125,13 @@ class BasePrimitive(ABC):
                 )
 
 
-def _isint(obj: Any) -> bool:
+def _isint(obj: Sequence[Sequence[float]] | Sequence[float] | float) -> bool:
     """Check if object is int."""
     int_types = (int, np.integer)
     return isinstance(obj, int_types) and not isinstance(obj, bool)
 
 
-def _isreal(obj: Any) -> bool | np.bool_:
+def _isreal(obj: Sequence[Sequence[float]] | Sequence[float] | float) -> bool:
     """Check if object is a real number: int or float except ``±Inf`` and ``NaN``."""
     float_types = (float, np.floating)
     return _isint(obj) or isinstance(obj, float_types) and float("-Inf") < obj < float("Inf")


### PR DESCRIPTION
### Summary

Following discussion, I'm splitting https://github.com/Qiskit/qiskit-terra/pull/8187 by module.

### Details and comments

<details>
<summary> Previous content </summary>
The are ~20 errors left:
```
qiskit/primitives/base_estimator.py:322: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[QuantumCircuit, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_estimator.py:342: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[ParameterView, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_estimator.py:345: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[ParameterView, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_estimator.py:349: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[QuantumCircuit, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_estimator.py:350: error: Invalid index type "Union[int, SparsePauliOp]" for "Tuple[SparsePauliOp, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_estimator.py:358: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, QuantumCircuit]"  [type-var]
qiskit/primitives/base_estimator.py:358: error: Unsupported operand types for <= ("int" and "QuantumCircuit")  [operator]
qiskit/primitives/base_estimator.py:358: note: Left operand is of type "Union[int, QuantumCircuit]"
qiskit/primitives/base_estimator.py:360: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, QuantumCircuit]"  [type-var]
qiskit/primitives/base_estimator.py:363: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, SparsePauliOp]"  [type-var]
qiskit/primitives/base_estimator.py:363: error: Unsupported operand types for <= ("int" and "SparsePauliOp")  [operator]
qiskit/primitives/base_estimator.py:363: note: Left operand is of type "Union[int, SparsePauliOp]"
qiskit/primitives/base_estimator.py:365: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, SparsePauliOp]"  [type-var]
qiskit/primitives/base_estimator.py:370: error: Argument "circuits" to "_call" of "BaseEstimator" has incompatible type "List[Union[int, QuantumCircuit]]"; expected "Sequence[int]"  [arg-type]
qiskit/primitives/base_estimator.py:371: error: Argument "observables" to "_call" of "BaseEstimator" has incompatible type "List[Union[int, SparsePauliOp]]"; expected "Sequence[int]"  [arg-type]
qiskit/primitives/base_sampler.py:243: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[QuantumCircuit, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_sampler.py:258: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[ParameterView, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_sampler.py:261: error: Invalid index type "Union[int, QuantumCircuit]" for "Tuple[ParameterView, ...]"; expected type "SupportsIndex"  [index]
qiskit/primitives/base_sampler.py:264: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, QuantumCircuit]"  [type-var]
qiskit/primitives/base_sampler.py:264: error: Unsupported operand types for <= ("int" and "QuantumCircuit")  [operator]
qiskit/primitives/base_sampler.py:264: note: Left operand is of type "Union[int, QuantumCircuit]"
qiskit/primitives/base_sampler.py:266: error: Value of type variable "SupportsRichComparisonT" of "max" cannot be "Union[int, QuantumCircuit]"  [type-var]
qiskit/primitives/base_sampler.py:271: error: Argument "circuits" to "_call" of "BaseSampler" has incompatible type "List[Union[int, QuantumCircuit]]"; expected "Sequence[int]"  [arg-type]
```

Large part of those errors can be fixed if the type cast is made explicit (I've added todo in corresponding places).
</details>

Edit (04.10.22): This fixes all remaining `primitives` errors.