### PR TITLE
Improve the performance of Clifford.from_circuit()

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/clifford.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2020
+# (C) Copyright IBM 2017--2022
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -565,10 +565,6 @@ class Clifford(BaseOperator, AdjointMixin, Operation):
         """
         if not isinstance(circuit, (QuantumCircuit, Instruction)):
             raise QiskitError("Input must be a QuantumCircuit or Instruction")
-
-        # Convert circuit to an instruction
-        if isinstance(circuit, QuantumCircuit):
-            circuit = circuit.to_instruction()
 
         # Initialize an identity Clifford
         clifford = Clifford(np.eye(2 * circuit.num_qubits), validate=False)

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -13,7 +13,6 @@
 Circuit simulation for the Clifford class.
 """
 
-from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.barrier import Barrier
 from qiskit.circuit.delay import Delay
 from qiskit.exceptions import QiskitError

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -96,15 +96,8 @@ def _append_operation(clifford, operation, qargs=None):
     # are a single qubit Clifford gate rather than raise an exception.
     if gate.definition is None:
         raise QiskitError(f"Cannot apply Instruction: {gate.name}")
-    # TODO: We could remove this check once gate.definition is typed as Optional[QuantumCircuit]
-    if isinstance(gate.definition, QuantumCircuit):
-        _append_circuit(clifford, gate.definition, qargs)
-    else:
-        raise QiskitError(
-            f"{gate.name} instruction definition is {type(gate.definition)}; expected QuantumCircuit"
-        )
 
-    return clifford
+    return _append_circuit(clifford, gate.definition, qargs)
 
 
 # ---------------------------------------------------------------------

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -69,29 +69,9 @@ def _append_operation(clifford, operation, qargs=None):
 
     gate = operation
 
-    # Basis Clifford Gates
-    basis_1q = {
-        "i": _append_i,
-        "id": _append_i,
-        "iden": _append_i,
-        "x": _append_x,
-        "y": _append_y,
-        "z": _append_z,
-        "h": _append_h,
-        "s": _append_s,
-        "sdg": _append_sdg,
-        "sinv": _append_sdg,
-        "v": _append_v,
-        "w": _append_w,
-    }
-    basis_2q = {"cx": _append_cx, "cz": _append_cz, "swap": _append_swap}
-
-    # Non-clifford gates
-    non_clifford = ["t", "tdg", "ccx", "ccz"]
-
     if isinstance(gate, str):
         # Check if gate is a valid Clifford basis gate string
-        if gate not in basis_1q and gate not in basis_2q:
+        if gate not in _BASIS_1Q and gate not in _BASIS_2Q:
             raise QiskitError(f"Invalid Clifford gate name string {gate}")
         name = gate
     else:
@@ -99,16 +79,16 @@ def _append_operation(clifford, operation, qargs=None):
         name = gate.name
 
     # Apply gate if it is a Clifford basis gate
-    if name in non_clifford:
+    if name in _NON_CLIFFORD:
         raise QiskitError(f"Cannot update Clifford with non-Clifford gate {name}")
-    if name in basis_1q:
+    if name in _BASIS_1Q:
         if len(qargs) != 1:
             raise QiskitError("Invalid qubits for 1-qubit gate.")
-        return basis_1q[name](clifford, qargs[0])
-    if name in basis_2q:
+        return _BASIS_1Q[name](clifford, qargs[0])
+    if name in _BASIS_2Q:
         if len(qargs) != 2:
             raise QiskitError("Invalid qubits for 2-qubit gate.")
-        return basis_2q[name](clifford, qargs[0], qargs[1])
+        return _BASIS_2Q[name](clifford, qargs[0], qargs[1])
 
     # If not a Clifford basis gate we try to unroll the gate and
     # raise an exception if unrolling reaches a non-Clifford gate.
@@ -340,3 +320,23 @@ def _append_swap(clifford, qubit0, qubit1):
     clifford.x[:, [qubit0, qubit1]] = clifford.x[:, [qubit1, qubit0]]
     clifford.z[:, [qubit0, qubit1]] = clifford.z[:, [qubit1, qubit0]]
     return clifford
+
+
+# Basis Clifford Gates
+_BASIS_1Q = {
+    "i": _append_i,
+    "id": _append_i,
+    "iden": _append_i,
+    "x": _append_x,
+    "y": _append_y,
+    "z": _append_z,
+    "h": _append_h,
+    "s": _append_s,
+    "sdg": _append_sdg,
+    "sinv": _append_sdg,
+    "v": _append_v,
+    "w": _append_w,
+}
+_BASIS_2Q = {"cx": _append_cx, "cz": _append_cz, "swap": _append_swap}
+# Non-clifford gates
+_NON_CLIFFORD = {"t", "tdg", "ccx", "ccz"}

