### PR TITLE
Fix mypy errors (opflow)

### DIFF
--- a/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
+++ b/qiskit/opflow/gradients/circuit_gradients/lin_comb.py
@@ -100,7 +100,7 @@ class LinComb(CircuitGradient):
     }
 
     # pylint: disable=signature-differs, arguments-differ
-    def __init__(self, aux_meas_op: OperatorBase = Z):
+    def __init__(self, aux_meas_op: OperatorBase = Z):  # type: ignore[override]
         """
         Args:
             aux_meas_op: The operator that the auxiliary qubit is measured with respect to.
@@ -751,7 +751,7 @@ class LinComb(CircuitGradient):
 
                         # compute the correct coefficient and append to list of circuits
                         coeff = np.sqrt(np.abs(grad_coeff)) * state_op.coeff
-                        state = CircuitStateFn(grad_circuit, coeff=coeff)
+                        state: OperatorBase = CircuitStateFn(grad_circuit, coeff=coeff)
 
                         # apply the chain rule if the parameter expression if required
                         param_expression = gate.params[idx]

--- a/qiskit/opflow/gradients/circuit_gradients/param_shift.py
+++ b/qiskit/opflow/gradients/circuit_gradients/param_shift.py
@@ -92,7 +92,7 @@ class ParamShift(CircuitGradient):
             Tuple[ParameterExpression, ParameterExpression],
             List[Tuple[ParameterExpression, ParameterExpression]],
         ],
-    ) -> OperatorBase:
+    ) -> OperatorBase:  # type: ignore[override]
         """
         Args:
             operator: The operator corresponding to our quantum state we are taking the

--- a/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
+++ b/qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py
@@ -40,7 +40,7 @@ class LinCombFull(CircuitQFI):
         self,
         aux_meas_op: OperatorBase = Z,
         phase_fix: bool = True,
-    ):
+    ):  # type: ignore[override]
         """
         Args:
             aux_meas_op: The operator that the auxiliary qubit is measured with respect to.

--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -47,7 +47,7 @@ class OperatorBase(StarAlgebraMixin, TensorMixin, ABC):
     def __init__(self) -> None:
         self._instance_id = next(self._count)
 
-    @property
+    @property  # type: ignore
     @abstractmethod
     def settings(self) -> Dict:
         """Return settings of this object in a dictionary.
@@ -66,7 +66,7 @@ class OperatorBase(StarAlgebraMixin, TensorMixin, ABC):
         """Return the unique instance id."""
         return self._instance_id
 
-    @property
+    @property  # type: ignore
     @abstractmethod
     def num_qubits(self) -> int:
         r"""The number of qubits over which the Operator is defined. If
@@ -309,7 +309,7 @@ class OperatorBase(StarAlgebraMixin, TensorMixin, ABC):
         """
         raise NotImplementedError
 
-    @property
+    @property  # type: ignore
     @abstractmethod
     def parameters(self):
         r"""Return a set of Parameter objects contained in the Operator."""

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -287,7 +287,7 @@ class PauliOp(PrimitiveOp):
             return PauliOp(self.primitive)
         if np.sum(sig_qubits) == 1:
             sig_qubit_index = sig_qubits.tolist().index(True)
