### PR TITLE
Make Clifford objects hashable

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -161,9 +161,12 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
             str(self.stabilizer.to_labels()), str(self.destabilizer.to_labels())
         )
 
+    def __hash__(self):
+        return hash(self.table)
+
     def __eq__(self, other):
         """Check if two Clifford tables are equal"""
-        return super().__eq__(other) and self._table == other._table
+        return super().__eq__(other) and self.table == other.table
 
     # ---------------------------------------------------------------------
     # Attributes

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -211,10 +211,17 @@ class StabilizerTable(PauliTable, AdjointMixin):
         """String representation"""
         return f"StabilizerTable: {self.to_labels()}"
 
+    def __hash__(self):
+        return hash((self.num_qubits, tuple(np.ravel(self._array)), tuple(self._phase)))
+
     def __eq__(self, other):
         """Test if two StabilizerTables are equal"""
         if isinstance(other, StabilizerTable):
-            return np.all(self._phase == other._phase) and self.pauli == other.pauli
+            return (
+                self.num_qubits == other.num_qubits
+                and np.all(self._phase == other._phase)
+                and np.all(self._array == other._array)
+            )
         return False
 
     def copy(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Make Clifford and StabilizerTable objects hashable so that they can be a key of mapping objects.

