### PR TITLE
"cregbundle set to False" warning should not raised when no classical bits are involved

### DIFF
--- a/qiskit/visualization/circuit_visualization.py
+++ b/qiskit/visualization/circuit_visualization.py
@@ -208,7 +208,7 @@ def circuit_drawer(
             "wire_order list for the index of each qubit and each clbit in the circuit."
         )
 
-    if cregbundle and (reverse_bits or wire_order is not None):
+    if circuit.clbits and cregbundle and (reverse_bits or wire_order is not None):
         cregbundle = False
         warn(
             "Cregbundle set to False since either reverse_bits or wire_order has been set.",

--- a/releasenotes/notes/no_warning_with_reverse_bits-b47cb1e357201593.yaml
+++ b/releasenotes/notes/no_warning_with_reverse_bits-b47cb1e357201593.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    When :func:`~circuit_drawer` was used with `reverse_bits=True` on a circuit without classical bits, warning about `cregbundle` was raised, creating confusion. The warning was removed for this case.

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -15,6 +15,7 @@
 import unittest
 import os
 from unittest.mock import patch
+from warnings import catch_warnings, simplefilter
 
 from qiskit import QuantumCircuit
 from qiskit.test import QiskitTestCase
@@ -119,3 +120,13 @@ class TestCircuitDrawer(QiskitTestCase):
 
         with self.assertWarnsRegex(RuntimeWarning, "Cregbundle set"):
             visualization.circuit_drawer(circuit, cregbundle=True, wire_order=[0, 1, 2, 5, 4, 3])
+
+    def test_reverse_bits(self):
+        """Test reverse_bits should not raise warnings when no classical qubits:
+        See:"""
+        circuit = QuantumCircuit(3)
+        circuit.x(1)
+
+        with catch_warnings():
+            simplefilter("error")
+            visualization.circuit_drawer(circuit, reverse_bits=True)


### PR DESCRIPTION
@Guillermo-Mijares-Vilarino discovered that the following code raises a very confusing warning:
```python
from qiskit.circuit.library import QFT
qft = QFT(3)
qft.decompose().draw('mpl', reverse_bits=True)
```
```
RuntimeWarning: Cregbundle set to False since either reverse_bits or wire_order has been set.
  wire_order=wire_order,
```

This fix checks if classical bits are involved before touching `cregbundle`.