### PR TITLE
Fix ``ParameterExpression.is_real`` if ``symengine`` is installed

### DIFF
--- a/qiskit/circuit/parameterexpression.py
+++ b/qiskit/circuit/parameterexpression.py
@@ -508,14 +508,21 @@ class ParameterExpression:
     def is_real(self):
         """Return whether the expression is real"""
 
-        if not self._symbol_expr.is_real and self._symbol_expr.is_real is not None:
+        # workaround for symengine behavior that const * (0 + 1 * I) is not real
+        # see https://github.com/symengine/symengine.py/issues/414
+        if _optionals.HAS_SYMENGINE and self._symbol_expr.is_real is None:
+            symbol_expr = self._symbol_expr.evalf()
+        else:
+            symbol_expr = self._symbol_expr
+
+        if not symbol_expr.is_real and symbol_expr.is_real is not None:
             # Symengine returns false for is_real on the expression if
             # there is a imaginary component (even if that component is 0),
             # but the parameter will evaluate as real. Check that if the
             # expression's is_real attribute returns false that we have a
             # non-zero imaginary
             if _optionals.HAS_SYMENGINE:
-                if self._symbol_expr.imag != 0.0:
+                if symbol_expr.imag != 0.0:
                     return False
             else:
                 return False

--- a/releasenotes/notes/fix-paramexpr-isreal-8d20348b4ce6cbe7.yaml
+++ b/releasenotes/notes/fix-paramexpr-isreal-8d20348b4ce6cbe7.yaml
@@ -10,5 +10,5 @@ fixes:
         x = Parameter("x")
         expr = 1j * x
         bound = expr.bind({x: 2})
-        print(bound.is_real())  # used to be True, but is not False
+        print(bound.is_real())  # used to be True, but is now False
 

--- a/releasenotes/notes/fix-paramexpr-isreal-8d20348b4ce6cbe7.yaml
+++ b/releasenotes/notes/fix-paramexpr-isreal-8d20348b4ce6cbe7.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fix a bug where a bound :class:`.ParameterExpression` was not identified as real 
+    if ``symengine`` was installed and the bound expression was not a plain ``1j``.
+    For example::
+  
+        from qiskit.circuit import Parameter
+
+        x = Parameter("x")
+        expr = 1j * x
+        bound = expr.bind({x: 2})
+        print(bound.is_real())  # used to be True, but is not False
+

--- a/test/python/circuit/test_parameters.py
+++ b/test/python/circuit/test_parameters.py
@@ -1718,6 +1718,14 @@ class TestParameterExpressions(QiskitTestCase):
             self.assertEqual(expr.gradient(x), 2 * x)
             self.assertEqual(expr.gradient(x).gradient(x), 2)
 
+    def test_bound_expression_is_real(self):
+        """Test is_real on bound parameters."""
+        x = Parameter("x")
+        expr = 1j * x
+        bound = expr.bind({x: 2})
+
+        self.assertFalse(bound.is_real())
+
 
 class TestParameterEquality(QiskitTestCase):
     """Test equality of Parameters and ParameterExpressions."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8417.

### Details and comments

This PR works around a case in symengine where an expression is not identified as real or imaginary if it is multiplied by a constant. This led to the unexpected behavior in Qiskit that e.g. `2 * I` was not being identified as imaginary:
```python  
from qiskit.circuit import Parameter
x = Parameter("x")
expr = 1j * x
bound = expr.bind({x: 2})
print(bound.is_real())  # used to be True, but is now False
```


