### PR TITLE
Sphinx 5.1 breaks doc building

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0
 reno>=3.4.0
-Sphinx>=3.0.0
+Sphinx>=3.0.0,<5.1
 qiskit-sphinx-theme>=1.6
 qiskit-toqm>=0.0.4;platform_machine != 'aarch64' or platform_system != 'Linux'
 sphinx-autodoc-typehints<1.14.0


### PR DESCRIPTION
Sphinx 5.1 released on July 24th is braking the documentation building, so `Sphinx>=3.0.0,<5.1`:
```
2022-07-25T07:40:25.9446794Z ##[section]Starting: Run Docs build
2022-07-25T07:40:25.9453658Z ==============================================================================
2022-07-25T07:40:25.9453901Z Task         : Bash
2022-07-25T07:40:25.9454101Z Description  : Run a Bash script on macOS, Linux, or Windows
2022-07-25T07:40:25.9454296Z Version      : 3.201.1
2022-07-25T07:40:25.9454465Z Author       : Microsoft Corporation
2022-07-25T07:40:25.9454724Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/bash
2022-07-25T07:40:25.9455011Z ==============================================================================
2022-07-25T07:40:26.0669105Z Generating script.
2022-07-25T07:40:26.0680924Z Script contents:
2022-07-25T07:40:26.0681701Z tox -edocs
2022-07-25T07:40:26.0691549Z ========================== Starting Command Output ===========================
2022-07-25T07:40:26.0702302Z [command]/usr/bin/bash /home/vsts/work/_temp/00bfa98f-44a4-44a9-aa47-2d76ccd577d2.sh
2022-07-25T07:40:26.2994882Z docs create: /home/vsts/work/1/s/.tox/docs
2022-07-25T07:40:27.3279705Z docs installdeps: -r/home/vsts/work/1/s/requirements-dev.txt, qiskit-aer
2022-07-25T07:41:47.3250126Z docs develop-inst: /home/vsts/work/1/s
2022-07-25T07:43:08.0601286Z docs installed: absl-py==1.2.0,alabaster==0.7.12,argon2-cffi==21.3.0,argon2-cffi-bindings==21.2.0,astroid==2.5.6,attrs==21.4.0,autopage==0.5.1,Babel==2.10.3,backcall==0.2.0,backports.zoneinfo==0.2.1,beautifulsoup4==4.11.1,black==22.6.0,bleach==5.0.1,certifi==2022.6.15,cffi==1.15.1,charset-normalizer==2.1.0,click==8.1.3,cliff==3.10.1,cmd2==2.4.2,coverage==6.4.2,cycler==0.11.0,ddt==1.5.0,decorator==5.1.1,defusedxml==0.7.1,Deprecated==1.2.13,dill==0.3.5.1,docplex==2.23.222,docutils==0.19,dulwich==0.20.45,entrypoints==0.4,etils==0.6.0,exceptiongroup==1.0.0rc8,extras==1.0.0,fastjsonschema==2.16.1,fixtures==4.0.1,fonttools==4.34.4,future==0.18.2,hypothesis==6.52.4,idna==3.3,imagesize==1.4.1,importlib-metadata==4.12.0,importlib-resources==5.9.0,ipykernel==5.5.0,ipython==7.21.0,ipython-genutils==0.2.0,ipywidgets==7.7.1,isort==5.10.1,jax==0.3.15,jaxlib==0.3.15,jedi==0.18.1,Jinja2==3.0.3,joblib==1.1.0,jsonschema==3.2.0,jupyter==1.0.0,jupyter-client==7.3.4,jupyter-console==6.4.4,jupyter-core==4.11.1,jupyter-sphinx==0.4.0,jupyterlab-pygments==0.2.2,jupyterlab-widgets==1.1.1,kiwisolver==1.4.4,lazy-object-proxy==1.7.1,MarkupSafe==2.1.1,matplotlib==3.5.2,mccabe==0.6.1,mistune==0.8.4,mpmath==1.2.1,mypy-extensions==0.4.3,nbclient==0.6.6,nbconvert==6.5.0,nbformat==5.4.0,nest-asyncio==1.5.5,networkx==2.6.3,notebook==6.4.12,numpy==1.21.6,opt-einsum==3.3.0,packaging==21.3,pandas==1.3.5,pandocfilters==1.5.0,parso==0.8.3,pathspec==0.9.0,pbr==5.9.0,pexpect==4.8.0,pickleshare==0.7.5,Pillow==9.2.0,platformdirs==2.5.2,ply==3.11,prettytable==3.3.0,prometheus-client==0.14.1,prompt-toolkit==3.0.30,psutil==5.9.1,ptyprocess==0.7.0,Py-BOBYQA==1.3,pycparser==2.21,pydot==1.4.2,PyGithub==1.55,Pygments==2.12.0,PyJWT==2.4.0,pylatexenc==2.10,pylint==2.8.3,PyNaCl==1.5.0,pyparsing==2.4.7,pyperclip==1.8.2,pyrsistent==0.18.1,python-constraint==1.4.0,python-dateutil==2.8.2,python-subunit==1.4.0,pytz==2022.1,pytz-deprecation-shim==0.1.0.post0,PyYAML==6.0,pyzmq==23.2.0,qiskit-aer==0.10.4,qiskit-sphinx-theme==1.8.7,-e git+***@2dd5d33ad0eb0001cda2f1aa7dab24ac9f462ec3#egg=qiskit_terra,qiskit-toqm==0.0.4,qtconsole==5.3.1,QtPy==2.1.0,reno==3.5.0,requests==2.28.1,retworkx==0.11.0,rpy2==3.5.3,scikit-learn==1.0.2,scikit-quant==0.7.0,scipy==1.7.3,seaborn==0.11.2,semantic-version==2.10.0,Send2Trash==1.8.0,setuptools-rust==1.4.1,shared-memory38==0.1.2,six==1.16.0,snowballstemmer==2.2.0,sortedcontainers==2.4.0,soupsieve==2.3.2.post1,Sphinx==5.1.0,sphinx-autodoc-typehints==1.13.1,sphinx_design==0.2.0,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==2.0.0,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.5,SQCommon==0.3.1,SQImFil==0.3.6,SQSnobFit==0.4.3,stestr==3.2.1,stevedore==3.5.0,symengine==0.9.2,sympy==1.10.1,terminado==0.15.0,testtools==2.5.0,threadpoolctl==3.1.0,tinycss2==1.1.1,tokenize-rt==4.2.1,toml==0.10.2,tomli==2.0.1,tornado==6.2,traitlets==5.3.0,tweedledum==1.1.1,typed-ast==1.4.3,typing_extensions==4.3.0,tzdata==2022.1,tzlocal==4.2,urllib3==1.26.10,voluptuous==0.13.1,wcwidth==0.2.5,webencodings==0.5.1,widgetsnbextension==3.6.1,wrapt==1.12.1,zipp==3.8.1
2022-07-25T07:43:08.0607309Z docs run-test-pre: PYTHONHASHSEED='3876380374'
2022-07-25T07:43:08.0608134Z docs run-test: commands[0] | sphinx-build -W -T --keep-going -b html docs/ docs/_build/html
2022-07-25T07:43:08.7251355Z Running Sphinx v5.1.0
2022-07-25T07:43:10.4712761Z making output directory... done
2022-07-25T07:43:10.4950674Z [autosummary] generating autosummary for: apidocs/algorithms.rst, apidocs/assembler.rst, apidocs/circuit.rst, apidocs/circuit_library.rst, apidocs/classicalfunction.rst, apidocs/compiler.rst, apidocs/converters.rst, apidocs/dagcircuit.rst, apidocs/execute.rst, apidocs/extensions.rst, ..., apidocs/transpiler.rst, apidocs/transpiler_builtin_plugins.rst, apidocs/transpiler_passes.rst, apidocs/transpiler_plugins.rst, apidocs/transpiler_preset.rst, apidocs/utils.rst, apidocs/utils_mitigation.rst, apidocs/visualization.rst, index.rst, release_notes.rst
2022-07-25T07:43:32.2807123Z [autosummary] generating autosummary for: /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AlgorithmError.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplificationProblem.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeAmplifier.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimationResult.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimator.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimatorResult.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.Eigensolver.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.EigensolverResult.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.EstimationProblem.rst, ..., /home/vsts/work/1/s/docs/stubs/qiskit.visualization.plot_state_paulivec.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.plot_state_qsphere.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXDebugging.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXSimple.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.draw.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.qcstyle.DefaultStyle.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.timeline.draw.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.timeline_drawer.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.visualize_transition.rst
2022-07-25T07:43:37.7936733Z [autosummary] generating autosummary for: /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeAmplifier.amplify.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.compute_confidence_interval.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.compute_mle.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.construct_circuit.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.estimate.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimation.evaluate_measurements.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimationResult.combine.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimator.estimate.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.AmplitudeEstimatorResult.combine.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.Eigensolver.compute_eigenvalues.rst, ..., /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.copy.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.fromkeys.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.get.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.items.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.keys.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.pop.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.popitem.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.setdefault.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.update.rst, /home/vsts/work/1/s/docs/stubs/qiskit.visualization.pulse_v2.IQXStandard.values.rst
2022-07-25T07:43:38.8345672Z [autosummary] generating autosummary for: /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.AbsoluteAverage.evaluate_classically.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.AbsoluteAverage.observable.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.AbsoluteAverage.observable_circuit.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.AbsoluteAverage.post_processing.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.HHL.construct_circuit.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.HHL.solve.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.LinearSolver.solve.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.LinearSolverResult.combine.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.LinearSystemMatrix.add_bits.rst, /home/vsts/work/1/s/docs/stubs/qiskit.algorithms.linear_solvers.LinearSystemMatrix.add_calibration.rst, ..., /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.eval.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.permute.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.primitive_strings.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.sample.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.tensor.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.to_circuit_op.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.to_density_matrix.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.to_dict_fn.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.to_matrix.rst, /home/vsts/work/1/s/docs/stubs/qiskit.opflow.state_fns.VectorStateFn.to_matrix_op.rst
2022-07-25T07:43:38.8348942Z loading intersphinx inventory from https://qiskit.org/documentation/retworkx/objects.inv...
2022-07-25T07:43:39.4401948Z building [mo]: targets for 0 po files that are out of date
2022-07-25T07:43:39.4414048Z building [html]: targets for 39 source files that are out of date
2022-07-25T07:43:39.5131122Z updating environment: [new config] 4424 added, 0 changed, 0 removed
2022-07-25T07:43:39.5155199Z reading sources... [  0%] apidocs/algorithms
2022-07-25T07:43:39.7744331Z reading sources... [  0%] apidocs/assembler
2022-07-25T07:43:39.8847362Z reading sources... [  0%] apidocs/circuit
2022-07-25T07:43:40.0529451Z executing circuit
2022-07-25T07:43:42.1002714Z reading sources... [  0%] apidocs/circuit_library
2022-07-25T07:43:43.0637797Z executing circuit_library
2022-07-25T07:43:46.1949243Z reading sources... [  0%] apidocs/classicalfunction
2022-07-25T07:43:46.2341982Z executing classicalfunction
2022-07-25T07:43:48.3043960Z reading sources... [  0%] apidocs/compiler
2022-07-25T07:43:48.6506055Z reading sources... [  0%] apidocs/converters
2022-07-25T07:43:48.7810867Z reading sources... [  0%] apidocs/dagcircuit
2022-07-25T07:43:48.8315369Z reading sources... [  0%] apidocs/execute
2022-07-25T07:43:48.9013635Z executing execute
2022-07-25T07:43:51.0207079Z reading sources... [  0%] apidocs/extensions
2022-07-25T07:43:51.0928023Z reading sources... [  0%] apidocs/opflow
2022-07-25T07:43:51.1775415Z reading sources... [  0%] apidocs/primitives
2022-07-25T07:43:51.2457580Z reading sources... [  0%] apidocs/providers
2022-07-25T07:43:51.4096713Z reading sources... [  0%] apidocs/providers_basicaer
2022-07-25T07:43:51.4483085Z executing providers_basicaer
2022-07-25T07:43:53.3111412Z reading sources... [  0%] apidocs/providers_fake_provider
2022-07-25T07:43:53.9047174Z executing providers_fake_provider
2022-07-25T07:43:57.6893928Z reading sources... [  0%] apidocs/providers_models
2022-07-25T07:43:57.7911922Z reading sources... [  0%] apidocs/pulse
2022-07-25T07:43:58.3648298Z executing pulse
2022-07-25T07:44:02.9314179Z reading sources... [  0%] apidocs/qasm
2022-07-25T07:44:02.9710346Z reading sources... [  0%] apidocs/qasm3
2022-07-25T07:44:02.9934272Z reading sources... [  0%] apidocs/qobj
2022-07-25T07:44:03.0992941Z reading sources... [  0%] apidocs/qpy
2022-07-25T07:44:03.2965461Z reading sources... [  0%] apidocs/quantum_info
2022-07-25T07:44:03.9387492Z 
2022-07-25T07:44:03.9388552Z Traceback (most recent call last):
2022-07-25T07:44:03.9389987Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/events.py", line 94, in emit
2022-07-25T07:44:03.9390636Z     results.append(listener.handler(self.app, *args))
2022-07-25T07:44:03.9391498Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/__init__.py", line 386, in _process_docstring
2022-07-25T07:44:03.9392123Z     obj, options)
2022-07-25T07:44:03.9393037Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/docstring.py", line 1147, in __init__
2022-07-25T07:44:03.9393712Z     super().__init__(docstring, config, app, what, name, obj, options)
2022-07-25T07:44:03.9395612Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/docstring.py", line 214, in __init__
2022-07-25T07:44:03.9396206Z     self._parse()
2022-07-25T07:44:03.9397001Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/docstring.py", line 594, in _parse
2022-07-25T07:44:03.9397562Z     res = self._parse_attribute_docstring()
2022-07-25T07:44:03.9398326Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/docstring.py", line 626, in _parse_attribute_docstring
2022-07-25T07:44:03.9398911Z     _type, _desc = self._consume_inline_attribute()
2022-07-25T07:44:03.9399675Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/napoleon/docstring.py", line 303, in _consume_inline_attribute
2022-07-25T07:44:03.9400227Z     line = self._lines.popleft()
2022-07-25T07:44:03.9400611Z IndexError: pop from an empty deque
2022-07-25T07:44:03.9400871Z 
2022-07-25T07:44:03.9401255Z The above exception was the direct cause of the following exception:
2022-07-25T07:44:03.9401550Z 
2022-07-25T07:44:03.9401896Z Traceback (most recent call last):
2022-07-25T07:44:03.9402575Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/cmd/build.py", line 277, in build_main
2022-07-25T07:44:03.9403108Z     app.build(args.force_all, filenames)
2022-07-25T07:44:03.9403786Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/application.py", line 349, in build
2022-07-25T07:44:03.9404308Z     self.builder.build_update()
2022-07-25T07:44:03.9405009Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 302, in build_update
2022-07-25T07:44:03.9405513Z     len(to_build))
2022-07-25T07:44:03.9406181Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 316, in build
2022-07-25T07:44:03.9406693Z     updated_docnames = set(self.read())
2022-07-25T07:44:03.9407389Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 423, in read
2022-07-25T07:44:03.9407889Z     self._read_serial(docnames)
2022-07-25T07:44:03.9408596Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 444, in _read_serial
2022-07-25T07:44:03.9409104Z     self.read_doc(docname)
2022-07-25T07:44:03.9409791Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 497, in read_doc
2022-07-25T07:44:03.9410287Z     publisher.publish()
2022-07-25T07:44:03.9410946Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/core.py", line 225, in publish
2022-07-25T07:44:03.9411574Z     self.settings)
2022-07-25T07:44:03.9412224Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/io.py", line 104, in read
2022-07-25T07:44:03.9412677Z     self.parse()
2022-07-25T07:44:03.9413345Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/readers/__init__.py", line 76, in parse
2022-07-25T07:44:03.9413864Z     self.parser.parse(self.input, document)
2022-07-25T07:44:03.9414545Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/parsers.py", line 78, in parse
2022-07-25T07:44:03.9415081Z     self.statemachine.run(inputlines, document, inliner=self.inliner)
2022-07-25T07:44:03.9415923Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 170, in run
2022-07-25T07:44:03.9416569Z     input_source=document['source'])
2022-07-25T07:44:03.9417266Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 234, in run
2022-07-25T07:44:03.9417780Z     context, state, transitions)
2022-07-25T07:44:03.9418469Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 445, in check_line
2022-07-25T07:44:03.9418993Z     return method(match, context, next_state)
2022-07-25T07:44:03.9419735Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2355, in explicit_markup
2022-07-25T07:44:03.9420295Z     nodelist, blank_finish = self.explicit_construct(match)
2022-07-25T07:44:03.9421061Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2367, in explicit_construct
2022-07-25T07:44:03.9421592Z     return method(self, expmatch)
2022-07-25T07:44:03.9422295Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2105, in directive
2022-07-25T07:44:03.9422835Z     directive_class, match, type_name, option_presets)
2022-07-25T07:44:03.9423729Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2154, in run_directive
2022-07-25T07:44:03.9424367Z     result = directive_instance.run()
2022-07-25T07:44:03.9425082Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autodoc/directive.py", line 159, in run
2022-07-25T07:44:03.9425654Z     result = parse_generated_content(self.state, params.result, documenter)
2022-07-25T07:44:03.9426449Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autodoc/directive.py", line 102, in parse_generated_content
2022-07-25T07:44:03.9427019Z     nested_parse_with_titles(state, content, node)
2022-07-25T07:44:03.9427763Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/util/nodes.py", line 340, in nested_parse_with_titles
2022-07-25T07:44:03.9428330Z     return state.nested_parse(content, 0, node, match_titles=1)
2022-07-25T07:44:03.9429080Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 280, in nested_parse
2022-07-25T07:44:03.9429623Z     node=node, match_titles=match_titles)
2022-07-25T07:44:03.9430397Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 195, in run
2022-07-25T07:44:03.9431313Z     results = StateMachineWS.run(self, input_lines, input_offset)
2022-07-25T07:44:03.9433829Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 234, in run
2022-07-25T07:44:03.9434211Z     context, state, transitions)
2022-07-25T07:44:03.9434754Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 445, in check_line
2022-07-25T07:44:03.9435153Z     return method(match, context, next_state)
2022-07-25T07:44:03.9435712Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 3024, in text
2022-07-25T07:44:03.9436270Z     self.section(title.lstrip(), source, style, lineno + 1, messages)
2022-07-25T07:44:03.9436881Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 325, in section
2022-07-25T07:44:03.9437284Z     self.new_subsection(title, lineno, messages)
2022-07-25T07:44:03.9437874Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 393, in new_subsection
2022-07-25T07:44:03.9438276Z     node=section_node, match_titles=True)
2022-07-25T07:44:03.9438846Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 280, in nested_parse
2022-07-25T07:44:03.9439317Z     node=node, match_titles=match_titles)
2022-07-25T07:44:03.9439875Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 195, in run
2022-07-25T07:44:03.9440292Z     results = StateMachineWS.run(self, input_lines, input_offset)
2022-07-25T07:44:03.9440872Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 234, in run
2022-07-25T07:44:03.9441232Z     context, state, transitions)
2022-07-25T07:44:03.9441769Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 445, in check_line
2022-07-25T07:44:03.9442153Z     return method(match, context, next_state)
2022-07-25T07:44:03.9442721Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2785, in underline
2022-07-25T07:44:03.9443283Z     self.section(title, source, style, lineno - 1, messages)
2022-07-25T07:44:03.9443869Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 325, in section
2022-07-25T07:44:03.9444256Z     self.new_subsection(title, lineno, messages)
2022-07-25T07:44:03.9444848Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 393, in new_subsection
2022-07-25T07:44:03.9445241Z     node=section_node, match_titles=True)
2022-07-25T07:44:03.9445814Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 280, in nested_parse
2022-07-25T07:44:03.9446200Z     node=node, match_titles=match_titles)
2022-07-25T07:44:03.9446754Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 195, in run
2022-07-25T07:44:03.9447158Z     results = StateMachineWS.run(self, input_lines, input_offset)
2022-07-25T07:44:03.9447736Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 234, in run
2022-07-25T07:44:03.9448085Z     context, state, transitions)
2022-07-25T07:44:03.9448634Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/statemachine.py", line 445, in check_line
2022-07-25T07:44:03.9449011Z     return method(match, context, next_state)
2022-07-25T07:44:03.9449599Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2355, in explicit_markup
2022-07-25T07:44:03.9450015Z     nodelist, blank_finish = self.explicit_construct(match)
2022-07-25T07:44:03.9450634Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2367, in explicit_construct
2022-07-25T07:44:03.9451020Z     return method(self, expmatch)
2022-07-25T07:44:03.9451579Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2105, in directive
2022-07-25T07:44:03.9451977Z     directive_class, match, type_name, option_presets)
2022-07-25T07:44:03.9452581Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/docutils/parsers/rst/states.py", line 2154, in run_directive
2022-07-25T07:44:03.9452964Z     result = directive_instance.run()
2022-07-25T07:44:03.9453529Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autosummary/__init__.py", line 232, in run
2022-07-25T07:44:03.9453970Z     items = self.get_items(names)
2022-07-25T07:44:03.9454555Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autosummary/__init__.py", line 372, in get_items
2022-07-25T07:44:03.9454927Z     documenter.add_content(None)
2022-07-25T07:44:03.9455495Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 2078, in add_content
2022-07-25T07:44:03.9455875Z     super().add_content(more_content)
2022-07-25T07:44:03.9456449Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 602, in add_content
2022-07-25T07:44:03.9456859Z     for i, line in enumerate(self.process_doc(docstrings)):
2022-07-25T07:44:03.9457517Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/ext/autodoc/__init__.py", line 549, in process_doc
2022-07-25T07:44:03.9457898Z     self.options, docstringlines)
2022-07-25T07:44:03.9458422Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/application.py", line 460, in emit
2022-07-25T07:44:03.9458854Z     return self.events.emit(event, *args, allowed_exceptions=allowed_exceptions)
2022-07-25T07:44:03.9459434Z   File "/home/vsts/work/1/s/.tox/docs/lib/python3.7/site-packages/sphinx/events.py", line 106, in emit
2022-07-25T07:44:03.9459824Z     (listener.handler, name), exc, modname=modname) from exc
2022-07-25T07:44:03.9460544Z sphinx.errors.ExtensionError: Handler <function _process_docstring at 0x7fb68efc8d40> for event 'autodoc-process-docstring' threw an exception (exception: pop from an empty deque)
2022-07-25T07:44:03.9460883Z 
2022-07-25T07:44:03.9461098Z Extension error (sphinx.ext.napoleon):
2022-07-25T07:44:03.9461817Z Handler <function _process_docstring at 0x7fb68efc8d40> for event 'autodoc-process-docstring' threw an exception (exception: pop from an empty deque)
2022-07-25T07:44:04.5382510Z ERROR: InvocationError for command /home/vsts/work/1/s/.tox/docs/bin/sphinx-build -W -T --keep-going -b html docs/ docs/_build/html (exited with code 2)
2022-07-25T07:44:04.5388124Z ___________________________________ summary ____________________________________
2022-07-25T07:44:04.5388477Z ERROR:   docs: commands failed
2022-07-25T07:44:04.5788694Z ##[error]Bash exited with code '1'.
2022-07-25T07:44:04.5803424Z ##[section]Finishing: Run Docs build
```