### PR TITLE
Uniquify weyl decompositions and add tests

### DIFF
--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -36,7 +36,7 @@ import numpy as np
 
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.quantumcircuit import QuantumCircuit, Gate
-from qiskit.circuit.library.standard_gates import CXGate, RXGate, RYGate, RZGate
+from qiskit.circuit.library.standard_gates import CXGate, RXGate, RZGate
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators import Operator
 from qiskit.quantum_info.synthesis.weyl import weyl_coordinates, transform_to_magic_basis
@@ -536,25 +536,34 @@ _oneq_xyx = OneQubitEulerDecomposer("XYX")
 _oneq_zyz = OneQubitEulerDecomposer("ZYZ")
 
 
+def _simplify_phi(theta, phi, lam, *, atol=DEFAULT_ATOL):
+    """Choose a phi to propagate through gates.
+    If theta is close to 0 or pi then propagate lam through as well"""
+    if abs(theta) < atol:
+        return phi + lam
+    elif abs(theta - np.pi) < atol:
+        return phi - lam
+    else:
+        return phi
+
+
 class TwoQubitWeylControlledEquiv(TwoQubitWeylDecomposition):
     """U ~ Ud(α, 0, 0) ~ Ctrl-U
 
-    This gate binds 4 parameters, we make it canonical by setting:
-        K2l = Ry(θl).Rx(λl) ,
-        K2r = Ry(θr).Rx(λr) .
-    """
+    This gate binds 4 parameters, we make it canonical by propagating local X rotations through"""
 
     _default_1q_basis = "XYX"
 
     def specialize(self):
         self.b = self.c = 0
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        k2rtheta, k2rphi, k2rlambda, k2rphase = _oneq_xyx.angles_and_phase(self.K2r)
-        self.global_phase += k2lphase + k2rphase
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K1r = self.K1r @ np.asarray(RXGate(k2rphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = np.asarray(RYGate(k2rtheta)) @ np.asarray(RXGate(k2rlambda))
+        phi_l = _simplify_phi(*_oneq_xyx.angles(self.K2l))
+        phi_r = _simplify_phi(*_oneq_xyx.angles(self.K2r))
+        corr_l = np.asarray(RXGate(phi_l))
+        corr_r = np.asarray(RXGate(phi_r))
+        self.K1l = self.K1l @ corr_l
+        self.K1r = self.K1r @ corr_r
+        self.K2l = corr_l.T.conj() @ self.K2l
+        self.K2r = corr_r.T.conj() @ self.K2r
 
 
 class TwoQubitControlledUDecomposer:
@@ -616,7 +625,7 @@ class TwoQubitControlledUDecomposer:
     def __call__(self, unitary, *, atol=DEFAULT_ATOL) -> QuantumCircuit:
         """Returns the Weyl decomposition in circuit form.
 
-        Note: atol ist passed to OneQubitEulerDecomposer.
+        Note: atol is passed to OneQubitEulerDecomposer.
         """
 
         # pylint: disable=attribute-defined-outside-init
@@ -723,20 +732,19 @@ class TwoQubitControlledUDecomposer:
 class TwoQubitWeylMirrorControlledEquiv(TwoQubitWeylDecomposition):
     """U ~ Ud(𝜋/4, 𝜋/4, α) ~ SWAP . Ctrl-U
 
-    This gate binds 4 parameters, we make it canonical by setting:
-        K2l = Ry(θl).Rz(λl) ,
-        K2r = Ry(θr).Rz(λr) .
+    This gate binds 4 parameters, we make it canonical by setting propagating local rotations.
     """
 
     def specialize(self):
         self.a = self.b = np.pi / 4
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_zyz.angles_and_phase(self.K2l)
-        k2rtheta, k2rphi, k2rlambda, k2rphase = _oneq_zyz.angles_and_phase(self.K2r)
-        self.global_phase += k2lphase + k2rphase
-        self.K1r = self.K1r @ np.asarray(RZGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RZGate(k2rphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RZGate(k2llambda))
-        self.K2r = np.asarray(RYGate(k2rtheta)) @ np.asarray(RZGate(k2rlambda))
+        phi_l = _simplify_phi(*_oneq_zyz.angles(self.K2l))
+        phi_r = _simplify_phi(*_oneq_zyz.angles(self.K2r))
+        corr_l = np.asarray(RZGate(phi_l))
+        corr_r = np.asarray(RZGate(phi_r))
+        self.K1l = self.K1l @ corr_r
+        self.K1r = self.K1r @ corr_l
+        self.K2l = corr_l.T.conj() @ self.K2l
+        self.K2r = corr_r.T.conj() @ self.K2r
 
     def _weyl_gate(self, simplify, circ: QuantumCircuit, atol):
         circ.swap(0, 1)
@@ -748,57 +756,51 @@ class TwoQubitWeylMirrorControlledEquiv(TwoQubitWeylDecomposition):
 class TwoQubitWeylfSimaabEquiv(TwoQubitWeylDecomposition):
     """U ~ Ud(α, α, β), α ≥ |β|
 
