### PR TITLE
Skip binding when parameter is None

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -102,7 +102,9 @@ class Estimator(BaseEstimator):
                     f"the number of parameters ({len(self._parameters[i])})."
                 )
             bound_circuits.append(
-                self._circuits[i].bind_parameters(dict(zip(self._parameters[i], value)))
+                self._circuits[i]
+                if len(value) == 0
+                else self._circuits[i].bind_parameters(dict(zip(self._parameters[i], value)))
             )
         sorted_observables = [self._observables[i] for i in observables]
         expectation_values = []

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -106,12 +106,11 @@ class Sampler(BaseSampler):
                     f"The number of values ({len(value)}) does not match "
                     f"the number of parameters ({len(self._parameters[i])})."
                 )
-            bound_circuit = (
+            bound_circuits.append(
                 self._circuits[i]
                 if len(value) == 0
                 else self._circuits[i].bind_parameters(dict(zip(self._parameters[i], value)))
             )
-            bound_circuits.append(bound_circuit)
             qargs_list.append(self._qargs_list[i])
         probabilities = [
             Statevector(circ).probabilities(qargs=qargs)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a part of https://github.com/Qiskit/qiskit-terra/pull/8367.
This PR reduces deepcopy of the circuit by not calling `bind_parameters` when no parameters exist.

### Details and comments


