### PR TITLE
Fixed random_circuit for large circuits

### DIFF
--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -146,8 +146,14 @@ def random_circuit(
 
             # with some low probability, condition on classical bit values
             if conditional and rng.choice(range(10)) == 0:
-                value = rng.integers(0, np.power(2, num_qubits))
-                op.condition = (cr, value)
+                parts = rng.integers(0, 1<<16, size=4)
+                shift = 0
+                condition_int = 0
+                for part in parts:
+                    ipart = (int)(part)
+                    condition_int += ipart << shift
+                    shift += 16
+                op.condition = (cr, condition_int)
 
             qc.append(op, register_operands)
 

--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -150,7 +150,7 @@ def random_circuit(
                 shift = 0
                 condition_int = 0
                 for part in parts:
-                    ipart = (int)(part)
+                    ipart = int(part)
                     condition_int += ipart << shift
                     shift += 16
                 op.condition = (cr, condition_int)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR resolves the issue  #6994 by the following approaches:

- Generating 4 random numbers using numpy rng and using them to form a random number of any number of bits as we want
- Using python int instead of numpy int so that there is no integer overflow due to the upper limit in numpy int


### Details and comments
The issue gets resolved if we do this in the random_circuit function:
```python
parts = rng.integers(0, 1<<16, size=4)
shift = 0
condition_int = 0
for part in parts:
     ipart = (int)(part)
     condition_int += ipart << shift
     shift += 16
op.condition = (cr, condition_int)
```
I have done typecasting on parts (numpy int) and created iparts (python int) so that the condition_int value is in python int. This ensures that condition_int has no upper limit like Numpy int.

We can see that for num_qubits > 63 (80 in my case) we get no error, so the issue is fixed

![image](https://user-images.githubusercontent.com/73956106/181817495-728ca421-f6c8-45eb-a682-2ab3e57d4edf.png)
