### PR TITLE
Fix _state_to_latex_ket prefix kwarg bug

### DIFF
--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -1311,13 +1311,14 @@ def numbers_to_latex_terms(numbers: List[complex]) -> List[str]:
     return terms
 
 
-def _state_to_latex_ket(data: List[complex], max_size: int = 12) -> str:
+def _state_to_latex_ket(data: List[complex], max_size: int = 12, prefix: str = "") -> str:
     """Convert state vector to latex representation
 
     Args:
         data: State vector
         max_size: Maximum number of non-zero terms in the expression. If the number of
                  non-zero terms is larger than the max_size, then the representation is truncated.
+        prefix: Latex string to be prepended to the latex, intended for labels.
 
     Returns:
         String with LaTeX representation of the state vector
@@ -1346,7 +1347,7 @@ def _state_to_latex_ket(data: List[complex], max_size: int = 12) -> str:
             term = latex_terms[idx]
             ket = ket_name(ket_idx)
             latex_str += f"{term} |{ket}\\rangle"
-    return latex_str
+    return prefix + latex_str
 
 
 class TextMatrix:

--- a/releasenotes/notes/rh1_state_to_latex_fix-e36e47cbdb25033e.yaml
+++ b/releasenotes/notes/rh1_state_to_latex_fix-e36e47cbdb25033e.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~.visualization.state_visualization.state_to_latex`
+    function: passing a latex string to the optional ``prefix`` argument of the function
+    would raise an error. Fixed `#8460 <https://github.com/Qiskit/qiskit-terra/issues/8460>`__

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -1130,6 +1130,15 @@ class TestStatevector(QiskitTestCase):
             " |111111111111101\\rangle+ |111111111111110\\rangle+ |111111111111111\\rangle",
         )
 
+    def test_state_to_latex_with_prefix(self):
+        """Test adding prefix to state vector latex output"""
+        psi = Statevector(np.array([np.sqrt(1 / 2), 0, 0, np.sqrt(1 / 2)]))
+        prefix = "|\\psi_{AB}\\rangle = "
+        latex_sv = state_to_latex(psi)
+        latex_expected = prefix + latex_sv
+        latex_representation = state_to_latex(psi, prefix=prefix)
+        self.assertEqual(latex_representation, latex_expected)
+
     def test_state_to_latex_for_large_sparse_statevector(self):
         """Test conversion of large sparse state vector"""
         sv = Statevector(np.eye(2**15, 1))


### PR DESCRIPTION
### Summary

Fix for #8460 

### Details and comments

Couldn't find tests for the `_state_to_latex_ket` function but happy to add this test case if they exist somewhere.
