### PR TITLE
Fix incorrect docs image in `plot_coupling_map`

### DIFF
--- a/qiskit/visualization/gate_map.py
+++ b/qiskit/visualization/gate_map.py
@@ -595,9 +595,9 @@ def plot_coupling_map(
             %matplotlib inline
 
             num_qubits = 8
-            coupling_map = [[0, 1], [1, 2], [2, 3], [3, 5], [4, 5], [5, 6], [2, 4], [6, 7]]
             qubit_coordinates = [[0, 1], [1, 1], [1, 0], [1, 2], [2, 0], [2, 2], [2, 1], [3, 1]]
-            plot_coupling_map(num_qubits, coupling_map, qubit_coordinates)
+            coupling_map = [[0, 1], [1, 2], [2, 3], [3, 5], [4, 5], [5, 6], [2, 4], [6, 7]]
+            plot_coupling_map(num_qubits, qubit_coordinates, coupling_map)
     """
     import matplotlib.pyplot as plt
     import matplotlib.patches as mpatches


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8670 

### Details and comments

The example for the "plot_coupling_map" function interchanged the order of the two inputs "qubits_coordinates" and "coupling_map" leading to an intermingled graph output. The proper output was obtained by simply interchanging the two inputs.

