### PR TITLE
Fix `EvolvedOp.to_instruction`

### DIFF
--- a/qiskit/opflow/evolutions/evolved_op.py
+++ b/qiskit/opflow/evolutions/evolved_op.py
@@ -169,7 +169,7 @@ class EvolvedOp(PrimitiveOp):
 
     # pylint: disable=arguments-differ
     def to_instruction(self, massive: bool = False) -> Instruction:
-        mat_op = self.primitive.to_matrix_op(massive=massive)
+        mat_op = self.to_matrix_op(massive=massive)
         if not isinstance(mat_op, MatrixOp):
             raise OpflowError("to_instruction is not allowed for ListOp.")
         return mat_op.to_instruction()

--- a/releasenotes/notes/fix-evolvedop-to-instruction-c90c4f1aa6b4232a.yaml
+++ b/releasenotes/notes/fix-evolvedop-to-instruction-c90c4f1aa6b4232a.yaml
@@ -1,0 +1,18 @@
+---
+fixes:
+  - |
+    Fix :meth:`~.EvolvedOp.to_instruction` which previously tried to create a 
+    :class:`~.UnitaryGate` without exponentiating the operator to evolve.
+    Since this operator is generally not unitary, this raised an error (and if 
+    the operator would have been unitary by chance, it would not have been the expected result).
+
+    Now calling :meth:`~.EvolvedOp.to_instruction` correctly produces a gate 
+    that implements the time evolution of the operator it holds::
+
+      >>> from qiskit.opflow import EvolvedOp, X
+      >>> op = EvolvedOp(0.5 * X)
+      >>> op.to_instruction()
+      Instruction(
+          name='unitary', num_qubits=1, num_clbits=0, 
+          params=[array([[0.87758256+0.j, 0.-0.47942554j], [0.-0.47942554j, 0.87758256+0.j]])]
+      )

--- a/test/python/opflow/test_evolution.py
+++ b/test/python/opflow/test_evolution.py
@@ -19,6 +19,7 @@ import scipy.linalg
 
 import qiskit
 from qiskit.circuit import Parameter, ParameterVector
+from qiskit.extensions import UnitaryGate
 from qiskit.opflow import (
     CX,
     CircuitOp,
@@ -363,6 +364,19 @@ class TestEvolution(QiskitOpflowTestCase):
             [[0.29192658 - 0.45464871j, -0.84147098j], [-0.84147098j, 0.29192658 + 0.45464871j]]
         )
         np.testing.assert_array_almost_equal(evolution.to_matrix(), matrix)
+
+    def test_evolved_op_to_instruction(self):
+        """Test calling `to_instruction` on a plain EvolvedOp.
+
+        Regression test of Qiskit/qiskit-terra#8025.
+        """
+        op = EvolvedOp(0.5 * X)
+        circuit = op.to_instruction()
+
+        unitary = scipy.linalg.expm(-0.5j * X.to_matrix())
+        expected = UnitaryGate(unitary)
+
+        self.assertEqual(circuit, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8025.

### Details and comments

As already described in #8025 by @kevinsung, the `EvolvedOp` should implement the unitary of `self.to_matrix()` and not `self.primitive.to_matrix()`, since the latter didn't yet exponentiate the operator.