### PR TITLE
Add optional category parameter to deprecate decorators

### DIFF
--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017.
+# (C) Copyright IBM 2017, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,16 +14,17 @@
 
 import functools
 import warnings
+from typing import Type
 
 
-def deprecate_arguments(kwarg_map):
+def deprecate_arguments(kwarg_map, category: Type[Warning] = DeprecationWarning):
     """Decorator to automatically alias deprecated argument names and warn upon use."""
 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if kwargs:
-                _rename_kwargs(func.__name__, kwargs, kwarg_map)
+                _rename_kwargs(func.__name__, kwargs, kwarg_map, category)
             return func(*args, **kwargs)
 
         return wrapper
@@ -31,12 +32,13 @@ def deprecate_arguments(kwarg_map):
     return decorator
 
 
-def deprecate_function(msg, stacklevel=2):
+def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = DeprecationWarning):
     """Emit a warning prior to calling decorated function.
 
     Args:
-        msg (str): Warning message to emit.
-        stacklevel (int): The warning stackevel to use, defaults to 2.
+        msg: Warning message to emit.
+        stacklevel: The warning stackevel to use, defaults to 2.
+        category: warning category, defaults to DeprecationWarning
 
     Returns:
         Callable: The decorated, deprecated callable.
@@ -45,7 +47,7 @@ def deprecate_function(msg, stacklevel=2):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
+            warnings.warn(msg, category=category, stacklevel=stacklevel)
             return func(*args, **kwargs)
 
         return wrapper
@@ -53,7 +55,7 @@ def deprecate_function(msg, stacklevel=2):
     return decorator
 
 
-def _rename_kwargs(func_name, kwargs, kwarg_map):
+def _rename_kwargs(func_name, kwargs, kwarg_map, category: Type[Warning] = DeprecationWarning):
     for old_arg, new_arg in kwarg_map.items():
         if old_arg in kwargs:
             if new_arg in kwargs:
@@ -63,14 +65,14 @@ def _rename_kwargs(func_name, kwargs, kwarg_map):
                 warnings.warn(
                     f"{func_name} keyword argument {old_arg} is deprecated and "
                     "will in future be removed.",
-                    DeprecationWarning,
+                    category=category,
                     stacklevel=3,
                 )
             else:
                 warnings.warn(
                     f"{func_name} keyword argument {old_arg} is deprecated and "
                     f"replaced with {new_arg}.",
-                    DeprecationWarning,
+                    category=category,
                     stacklevel=3,
                 )
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The current deprecate decorators only support `DeprecationWarning`
If someone needs to use `PendingDeprecationWarning` there isn't decorator support.
This PR adds an optional category to the decorators that defaults to `DeprecationWarning`


### Details and comments
This seems to me a much required feature for all the deprecation that will be written for algorithms.

