### PR TITLE
Improve the performance of assemble when parameter_binds is a list of empty dicts

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -570,7 +570,7 @@ def _expand_parameters(circuits, run_config):
 
     if (
         parameter_binds
-        and any(binds for binds in parameter_binds)
+        and any(parameter_binds)
         or any(circuit.parameters for circuit in circuits)
     ):
 

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -568,11 +568,7 @@ def _expand_parameters(circuits, run_config):
     """
     parameter_binds = run_config.parameter_binds
 
-    if (
-        parameter_binds
-        and any(parameter_binds)
-        or any(circuit.parameters for circuit in circuits)
-    ):
+    if parameter_binds and any(parameter_binds) or any(circuit.parameters for circuit in circuits):
 
         # Unroll params here in order to handle ParamVects
         all_bind_parameters = [

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -16,19 +16,18 @@ import logging
 import uuid
 import warnings
 from time import time
-from typing import Union, List, Dict, Optional
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 
 from qiskit.assembler import assemble_circuits, assemble_schedules
 from qiskit.assembler.run_config import RunConfig
-from qiskit.circuit import QuantumCircuit, Qubit, Parameter
+from qiskit.circuit import Parameter, QuantumCircuit, Qubit
 from qiskit.exceptions import QiskitError
 from qiskit.providers.backend import Backend
-from qiskit.pulse import LoConfig, Instruction
-from qiskit.pulse import Schedule, ScheduleBlock
+from qiskit.pulse import Instruction, LoConfig, Schedule, ScheduleBlock
 from qiskit.pulse.channels import PulseChannel
-from qiskit.qobj import QobjHeader, Qobj
+from qiskit.qobj import Qobj, QobjHeader
 from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 logger = logging.getLogger(__name__)
@@ -569,7 +568,11 @@ def _expand_parameters(circuits, run_config):
     """
     parameter_binds = run_config.parameter_binds
 
-    if parameter_binds or any(circuit.parameters for circuit in circuits):
+    if (
+        parameter_binds
+        and any(binds for binds in parameter_binds)
+        or any(circuit.parameters for circuit in circuits)
+    ):
 
         # Unroll params here in order to handle ParamVects
         all_bind_parameters = [


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When the `parameter_binds` are `[{}]`, the condition becomes `True`. So it causes unnecessary copies, resulting in lower performance.

### Details and comments


