### PR TITLE
Improve error message on QASM 2 export of single-bit conditions

### DIFF
--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -40,6 +40,7 @@ import numpy
 from qiskit.circuit.exceptions import CircuitError
 from qiskit.circuit.quantumregister import QuantumRegister
 from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
+from qiskit.qasm.exceptions import QasmError
 from qiskit.qobj.qasm_qobj import QasmQobjInstruction
 from qiskit.circuit.parameter import ParameterExpression
 from qiskit.circuit.operation import Operation
@@ -438,6 +439,10 @@ class Instruction(Operation):
         """Print an if statement if needed."""
         if self.condition is None:
             return string
+        if not isinstance(self.condition[0], ClassicalRegister):
+            raise QasmError(
+                "OpenQASM 2 can only condition on registers, but got '{self.condition[0]}'"
+            )
         return "if(%s==%d) " % (self.condition[0].name, self.condition[1]) + string
 
     def qasm(self):

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -450,3 +450,12 @@ custom_{id(gate2)} q[1],q[0];\n"""
         names = ["invalid??", "invalid[]"]
         for idx, instruction in enumerate(base._data):
             self.assertEqual(instruction.operation.name, names[idx])
+
+    def test_circuit_raises_on_single_bit_condition(self):
+        """OpenQASM 2 can't represent single-bit conditions, so test that a suitable error is
+        printed if this is attempted."""
+        qc = QuantumCircuit(1, 1)
+        qc.x(0).c_if(0, True)
+
+        with self.assertRaisesRegex(QasmError, "OpenQASM 2 can only condition on registers"):
+            qc.qasm()


### PR DESCRIPTION
### Summary

OpenQASM 2 can't represent single bit conditions, so it's impossible for us to output sensible code in this case.  Instead, we just make sure the error message clearly explains what's going on.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #8700.