-            coeff = (
+            coeff: Union[float, ParameterExpression] = (
                 np.real(self.coeff)
                 if not isinstance(self.coeff, ParameterExpression)
                 else self.coeff

--- a/qiskit/opflow/state_fns/circuit_state_fn.py
+++ b/qiskit/opflow/state_fns/circuit_state_fn.py
@@ -11,8 +11,7 @@
 # that they have been altered from the originals.
 
 """ CircuitStateFn Class """
-
-
+import typing
 from typing import Dict, List, Optional, Set, Union, cast
 
 import numpy as np
@@ -47,7 +46,7 @@ class CircuitStateFn(StateFn):
     def __init__(
         self,
         primitive: Union[QuantumCircuit, Instruction] = None,
-        coeff: Union[complex, ParameterExpression] = 1.0,
+        coeff: Union[typing.SupportsComplex, ParameterExpression] = 1.0,
         is_measurement: bool = False,
         from_operator: bool = False,
     ) -> None:


### PR DESCRIPTION
### Summary

Following discussion, I'm splitting https://github.com/Qiskit/qiskit-terra/pull/8187 by module.

### Details and comments
I've added some ignores to override, since those are already ignored by pylint. As per https://github.com/Qiskit/qiskit-terra/pull/8187#issuecomment-1168867044 we may want to reconsider it.

The are ~215 errors left, this is one of three modules with most mypy errors:

<details>
<summary> All error list </summary>

```
qiskit/opflow/converters/circuit_sampler.py:366: error: Incompatible types in assignment (expression has type "StateFn", variable has type "DictStateFn")  [assignment]
qiskit/opflow/converters/circuit_sampler.py:381: error: "DictStateFn" has no attribute "execution_results"  [attr-defined]
qiskit/opflow/converters/circuit_sampler.py:384: error: Incompatible return value type (got "Dict[int, List[DictStateFn]]", expected "Dict[int, List[StateFn]]")  [return-value]
qiskit/opflow/evolutions/evolved_op.py:146: error: "OperatorBase" has no attribute "exp_i"  [attr-defined]
qiskit/opflow/evolutions/evolved_op.py:160: error: "OperatorBase" has no attribute "exp_i"  [attr-defined]
qiskit/opflow/evolutions/pauli_trotter_evolution.py:120: error: Argument "time" to "PauliEvolutionGate" has incompatible type "Union[complex, Any]"; expected "Union[int, float, ParameterExpression]"  [arg-type]
qiskit/opflow/evolutions/pauli_trotter_evolution.py:159: error: "OperatorBase" has no attribute "primitive"  [attr-defined]
qiskit/opflow/evolutions/trotterizations/qdrift.py:75: error: Module has no attribute "random"  [attr-defined]
qiskit/opflow/gradients/circuit_gradients/circuit_gradient.py:92: error: Incompatible types in assignment (expression has type "Union[QuantumCircuit, List[QuantumCircuit]]", variable has type "QuantumCircuit")  [assignment]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: error: Signature of "convert" incompatible with supertype "CircuitGradient"  [override]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:      Superclass:
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:          def convert(self, operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], None] = ...) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:      Subclass:
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:          def convert(operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:121: note:          def convert(operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:199: error: "OperatorBase" has no attribute "primitive"  [attr-defined]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:199: error: "OperatorBase" has no attribute "coeff"  [attr-defined]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:214: error: Argument "target_params" to "_gradient_states" of "LinComb" has incompatible type "Union[ParameterExpression, ParameterVector, List[ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]"; expected "Union[Parameter, List[Parameter], None]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:223: error: Argument "target_params" to "_hessian_states" of "LinComb" has incompatible type "Union[List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]"; expected "Union[Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], None]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:277: error: Argument "target_params" to "_gradient_states" of "LinComb" has incompatible type "Union[ParameterExpression, ParameterVector, List[ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]"; expected "Union[Parameter, List[Parameter], None]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:660: error: Value of type "OperatorBase" is not indexable  [index]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:668: error: Incompatible types in assignment (expression has type "PauliBasisChange", variable has type "OperatorBase")  [assignment]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:669: error: "OperatorBase" has no attribute "convert"  [attr-defined]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:670: error: Value of type "OperatorBase" is not indexable  [index]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:859: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:867: error: Incompatible types in assignment (expression has type "ListOp", variable has type "CircuitStateFn")  [assignment]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:885: error: Argument 1 to "SummedOp" has incompatible type "List[CircuitStateFn]"; expected "List[OperatorBase]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:885: note: "List" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
qiskit/opflow/gradients/circuit_gradients/lin_comb.py:885: note: Consider using "Sequence" instead, which is covariant
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: error: Signature of "convert" incompatible with supertype "CircuitGradient"  [override]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:      Superclass:
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:          def convert(self, operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], None] = ...) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:      Subclass:
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:          def convert(operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/param_shift.py:85: note:          def convert(operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]) -> OperatorBase
qiskit/opflow/gradients/circuit_gradients/param_shift.py:125: error: Value of type "Union[Any, ParameterExpression, Tuple[ParameterExpression, ParameterExpression]]" is not indexable  [index]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:184: error: Incompatible types in assignment (expression has type "Callable[..., Any]", target has type "Union[complex, ParameterExpression]")  [assignment]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:185: error: Argument 2 to "ListOp" has incompatible type "**Dict[str, Union[complex, ParameterExpression]]"; expected "Optional[Callable[..., Any]]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:185: error: Argument 2 to "ListOp" has incompatible type "**Dict[str, Union[complex, ParameterExpression]]"; expected "bool"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: error: No overload variant of "__call__" of "_UFunc_Nin2_Nout1" matches argument types "Iterable[Any]", "Any"  [call-overload]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: note: Possible overload variants:
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: note:     def __call__(self, Union[int, float, complex, str, bytes, generic], Union[int, float, complex, str, bytes, generic], out: None = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str, str]] = ..., extobj: List[Any] = ...) -> Any
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: note:     def __call__(self, Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], out: Union[ndarray[Any, dtype[Any]], Tuple[ndarray[Any, dtype[Any]]]] = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str, str]] = ..., extobj: List[Any] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: error: No overload variant of "__call__" of "_UFunc_Nin1_Nout1" matches argument type "Iterable[Any]"  [call-overload]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: note:     def __call__(self, Union[int, float, complex, str, bytes, generic], out: None = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str]] = ..., extobj: List[Any] = ...) -> Any
qiskit/opflow/gradients/circuit_gradients/param_shift.py:343: note:     def __call__(self, Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], out: Union[ndarray[Any, dtype[Any]], Tuple[ndarray[Any, dtype[Any]]]] = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str]] = ..., extobj: List[Any] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:350: error: No overload variant of "__call__" of "_UFunc_Nin2_Nout1" matches argument types "Iterable[Any]", "Any"  [call-overload]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:350: note: Possible overload variants:
qiskit/opflow/gradients/circuit_gradients/param_shift.py:350: note:     def __call__(self, Union[int, float, complex, str, bytes, generic], Union[int, float, complex, str, bytes, generic], out: None = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str, str]] = ..., extobj: List[Any] = ...) -> Any
qiskit/opflow/gradients/circuit_gradients/param_shift.py:350: note:     def __call__(self, Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], out: Union[ndarray[Any, dtype[Any]], Tuple[ndarray[Any, dtype[Any]]]] = ..., *, where: Union[_SupportsArray[dtype[bool_]], _NestedSequence[_SupportsArray[dtype[bool_]]], bool, _NestedSequence[bool]] = ..., casting: Literal['no', 'equiv', 'safe', 'same_kind', 'unsafe'] = ..., order: Optional[Literal['K', 'A', 'C', 'F']] = ..., dtype: Union[dtype[Any], None, Type[Any], _SupportsDType[dtype[Any]], str, Union[Tuple[Any, int], Tuple[Any, Union[SupportsIndex, Sequence[SupportsIndex]]], List[Any], _DTypeDict, Tuple[Any, Any]]] = ..., subok: bool = ..., signature: Union[str, Tuple[str, str, str]] = ..., extobj: List[Any] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:369: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:396: error: Item "OperatorBase" of "Union[OperatorBase, List[OperatorBase]]" has no attribute "__iter__" (not iterable)  [union-attr]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:421: error: List comprehension has incompatible type List[Union[OperatorBase, List[OperatorBase]]]; expected List[OperatorBase]  [misc]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:422: error: "OperatorBase" has no attribute "primitive"  [attr-defined]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:423: error: Too many arguments for "OperatorBase"  [call-arg]
qiskit/opflow/gradients/circuit_gradients/param_shift.py:423: error: "OperatorBase" has no attribute "primitive"  [attr-defined]
qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py:40: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py:40: note:      Superclass:
qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py:40: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py:40: note:      Subclass:
qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py:40: note:          def convert(self, operator: OperatorBase, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]) -> OperatorBase
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: error: Argument 1 of "convert" is incompatible with supertype "CircuitQFI"; supertype defines the argument type as "OperatorBase"  [override]
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note: This violates the Liskov substitution principle
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note:      Superclass:
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note:      Subclass:
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:64: note:          def convert(operator: CircuitStateFn, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]) -> ListOp
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:106: error: Argument "target_params" to "_gradient_states" of "LinComb" has incompatible type "Union[ParameterExpression, ParameterVector, List[ParameterExpression]]"; expected "Union[Parameter, List[Parameter], None]"  [arg-type]
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:131: error: Argument 1 to "enumerate" has incompatible type "Union[ParameterExpression, ParameterVector, List[ParameterExpression]]"; expected "Iterable[Any]"  [arg-type]
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:133: error: Value of type "Union[ParameterExpression, ParameterVector, List[ParameterExpression]]" is not indexable  [index]
qiskit/opflow/gradients/circuit_qfis/lin_comb_full.py:192: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: error: Argument 1 of "convert" is incompatible with supertype "CircuitQFI"; supertype defines the argument type as "OperatorBase"  [override]
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note: This violates the Liskov substitution principle
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note:      Superclass:
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note:      Subclass:
qiskit/opflow/gradients/circuit_qfis/overlap_block_diag.py:41: note:          def convert(operator: Union[CircuitOp, CircuitStateFn], params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]) -> ListOp
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: error: Argument 1 of "convert" is incompatible with supertype "CircuitQFI"; supertype defines the argument type as "OperatorBase"  [override]
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note: This violates the Liskov substitution principle
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note:      Superclass:
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note:      Subclass:
qiskit/opflow/gradients/circuit_qfis/overlap_diag.py:39: note:          def convert(operator: Union[CircuitOp, CircuitStateFn], params: Union[ParameterExpression, ParameterVector, List[ParameterExpression]]) -> ListOp
qiskit/opflow/gradients/derivative_base.py:111: error: Argument 2 to "convert" of "DerivativeBase" has incompatible type "Union[ParameterExpression, ParameterVector, List[ParameterExpression], Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]]]"; expected "Union[ParameterVector, ParameterExpression, List[ParameterExpression], None]"  [arg-type]
qiskit/opflow/gradients/derivative_base.py:211: error: "OperatorBase" has no attribute "coeff"  [attr-defined]
qiskit/opflow/gradients/gradient.py:61: error: Argument 1 to "cmp_to_key" has incompatible type "Callable[[Parameter, Parameter], int]"; expected "Callable[[ParameterExpression, ParameterExpression], int]"  [arg-type]
qiskit/opflow/gradients/gradient.py:81: error: Missing return statement  [return]
qiskit/opflow/gradients/gradient.py:135: error: "OperatorBase" has no attribute "_coeff"  [attr-defined]
qiskit/opflow/gradients/gradient.py:137: error: "OperatorBase" has no attribute "_coeff"  [attr-defined]
qiskit/opflow/gradients/gradient.py:158: error: Incompatible return value type (got "int", expected "OperatorBase")  [return-value]
qiskit/opflow/gradients/hessian.py:41: error: Argument 2 of "convert" is incompatible with supertype "DerivativeBase"; supertype defines the argument type as "Union[ParameterVector, ParameterExpression, List[ParameterExpression], None]"  [override]
qiskit/opflow/gradients/hessian.py:41: note: This violates the Liskov substitution principle
qiskit/opflow/gradients/hessian.py:41: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
qiskit/opflow/gradients/hessian.py:129: error: Argument 2 to "get_hessian" of "Hessian" has incompatible type "Union[Tuple[ParameterExpression, ParameterExpression], ParameterExpression, Any]"; expected "Union[Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], List[ParameterExpression], ParameterVector, None]"  [arg-type]
qiskit/opflow/gradients/hessian.py:150: error: "OperatorBase" has no attribute "_coeff"  [attr-defined]
qiskit/opflow/gradients/hessian.py:152: error: "OperatorBase" has no attribute "_coeff"  [attr-defined]
qiskit/opflow/gradients/hessian.py:155: error: Argument 2 to "get_hessian" of "Hessian" has incompatible type "ParameterExpression"; expected "Union[Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], List[ParameterExpression], ParameterVector, None]"  [arg-type]
qiskit/opflow/gradients/hessian.py:156: error: Argument 2 to "get_hessian" of "Hessian" has incompatible type "ParameterExpression"; expected "Union[Tuple[ParameterExpression, ParameterExpression], List[Tuple[ParameterExpression, ParameterExpression]], List[ParameterExpression], ParameterVector, None]"  [arg-type]
qiskit/opflow/gradients/hessian.py:178: error: Incompatible return value type (got "int", expected "OperatorBase")  [return-value]
qiskit/opflow/gradients/natural_gradient.py:120: error: Argument 1 to "cmp_to_key" has incompatible type "Callable[[Parameter, Parameter], int]"; expected "Callable[[ParameterExpression, ParameterExpression], int]"  [arg-type]
qiskit/opflow/gradients/natural_gradient.py:122: error: List item 0 has incompatible type "Union[ParameterVector, ParameterExpression]"; expected "ParameterExpression"  [list-item]
qiskit/opflow/gradients/natural_gradient.py:267: error: No overload variant of "max" matches argument types "floating[Any]", "float"  [call-overload]
qiskit/opflow/gradients/natural_gradient.py:267: note: Possible overload variants:
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [SupportsRichComparisonT] max(__arg1, SupportsRichComparisonT, SupportsRichComparisonT, *_args: SupportsRichComparisonT, key: None = ...) -> SupportsRichComparisonT
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [_T] max(__arg1, _T, _T, *_args: _T, key: Callable[[_T], Union[SupportsDunderLT, SupportsDunderGT]]) -> _T
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [SupportsRichComparisonT] max(__iterable, Iterable[SupportsRichComparisonT], *, key: None = ...) -> SupportsRichComparisonT
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [_T] max(__iterable, Iterable[_T], *, key: Callable[[_T], Union[SupportsDunderLT, SupportsDunderGT]]) -> _T
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [SupportsRichComparisonT, _T] max(__iterable, Iterable[SupportsRichComparisonT], *, key: None = ..., default: _T) -> Union[SupportsRichComparisonT, _T]
qiskit/opflow/gradients/natural_gradient.py:267: note:     def [_T1, _T2] max(__iterable, Iterable[_T1], *, key: Callable[[_T1], Union[SupportsDunderLT, SupportsDunderGT]], default: _T2) -> Union[_T1, _T2]
qiskit/opflow/gradients/natural_gradient.py:324: error: Incompatible return value type (got "Tuple[Any, float]", expected "Tuple[float, ndarray[Any, Any]]")  [return-value]
qiskit/opflow/gradients/qfi.py:38: error: Argument 1 of "convert" is incompatible with supertype "DerivativeBase"; supertype defines the argument type as "OperatorBase"  [override]
qiskit/opflow/gradients/qfi.py:38: note: This violates the Liskov substitution principle
qiskit/opflow/gradients/qfi.py:38: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
qiskit/opflow/gradients/qfi.py:38: error: Signature of "convert" incompatible with supertype "ConverterBase"  [override]
qiskit/opflow/gradients/qfi.py:38: note:      Superclass:
qiskit/opflow/gradients/qfi.py:38: note:          def convert(self, operator: OperatorBase) -> OperatorBase
qiskit/opflow/gradients/qfi.py:38: note:      Subclass:
qiskit/opflow/gradients/qfi.py:38: note:          def convert(operator: CircuitStateFn, params: Union[ParameterExpression, ParameterVector, List[ParameterExpression], None] = ...) -> ListOp
qiskit/opflow/gradients/qfi.py:65: error: Argument 1 to "cmp_to_key" has incompatible type "Callable[[Parameter, Parameter], int]"; expected "Callable[[ParameterExpression, ParameterExpression], int]"  [arg-type]
qiskit/opflow/gradients/qfi.py:66: error: Incompatible return value type (got "OperatorBase", expected "ListOp")  [return-value]
qiskit/opflow/list_ops/list_op.py:185: error: "OperatorBase" has no attribute "coeff"  [attr-defined]
qiskit/opflow/operator_base.py:489: error: Module has no attribute "massive"  [attr-defined]
qiskit/opflow/primitive_ops/circuit_op.py:133: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/primitive_ops/circuit_op.py:142: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, Any]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/primitive_ops/circuit_op.py:183: error: Argument 1 to "assign_parameters" of "QuantumCircuit" has incompatible type "Dict[ParameterExpression, complex]"; expected "Union[Mapping[Parameter, Union[ParameterExpression, float]], Sequence[Union[ParameterExpression, float]]]"  [arg-type]
qiskit/opflow/primitive_ops/pauli_op.py:335: error: Incompatible types in assignment (expression has type "PauliGate", variable has type "Type[Gate]")  [assignment]
qiskit/opflow/primitive_ops/pauli_op.py:336: error: Argument 1 to "append" of "QuantumCircuit" has incompatible type "Type[Gate]"; expected "Union[Instruction, CircuitInstruction]"  [arg-type]
qiskit/opflow/primitive_ops/primitive_op.py:265: error: "OperatorBase" has no attribute "_coeff"  [attr-defined]
qiskit/opflow/state_fns/circuit_state_fn.py:49: error: Incompatible default for argument "coeff" (default has type "float", argument has type "Union[SupportsComplex, ParameterExpression]")  [assignment]
qiskit/opflow/state_fns/circuit_state_fn.py:78: error: Argument "coeff" to "__init__" of "StateFn" has incompatible type "Union[SupportsComplex, ParameterExpression]"; expected "Union[complex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:150: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, Any]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:165: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:176: error: "OperatorBase" has no attribute "from_operator"  [attr-defined]
qiskit/opflow/state_fns/circuit_state_fn.py:191: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, Any]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:232: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:298: error: Argument 1 to "assign_parameters" of "QuantumCircuit" has incompatible type "Dict[ParameterExpression, complex]"; expected "Union[Mapping[Parameter, Union[ParameterExpression, float]], Sequence[Union[ParameterExpression, float]]]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:299: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/circuit_state_fn.py:398: error: Argument "coeff" to "CircuitStateFn" has incompatible type "Union[complex, ParameterExpression]"; expected "Union[SupportsComplex, ParameterExpression]"  [arg-type]
qiskit/opflow/state_fns/cvar_measurement.py:381: error: Incompatible return value type (got "bool_", expected "bool")  [return-value]
qiskit/opflow/state_fns/dict_state_fn.py:310: error: Argument 1 to "__call__" of "_UFunc_Nin1_Nout1" has incompatible type "Union[OperatorBase, complex]"; expected "Union[int, float, complex, str, bytes, generic]"  [arg-type]
qiskit/opflow/state_fns/dict_state_fn.py:326: error: No overload variant of "unique" matches argument types "Any", "bool"  [call-overload]
qiskit/opflow/state_fns/dict_state_fn.py:326: note: Possible overload variants:
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[_SCT]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:326: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/dict_state_fn.py:327: error: Module has no attribute "random"  [attr-defined]
qiskit/opflow/state_fns/operator_state_fn.py:249: error: Incompatible types in assignment (expression has type "Union[OperatorBase, complex]", variable has type "Union[str, Dict[Any, Any], ndarray[Any, Any], OperatorBase, Statevector, None]")  [assignment]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:203: error: Argument 1 to "__call__" of "_UFunc_Nin1_Nout1" has incompatible type "Union[OperatorBase, complex]"; expected "Union[int, float, complex, str, bytes, generic]"  [arg-type]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: error: No overload variant of "unique" matches argument types "Any", "bool"  [call-overload]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note: Possible overload variants:
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[_SCT]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:218: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/sparse_vector_state_fn.py:219: error: Module has no attribute "random"  [attr-defined]
qiskit/opflow/state_fns/state_fn.py:115: note: "StateFn" defined here
qiskit/opflow/state_fns/state_fn.py:209: error: Unexpected keyword argument "from_operator" for "StateFn"  [call-arg]
qiskit/opflow/state_fns/state_fn.py:213: error: "StateFn" has no attribute "from_operator"  [attr-defined]
qiskit/opflow/state_fns/state_fn.py:326: error: "OperatorBase" has no attribute "coeff"  [attr-defined]
qiskit/opflow/state_fns/vector_state_fn.py:228: error: Argument 1 to "__call__" of "_UFunc_Nin1_Nout1" has incompatible type "Union[OperatorBase, complex]"; expected "Union[int, float, complex, str, bytes, generic]"  [arg-type]
qiskit/opflow/state_fns/vector_state_fn.py:241: error: No overload variant of "unique" matches argument types "Any", "bool"  [call-overload]
qiskit/opflow/state_fns/vector_state_fn.py:241: note: Possible overload variants:
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[_SCT]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> ndarray[Any, dtype[Any]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[False] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[False] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[False] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def [_SCT <: generic] unique(ar: Union[_SupportsArray[dtype[_SCT]], Sequence[_SupportsArray[dtype[_SCT]]], Sequence[Sequence[_SupportsArray[dtype[_SCT]]]], Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]], Sequence[Sequence[Sequence[Sequence[_SupportsArray[dtype[_SCT]]]]]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[_SCT]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:241: note:     def unique(ar: Union[_SupportsArray[dtype[Any]], _NestedSequence[_SupportsArray[dtype[Any]]], bool, int, float, complex, str, bytes, _NestedSequence[Union[bool, int, float, complex, str, bytes]]], return_index: Literal[True] = ..., return_inverse: Literal[True] = ..., return_counts: Literal[True] = ..., axis: Optional[SupportsIndex] = ...) -> Tuple[ndarray[Any, dtype[Any]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]], ndarray[Any, dtype[signedinteger[Any]]]]
qiskit/opflow/state_fns/vector_state_fn.py:242: error: Module has no attribute "random"  [attr-defined]
```

</details>

There are many additional incompatibilities between type and its parent. I'm not sure whether it is feasible and desirable to fix it.