### PR TITLE
Rename `multiplexer_dg` with `multiplexer_decomp_dg` after `UC.inverse()`

### DIFF
--- a/qiskit/extensions/quantum_initializer/uc.py
+++ b/qiskit/extensions/quantum_initializer/uc.py
@@ -104,7 +104,7 @@ class UCGate(Gate):
         gates but simply inverts the existing decomposition.
         """
         inverse_gate = Gate(
-            name=self.name + "_dg", num_qubits=self.num_qubits, params=[]
+            name=self.name + "decomp_dg", num_qubits=self.num_qubits, params=[]
         )  # removing the params because arrays are deprecated
 
         definition = QuantumCircuit(*self.definition.qregs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

#8231 produced regression in transpilation from inverse isometry to multiplexer. `Isometry.inverse()` generates a `multiplexer` gate with basic `Gate` class. However, originally, `multiplexer` is based on `UCGate` that has parameters.

This PR provides a work around by naming `multiplexer_decomp(_dg)` instead of `multiplexer(_dg)` to generated `multiplexer` gates of `Gate` class.

### Details and comments

This bug exists before #8231. `UCGate.inverse().inverse()` returns `Gate` instance that has not any parameters even though its name is `multiplexer`. `Isometry.inverse()` internally call `UCGate.inverse().inverse()` since #8231.

```
import numpy as np
from qiskit import QuantumCircuit
from qiskit.quantum_info.states import Statevector

qc = QuantumCircuit(1,1)
vector = [0.2, 0.1]
vector_circuit = QuantumCircuit(1)
vector_circuit.isometry(vector / np.linalg.norm(vector), [0], None)
vector_circuit = vector_circuit.inverse()
qc.append(vector_circuit, [0])

sv = Statevector(qc)
gate_list = [np.array([[sv[0], -sv[1]], [sv[1], sv[0]]])]
qc = QuantumCircuit(1,1)
qc.uc(gate_list, [], [0])

uc = qc.data[0][0]
uc_inverse = uc.inverse()
uc_inverse_inverse = uc_inverse.inverse()
print(uc.__class__, ", param_len=", len(uc.params), ", name=", uc.name)
print(uc_inverse.__class__, ", param_len=", len(uc_inverse.params), ", name=", uc_inverse.name)
print(uc_inverse_inverse.__class__, ", param_len=", len(uc_inverse_inverse.params), ", name=", uc_inverse_inverse.name)
```
Output:
```
<class 'qiskit.extensions.quantum_initializer.uc.UCGate'> , param_len= 1 , name= multiplexer
<class 'qiskit.circuit.gate.Gate'> , param_len= 0 , name= multiplexer_dg
<class 'qiskit.circuit.gate.Gate'> , param_len= 0 , name= multiplexer
```

If `multiplexer` must have parameter [`gatelist` ](https://github.com/Qiskit/qiskit-terra/blob/2bab09c1aae84e5bf38ba52fa3a272667c1887cc/qiskit/extensions/quantum_initializer/uc.py#L64-L65), `UCGate.inverse()` should not name  `multiplexer_dg` to a returned `Gate` instance because it may produce `multiplexer` gate with its `inverse()`.

This PR names `multiplexer_decomp_dg` to a returned `Gate` instance produced by `UCGate.inverse()`. 