-    This gate binds 5 parameters, we make it canonical by setting:
-        K2l = Ry(θl).Rz(λl) .
-    """
+    This gate binds 5 parameters, we make it canonical by setting propagating a local Z rotation"""
 
     def specialize(self):
         self.a = self.b = (self.a + self.b) / 2
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_zyz.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ np.asarray(RZGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RZGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RZGate(k2llambda))
-        self.K2r = np.asarray(RZGate(-k2lphi)) @ self.K2r
+        phi_l = _simplify_phi(*_oneq_zyz.angles(self.K2l))
+        corr_l = np.asarray(RZGate(phi_l))
+        self.K1r = self.K1r @ corr_l
+        self.K1l = self.K1l @ corr_l
+        self.K2l = corr_l.T.conj() @ self.K2l
+        self.K2r = corr_l.T.conj() @ self.K2r
 
 
 class TwoQubitWeylfSimabbEquiv(TwoQubitWeylDecomposition):
     """U ~ Ud(α, β, β), α ≥ β
 
-    This gate binds 5 parameters, we make it canonical by setting:
-        K2l = Ry(θl).Rx(λl) .
-    """
+    This gate binds 5 parameters, we make it canonical by propagating a local X rotation"""
 
     _default_1q_basis = "XYX"
 
     def specialize(self):
         self.b = self.c = (self.b + self.c) / 2
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ np.asarray(RXGate(k2lphi))
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = np.asarray(RXGate(-k2lphi)) @ self.K2r
+        phi_l = _simplify_phi(*_oneq_xyx.angles(self.K2l))
+        corr_l = np.asarray(RXGate(phi_l))
+        self.K1r = self.K1r @ corr_l
+        self.K1l = self.K1l @ corr_l
+        self.K2l = corr_l.T.conj() @ self.K2l
+        self.K2r = corr_l.T.conj() @ self.K2r
 
 
 class TwoQubitWeylfSimabmbEquiv(TwoQubitWeylDecomposition):
     """U ~ Ud(α, β, -β), α ≥ β ≥ 0
 
-    This gate binds 5 parameters, we make it canonical by setting:
-        K2l = Ry(θl).Rx(λl) .
-    """
+    This gate binds 5 parameters, we make it canonical by propagating a local X rotation"""
 
     _default_1q_basis = "XYX"
 
     def specialize(self):
         self.b = (self.b - self.c) / 2
         self.c = -self.b
-        k2ltheta, k2lphi, k2llambda, k2lphase = _oneq_xyx.angles_and_phase(self.K2l)
-        self.global_phase += k2lphase
-        self.K1r = self.K1r @ _ipz @ np.asarray(RXGate(k2lphi)) @ _ipz
-        self.K1l = self.K1l @ np.asarray(RXGate(k2lphi))
-        self.K2l = np.asarray(RYGate(k2ltheta)) @ np.asarray(RXGate(k2llambda))
-        self.K2r = _ipz @ np.asarray(RXGate(-k2lphi)) @ _ipz @ self.K2r
+        phi_l = _simplify_phi(*_oneq_xyx.angles(self.K2l))
+        corr_l = np.asarray(RXGate(phi_l))
+        self.K1r = self.K1r @ corr_l.T.conj()
+        self.K1l = self.K1l @ corr_l
+        self.K2l = corr_l.T.conj() @ self.K2l
+        self.K2r = corr_l @ self.K2r
 
 
 class TwoQubitWeylGeneral(TwoQubitWeylDecomposition):

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -72,6 +72,7 @@ from qiskit.quantum_info.synthesis.two_qubit_decompose import (
     Ud,
     decompose_two_qubit_product_gate,
 )
