### PR TITLE
Make docstring for Counts more precise and validate input

### DIFF
--- a/qiskit/result/counts.py
+++ b/qiskit/result/counts.py
@@ -36,10 +36,11 @@ class Counts(dict):
             data (dict): The dictionary input for the counts. Where the keys
                 represent a measured classical value and the value is an
                 integer the number of shots with that result.
-                The keys can be one of several formats:
+                All keys must be of the same format. This format must be one of the following.
 
                      * A hexadecimal string of the form ``"0x4a"``
-                     * A bit string prefixed with ``0b`` for example ``'0b1011'``
+                     * A bit string prefixed with ``0b``, for example ``'0b1011'``
+                     * A bit string prefixed with no prefix, for example ``'1011'``
                      * A bit string formatted across register and memory slots.
                        For example, ``'00 10'``.
                      * A dit string, for example ``'02'``. Note for objects created
@@ -80,9 +81,13 @@ class Counts(dict):
                     self.hex_raw = {hex(key): value for key, value in self.int_raw.items()}
                 else:
                     if not creg_sizes and not memory_slots:
+                        # bit strings with no leading 0b or dit strings
                         self.hex_raw = None
                         self.int_raw = None
-                        bin_data = data
+                        if all(isinstance(k, str) for k in data):
+                            bin_data = data
+                        else:
+                            raise ValueError("All keys must be of the same type")
                     else:
                         hex_dict = {}
                         int_dict = {}

--- a/test/python/result/test_counts.py
+++ b/test/python/result/test_counts.py
@@ -142,6 +142,9 @@ class TestCounts(unittest.TestCase):
     def test_invalid_input_type(self):
         self.assertRaises(TypeError, counts.Counts, {2.4: 1024})
 
+    def test_mixed_input_types(self):
+        self.assertRaises(ValueError, counts.Counts, {"0101": 1, 3: 1})
+
     def test_just_bitstring_counts(self):
         raw_counts = {"0": 21, "10": 12}
         expected = {"0": 21, "10": 12}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Make `Counts` interface a bit more safe and precise.

### Details

* Modify the doc string to make more clear what the allowed input formats are.
* Raise error if the first input key is a string, but one of the subsequent keys is not.


### Comments

This addresses some of the least disruptive issues raised in #8623