### PR TITLE
modified reps for ZZFeatureMap object created, to fit printed circuit

### DIFF
--- a/qiskit/circuit/library/data_preparation/zz_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/zz_feature_map.py
@@ -37,7 +37,7 @@ class ZZFeatureMap(PauliFeatureMap):
 
     Examples:
 
-        >>> prep = ZZFeatureMap(2, reps=2)
+        >>> prep = ZZFeatureMap(2, reps=1)
         >>> print(prep)
              ┌───┐┌──────────────┐
         q_0: ┤ H ├┤ U1(2.0*x[0]) ├──■───────────────────────────────────────■──


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixed example code for ZZFeatureMap object to match actual circuit printed

### Details and comments

In Example 1, `prep = ZZFeatureMap(2, reps=2)` was used to print out a state preparation circuit with only 1 rep.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/18029177/178673644-7c7329f7-597c-4b3a-8652-2d5088108afc.png">

Modified the reps to `prep = ZZFeatureMap(2, reps=1)` to match what was printed in Example 1.