+from qiskit.quantum_info.synthesis.weyl import weyl_coordinates
 
 from qiskit.quantum_info.synthesis.ion_decompose import cnot_rxx_decompose
 import qiskit.quantum_info.synthesis.qsd as qsd
@@ -181,6 +182,18 @@ class CheckDecompositions(QiskitTestCase):
         # pylint: disable=invalid-name
         with self.assertDebugOnly():
             decomp = TwoQubitWeylDecomposition(target_unitary, fidelity=None)
+        wa, wb, wc = weyl_coordinates(target_unitary)
+        max_diff_norm = max(abs(wa - decomp.a), abs(wb - decomp.b), abs(wc - decomp.c))
+        max_diff_flip = max(
+            abs((np.pi / 2 - wa) - decomp.a), abs(wb - decomp.b), abs(-wc - decomp.c)
+        )
+        max_weyl_diff = min(max_diff_norm, max_diff_flip)
+        self.assertLess(
+            max_weyl_diff,
+            tolerance,
+            f"{decomp}\nUnitary {target_unitary}\nWeyl coordinates {(wa, wb, wc)} "
+            f"differ from decomp {(decomp.a, decomp.b, decomp.c)} by {max_weyl_diff}",
+        )
         # self.assertRoundTrip(decomp)  # Too slow
         op = np.exp(1j * decomp.global_phase) * Operator(np.eye(4))
         for u, qs in (
@@ -205,7 +218,7 @@ class CheckDecompositions(QiskitTestCase):
     ):
         """Check that the two qubit Weyl decomposition gets specialized as expected"""
 
-        # Loop to check both for implicit and explicity specialization
+        # Loop to check both for implicit and explicit specialization
         for decomposer in (TwoQubitWeylDecomposition, expected_specialization):
             with self.assertDebugOnly():
                 decomp = decomposer(target_unitary, fidelity=fidelity)
@@ -235,6 +248,25 @@ class CheckDecompositions(QiskitTestCase):
             with self.assertRaises(QiskitError) as exc:
                 _ = expected_specialization(target_unitary, fidelity=1.0)
             self.assertIn("worse than requested", exc.exception.message)
+
+    def check_two_qubit_weyl_specialization_special(
+        self, target_unitary, fidelity, expected_specialization, expected_gates
+    ):
+        """Check that when theta in {0,pi} phi and lam get combined"""
+
+        with self.assertDebugOnly():
+            decomp = TwoQubitWeylDecomposition(target_unitary, fidelity=fidelity)
+        self.assertIsInstance(decomp, expected_specialization, "Incorrect Weyl specialization.")
+        circ = decomp.circuit(simplify=True)
+        ops = circ.count_ops()
+        for key in expected_gates:
+            self.assertEqual(ops[key], expected_gates[key], f"Wrong number of {key}")
+        actual_fid = decomp.actual_fidelity()
+        self.assertAlmostEqual(decomp.calculated_fidelity, actual_fid, places=13)
+        self.assertGreaterEqual(actual_fid, fidelity, "fidelity")
+        actual_unitary = Operator(circ).data
+        trace = np.trace(actual_unitary.T.conj() @ target_unitary)
+        self.assertAlmostEqual(trace.imag, 0, places=12, msg="Real trace")
 
     def check_exact_decomposition(
         self, target_unitary, decomposer, tolerance=1.0e-12, num_basis_uses=None
@@ -738,6 +770,15 @@ K1K2SB = [
         [(0.21, 0.13, 0.45), (2.1, 0.77, 0.88), (1.5, 2.3, 2.3), (2.1, 0.4, 1.7)],
     ]
 ]
