### PR TITLE
deprecate qiskit.pulse.utils.deprecated_functionality in favor of qiskit.utils.deprecation.deprecate_function

### DIFF
--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -98,9 +98,7 @@ def instruction_duration_validation(duration: int):
         )
 
 
-@deprecate_function(
-    "Use the standard qiskit.utils.deprecate_function with the non-alternative message"
-)
+@deprecate_function("Deprecated since Terra 0.22.0. Use 'qiskit.utils.deprecate_function' instead.")
 def deprecated_functionality(func):
     """A decorator that raises deprecation warning without showing alternative method."""
     return deprecate_function(

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.exceptions import UnassignedDurationError, QiskitError
-from qiskit.utils import deprecate_function
+from qiskit.utils import deprecate_function  # pylint: disable=cyclic-import
 
 
 def format_meas_map(meas_map: List[List[int]]) -> Dict[int, List[int]]:

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -12,13 +12,13 @@
 
 """Module for common pulse programming utilities."""
 import functools
-import warnings
 from typing import List, Dict, Union
 
 import numpy as np
 
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.exceptions import UnassignedDurationError, QiskitError
+from qiskit.utils import deprecate_function
 
 
 def format_meas_map(meas_map: List[List[int]]) -> Dict[int, List[int]]:
@@ -98,19 +98,16 @@ def instruction_duration_validation(duration: int):
         )
 
 
+@deprecate_function(
+    "Use the standard qiskit.utils.deprecate_function with the non-alternative message"
+)
 def deprecated_functionality(func):
     """A decorator that raises deprecation warning without showing alternative method."""
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        warnings.warn(
-            f"Calling {func.__name__} is being deprecated and will be removed soon. "
-            "No alternative method will be provided with this change. "
-            "If there is any practical usage of this functionality, please write "
-            "an issue in Qiskit/qiskit-terra repository.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        return func(*args, **kwargs)
-
-    return wrapper
+    return deprecate_function(
+        f"Calling {func.__name__} is being deprecated and will be removed soon. "
+        "No alternative method will be provided with this change. "
+        "If there is any practical usage of this functionality, please write "
+        "an issue in Qiskit/qiskit-terra repository.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )(func)

--- a/releasenotes/notes/deprecated-pulse-deprecator-394ec75079441cda.yaml
+++ b/releasenotes/notes/deprecated-pulse-deprecator-394ec75079441cda.yaml
@@ -1,0 +1,7 @@
+---
+deprecations:
+  - |
+    The pulse-module function ``qiskit.pulse.utils.deprecate_functionality`` is
+    deprecated and will be removed in a future release.  This was a primarily
+    internal-only function.  The same functionality is supplied by
+    ``qiskit.utils.deprecate_function``, which should be used instead.


### PR DESCRIPTION
The decorator `deprecate qiskit.pulse.utils.deprecated_functionality` was introduced in https://github.com/Qiskit/qiskit-terra/pull/5854/ and its functionality is fully covered by the current `qiskit.utils.deprecation.deprecate_function`.