### PR TITLE
Enable Rust backtraces in CI

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -112,6 +112,7 @@ jobs:
           popd
         env:
           QISKIT_PARALLEL: FALSE
+          RUST_BACKTRACE: 1
         displayName: 'Run tests'
 
       - bash: |

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -60,6 +60,7 @@ jobs:
           python ./tools/verify_parallel_map.py
         env:
           QISKIT_PARALLEL: FALSE
+          RUST_BACKTRACE: 1
         displayName: "Run tests"
 
       - bash: |

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -53,6 +53,7 @@ jobs:
           LANG: 'C.UTF-8'
           PYTHONIOENCODING: 'utf-8:backslashreplace'
           QISKIT_PARALLEL: FALSE
+          RUST_BACKTRACE: 1
         displayName: 'Run tests'
 
       - bash: |

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -24,6 +24,8 @@ jobs:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
       - name: Run randomized tests
         run: make test_randomized
+        env:
+          RUST_BACKTRACE=1
       - name: Create comment on failed test run
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This should hopefully just help a bit with the logging when CI fails due to Rust panics.  We've seen a couple of places where it could have been useful in the randomised tests recently.

### Details and comments