+K1K2SBzyz = [
+    [Operator(U3Gate(*xyz)) for xyz in xyzs]
+    for xyzs in [
+        [(1.0e-13, 0.3, 0.1), (np.pi - 1.0e-13, 0.15, 0.22), (0.12, 0.97, 2.2), (3.14, 2.1, 0.9)],
+        [(np.pi - 1.0e-13, 0.13, 0.45), (1.0e-13, 0.77, 0.88), (1.5, 2.32, 2.3), (2.1, 0.4, 1.7)],
+    ]
+]
+Y90 = np.array([[1, -1], [1, 1]]) / np.sqrt(2)
+
 DELTAS = [
     (-0.019, 0.018, 0.021),
     (0.01, 0.015, 0.02),
@@ -820,7 +861,7 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                 )
 
     def test_weyl_specialize_fsim_aab(self, aaa=0.456, bbb=0.132):
-        """Weyl specialization for partial swap gate"""
+        """Weyl specialization for fsim(a, a, b) gate"""
         a, b, c = aaa, aaa, bbb
         for da, db, dc in DELTAS:
             for k1l, k1r, k2l, k2r in K1K2SB:
@@ -833,8 +874,21 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                     {"rz": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
+    def test_weyl_specialize_fsim_aab_special(self, aaa=0.456, bbb=0.132):
+        """Weyl specialization for fsim(a, a, b), theta in {0, pi}"""
+        a, b, c = aaa, aaa, bbb
+        for k1l, k1r, k2l, k2r in K1K2SBzyz:
+            k1 = np.kron(k1l.data, k1r.data)
+            k2 = np.kron(k2l.data, k2r.data)
+            self.check_two_qubit_weyl_specialization_special(
+                k1 @ Ud(a, b, c) @ k2,
+                0.999,
+                TwoQubitWeylfSimaabEquiv,
+                {"rz": 5, "rxx": 1, "ryy": 1, "rzz": 1},  # num ry is unstable
+            )
+
     def test_weyl_specialize_fsim_abb(self, aaa=0.456, bbb=0.132):
-        """Weyl specialization for partial swap gate"""
+        """Weyl specialization for fsim(a, b, b)"""
         a, b, c = aaa, bbb, bbb
         for da, db, dc in DELTAS:
             for k1l, k1r, k2l, k2r in K1K2SB:
@@ -847,8 +901,21 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
+    def test_weyl_specialize_fsim_abb_special(self, aaa=0.456, bbb=0.132):
+        """Weyl specialization for fsim(a, b, b), theta in {0, pi}"""
+        a, b, c = aaa, bbb, bbb
+        for k1l, k1r, k2l, k2r in K1K2SBzyz:
+            k1 = np.kron(Y90 @ k1l.data @ Y90, Y90 @ k1r.data @ Y90)
+            k2 = np.kron(Y90 @ k2l.data @ Y90, Y90 @ k2r.data @ Y90)
+            self.check_two_qubit_weyl_specialization_special(
+                k1 @ Ud(a, b, c) @ k2,
+                0.999,
+                TwoQubitWeylfSimabbEquiv,
+                {"rx": 5, "rxx": 1, "ryy": 1, "rzz": 1},  # num ry is unstable
+            )
+
     def test_weyl_specialize_fsim_abmb(self, aaa=0.456, bbb=0.132):
-        """Weyl specialization for partial swap gate"""
+        """Weyl specialization for fsim(a, b, -b)"""
         a, b, c = aaa, bbb, -bbb
         for da, db, dc in DELTAS:
             for k1l, k1r, k2l, k2r in K1K2SB:
@@ -861,8 +928,21 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                     {"rx": 7, "ry": 4, "rxx": 1, "ryy": 1, "rzz": 1},
                 )
 
+    def test_weyl_specialize_fsim_abmb_special(self, aaa=0.456, bbb=0.132):
+        """Weyl specialization for fsim(a, b, -b), theta in {0, pi}"""
+        a, b, c = aaa, bbb, -bbb
+        for k1l, k1r, k2l, k2r in K1K2SBzyz:
+            k1 = np.kron(Y90 @ k1l.data @ Y90, Y90 @ k1r.data @ Y90)
+            k2 = np.kron(Y90 @ k2l.data @ Y90, Y90 @ k2r.data @ Y90)
+            self.check_two_qubit_weyl_specialization_special(
+                k1 @ Ud(a, b, c) @ k2,
+                0.999,
+                TwoQubitWeylfSimabmbEquiv,
+                {"rx": 5, "rxx": 1, "ryy": 1, "rzz": 1},  # num ry is unstable
+            )
+
     def test_weyl_specialize_ctrl(self, aaa=0.456):
