### PR TITLE
[WIP] Switch from `retworkx` to `rustworkx`

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,7 +33,7 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-allow-list=retworkx, numpy, tweedledum, qiskit._accelerate
+extension-pkg-allow-list=rustworkx, numpy, tweedledum, qiskit._accelerate
 
 
 [MESSAGES CONTROL]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
  "rand_distr",
  "rand_pcg",
  "rayon",
- "retworkx-core",
+ "rustworkx-core",
 ]
 
 [[package]]
@@ -507,7 +507,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "retworkx-core"
+name = "rustworkx-core"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353bcdcdab6c754ea32bce39ee7a763c8a3c16c91a8dd648befd14fbcb0d5b68"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
+name = "priority-queue"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815082d99af3acc75a3e67efd2a07f72e67b4e81b4344eb8ca34c6ebf3dfa9c5"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,14 +518,17 @@ dependencies = [
 
 [[package]]
 name = "rustworkx-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353bcdcdab6c754ea32bce39ee7a763c8a3c16c91a8dd648befd14fbcb0d5b68"
+checksum = "23f8a8866a33f4f8b06ed2a4120d3c08a0be63a9c18a53b4238e53922edfc953"
 dependencies = [
  "ahash 0.7.6",
+ "fixedbitset",
  "hashbrown 0.11.2",
  "indexmap",
+ "num-traits",
  "petgraph",
+ "priority-queue",
  "rayon",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand_distr = "0.4.3"
 ahash = "0.8.0"
 num-complex = "0.4"
 num-bigint = "0.4"
-rustworkx-core = "0.11"
+rustworkx-core = "0.12"
 
 [dependencies.pyo3]
 version = "0.16.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand_distr = "0.4.3"
 ahash = "0.8.0"
 num-complex = "0.4"
 num-bigint = "0.4"
-retworkx-core = "0.11"
+rustworkx-core = "0.11"
 
 [dependencies.pyo3]
 version = "0.16.6"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,7 +61,7 @@ add_module_names = False
 modindex_common_prefix = ["qiskit."]
 
 intersphinx_mapping = {
-    "retworkx": ("https://qiskit.org/documentation/retworkx/", None),
+    "rustworkx": ("https://qiskit.org/documentation/rustworkx/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -14,8 +14,8 @@
 
 from collections import namedtuple
 
-from retworkx.visualization import graphviz_draw
-import retworkx as rx
+from rustworkx.visualization import graphviz_draw
+import rustworkx as rx
 
 from qiskit.exceptions import InvalidFileError
 from .exceptions import CircuitError

--- a/qiskit/circuit/library/graph_state.py
+++ b/qiskit/circuit/library/graph_state.py
@@ -44,7 +44,7 @@ class GraphState(QuantumCircuit):
 
         from qiskit.circuit.library import GraphState
         import qiskit.tools.jupyter
-        import retworkx as rx
+        import rustworkx as rx
         G = rx.generators.cycle_graph(5)
         circuit = GraphState(rx.adjacency_matrix(G))
         %circuit_library_info circuit

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -26,7 +26,7 @@ import itertools
 import math
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit import ControlFlowOp, ForLoopOp, IfElseOp, WhileLoopOp
 from qiskit.circuit.exceptions import CircuitError
@@ -1289,7 +1289,7 @@ class DAGCircuit:
             self.global_phase += in_dag.global_phase
 
         # Add wire from pred to succ if no ops on mapped wire on ``in_dag``
-        # retworkx's substitute_node_with_subgraph lacks the DAGCircuit
+        # rustworkx's substitute_node_with_subgraph lacks the DAGCircuit
         # context to know what to do in this case (the method won't even see
         # these nodes because they're filtered) so we manually retain the
         # edges prior to calling substitute_node_with_subgraph and set the
@@ -1325,8 +1325,8 @@ class DAGCircuit:
                 wire_output_id = in_dag.output_map[wire]._node_id
                 out_index = in_dag._multi_graph.predecessor_indices(wire_output_id)[0]
                 # Edge directly from from input nodes to output nodes in in_dag are
-                # already handled prior to calling retworkx. Don't map these edges
-                # in retworkx.
+                # already handled prior to calling rustworkx. Don't map these edges
+                # in rustworkx.
                 if not isinstance(in_dag._multi_graph[out_index], DAGOpNode):
                     return None
             # predecessor edge
@@ -1334,8 +1334,8 @@ class DAGCircuit:
                 wire_input_id = in_dag.input_map[wire]._node_id
                 out_index = in_dag._multi_graph.successor_indices(wire_input_id)[0]
                 # Edge directly from from input nodes to output nodes in in_dag are
-                # already handled prior to calling retworkx. Don't map these edges
-                # in retworkx.
+                # already handled prior to calling rustworkx. Don't map these edges
+                # in rustworkx.
                 if not isinstance(in_dag._multi_graph[out_index], DAGOpNode):
                     return None
             return out_index

--- a/qiskit/dagcircuit/dagdependency.py
+++ b/qiskit/dagcircuit/dagdependency.py
@@ -18,7 +18,7 @@ import heapq
 from collections import OrderedDict, defaultdict
 import warnings
 
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit.quantumregister import QuantumRegister, Qubit
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
@@ -183,8 +183,8 @@ class DAGDependency:
                 dag_networkx.add_edge(self.get_node(source_id), self.get_node(dest_id), **edge)
         return dag_networkx
 
-    def to_retworkx(self):
-        """Returns the DAGDependency in retworkx format."""
+    def to_rustworkx(self):
+        """Returns the DAGDependency in rustworkx format."""
         return self._multi_graph
 
     def size(self):

--- a/qiskit/opflow/converters/abelian_grouper.py
+++ b/qiskit/opflow/converters/abelian_grouper.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 from typing import List, Tuple, Union, cast
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.opflow.converters.converter_base import ConverterBase
 from qiskit.opflow.evolutions.evolved_op import EvolvedOp

--- a/qiskit/pulse/schedule.py
+++ b/qiskit/pulse/schedule.py
@@ -42,7 +42,7 @@ import warnings
 from typing import List, Tuple, Iterable, Union, Dict, Callable, Set, Optional, Any
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType

--- a/qiskit/pulse/transforms/dag.py
+++ b/qiskit/pulse/transforms/dag.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 """A collection of functions to convert ScheduleBlock to DAG representation."""
 
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.pulse.exceptions import UnassignedReferenceError
 

--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -16,7 +16,7 @@ Optimized list of Pauli operators
 from collections import defaultdict
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.custom_iterator import CustomIterator
@@ -1109,7 +1109,7 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
                 or on a per-qubit basis.
 
         Returns:
-            retworkx.PyGraph: A class of undirected graphs
+            rustworkx.PyGraph: A class of undirected graphs
         """
 
         edges = self._noncommutation_graph(qubit_wise)

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -18,7 +18,7 @@ from numbers import Number
 from typing import Dict, Optional
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit._accelerate.sparse_pauli_op import unordered_unique  # pylint: disable=import-error
 from qiskit.exceptions import QiskitError
@@ -929,7 +929,7 @@ class SparsePauliOp(LinearOp):
                 or on a per-qubit basis.
 
         Returns:
-            retworkx.PyGraph: A class of undirected graphs
+            rustworkx.PyGraph: A class of undirected graphs
         """
 
         edges = self.paulis._noncommutation_graph(qubit_wise)

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -22,8 +22,8 @@ onto a device with this coupling.
 import warnings
 
 import numpy as np
-import retworkx as rx
-from retworkx.visualization import graphviz_draw
+import rustworkx as rx
+from rustworkx.visualization import graphviz_draw
 
 from qiskit.transpiler.exceptions import CouplingError
 
@@ -409,8 +409,8 @@ class CouplingMap:
     def draw(self):
         """Draws the coupling map.
 
-        This function calls the :func:`~retworkx.visualization.graphviz_draw` function from the
-        ``retworkx`` package to draw the :class:`CouplingMap` object.
+        This function calls the :func:`~rustworkx.visualization.graphviz_draw` function from the
+        ``rustworkx`` package to draw the :class:`CouplingMap` object.
 
         Returns:
             PIL.Image: Drawn coupling map.

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -19,7 +19,7 @@ from itertools import zip_longest
 from collections import defaultdict
 from functools import singledispatch
 
-import retworkx
+import rustworkx
 
 from qiskit.circuit import Gate, ParameterVector, QuantumRegister, ControlFlowOp, QuantumCircuit
 from qiskit.dagcircuit import DAGCircuit
@@ -363,11 +363,11 @@ def _(circ: QuantumCircuit):
 
 
 class StopIfBasisRewritable(Exception):
-    """Custom exception that signals `retworkx.dijkstra_search` to stop."""
+    """Custom exception that signals `rustworkx.dijkstra_search` to stop."""
 
 
-class BasisSearchVisitor(retworkx.visit.DijkstraVisitor):
-    """Handles events emitted during `retworkx.dijkstra_search`."""
+class BasisSearchVisitor(rustworkx.visit.DijkstraVisitor):
+    """Handles events emitted during `rustworkx.dijkstra_search`."""
 
     def __init__(self, graph, source_basis, target_basis, num_gates_for_rule):
         self.graph = graph
@@ -412,7 +412,7 @@ class BasisSearchVisitor(retworkx.visit.DijkstraVisitor):
         # if there are gates in this `rule` that we have not yet generated, we can't apply
         # this `rule`. if `target` is already in basis, it's not beneficial to use this rule.
         if self._num_gates_remain_for_rule[index] > 0 or target in self.target_basis:
-            raise retworkx.visit.PruneSearch
+            raise rustworkx.visit.PruneSearch
 
     def edge_relaxed(self, edge):
         _, target, edata = edge
@@ -478,7 +478,7 @@ def _basis_search(equiv_lib, source_basis, target_basis):
 
     all_gates_in_lib = set()
 
-    graph = retworkx.PyDiGraph()
+    graph = rustworkx.PyDiGraph()
     nodes_to_indices = dict()
     num_gates_for_rule = dict()
 
@@ -525,7 +525,7 @@ def _basis_search(equiv_lib, source_basis, target_basis):
     graph.add_edges_from_no_data([(dummy, nodes_to_indices[key]) for key in target_basis_keys])
     rtn = None
     try:
-        retworkx.digraph_dijkstra_search(graph, [dummy], vis.edge_cost, vis)
+        rustworkx.digraph_dijkstra_search(graph, [dummy], vis.edge_cost, vis)
     except StopIfBasisRewritable:
         rtn = vis.basis_transforms
 

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -14,7 +14,7 @@
 
 
 import numpy as np
-import retworkx
+import rustworkx
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
@@ -53,12 +53,12 @@ class DenseLayout(AnalysisPass):
             num_qubits = target.num_qubits
             self.coupling_map = target.build_coupling_map()
             if self.coupling_map is not None:
-                self.adjacency_matrix = retworkx.adjacency_matrix(self.coupling_map.graph)
+                self.adjacency_matrix = rustworkx.adjacency_matrix(self.coupling_map.graph)
             self.error_mat, self._use_error = _build_error_matrix(num_qubits, target=target)
         else:
             if self.coupling_map:
                 num_qubits = self.coupling_map.size()
-                self.adjacency_matrix = retworkx.adjacency_matrix(self.coupling_map.graph)
+                self.adjacency_matrix = rustworkx.adjacency_matrix(self.coupling_map.graph)
             self.error_mat, self._use_error = _build_error_matrix(
                 num_qubits, backend_prop=self.backend_prop, coupling_map=self.coupling_map
             )

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -14,7 +14,7 @@
 
 import math
 
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass

--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -15,7 +15,7 @@ from enum import Enum
 import logging
 import time
 
-from retworkx import vf2_mapping
+from rustworkx import vf2_mapping
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass

--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -15,7 +15,7 @@ from enum import Enum
 import logging
 import time
 
-from retworkx import PyDiGraph, vf2_mapping, PyGraph
+from rustworkx import PyDiGraph, vf2_mapping, PyGraph
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 import statistics
 import random
 
-from retworkx import PyDiGraph, PyGraph
+from rustworkx import PyDiGraph, PyGraph
 
 from qiskit.circuit import ControlFlowOp, ForLoopOp
 from qiskit.converters import circuit_to_dag

--- a/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
+++ b/qiskit/transpiler/passes/routing/algorithms/token_swapper.py
@@ -31,7 +31,7 @@ import logging
 from typing import Iterator, Mapping, MutableMapping, MutableSet, List, Iterable, Union
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from .types import Swap, Permutation
 from .util import PermutationCircuit, permutation_circuit

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -16,7 +16,7 @@ import logging
 from copy import copy, deepcopy
 
 import numpy as np
-import retworkx
+import rustworkx
 
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
@@ -148,7 +148,7 @@ class SabreSwap(TransformationPass):
             self.coupling_map.make_symmetric()
         self._neighbor_table = None
         if coupling_map is not None:
-            self._neighbor_table = NeighborTable(retworkx.adjacency_matrix(self.coupling_map.graph))
+            self._neighbor_table = NeighborTable(rustworkx.adjacency_matrix(self.coupling_map.graph))
 
         self.heuristic = heuristic
 

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -510,9 +510,9 @@ def get_vf2_call_limit(
     vf2_call_limit = None
     if layout_method is None and initial_layout is None:
         if optimization_level == 1:
-            vf2_call_limit = int(5e4)  # Set call limit to ~100ms with retworkx 0.10.2
+            vf2_call_limit = int(5e4)  # Set call limit to ~100ms with rustworkx 0.10.2
         elif optimization_level == 2:
-            vf2_call_limit = int(5e6)  # Set call limit to ~10 sec with retworkx 0.10.2
+            vf2_call_limit = int(5e6)  # Set call limit to ~10 sec with rustworkx 0.10.2
         elif optimization_level == 3:
-            vf2_call_limit = int(3e7)  # Set call limit to ~60 sec with retworkx 0.10.2
+            vf2_call_limit = int(3e7)  # Set call limit to ~60 sec with rustworkx 0.10.2
     return vf2_call_limit

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -127,7 +127,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         else VF2Layout(
             coupling_map,
             seed=seed_transpiler,
-            call_limit=int(5e4),  # Set call limit to ~100ms with retworkx 0.10.2
+            call_limit=int(5e4),  # Set call limit to ~100ms with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
         )

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -117,7 +117,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         else VF2Layout(
             coupling_map,
             seed=seed_transpiler,
-            call_limit=int(5e6),  # Set call limit to ~10 sec with retworkx 0.10.2
+            call_limit=int(5e6),  # Set call limit to ~10 sec with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
         )

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -123,7 +123,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         else VF2Layout(
             coupling_map,
             seed=seed_transpiler,
-            call_limit=int(3e7),  # Set call limit to ~60 sec with retworkx 0.10.2
+            call_limit=int(3e7),  # Set call limit to ~60 sec with rustworkx 0.10.2
             properties=backend_properties,
             target=target,
         )

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -23,7 +23,7 @@ import datetime
 import io
 import logging
 
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -93,8 +93,8 @@ External Python Libraries
         be installed in order to use them.
 
     * - .. py:data:: HAS_NETWORKX
-      - Internally, Qiskit uses the high-performance `retworkx
-        <https://github.com/Qiskit/retworkx>`__ library as a core dependency, but sometimes it can
+      - Internally, Qiskit uses the high-performance `rustworkx
+        <https://github.com/Qiskit/rustworkx>`__ library as a core dependency, but sometimes it can
         be convenient to convert things into the Python-only `NetworkX <https://networkx.org/>`__
         format.  There are converter methods on :class:`.DAGCircuit` if NetworkX is present.
 

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -15,7 +15,7 @@
 """
 Visualization function for DAG circuit representation.
 """
-from retworkx.visualization import graphviz_draw
+from rustworkx.visualization import graphviz_draw
 
 from qiskit.dagcircuit.dagnode import DAGOpNode, DAGInNode, DAGOutNode
 from qiskit.circuit import Qubit
@@ -29,7 +29,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
     """Plot the directed acyclic graph (dag) to represent operation dependencies
     in a quantum circuit.
 
-    This function calls the :func:`~retworkx.visualization.graphviz_draw` function from the ``retworkx``
+    This function calls the :func:`~rustworkx.visualization.graphviz_draw` function from the ``rustworkx``
     package to draw the DAG.
 
     Args:

--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -16,7 +16,7 @@ import math
 from typing import List
 
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.exceptions import QiskitError
 from qiskit.utils import optionals as _optionals
@@ -498,7 +498,7 @@ def plot_gate_map(
         qubit_coordinates = qubit_coordinates_map.get(num_qubits, None)
 
     if qubit_coordinates is None:
-        # Replace with planar_layout() when retworkx offers it
+        # Replace with planar_layout() when rustworkx offers it
         qubit_coordinates_rx = rx.spring_layout(coupling_map.graph, seed=1234)
         scaling_factor = 10 ** int(math.log10(num_qubits) + 1)
         qubit_coordinates = [

--- a/releasenotes/notes/0.13/0.13.0-release-a92553cf72c203aa.yaml
+++ b/releasenotes/notes/0.13/0.13.0-release-a92553cf72c203aa.yaml
@@ -6,7 +6,7 @@ prelude: |
     For the transpiler we have switched the graph library used to build the
     :class:`qiskit.dagcircuit.DAGCircuit` class which is the underlying data
     structure behind all operations to be based on
-    `retworkx <https://pypi.org/project/retworkx/>`_ for greatly improved
+    `rustworkx <https://pypi.org/project/rustworkx/>`_ for greatly improved
     performance. Circuit transpilation speed in the 0.13.0 release should
     be significanlty faster than in previous releases.
 

--- a/releasenotes/notes/0.13/retworkx-ccd3019aae7cfb7d.yaml
+++ b/releasenotes/notes/0.13/retworkx-ccd3019aae7cfb7d.yaml
@@ -2,17 +2,17 @@
 upgrade:
   - |
     A new requirement has been added to the requirements list,
-    `retworkx <https://pypi.org/project/retworkx/>`_. It is an Apache 2.0
+    `rustworkx <https://pypi.org/project/rustworkx/>`_. It is an Apache 2.0
     licensed graph library that has a similar API to networkx and is being used
     to significantly speed up the :class:`qiskit.dagcircuit.DAGCircuit`
     operations as part of the transpiler. There are binaries published on PyPI
     for all the platforms supported by Qiskit Terra but if you're using a
     platform where there aren't precompiled binaries published refer to the
-    `retworkx documentation
-    <https://retworkx.readthedocs.io/en/stable/README.html#installing-retworkx>`_
+    `rustworkx documentation
+    <https://rustworkx.readthedocs.io/en/stable/README.html#installing-rustworkx>`_
     for instructions on pip installing from sdist.
 
     If you encounter any issues with the transpiler or DAGCircuit class as part
     of the transition you can switch back to the previous networkx
-    implementation by setting the environment variable ``USE_RETWORKX`` to
+    implementation by setting the environment variable ``USE_rustworkx`` to
     ``N``. This option will be removed in the 0.14.0 release.

--- a/releasenotes/notes/0.15/add-dagcircuit-from-networkx-7815b9c575232b14.yaml
+++ b/releasenotes/notes/0.15/add-dagcircuit-from-networkx-7815b9c575232b14.yaml
@@ -10,7 +10,7 @@ features:
     `graph algorithm library
     <https://networkx.github.io/documentation/stable/reference/algorithms/index.html>`__
     if a function is missing from the
-    `retworkx API <https://retworkx.readthedocs.io/en/latest/api.html>`_.
+    `rustworkx API <https://rustworkx.readthedocs.io/en/latest/api.html>`_.
     Although, hopefully in such casses an issue will be opened with
-    `retworkx issue tracker <https://github.com/Qiskit/retworkx/issues>`__ (or
+    `rustworkx issue tracker <https://github.com/Qiskit/rustworkx/issues>`__ (or
     even better a pull request submitted).

--- a/releasenotes/notes/0.15/remove-use_networkx-e1c846a9f8f2ff6a.yaml
+++ b/releasenotes/notes/0.15/remove-use_networkx-e1c846a9f8f2ff6a.yaml
@@ -1,10 +1,10 @@
 ---
 upgrade:
   - |
-    Support for the use of the ``USE_RETWORKX`` environment variable which was
+    Support for the use of the ``USE_rustworkx`` environment variable which was
     introduced in the 0.13.0 release to provide an optional fallback to the
     legacy `networkx <https://networkx.github.io/>`__ based
     :class:`qiskit.dagcircuit.DAGCircuit` implementation
     has been removed. This flag was only intended as provide a relief valve
     for any users that encountered a problem with the new implementation for
-    one release during the transition to retworkx.
+    one release during the transition to rustworkx.

--- a/releasenotes/notes/0.18/bump-retworkx-59c7ab59ad02c3c0.yaml
+++ b/releasenotes/notes/0.18/bump-retworkx-59c7ab59ad02c3c0.yaml
@@ -6,6 +6,6 @@ features:
     is either a successor or predecessor of another node on the :class:`~qiskit.dagcircuit.DAGCircuit`.
 upgrade:
   - |
-    The minimum version of the `retworkx <https://pypi.org/project/retworkx/>`_ dependency
+    The minimum version of the `rustworkx <https://pypi.org/project/rustworkx/>`_ dependency
     was increased to version `0.9.0`. This was done to use new APIs introduced in that release
     which improved the performance of some transpiler passes.

--- a/releasenotes/notes/0.19/bump-retworkx-0.10.1-1fcf4fc746bd754a.yaml
+++ b/releasenotes/notes/0.19/bump-retworkx-0.10.1-1fcf4fc746bd754a.yaml
@@ -1,5 +1,5 @@
 ---
 upgrade:
   - |
-    The core dependency ``retworkx`` had its version requirement bumped to 0.10.1, up from 0.9.
+    The core dependency ``rustworkx`` had its version requirement bumped to 0.10.1, up from 0.9.
     This enables several performance improvements across different transpilation passes.

--- a/releasenotes/notes/0.19/retworkx-substitute_node_with_dag-speedup-d7d1f0d33716131d.yaml
+++ b/releasenotes/notes/0.19/retworkx-substitute_node_with_dag-speedup-d7d1f0d33716131d.yaml
@@ -1,8 +1,8 @@
 ---
 features:
   - |
-    Various transpilation internals now use new features in `retworkx
-    <https://github.com/Qiskit/retworkx>`__ 0.10 when operating on the internal
+    Various transpilation internals now use new features in `rustworkx
+    <https://github.com/Qiskit/rustworkx>`__ 0.10 when operating on the internal
     circuit representation.  This can often result in speedups in calls to
     :obj:`~.compiler.transpile` of around 10-40%, with greater effects at higher
     optimization levels.  See `#6302

--- a/releasenotes/notes/0.19/vf2layout-4cea88087c355769.yaml
+++ b/releasenotes/notes/0.19/vf2layout-4cea88087c355769.yaml
@@ -3,8 +3,8 @@ features:
   - |
     Added a new transpiler pass, :class:`~qiskit.transpiler.passes.VF2Layout`.
     This pass models the layout allocation problem as a subgraph isomorphism
-    problem and uses the `VF2 algorithm`_ implementation in `retworkx
-    <https://qiskit.org/documentation/retworkx/stubs/retworkx.vf2_mapping.html>`__
+    problem and uses the `VF2 algorithm`_ implementation in `rustworkx
+    <https://qiskit.org/documentation/rustworkx/stubs/rustworkx.vf2_mapping.html>`__
     to find a perfect layout (a layout which would not require additional
     routing) if one exists. The functionality exposed by this new pass is very
     similar to exisiting :class:`~qiskit.transpiler.passes.CSPLayout` but

--- a/releasenotes/notes/0.20/bump-retworkx-0.11.0-97db170ae39cacf8.yaml
+++ b/releasenotes/notes/0.20/bump-retworkx-0.11.0-97db170ae39cacf8.yaml
@@ -1,6 +1,6 @@
 ---
 upgrade:
   - |
-    The core dependency ``retworkx`` had its version requirement bumped to 0.11.0, up from 0.10.1.
+    The core dependency ``rustworkx`` had its version requirement bumped to 0.11.0, up from 0.10.1.
     This improves the performance of transpilation pass
     :class:`~qiskit.transpiler.passes.ConsolidateBlocks`.

--- a/releasenotes/notes/0.20/update-plot-gate-map-9ed6ad5490bafbbf.yaml
+++ b/releasenotes/notes/0.20/update-plot-gate-map-9ed6ad5490bafbbf.yaml
@@ -13,8 +13,8 @@ features:
     on top of it, :func:`~.plot_error_map` and :func:`~.plot_circuit_layout`,
     now are able to plot any backend not just those with the number of qubits
     equal to one of the IBM backends. This relies on
-    the retworkx ``spring_layout()``
-    `function <https://qiskit.org/documentation/retworkx/apiref/retworkx.spring_layout.html>`__
+    the rustworkx ``spring_layout()``
+    `function <https://qiskit.org/documentation/rustworkx/apiref/rustworkx.spring_layout.html>`__
     to generate the layout for the visualization. If the default layout doesn't
     work with a backend's particular coupling graph you can use the
     ``qubit_coordinates`` function to set a custom layout.

--- a/releasenotes/notes/0.21/deprecate-nx-dag-f8a8d947186222c2.yaml
+++ b/releasenotes/notes/0.21/deprecate-nx-dag-f8a8d947186222c2.yaml
@@ -6,12 +6,12 @@ deprecations:
     :meth:`~.DAGCircuit.from_networkx`, along with the
     :meth:`.DAGDependency.to_networkx` method have been deprecated and will be
     removed in a future release. Qiskit has been using
-    `retworkx <https://qiskit.org/documentation/retworkx/>`__ as its graph
+    `rustworkx <https://qiskit.org/documentation/rustworkx/>`__ as its graph
     library since the qiskit-terra 0.12.0 release, and since then the networkx
     converter functions have been lossy. They were originally added so
     that users could leverage functionality in NetworkX's algorithms library
-    not present in retworkx.  Since that time, retworkx has matured
+    not present in rustworkx.  Since that time, rustworkx has matured
     and offers more functionality, and the :class:`~.DAGCircuit` is tightly
-    coupled to retworkx for its operation. Having these converter methods
+    coupled to rustworkx for its operation. Having these converter methods
     provides limited value moving forward and are therefore going to be
     removed in a future release.

--- a/releasenotes/notes/0.21/vf2-post-layout-f0213e2c7ebb645c.yaml
+++ b/releasenotes/notes/0.21/vf2-post-layout-f0213e2c7ebb645c.yaml
@@ -14,7 +14,7 @@ features:
 
     This pass is similar to the :class:`~.VF2Layout` pass and both internally
     use the same VF2 implementation from 
-    `retworkx <https://github.com/Qiskit/retworkx>`__. However,
+    `rustworkx <https://github.com/Qiskit/rustworkx>`__. However,
     :class:`~.VF2PostLayout` is deisgned to run after initial layout, routing,
     basis translation, and any optimization passes run and will only work if
     a layout has already been applied, the circuit has been routed, and all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-retworkx>=0.11.0
+rustworkx>=0.12.0
 numpy>=1.17
 ply>=3.10
 psutil>=5

--- a/src/sabre_swap/mod.rs
+++ b/src/sabre_swap/mod.rs
@@ -29,10 +29,10 @@ use rand::prelude::SliceRandom;
 use rand::prelude::*;
 use rand_pcg::Pcg64Mcg;
 use rayon::prelude::*;
-use retworkx_core::dictmap::*;
-use retworkx_core::petgraph::prelude::*;
-use retworkx_core::petgraph::visit::EdgeRef;
-use retworkx_core::shortest_path::dijkstra;
+use rustworkx_core::dictmap::*;
+use rustworkx_core::petgraph::prelude::*;
+use rustworkx_core::petgraph::visit::EdgeRef;
+use rustworkx_core::shortest_path::dijkstra;
 
 use crate::getenv_use_multiple_threads;
 use crate::nlayout::NLayout;

--- a/src/sabre_swap/neighbor_table.rs
+++ b/src/sabre_swap/neighbor_table.rs
@@ -22,7 +22,7 @@ use rayon::prelude::*;
 /// This object is typically created once from the adjacency matrix of
 /// a coupling map, for example::
 ///
-///     neigh_table = NeighborTable(retworkx.adjacency_matrix(coupling_map.graph))
+///     neigh_table = NeighborTable(rustworkx.adjacency_matrix(coupling_map.graph))
 ///
 /// and used solely to represent neighbors of each node in qiskit-terra's rust
 /// module.

--- a/src/sabre_swap/sabre_dag.rs
+++ b/src/sabre_swap/sabre_dag.rs
@@ -13,7 +13,7 @@
 use hashbrown::{HashMap, HashSet};
 use numpy::PyReadonlyArray1;
 use pyo3::prelude::*;
-use retworkx_core::petgraph::prelude::*;
+use rustworkx_core::petgraph::prelude::*;
 
 /// A DAG object used to represent the data interactions from a DAGCircuit
 /// to run the the sabre algorithm. This is structurally identical to the input

--- a/test/python/algorithms/minimum_eigensolvers/test_qaoa.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_qaoa.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.optimize import minimize as scipy_minimize
 from ddt import ddt, idata, unpack
 
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit import QuantumCircuit
 from qiskit.algorithms.minimum_eigensolvers import QAOA

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -17,7 +17,7 @@ import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase
 from ddt import ddt, data, unpack
 import numpy as np
-import retworkx as rx
+import rustworkx as rx
 from qiskit import QuantumCircuit, execute
 from qiskit.quantum_info import Pauli
 from qiskit.exceptions import QiskitError

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -20,7 +20,7 @@ import math
 import numpy as np
 from scipy.optimize import minimize as scipy_minimize
 from ddt import ddt, idata, unpack
-import retworkx as rx
+import rustworkx as rx
 
 from qiskit.algorithms import QAOA
 from qiskit.algorithms.optimizers import COBYLA, NELDER_MEAD

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -17,7 +17,7 @@ import unittest
 
 from ddt import ddt, data
 
-import retworkx as rx
+import rustworkx as rx
 from numpy import pi
 
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGInNode, DAGOutNode

--- a/test/python/dagcircuit/test_dagdependency.py
+++ b/test/python/dagcircuit/test_dagdependency.py
@@ -24,7 +24,7 @@ from qiskit.converters import circuit_to_dagdependency
 from qiskit.test import QiskitTestCase
 
 try:
-    import retworkx as rx
+    import rustworkx as rx
 except ImportError:
     pass
 

--- a/test/python/transpiler/test_token_swapper.py
+++ b/test/python/transpiler/test_token_swapper.py
@@ -28,7 +28,7 @@
 
 import itertools
 
-import retworkx as rx
+import rustworkx as rx
 from numpy import random
 from qiskit.transpiler.passes.routing.algorithms import ApproximateTokenSwapper
 from qiskit.transpiler.passes.routing.algorithms import util

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -17,7 +17,7 @@ from math import pi
 
 import ddt
 import numpy
-import retworkx
+import rustworkx
 
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.circuit import ControlFlowOp
@@ -225,12 +225,12 @@ class TestVF2LayoutLattice(LayoutTestCase):
 
     def graph_state_from_pygraph(self, graph):
         """Creates a GraphState circuit from a PyGraph"""
-        adjacency_matrix = retworkx.adjacency_matrix(graph)
+        adjacency_matrix = rustworkx.adjacency_matrix(graph)
         return GraphState(adjacency_matrix).decompose()
 
     def test_hexagonal_lattice_graph_20_in_25(self):
         """A 20x20 interaction map in 25x25 coupling map"""
-        graph_20_20 = retworkx.generators.hexagonal_lattice_graph(20, 20)
+        graph_20_20 = rustworkx.generators.hexagonal_lattice_graph(20, 20)
         circuit = self.graph_state_from_pygraph(graph_20_20)
 
         dag = circuit_to_dag(circuit)
@@ -240,7 +240,7 @@ class TestVF2LayoutLattice(LayoutTestCase):
 
     def test_hexagonal_lattice_graph_9_in_25(self):
         """A 9x9 interaction map in 25x25 coupling map"""
-        graph_9_9 = retworkx.generators.hexagonal_lattice_graph(9, 9)
+        graph_9_9 = rustworkx.generators.hexagonal_lattice_graph(9, 9)
         circuit = self.graph_state_from_pygraph(graph_9_9)
 
         dag = circuit_to_dag(circuit)

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -12,7 +12,7 @@
 
 """Test the VF2Layout pass"""
 
-import retworkx
+import rustworkx
 
 from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import ControlFlowOp
@@ -334,7 +334,7 @@ class TestVF2PostLayoutScoring(QiskitTestCase):
         """Test error rate is 0 for empty circuit."""
         bit_map = {}
         reverse_bit_map = {}
-        im_graph = retworkx.PyDiGraph()
+        im_graph = rustworkx.PyDiGraph()
         backend = FakeYorktownV2()
         vf2_pass = VF2PostLayout(target=backend.target)
         layout = Layout()
@@ -345,7 +345,7 @@ class TestVF2PostLayoutScoring(QiskitTestCase):
         """Test error rate for all 1q input."""
         bit_map = {Qubit(): 0, Qubit(): 1}
         reverse_bit_map = {v: k for k, v in bit_map.items()}
-        im_graph = retworkx.PyDiGraph()
+        im_graph = rustworkx.PyDiGraph()
         im_graph.add_node({"sx": 1})
         im_graph.add_node({"sx": 1})
         backend = FakeYorktownV2()
@@ -358,7 +358,7 @@ class TestVF2PostLayoutScoring(QiskitTestCase):
         """Test average scoring for all 1q input."""
         bit_map = {Qubit(): 0, Qubit(): 1}
         reverse_bit_map = {v: k for k, v in bit_map.items()}
-        im_graph = retworkx.PyDiGraph()
+        im_graph = rustworkx.PyDiGraph()
         im_graph.add_node({"sx": 1})
         im_graph.add_node({"sx": 1})
         backend = FakeYorktownV2()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Related to https://github.com/Qiskit/retworkx/issues/641

`retworkx` will change its name as a courtesy to the NetworkX developers. This is the PR to migrate to the new name in qiskit-terra. Even though `retworkx` will continue working, it is worth migrating to the new name as soon as possible as the old name will be deprecated in two releases.

### Details and comments

Depends on `rustworkx` 0.12 (or the new name if it changes) being released to PyPI
