### PR TITLE
Added links from UGate, CUGate and CCUGate to their corresponding QuantumCircuit methods

### DIFF
--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -128,6 +128,9 @@ class XGate(Gate):
 class CXGate(ControlledGate):
     r"""Controlled-X gate.
 
+    Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
+    with the :meth:`~qiskit.circuit.QuantumCircuit.cx` method.
+
     **Circuit symbol:**
 
     .. parsed-literal::

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -260,6 +260,9 @@ class CXGate(ControlledGate):
 class CCXGate(ControlledGate):
     r"""CCX gate, also known as Toffoli gate.
 
+    Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
+    with the :meth:`~qiskit.circuit.QuantumCircuit.ccx` method.
+
     **Circuit symbol:**
 
     .. parsed-literal::

--- a/qiskit/circuit/library/standard_gates/x.py
+++ b/qiskit/circuit/library/standard_gates/x.py
@@ -30,6 +30,9 @@ from .sx import SXGate
 class XGate(Gate):
     r"""The single-qubit Pauli-X gate (:math:`\sigma_x`).
 
+    Can be applied to a :class:`~qiskit.circuit.QuantumCircuit`
+    with the :meth:`~qiskit.circuit.QuantumCircuit.x` method.
+
     **Matrix Representation:**
 
     .. math::


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Added links from `XGate` circuit library page to `QuantumCircuit.x` API reference, from `CXGate` to `QuantumCircuit.cx` and from `CCXGate` to `QuantunCircuit.ccx`.


### Details and comments
Fixes part of #8368