-        """Weyl specialization for partial swap gate"""
+        """Weyl specialization for ctrl-U gate"""
         a, b, c = aaa, 0.0, 0.0
         for da, db, dc in DELTAS:
             for k1l, k1r, k2l, k2r in K1K2SB:
@@ -875,8 +955,21 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                     {"rx": 6, "ry": 4, "rxx": 1},
                 )
 
+    def test_weyl_specialize_fsim_ctrl_special(self, aaa=0.456):
+        """Weyl specialization for ctrl-U, theta in {0, pi}"""
+        a, b, c = aaa, 0.0, 0.0
+        for k1l, k1r, k2l, k2r in K1K2SBzyz:
+            k1 = np.kron(Y90 @ k1l.data @ Y90, Y90 @ k1r.data @ Y90)
+            k2 = np.kron(Y90 @ k2l.data @ Y90, Y90 @ k2r.data @ Y90)
+            self.check_two_qubit_weyl_specialization_special(
+                k1 @ Ud(a, b, c) @ k2,
+                0.999,
+                TwoQubitWeylControlledEquiv,
+                {"rx": 4, "rxx": 1},  # num ry is unstable
+            )
+
     def test_weyl_specialize_mirror_ctrl(self, aaa=-0.456):
-        """Weyl specialization for partial swap gate"""
+        """Weyl specialization for ctrl-U SWAP gate"""
         a, b, c = np.pi / 4, np.pi / 4, aaa
         for da, db, dc in DELTAS:
             for k1l, k1r, k2l, k2r in K1K2SB:
@@ -888,6 +981,19 @@ class TestTwoQubitWeylDecompositionSpecialization(CheckDecompositions):
                     TwoQubitWeylMirrorControlledEquiv,
                     {"rz": 6, "ry": 4, "rzz": 1, "swap": 1},
                 )
+
+    def test_weyl_specialize_mirror_ctrl_special(self, aaa=-0.456):
+        """Weyl specialization for ctrl-U SWAP, theta~{0,pi}"""
+        a, b, c = np.pi / 4, np.pi / 4, aaa
+        for k1l, k1r, k2l, k2r in K1K2SBzyz:
+            k1 = np.kron(k1l.data, k1r.data)
+            k2 = np.kron(k2l.data, k2r.data)
+            self.check_two_qubit_weyl_specialization_special(
+                k1 @ Ud(a, b, c) @ k2,
+                0.999,
+                TwoQubitWeylMirrorControlledEquiv,
+                {"rz": 4, "rzz": 1, "swap": 1},  # num ry is unstable
+            )
 
     def test_weyl_specialize_general(self, aaa=0.456, bbb=0.345, ccc=0.123):
         """Weyl specialization for partial swap gate"""


### PR DESCRIPTION
### Summary
This is a fix for #8287 
The problem is that for a few of the `TwoQubitWeylDecomposition` subclasses, namely the (mirror-) controlled and the fsim cases, a one-qubit Z or X rotation is propagated through the 2-qubit piece, in an attempt to make the decomposition unique. However at high-symmetry points (eg CNOT) the ZYZ or XYX decomposition of the 1Q unitaries is unstable when the theta parameter is close to 0 or pi. (This can't be cleaned up later by the `OneQubitDecomposer` because it needs to propagate through the 2-qubit piece). 

This PR recognizes those cases and takes the phi and lambda parameters in a stable combination (either sum or difference). I chose to do this by recognizing when theta is within tolerance of those symmetric points. An alternative approach would be to choose to always propagate through a rotation by an angle that smoothly interpolates between phi+lam and phi-lam, eg phi+cos(theta)*lambda. I decided against it since this causes less simple-looking (but still unique) decompositions away from the symmetry points.

After this PR I think all the remaining *continuous* symmetries of the decomposition are removed.
There are still a couple *discrete* symmetries remaining even after this PR: 

- for general point in Weyl chamber (p⊗p).Ud(a, b, c).(p⊗p) = Ud(a,b,c) for any Pauli p
- CNOT and iSWAP equivalents have an additional discrete symmetry since they are Clifford

I'll leave this in draft for a bit while I scratch my head to see if I can think of a way to make a stable choice of the discrete symmetries.