### PR TITLE
Added deprecated flag to QuantumCircuit.label arguments for all relevant gates.

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -46,6 +46,7 @@ from qiskit.qasm.qasm import Qasm
 from qiskit.qasm.exceptions import QasmError
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.utils.deprecation import deprecate_function
+from qiskit.utils.deprecation import deprecate_arguments
 from .parameterexpression import ParameterExpression, ParameterValueType
 from .quantumregister import QuantumRegister, Qubit, AncillaRegister, AncillaQubit
 from .classicalregister import ClassicalRegister, Clbit
@@ -674,6 +675,7 @@ class QuantumCircuit:
         power_circuit.append(gate.power(power), list(range(gate.num_qubits)))
         return power_circuit
 
+    @deprecate_arguments({"label"})
     def control(
         self,
         num_ctrl_qubits: int = 1,
@@ -2844,6 +2846,7 @@ class QuantumCircuit:
 
         return self.append(HGate(), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def ch(
         self,
         control_qubit: QubitSpecifier,
@@ -2936,6 +2939,7 @@ class QuantumCircuit:
 
         return self.append(PhaseGate(theta), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cp(
         self,
         theta: ParameterValueType,
@@ -3085,6 +3089,7 @@ class QuantumCircuit:
             RC3XGate(), [control_qubit1, control_qubit2, control_qubit3, target_qubit], []
         )
 
+    @deprecate_arguments({"label"})
     def rx(
         self, theta: ParameterValueType, qubit: QubitSpecifier, label: Optional[str] = None
     ) -> InstructionSet:
@@ -3104,6 +3109,7 @@ class QuantumCircuit:
 
         return self.append(RXGate(theta, label=label), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def crx(
         self,
         theta: ParameterValueType,
@@ -3153,6 +3159,7 @@ class QuantumCircuit:
 
         return self.append(RXXGate(theta), [qubit1, qubit2], [])
 
+    @deprecate_arguments({"label"})
     def ry(
         self, theta: ParameterValueType, qubit: QubitSpecifier, label: Optional[str] = None
     ) -> InstructionSet:
@@ -3172,6 +3179,7 @@ class QuantumCircuit:
 
         return self.append(RYGate(theta, label=label), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cry(
         self,
         theta: ParameterValueType,
@@ -3237,6 +3245,7 @@ class QuantumCircuit:
 
         return self.append(RZGate(phi), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def crz(
         self,
         theta: ParameterValueType,
@@ -3380,6 +3389,7 @@ class QuantumCircuit:
 
         return self.append(iSwapGate(), [qubit1, qubit2], [])
 
+    @deprecate_arguments({"label"})
     def cswap(
         self,
         control_qubit: QubitSpecifier,
@@ -3465,6 +3475,7 @@ class QuantumCircuit:
 
         return self.append(SXdgGate(), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def csx(
         self,
         control_qubit: QubitSpecifier,
@@ -3549,6 +3560,7 @@ class QuantumCircuit:
 
         return self.append(UGate(theta, phi, lam), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cu(
         self,
         theta: ParameterValueType,
@@ -3617,6 +3629,7 @@ class QuantumCircuit:
         "QuantumCircuit.cp method instead, which acts "
         "identically."
     )
+    @deprecate_arguments({"label"})
     def cu1(
         self,
         theta: ParameterValueType,
@@ -3742,6 +3755,7 @@ class QuantumCircuit:
         "use the QuantumCircuit.cu method instead, where "
         "cu3(ϴ,φ,λ) = cu(ϴ,φ,λ,0)."
     )
+    @deprecate_arguments({"label"})
     def cu3(
         self,
         theta: ParameterValueType,
@@ -3778,6 +3792,7 @@ class QuantumCircuit:
             [],
         )
 
+    @deprecate_arguments({"label"})
     def x(self, qubit: QubitSpecifier, label: Optional[str] = None) -> InstructionSet:
         r"""Apply :class:`~qiskit.circuit.library.XGate`.
 
@@ -3794,6 +3809,7 @@ class QuantumCircuit:
 
         return self.append(XGate(label=label), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cx(
         self,
         control_qubit: QubitSpecifier,
@@ -3823,6 +3839,7 @@ class QuantumCircuit:
             CXGate(label=label, ctrl_state=ctrl_state), [control_qubit, target_qubit], []
         )
 
+    @deprecate_arguments({"label"})
     def cnot(
         self,
         control_qubit: QubitSpecifier,
@@ -4049,6 +4066,7 @@ class QuantumCircuit:
 
         return self.append(YGate(), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cy(
         self,
         control_qubit: QubitSpecifier,
@@ -4092,6 +4110,7 @@ class QuantumCircuit:
 
         return self.append(ZGate(), [qubit], [])
 
+    @deprecate_arguments({"label"})
     def cz(
         self,
         control_qubit: QubitSpecifier,

--- a/releasenotes/notes/deprecated-label-parameter-for-QuantumCircuit-gates-759af94b09267a85.yaml
+++ b/releasenotes/notes/deprecated-label-parameter-for-QuantumCircuit-gates-759af94b09267a85.yaml
@@ -1,0 +1,10 @@
+---
+deprecations:
+  - |
+    The ``QuantumCircuit.label`` parameter has been deprecated and will be removed in a future release.
+    It's functionality is achieved by ``QuantumCircuit.append``, and therefore ``label`` is being removed for consistency.
+    The gates affected are as follows: ``control, ch, cp, rx, crx, ry, cry, crz, cswap, csx, cu, cu1, cu3, x, cx, cnot, cy, cz``
+fixes:
+  - |
+    Modified the tests ``test_circuit_text_drawer`` and ``test_circuit_matplotlib_drawer``  to use ``.append`` instead of
+    creating gates with ``label`` parameters.

--- a/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -36,6 +36,9 @@ from qiskit.circuit.library import (
     SGate,
     U1Gate,
     CPhaseGate,
+    CYGate,
+    CHGate,
+    CUGate,
 )
 from qiskit.circuit.library import MCXVChain
 from qiskit.extensions import HamiltonianGate
@@ -464,9 +467,10 @@ class TestMatplotlibDrawer(QiskitTestCase):
         """Test control labels"""
         qr = QuantumRegister(4, "q")
         circuit = QuantumCircuit(qr)
-        circuit.cy(1, 0, label="Bottom Y label")
-        circuit.cu(pi / 2, pi / 2, pi / 2, 0, 2, 3, label="Top U label")
-        circuit.ch(0, 1, label="Top H label")
+        circuit.append(CYGate(label="Bottom Y label"), [1, 0])
+        circuit.append(CYGate(label="Top Y label"), [2, 3])
+        circuit.append(CUGate(pi / 2, pi / 2, pi / 2, 0, label="Top U label"), [2, 3])
+        circuit.append(CHGate(label="Top H label"), [0, 1])
         circuit.append(
             HGate(label="H gate label").control(3, label="H control label", ctrl_state="010"),
             [qr[1], qr[2], qr[3], qr[0]],

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1249,7 +1249,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         )
         circuit = QuantumCircuit(3)
         circuit.rzz(pi / 2, 0, 1)
-        circuit.x(2, label="This is a really long long long box")
+        circuit.append(XGate(label="This is a really long long long box"), [2])
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 
@@ -1269,7 +1269,7 @@ class TestTextDrawerLabels(QiskitTestCase):
         )
         circuit = QuantumCircuit(3)
         circuit.append(CU1Gate(pi / 2), [0, 1])
-        circuit.x(2, label="This is a really long long long box")
+        circuit.append(XGate(label="This is a really long long long box"), [2])
 
         self.assertEqual(str(_text_circuit_drawer(circuit)), expected)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #5098.
Some `QauntumCircuit` gates accept `label` parameters where others do not, creating a discrepancy. It was decided that these `label` parameters should eventually be removed so for now the relevant gates have received `@deprecated_arguments` flags.

### Details and comments
The circuits `control, ch, cp, rx, crx, ry, cry, crz, cswap, csx, cu, cu1, cu3, x, cx, cnot, cy, cz` now have an `@deprecated_arguments` flag on their `label` parameters.
The two tests `test_circuit_text_drawer` and `test_circuit_matplotlib_drawer` now use the `.append` method instead of constructing gates with `label` parameters.

