### PR TITLE
Remove deprecated pulse-builder contexts

### DIFF
--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -92,7 +92,6 @@ from qiskit.pulse.builder import (
     align_sequential,
     circuit_scheduler_settings,
     frequency_offset,
-    inline,
     pad,
     phase_offset,
     transpiler_settings,

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -92,7 +92,6 @@ from qiskit.pulse.builder import (
     align_sequential,
     circuit_scheduler_settings,
     frequency_offset,
-    pad,
     phase_offset,
     transpiler_settings,
     # Macros.

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -339,7 +339,6 @@ be used to align all pulses as late as possible in a pulse program.
     align_sequential
     circuit_scheduler_settings
     frequency_offset
-    inline
     pad
     phase_offset
     transpiler_settings

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -473,7 +473,6 @@ from qiskit.pulse import (
     macros,
     library,
     transforms,
-    utils,
 )
 from qiskit.pulse.instructions import directives
 from qiskit.pulse.schedule import Schedule, ScheduleBlock
@@ -1370,35 +1369,6 @@ def general_transforms(alignment_context: AlignmentKind) -> ContextManager[None]
     finally:
         current = builder.pop_context()
         builder.append_block(current)
-
-
-@utils.deprecated_functionality
-@contextmanager
-def inline() -> ContextManager[None]:
-    """Deprecated. Inline all instructions within this context into the parent context,
-    inheriting the scheduling policy of the parent context.
-
-    .. warning:: This will cause all scheduling directives within this context
-        to be ignored.
-    """
-
-    def _flatten(block):
-        for inst in block.blocks:
-            if isinstance(inst, ScheduleBlock):
-                yield from _flatten(inst)
-            else:
-                yield inst
-
-    builder = _active_builder()
-
-    # set a placeholder
-    builder.push_context(transforms.AlignLeft())
-    try:
-        yield
-    finally:
-        placeholder = builder.pop_context()
-        for inst in _flatten(placeholder):
-            builder.append_instruction(inst)
 
 
 @contextmanager

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -339,7 +339,6 @@ be used to align all pulses as late as possible in a pulse program.
     align_sequential
     circuit_scheduler_settings
     frequency_offset
-    pad
     phase_offset
     transpiler_settings
 
@@ -441,7 +440,6 @@ import collections
 import contextvars
 import functools
 import itertools
-import warnings
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -1368,33 +1366,6 @@ def general_transforms(alignment_context: AlignmentKind) -> ContextManager[None]
     finally:
         current = builder.pop_context()
         builder.append_block(current)
-
-
-@contextmanager
-def pad(*chs: chans.Channel) -> ContextManager[None]:  # pylint: disable=unused-argument
-    """Deprecated. Pad all available timeslots with delays upon exiting context.
-
-    Args:
-        chs: Channels to pad with delays. Defaults to all channels in context
-            if none are supplied.
-
-    Yields:
-        None
-    """
-    warnings.warn(
-        "Context-wise padding is being deprecated. Requested padding is being ignored. "
-        "Now the pulse builder generate a program in `ScheduleBlock` representation. "
-        "The padding with delay as a blocker is no longer necessary for this program. "
-        "However, if you still want delays, you can convert the output program "
-        "into `Schedule` representation by calling "
-        "`qiskit.pulse.transforms.target_qobj_transform`. Then, you can apply "
-        "`qiskit.pulse.transforms.pad` to the converted schedule. ",
-        DeprecationWarning,
-    )
-    try:
-        yield
-    finally:
-        pass
 
 
 @contextmanager

--- a/releasenotes/notes/qiskit.pulse.builder-ddefe88dca5765b9.yaml
+++ b/releasenotes/notes/qiskit.pulse.builder-ddefe88dca5765b9.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+   The functions `qiskit.pulse.builder.inline` and `qiskit.pulse.builder.pad` are deprecated since  0.18.0 (July 2021) and are being now removed.

--- a/releasenotes/notes/qiskit.pulse.builder-ddefe88dca5765b9.yaml
+++ b/releasenotes/notes/qiskit.pulse.builder-ddefe88dca5765b9.yaml
@@ -1,4 +1,8 @@
 ---
 upgrade:
   - |
-   The functions `qiskit.pulse.builder.inline` and `qiskit.pulse.builder.pad` are deprecated since  0.18.0 (July 2021) and are being now removed.
+    The ``qiskit.pulse.builder`` contexts ``inline`` and ``pad`` have been
+    removed.  These were first deprecated in Terra 0.18.0 (July 2021).  There is
+    no replacement for ``inline``; one can simply write the pulses in the
+    containing scope.  The ``pad`` context manager has had no effect since it
+    was deprecated.

--- a/test/python/pulse/test_builder.py
+++ b/test/python/pulse/test_builder.py
@@ -184,28 +184,6 @@ class TestContexts(TestBuilder):
 
         self.assertScheduleEqual(schedule, reference)
 
-    def test_inline(self):
-        """Test the inlining context."""
-        d0 = pulse.DriveChannel(0)
-        d1 = pulse.DriveChannel(1)
-
-        with pulse.build() as schedule:
-            pulse.delay(3, d0)
-            with pulse.inline():
-                # this alignment will be ignored due to inlining.
-                with pulse.align_right():
-                    pulse.delay(5, d1)
-                    pulse.delay(7, d0)
-
-        reference = pulse.Schedule()
-        # d0
-        reference += instructions.Delay(3, d0)
-        reference += instructions.Delay(7, d0)
-        # d1
-        reference += instructions.Delay(5, d1)
-
-        self.assertScheduleEqual(schedule, reference)
-
     def test_transpiler_settings(self):
         """Test the transpiler settings context.
 


### PR DESCRIPTION
In https://github.com/Qiskit/qiskit-terra/pull/6158 (released in 0.18.0, July 2021) the functions `qiskit.pulse.builder.inline` and `qiskit.pulse.builder.pad` are deprecated. Time to remove them.
