### PR TITLE
Fix lint failure in qiskit/extensions/unitary.py

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -14,7 +14,6 @@
 Arbitrary unitary circuit instruction.
 """
 
-from collections import OrderedDict
 import numpy
 
 from qiskit.circuit import Gate, ControlledGate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Recently the pylint CI runs have all started failing because of an
unused OrderedDict import failure in qiskit/extensions/unitary.py. The
OrderedDict usage was removed in #8234 but the import was left in
accidently. This should have been caught by the lint job on that PR but
for some reason it was not caught and has sat there until relatively
recently when pylint started erroring because of the error. Normally for
failures like this they can be attributed to environment differences,
typically a release of pylint or astroid. However, we pin those package
versions because of their tendancy to change behavior, and also a diff
between the installed python packages in CI doesn't show any differences.
Regardless of the underlying cause to unblock CI this commit is necessary
to fix the unused import error.

### Details and comments


