### PR TITLE
Improve performance of `Estimator` and `Sampler` by avoiding deep copy at `circuit_to_instruction`.

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -75,6 +75,10 @@ class Estimator(BaseEstimator):
 
     @staticmethod
     def _bound_circuit_to_instruction(circuit: QuantumCircuit) -> Instruction:
+        if len(circuit.qregs) > 1:
+            return circuit.to_instruction()
+
+        # len(circuit.qregs) == 1 -> No need to flatten qregs
         inst = Instruction(
             name=circuit.name,
             num_qubits=circuit.num_qubits,

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -29,7 +29,7 @@ from qiskit.result import QuasiDistribution
 from .base_sampler import BaseSampler
 from .primitive_job import PrimitiveJob
 from .sampler_result import SamplerResult
-from .utils import final_measurement_mapping, init_circuit
+from .utils import bound_circuit_to_instruction, final_measurement_mapping, init_circuit
 
 
 class Sampler(BaseSampler):
@@ -106,15 +106,14 @@ class Sampler(BaseSampler):
                     f"The number of values ({len(value)}) does not match "
                     f"the number of parameters ({len(self._parameters[i])})."
                 )
-            bound_circuit = (
+            bound_circuits.append(
                 self._circuits[i]
                 if len(value) == 0
                 else self._circuits[i].bind_parameters(dict(zip(self._parameters[i], value)))
             )
-            bound_circuits.append(bound_circuit)
             qargs_list.append(self._qargs_list[i])
         probabilities = [
-            Statevector(circ).probabilities(qargs=qargs)
+            Statevector(bound_circuit_to_instruction(circ)).probabilities(qargs=qargs)
             for circ, qargs in zip(bound_circuits, qargs_list)
         ]
         if shots is not None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

This PR Improves performance of `Estimator` by converting circuits to instructions manually to avoid parameter binding in `circuit_to_instruction` method.

Address the same issue with #8367 

TODO
- [x] This PR might be over optimization. I need to check whether operations in `ciurcuit_to_instruction` can be optimized out or not.

### Details and comments

Comparison with microbenchmark
```python
from timeit import default_timer

from qiskit.circuit import QuantumCircuit
from qiskit.primitives import Estimator
from qiskit.quantum_info.random import random_pauli

num_qubits = 6
num_operators = 100
num_circuits = 100

circ = QuantumCircuit(num_qubits)
circ.x(range(num_qubits))
observables = [random_pauli(num_qubits, seed=seed) for seed in range(1, num_operators + 1)]

start = default_timer()
estimator = Estimator()
for _ in range(num_circuits):
    a = estimator.run([circ] * num_operators, observables)
print(f"{default_timer() - start} sec")
```

```
main branch
5.699802217999999 sec
```

```
this PR
3.949981157 sec
```

```
#8605 
5.321556266 sec
```