### PR TITLE
[WIP] block collection strategies

### DIFF
--- a/qiskit/converters/dagdependency_to_circuit.py
+++ b/qiskit/converters/dagdependency_to_circuit.py
@@ -11,14 +11,17 @@
 # that they have been altered from the originals.
 
 """Helper function for converting a dag dependency to a circuit"""
+
+from typing import Optional
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
 
 
-def dagdependency_to_circuit(dagdependency):
+def dagdependency_to_circuit(dagdependency, optimize_depth: Optional[bool] = False):
     """Build a ``QuantumCircuit`` object from a ``DAGDependency``.
 
     Args:
         dagdependency (DAGDependency): the input dag.
+        optimize_depth: an optional argument to optimize depth using commutativity analysis.
 
     Return:
         QuantumCircuit: the circuit representing the input dag dependency.
@@ -36,7 +39,7 @@ def dagdependency_to_circuit(dagdependency):
 
     circuit.calibrations = dagdependency.calibrations
 
-    for node in dagdependency.get_nodes():
+    for node in dagdependency.topological_nodes(optimize_depth=optimize_depth):
         circuit._append(CircuitInstruction(node.op.copy(), node.qargs, node.cargs))
 
     return circuit

--- a/qiskit/converters/dagdependency_to_dag.py
+++ b/qiskit/converters/dagdependency_to_dag.py
@@ -11,14 +11,17 @@
 # that they have been altered from the originals.
 
 """Helper function for converting a dag dependency to a dag circuit"""
+
+from typing import Optional
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
 
 
-def dagdependency_to_dag(dagdependency):
+def dagdependency_to_dag(dagdependency, optimize_depth: Optional[bool] = False):
     """Build a ``DAGCircuit`` object from a ``DAGDependency``.
 
     Args:
         dag dependency (DAGDependency): the input dag.
+        optimize_depth: an optional argument to optimize depth using commutativity analysis.
 
     Return:
         DAGCircuit: the DAG representing the input circuit.
@@ -37,7 +40,7 @@ def dagdependency_to_dag(dagdependency):
     for register in dagdependency.cregs.values():
         dagcircuit.add_creg(register)
 
-    for node in dagdependency.get_nodes():
+    for node in dagdependency.topological_nodes(optimize_depth=optimize_depth):
         # Get arguments for classical control (if any)
         inst = node.op.copy()
         dagcircuit.apply_operation_back(inst, node.qargs, node.cargs)

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -632,9 +632,6 @@ class DAGDependency:
             should_update_edges=False
         )
 
