### PR TITLE
Use np.array_split instead of np.split to support uneven splits in spsa._batch_evaluate

### DIFF
--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -727,7 +727,7 @@ def _batch_evaluate(function, points, max_evals_grouped):
         num_batches += 1
 
     # split the points
-    batched_points = np.split(np.asarray(points), num_batches)
+    batched_points = np.array_split(np.asarray(points), num_batches)
 
     results = []
     for batch in batched_points:

--- a/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
+++ b/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    When the class :class:`~SPSA` was using `np.split` (from NumPy) for splitting the jobs in even batches,
+    When the class :class:`~.SPSA` was using `np.split` (from NumPy) for splitting the jobs in even batches,
     resulting in an exception if a perfectly even split was not possible. Now, it uses `np.array_split`, which is safer
     for these cases.

--- a/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
+++ b/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
@@ -2,5 +2,5 @@
 fixes:
   - |
     When the class :class:`~SPSA` was using `np.split` (from NumPy) for splitting the jobs in even batches,
-    resulting in an exception one a perfectly even split was not possible. Now, it uses `np.array_split`, which is safer
+    resulting in an exception if a perfectly even split was not possible. Now, it uses `np.array_split`, which is safer
     for these cases.

--- a/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
+++ b/releasenotes/notes/qiskit-nature-797-8f1b0975309b8756.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    When the class :class:`~SPSA` was using `np.split` (from NumPy) for splitting the jobs in even batches,
+    resulting in an exception one a perfectly even split was not possible. Now, it uses `np.array_split`, which is safer
+    for these cases.

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -188,7 +188,7 @@ class TestSPSA(QiskitAlgorithmsTestCase):
         See https://github.com/Qiskit/qiskit-nature/issues/797"""
 
         def objective(x):
-            if len(x.shape == 2):
+            if x.shape == 2:
                 return np.array([sum(x_i) for x_i in x])
             return sum(x)
 

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -188,8 +188,8 @@ class TestSPSA(QiskitAlgorithmsTestCase):
         See https://github.com/Qiskit/qiskit-nature/issues/797"""
 
         def objective(x):
-            if isinstance(x, list):
-                return [sum(x_i) for x_i in x]
+            if len(x.shape == 2):
+                return np.array([sum(x_i) for x_i in x])
             return sum(x)
 
         point = np.ones(5)

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -182,47 +182,16 @@ class TestSPSA(QiskitAlgorithmsTestCase):
             self.assertTrue(all(isinstance(value, expected_types[i]) for value in values))
             self.assertEqual(len(history[key]), maxiter)
 
-    def test_estimate_stddev(self):
-        """Test the estimate_stddev"""
-
-        def objective(x):
-            ret = 0.0
-            for array in x:
-                ret += sum(array)
-            return ret
-
-        points = np.arange(8.0)
-        result = SPSA.estimate_stddev(objective, [points, points * 0.8])
-
-        self.assertEqual(result, 0.0)
-
-    def test_estimate_stddev_split(self):
-        """Test the estimate_stddev with max_evals_grouped"""
-
-        def objective(x):
-            ret = 0.0
-            for array in x:
-                ret += sum(array)
-            return ret
-
-        points = np.arange(8.0)
-        result = SPSA.estimate_stddev(objective, [points, points * 0.8], max_evals_grouped=2)
-
-        self.assertEqual(result, 8.18124930781885)
-
-    def test_estimate_stddev_uneven_split(self):
-        """Test the estimate_stddev with uneven split
+    @data(1, 2, 3, 4)
+    def test_estimate_stddev(self, max_evals_grouped):
+        """Test the estimate_stddev
         See https://github.com/Qiskit/qiskit-nature/issues/797"""
 
         def objective(x):
-            ret = 0.0
-            for array in x:
-                ret += sum(array)
-            return ret
+            if isinstance(x, list):
+                return [sum(x_i) for x_i in x]
+            return sum(x)
 
-        points = np.arange(8.0)
-        result = SPSA.estimate_stddev(
-            objective, [points, points * 0.8], avg=13, max_evals_grouped=3
-        )
-
-        self.assertEqual(result, 11.340000000000002)
+        point = np.ones(5)
+        result = SPSA.estimate_stddev(objective, point, avg=10, max_evals_grouped=max_evals_grouped)
+        self.assertAlmostEqual(result, 0)

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -188,7 +188,7 @@ class TestSPSA(QiskitAlgorithmsTestCase):
         See https://github.com/Qiskit/qiskit-nature/issues/797"""
 
         def objective(x):
-            if x.shape == 2:
+            if len(x.shape) == 2:
                 return np.array([sum(x_i) for x_i in x])
             return sum(x)
 

--- a/test/python/algorithms/optimizers/test_spsa.py
+++ b/test/python/algorithms/optimizers/test_spsa.py
@@ -181,3 +181,48 @@ class TestSPSA(QiskitAlgorithmsTestCase):
         for i, (key, values) in enumerate(history.items()):
             self.assertTrue(all(isinstance(value, expected_types[i]) for value in values))
             self.assertEqual(len(history[key]), maxiter)
+
+    def test_estimate_stddev(self):
+        """Test the estimate_stddev"""
+
+        def objective(x):
+            ret = 0.0
+            for array in x:
+                ret += sum(array)
+            return ret
+
+        points = np.arange(8.0)
+        result = SPSA.estimate_stddev(objective, [points, points * 0.8])
+
+        self.assertEqual(result, 0.0)
+
+    def test_estimate_stddev_split(self):
+        """Test the estimate_stddev with max_evals_grouped"""
+
+        def objective(x):
+            ret = 0.0
+            for array in x:
+                ret += sum(array)
+            return ret
+
+        points = np.arange(8.0)
+        result = SPSA.estimate_stddev(objective, [points, points * 0.8], max_evals_grouped=2)
+
+        self.assertEqual(result, 8.18124930781885)
+
+    def test_estimate_stddev_uneven_split(self):
+        """Test the estimate_stddev with uneven split
+        See https://github.com/Qiskit/qiskit-nature/issues/797"""
+
+        def objective(x):
+            ret = 0.0
+            for array in x:
+                ret += sum(array)
+            return ret
+
+        points = np.arange(8.0)
+        result = SPSA.estimate_stddev(
+            objective, [points, points * 0.8], avg=13, max_evals_grouped=3
+        )
+
+        self.assertEqual(result, 11.340000000000002)


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit-nature/issues/797

### Summary

The internal function `qiskit.algorithms.optimizers.spsa._batch_evaluate` uses `np.split` instead of `np.array_split`. This results in an exception as described [here](https://github.com/Qiskit/qiskit-nature/issues/797) when the split is uneven.

### Details and comments

I used the static method `qiskit.algorithms.SPSA.estimate_stddev` for testing, since it was not directly tested and the method made it easier to parametrize in a way to cover the fix. However, I'm not sure if my input for that test is making any sense.