### PR TITLE
Support deprecate_arguments with new_arg None

### DIFF
--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -62,14 +62,14 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
             if new_arg is None:
                 warnings.warn(
                     f"{func_name} keyword argument {old_arg} is deprecated and "
-                    "will in future be ignored."
+                    "will in future be ignored.",
                     DeprecationWarning,
                     stacklevel=3,
                 )
             else:
                 warnings.warn(
                     f"{func_name} keyword argument {old_arg} is deprecated and "
-                    f"replaced with {new_arg}."
+                    f"replaced with {new_arg}.",
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -61,7 +61,8 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
 
             if new_arg is None:
                 warnings.warn(
-                    f"{func_name} keyword argument {old_arg} is deprecated and ignored."
+                    f"{func_name} keyword argument {old_arg} is deprecated and "
+                    "will in future be ignored."
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -62,7 +62,7 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
             if new_arg is None:
                 warnings.warn(
                     f"{func_name} keyword argument {old_arg} is deprecated and "
-                    "will in future be ignored.",
+                    "will in future be removed.",
                     DeprecationWarning,
                     stacklevel=3,
                 )

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -59,11 +59,18 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
             if new_arg in kwargs:
                 raise TypeError(f"{func_name} received both {new_arg} and {old_arg} (deprecated).")
 
-            warnings.warn(
-                "{} keyword argument {} is deprecated and "
-                "replaced with {}.".format(func_name, old_arg, new_arg),
-                DeprecationWarning,
-                stacklevel=3,
-            )
+            if new_arg is None:
+                warnings.warn(
+                    f"{func_name} keyword argument {old_arg} is deprecated and ignored."
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+            else:
+                warnings.warn(
+                    f"{func_name} keyword argument {old_arg} is deprecated and "
+                    f"replaced with {new_arg}."
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
 
-            kwargs[new_arg] = kwargs.pop(old_arg)
+                kwargs[new_arg] = kwargs.pop(old_arg)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Currently there is no way to warn when an argument is deprecated and no replacement is provided. 
I propose that passing None as `new_arg`.
This comes from the comment https://github.com/Qiskit/qiskit-terra/pull/8510#discussion_r942583962

### Details and comments

Comments are welcome.