-        for x in node_block:
-            print(f"contracting: {x.op.__repr__(), x.qargs}")
-
         try:
             new_node.node_id = self._multi_graph.contract_nodes(
                 block_ids, new_node, check_cycle=cycle_check
@@ -643,7 +640,6 @@ class DAGDependency:
             raise DAGDependencyError(
                 "Replacing the specified node block would introduce a cycle"
             ) from ex
-        print(f"new_node_id = {new_node.node_id}")
 
     def print(self):
         nodes = list(self._multi_graph.nodes())

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -72,6 +72,7 @@ Optimizations
    Collect2qBlocks
    CollectMultiQBlocks
    CollectLinearFunctions
+   CollectCliffords
    ConsolidateBlocks
    CXCancellation
    InverseCancellation
@@ -85,6 +86,7 @@ Optimizations
    TemplateOptimization
    EchoRZXWeylDecomposition
    OptimizeDepth
+   CollapseChains
 
 Calibration
 =============
@@ -219,7 +221,9 @@ from .optimization import TemplateOptimization
 from .optimization import InverseCancellation
 from .optimization import EchoRZXWeylDecomposition
 from .optimization import CollectLinearFunctions
+from .optimization import CollectCliffords
 from .optimization import OptimizeDepth
+from .optimization import CollapseChains
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -84,6 +84,7 @@ Optimizations
    HoareOptimizer
    TemplateOptimization
    EchoRZXWeylDecomposition
+   OptimizeDepth
 
 Calibration
 =============
@@ -218,6 +219,7 @@ from .optimization import TemplateOptimization
 from .optimization import InverseCancellation
 from .optimization import EchoRZXWeylDecomposition
 from .optimization import CollectLinearFunctions
+from .optimization import OptimizeDepth
 
 # circuit analysis
 from .analysis import ResourceEstimation

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -31,3 +31,4 @@ from .inverse_cancellation import InverseCancellation
 from .collect_1q_runs import Collect1qRuns
 from .echo_rzx_weyl_decomposition import EchoRZXWeylDecomposition
 from .collect_linear_functions import CollectLinearFunctions
+from .optimize_depth import OptimizeDepth

--- a/qiskit/transpiler/passes/optimization/__init__.py
+++ b/qiskit/transpiler/passes/optimization/__init__.py
@@ -31,4 +31,6 @@ from .inverse_cancellation import InverseCancellation
 from .collect_1q_runs import Collect1qRuns
 from .echo_rzx_weyl_decomposition import EchoRZXWeylDecomposition
 from .collect_linear_functions import CollectLinearFunctions
+from .collect_cliffords import CollectCliffords
 from .optimize_depth import OptimizeDepth
+from .collapse_chains import CollapseChains

--- a/qiskit/transpiler/passes/optimization/collapse_chains.py
+++ b/qiskit/transpiler/passes/optimization/collapse_chains.py
@@ -1,0 +1,99 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Collect and collapse chains of matching nodes."""
+from abc import ABC, abstractmethod
+from typing import List, Optional, Union
+
+from qiskit.transpiler import TransformationPass
+from qiskit.converters import dag_to_dagdependency, dagdependency_to_dag
+from qiskit.dagcircuit import DAGNode, DAGDepNode
+from .collect_blocks import BlockCollector, BlockSplitter
+
+# ToDo: fix inheritance from ABC
+
+
+class CollapseChains(TransformationPass):
+    """Provides an API for collecting and collapsing blocks of nodes.
+
+    A derived class is required to implement two functions:
+        filter_function: specifying which nodes to collect into blocks
+        collapse_function: specifying what to do with collected blocks
+    """
+
+    def __init__(self,
+                 do_commutative_analysis=True,
+                 split_blocks=True,
+                 min_nodes_per_block=2):
+        """CollapseChains is a transformation pass that collect maximal blocks
+        of nodes matching a given filter function and processes these blocks of
+        nodes as specified by collapse_function.
+
+        Args:
+            do_commutative_analysis (bool): if True, exploits commutativity relations.
+            split_blocks (bool): if True, splits detected blocks into sub-blocks over disjoint qubit sets.
+            min_nodes_per_block (int): specifies the minimum number of nodes in a block on
+                which to apply collapse_function.
+        """
+        self.do_commutative_analysis = do_commutative_analysis
+        self.split_blocks = split_blocks
+        self.min_nodes_per_block = min_nodes_per_block
+
+        super().__init__()
+
+    def run(self, dag):
+        """Run the CollapseChainsPass pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+
+        if self.do_commutative_analysis:
+            processed_dag = dag_to_dagdependency(dag)
+        else:
+            processed_dag = dag
+
+        matching_blocks = BlockCollector(processed_dag).collect_all_matching_blocks(filter_fn=self.filter_function)
+
+        if self.split_blocks:
+            blocks = []
+            for block in matching_blocks:
+                blocks.extend(BlockSplitter().run(block))
+        else:
+            blocks = matching_blocks
+
+        filtered_blocks = [block for block in blocks if len(block) >= self.min_nodes_per_block]
+
+        collapsed_dep_dag = self.collapse_function(filtered_blocks, processed_dag)
+
+        if self.do_commutative_analysis:
+            collapsed_dag = dagdependency_to_dag(collapsed_dep_dag)
+        else:
+            collapsed_dag = collapsed_dep_dag
+
+        return collapsed_dag
+
+    @abstractmethod
+    def filter_function(self, node: Union[DAGNode, DAGDepNode]) -> bool:
+        """Specifies which nodes to collect into blocks.
+        """
+        pass
+
+    @abstractmethod
+    def collapse_function(self, blocks: Union[List[List[DAGNode]], List[List[DAGDepNode]]], dag):
+        """Specifies what to do with collected blocks.
+        """
+        pass

--- a/qiskit/transpiler/passes/optimization/collect_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_blocks.py
@@ -28,7 +28,6 @@ class BlockCollector:
     as it does not require to construct a DAGDependency beforehand. This may be useful
     with lower transpiler settings.
 
-
     Collecting blocks is generally not unique. The strategies explored here deal with
     heuristic approaches of the form 'starting from the input nodes of a DAG, collect
     the (heuristically) largest blocks of nodes that match certain criteria'.
@@ -197,8 +196,7 @@ class BlockCollector:
         Intuitively, extracting larger blocks of non-matching nodes helps to find larger blocks of
         following matching nodes.
 
-        For now, we return both the list of all blocks (including blocks of matching and non-matching
-        nodes) and the list of matching blocks only.
+        Returns the list of matching blocks only.
         """
 
         def not_filter_fn(node):
@@ -226,7 +224,7 @@ class BlockCollector:
         collects possibly multiple blocks of commuting nodes that match filter_fn,
         repeating the process until no more uncollected nodes remain.
 
-        For now, we return both the list of all blocks and the list of commuting blocks.
+        Returns the list of matching blocks only.
         """
 
         def not_filter_fn(node):
@@ -237,21 +235,21 @@ class BlockCollector:
         #   Collect non-matching nodes.
         #   Collect layers of commuting nodes (while possible).
         matching_blocks = []
-        all_blocks = []
+        # all_blocks = []
         while self.have_uncollected_nodes():
             non_matching_block = self.collect_matching_block(not_filter_fn)
-            if non_matching_block:
-                all_blocks.append(non_matching_block)
+            # if non_matching_block:
+            #     all_blocks.append(non_matching_block)
 
             while True:
                 commuting_block = self.collect_commuting_block(filter_fn)
                 if commuting_block:
                     matching_blocks.append(commuting_block)
-                    all_blocks.append(commuting_block)
+                    # all_blocks.append(commuting_block)
                 else:
                     break
 
-        return matching_blocks, all_blocks
+        return matching_blocks
 
     def collect_all_parallel_blocks(self):
         """Collects all blocks of parallel nodes.
@@ -261,7 +259,7 @@ class BlockCollector:
         This is useful to try to rearrange nodes in the quantum circuit exploiting commutativity
         relations in the attempt to decrease the depth of the circuit.
 
-        We return both the list of all blocks.
+        Return both the list of all blocks.
         """
 
         # Iteratively:
@@ -278,7 +276,7 @@ class BlockCollector:
 
 class BlockSplitter:
     """Splits a block of nodes into blocks over disjoint qubits.
-    Implements Disjoint Set Union data structure."""
+    This is an implementation of the Disjoint Set Union data structure."""
 
     def __init__(self):
         self.leader = {}  # qubit's group leader

--- a/qiskit/transpiler/passes/optimization/collect_blocks.py
+++ b/qiskit/transpiler/passes/optimization/collect_blocks.py
@@ -1,0 +1,315 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Various ways to divide up DAG into blocks of nodes."""
+
+from qiskit.dagcircuit import DAGOpNode
+from qiskit.converters import dag_to_dagdependency
+
+
+class BlockCollector:
+    """Collecting blocks from DagDependency and DagCircuit.
+
+    This class implements various strategies of dividing a DAG (direct acyclic graph)
+    into blocks of nodes that satisfy certain criteria. It works both with the DagCircuit
+    representation of a DAG, and the DagDependency representation of a DAG, where
+    DagDependency takes into account commutativity between nodes.
+
+    Collecting blocks is generally not unique. The strategies explored here deal with
+    heuristic approaches of the form 'starting from the input nodes of a DAG, collect
+    the (heuristically) largest blocks of nodes that match certain criteria'.
+
+    See Qiskit issue #5775 for additional details.
+    """
+
+    def __init__(self, dag, do_commutative_analysis=True):
+        """
+        Args:
+            dag (DagCircuit): The input DagCircuit.
+            do_commutative_analysis (bool): Whether to exploit commutativity between nodes
+                by building DagDependency from DagCircuit.
+        """
+
+        if not do_commutative_analysis:
+            # We will do the analysis on the original DagCircuit.
+            # This will generally lead to less optimal results, but should be very fast, as it does
+            # not require building to construct DagDependency. This may be useful with lower transpiler
+            # settings.
+            self.dag = dag
+            self.is_dag_dependency = False
+
+        else:
+            # We will construct the "canonical" DagDependency structure, and use it for the analysis
+            # instead of the original DagCircuit.
+            self.dag = dag_to_dagdependency(dag)
+            self.is_dag_dependency = True
+
+        # For efficiency, we will compute (and keep updating) the in_degree for every node, that is
+        # the number of the node's immediate predecessors. A node is a leaf (input) node iff its
+        # in_degree is 0. When a node is (marked as) collected, the in_degrees of its immediate
+        # successors are updated (by subtracting 1).
+        # Additionally, we will explicitly keep the list of nodes with in_degree 0 as pending_nodes.
+        self.pending_nodes = []
+        self.in_degree = dict()
+        for node in self._op_nodes():
+            deg = len(self._direct_preds(node))
+            self.in_degree[node] = deg
+            if deg == 0:
+                self.pending_nodes.append(node)
+
+    def _op_nodes(self):
+        """Returns DAG nodes
+        (wrapper to handle both DagCircuit and DagDependency)."""
+        if not self.is_dag_dependency:
+            return self.dag.op_nodes()
+        else:
+            return self.dag.get_nodes()
+
+    def _direct_preds(self, node):
+        """Returns direct predecessors of a node
+        (wrapper to handle both DagCircuit and DagDependency).
+        """
+        if not self.is_dag_dependency:
+            return [pred for pred in self.dag.predecessors(node) if isinstance(pred, DAGOpNode)]
+        else:
+            return [
+                self.dag.get_node(pred_id) for pred_id in self.dag.direct_predecessors(node.node_id)
+            ]
+
+    def _direct_succs(self, node):
+        """Returns direct successors of a node
+        (wrapper to handle both DagCircuit and DagDependency).
+        """
+        if not self.is_dag_dependency:
+            return [succ for succ in self.dag.successors(node) if isinstance(succ, DAGOpNode)]
+        else:
+            return [
+                self.dag.get_node(succ_id) for succ_id in self.dag.direct_successors(node.node_id)
+            ]
+
+    def have_uncollected_nodes(self):
+        """Returns whether there are uncollected (pending) nodes"""
+        return len(self.pending_nodes) > 0
+
+    def _mark_node_as_collected(self, node):
+        """Marks node as collected (updates in_degrees of successors and updates pending_nodes)."""
+        self.pending_nodes.remove(node)
+        for suc in self._direct_succs(node):
+            self.in_degree[suc] -= 1
+            if self.in_degree[suc] == 0:
+                self.pending_nodes.append(suc)
+
+    def collect_matching_block(self, filter_fn):
+        """Iteratively collects the largest block of input (aka in_degree=0) nodes that match a
+        given filtering function. Examples of this include collecting blocks of swap gates,
+        blocks of linear gates (CXs and SWAPs), blocks of Clifford gates, blocks of single-qubit gates,
+        blocks of two-qubit gates, etc..  Here 'iteratively' means that once a node is collected,
+        the in_degrees of its immediate successors are decreased by 1, allowing more nodes to become
+        leaf and to be eligible for collecting into the current block.
+        Returns a block of collected nodes.
+        """
+        current_block = []
+        unprocessed_pending_nodes = self.pending_nodes
+        self.pending_nodes = []
+
+        # Iteratively process unprocessed_pending_nodes:
+        # - any node that cannot be collected is added to pending_nodes,
+        # - any node that can be collected is added to the current_block,
+        #   and some of its successors can be moved to unprocessed_pending_nodes.
+        while unprocessed_pending_nodes:
+            new_pending_nodes = []
+            for node in unprocessed_pending_nodes:
+                can_be_added = filter_fn(node)
+                if can_be_added:
+                    current_block.append(node)
+
+                    # update the in_degree of node's successors
+                    for suc in self._direct_succs(node):
+                        self.in_degree[suc] -= 1
+                        if self.in_degree[suc] == 0:
+                            new_pending_nodes.append(suc)
+                else:
+                    self.pending_nodes.append(node)
+            unprocessed_pending_nodes = new_pending_nodes
+
+        return current_block
+
+    def collect_commuting_block(self, filter_fn):
+        """
+        Collects the largest block of commuting input nodes that match a given
+        filtering function. In a DagDependency nodes with in_degree=0 necessarily commute,
+        and a node with in_degree>0 does not commute with any of its immediate predecessors.
+        """
+        current_block = []
+
+        # nodes with in_degree=0 that match filter_fn
+        for node in self.pending_nodes:
+            if filter_fn(node):
+                current_block.append(node)
+
+        for node in current_block:
+            self._mark_node_as_collected(node)
+
+        return current_block
+
+    def collect_parallel_block(self):
+        """
+        Collects the largest block of 'parallel' input nodes, where 'parallel' means that
+        all nodes in the same block must be over pairwise disjoint qubits.
+        """
+        current_block = []
+        current_qubits = set()
+
+        # This is a simple greedy algorithm.
+        # Though it seems beneficial to sort nodes by the number of qubits (from largest to smallest).
+        self.pending_nodes.sort(key=lambda nd: -len(nd.qargs))
+
+        for node in self.pending_nodes:
+            node_qubits = set(node.qargs)
+            # print(f"--{len(node_qubits)}")
+            if current_qubits.isdisjoint(node_qubits):
+                current_block.append(node)
+                current_qubits = current_qubits.union(node_qubits)
+
+        for node in current_block:
+            self._mark_node_as_collected(node)
+
+        return current_block
+
+    def split_block_into_components(self, block):
+        """Given a block of nodes, splits it into connected components."""
+
+        if len(block) == 0:
+            return block
+
+        nodeset = set(block)
+        colors = dict()
+        color = -1
+
+        def process_node_rec(node):
+            """Given a node, recursively assigns the current color to all of its
+            immediate successors and predecessors."""
+
+            if node not in colors.keys():
+                colors[node] = color
+
+                for pred in self._direct_preds(node):
+                    if node not in nodeset:
+                        continue
+                    process_node_rec(pred)
+
+                for suc in self._direct_succs(node):
+                    if node not in nodeset:
+                        continue
+                    process_node_rec(suc)
+
+        # Assign colors to nodes, so that nodes are in the same component iff they
+        # have the same color
+        for node in block:
+            if node not in colors.keys():
+                color = color + 1
+                process_node_rec(node)
+
+        # Split blocks based on color
+        split_blocks = [[] for _ in range(color + 1)]
+        for node in block:
+            split_blocks[colors[node]].append(node)
+
+        return split_blocks
+
+    def collect_all_matching_blocks(self, filter_fn):
+        """Collects all blocks that match a given filtering function filter_fn.
+
+        This iteratively finds the largest block that does not match filter_fn, then the largest block
+        that matches filter_fn, and so on, until no more uncollected nodes remain.
+
+        Intuitively, extracting larger blocks of non-matching nodes helps to find larger blocks of
+        following matching nodes.
+
+        For now, we return both the list of all blocks (including blocks of matching and non-matching
+        nodes) and the list of matching blocks only.
+        """
+
+        def not_filter_fn(node):
+            """Returns the opposite of filter_fn."""
+            return not filter_fn(node)
+
+        # Iteratively collect non-matching and matching blocks.
+        matching_blocks = []
+        all_blocks = []
+        while self.have_uncollected_nodes():
+            non_matching_block = self.collect_matching_block(not_filter_fn)
+            if non_matching_block:
+                all_blocks.append(non_matching_block)
+            matching_block = self.collect_matching_block(filter_fn)
+            if matching_block:
+                all_blocks.append(matching_block)
+                matching_blocks.append(matching_block)
+
+        return matching_blocks, all_blocks
+
+    def collect_all_commuting_blocks(self, filter_fn):
+        """Collects all commuting blocks that match a given filtering function filter_fn.
+
+        This iteratively finds the largest block that does not match filter_fn, then
+        collects possibly multiple blocks of commuting nodes that match filter_fn,
+        repeating the process until no more uncollected nodes remain.
+
+        For now, we return both the list of all blocks and the list of commuting blocks.
+        """
+
+        def not_filter_fn(node):
+            """Returns the opposite of filter_fn."""
+            return not filter_fn(node)
+
+        # Iteratively:
+        #   Collect non-matching nodes.
+        #   Collect layers of commuting nodes (while possible).
+        matching_blocks = []
+        all_blocks = []
+        while self.have_uncollected_nodes():
+            non_matching_block = self.collect_matching_block(not_filter_fn)
+            if non_matching_block:
+                all_blocks.append(non_matching_block)
+
+            while True:
+                commuting_block = self.collect_commuting_block(filter_fn)
+                if commuting_block:
+                    matching_blocks.append(commuting_block)
+                    all_blocks.append(commuting_block)
+                else:
+                    break
+
+        return matching_blocks, all_blocks
+
+    def collect_all_parallel_blocks(self):
+        """Collects all blocks of parallel nodes.
+
+        Here, 'parallel'  means that nodes in the same block must have pairwise disjoint qubits.
+
+        This is useful to try to rearrange nodes in the quantum circuit exploiting commutativity
+        relations in the attempt to decrease the depth of the circuit.
+
+        We return both the list of all blocks.
+        """
+
+        # Iteratively:
+        #   Collect non-matching nodes.
+        #   Collect layers of commuting nodes (while possible)
+        all_blocks = []
+        while self.have_uncollected_nodes():
+            parallel_block = self.collect_parallel_block()
+            assert parallel_block
+            if parallel_block:
+                all_blocks.append(parallel_block)
+        return all_blocks

--- a/qiskit/transpiler/passes/optimization/collect_cliffords.py
+++ b/qiskit/transpiler/passes/optimization/collect_cliffords.py
@@ -11,31 +11,40 @@
 # that they have been altered from the originals.
 
 
-"""Replace each sequence of CX and SWAP gates by a single LinearFunction gate."""
+"""Replace each sequence of Clifford gates by a single Clifford gate."""
 
-from qiskit.circuit.library.generalized_gates import LinearFunction
+from qiskit.circuit.library.standard_gates import XGate, YGate, ZGate, HGate, SGate, SdgGate, CXGate, CYGate, CZGate, SwapGate
+from qiskit.quantum_info.operators import Clifford
 from qiskit.circuit import QuantumCircuit
 from .collapse_chains import CollapseChains
 
 
-class CollectLinearFunctions(CollapseChains):
-    """Collect blocks of linear gates (:class:`.CXGate` and :class:`.SwapGate` gates)
-    and replaces them by linear functions (:class:`.LinearFunction`)."""
+clifford_gate_name_to_gate_class = {
+    "x": XGate,
+    "y": YGate,
+    "z": ZGate,
+    "h": HGate,
+    "s": SGate,
+    "sdg": SdgGate,
+    "cx": CXGate,
+    "cy": CYGate,
+    "cz": CZGate,
+    "swap": SwapGate,
+}
+
+
+class CollectCliffords(CollapseChains):
+    """Collect blocks of Clifford gates and replaces them by a single Clifford."""
 
     def filter_function(self, node):
         """Specifies which nodes to collect into blocks."""
-        return node.op.name in ("cx", "swap") and node.op.condition is None
+        return node.op.name in clifford_gate_name_to_gate_class.keys() and node.op.condition is None
 
     def collapse_function(self, blocks, dag):
-        """Specifies what to do with collected blocks.
-        """
-        # Replace every discovered block by a linear function
+        """Specifies what to do with collected blocks."""
+        # Replace every discovered block by a Clifford
         global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
         for block in blocks:
-            # Create linear functions only out of blocks with at least 2 gates
-            if len(block) == 1:
-                continue
-
             # Find the set of all qubits used in this block
             cur_qubits = set()
             for node in block:
@@ -48,13 +57,13 @@ class CollectLinearFunctions(CollapseChains):
             # Construct a linear circuit
             qc = QuantumCircuit(len(cur_qubits))
             for node in block:
-                if node.op.name == "cx":
-                    qc.cx(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
-                elif node.op.name == "swap":
-                    qc.swap(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
+                positions = [wire_pos_map[qarg] for qarg in node.qargs]
+                qc.append(clifford_gate_name_to_gate_class[node.op.name](), positions)
 
-            # Create a linear function from this quantum circuit
-            op = LinearFunction(qc)
+            # Create a Clifford from this quantum circuit
+            # Before the PR on Cliffords as HLOs in merged, we unfortunately need to convert
+            # Clifford to instruction
+            op = Clifford(qc).to_instruction()
 
             # Replace the block by the constructed circuit
             dag.replace_block_with_op(block, op, wire_pos_map, cycle_check=False)

--- a/qiskit/transpiler/passes/optimization/collect_linear_functions.py
+++ b/qiskit/transpiler/passes/optimization/collect_linear_functions.py
@@ -32,10 +32,6 @@ class CollectLinearFunctions(CollapseChains):
         # Replace every discovered block by a linear function
         global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
         for block in blocks:
-            # Create linear functions only out of blocks with at least 2 gates
-            if len(block) == 1:
-                continue
-
             # Find the set of all qubits used in this block
             cur_qubits = set()
             for node in block:

--- a/qiskit/transpiler/passes/optimization/optimize_depth.py
+++ b/qiskit/transpiler/passes/optimization/optimize_depth.py
@@ -1,0 +1,45 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+
+"""Depth optimization using commutativity analysis."""
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.converters import dag_to_dagdependency, dagdependency_to_dag
+
+
+class OptimizeDepth(TransformationPass):
+    """Optimize depth using commutativity analysis."""
+
+    def run(self, dag):
+        """Run the OptimizeDepth pass on `dag`.
+
+        Internally, converts DagCircuit to DagDependency, and then
+        converts DagDependency back to DagCircuit (using depth minimization heuristic).
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+
+        original_depth = dag.depth()
+        dagdependency = dag_to_dagdependency(dag)
+        optimized_dag = dagdependency_to_dag(dagdependency, optimize_depth=True)
+        optimized_depth = optimized_dag.depth()
+
+        # Since "depth minimization" is heuristic, we return the optimized dag
+        # only if it's depth is really smaller.
+        if optimized_depth < original_depth:
+            return optimized_dag
+        else:
+            return dag

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/__init__.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/__init__.py
@@ -23,3 +23,4 @@ Further details can also be found here: https://arxiv.org/abs/2202.03459.
 from .swap_strategy import SwapStrategy
 from .pauli_2q_evolution_commutation import FindCommutingPauliEvolutions
 from .commuting_2q_gate_router import Commuting2qGateRouter
+from .commuting_2q_gate_grouper import Commuting2qGateGrouper

--- a/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_grouper.py
+++ b/qiskit/transpiler/passes/routing/commuting_2q_gate_routing/commuting_2q_gate_grouper.py
@@ -1,0 +1,99 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""This pass collapses 2-qubit gates that commute into :class:`.Commuting2qBlock`."""
+
+
+from qiskit.circuit import Qubit, Gate
+from qiskit.converters import dag_to_dagdependency, dagdependency_to_dag
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.transpiler.passes.optimization.collect_blocks import BlockSplitter, BlockCollector
+from qiskit.transpiler.passes.optimization.commutation_analysis import CommutationAnalysis
+from qiskit.transpiler import TransformationPass, TranspilerError
+
+from qiskit.transpiler.passes.routing.commuting_2q_gate_routing.commuting_2q_block import (
+    Commuting2qBlock,
+)
+
+
+class Commuting2qGateGrouper(TransformationPass):
+    """A pass that collapses 2-qubit gates that commute into :class:`.Commuting2qBlock`."""
+
+    def __init__(self, split_blocks=True, min_nodes_per_block=2):
+        """
+        Args:
+            split_blocks (bool): if True, splits detected blocks into sub-blocks over disjoint qubit sets.
+            min_nodes_per_block (int): specifies the minimum number of nodes in a block on
+                which to apply collapse_function.
+        """
+        self.split_blocks = split_blocks
+        self.min_nodes_per_block = min_nodes_per_block
+
+        super().__init__()
+
+    def collapse_function(self, blocks, dag):
+        """Specifies what to do with collected blocks.
+        """
+        # Replace every discovered block by a linear function
+        global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
+        for commuting_op_set in blocks:
+            # Find the set of all qubits used in this block
+            cur_qubits = set()
+            for node in commuting_op_set:
+                cur_qubits.update(node.qargs)
+
+            # For reproducibility, order these qubits compatibly with the global order
+            sorted_qubits = sorted(cur_qubits, key=lambda x: global_index_map[x])
+            wire_pos_map = dict((qb, ix) for ix, qb in enumerate(sorted_qubits))
+
+            op = Commuting2qBlock(commuting_op_set)
+
+            # Replace the block by the constructed circuit
+            # QUESTION: WHAT TO DO WITH CLASSICAL BITS?!
+            dag.replace_block_with_op(commuting_op_set, op, wire_pos_map, cycle_check=False)
+
+        return dag
+
+    def run(self, dag):
+        """Run the Commuting2qGateGrouper pass on `dag`.
+
+        Args:
+            dag (DAGCircuit): the DAG to be optimized.
+
+        Returns:
+            DAGCircuit: the optimized DAG.
+        """
+
+        def _is_2q(node):
+            """Two-qubit gates."""
+            return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 2
+
+        processed_dag = dag_to_dagdependency(dag)
+
+        matching_blocks = BlockCollector(processed_dag).collect_all_commuting_blocks(filter_fn=_is_2q)
+
+        if self.split_blocks:
+            blocks = []
+            for block in matching_blocks:
+                blocks.extend(BlockSplitter().run(block))
+        else:
+            blocks = matching_blocks
+
+        filtered_blocks = [block for block in blocks if len(block) >= self.min_nodes_per_block]
+
+        collapsed_dep_dag = self.collapse_function(filtered_blocks, processed_dag)
+
+        collapsed_dag = dagdependency_to_dag(collapsed_dep_dag)
+
+        return collapsed_dag
+
+

--- a/test/python/transpiler/test_collect_blocks.py
+++ b/test/python/transpiler/test_collect_blocks.py
@@ -1,0 +1,196 @@
+from qiskit.circuit import QuantumCircuit, CircuitInstruction, Gate
+from qiskit.circuit.library import RealAmplitudes
+from qiskit.converters import circuit_to_dag
+from qiskit.transpiler import PassManager
+from qiskit.transpiler.passes.optimization.collect_blocks import BlockCollector
+from qiskit.circuit.random import random_circuit
+from qiskit.transpiler.passes import Collect1qRuns
+from test.python.quantum_info.operators.symplectic.test_clifford import random_clifford_circuit
+
+
+def _split_blocks_with_barriers_circuit(dag, all_blocks):
+    """
+    A hack (copy-pasting code from dag_to_circuit) that creates circuit from dag,
+    based on the division of dag's nodes into blocks, that simply puts barriers
+    after every block.
+    """
+    name = dag.name or None
+    circuit = QuantumCircuit(
+        dag.qubits,
+        dag.clbits,
+        *dag.qregs.values(),
+        *dag.cregs.values(),
+        name=name,
+        global_phase=dag.global_phase,
+    )
+    circuit.metadata = dag.metadata
+    circuit.calibrations = dag.calibrations
+
+    for block in all_blocks:
+        for node in block:
+            circuit._append(CircuitInstruction(node.op.copy(), node.qargs, node.cargs))
+        circuit.barrier()
+
+    circuit.duration = dag.duration
+    circuit.unit = dag.unit
+    return circuit
+
+
+def test_collect_matching_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
+    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
+    if print_circuits:
+        print("Original Circuit:")
+        print(circuit)
+
+    dag = circuit_to_dag(circuit)
+
+    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
+    matching_blocks, all_blocks = block_collector.collect_all_matching_blocks(filter_fn=filter_fn)
+
+    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
+    print(f"Num matching blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
+    # print(f"Matching blocks have lengths: {[len(b) for b in matching_blocks]}")
+
+    if print_circuits:
+        print("Block Circuit:")
+        print(circuit2)
+
+
+def test_collect_commuting_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
+    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
+    if print_circuits:
+        print("Original Circuit:")
+        print(circuit)
+
+    dag = circuit_to_dag(circuit)
+
+    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
+    matching_blocks, all_blocks = block_collector.collect_all_commuting_blocks(filter_fn=filter_fn)
+
+    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
+    print(f"Num commuting blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
+    # print(f"Commuting blocks have lengths: {[len(b) for b in matching_blocks]}")
+
+    if print_circuits:
+        print("Block Circuit:")
+        print(circuit2)
+
+
+def test_collect_parallel_blocks(circuit, do_commutative_analysis, print_circuits=False):
+    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
+    if print_circuits:
+        print("Original Circuit:")
+        print(circuit)
+
+    dag = circuit_to_dag(circuit)
+
+    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
+    all_blocks = block_collector.collect_all_parallel_blocks()
+
+    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
+    print(f"Num all blocks: {len(all_blocks)}")
+    # print(f"Blocks have lengths: {[len(b) for b in all_blocks]}")
+
+    if print_circuits:
+        print("Block Circuit:")
+        print(circuit2)
+
+
+# Different filtering functions
+
+def _is_linear(node):
+    """Linear gates."""
+    return node.op.name in ("cx", "swap") and node.op.condition is None
+
+
+def _is_clifford(node):
+    """Linear gates."""
+    return node.op.name in ("x", "y", "z", "h", "s", "sdg", "cx", "cz", "swap") and node.op.condition is None
+
+
+def _is_2q(node):
+    """Two-qubit gates."""
+    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 2
+
+
+def _is_1q(node):
+    """Single-qubit gates"""
+    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 1
+
+
+# Actual examples
+
+def test_collect_linear_blocks_from_real_amplitudes():
+    print("test_collect_linear_blocks_from_real_amplitudes:")
+    ansatz = RealAmplitudes(4, reps=2)
+    circuit = ansatz.decompose()
+    # test_collect_matching_blocks(circuit, _is_linear, do_commutative_analysis=False, print_circuits=True)
+    test_collect_matching_blocks(circuit, _is_linear, do_commutative_analysis=True, print_circuits=True)
+
+
+def test_collect_linear_blocks_exploring_commutativity():
+    print("test_collect_linear_blocks_exploring_commutativity:")
+    qc = QuantumCircuit(5)
+    qc.cx(0, 1)
+    qc.cx(0, 2)
+    qc.z(0)
+    qc.cx(0, 3)
+    qc.cx(0, 4)
+    # test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=False, print_circuits=True)
+    test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=True, print_circuits=True)
+
+
+def test_commuting_2q_gate_grouper():
+    print("test_commuting_2q_gate_grouper:")
+    from qiskit.circuit.library import TwoLocal
+    circuit = TwoLocal(5, "ry", "cz", entanglement='pairwise').decompose()
+    # test_collect_commuting_blocks(circuit, _is_2q, do_commutative_analysis=False, print_circuits=True)
+    test_collect_commuting_blocks(circuit, _is_2q, do_commutative_analysis=True, print_circuits=True)
+
+
+def test_collect_linear_blocks_random_circuit():
+    print("test_collect_linear_blocks_random_circuit:")
+    for seed in range(1):
+        qc = random_circuit(5, 100, max_operands=2, seed=seed)
+        test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=False, print_circuits=False)
+        test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=True, print_circuits=False)
+        print("")
+
+
+def test_collect_clifford_blocks_random_circuit():
+    print("test_collect_clifford_blocks_random_circuit:")
+    for seed in range(10):
+        qc = random_circuit(5, 100, max_operands=2, seed=seed)
+        test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=False, print_circuits=False)
+        test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=True, print_circuits=False)
+        print("")
+
+
+def test_random_circuit_depth_min():
+    print("test_random_circuit_depth_min:")
+    # it seems that random_circuits come quite depth-optimized, so the technique performs worse
+    for seed in range(1):
+        qc = random_circuit(5, 100, max_operands=2, seed=seed)
+        test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
+        test_collect_parallel_blocks(qc, do_commutative_analysis=True, print_circuits=False)
+        print("")
+
+
+def test_random_clifford_circuit_depth_min():
+    print("test_random_clifford_circuit_depth_min:")
+    gates = ["x", "y", "z", "h", "s", "sdg", "cx", "cz", "swap"]
+    for seed in range(1):
+        qc = random_clifford_circuit(5, 100, gates, seed=seed)
+        test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
+        test_collect_parallel_blocks(qc, do_commutative_analysis=True, print_circuits=False)
+        print("")
+
+
+if __name__ == "__main__":
+    test_collect_linear_blocks_from_real_amplitudes()
+    test_collect_linear_blocks_exploring_commutativity()
+    test_commuting_2q_gate_grouper()
+    test_collect_linear_blocks_random_circuit()
+    test_collect_clifford_blocks_random_circuit()
+    test_random_circuit_depth_min()
+    test_random_clifford_circuit_depth_min()

