### PR TITLE
Fix `PrimitivesJob`'s status method

### DIFF
--- a/qiskit/primitives/primitive_job.py
+++ b/qiskit/primitives/primitive_job.py
@@ -59,7 +59,7 @@ class PrimitiveJob(JobV1):
             return JobStatus.RUNNING
         elif self._future.cancelled():
             return JobStatus.CANCELLED
-        elif self._future.done() and self._future._exception() is None:
+        elif self._future.done() and self._future.exception() is None:
             return JobStatus.DONE
         return JobStatus.ERROR
 

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -23,7 +23,7 @@ from qiskit.circuit import Parameter
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.exceptions import QiskitError
 from qiskit.primitives import Sampler, SamplerResult
-from qiskit.providers import JobV1
+from qiskit.providers import JobStatus, JobV1
 from qiskit.test import QiskitTestCase
 
 
@@ -650,6 +650,13 @@ class TestSampler(QiskitTestCase):
             [self._pqc], parameter_values=[[0, 1, 1, 2, 3, 5]], shots=None, seed=15
         ).result()
         self.assertDictAlmostEqual(result_42.quasi_dists, result_15.quasi_dists)
+
+    def test_primitive_job_status_done(self):
+        """test primitive job's status"""
+        bell = self._circuit[1]
+        sampler = Sampler()
+        job = sampler.run(circuits=[bell])
+        self.assertEqual(job.status(), JobStatus.DONE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes `PrimitiveJob`'s `status` to correctly return `JobStatus.DONE` when there were no errors.


### Details and comments


