### PR TITLE
Fix `code-block:: python` in docs

### DIFF
--- a/qiskit/extensions/unitary.py
+++ b/qiskit/extensions/unitary.py
@@ -43,7 +43,7 @@ class UnitaryGate(Gate):
         to a quantum circuit. The matrix can also be directly applied
         to the quantum circuit, see :meth:`~qiskit.QuantumCircuit.unitary`.
 
-        .. code-block::python
+        .. code-block:: python
 
             from qiskit import QuantumCircuit
             from qiskit.extensions import UnitaryGate
@@ -230,7 +230,7 @@ def unitary(self, obj, qubits, label=None):
 
         Apply a gate specified by a unitary matrix to a quantum circuit
 
-        .. code-block::python
+        .. code-block:: python
 
             from qiskit import QuantumCircuit
             matrix = [[0, 0, 0, 1],

--- a/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
+++ b/qiskit/transpiler/passes/scheduling/padding/pad_delay.py
@@ -24,7 +24,7 @@ class PadDelay(BasePadding):
 
     Consecutive delays will be merged in the output of this pass.
 
-    .. code-block::python
+    .. code-block:: python
 
         durations = InstructionDurations([("x", None, 160), ("cx", None, 800)])
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Using `code-block::python` without the space between the colon and `python` seems to be invalid and the docs do not display the code block at all. This is also used in a releasenote from 0.18. Can we still fix that by updating the files in this repo?

I also moved the trailing Example from SPSA's initializer to the class docstring, where all the others are.

### Details and comments

For example the `UnitaryGate` docs contain the snippet

```
    Example:

        We can create a unitary gate from a unitary matrix then add it
        to a quantum circuit. The matrix can also be directly applied
        to the quantum circuit, see :meth:`~qiskit.QuantumCircuit.unitary`.

        .. code-block::python  # no space here!

            from qiskit import QuantumCircuit
            from qiskit.extensions import UnitaryGate

            matrix = [[0, 0, 0, 1],
                      [0, 0, 1, 0],
                      [1, 0, 0, 0],
                      [0, 1, 0, 0]]
            gate = UnitaryGate(matrix)

            circuit = QuantumCircuit(2)
            circuit.append(gate, [0, 1])
```
but render as 

<img width="858" alt="image" src="https://user-images.githubusercontent.com/5978796/182323097-e416ab11-8193-4bfe-b4c8-c8b271962829.png">

This doesn't happen if the code block is annotated as `code-block:: python` (with the space).
