### PR TITLE
Fix panic in SabreSwap with classical bits

### DIFF
--- a/src/sabre_swap/sabre_dag.rs
+++ b/src/sabre_swap/sabre_dag.rs
@@ -54,7 +54,7 @@ impl SabreDAG {
             }
             for x in cargs {
                 if clbit_pos[*x] != usize::MAX {
-                    dag.add_edge(NodeIndex::new(qubit_pos[*x]), gate_index, ());
+                    dag.add_edge(NodeIndex::new(clbit_pos[*x]), gate_index, ());
                 }
                 clbit_pos[*x] = gate_index.index();
             }

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -19,7 +19,9 @@ from qiskit.transpiler import CouplingMap
 from qiskit.transpiler.passes import SabreLayout
 from qiskit.converters import circuit_to_dag
 from qiskit.test import QiskitTestCase
+from qiskit.compiler.transpiler import transpile
 from qiskit.providers.fake_provider import FakeAlmaden
+from qiskit.providers.fake_provider import FakeKolkata
 
 
 class TestSabreLayout(QiskitTestCase):
@@ -98,6 +100,43 @@ class TestSabreLayout(QiskitTestCase):
         self.assertEqual(layout[qr1[0]], 3)
         self.assertEqual(layout[qr1[1]], 12)
         self.assertEqual(layout[qr1[2]], 11)
+
+    def test_layout_with_classical_bits(self):
+        """Test sabre layout with classical bits recreate from issue #8635."""
+        qc = QuantumCircuit.from_qasm_str("""
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q4833[1];
+qreg q4834[6];
+qreg q4835[7];
+creg c982[2];
+creg c983[2];
+creg c984[2];
+rzz(0) q4833[0],q4834[4];
+cu(0,-6.1035156e-05,0,1e-05) q4834[1],q4835[2];
+swap q4834[0],q4834[2];
+cu(-1.1920929e-07,0,-0.33333333,0) q4833[0],q4834[2];
+ccx q4835[2],q4834[5],q4835[4];
+measure q4835[4] -> c984[0];
+ccx q4835[2],q4835[5],q4833[0];
+measure q4835[5] -> c984[1];
+measure q4834[0] -> c982[1];
+u(10*pi,0,1.9) q4834[5];
+measure q4834[3] -> c984[1];
+measure q4835[0] -> c982[0];
+rz(0) q4835[1];
+""")
+        res = transpile(qc, FakeKolkata(), layout_method="sabre", seed_transpiler=1234)
+        self.assertIsInstance(res, QuantumCircuit)
+        layout = res._layout
+        self.assertEqual(layout[qc.qubits[0]], 14)
+        self.assertEqual(layout[qc.qubits[1]], 19)
+        self.assertEqual(layout[qc.qubits[2]], 7)
+        self.assertEqual(layout[qc.qubits[3]], 13)
+        self.assertEqual(layout[qc.qubits[4]], 6)
+        self.assertEqual(layout[qc.qubits[5]], 16)
+        self.assertEqual(layout[qc.qubits[6]], 18)
+        self.assertEqual(layout[qc.qubits[7]], 26)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_sabre_layout.py
+++ b/test/python/transpiler/test_sabre_layout.py
@@ -103,7 +103,8 @@ class TestSabreLayout(QiskitTestCase):
 
     def test_layout_with_classical_bits(self):
         """Test sabre layout with classical bits recreate from issue #8635."""
-        qc = QuantumCircuit.from_qasm_str("""
+        qc = QuantumCircuit.from_qasm_str(
+            """
 OPENQASM 2.0;
 include "qelib1.inc";
 qreg q4833[1];
@@ -125,7 +126,8 @@ u(10*pi,0,1.9) q4834[5];
 measure q4834[3] -> c984[1];
 measure q4835[0] -> c982[0];
 rz(0) q4835[1];
-""")
+"""
+        )
         res = transpile(qc, FakeKolkata(), layout_method="sabre", seed_transpiler=1234)
         self.assertIsInstance(res, QuantumCircuit)
         layout = res._layout


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a bug introduced in SabreSwap that was caught by the
randomized testing in #8635. A copy paste error was causing the rusty
sabre code to panic in cases where there were classical bits of a
particular index assigned prior to the qubit with the same index. This
commit fixes the typo so the behavior is corrected in general and the
panic is also fixed.

### Details and comments

Fixes #8635
