### PR TITLE
Fix github actions yaml syntax for randomized testing

### DIFF
--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run randomized tests
         run: make test_randomized
         env:
-          RUST_BACKTRACE=1
+          RUST_BACKTRACE: 1
       - name: Create comment on failed test run
         if: ${{ failure() }}
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #8639 we added an environment variable to enable printing the rust
back traces when the rust code under test panics. However, that PR had a
small syntax error as it used the bash syntax for setting an env
variable and not the correct yaml syntax for github actions. This commit
corrects the oversight to fix the job configuration so that the jobs run
again.

### Details and comments