### PR TITLE
[WIP] #8086 - Support RZX in list of known gates for QASM 2

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1692,6 +1692,7 @@ class QuantumCircuit:
             "cu",
             "rxx",
             "rzz",
+            "rzx",
             "rccx",
             "rc3x",
             "c3x",

--- a/qiskit/qasm/libs/qelib1.inc
+++ b/qiskit/qasm/libs/qelib1.inc
@@ -168,6 +168,15 @@ gate rzz(theta) a,b
   u1(theta) b;
   cx a,b;
 }
+// two-qubit ZX rotation
+gate rzx(theta) a,b
+{
+  h b;
+  cx a,b;
+  rz(theta) b;
+  cx a,b;
+  h b;
+}
 // relative-phase CCX
 gate rccx a,b,c
 {

--- a/qiskit/qasm/pygments/lexer.py
+++ b/qiskit/qasm/pygments/lexer.py
@@ -89,6 +89,7 @@ class OpenQASMLexer(RegexLexer):
         "cu3",
         "rxx",
         "rzz",
+        "rzx",
         "rccx",
         "rc3x",
         "u1",

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -48,6 +48,7 @@ class TestCircuitQasm(QiskitTestCase):
         qc.measure(qr1[0], cr[0])
         qc.measure(qr2[0], cr[1])
         qc.measure(qr2[1], cr[2])
+        qc.rzx(pi / 4, qr1[0], qr2[1])
         expected_qasm = """OPENQASM 2.0;
 include "qelib1.inc";
 qreg qr1[1];
@@ -67,7 +68,8 @@ if(cr==2) z qr1[0];
 barrier qr1[0],qr2[0],qr2[1];
 measure qr1[0] -> cr[0];
 measure qr2[0] -> cr[1];
-measure qr2[1] -> cr[2];\n"""
+measure qr2[1] -> cr[2];
+rzx(pi/4) qr1[0],qr2[1];\n"""
         self.assertEqual(qc.qasm(), expected_qasm)
 
     def test_circuit_qasm_with_composite_circuit(self):
@@ -241,7 +243,8 @@ qreg q[3];
 qreg r[3];
 creg c[3];
 creg d[3];
-nG0(pi,pi/2) q[0],r[0];\n"""
+nG0(pi,pi/2) q[0],r[0];
+rzx(pi/2) q[0],r[0];\n"""
         qc = QuantumCircuit.from_qasm_str(original_str)
 
         self.assertEqual(original_str, qc.qasm())


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8086 by including RZX in the list of known gates in qelib1.inc. RXX and RZZ were there so it didn't seem to be much of a stretch to include RZX as well.

### Details and comments

Tested using code slightly modified version of code in issue:

```python
from qiskit import QuantumCircuit

circuit = QuantumCircuit(2)
circuit.ecr(0, 1)
qasm_str = circuit.qasm()
print(qasm_str)
another_circuit = QuantumCircuit.from_qasm_str(qasm_str)
print(another_circuit)
print(circuit)

```
Results were:

```text
OPENQASM 2.0;
include "qelib1.inc";
gate ecr q0,q1 { rzx(pi/4) q0,q1; x q0; rzx(-pi/4) q0,q1; }
qreg q[2];
ecr q[0],q[1];

     ┌──────┐
q_0: ┤0     ├
     │  ecr │
q_1: ┤1     ├
     └──────┘
     ┌──────┐
q_0: ┤0     ├
     │  Ecr │
q_1: ┤1     ├
     └──────┘
```

On unit testing, I have appended data to existing test cases which seemed appropriately named but am happy to move this new code into dedicated tests if that would be  better.
