### PR TITLE
QuantumCircuit.save_statevector: Inform user when Aer backend is not initialized

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4767,6 +4767,20 @@ class QuantumCircuit:
 
         return 0  # If there are no instructions over bits
 
+    def save_statevector(
+        self, label: str = "statevector", pershot: bool = False, conditional: bool = False
+    ) -> "QuantumCircuit":
+        """This is a placeholder class that is then monkey-patched only when
+        the user initializes the Aer backend. The default behavior is to raise
+        a QiskitError.
+        See the file qiskit/providers/aer/library/save_instructions/save_statevector.py
+        in qiskit-aer.
+        """
+        raise QiskitError(
+            "To use this method, you must first initialize the Aer simulator backend, e.g. "
+            "backend = Aer.get_backend('aer_simulator')"
+        )
+
 
 def _circuit_from_qasm(qasm: Qasm) -> "QuantumCircuit":
     # pylint: disable=cyclic-import

--- a/test/python/circuit/test_initializer.py
+++ b/test/python/circuit/test_initializer.py
@@ -77,6 +77,20 @@ class TestInitialize(QiskitTestCase):
         qc.initialize(statevector, [0, 1])
         self.assertEqual(qc.data[0].operation.params, desired_vector)
 
+    def test_save_statevector(self):
+        """Run `qc.save_statevector()` and expects an exception.
+        `qc.save_statevector` is defined only when the backend is aer_simulator.
+        """
+        import importlib
+        import qiskit.circuit.quantumcircuit
+
+        # Undo the monkey patching done by Aer backend initialization, so that
+        # we can test the original method.
+        importlib.reload(qiskit.circuit.quantumcircuit)
+
+        qc = qiskit.circuit.quantumcircuit.QuantumCircuit(1)
+        self.assertRaises(QiskitError, qc.save_statevector)
+
     def test_bell_state(self):
         """Initialize a Bell state on 2 qubits."""
         desired_vector = [1 / math.sqrt(2), 0, 0, 1 / math.sqrt(2)]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

The `QuantumCircuit` class doesn't have the `save_statevector` until it is monkey-patched during the Aer backend initialization. Adding a placeholder method (by this PR) gives an informative error message.

Fixes #8325. (And maybe #6346)