### PR TITLE
Handle repeated stage names in StagedPassManager

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -407,7 +407,7 @@ class StagedPassManager(PassManager):
         super().__setattr__("_expanded_stages", tuple(self._generate_expanded_stages()))
         super().__init__()
         self._validate_init_kwargs(kwargs)
-        for stage in self.expanded_stages:
+        for stage in set(self.expanded_stages):
             pm = kwargs.get(stage, None)
             setattr(self, stage, pm)
 

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -362,10 +362,12 @@ class StagedPassManager(PassManager):
         users as the relative positions of the stage are preserved so the behavior
         will not change between releases.
 
-    These stages will be executed in order and any stage set to ``None`` will be skipped. If
-    a :class:`~qiskit.transpiler.PassManager` input is being used for more than 1 stage here
-    (for example in the case of a :class:`~.Pass` that covers both Layout and Routing) you will want
-    to set that to the earliest stage in sequence that it covers.
+    These stages will be executed in order and any stage set to ``None`` will be skipped.
+    If a stage is provided multiple times (i.e. at diferent relative positions), the
+    associated passes, including pre and post, will run once per declaration.
+    If a :class:`~qiskit.transpiler.PassManager` input is being used for more than 1 stage here
+    (for example in the case of a :class:`~.Pass` that covers both Layout and Routing) you will
+    want to set that to the earliest stage in sequence that it covers.
     """
 
     invalid_stage_regex = re.compile(
@@ -380,6 +382,8 @@ class StagedPassManager(PassManager):
                 instance. If this is not specified the default stages list
                 ``['init', 'layout', 'routing', 'translation', 'optimization', 'scheduling']`` is
                 used. After instantiation, the final list will be immutable and stored as tuple.
+                If a stage is provided multiple times (i.e. at diferent relative positions), the
+                associated passes, including pre and post, will run once per declaration.
             kwargs: The initial :class:`~.PassManager` values for any stages
                 defined in ``stages``. If a argument is not defined the
                 stages will default to ``None`` indicating an empty/undefined

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -422,7 +422,8 @@ class StagedPassManager(PassManager):
         if len(tuple(stages)) != len(set(stages)):
             repeated_stages = {s for s in stages if stages.count(s) > 1}
             warn(
-                f"Stage names {repeated_stages} provided several times, only first occurances preserved.",
+                f"Stage names {repeated_stages} provided several times, "
+                "only first occurances preserved.",
                 UserWarning,
             )
         return tuple(dict.fromkeys(stages))  # Deletes repetitions preserving order

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -15,7 +15,6 @@
 import io
 import re
 from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
-from warnings import warn
 
 import dill
 
@@ -398,18 +397,17 @@ class StagedPassManager(PassManager):
             "optimization",
             "scheduling",
         ]
-        stages = self._parse_stages(stages)
-        # Set through parent class since `self.__setattr__` requieres predefined `expanded_stages`
-        super().__setattr__("_stages", stages)
-        expanded_stages = tuple(self._generate_expanded_stages())
-        super().__setattr__("_expanded_stages", expanded_stages)
+        self._validate_stages(stages)
+        # Set through parent class since `__setattr__` requieres `expanded_stages` to be defined
+        super().__setattr__("_stages", tuple(stages))
+        super().__setattr__("_expanded_stages", tuple(self._generate_expanded_stages()))
         super().__init__()
         self._validate_init_kwargs(kwargs)
         for stage in self.expanded_stages:
             pm = kwargs.get(stage, None)
             setattr(self, stage, pm)
 
-    def _parse_stages(self, stages: Iterable[str]) -> Tuple[str]:
+    def _validate_stages(self, stages: Iterable[str]) -> None:
         invalid_stages = [
             stage for stage in stages if self.invalid_stage_regex.search(stage) is not None
         ]
@@ -419,14 +417,6 @@ class StagedPassManager(PassManager):
                 for invalid_stage in invalid_stages[1:]:
                     msg.write(f", {invalid_stage}")
                 raise ValueError(msg.getvalue())
-        if len(tuple(stages)) != len(set(stages)):
-            repeated_stages = {s for s in stages if stages.count(s) > 1}
-            warn(
-                f"Stage names {repeated_stages} provided several times, "
-                "only first occurances preserved.",
-                UserWarning,
-            )
-        return tuple(dict.fromkeys(stages))  # Deletes repetitions preserving order
 
     def _validate_init_kwargs(self, kwargs: Dict[str, Any]) -> None:
         expanded_stages = set(self.expanded_stages)

--- a/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
+++ b/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Handles repeated stage names provided on :class:`qiskit.transpiler.StagedPassManager`
+    initialization. UserWarning is thrown, and only first occurances are preserved.

--- a/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
+++ b/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
@@ -1,5 +1,5 @@
 ---
-fixes:
+other:
   - |
-    Handles repeated stage names provided on :class:`qiskit.transpiler.StagedPassManager`
-    initialization. UserWarning is thrown, and only first occurances are preserved.
+    Updates documentaiton on how repeated stage names are handled in
+    :class:`qiskit.transpiler.StagedPassManager`, and adds test to check for correctness.

--- a/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
+++ b/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
@@ -1,5 +1,5 @@
 ---
-fixes:
+upgrade:
   - |
     Handles repeated stage names provided on :class:`qiskit.transpiler.StagedPassManager`
     initialization. UserWarning is thrown, and only first occurances are preserved.

--- a/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
+++ b/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
@@ -1,5 +1,0 @@
----
-other:
-  - |
-    Updates documentaiton on how repeated stage names are handled in
-    :class:`qiskit.transpiler.StagedPassManager`, and adds test to check for correctness.

--- a/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
+++ b/releasenotes/notes/fix-staged-passmanager-c2e423ebf17eb57e.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+fixes:
   - |
     Handles repeated stage names provided on :class:`qiskit.transpiler.StagedPassManager`
     initialization. UserWarning is thrown, and only first occurances are preserved.

--- a/test/python/transpiler/test_staged_passmanager.py
+++ b/test/python/transpiler/test_staged_passmanager.py
@@ -98,13 +98,6 @@ class TestStagedPassManager(QiskitTestCase):
         for stage in invalid_stages:
             self.assertIn(stage, message)
 
-    def test_repeated_stages(self):
-        stages = ["alpha", "omega", "alpha"]
-        clean_stages = ("alpha", "omega")
-        with self.assertWarns(UserWarning):
-            spm = StagedPassManager(stages)
-        self.assertEqual(spm.stages, clean_stages)
-
     def test_edit_stages(self):
         spm = StagedPassManager()
         with self.assertRaises(AttributeError):
@@ -127,8 +120,6 @@ class TestStagedPassManager(QiskitTestCase):
             spm.init = spm
         mock_target = "qiskit.transpiler.passmanager.StagedPassManager._update_passmanager"
         with patch(mock_target, spec=True) as mock:
-            spm.max_iteration = spm.max_iteration
-            mock.assert_not_called()
             spm.init = None
             mock.assert_called_once()
 

--- a/test/python/transpiler/test_staged_passmanager.py
+++ b/test/python/transpiler/test_staged_passmanager.py
@@ -98,6 +98,13 @@ class TestStagedPassManager(QiskitTestCase):
         for stage in invalid_stages:
             self.assertIn(stage, message)
 
+    def test_repeated_stages(self):
+        stages = ["alpha", "omega", "alpha"]
+        clean_stages = ("alpha", "omega")
+        with self.assertWarns(UserWarning):
+            spm = StagedPassManager(stages)
+        self.assertEqual(spm.stages, clean_stages)
+
     def test_edit_stages(self):
         spm = StagedPassManager()
         with self.assertRaises(AttributeError):
@@ -120,6 +127,8 @@ class TestStagedPassManager(QiskitTestCase):
             spm.init = spm
         mock_target = "qiskit.transpiler.passmanager.StagedPassManager._update_passmanager"
         with patch(mock_target, spec=True) as mock:
+            spm.max_iteration = spm.max_iteration
+            mock.assert_not_called()
             spm.init = None
             mock.assert_called_once()
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Handle repeated stage names provided on `StagedPassManager` initialization.


### Details and comments
`UserWarning` is thrown and only first occurrences are preserved.