--- a/test/python/transpiler/test_collect_blocks.py
+++ b/test/python/transpiler/test_collect_blocks.py
@@ -1,46 +1,27 @@
 from qiskit.circuit import QuantumCircuit, CircuitInstruction, Gate
 from qiskit.circuit.library import RealAmplitudes, LinearFunction
-from qiskit.converters import circuit_to_dag, dag_to_dagdependency, dag_to_circuit, dagdependency_to_circuit, dagdependency_to_dag
+from qiskit.converters import circuit_to_dag, dag_to_dagdependency, dag_to_circuit, dagdependency_to_circuit, \
+    dagdependency_to_dag
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes.optimization.collect_blocks import BlockCollector
 from qiskit.circuit.random import random_circuit
 from qiskit.transpiler.passes import Collect1qRuns
 from test.python.quantum_info.operators.symplectic.test_clifford import random_clifford_circuit
 import time
-
-
-def _split_blocks_with_barriers_circuit(dag, all_blocks):
-    """
-    A hack (copy-pasting code from dag_to_circuit) that creates circuit from dag,
-    based on the division of dag's nodes into blocks, that simply puts barriers
-    after every block.
-    """
-    name = dag.name or None
-    circuit = QuantumCircuit(
-        dag.qubits,
-        dag.clbits,
-        *dag.qregs.values(),
-        *dag.cregs.values(),
-        name=name,
-        global_phase=dag.global_phase,
-    )
-    circuit.metadata = dag.metadata
-    circuit.calibrations = dag.calibrations
-
-    for block in all_blocks:
-        for node in block:
-            circuit._append(CircuitInstruction(node.op.copy(), node.qargs, node.cargs))
-        circuit.barrier()
-
-    circuit.duration = dag.duration
-    circuit.unit = dag.unit
-    return circuit
+from qiskit.transpiler import PassManager, CouplingMap, Layout
+from qiskit.transpiler.passes import CommutationAnalysis
+from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import Commuting2qGateGrouper, SwapStrategy
+from qiskit.transpiler.passes import FullAncillaAllocation
+from qiskit.transpiler.passes import EnlargeWithAncilla
+from qiskit.transpiler.passes import ApplyLayout
+from qiskit.transpiler.passes import SetLayout
+from qiskit.transpiler.passes import Commuting2qGateRouter
+from qiskit.circuit.library import TwoLocal
 
 
 def test_collect_linear_blocks(circuit, do_commutative_analysis, print_circuits=False):
     print(f"Original circuit: has gates = {circuit.count_ops()}, depth = {circuit.depth()}")
     if print_circuits:
