### PR TITLE
Add setuptools_rust to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ setenv =
   {[testenv]setenv}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
+  setuptools_rust
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ setenv =
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
 passenv = RAYON_NUM_THREADS OMP_NUM_THREADS QISKIT_PARALLEL RUST_BACKTRACE SETUPTOOLS_ENABLE_FEATURES
-deps = -r{toxinidir}/requirements.txt
+deps = setuptools_rust
+       -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 commands =
   stestr run {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
   QISKIT_TEST_CAPTURE_STREAMS=1
   QISKIT_PARALLEL=FALSE
 passenv = RAYON_NUM_THREADS OMP_NUM_THREADS QISKIT_PARALLEL RUST_BACKTRACE SETUPTOOLS_ENABLE_FEATURES
-deps = setuptools_rust
+deps = setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
        -r{toxinidir}/requirements.txt
        -r{toxinidir}/requirements-dev.txt
 commands =
@@ -74,7 +74,7 @@ setenv =
   {[testenv]setenv}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
 deps =
-  setuptools_rust
+  setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
 commands =


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the second run of `tox`, it fails as follows:
```
Traceback (most recent call last):
  File "qiskit-terra/setup.py", line 19, in <module>
    from setuptools_rust import Binding, RustExtension
ModuleNotFoundError: No module named 'setuptools_rust'
ERROR: invocation failed (exit code 1)
__________________________________________________________________________________________________________________________________ summary __________________________________________________________________________________________________________________________________
ERROR:   py39: InvocationError for command qiskit-terra/.tox/py39/bin/python setup.py --name (exited with code 1)
```

This PR add the dependency (`setuptools_rust`) to `tox.ini`.

### Details and comments


