### PR TITLE
Fix compatibility with Scipy 1.9.0

### DIFF
--- a/qiskit/algorithms/optimizers/scipy_optimizer.py
+++ b/qiskit/algorithms/optimizers/scipy_optimizer.py
@@ -138,6 +138,13 @@ class SciPyOptimizer(Optimizer):
         if jac is not None and self._method == "l-bfgs-b":
             jac = self._wrap_gradient(jac)
 
+        # Starting in scipy 1.9.0 maxiter is deprecated and maxfun (added in 1.5.0)
+        # should be used instead
+        swapped_deprecated_args = False
+        if self._method == "tnc" and "maxiter" in self._options:
+            swapped_deprecated_args = True
+            self._options["maxfun"] = self._options.pop("maxiter")
+
         raw_result = minimize(
             fun=fun,
             x0=x0,
@@ -147,6 +154,9 @@ class SciPyOptimizer(Optimizer):
             options=self._options,
             **self._kwargs,
         )
+        if swapped_deprecated_args:
+            self._options["maxiter"] = self._options.pop("maxfun")
+
         result = OptimizerResult()
         result.x = raw_result.x
         result.fun = raw_result.fun

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -228,6 +228,8 @@ class QiskitTestCase(BaseQiskitTestCase):
             # Internal deprecation warning emitted by jupyter client when
             # calling nbconvert in python 3.10
             r"There is no current event loop",
+            # Caused by internal scikit-learn scipy usage
+            r"The 'sym_pos' keyword is deprecated and should be replaced by using",
         ]
         for msg in allow_DeprecationWarning_message:
             warnings.filterwarnings("default", category=DeprecationWarning, message=msg)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Scipy 1.9.0 was recently released and introduced a few new deprecation
warnings. Due to the terra test suite being configured to make
DeprecationWarnings raised during the execution of tests fatal this is
causing failures in CI and local test runs when scipy 1.9.0 is used.
The first deprecation warning is that the minimize function has
deprecated the maxiter kwarg and replaced it with the maxfun argument
(which was introduced in scipy 1.5.0) for the TNC optimizer. To address
this the maxiter argument for the algorithms scipy optimizer is changed
to translate maxiter arguments (which is part of qiskit's api) when the
tnc optimizer is being used to send maxfun to scipy instead to avoid the
warning. The second warning being emitted is caused by scikit-learn's
internal usage of scipy. To avoid a failure in CI an exclude is added to
the test suite to ignore that deprecation warning.

### Details and comments

Fixes #8424
