### PR TITLE
Remove qiskit.pulse.builder.pad as deprecated in 0.18.0 (2021-07-13)

### DIFF
--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -93,7 +93,6 @@ from qiskit.pulse.builder import (
     circuit_scheduler_settings,
     frequency_offset,
     inline,
-    pad,
     phase_offset,
     transpiler_settings,
     # Macros.

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -442,7 +442,6 @@ import collections
 import contextvars
 import functools
 import itertools
-import warnings
 from contextlib import contextmanager
 from typing import (
     Any,
@@ -1399,33 +1398,6 @@ def inline() -> ContextManager[None]:
         placeholder = builder.pop_context()
         for inst in _flatten(placeholder):
             builder.append_instruction(inst)
-
-
-@contextmanager
-def pad(*chs: chans.Channel) -> ContextManager[None]:  # pylint: disable=unused-argument
-    """Deprecated. Pad all available timeslots with delays upon exiting context.
-
-    Args:
-        chs: Channels to pad with delays. Defaults to all channels in context
-            if none are supplied.
-
-    Yields:
-        None
-    """
-    warnings.warn(
-        "Context-wise padding is being deprecated. Requested padding is being ignored. "
-        "Now the pulse builder generate a program in `ScheduleBlock` representation. "
-        "The padding with delay as a blocker is no longer necessary for this program. "
-        "However, if you still want delays, you can convert the output program "
-        "into `Schedule` representation by calling "
-        "`qiskit.pulse.transforms.target_qobj_transform`. Then, you can apply "
-        "`qiskit.pulse.transforms.pad` to the converted schedule. ",
-        DeprecationWarning,
-    )
-    try:
-        yield
-    finally:
-        pass
 
 
 @contextmanager

--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -340,7 +340,6 @@ be used to align all pulses as late as possible in a pulse program.
     circuit_scheduler_settings
     frequency_offset
     inline
-    pad
     phase_offset
     transpiler_settings
 


### PR DESCRIPTION
In https://github.com/Qiskit/qiskit-terra/pull/6158 the function `qiskit.pulse.builder.pad` is deprecated (released in 0.18, July 2021). Time to remove it.