-        print("Original Circuit:")
         print(circuit)
 
     from qiskit.transpiler.passes.optimization import CollectLinearFunctions
@@ -57,7 +38,6 @@ def test_collect_linear_blocks(circuit, do_commutative_analysis, print_circuits=
 def test_collect_clifford_blocks(circuit, do_commutative_analysis, print_circuits=False):
     print(f"Original circuit: has gates = {circuit.count_ops()}, depth = {circuit.depth()}")
     if print_circuits:
-        print("Original Circuit:")
         print(circuit)
 
     from qiskit.transpiler.passes.optimization import CollectCliffords
@@ -71,36 +51,9 @@ def test_collect_clifford_blocks(circuit, do_commutative_analysis, print_circuit
         print(circuit2)
 
 
-
-
-
-
-def test_collect_commuting_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
-    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
-    if print_circuits:
-        print("Original Circuit:")
-        print(circuit)
-
-    dag = circuit_to_dag(circuit)
-    if do_commutative_analysis:
-        dag = dag_to_dagdependency(dag)
-
-    block_collector = BlockCollector(dag)
-    matching_blocks, all_blocks = block_collector.collect_all_commuting_blocks(filter_fn=filter_fn)
-
-    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
-    print(f"Num commuting blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
-    # print(f"Commuting blocks have lengths: {[len(b) for b in matching_blocks]}")
-
-    if print_circuits:
-        print("Block Circuit:")
-        print(circuit2)
-
-
 def test_collect_parallel_blocks(circuit, do_commutative_analysis, print_circuits=False):
     print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
     if print_circuits:
-        print("Original Circuit:")
         print(circuit)
 
     from qiskit.transpiler.passes.optimization import OptimizeDepth
@@ -109,22 +62,21 @@ def test_collect_parallel_blocks(circuit, do_commutative_analysis, print_circuit
 
     print(f"Final circuit: has #gates = {len(circuit2.data)}, depth = {circuit2.depth()}")
     if print_circuits:
-        print("Block Circuit:")
         print(circuit2)
 
 
-# Different filtering functions
+def test_collect_commuting_2q_blocks(circuit, split_blocks, min_nodes_per_block, print_circuits=False):
+    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
+    if print_circuits:
+        print(circuit)
 
+    from qiskit.transpiler.passes.routing.commuting_2q_gate_routing import Commuting2qGateGrouper
+    circuit2 = PassManager(
+        Commuting2qGateGrouper(split_blocks=split_blocks, min_nodes_per_block=min_nodes_per_block)).run(circuit)
 
-
-def _is_2q(node):
-    """Two-qubit gates."""
-    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 2
-
-
-def _is_1q(node):
-    """Single-qubit gates"""
-    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 1
+    print(f"Final Circuit: has #gates = {len(circuit2.data)}, depth = {circuit2.depth()}")
+    if print_circuits:
+        print(circuit2)
 
 
 # Actual examples
@@ -135,7 +87,6 @@ def test_collect_linear_blocks_from_real_amplitudes():
     circuit = ansatz.decompose()
     test_collect_linear_blocks(circuit, do_commutative_analysis=False, print_circuits=True)
     test_collect_linear_blocks(circuit, do_commutative_analysis=True, print_circuits=True)
-
 
 
 def test_collect_linear_blocks_exploring_commutativity():
@@ -170,23 +121,11 @@ def test_collect_linear_blocks_random_circuit():
         print("")
 
 
-
-
-
-
-def test_commuting_2q_gate_grouper():
-    print("test_commuting_2q_gate_grouper:")
-    from qiskit.circuit.library import TwoLocal
-    circuit = TwoLocal(5, "ry", "cz", entanglement='pairwise').decompose()
-    # test_collect_commuting_blocks(circuit, _is_2q, do_commutative_analysis=False, print_circuits=True)
-    test_collect_commuting_blocks(circuit, _is_2q, do_commutative_analysis=True, print_circuits=True)
-
-
 def test_collect_clifford_blocks_random_circuit():
     print("test_collect_clifford_blocks_random_circuit:")
     for seed in range(10):
         qc = random_circuit(5, 100, max_operands=2, seed=seed)
-        # test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=False, print_circuits=False)
+        test_collect_clifford_blocks(qc, do_commutative_analysis=False, print_circuits=False)
         test_collect_clifford_blocks(qc, do_commutative_analysis=True, print_circuits=False)
         print("")
 
@@ -211,20 +150,98 @@ def test_random_clifford_circuit_depth_min():
         print("")
 
 
+# EXPERIMENTS WITH COMMUTING GATES
+
+def test_commuting_2q_gate_grouper_example1():
+    print("test_commuting_2q_gate_grouper_example1:")
+    from qiskit.circuit.library import TwoLocal
+    circuit = TwoLocal(5, "ry", "cz", entanglement='pairwise').decompose()
+    test_collect_commuting_2q_blocks(circuit, split_blocks=True, min_nodes_per_block=2, print_circuits=True)
+
+
+def test_commuting_2q_gate_grouper_example2():
+    print("test_commuting_2q_gate_grouper_example2:")
+    circuit = TwoLocal(5, "ry", "cz", entanglement='full', reps=2).decompose()
+    print("Original circuit:")
+    print(circuit)
+    swap_strat = SwapStrategy.from_line([0, 1, 2, 3, 4])
+    backend_cmap = CouplingMap(couplinglist=[(0, 1), (1, 2), (1, 3), (3, 4), (4, 5), (5, 6)])
+    initial_layout = Layout.from_intlist([0, 1, 3, 4, 5], *circuit.qregs)
+
+    passmanager = PassManager(
+        [
+            CommutationAnalysis(),
+            Commuting2qGateGrouper(),
+            Commuting2qGateRouter(swap_strat),
+            SetLayout(initial_layout),
+            FullAncillaAllocation(backend_cmap),
+            EnlargeWithAncilla(),
+            ApplyLayout(),
+        ]
+    )
+    print("Transpiled circuit:")
+
+    result = passmanager.run(circuit)
+    print(result)
+
+
+
+def test_commuting_2q_gate_grouper_example3():
+    print("test_commuting_2q_gate_grouper_example3:")
+
+    circ = QuantumCircuit(8)
+    circ.cz(0, 1)
+    circ.cz(2, 3)
+    circ.cz(0, 2)
+    circ.cz(1, 3)
+    circ.cz(0, 3)
+
+    circ.cz(5, 6)
+    circ.cz(6, 7)
+    circ.cz(5, 7)
+
+    print(circ)
+
+    passmanager = PassManager([Commuting2qGateGrouper(split_blocks=True, min_nodes_per_block=2)])
+    res = passmanager.run(circ)
+    print(res)
+
+
+
+
+def test_commuting_2q_gate_grouper_example4():
+    print("test_commuting_2q_gate_grouper_example4:")
+
+    circ = QuantumCircuit(4)
+    circ.cx(0, 1)
+    circ.cx(1, 2)
+
+    cmap = CouplingMap([[0, 1], [1, 2], [1, 3], [3, 4]])
+    cmap.make_symmetric()
+
+    print(circ)
+
+    passmanager = PassManager([Commuting2qGateGrouper(min_nodes_per_block=2)])
+    res = passmanager.run(circ)
+    print(res)
+
+
 if __name__ == "__main__":
     start_time = time.time()
-
     # test_collect_linear_blocks_from_real_amplitudes()
     # test_collect_linear_blocks_exploring_commutativity()
-    # test_collect_linear_blocks_random_circuit()
     # test_collect_linear_blocks_split()
+    # test_collect_linear_blocks_random_circuit()
 
-    test_collect_clifford_blocks_random_circuit()
+    # test_collect_clifford_blocks_random_circuit()
 
-    # test_commuting_2q_gate_grouper()
     # test_random_circuit_depth_min()
     # test_random_clifford_circuit_depth_min()
 
+    test_commuting_2q_gate_grouper_example1()
+    test_commuting_2q_gate_grouper_example2()
+    test_commuting_2q_gate_grouper_example3()
+    test_commuting_2q_gate_grouper_example4()
 
     end_time = time.time()
-    print(f"Total time = {end_time-start_time:.4}")
+    print(f"Total time = {end_time - start_time:.4}")

--- a/test/python/transpiler/test_collect_blocks.py
+++ b/test/python/transpiler/test_collect_blocks.py
@@ -37,77 +37,42 @@ def _split_blocks_with_barriers_circuit(dag, all_blocks):
     return circuit
 
 
-def _replace_linear_block_with_op(dag, block):
-    # Replace every discovered block by a linear function
-    global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
-
-    # Create linear functions only out of blocks with at least 2 gates
-    if len(block) == 1:
-        return
-
-    # Find the set of all qubits used in this block
-    cur_qubits = set()
-    for node in block:
-        cur_qubits.update(node.qargs)
-
-    # For reproducibility, order these qubits compatibly with the global order
-    sorted_qubits = sorted(cur_qubits, key=lambda x: global_index_map[x])
-    wire_pos_map = dict((qb, ix) for ix, qb in enumerate(sorted_qubits))
-
-    # Construct a linear circuit
-    qc = QuantumCircuit(len(cur_qubits))
-    for node in block:
-        if node.op.name == "cx":
-            qc.cx(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
-        elif node.op.name == "swap":
-            qc.swap(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
-
-    # Create a linear function from this quantum circuit
-    op = LinearFunction(qc)
-
-    # Replace the block by the constructed circuit
-    dag.replace_block_with_op(block, op, wire_pos_map, cycle_check=False)
-
-
-def test_collect_matching_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
-    print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
+def test_collect_linear_blocks(circuit, do_commutative_analysis, print_circuits=False):
+    print(f"Original circuit: has gates = {circuit.count_ops()}, depth = {circuit.depth()}")
     if print_circuits:
         print("Original Circuit:")
         print(circuit)
 
-    dag = circuit_to_dag(circuit)
-    if do_commutative_analysis:
-        dag = dag_to_dagdependency(dag)
+    from qiskit.transpiler.passes.optimization import CollectLinearFunctions
+    circuit2 = PassManager(CollectLinearFunctions(split_blocks=True,
+                                                  do_commutative_analysis=do_commutative_analysis,
+                                                  min_nodes_per_block=1)).run(circuit)
 
-    # dag.print()
-
-    block_collector = BlockCollector(dag)
-    matching_blocks, all_blocks = block_collector.collect_all_matching_blocks(filter_fn=filter_fn)
-
-    for block in matching_blocks:
-        _replace_linear_block_with_op(dag, block)
-
-    # print(f"AFTER")
-    # dag.print()
-
-
-    circuit2 = dagdependency_to_circuit(dag)
-
-
-    if do_commutative_analysis:
-        circuit2 = dagdependency_to_circuit(dag)
-    else:
-        circuit2 = dag_to_circuit(dag)
-
-    # circuit2 = dag_to_circuit(dag)
-
-    # circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
-    # # print(f"Num matching blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
-    # # print(f"Matching blocks have lengths: {[len(b) for b in matching_blocks]}")
+    print(f"Block circuit: has gates = {circuit2.count_ops()}, depth = {circuit.depth()}")
 
     if print_circuits:
-        print("Block Circuit:")
         print(circuit2)
+
+
+def test_collect_clifford_blocks(circuit, do_commutative_analysis, print_circuits=False):
+    print(f"Original circuit: has gates = {circuit.count_ops()}, depth = {circuit.depth()}")
+    if print_circuits:
+        print("Original Circuit:")
+        print(circuit)
+
+    from qiskit.transpiler.passes.optimization import CollectCliffords
+    circuit2 = PassManager(CollectCliffords(split_blocks=True,
+                                            do_commutative_analysis=do_commutative_analysis,
+                                            min_nodes_per_block=1)).run(circuit)
+
+    print(f"Block circuit: has gates = {circuit2.count_ops()}, depth = {circuit.depth()}")
+
+    if print_circuits:
+        print(circuit2)
+
+
+
+
 
 
 def test_collect_commuting_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
@@ -150,14 +115,6 @@ def test_collect_parallel_blocks(circuit, do_commutative_analysis, print_circuit
 
 # Different filtering functions
 
-def _is_linear(node):
-    """Linear gates."""
-    return node.op.name in ("cx", "swap") and node.op.condition is None
-
-
-def _is_clifford(node):
-    """Linear gates."""
-    return node.op.name in ("x", "y", "z", "h", "s", "sdg", "cx", "cz", "swap") and node.op.condition is None
 
 
 def _is_2q(node):
@@ -176,8 +133,9 @@ def test_collect_linear_blocks_from_real_amplitudes():
     print("test_collect_linear_blocks_from_real_amplitudes:")
     ansatz = RealAmplitudes(4, reps=2)
     circuit = ansatz.decompose()
-    # test_collect_matching_blocks(circuit, _is_linear, do_commutative_analysis=False, print_circuits=True)
-    test_collect_matching_blocks(circuit, _is_linear, do_commutative_analysis=True, print_circuits=True)
+    test_collect_linear_blocks(circuit, do_commutative_analysis=False, print_circuits=True)
+    test_collect_linear_blocks(circuit, do_commutative_analysis=True, print_circuits=True)
+
 
 
 def test_collect_linear_blocks_exploring_commutativity():
@@ -188,8 +146,32 @@ def test_collect_linear_blocks_exploring_commutativity():
     qc.z(0)
     qc.cx(0, 3)
     qc.cx(0, 4)
-    # test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=False, print_circuits=True)
-    test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=True, print_circuits=True)
+    test_collect_linear_blocks(qc, do_commutative_analysis=False, print_circuits=True)
+    test_collect_linear_blocks(qc, do_commutative_analysis=True, print_circuits=True)
+
+
+def test_collect_linear_blocks_split():
+    print("test_collect_linear_blocks_split:")
+    qc = QuantumCircuit(6)
+    qc.cx(0, 1)
+    qc.swap(3, 5)
+    qc.cx(2, 1)
+    qc.cx(5, 3)
+    test_collect_linear_blocks(qc, do_commutative_analysis=False, print_circuits=True)
+    test_collect_linear_blocks(qc, do_commutative_analysis=True, print_circuits=True)
+
+
+def test_collect_linear_blocks_random_circuit():
+    print("test_collect_linear_blocks_random_circuit:")
+    for seed in range(1):
+        qc = random_circuit(5, 100, max_operands=2, seed=seed)
+        test_collect_linear_blocks(qc, do_commutative_analysis=False, print_circuits=False)
+        test_collect_linear_blocks(qc, do_commutative_analysis=True, print_circuits=False)
+        print("")
+
+
+
+
 
 
 def test_commuting_2q_gate_grouper():
@@ -200,21 +182,12 @@ def test_commuting_2q_gate_grouper():
     test_collect_commuting_blocks(circuit, _is_2q, do_commutative_analysis=True, print_circuits=True)
 
 
-def test_collect_linear_blocks_random_circuit():
-    print("test_collect_linear_blocks_random_circuit:")
-    for seed in range(1):
-        qc = random_circuit(5, 100, max_operands=2, seed=seed)
-        test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=False, print_circuits=False)
-        test_collect_matching_blocks(qc, _is_linear, do_commutative_analysis=True, print_circuits=False)
-        print("")
-
-
 def test_collect_clifford_blocks_random_circuit():
     print("test_collect_clifford_blocks_random_circuit:")
     for seed in range(10):
         qc = random_circuit(5, 100, max_operands=2, seed=seed)
-        test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=False, print_circuits=False)
-        test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=True, print_circuits=False)
+        # test_collect_matching_blocks(qc, _is_clifford, do_commutative_analysis=False, print_circuits=False)
+        test_collect_clifford_blocks(qc, do_commutative_analysis=True, print_circuits=False)
         print("")
 
 
@@ -240,12 +213,18 @@ def test_random_clifford_circuit_depth_min():
 
 if __name__ == "__main__":
     start_time = time.time()
+
     # test_collect_linear_blocks_from_real_amplitudes()
     # test_collect_linear_blocks_exploring_commutativity()
-    # test_commuting_2q_gate_grouper()
     # test_collect_linear_blocks_random_circuit()
-    # test_collect_clifford_blocks_random_circuit()
+    # test_collect_linear_blocks_split()
+
+    test_collect_clifford_blocks_random_circuit()
+
+    # test_commuting_2q_gate_grouper()
     # test_random_circuit_depth_min()
-    test_random_clifford_circuit_depth_min()
+    # test_random_clifford_circuit_depth_min()
+
+
     end_time = time.time()
     print(f"Total time = {end_time-start_time:.4}")

--- a/test/python/transpiler/test_collect_blocks.py
+++ b/test/python/transpiler/test_collect_blocks.py
@@ -1,11 +1,12 @@
 from qiskit.circuit import QuantumCircuit, CircuitInstruction, Gate
-from qiskit.circuit.library import RealAmplitudes
-from qiskit.converters import circuit_to_dag
+from qiskit.circuit.library import RealAmplitudes, LinearFunction
+from qiskit.converters import circuit_to_dag, dag_to_dagdependency, dag_to_circuit, dagdependency_to_circuit, dagdependency_to_dag
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes.optimization.collect_blocks import BlockCollector
 from qiskit.circuit.random import random_circuit
 from qiskit.transpiler.passes import Collect1qRuns
 from test.python.quantum_info.operators.symplectic.test_clifford import random_clifford_circuit
+import time
 
 
 def _split_blocks_with_barriers_circuit(dag, all_blocks):
@@ -36,6 +37,38 @@ def _split_blocks_with_barriers_circuit(dag, all_blocks):
     return circuit
 
 
+def _replace_linear_block_with_op(dag, block):
+    # Replace every discovered block by a linear function
+    global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
+
+    # Create linear functions only out of blocks with at least 2 gates
+    if len(block) == 1:
+        return
+
+    # Find the set of all qubits used in this block
+    cur_qubits = set()
+    for node in block:
+        cur_qubits.update(node.qargs)
+
+    # For reproducibility, order these qubits compatibly with the global order
+    sorted_qubits = sorted(cur_qubits, key=lambda x: global_index_map[x])
+    wire_pos_map = dict((qb, ix) for ix, qb in enumerate(sorted_qubits))
+
+    # Construct a linear circuit
+    qc = QuantumCircuit(len(cur_qubits))
+    for node in block:
+        if node.op.name == "cx":
+            qc.cx(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
+        elif node.op.name == "swap":
+            qc.swap(wire_pos_map[node.qargs[0]], wire_pos_map[node.qargs[1]])
+
+    # Create a linear function from this quantum circuit
+    op = LinearFunction(qc)
+
+    # Replace the block by the constructed circuit
+    dag.replace_block_with_op(block, op, wire_pos_map, cycle_check=False)
+
+
 def test_collect_matching_blocks(circuit, filter_fn, do_commutative_analysis, print_circuits=False):
     print(f"Original circuit: has #gates = {len(circuit.data)}, depth = {circuit.depth()}")
     if print_circuits:
@@ -43,13 +76,34 @@ def test_collect_matching_blocks(circuit, filter_fn, do_commutative_analysis, pr
         print(circuit)
 
     dag = circuit_to_dag(circuit)
+    if do_commutative_analysis:
+        dag = dag_to_dagdependency(dag)
 
-    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
+    # dag.print()
+
+    block_collector = BlockCollector(dag)
     matching_blocks, all_blocks = block_collector.collect_all_matching_blocks(filter_fn=filter_fn)
 
-    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
-    print(f"Num matching blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
-    # print(f"Matching blocks have lengths: {[len(b) for b in matching_blocks]}")
+    for block in matching_blocks:
+        _replace_linear_block_with_op(dag, block)
+
+    # print(f"AFTER")
+    # dag.print()
+
+
+    circuit2 = dagdependency_to_circuit(dag)
+
+
+    if do_commutative_analysis:
+        circuit2 = dagdependency_to_circuit(dag)
+    else:
+        circuit2 = dag_to_circuit(dag)
+
+    # circuit2 = dag_to_circuit(dag)
+
+    # circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
+    # # print(f"Num matching blocks: {len(matching_blocks)}, num all blocks: {len(all_blocks)}")
+    # # print(f"Matching blocks have lengths: {[len(b) for b in matching_blocks]}")
 
     if print_circuits:
         print("Block Circuit:")
@@ -63,8 +117,10 @@ def test_collect_commuting_blocks(circuit, filter_fn, do_commutative_analysis, p
         print(circuit)
 
     dag = circuit_to_dag(circuit)
+    if do_commutative_analysis:
+        dag = dag_to_dagdependency(dag)
 
-    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
+    block_collector = BlockCollector(dag)
     matching_blocks, all_blocks = block_collector.collect_all_commuting_blocks(filter_fn=filter_fn)
 
     circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
@@ -82,15 +138,11 @@ def test_collect_parallel_blocks(circuit, do_commutative_analysis, print_circuit
         print("Original Circuit:")
         print(circuit)
 
-    dag = circuit_to_dag(circuit)
+    from qiskit.transpiler.passes.optimization import OptimizeDepth
 
-    block_collector = BlockCollector(dag, do_commutative_analysis=do_commutative_analysis)
-    all_blocks = block_collector.collect_all_parallel_blocks()
+    circuit2 = PassManager(OptimizeDepth()).run(circuit)
 
-    circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
-    print(f"Num all blocks: {len(all_blocks)}")
-    # print(f"Blocks have lengths: {[len(b) for b in all_blocks]}")
-
+    print(f"Final circuit: has #gates = {len(circuit2.data)}, depth = {circuit2.depth()}")
     if print_circuits:
         print("Block Circuit:")
         print(circuit2)
@@ -169,9 +221,9 @@ def test_collect_clifford_blocks_random_circuit():
 def test_random_circuit_depth_min():
     print("test_random_circuit_depth_min:")
     # it seems that random_circuits come quite depth-optimized, so the technique performs worse
-    for seed in range(1):
+    for seed in range(10):
         qc = random_circuit(5, 100, max_operands=2, seed=seed)
-        test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
+        # test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
         test_collect_parallel_blocks(qc, do_commutative_analysis=True, print_circuits=False)
         print("")
 
@@ -179,18 +231,21 @@ def test_random_circuit_depth_min():
 def test_random_clifford_circuit_depth_min():
     print("test_random_clifford_circuit_depth_min:")
     gates = ["x", "y", "z", "h", "s", "sdg", "cx", "cz", "swap"]
-    for seed in range(1):
+    for seed in range(10):
         qc = random_clifford_circuit(5, 100, gates, seed=seed)
-        test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
+        # test_collect_parallel_blocks(qc, do_commutative_analysis=False, print_circuits=False)
         test_collect_parallel_blocks(qc, do_commutative_analysis=True, print_circuits=False)
         print("")
 
 
 if __name__ == "__main__":
-    test_collect_linear_blocks_from_real_amplitudes()
-    test_collect_linear_blocks_exploring_commutativity()
-    test_commuting_2q_gate_grouper()
-    test_collect_linear_blocks_random_circuit()
-    test_collect_clifford_blocks_random_circuit()
-    test_random_circuit_depth_min()
+    start_time = time.time()
+    # test_collect_linear_blocks_from_real_amplitudes()
+    # test_collect_linear_blocks_exploring_commutativity()
+    # test_commuting_2q_gate_grouper()
+    # test_collect_linear_blocks_random_circuit()
+    # test_collect_clifford_blocks_random_circuit()
+    # test_random_circuit_depth_min()
     test_random_clifford_circuit_depth_min()
+    end_time = time.time()
+    print(f"Total time = {end_time-start_time:.4}")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

**needs to be updated to reflect the latest changes**

This is a draft PR that illustrates different block collection methods from #5775. 

I am not yet sure how the final API should look like, and would be happy to get feedback!

One tricky point: when using `DagDependency`, the returned blocks are lists of `DagDepNodes`. Based on the suggestion by @mtreinish, I have adapted the function `replace_block_with_op` from `DagCircuit` to `DagDependency` (in either case it boils down to a function in `retworkx`).  

There is one additional caveat when applying `replace_block_with_op` on a `DagDependency`: the obtained`DagDependency` may miss some commutativity relations (and thus is not necessarily canonical). However, it is guaranteed to be valid. On the other hand, I have no idea how to replace a node by a block of nodes in a `DagDependency` without risking to obtain incorrect results.


Thoughts and comments are welcome.

### Details and comments

There are two files:
`collect_blocks.py` implements block collection methods described in [this comment](https://github.com/Qiskit/qiskit-terra/issues/5775#issuecomment-1180033016).
`test_collect_blocks.py` is not a real test file, but rather includes several examples.

### A few experiments

1. **collect_all_matching_blocks**

The following code:
```
def _is_linear(node):
    """Linear gates."""
    return node.op.name in ("cx", "swap") and node.op.condition is None

print("Original Circuit:")
print(circuit)
dag = circuit_to_dag(circuit)
block_collector = BlockCollector(dag, do_commutative_analysis=True)
matching_blocks, all_blocks = block_collector.collect_all_matching_blocks(filter_fn=_is_linear)
circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
print("Block Circuit:")
print(circuit2)
```
extracts all blocks of linear gates from a quantum circuit, generalizing code in `collect_linear_functions`. Here is a specific example:
```
Original Circuit:
               ┌───┐          
q_0: ──■────■──┤ Z ├──■────■──
     ┌─┴─┐  │  └───┘  │    │  
q_1: ┤ X ├──┼─────────┼────┼──
     └───┘┌─┴─┐       │    │  
q_2: ─────┤ X ├───────┼────┼──
          └───┘     ┌─┴─┐  │  
q_3: ───────────────┤ X ├──┼──
                    └───┘┌─┴─┐
q_4: ────────────────────┤ X ├
                         └───┘

Block Circuit:
     ┌───┐ ░                      ░ 
q_0: ┤ Z ├─░───■────■────■────■───░─
     └───┘ ░ ┌─┴─┐  │    │    │   ░ 
q_1: ──────░─┤ X ├──┼────┼────┼───░─
           ░ └───┘┌─┴─┐  │    │   ░ 
q_2: ──────░──────┤ X ├──┼────┼───░─
           ░      └───┘┌─┴─┐  │   ░ 
q_3: ──────░───────────┤ X ├──┼───░─
           ░           └───┘┌─┴─┐ ░ 
q_4: ──────░────────────────┤ X ├─░─
           ░                └───┘ ░ 
```
It also shows that exploiting commutativity analysis is beneficial.

2. **test_collect_commuting_blocks**

The following code:
```
def _is_2q(node):
    """Two-qubit gates."""
    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 2

print("Original Circuit:")
print(circuit)
dag = circuit_to_dag(circuit)
block_collector = BlockCollector(dag, do_commutative_analysis=True)
matching_blocks, all_blocks = block_collector.collect_all_commuting_blocks(filter_fn=_is_2q)
circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
print("Block Circuit:")
print(circuit2)
```
mimics the behavior of `Commuting2qGateGrouper` pass in #8034:
```
Original Circuit:
     ┌──────────┐   ┌──────────┐               ┌───────────┐                »
q_0: ┤ Ry(θ[0]) ├─■─┤ Ry(θ[5]) ├─────────────■─┤ Ry(θ[10]) ├──────────────■─»
     ├──────────┤ │ └──────────┘┌──────────┐ │ └───────────┘┌───────────┐ │ »
q_1: ┤ Ry(θ[1]) ├─■──────■──────┤ Ry(θ[6]) ├─■───────■──────┤ Ry(θ[11]) ├─■─»
     ├──────────┤        │      ├──────────┤         │      ├───────────┤   »
q_2: ┤ Ry(θ[2]) ├─■──────■──────┤ Ry(θ[7]) ├─■───────■──────┤ Ry(θ[12]) ├─■─»
     ├──────────┤ │             ├──────────┤ │              ├───────────┤ │ »
q_3: ┤ Ry(θ[3]) ├─■──────■──────┤ Ry(θ[8]) ├─■───────■──────┤ Ry(θ[13]) ├─■─»
     ├──────────┤        │      ├──────────┤         │      ├───────────┤   »
q_4: ┤ Ry(θ[4]) ├────────■──────┤ Ry(θ[9]) ├─────────■──────┤ Ry(θ[14]) ├───»
     └──────────┘               └──────────┘                └───────────┘   »
«     ┌───────────┐             
«q_0: ┤ Ry(θ[15]) ├─────────────
«     └───────────┘┌───────────┐
«q_1: ──────■──────┤ Ry(θ[16]) ├
«           │      ├───────────┤
«q_2: ──────■──────┤ Ry(θ[17]) ├
«                  ├───────────┤
«q_3: ──────■──────┤ Ry(θ[18]) ├
«           │      ├───────────┤
«q_4: ──────■──────┤ Ry(θ[19]) ├
«                  └───────────┘

Block Circuit:
     ┌──────────┐ ░              ░ ┌──────────┐ ░              ░ ┌───────────┐»
q_0: ┤ Ry(θ[0]) ├─░──■───────────░─┤ Ry(θ[5]) ├─░──■───────────░─┤ Ry(θ[10]) ├»
     ├──────────┤ ░  │           ░ ├──────────┤ ░  │           ░ ├───────────┤»
q_1: ┤ Ry(θ[1]) ├─░──■──■────────░─┤ Ry(θ[6]) ├─░──■──■────────░─┤ Ry(θ[11]) ├»
     ├──────────┤ ░     │        ░ ├──────────┤ ░     │        ░ ├───────────┤»
q_2: ┤ Ry(θ[2]) ├─░─────■──■─────░─┤ Ry(θ[7]) ├─░─────■──■─────░─┤ Ry(θ[12]) ├»
     ├──────────┤ ░        │     ░ ├──────────┤ ░        │     ░ ├───────────┤»
q_3: ┤ Ry(θ[3]) ├─░────────■──■──░─┤ Ry(θ[8]) ├─░────────■──■──░─┤ Ry(θ[13]) ├»
     ├──────────┤ ░           │  ░ ├──────────┤ ░           │  ░ ├───────────┤»
q_4: ┤ Ry(θ[4]) ├─░───────────■──░─┤ Ry(θ[9]) ├─░───────────■──░─┤ Ry(θ[14]) ├»
     └──────────┘ ░              ░ └──────────┘ ░              ░ └───────────┘»
«      ░              ░ ┌───────────┐ ░ 
«q_0: ─░──■───────────░─┤ Ry(θ[15]) ├─░─
«      ░  │           ░ ├───────────┤ ░ 
«q_1: ─░──■──■────────░─┤ Ry(θ[16]) ├─░─
«      ░     │        ░ ├───────────┤ ░ 
«q_2: ─░─────■──■─────░─┤ Ry(θ[17]) ├─░─
«      ░        │     ░ ├───────────┤ ░ 
«q_3: ─░────────■──■──░─┤ Ry(θ[18]) ├─░─
«      ░           │  ░ ├───────────┤ ░ 
«q_4: ─░───────────■──░─┤ Ry(θ[19]) ├─░─
«      ░              ░ └───────────┘ ░ 
```

3. **test_collect_parallel_blocks**

The following code:
```
def _is_2q(node):
    """Two-qubit gates."""
    return isinstance(node.op, Gate) and node.op.condition is None and len(node.qargs) == 2

dag = circuit_to_dag(circuit)
block_collector = BlockCollector(dag, do_commutative_analysis=True)
all_blocks = block_collector.collect_all_parallel_blocks()
circuit2 = _split_blocks_with_barriers_circuit(dag, all_blocks)
```
can be used to rearrange gates exploiting commutativity analysis in the attempt to decrease the overall depth. Here are the numbers for 10 experiments for random Clifford circuits (where `Num all blocks` represents the minimized depth)
```
Original circuit: has #gates = 100, depth = 40
Num all blocks: 38

Original circuit: has #gates = 100, depth = 42
Num all blocks: 38

Original circuit: has #gates = 100, depth = 45
Num all blocks: 44

Original circuit: has #gates = 100, depth = 43
Num all blocks: 37

Original circuit: has #gates = 100, depth = 44
Num all blocks: 44

Original circuit: has #gates = 100, depth = 40
Num all blocks: 37

Original circuit: has #gates = 100, depth = 43
Num all blocks: 36

Original circuit: has #gates = 100, depth = 49
Num all blocks: 44

Original circuit: has #gates = 100, depth = 43
Num all blocks: 41

Original circuit: has #gates = 100, depth = 49
Num all blocks: 47
```
