### PR TITLE
Fix converting `VectorStateFn` to a `CircuitStateFn`

### DIFF
--- a/qiskit/opflow/state_fns/circuit_state_fn.py
+++ b/qiskit/opflow/state_fns/circuit_state_fn.py
@@ -20,8 +20,7 @@ import numpy as np
 from qiskit import BasicAer, ClassicalRegister, QuantumCircuit, transpile
 from qiskit.circuit import Instruction, ParameterExpression
 from qiskit.circuit.exceptions import CircuitError
-from qiskit.circuit.library import IGate
-from qiskit.extensions import Initialize
+from qiskit.circuit.library import IGate, StatePreparation
 from qiskit.opflow.exceptions import OpflowError
 from qiskit.opflow.list_ops.composed_op import ComposedOp
 from qiskit.opflow.list_ops.list_op import ListOp
@@ -123,7 +122,7 @@ class CircuitStateFn(StateFn):
         """
         normalization_coeff = np.linalg.norm(statevector)
         normalized_sv = statevector / normalization_coeff
-        return CircuitStateFn(Initialize(normalized_sv), coeff=normalization_coeff)
+        return CircuitStateFn(StatePreparation(normalized_sv), coeff=normalization_coeff)
 
     def primitive_strings(self) -> Set[str]:
         return {"QuantumCircuit"}

--- a/releasenotes/notes/fix-opflow-vector-to-circuit-fn-02cb3424269fa733.yaml
+++ b/releasenotes/notes/fix-opflow-vector-to-circuit-fn-02cb3424269fa733.yaml
@@ -1,0 +1,21 @@
+---
+fixes:
+  - |
+    Previously it was not possible to adjoint a :class:`.CircuitStateFn` that has been
+    constructed from a :class:`.VectorStateFn`. That's because the statevector has been 
+    converted to a circuit with the :class:`~qiskit.extensions.Initialize` instruction, which
+    is not unitary. This problem is now fixed by instead using the :class:`.StatePreparation`
+    instruction, which can be used since the state is assumed to start out in the all 0 state.
+
+    For example we can now do::
+
+        from qiskit import QuantumCircuit
+        from qiskit.opflow import StateFn
+
+        left = StateFn([0, 1])
+        left_circuit = left.to_circuit_op().primitive
+
+        right_circuit = QuantumCircuit(1)
+        right_circuit.x(0)
+
+        overlap = left_circuit.inverse().compose(right_circuit)  # this line raised an error before!

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -24,6 +24,7 @@ from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.utils import QuantumInstance
 from qiskit.opflow import StateFn, Zero, One, H, X, I, Z, Plus, Minus, CircuitSampler, ListOp
 from qiskit.opflow.exceptions import OpflowError
+from qiskit.quantum_info import Statevector
 
 
 @ddt
@@ -216,6 +217,18 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
         sampler = CircuitSampler(backend)
         res = sampler.convert(~Plus @ Plus).eval()
         self.assertAlmostEqual(res, 1 + 0j, places=2)
+
+    def test_adjoint_vector_to_circuit_fn(self):
+        """Test it is possible to adjoint a VectorStateFn that was converted to a CircuitStateFn."""
+        left = StateFn([0, 1])
+        left_circuit = left.to_circuit_op().primitive
+
+        right_circuit = QuantumCircuit(1)
+        right_circuit.x(0)
+
+        circuit = left_circuit.inverse().compose(right_circuit)
+
+        self.assertTrue(Statevector(circuit).equiv([1, 0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix converting a `VectorStateFn` to a `CircuitStateFn`, which previously resulted in a `StateFn` that couldn't be adjoint.

### Details and comments

Previously it was not possible to adjoint a `CircuitStateFn` that has been
constructed from a `VectorStateFn`, because the statevector has been 
converted to a circuit with the `Initialize` instruction, which
is not unitary. This problem is now fixed by instead using the `StatePreparation`
instruction, which can be used since the state is assumed to start out in the all 0 state.

For example we can now do:

```python
from qiskit import QuantumCircuit
from qiskit.opflow import StateFn

left = StateFn([0, 1])
left_circuit = left.to_circuit_op().primitive

right_circuit = QuantumCircuit(1)
right_circuit.x(0)

overlap = left_circuit.inverse().compose(right_circuit)  # this line raised an error before!
```

This also enables using initial states in #8304.