### PR TITLE
Ensure QPY test circuits have non-generated names

### DIFF
--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -491,7 +491,7 @@ def generate_controlled_gates():
 def generate_open_controlled_gates():
     """Test QPY serialization with custom ControlledGates with open controls."""
     circuits = []
-    qc = QuantumCircuit(3)
+    qc = QuantumCircuit(3, name="open_controls_simple")
     controlled_gate = DCXGate().control(1, ctrl_state=0)
     qc.append(controlled_gate, [0, 1, 2])
     circuits.append(qc)
@@ -502,7 +502,7 @@ def generate_open_controlled_gates():
     custom_definition.rz(1.5, 0)
     custom_definition.sdg(0)
     custom_gate.definition = custom_definition
-    nested_qc = QuantumCircuit(3)
+    nested_qc = QuantumCircuit(3, name="open_controls_nested")
     nested_qc.append(custom_gate, [0])
     controlled_gate = custom_gate.control(2, ctrl_state=1)
     nested_qc.append(controlled_gate, [0, 1, 2])


### PR DESCRIPTION
### Summary

Circuits in QPY backwards compatibility should always have fixed names,
to avoid changes in the number of circuits constructed during library
set-up code affected the output names.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fixes CI failing in the QPY tests (which only run on 3.10 / Linux).