### PR TITLE
Remove stale note about pending QPY support for SymbolicPulse

### DIFF
--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -374,11 +374,6 @@ class SymbolicPulse(Pulse):
     even within the environment not having original class definition loaded.
     This mechanism also allows us to easily share a pulse program including
     custom pulse instructions with collaborators.
-
-    .. note::
-
-        Currently QPY serialization of :class:`SymbolicPulse` is not available.
-        This feature will be implemented shortly.
     """
 
     __slots__ = (


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The support for serializing SymbolicPulse objects using QPY was added in
PR #7300 and has been released as part of 0.21.0. However, the
documentation for the SymbolicPulse class had a note saying the QPY
support was pending. This was necessary when the SymbolicPulse class was
added in #7821 because it was unclear when we'd be able to add the QPY
support. But, #7300 was updated and merged soon after #7821, but we
neglected to remove that note. This commit corrects the oversight and
removes the stale note.

### Details and comments