--- a/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
+++ b/qiskit/quantum_info/operators/symplectic/clifford_circuits.py
@@ -74,8 +74,10 @@ def _append_operation(clifford, operation, qargs=None):
             raise QiskitError(f"Invalid Clifford gate name string {gate}")
         name = gate
     else:
-        # Assume gate is an Instruction
+        # assert isinstance(gate, Instruction)
         name = gate.name
+        if getattr(gate, "condition", None) is not None:
+            raise QiskitError("Conditional gate is not a valid Clifford operation.")
 
     # Apply gate if it is a Clifford basis gate
     if name in _NON_CLIFFORD:

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -422,6 +422,15 @@ class TestCliffordGates(QiskitTestCase):
         value = Clifford(circ)
         self.assertEqual(value, target)
 
+    def test_from_circuit_with_conditional_gate(self):
+        """Test initialization from circuit with conditional gate."""
+        qc = QuantumCircuit(2, 1)
+        qc.h(0).c_if(0, 0)
+        qc.cx(0, 1)
+
+        with self.assertRaises(QiskitError):
+            Clifford(qc)
+
 
 @ddt
 class TestCliffordSynthesis(QiskitTestCase):

--- a/test/python/quantum_info/operators/symplectic/test_clifford.py
+++ b/test/python/quantum_info/operators/symplectic/test_clifford.py
@@ -35,7 +35,7 @@ from qiskit.circuit.library import (
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info import random_clifford
 from qiskit.quantum_info.operators import Clifford, Operator
-from qiskit.quantum_info.operators.symplectic.clifford_circuits import _append_circuit
+from qiskit.quantum_info.operators.symplectic.clifford_circuits import _append_operation
 from qiskit.quantum_info.synthesis.clifford_decompose import (
     decompose_clifford_ag,
     decompose_clifford_bm,
@@ -187,7 +187,7 @@ class TestCliffordGates(QiskitTestCase):
         for gate_name in ("i", "id", "iden", "x", "y", "z", "h", "s", "sdg", "v", "w"):
             with self.subTest(msg="append gate %s" % gate_name):
                 cliff = Clifford([[1, 0], [0, 1]])
-                cliff = _append_circuit(cliff, gate_name, [0])
+                cliff = _append_operation(cliff, gate_name, [0])
                 value_table = cliff.table._array
                 value_phase = cliff.table._phase
                 value_stabilizer = cliff.stabilizer.to_labels()
@@ -221,8 +221,8 @@ class TestCliffordGates(QiskitTestCase):
             with self.subTest(msg="identity for gate %s" % gate_name):
                 cliff = Clifford([[1, 0], [0, 1]])
                 cliff1 = cliff.copy()
-                cliff = _append_circuit(cliff, gate_name, [0])
-                cliff = _append_circuit(cliff, gate_name, [0])
+                cliff = _append_operation(cliff, gate_name, [0])
+                cliff = _append_operation(cliff, gate_name, [0])
                 self.assertEqual(cliff, cliff1)
 
         gates = ["s", "s", "v"]
@@ -232,8 +232,8 @@ class TestCliffordGates(QiskitTestCase):
             with self.subTest(msg="identity for gate %s" % gate_name):
                 cliff = Clifford([[1, 0], [0, 1]])
                 cliff1 = cliff.copy()
-                cliff = _append_circuit(cliff, gate_name, [0])
-                cliff = _append_circuit(cliff, inv_gate, [0])
+                cliff = _append_operation(cliff, gate_name, [0])
+                cliff = _append_operation(cliff, inv_gate, [0])
                 self.assertEqual(cliff, cliff1)
 
     def test_1_qubit_mult_relations(self):
@@ -255,9 +255,9 @@ class TestCliffordGates(QiskitTestCase):
                 split_rel = rel.split()
                 cliff = Clifford([[1, 0], [0, 1]])
                 cliff1 = cliff.copy()
-                cliff = _append_circuit(cliff, split_rel[0], [0])
-                cliff = _append_circuit(cliff, split_rel[2], [0])
-                cliff1 = _append_circuit(cliff1, split_rel[4], [0])
+                cliff = _append_operation(cliff, split_rel[0], [0])
+                cliff = _append_operation(cliff, split_rel[2], [0])
+                cliff1 = _append_operation(cliff1, split_rel[4], [0])
                 self.assertEqual(cliff, cliff1)
 
     def test_1_qubit_conj_relations(self):
@@ -277,10 +277,10 @@ class TestCliffordGates(QiskitTestCase):
                 split_rel = rel.split()
                 cliff = Clifford([[1, 0], [0, 1]])
                 cliff1 = cliff.copy()
-                cliff = _append_circuit(cliff, split_rel[0], [0])
-                cliff = _append_circuit(cliff, split_rel[2], [0])
-                cliff = _append_circuit(cliff, split_rel[4], [0])
-                cliff1 = _append_circuit(cliff1, split_rel[6], [0])
+                cliff = _append_operation(cliff, split_rel[0], [0])
+                cliff = _append_operation(cliff, split_rel[2], [0])
+                cliff = _append_operation(cliff, split_rel[4], [0])
+                cliff1 = _append_operation(cliff1, split_rel[6], [0])
                 self.assertEqual(cliff, cliff1)
 
     @combine(gate_name=("cx", "cz", "swap"), qubits=([0, 1], [1, 0]))
@@ -339,7 +339,7 @@ class TestCliffordGates(QiskitTestCase):
         }
 
         gate_qubits = gate_name + " " + str(qubits)
-        cliff = _append_circuit(Clifford(np.eye(4)), gate_name, qubits)
+        cliff = _append_operation(Clifford(np.eye(4)), gate_name, qubits)
         target = targets_cliffords[gate_qubits]
         self.assertEqual(target, cliff)
 
@@ -351,8 +351,8 @@ class TestCliffordGates(QiskitTestCase):
                 with self.subTest(msg=f"append gate {gate_name} {qubits}"):
                     cliff = Clifford(np.eye(4))
                     cliff1 = cliff.copy()
-                    cliff = _append_circuit(cliff, gate_name, qubits)
-                    cliff = _append_circuit(cliff, gate_name, qubits)
+                    cliff = _append_operation(cliff, gate_name, qubits)
+                    cliff = _append_operation(cliff, gate_name, qubits)
                     self.assertEqual(cliff, cliff1)
 
     def test_2_qubit_relations(self):
@@ -361,50 +361,50 @@ class TestCliffordGates(QiskitTestCase):
         with self.subTest(msg="relation between cx, h and cz"):
             cliff = Clifford(np.eye(4))
             cliff1 = cliff.copy()
-            cliff = _append_circuit(cliff, "h", [1])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "h", [1])
-            cliff = _append_circuit(cliff, "cz", [0, 1])
+            cliff = _append_operation(cliff, "h", [1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "h", [1])
+            cliff = _append_operation(cliff, "cz", [0, 1])
             self.assertEqual(cliff, cliff1)
 
         with self.subTest(msg="relation between cx and swap"):
             cliff = Clifford(np.eye(4))
             cliff1 = cliff.copy()
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "cx", [1, 0])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "swap", [0, 1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "cx", [1, 0])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "swap", [0, 1])
             self.assertEqual(cliff, cliff1)
 
         with self.subTest(msg="relation between cx and x"):
             cliff = Clifford(np.eye(4))
             cliff1 = cliff.copy()
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "x", [0])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "x", [0])
-            cliff = _append_circuit(cliff, "x", [1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "x", [0])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "x", [0])
+            cliff = _append_operation(cliff, "x", [1])
             self.assertEqual(cliff, cliff1)
 
         with self.subTest(msg="relation between cx and z"):
             cliff = Clifford(np.eye(4))
             cliff1 = cliff.copy()
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "z", [1])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "z", [0])
-            cliff = _append_circuit(cliff, "z", [1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "z", [1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "z", [0])
+            cliff = _append_operation(cliff, "z", [1])
             self.assertEqual(cliff, cliff1)
 
         with self.subTest(msg="relation between cx and s"):
             cliff = Clifford(np.eye(4))
             cliff1 = cliff.copy()
-            cliff = _append_circuit(cliff, "cx", [1, 0])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "s", [1])
-            cliff = _append_circuit(cliff, "cx", [0, 1])
-            cliff = _append_circuit(cliff, "cx", [1, 0])
-            cliff = _append_circuit(cliff, "sdg", [0])
+            cliff = _append_operation(cliff, "cx", [1, 0])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "s", [1])
+            cliff = _append_operation(cliff, "cx", [0, 1])
+            cliff = _append_operation(cliff, "cx", [1, 0])
+            cliff = _append_operation(cliff, "sdg", [0])
             self.assertEqual(cliff, cliff1)
 
     def test_barrier_delay_sim(self):


### PR DESCRIPTION
### Summary
Improve the performance of Clifford.from_circuit() by avoiding unnecessary `to_instruction` calls.

### Details and comments
As a by-product, the `clifford_circuits._append_circuit` function is refactored into two functions `clifford_circuits._append_circuit` and `clifford_circuits._append_operation` for readability.