### PR TITLE
Minimizer was missing from API reference

### DIFF
--- a/qiskit/algorithms/optimizers/__init__.py
+++ b/qiskit/algorithms/optimizers/__init__.py
@@ -37,6 +37,7 @@ Optimizer Base Class
    OptimizerResult
    OptimizerSupportLevel
    Optimizer
+   Minimizer
 
 Local Optimizers
 ================
@@ -133,6 +134,8 @@ from .umda import UMDA
 __all__ = [
     "Optimizer",
     "OptimizerSupportLevel",
+    "OptimizerResult",
+    "Minimizer",
     "ADAM",
     "AQGD",
     "CG",

--- a/qiskit/algorithms/optimizers/optimizer.py
+++ b/qiskit/algorithms/optimizers/optimizer.py
@@ -110,7 +110,25 @@ class OptimizerResult(AlgorithmResult):
 
 
 class Minimizer(Protocol):
-    """Callback Protocol for minimizer."""
+    """Callable Protocol for minimizer.
+
+    This interface is based on `SciPy's optimize module
+    <https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html>`__.
+
+     This protocol defines a callable taking the following parameters:
+
+         fun
+             The objective function to minimize (for example the energy in the case of the VQE).
+         x0
+             The initial point for the optimization.
+         jac
+             The gradient of the objective function.
+         bounds
+             Parameters bounds for the optimization. Note that these might not be supported
+             by all optimizers.
+
+     and which returns a minimization result object (either SciPy's or Qiskit's).
+    """
 
     # pylint: disable=invalid-name
     def __call__(


### PR DESCRIPTION
Adds an entry so recently introduced `Minimizer` protocol in included in the API reference. Algorithm such as VQE can take an optimizer based on this protocol and so while the typehints showed this it was not a clickable link. And since the docs for \_\_call\_\_ are not included in the html I added similar information to it main docstring.

Also added it, and another missing class to the \_\_all\_\_ section.



