### PR TITLE
Allow optional backend in Job

### DIFF
--- a/qiskit/providers/job.py
+++ b/qiskit/providers/job.py
@@ -12,13 +12,14 @@
 
 """Job abstract interface."""
 
+import time
 from abc import ABC, abstractmethod
 from typing import Callable, Optional
-import time
 
-from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
-from qiskit.providers.exceptions import JobTimeoutError
+from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
+from qiskit.providers.exceptions import JobTimeoutError
+from qiskit.providers.jobstatus import JOB_FINAL_STATES, JobStatus
 
 
 class Job:
@@ -46,7 +47,7 @@ class JobV1(Job, ABC):
     version = 1
     _async = True
 
-    def __init__(self, backend: Backend, job_id: str, **kwargs) -> None:
+    def __init__(self, backend: Optional[Backend], job_id: str, **kwargs) -> None:
         """Initializes the asynchronous job.
 
         Args:
@@ -65,6 +66,8 @@ class JobV1(Job, ABC):
 
     def backend(self) -> Backend:
         """Return the backend where this job was executed."""
+        if self._backend is None:
+            raise QiskitError("The job does not have the backend.")
         return self._backend
 
     def done(self) -> bool:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

It is proposed that backend be set to None in the `Job` to use the `Job` that is not related to `backend`.
https://github.com/Qiskit/qiskit-terra/pull/8382#discussion_r929460615

Can we extend the job like this PR?
Or, should we design the specific job class?

### Details and comments


