### PR TITLE
VQE implementation with estimator primitive

### DIFF
--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -212,6 +212,7 @@ Algorithms that can find the minimum eigenvalue of an operator and leverage prim
 
 .. autosummary::
    :toctree: ../stubs/
+   
    minimum_eigensolvers
 
 

--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -187,6 +187,8 @@ Minimum Eigen Solvers
 ---------------------
 
 Algorithms that can find the minimum eigenvalue of an operator.
+These algorithms are pending depreciation. One should instead make use of the
+Minimum Eigensolver classes in the section below, which leverage Runtime primitives.
 
 .. autosummary::
    :toctree: ../stubs/

--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -212,7 +212,7 @@ Algorithms that can find the minimum eigenvalue of an operator and leverage prim
 
 .. autosummary::
    :toctree: ../stubs/
-   
+
    minimum_eigensolvers
 
 

--- a/qiskit/algorithms/__init__.py
+++ b/qiskit/algorithms/__init__.py
@@ -183,8 +183,8 @@ Algorithms to solve linear systems of equations.
    linear_solvers
 
 
-Minimum Eigensolvers
---------------------
+Minimum Eigen Solvers
+---------------------
 
 Algorithms that can find the minimum eigenvalue of an operator.
 
@@ -202,6 +202,15 @@ Algorithms that can find the minimum eigenvalue of an operator.
    NumPyMinimumEigensolver
    QAOA
    VQE
+
+Minimum Eigensolvers
+--------------------
+
+Algorithms that can find the minimum eigenvalue of an operator and leverage primitives.
+
+.. autosummary::
+   :toctree: ../stubs/
+   minimum_eigensolvers
 
 
 Optimizers

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -40,7 +40,6 @@ from qiskit.providers import Backend
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.utils.backend_utils import is_aer_provider
 from qiskit.utils.validation import validate_min
-from qiskit.utils.deprecation import deprecate_function
 
 from ..aux_ops_evaluator import eval_observables
 from ..exceptions import AlgorithmError

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -121,13 +121,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     """
 
-    @deprecate_function(
-        "The VQE class has been superseded by the "
-        "qiskit.algorithms.minimum_eigensolvers.VQE class. "
-        "This class will be deprecated in a future release and subsequently "
-        "removed after that.",
-        category=PendingDeprecationWarning,
-    )
     def __init__(
         self,
         ansatz: Optional[QuantumCircuit] = None,

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -644,13 +644,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 class VQEResult(VariationalResult, MinimumEigensolverResult):
     """VQE Result."""
 
-    @deprecate_function(
-        "The VQEResult class has been superseded by the "
-        "qiskit.algorithms.minimum_eigensolvers.VQEResult class. "
-        "This class will be deprecated in a future release and subsequently "
-        "removed after that.",
-        category=PendingDeprecationWarning,
-    )
     def __init__(self) -> None:
         super().__init__()
         self._cost_function_evals = None

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -40,6 +40,7 @@ from qiskit.providers import Backend
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.utils.backend_utils import is_aer_provider
 from qiskit.utils.validation import validate_min
+from qiskit.utils.deprecation import deprecate_function
 
 from ..aux_ops_evaluator import eval_observables
 from ..exceptions import AlgorithmError
@@ -120,6 +121,13 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     """
 
+    @deprecate_function(
+        "The VQE class has been superseded by the "
+        "qiskit.algorithms.minimum_eigensolvers.VQE class. "
+        "This class will be deprecated in a future release and subsequently "
+        "removed after that.",
+        category=PendingDeprecationWarning,
+    )
     def __init__(
         self,
         ansatz: Optional[QuantumCircuit] = None,
@@ -643,6 +651,13 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 class VQEResult(VariationalResult, MinimumEigensolverResult):
     """VQE Result."""
 
+    @deprecate_function(
+        "The VQEResult class has been superseded by the "
+        "qiskit.algorithms.minimum_eigensolvers.VQEResult class. "
+        "This class will be deprecated in a future release and subsequently "
+        "removed after that.",
+        category=PendingDeprecationWarning,
+    )
     def __init__(self) -> None:
         super().__init__()
         self._cost_function_evals = None

--- a/qiskit/algorithms/minimum_eigensolvers/__init__.py
+++ b/qiskit/algorithms/minimum_eigensolvers/__init__.py
@@ -10,30 +10,30 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-=====================================================================
+"""
+============================================================================
 Minimum Eigensolvers Package (:mod:`qiskit.algorithms.minimum_eigensolvers`)
-=====================================================================
+============================================================================
 
 .. currentmodule:: qiskit.algorithms.minimum_eigensolvers
 
 Minimum Eigensolvers
-================
+====================
 .. autosummary::
    :toctree: ../stubs/
 
    MinimumEigensolver
    NumPyMinimumEigensolver
-   QAOA
    VQE
-   
+
 .. autosummary::
    :toctree: ../stubs/
 
    MinimumEigensolverResult
    NumPyMinimumEigensolverResult
    VQEResult
+"""
 
-   
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 from .numpy_minimum_eigensolver import NumPyMinimumEigensolver, NumPyMinimumEigensolverResult
 from .vqe import VQE, VQEResult

--- a/qiskit/algorithms/minimum_eigensolvers/__init__.py
+++ b/qiskit/algorithms/minimum_eigensolvers/__init__.py
@@ -10,8 +10,30 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""The minimum eigensolvers package."""
+=====================================================================
+Minimum Eigensolvers Package (:mod:`qiskit.algorithms.minimum_eigensolvers`)
+=====================================================================
 
+.. currentmodule:: qiskit.algorithms.minimum_eigensolvers
+
+Minimum Eigensolvers
+================
+.. autosummary::
+   :toctree: ../stubs/
+
+   MinimumEigensolver
+   NumPyMinimumEigensolver
+   QAOA
+   VQE
+   
+.. autosummary::
+   :toctree: ../stubs/
+
+   MinimumEigensolverResult
+   NumPyMinimumEigensolverResult
+   VQEResult
+
+   
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 from .numpy_minimum_eigensolver import NumPyMinimumEigensolver, NumPyMinimumEigensolverResult
 from .vqe import VQE, VQEResult

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
@@ -74,7 +75,7 @@ class MinimumEigensolverResult(AlgorithmResult):
     def __init__(self) -> None:
         super().__init__()
         self._eigenvalue = None
-        self._aux_operator_eigenvalues = None
+        self._aux_operators_evaluated = None
 
     @property
     def eigenvalue(self) -> complex | None:
@@ -86,15 +87,13 @@ class MinimumEigensolverResult(AlgorithmResult):
         self._eigenvalue = value
 
     @property
-    def aux_operator_eigenvalues(self) -> ListOrDict[tuple[complex, tuple[complex, int]]] | None:
+    def aux_operators_evaluated(self) -> ListOrDict[tuple[complex, dict[str, Any]]] | None:
         """The aux operator expectation values.
 
         These values are in fact tuples formatted as (mean, (variance, shots)).
         """
-        return self._aux_operator_eigenvalues
+        return self._aux_operators_evaluated
 
-    @aux_operator_eigenvalues.setter
-    def aux_operator_eigenvalues(
-        self, value: ListOrDict[tuple[complex, tuple[complex, int]]]
-    ) -> None:
-        self._aux_operator_eigenvalues = value
+    @aux_operators_evaluated.setter
+    def aux_operators_evaluated(self, value: ListOrDict[tuple[complex, dict[str, Any]]]) -> None:
+        self._aux_operators_evaluated = value

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -86,13 +86,13 @@ class MinimumEigensolverResult(AlgorithmResult):
         self._eigenvalue = value
 
     @property
-    def aux_operator_eigenvalues(self) -> ListOrDict[tuple[complex, complex]] | None:
+    def aux_operator_eigenvalues(self) -> ListOrDict[tuple[complex, tuple[complex, int]]] | None:
         """The aux operator expectation values.
 
-        These values are in fact tuples formatted as (mean, standard deviation).
+        These values are in fact tuples formatted as (mean, (variance, shots)).
         """
         return self._aux_operator_eigenvalues
 
     @aux_operator_eigenvalues.setter
-    def aux_operator_eigenvalues(self, value: ListOrDict[tuple[complex, complex]]) -> None:
+    def aux_operator_eigenvalues(self, value: ListOrDict[tuple[complex, tuple[complex, int]]]) -> None:
         self._aux_operator_eigenvalues = value

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -94,5 +94,7 @@ class MinimumEigensolverResult(AlgorithmResult):
         return self._aux_operator_eigenvalues
 
     @aux_operator_eigenvalues.setter
-    def aux_operator_eigenvalues(self, value: ListOrDict[tuple[complex, tuple[complex, int]]]) -> None:
+    def aux_operator_eigenvalues(
+        self, value: ListOrDict[tuple[complex, tuple[complex, int]]]
+    ) -> None:
         self._aux_operator_eigenvalues = value

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -37,9 +37,10 @@ class MinimumEigensolver(ABC):
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
     ) -> "MinimumEigensolverResult":
         """
-        Computes minimum eigenvalue. Operator and aux_operators can be supplied here and if not None
-        will override any already set into algorithm so it can be reused with different operators.
-        While an operator is required by algorithms, aux_operators are optional.
+        Computes the minimum eigenvalue. The `operator` and `aux_operators` can be supplied here
+        and if not ``None`` will override any already set into algorithm so it can be reused with
+        different operators. While an ``operator`` is required by algorithms, ``aux_operators`` are
+        optional.
 
         Args:
             operator: Qubit operator of the observable.
@@ -57,8 +58,9 @@ class MinimumEigensolver(ABC):
     def supports_aux_operators(cls) -> bool:
         """Whether computing the expectation value of auxiliary operators is supported.
 
-        If the minimum eigensolver computes an eigenvalue of the main operator then it can compute
-        the expectation value of the aux_operators for that state. Otherwise they will be ignored.
+        If the minimum eigensolver computes an eigenvalue of the main ``operator`` then it can
+        compute the expectation value of the ``aux_operators`` for that state. Otherwise they will
+        be ignored.
 
         Returns:
             True if aux_operator expectations can be evaluated, False otherwise
@@ -76,17 +78,16 @@ class MinimumEigensolverResult(AlgorithmResult):
 
     @property
     def eigenvalue(self) -> complex | None:
-        """Return the eigenvalue."""
+        """The computed minimum eigenvalue."""
         return self._eigenvalue
 
     @eigenvalue.setter
     def eigenvalue(self, value: complex) -> None:
-        """Set the eigenvalue."""
         self._eigenvalue = value
 
     @property
     def aux_operator_eigenvalues(self) -> ListOrDict[tuple[complex, complex]] | None:
-        """Return aux operator expectation values.
+        """The aux operator expectation values.
 
         These values are in fact tuples formatted as (mean, standard deviation).
         """
@@ -94,5 +95,4 @@ class MinimumEigensolverResult(AlgorithmResult):
 
     @aux_operator_eigenvalues.setter
     def aux_operator_eigenvalues(self, value: ListOrDict[tuple[complex, complex]]) -> None:
-        """set aux operator eigenvalues"""
         self._aux_operator_eigenvalues = value

--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -37,7 +37,7 @@ class MinimumEigensolver(ABC):
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
     ) -> "MinimumEigensolverResult":
         """
-        Computes the minimum eigenvalue. The `operator` and `aux_operators` can be supplied here
+        Computes the minimum eigenvalue. The ``operator`` and ``aux_operators`` can be supplied here
         and if not ``None`` will override any already set into algorithm so it can be reused with
         different operators. While an ``operator`` is required by algorithms, ``aux_operators`` are
         optional.

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""The NumPy minimum eigensolver algorithm."""
+"""The NumPy minimum eigensolver algorithm and result."""
 
 from __future__ import annotations
 

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -28,6 +28,8 @@ from ..list_or_dict import ListOrDict
 
 logger = logging.getLogger(__name__)
 
+FilterType = Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool]
+
 
 class NumPyMinimumEigensolver(MinimumEigensolver):
     """
@@ -36,9 +38,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
 
     def __init__(
         self,
-        filter_criterion: Callable[
-            [list | np.ndarray, float, ListOrDict[float] | None], bool
-        ] = None,
+        filter_criterion: FilterType | None = None,
     ) -> None:
         """
         Args:
@@ -54,14 +54,14 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     @property
     def filter_criterion(
         self,
-    ) -> Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool] | None:
+    ) -> FilterType | None:
         """Returns the criterion for filtering eigenstates/eigenvalues."""
         return self._eigensolver.filter_criterion
 
     @filter_criterion.setter
     def filter_criterion(
         self,
-        filter_criterion: Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool],
+        filter_criterion: FilterType,
     ) -> None:
         self._eigensolver.filter_criterion = filter_criterion
 
@@ -81,7 +81,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
             result.eigenvalue = eigensolver_result.eigenvalues[0]
             result.eigenstate = eigensolver_result.eigenstates[0]
             if eigensolver_result.aux_operator_eigenvalues:
-                result.aux_operator_eigenvalues = eigensolver_result.aux_operator_eigenvalues[0]
+                result.aux_operators_evaluated = eigensolver_result.aux_operator_eigenvalues[0]
 
         logger.debug("NumPy minimum eigensolver result: %s", result)
 

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -97,7 +97,7 @@ class NumPyMinimumEigensolverResult(MinimumEigensolverResult):
 
     @property
     def eigenstate(self) -> np.ndarray | None:
-        """The eigenstate corresponding to the computed minimum eigenvalue."""
+        """Returns the eigenstate corresponding to the computed minimum eigenvalue."""
         return self._eigenstate
 
     @eigenstate.setter

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
+from qiskit.utils.deprecation import deprecate_function
 
 # TODO this path will need updating
 from ..eigen_solvers.numpy_eigen_solver import NumPyEigensolver
@@ -34,6 +35,13 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     The NumPy minimum eigensolver algorithm.
     """
 
+    @deprecate_function(
+        "The NumPyMinimumEigensolver class has been superseded by the "
+        "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver class. "
+        "This class will be deprecated in a future release and subsequently "
+        "removed after that.",
+        category=PendingDeprecationWarning,
+    )
     def __init__(
         self,
         filter_criterion: Callable[

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -35,13 +35,6 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     The NumPy minimum eigensolver algorithm.
     """
 
-    @deprecate_function(
-        "The NumPyMinimumEigensolver class has been superseded by the "
-        "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver class. "
-        "This class will be deprecated in a future release and subsequently "
-        "removed after that.",
-        category=PendingDeprecationWarning,
-    )
     def __init__(
         self,
         filter_criterion: Callable[

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -20,7 +20,6 @@ import numpy as np
 
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.utils.deprecation import deprecate_function
 
 # TODO this path will need updating
 from ..eigen_solvers.numpy_eigen_solver import NumPyEigensolver

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -55,7 +55,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     def filter_criterion(
         self,
     ) -> Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool] | None:
-        """returns the filter criterion if set"""
+        """Filters the eigenstates/eigenvalues."""
         return self._ces.filter_criterion
 
     @filter_criterion.setter
@@ -63,7 +63,6 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         self,
         filter_criterion: Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool],
     ) -> None:
-        """set the filter criterion"""
         self._ces.filter_criterion = filter_criterion
 
     @classmethod
@@ -84,7 +83,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
             if result_ces.aux_operator_eigenvalues:
                 result.aux_operator_eigenvalues = result_ces.aux_operator_eigenvalues[0]
 
-        logger.debug(f"MinimumEigensolver:\n{result}")
+        logger.debug("NumPy minimum eigensolver result: %s", result)
 
         return result
 
@@ -98,10 +97,9 @@ class NumPyMinimumEigensolverResult(MinimumEigensolverResult):
 
     @property
     def eigenstate(self) -> np.ndarray | None:
-        """Return eigenstate."""
+        """The eigenstate corresponding to the computed minimum eigenvalue."""
         return self._eigenstate
 
     @eigenstate.setter
     def eigenstate(self, value: np.ndarray) -> None:
-        """Set eigenstate."""
         self._eigenstate = value

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -49,21 +49,21 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
                 whether to consider this value or not. If there is no
                 feasible element, the result can even be empty.
         """
-        self._ces = NumPyEigensolver(filter_criterion=filter_criterion)
+        self._eigensolver = NumPyEigensolver(filter_criterion=filter_criterion)
 
     @property
     def filter_criterion(
         self,
     ) -> Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool] | None:
-        """Filters the eigenstates/eigenvalues."""
-        return self._ces.filter_criterion
+        """Returns the criterion for filtering eigenstates/eigenvalues."""
+        return self._eigensolver.filter_criterion
 
     @filter_criterion.setter
     def filter_criterion(
         self,
         filter_criterion: Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool],
     ) -> None:
-        self._ces.filter_criterion = filter_criterion
+        self._eigensolver.filter_criterion = filter_criterion
 
     @classmethod
     def supports_aux_operators(cls) -> bool:
@@ -75,13 +75,13 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
     ) -> NumPyMinimumEigensolverResult:
         super().compute_minimum_eigenvalue(operator, aux_operators)
-        result_ces = self._ces.compute_eigenvalues(operator, aux_operators)
+        eigensolver_result = self._eigensolver.compute_eigenvalues(operator, aux_operators)
         result = NumPyMinimumEigensolverResult()
-        if result_ces.eigenvalues is not None and len(result_ces.eigenvalues) > 0:
-            result.eigenvalue = result_ces.eigenvalues[0]
-            result.eigenstate = result_ces.eigenstates[0]
-            if result_ces.aux_operator_eigenvalues:
-                result.aux_operator_eigenvalues = result_ces.aux_operator_eigenvalues[0]
+        if eigensolver_result.eigenvalues is not None and len(eigensolver_result.eigenvalues) > 0:
+            result.eigenvalue = eigensolver_result.eigenvalues[0]
+            result.eigenstate = eigensolver_result.eigenstates[0]
+            if eigensolver_result.aux_operator_eigenvalues:
+                result.aux_operator_eigenvalues = eigensolver_result.aux_operator_eigenvalues[0]
 
         logger.debug("NumPy minimum eigensolver result: %s", result)
 

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -14,21 +14,22 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, List, Union, Optional
 import logging
 import numpy as np
 
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
-# TODO this path will need updating
+# TODO this path will need updating when VQD is merged
 from ..eigen_solvers.numpy_eigen_solver import NumPyEigensolver
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 from ..list_or_dict import ListOrDict
 
 logger = logging.getLogger(__name__)
 
-FilterType = Callable[[list | np.ndarray, float, ListOrDict[float] | None], bool]
+# future type annotations not supported in type aliases in 3.8
+FilterType = Callable[[Union[List, np.ndarray], float, Optional[ListOrDict[float]]], bool]
 
 
 class NumPyMinimumEigensolver(MinimumEigensolver):

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -45,9 +45,9 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
             filter_criterion: callable that allows to filter eigenvalues/eigenstates. The minimum
                 eigensolver is only searching over feasible states and returns an eigenstate that
                 has the smallest eigenvalue among feasible states. The callable has the signature
-                `filter(eigenstate, eigenvalue, aux_values)` and must return a boolean to indicate
-                whether to consider this value or not. If there is no
-                feasible element, the result can even be empty.
+                ``filter(eigenstate, eigenvalue, aux_values)`` and must return a boolean to indicate
+                whether to consider this value or not. If there is no feasible element, the result
+                can even be empty.
         """
         self._eigensolver = NumPyEigensolver(filter_criterion=filter_criterion)
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -46,10 +46,10 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     The VQE algorithm is executed using an :attr:`estimator` primitive, which must be specified as
     the first argument on instantiation.
 
-    An instance of ``VQE`` also requires an :attr:`ansatz` parameterized :class:`.QuantumCircuit` to
-    prepare the trial state :math:`|\psi(\vec\theta)\rangle`, as well as a classical
-    :attr:`optimizer`. The optimizer varies the circuit parameters :math:`\vec\theta` such that the
-    expectation value of the operator on the corresponding state approaches a minimum,
+    An instance of ``VQE`` also requires an :attr:`ansatz`, a parameterized :class:`.QuantumCircuit`, to
+    prepare the trial state :math:`|\psi(\vec\theta)\rangle`. It also needs a classical
+    :attr:`optimizer` which varies the circuit parameters :math:`\vec\theta` such that the
+    expectation value of the operator on the corresponding state approaches a minimum.
 
     .. math::
 
@@ -77,7 +77,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             result.fun = # optimal function value
             return result
 
-    The above signature also allows one to directly pass any SciPy minimizer, for instance as
+    The above signature also allows one to use any SciPy minimizer, for instance as
 
     .. code-block:: python
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -34,7 +34,7 @@ from ..optimizers import Optimizer, Minimizer, SLSQP
 from ..variational_algorithm import VariationalAlgorithm, VariationalResult
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 
-# from qiskit.algorithms.observables_evaluator import eval_observables
+from ..observables_evaluator import estimate_observables
 
 logger = logging.getLogger(__name__)
 
@@ -201,12 +201,9 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             result.optimal_point,
         )
 
-        if aux_operators:
-            # not None and not empty list or dict
+        if aux_operators is not None:
             bound_ansatz = ansatz.bind_parameters(opt_result.x)
-            # aux_values = eval_observables(self.estimator, bound_ansatz, aux_operators)
-            # TODO remove once eval_operators have been ported.
-            aux_values = self._eval_aux_ops(bound_ansatz, aux_operators)
+            aux_values = estimate_observables(self.estimator, bound_ansatz, aux_operators)
             result.aux_operator_eigenvalues = aux_values
 
         return result

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -161,18 +161,18 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         operator: BaseOperator | PauliSumOp,
         aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None,
     ) -> VQEResult:
-        self._check_operator_ansatz(operator)
+        ansatz = self._check_operator_ansatz(operator)
 
-        initial_point = _validate_initial_point(self.initial_point, self.ansatz)
+        initial_point = _validate_initial_point(self.initial_point, ansatz)
 
-        bounds = _validate_bounds(self.ansatz)
+        bounds = _validate_bounds(ansatz)
 
         start_time = time()
 
-        evaluate_energy = self._get_evaluate_energy(self.ansatz, operator)
+        evaluate_energy = self._get_evaluate_energy(ansatz, operator)
 
         if self.gradient is not None:
-            evaluate_gradient = self._get_evaluate_gradient(self.ansatz, operator)
+            evaluate_gradient = self._get_evaluate_gradient(ansatz, operator)
         else:
             evaluate_gradient = None
 
@@ -192,7 +192,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         result.eigenvalue = opt_result.fun
         result.cost_function_evals = opt_result.nfev
         result.optimal_point = opt_result.x
-        result.optimal_parameters = dict(zip(self.ansatz.parameters, opt_result.x))
+        result.optimal_parameters = dict(zip(ansatz.parameters, opt_result.x))
         result.optimal_value = opt_result.fun
         result.optimizer_time = eval_time
 
@@ -203,7 +203,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         )
 
         if aux_operators is not None:
-            bound_ansatz = self.ansatz.bind_parameters(opt_result.x)
+            bound_ansatz = ansatz.bind_parameters(opt_result.x)
             aux_values = estimate_observables(self.estimator, bound_ansatz, aux_operators)
             result.aux_operator_eigenvalues = aux_values
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -314,28 +314,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
         return ansatz
 
-    def _eval_aux_ops(
-        self,
-        ansatz: QuantumCircuit,
-        aux_operators: ListOrDict[BaseOperator | PauliSumOp],
-    ) -> ListOrDict[tuple(complex, complex)]:
-        """Compute auxiliary operator eigenvalues."""
-
-        if isinstance(aux_operators, dict):
-            aux_ops = list(aux_operators.values())
-        else:
-            aux_ops = aux_operators
-
-        num_aux_ops = len(aux_ops)
-        aux_job = self.estimator.run([ansatz] * num_aux_ops, aux_ops)
-        aux_values = aux_job.result().values
-        aux_values = list(zip(aux_values, [0] * len(aux_values)))
-
-        if isinstance(aux_operators, dict):
-            aux_values = dict(zip(aux_operators.keys(), aux_values))
-
-        return aux_values
-
 
 def _validate_initial_point(point: Sequence[float], ansatz: QuantumCircuit) -> Sequence[float]:
     expected_size = ansatz.num_parameters

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -278,8 +278,8 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         def evaluate_gradient(parameters):
             # broadcasting not required for the estimator gradients
             try:
-                result = self.gradient.run([ansatz], [operator], [parameters]).result()
-                gradients = result.gradients
+                job = self.gradient.run([ansatz], [operator], [parameters])
+                gradients = job.result().gradients
             except Exception as exc:
                 raise AlgorithmError("The primitive job to evaluate the gradient failed!") from exc
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -23,7 +23,7 @@ import numpy as np
 from qiskit.algorithms.gradients import BaseEstimatorGradient
 from qiskit.circuit import QuantumCircuit
 from qiskit.opflow import PauliSumOp
-from qiskit.primitives import BaseEstimator, EstimatorResult
+from qiskit.primitives import BaseEstimator
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 from qiskit.utils import algorithm_globals
 
@@ -117,7 +117,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         *,
         gradient: BaseEstimatorGradient | None = None,
         initial_point: Sequence[float] | None = None,
-        callback: Callable[[int, np.ndarray, float, float, int], None] | None = None,
+        callback: Callable[[int, np.ndarray, float, dict], None] | None = None,
     ) -> None:
         """
         Args:
@@ -134,7 +134,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 Four parameter values are passed to the callback as follows during each evaluation
                 by the optimizer for its current set of parameters as it works towards the minimum.
                 These are: the evaluation count, the optimizer parameters for the ansatz, the
-                evaluated mean, the evaluated variance, and the number of shots.
+                evaluated mean and the metadata dictionary.
         """
         super().__init__()
 
@@ -245,9 +245,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 metadata = estimator_result.metadata
                 for params, value, meta in zip(parameters, values, metadata):
                     eval_count += 1
-                    variance = meta.pop("variance", 0.0)
-                    shots = meta.pop("shots", 0)
-                    self.callback(eval_count, params, value, variance, shots)
+                    self.callback(eval_count, params, value, meta)
 
             energy = values[0] if len(values) == 1 else values
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -22,7 +22,6 @@ import numpy as np
 
 from qiskit.algorithms.gradients import BaseEstimatorGradient
 from qiskit.circuit import QuantumCircuit
-from qiskit.circuit.library import RealAmplitudes
 from qiskit.opflow import PauliSumOp
 from qiskit.primitives import BaseEstimator
 from qiskit.quantum_info.operators.base_operator import BaseOperator

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -257,7 +257,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         self,
         ansatz: QuantumCircuit,
         operator: BaseOperator | PauliSumOp,
-    ) -> tuple[Callable[[np.ndarray], np.ndarray]]:
+    ) -> Callable[[np.ndarray], np.ndarray]:
         """Get a function handle to evaluate the gradient at given parameters for the ansatz.
 
         Args:

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -41,15 +41,15 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     r"""The variational quantum eigensolver (VQE) algorithm.
 
     VQE is a hybrid quantum-classical algorithm that uses a variational technique to find the
-    minimum eigenvalue of a given Hamiltonian operator.
+    minimum eigenvalue of a given Hamiltonian operator :math:`\vec\theta`.
 
-    The VQE algorithm is executed using an Estimator primitive, which must be specified as the first
-    argument on instantiation.
+    The VQE algorithm is executed using an :attr:`estimator` primitive, which must be specified as
+    the first argument on instantiation.
 
-    An instance of VQE also requires defining an ansatz (a.k.a. trial state), given by a
-    parameterized :class:`.QuantumCircuit`, as well as a classical optimizer. The optimizer varies
-    the circuit parameters :math:`\vec\theta` such that the expectation value of the operator
-    :math:`H` on the corresponding state :math:`|{\psi(\vec\theta)\rangle` approaches a minimum,
+    An instance of ``VQE`` also requires an :attr:`ansatz` parameterized :class:`.QuantumCircuit` to
+    prepare the trial state :math:`|\psi(\vec\theta)\rangle`, as well as a classical
+    :attr:`optimizer`. The optimizer varies the circuit parameters :math:`\vec\theta` such that the
+    expectation value of the operator :math:`H` on the corresponding state approaches a minimum,
 
     ..math::
 
@@ -88,22 +88,22 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     Attributes:
         estimator (BaseEstimator): The estimator primitive to compute the expectation value of the
-            circuits.
-        ansatz (Quantum Circuit): A parameterized circuit, preparing the ansatz for the wave
-            function.
+            Hamiltonian operator.
+        ansatz (QuantumCircuit): A parameterized quantum circuit to prepare the trial state.
         optimizer (Optimizer | Minimizer): A classical optimizer to find the minimum energy. This
             can either be a Qiskit :class:`.Optimizer` or a callable implementing the
             :class:`.Minimizer` protocol.
         gradient (BaseEstimatorGradient | None): An optional estimator gradient to be used with the
             optimizer.
         initial_point (Sequence[float] | None): An optional initial point (i.e. initial parameter
-            values) for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
-            point and if not will simply compute a random one.
-        callback (Callable[[int, np.ndarray, float, dict], None] | None): A callback that can
-            access the intermediate data during the optimization. Four parameter values are passed
-            to the callback as follows during each evaluation by the optimizer for its current set
-            of parameters as it works towards the minimum. These are: the evaluation count, the
-            optimizer parameters for the ansatz, the evaluated mean and the metadata dictionary.
+            values) for the optimizer. The length of the initial point must match the number of
+            :attr:`ansatz` parameters. If ``None``, a random point will be generated within certain
+            parameter bounds. ``VQE`` will look to the ansatz for these bounds. If the ansatz does
+            not specify bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
+        callback (Callable[[int, np.ndarray, float, dict], None] | None): A callback that can access
+            the intermediate data at each optimization step. These data are: the evaluation count,
+            the optimizer parameters for the ansatz, the evaluated mean, and the metadata
+            dictionary.
 
     References:
         [1] Peruzzo et al, "A variational eigenvalue solver on a quantum processor"
@@ -122,20 +122,21 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     ) -> None:
         """
         Args:
-            estimator: The estimator primitive to compute the expectation value of the circuits.
-            ansatz: A parameterized circuit, preparing the ansatz for the wave function.
-            optimizer: A classical optimizer to find the minimum energy. This can either be a
-                Qiskit :class:`.Optimizer` or a callable implementing the :class:`.Minimizer`
-                protocol.
+            estimator: The estimator primitive to compute the expectation value of the
+                Hamiltonian operator.
+            ansatz: A parameterized quantum circuit to prepare the trial state.
+            optimizer: A classical optimizer to find the minimum energy. This
+                can either be a Qiskit :class:`.Optimizer` or a callable implementing the
+                :class:`.Minimizer` protocol.
             gradient: An optional estimator gradient to be used with the optimizer.
-            initial_point: An optional initial point (i.e. initial parameter values)
-                for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
-                point and if not will simply compute a random one.
-            callback: A callback that can access the intermediate data during the optimization.
-                Four parameter values are passed to the callback as follows during each evaluation
-                by the optimizer for its current set of parameters as it works towards the minimum.
-                These are: the evaluation count, the optimizer parameters for the ansatz, the
-                evaluated mean and the metadata dictionary.
+            initial_point: An optional initial point (i.e. initial parameter values) for the optimizer.
+                The length of the initial point must match the number of :attr:`ansatz` parameters.
+                If ``None``, a random point will be generated within certain parameter bounds.
+                ``VQE`` will look to the ansatz for these bounds. If the ansatz does not specify
+                bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
+            callback: A callback that can access the intermediate data at each optimization step.
+                These data are: the evaluation count, the optimizer parameters for the ansatz, the
+                evaluated mean, and the metadata dictionary.
         """
         super().__init__()
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -49,7 +49,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     An instance of ``VQE`` also requires an :attr:`ansatz`, a parameterized
     :class:`.QuantumCircuit`, to prepare the trial state :math:`|\psi(\vec\theta)\rangle`. It also
     needs a classical :attr:`optimizer` which varies the circuit parameters :math:`\vec\theta` such
-    that the expectation value of the operator on the corresponding state approaches a minimum.
+    that the expectation value of the operator on the corresponding state approaches a minimum,
 
     .. math::
 
@@ -209,11 +209,14 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     ) -> Callable[[np.ndarray], np.ndarray | float]:
         """Returns a function handle to evaluate the energy at given parameters for the ansatz.
         This is the objective function to be passed to the optimizer that is used for evaluation.
+
         Args:
             ansatz: The ansatz preparing the quantum state.
             operator: The operator whose energy to evaluate.
+
         Returns:
             A callable that computes and returns the energy of the hamiltonian of each parameter.
+
         Raises:
             AlgorithmError: If the primitive job to evaluate the energy fails.
         """

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -41,7 +41,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     r"""The variational quantum eigensolver (VQE) algorithm.
 
     VQE is a hybrid quantum-classical algorithm that uses a variational technique to find the
-    minimum eigenvalue of a given Hamiltonian operator :math:`\vec\theta`.
+    minimum eigenvalue of a given Hamiltonian operator :math:`H`.
 
     The VQE algorithm is executed using an :attr:`estimator` primitive, which must be specified as
     the first argument on instantiation.
@@ -49,9 +49,9 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     An instance of ``VQE`` also requires an :attr:`ansatz` parameterized :class:`.QuantumCircuit` to
     prepare the trial state :math:`|\psi(\vec\theta)\rangle`, as well as a classical
     :attr:`optimizer`. The optimizer varies the circuit parameters :math:`\vec\theta` such that the
-    expectation value of the operator :math:`H` on the corresponding state approaches a minimum,
+    expectation value of the operator on the corresponding state approaches a minimum,
 
-    ..math::
+    .. math::
 
         \min_{\vec\theta} \langle\psi(\vec\theta)|H|\psi(\vec\theta)\rangle.
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -43,19 +43,19 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     VQE is a hybrid quantum-classical algorithm that uses a variational technique to find the
     minimum eigenvalue of a given Hamiltonian operator :math:`H`.
 
-    The VQE algorithm is executed using an :attr:`estimator` primitive, which must be specified as
-    the first argument on instantiation.
+    The ``VQE`` algorithm is executed using an :attr:`estimator` primitive, which computes
+    expectation values of operators (observables).
 
-    An instance of ``VQE`` also requires an :attr:`ansatz`, a parameterized :class:`.QuantumCircuit`, to
-    prepare the trial state :math:`|\psi(\vec\theta)\rangle`. It also needs a classical
-    :attr:`optimizer` which varies the circuit parameters :math:`\vec\theta` such that the
-    expectation value of the operator on the corresponding state approaches a minimum.
+    An instance of ``VQE`` also requires an :attr:`ansatz`, a parameterized
+    :class:`.QuantumCircuit`, to prepare the trial state :math:`|\psi(\vec\theta)\rangle`. It also
+    needs a classical :attr:`optimizer` which varies the circuit parameters :math:`\vec\theta` such
+    that the expectation value of the operator on the corresponding state approaches a minimum.
 
     .. math::
 
         \min_{\vec\theta} \langle\psi(\vec\theta)|H|\psi(\vec\theta)\rangle.
 
-    The Estimator is used to compute this expectation value for every optimization step.
+    The :attr:`estimator` is used to compute this expectation value for every optimization step.
 
     The optimizer can either be one of Qiskit's optimizers, such as
     :class:`~qiskit.algorithms.optimizers.SPSA` or a callable with the following signature:

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -96,7 +96,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         initial_point (Sequence[float] | None): An optional initial point (i.e. initial parameter
             values) for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
             point and if not will simply compute a random one.
-        callback (Callable[[int, np.ndarray, float, float], None] | None): A callback that can
+        callback (Callable[[int, np.ndarray, float, dict], None] | None): A callback that can
             access the intermediate data during the optimization. Four parameter values are passed
             to the callback as follows during each evaluation by the optimizer for its current set
             of parameters as it works towards the minimum. These are: the evaluation count, the

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -216,7 +216,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             ansatz: The ansatz preparing the quantum state.
             operator: The operator whose energy to evaluate.
         Returns:
-            Energy of the Hamiltonian of each parameter.
+            A callable that computes and returns the energy of the hamiltonian of each parameter.
         Raises:
             AlgorithmError: If the primitive job to evaluate the energy fails.
         """

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -136,7 +136,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
             callback: A callback that can access the intermediate data at each optimization step.
                 These data are: the evaluation count, the optimizer parameters for the ansatz, the
-                evaluated mean, and the metadata dictionary.
+                estimated value, and the metadata dictionary.
         """
         super().__init__()
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -30,7 +30,7 @@ from qiskit.utils import algorithm_globals
 
 from ..exceptions import AlgorithmError
 from ..list_or_dict import ListOrDict
-from ..optimizers import Optimizer, Minimizer, SLSQP
+from ..optimizers import Optimizer, Minimizer
 from ..variational_algorithm import VariationalAlgorithm, VariationalResult
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -86,21 +86,25 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         optimizer = partial(minimize, method="L-BFGS-B")
 
     Attributes:
-        estimator: The estimator primitive to compute the expectation value of the circuits.
-        ansatz: A parameterized circuit, preparing the ansatz for the wave function. If
-            provided with ``None``, this defaults to a :class:`.RealAmplitudes` circuit.
-        optimizer: A classical optimizer to find the minimum energy. This can either be a
-            Qiskit :class:`.Optimizer` or a callable implementing the :class:`.Minimizer`
-            protocol.
-        gradient: An optional estimator gradient to be used with the optimizer.
-        initial_point: An optional initial point (i.e. initial parameter values)
-            for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
+        estimator (BaseEstimator): The estimator primitive to compute the expectation value of the
+            circuits.
+        ansatz (Quantum Circuit | None): A parameterized circuit, preparing the ansatz for the wave
+            function. If provided with ``None``, this defaults to a :class:`.RealAmplitudes`
+            circuit.
+        optimizer (Optimizer | Minimizer): A classical optimizer to find the minimum energy. This
+            can either be a Qiskit :class:`.Optimizer` or a callable implementing the
+            :class:`.Minimizer` protocol.
+        gradient (BaseEstimatorGradient | None): An optional estimator gradient to be used with the
+            optimizer.
+        initial_point (Sequence[float] | None): An optional initial point (i.e. initial parameter
+            values) for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
             point and if not will simply compute a random one.
-        callback: A callback that can access the intermediate data during the optimization.
-            Four parameter values are passed to the callback as follows during each evaluation
-            by the optimizer for its current set of parameters as it works towards the minimum.
-            These are: the evaluation count, the optimizer parameters for the ansatz, the
-            evaluated mean and the evaluated standard deviation.
+        callback (Callable[[int, np.ndarray, float, float], None] | None): A callback that can
+            access the intermediate data during the optimization. Four parameter values are passed
+            to the callback as follows during each evaluation by the optimizer for its current set
+            of parameters as it works towards the minimum. These are: the evaluation count, the
+            optimizer parameters for the ansatz, the evaluated mean and the evaluated standard
+            deviation.
 
     References:
         [1] Peruzzo et al, "A variational eigenvalue solver on a quantum processor"

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from time import time
 from collections.abc import Callable, Sequence
+from typing import Any
 
 import numpy as np
 
@@ -95,10 +96,10 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             :class:`.Minimizer` protocol.
         gradient (BaseEstimatorGradient | None): An optional estimator gradient to be used with the
             optimizer.
-        callback (Callable[[int, np.ndarray, float, dict], None] | None): A callback that can access
-            the intermediate data at each optimization step. These data are: the evaluation count,
-            the optimizer parameters for the ansatz, the evaluated mean, and the metadata
-            dictionary.
+        callback (Callable[[int, np.ndarray, float, dict[str, Any]], None] | None): A callback that
+            can access the intermediate data at each optimization step. These data are: the
+            evaluation count, the optimizer parameters for the ansatz, the evaluated mean, and the
+            metadata dictionary.
 
     References:
         [1] Peruzzo et al, "A variational eigenvalue solver on a quantum processor"
@@ -113,7 +114,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         *,
         gradient: BaseEstimatorGradient | None = None,
         initial_point: Sequence[float] | None = None,
-        callback: Callable[[int, np.ndarray, float, dict], None] | None = None,
+        callback: Callable[[int, np.ndarray, float, dict[str, Any]], None] | None = None,
     ) -> None:
         r"""
         Args:
@@ -124,11 +125,11 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 can either be a Qiskit :class:`.Optimizer` or a callable implementing the
                 :class:`.Minimizer` protocol.
             gradient: An optional estimator gradient to be used with the optimizer.
-            initial_point: An optional initial point (i.e. initial parameter values) for the optimizer.
-                The length of the initial point must match the number of :attr:`ansatz` parameters.
-                If ``None``, a random point will be generated within certain parameter bounds.
-                ``VQE`` will look to the ansatz for these bounds. If the ansatz does not specify
-                bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
+            initial_point: An optional initial point (i.e. initial parameter values) for the
+                optimizer. The length of the initial point must match the number of :attr:`ansatz`
+                parameters. If ``None``, a random point will be generated within certain parameter
+                bounds. ``VQE`` will look to the ansatz for these bounds. If the ansatz does not
+                specify bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
             callback: A callback that can access the intermediate data at each optimization step.
                 These data are: the evaluation count, the optimizer parameters for the ansatz, the
                 estimated value, and the metadata dictionary.

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -87,6 +87,9 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
         optimizer = partial(minimize, method="L-BFGS-B")
 
+    The following attributes can be set via the initializer but can also be read and updated once
+    the VQE object has been constructed.
+
     Attributes:
         estimator (BaseEstimator): The estimator primitive to compute the expectation value of the
             Hamiltonian operator.

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -182,22 +182,22 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 fun=evaluate_energy, x0=initial_point, jac=evaluate_gradient, bounds=bounds
             )
 
-        eval_time = time() - start_time
+        optimizer_time = time() - start_time
 
         logger.info(
             "Optimization complete in %s seconds.\nFound optimal point %s",
-            eval_time,
+            optimizer_time,
             optimizer_result.x,
         )
 
         if aux_operators is not None:
-            aux_values = estimate_observables(
+            aux_operators_evaluated = estimate_observables(
                 self.estimator, self.ansatz, aux_operators, optimizer_result.x
             )
         else:
-            aux_values = None
+            aux_operators_evaluated = None
 
-        return self._build_vqe_result(optimizer_result, aux_values, eval_time)
+        return self._build_vqe_result(optimizer_result, aux_operators_evaluated, optimizer_time)
 
     @classmethod
     def supports_aux_operators(cls) -> bool:
@@ -306,8 +306,8 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     def _build_vqe_result(
         self,
         optimizer_result: OptimizerResult,
-        aux_values: ListOrDict[tuple[complex, tuple[complex, int]]],
-        eval_time: float,
+        aux_operators_evaluated: ListOrDict[tuple[complex, tuple[complex, int]]],
+        optimizer_time: float,
     ) -> VQEResult:
         result = VQEResult()
         result.eigenvalue = optimizer_result.fun
@@ -315,8 +315,8 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         result.optimal_point = optimizer_result.x
         result.optimal_parameters = dict(zip(self.ansatz.parameters, optimizer_result.x))
         result.optimal_value = optimizer_result.fun
-        result.optimizer_time = eval_time
-        result.aux_operator_eigenvalues = aux_values
+        result.optimizer_time = optimizer_time
+        result.aux_operators_evaluated = aux_operators_evaluated
         result.optimizer_result = optimizer_result
         return result
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -117,12 +117,17 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             ansatz: A parameterized circuit, preparing the ansatz for the wave function. If not
                 provided, this defaults to a :class:`.RealAmplitudes` circuit.
             optimizer: A classical optimizer to find the minimum energy. This can either be a
-                Qiskit :class:`.Optimizer` or a callable implementing the :class:`.Minimizer` protocol.
-                Defaults to :class:`.SLSQP`.
-            gradient: An optional gradient function or operator for the optimizer.
-            initial_point: An optional initial point (i.e. initial parameter values)
+                Qiskit :class:`.Optimizer` or a callable implementing the :class:`.Minimizer`
+                protocol. Defaults to :class:`.SLSQP`.
+            gradient: An optional gradient function or operator for the optimizer. initial_point: An
+            optional initial point (i.e. initial parameter values)
                 for the optimizer. If ``None`` then VQE will look to the ansatz for a preferred
                 point and if not will simply compute a random one.
+            callback: A callback that can access the intermediate data during the optimization.
+                Four parameter values are passed to the callback as follows during each evaluation
+                by the optimizer for its current set of parameters as it works towards the minimum.
+                These are: the evaluation count, the optimizer parameters for the ansatz, the
+                evaluated mean and the evaluated standard deviation.
         """
         super().__init__()
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -190,8 +190,9 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         )
 
         if aux_operators is not None:
-            bound_ansatz = self.ansatz.bind_parameters(optimizer_result.x)
-            aux_values = estimate_observables(self.estimator, bound_ansatz, aux_operators)
+            aux_values = estimate_observables(
+                self.estimator, self.ansatz, aux_operators, optimizer_result.x
+            )
         else:
             aux_values = None
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -217,7 +217,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         self,
         ansatz: QuantumCircuit,
         operator: BaseOperator | PauliSumOp,
-    ) -> tuple[Callable[[np.ndarray], float | list[float]], dict]:
+    ) -> Callable[[np.ndarray], np.ndarray | float]:
         """Returns a function handle to evaluate the energy at given parameters for the ansatz.
         This is the objective function to be passed to the optimizer that is used for evaluation.
         Args:
@@ -233,7 +233,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         # avoid creating an instance variable to remain stateless regarding results
         eval_count = 0
 
-        def evaluate_energy(parameters):
+        def evaluate_energy(parameters: np.ndarray) -> np.ndarray | float:
             nonlocal eval_count
 
             # handle broadcasting: ensure parameters is of shape [array, array, ...]
@@ -246,7 +246,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             except Exception as exc:
                 raise AlgorithmError("The primitive job to evaluate the energy failed!") from exc
 
-            # TODO recover variance from estimator if has metadata has shots?
+            # TODO recover variance from estimator if metadata has shots?
 
             if self.callback is not None:
                 for params, value in zip(parameters, values):
@@ -275,7 +275,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             AlgorithmError: If the primitive job to evaluate the gradient fails.
         """
 
-        def evaluate_gradient(parameters):
+        def evaluate_gradient(parameters: np.ndarray) -> np.ndarray:
             # broadcasting not required for the estimator gradients
             try:
                 job = self.gradient.run([ansatz], [operator], [parameters])

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -95,11 +95,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             :class:`.Minimizer` protocol.
         gradient (BaseEstimatorGradient | None): An optional estimator gradient to be used with the
             optimizer.
-        initial_point (Sequence[float] | None): An optional initial point (i.e. initial parameter
-            values) for the optimizer. The length of the initial point must match the number of
-            :attr:`ansatz` parameters. If ``None``, a random point will be generated within certain
-            parameter bounds. ``VQE`` will look to the ansatz for these bounds. If the ansatz does
-            not specify bounds, bounds of :math:`-2\pi`, :math:`2\pi` will be used.
         callback (Callable[[int, np.ndarray, float, dict], None] | None): A callback that can access
             the intermediate data at each optimization step. These data are: the evaluation count,
             the optimizer parameters for the ansatz, the evaluated mean, and the metadata
@@ -107,7 +102,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     References:
         [1] Peruzzo et al, "A variational eigenvalue solver on a quantum processor"
-            `arXiv:1304.3061 https://arxiv.org/abs/1304.3061>`_
+            `arXiv:1304.3061 <https://arxiv.org/abs/1304.3061>`__
     """
 
     def __init__(
@@ -317,6 +312,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         result.optimal_value = optimizer_result.fun
         result.optimizer_time = eval_time
         result.aux_operator_eigenvalues = aux_values
+        result.optimizer_result = optimizer_result
         return result
 
 

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -100,8 +100,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
             access the intermediate data during the optimization. Four parameter values are passed
             to the callback as follows during each evaluation by the optimizer for its current set
             of parameters as it works towards the minimum. These are: the evaluation count, the
-            optimizer parameters for the ansatz, the evaluated mean and the evaluated standard
-            deviation.
+            optimizer parameters for the ansatz, the evaluated mean and the metadata dictionary.
 
     References:
         [1] Peruzzo et al, "A variational eigenvalue solver on a quantum processor"
@@ -147,12 +146,11 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     @property
     def initial_point(self) -> Sequence[float] | None:
-        """Return the initial point."""
+        """The initial point of the optimization."""
         return self._initial_point
 
     @initial_point.setter
     def initial_point(self, value: Sequence[float] | None) -> None:
-        """Set the initial point."""
         self._initial_point = value
 
     def compute_minimum_eigenvalue(

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -218,13 +218,13 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         ansatz: QuantumCircuit,
         operator: BaseOperator | PauliSumOp,
     ) -> tuple[Callable[[np.ndarray], float | list[float]], dict]:
-        """Returns a function handle to evaluates the energy at given parameters for the ansatz.
+        """Returns a function handle to evaluate the energy at given parameters for the ansatz.
         This is the objective function to be passed to the optimizer that is used for evaluation.
         Args:
             ansatz: The ansatz preparing the quantum state.
             operator: The operator whose energy to evaluate.
         Returns:
-            Energy of the hamiltonian of each parameter.
+            Energy of the Hamiltonian of each parameter.
         Raises:
             AlgorithmError: If the primitive job to evaluate the energy fails.
         """

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -40,19 +40,22 @@ logger = logging.getLogger(__name__)
 class VQE(VariationalAlgorithm, MinimumEigensolver):
     r"""The variational quantum eigensolver (VQE) algorithm.
 
-    VQE is a quantum algorithm that uses a variational technique to find the minimum eigenvalue of
-    the Hamiltonian :math:`H` of a given system [1].
+    VQE is a hybrid quantum-classical algorithm that uses a variational technique to find the
+    minimum eigenvalue of a given Hamiltonian operator.
 
-    The central sub-component of VQE is an Estimator primitive, which must be passed in as the
-    first argument. This is used to estimate the expectation values of :math:`H`.
+    The VQE algorithm is executed using an Estimator primitive, which must be specified as the first
+    argument on instantiation.
 
-    An instance of VQE also requires defining two algorithmic sub-components: a trial state (a.k.a.
-    ansatz) which is a :class:`QuantumCircuit`, and one of the classical
-    :mod:`~qiskit.algorithms.optimizers`.
+    An instance of VQE also requires defining an ansatz (a.k.a. trial state), given by a
+    parameterized :class:`.QuantumCircuit`, as well as a classical optimizer. The optimizer varies
+    the circuit parameters :math:`\vec\theta` such that the expectation value of the operator
+    :math:`H` on the corresponding state :math:`|{\psi(\vec\theta)\rangle` approaches a minimum,
 
-    The ansatz is varied, via its set of parameters, by the optimizer, such that it works towards a
-    state, as determined by the parameters applied to the ansatz, that will result in the minimum
-    expectation value being measured of the input operator (Hamiltonian).
+    ..math::
+
+        \min_{\vec\theta} \langle\psi(\vec\theta)|H|\psi(\vec\theta)\rangle.
+
+    The Estimator is used to compute this expectation value for every optimization step.
 
     The optimizer can either be one of Qiskit's optimizers, such as
     :class:`~qiskit.algorithms.optimizers.SPSA` or a callable with the following signature:
@@ -146,7 +149,6 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
 
     @property
     def initial_point(self) -> Sequence[float] | None:
-        """The initial point of the optimization."""
         return self._initial_point
 
     @initial_point.setter

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -257,11 +257,14 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         ansatz: QuantumCircuit,
         operator: BaseOperator | PauliSumOp,
     ) -> tuple[Callable[[np.ndarray], np.ndarray]]:
-        """Returns a function handle to evaluate the gradient at given parameters for the ansatz.
+        """Get a function handle to evaluate the gradient at given parameters for the ansatz.
 
         Args:
             ansatz: The ansatz preparing the quantum state.
             operator: The operator whose energy to evaluate.
+
+        Returns:
+            A function handle to evaluate the gradient at given parameters for the ansatz.
 
         Raises:
             AlgorithmError: If the primitive job to evaluate the gradient fails.

--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -32,7 +32,7 @@ from ..optimizers import Optimizer, Minimizer, OptimizerResult
 from ..variational_algorithm import VariationalAlgorithm, VariationalResult
 from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
 from ..observables_evaluator import estimate_observables
-from ..utils import _validate_initial_point, _validate_bounds
+from ..utils import validate_initial_point, validate_bounds
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +120,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         initial_point: Sequence[float] | None = None,
         callback: Callable[[int, np.ndarray, float, dict], None] | None = None,
     ) -> None:
-        """
+        r"""
         Args:
             estimator: The estimator primitive to compute the expectation value of the
                 Hamiltonian operator.
@@ -163,9 +163,9 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
     ) -> VQEResult:
         self._check_operator_ansatz(operator)
 
-        initial_point = _validate_initial_point(self.initial_point, self.ansatz)
+        initial_point = validate_initial_point(self.initial_point, self.ansatz)
 
-        bounds = _validate_bounds(self.ansatz)
+        bounds = validate_bounds(self.ansatz)
 
         start_time = time()
 
@@ -200,7 +200,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         else:
             aux_values = None
 
-        return _build_vqe_result(optimizer_result, aux_values, eval_time)
+        return self._build_vqe_result(optimizer_result, aux_values, eval_time)
 
     @classmethod
     def supports_aux_operators(cls) -> bool:

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -29,11 +29,12 @@ def estimate_observables(
     quantum_state: QuantumCircuit,
     observables: ListOrDict[BaseOperator | PauliSumOp],
     threshold: float = 1e-12,
-) -> ListOrDict[tuple[complex, tuple[complex, int]]]:
+) -> ListOrDict[tuple[complex, dict]]:
     """
     Accepts a sequence of operators and calculates their expectation values - means
-    and standard deviations. They are calculated with respect to a quantum state provided. A user
+    and metadata. They are calculated with respect to a quantum state provided. A user
     can optionally provide a threshold value which filters mean values falling below the threshold.
+
     Args:
         estimator: An estimator primitive used for calculations.
         quantum_state: An unparametrized quantum circuit representing a quantum state that
@@ -42,8 +43,10 @@ def estimate_observables(
             calculated.
         threshold: A threshold value that defines which mean values should be neglected (helpful for
             ignoring numerical instabilities close to 0).
+
     Returns:
-        A list or a dictionary of tuples (mean, (variance, shots)).
+        A list or a dictionary of tuples (mean, metadata).
+
     Raises:
         ValueError: If a ``quantum_state`` with free parameters is provided.
         AlgorithmError: If a primitive job is not successful.
@@ -73,7 +76,7 @@ def estimate_observables(
     metadata = estimator_job.result().metadata
     # Discard values below threshold
     observables_means = expectation_values * (np.abs(expectation_values) > threshold)
-    # zip means and standard deviations into tuples
+    # zip means and metadata into tuples
     observables_results = list(zip(observables_means, metadata))
 
     return _prepare_result(observables_results, observables)
@@ -93,18 +96,20 @@ def _handle_zero_ops(
 
 
 def _prepare_result(
-    observables_results: list[tuple[complex, tuple[complex, int]]],
+    observables_results: list[tuple[complex, dict]],
     observables: ListOrDict[BaseOperator | PauliSumOp],
-) -> ListOrDict[tuple[complex, tuple[complex, int]]]:
+) -> ListOrDict[tuple[complex, dict]]:
     """
-    Prepares a list of tuples of eigenvalues and (variance, shots) tuples from
+    Prepares a list of tuples of eigenvalues and metadata tuples from
     ``observables_results`` and ``observables``.
+
     Args:
-        observables_results: A list of tuples (mean, (variance, shots)).
+        observables_results: A list of tuples (mean, metadata).
         observables: A list or a dictionary of operators whose expectation values are to be
             calculated.
+
     Returns:
-        A list or a dictionary of tuples (mean, (variance, shots)).
+        A list or a dictionary of tuples (mean, metadata).
     """
 
     if isinstance(observables, list):

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -39,8 +39,8 @@ def estimate_observables(
 
     Args:
         estimator: An estimator primitive used for calculations.
-        quantum_state: An parametrized quantum circuit representing a quantum state that
-            expectation values are computed against.
+        quantum_state: A quantum circuit preparing a quantum state that expectation values are
+            computed against.
         observables: A list or a dictionary of operators whose expectation values are to be
             calculated.
         parameter_values: Optional list of parameters values to evaluate the quantum circuit on.

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -71,7 +71,7 @@ def estimate_observables(
     except Exception as exc:
         raise AlgorithmError("The primitive job failed!") from exc
 
-    variance_and_shots = _prep_variance_and_shots(estimator_job, len(expectation_values))
+    variance_and_shots = _prep_variance_and_shots(estimator_job.result(), len(expectation_values))
 
     # Discard values below threshold
     observables_means = expectation_values * (np.abs(expectation_values) > threshold)

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -39,8 +39,8 @@ def estimate_observables(
 
     Args:
         estimator: An estimator primitive used for calculations.
-        quantum_state: A quantum circuit preparing a quantum state that expectation values are
-            computed against.
+        quantum_state: A (parameterized) quantum circuit preparing a quantum state that expectation
+            values are computed against.
         observables: A list or a dictionary of operators whose expectation values are to be
             calculated.
         parameter_values: Optional list of parameters values to evaluate the quantum circuit on.

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 
@@ -31,7 +32,7 @@ def estimate_observables(
     observables: ListOrDict[BaseOperator | PauliSumOp],
     parameter_values: Sequence[float] | None = None,
     threshold: float = 1e-12,
-) -> ListOrDict[tuple[complex, dict]]:
+) -> ListOrDict[tuple[complex, dict[str, Any]]]:
     """
     Accepts a sequence of operators and calculates their expectation values - means
     and metadata. They are calculated with respect to a quantum state provided. A user
@@ -94,7 +95,7 @@ def _handle_zero_ops(
 def _prepare_result(
     observables_results: list[tuple[complex, dict]],
     observables: ListOrDict[BaseOperator | PauliSumOp],
-) -> ListOrDict[tuple[complex, dict]]:
+) -> ListOrDict[tuple[complex, dict[str, Any]]]:
     """
     Prepares a list of tuples of eigenvalues and metadata tuples from
     ``observables_results`` and ``observables``.

--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -9,7 +9,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
 """Evaluator of observables for algorithms."""
+
 from __future__ import annotations
 
 import numpy as np

--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -742,7 +742,7 @@ def _batch_evaluate(function, points, max_evals_grouped, unpack_points=False):
 
 def _as_list(obj):
     """Convert a list or numpy array into a list."""
-    return obj if isinstance(obj, list) else obj.tolist()
+    return obj.tolist() if isinstance(obj, np.ndarray) else obj
 
 
 def _repack_points(points):

--- a/qiskit/algorithms/time_evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/time_evolvers/trotterization/trotter_qrte.py
@@ -168,6 +168,7 @@ class TrotterQRTE(RealTimeEvolver):
                 self.estimator,
                 evolved_state,
                 evolution_problem.aux_operators,
+                None,
                 evolution_problem.truncation_threshold,
             )
 

--- a/qiskit/algorithms/utils/__init__.py
+++ b/qiskit/algorithms/utils/__init__.py
@@ -1,0 +1,21 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Common Qiskit algorithms utility functions."""
+
+from .validate_initial_point import _validate_initial_point
+from .validate_bounds import _validate_bounds
+
+__all__ = [
+    "_validate_initial_point",
+    "_validate_bounds",
+]

--- a/qiskit/algorithms/utils/__init__.py
+++ b/qiskit/algorithms/utils/__init__.py
@@ -12,10 +12,10 @@
 
 """Common Qiskit algorithms utility functions."""
 
-from .validate_initial_point import _validate_initial_point
-from .validate_bounds import _validate_bounds
+from .validate_initial_point import validate_initial_point
+from .validate_bounds import validate_bounds
 
 __all__ = [
-    "_validate_initial_point",
-    "_validate_bounds",
+    "validate_initial_point",
+    "validate_bounds",
 ]

--- a/qiskit/algorithms/utils/validate_bounds.py
+++ b/qiskit/algorithms/utils/validate_bounds.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from qiskit.circuit import QuantumCircuit
 
 
-def _validate_bounds(ansatz: QuantumCircuit) -> list[tuple(float | None, float | None)]:
+def validate_bounds(ansatz: QuantumCircuit) -> list[tuple(float | None, float | None)]:
     if hasattr(ansatz, "parameter_bounds") and ansatz.parameter_bounds is not None:
         bounds = ansatz.parameter_bounds
         if len(bounds) != ansatz.num_parameters:

--- a/qiskit/algorithms/utils/validate_bounds.py
+++ b/qiskit/algorithms/utils/validate_bounds.py
@@ -17,15 +17,28 @@ from __future__ import annotations
 from qiskit.circuit import QuantumCircuit
 
 
-def validate_bounds(ansatz: QuantumCircuit) -> list[tuple(float | None, float | None)]:
-    if hasattr(ansatz, "parameter_bounds") and ansatz.parameter_bounds is not None:
-        bounds = ansatz.parameter_bounds
-        if len(bounds) != ansatz.num_parameters:
+def validate_bounds(circuit: QuantumCircuit) -> list[tuple(float | None, float | None)]:
+    """
+    Validate the bounds provided by a quantum circuit against its number of parameters.
+    If no bounds are obtained, return ``None`` for all lower and upper bounds.
+
+    Args:
+        circuit: A parameterized quantum circuit.
+
+    Returns:
+        A list of tuples (lower_bound, upper_bound)).
+
+    Raises:
+        ValueError: If the number of bounds does not the match the number of circuit parameters.
+    """
+    if hasattr(circuit, "parameter_bounds") and circuit.parameter_bounds is not None:
+        bounds = circuit.parameter_bounds
+        if len(bounds) != circuit.num_parameters:
             raise ValueError(
                 f"The number of bounds ({len(bounds)}) does not match the number of "
-                f"parameters in the circuit ({ansatz.num_parameters})."
+                f"parameters in the circuit ({circuit.num_parameters})."
             )
     else:
-        bounds = [(None, None)] * ansatz.num_parameters
+        bounds = [(None, None)] * circuit.num_parameters
 
     return bounds

--- a/qiskit/algorithms/utils/validate_bounds.py
+++ b/qiskit/algorithms/utils/validate_bounds.py
@@ -1,0 +1,31 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Validate parameter bounds."""
+
+from __future__ import annotations
+
+from qiskit.circuit import QuantumCircuit
+
+
+def _validate_bounds(ansatz: QuantumCircuit) -> list[tuple(float | None, float | None)]:
+    if hasattr(ansatz, "parameter_bounds") and ansatz.parameter_bounds is not None:
+        bounds = ansatz.parameter_bounds
+        if len(bounds) != ansatz.num_parameters:
+            raise ValueError(
+                f"The number of bounds ({len(bounds)}) does not match the number of "
+                f"parameters in the circuit ({ansatz.num_parameters})."
+            )
+    else:
+        bounds = [(None, None)] * ansatz.num_parameters
+
+    return bounds

--- a/qiskit/algorithms/utils/validate_initial_point.py
+++ b/qiskit/algorithms/utils/validate_initial_point.py
@@ -23,13 +23,30 @@ from qiskit.utils import algorithm_globals
 
 
 def validate_initial_point(
-    point: Sequence[float] | None, ansatz: QuantumCircuit
+    point: Sequence[float] | None, circuit: QuantumCircuit
 ) -> Sequence[float]:
-    expected_size = ansatz.num_parameters
+    r"""
+    Validate a choice of initial point against a choice of circuit. If no point is provided, a
+    random point will be generated within certain parameter bounds. It will first look to the
+    circuit for these bounds. If the circuit does not specify bounds, bounds of :math:`-2\pi`,
+    :math:`2\pi` will be used.
+
+    Args:
+        point: An initial point.
+        circuit: A parameterized quantum circuit.
+
+    Returns:
+        A validated initial point.
+
+    Raises:
+        ValueError: If the dimension of the initial point does not match the number of circuit
+        parameters.
+    """
+    expected_size = circuit.num_parameters
 
     if point is None:
-        # get bounds if ansatz has them set, otherwise use [-2pi, 2pi] for each parameter
-        bounds = getattr(ansatz, "parameter_bounds", None)
+        # get bounds if circuit has them set, otherwise use [-2pi, 2pi] for each parameter
+        bounds = getattr(circuit, "parameter_bounds", None)
         if bounds is None:
             bounds = [(-2 * np.pi, 2 * np.pi)] * expected_size
 

--- a/qiskit/algorithms/utils/validate_initial_point.py
+++ b/qiskit/algorithms/utils/validate_initial_point.py
@@ -22,7 +22,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.utils import algorithm_globals
 
 
-def _validate_initial_point(
+def validate_initial_point(
     point: Sequence[float] | None, ansatz: QuantumCircuit
 ) -> Sequence[float]:
     expected_size = ansatz.num_parameters

--- a/qiskit/algorithms/variational_algorithm.py
+++ b/qiskit/algorithms/variational_algorithm.py
@@ -31,6 +31,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 
 from .algorithm_result import AlgorithmResult
+from .optimizers import OptimizerResult
 
 
 class VariationalAlgorithm(ABC):
@@ -109,3 +110,13 @@ class VariationalResult(AlgorithmResult):
     def optimal_parameters(self, value: Dict) -> None:
         """Sets optimal parameters"""
         self._optimal_parameters = value
+
+    @property
+    def optimizer_result(self) -> Optional[OptimizerResult]:
+        """Returns the optimizer result"""
+        return self._optimizer_result
+
+    @optimizer_result.setter
+    def optimizer_result(self, value: OptimizerResult) -> None:
+        """Sets optimizer result"""
+        self._optimizer_result = value

--- a/releasenotes/notes/0.19/add-getters-and-setters-for-vqe-edc753591b368980.yaml
+++ b/releasenotes/notes/0.19/add-getters-and-setters-for-vqe-edc753591b368980.yaml
@@ -3,8 +3,10 @@ features:
   - |
     Every attribute of the :class:`~qiskit.algorithms.VQE` class that is set at
     the initialization is now accessible with getters and setters. Further, the
-    default values of the VQE attributes :attr:`~.VQE.ansatz` and
-    :attr:`~.VQE.optimizer` can be reset by assigning ``None`` to them::
+    default values of the VQE attributes 
+    :attr:`~qiskit.algorithms.minimimum_eigen_solvers.VQE.ansatz` and
+    :attr:`~qiskit.algorithms.minimimum_eigen_solvers.VQE.optimizer` can be 
+    reset by assigning ``None`` to them::
     
         vqe = VQE(my_ansatz, my_optimizer)
         vqe.ansatz = None   # reset to default: RealAmplitudes ansatz

--- a/releasenotes/notes/0.19/support-dict-for-aux-operators-c3c9ad380c208afd.yaml
+++ b/releasenotes/notes/0.19/support-dict-for-aux-operators-c3c9ad380c208afd.yaml
@@ -1,9 +1,11 @@
 ---
 features:
   - |
-    The :obj:`.Eigensolver` and :obj:`.MinimumEigensolver` interfaces now support the type
+    The :obj:`.Eigensolver` and :obj:`~qiskit.algorithms.minimimum_eigen_solvers.MinimumEigensolver`
+    interfaces now support the type
     ``Dict[str, Optional[OperatorBase]]`` for the ``aux_operators`` parameter in their respective
-    :meth:`~.Eigensolver.compute_eigenvalues` and :meth:`~.MinimumEigensolver.compute_minimum_eigenvalue` methods.
+    :meth:`~.Eigensolver.compute_eigenvalues` and 
+    :meth:`~qiskit.algorithms.minimimum_eigen_solvers.MinimumEigensolver.compute_minimum_eigenvalue` methods.
     In this case, the auxiliary eigenvalues are also stored in a dictionary under the same keys
     provided by the ``aux_operators`` dictionary. Keys that correspond to an operator that does not commute
     with the main operator are dropped.

--- a/releasenotes/notes/0.19/taper_empty_operator_fix-53ce20e5d2b68fd6.yaml
+++ b/releasenotes/notes/0.19/taper_empty_operator_fix-53ce20e5d2b68fd6.yaml
@@ -1,11 +1,11 @@
 ---
 fixes:
   - |
-    When tapering an empty zero operator in :mod:`qiskit.opflow`, the code, on detecting it was zero, logged a
-    warning and returned the original operator.  Such operators are commonly found in
-    the auxiliary operators, when using Qiskit Nature, and the above behavior caused :obj:`.VQE`
-    to throw an exception as tapered non-zero operators were a different number of qubits
-    from the tapered zero operators (since taper has returned the input operator unchanged).
-    The code will now correctly taper a zero operator such that the number of qubits is
-    reduced as expected and matches to tapered non-zero operators e.g ```0*"IIII"``` when we are
-    tapering by 3 qubits will become ``0*"I"``.
+    When tapering an empty zero operator in :mod:`qiskit.opflow`, the code, on detecting it was
+    zero, logged a warning and returned the original operator.  Such operators are commonly found in
+    the auxiliary operators, when using Qiskit Nature, and the above behavior caused
+    :obj:`~qiskit.algorithms.minimimum_eigen_solvers.VQE` to throw an exception as tapered non-zero
+    operators were a different number of qubits from the tapered zero operators (since taper has
+    returned the input operator unchanged). The code will now correctly taper a zero operator such
+    that the number of qubits is reduced as expected and matches to tapered non-zero operators e.g
+    ```0*"IIII"``` when we are tapering by 3 qubits will become ``0*"I"``.

--- a/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
+++ b/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
@@ -4,7 +4,6 @@ features:
      Added :class:`qiskit.algorithms.minimum_eigensolvers` package to include
      interfaces for primitive-enabled algorithms. Refactored
      :class:`qiskit.algorithms.minimum_eigensolvers.VQE` to leverage primitives.
-     Please see the Qiskit Runtime migration guide for more information.
 deprecations:
   - |
      :class:`qiskit.algorithms.minimum_eigen_solvers` package will now issue a

--- a/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
+++ b/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+     Added :class:`qiskit.algorithms.minimum_eigensolvers` package to include
+     interfaces for primitive-enabled algorithms. Refactored
+     :class:`qiskit.algorithms.minimum_eigensolvers.VQE` to leverage primitives.
+     Please see the Qiskit Runtime migration guide for more information.
+deprecations:
+  - |
+     :class:`qiskit.algorithms.minimum_eigen_solvers` package will now issue a
+     ``PendingDeprecationWarning``. It will be deprecated in a future release and subsequently
+     removed after that. This is being replaced by the new
+     :class:`qiskit.algorithms.minimum_eigensolvers` package that will host primitive-enabled
+     algorithms.

--- a/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
+++ b/releasenotes/notes/vqe-with-estimator-primitive-7cbcc462ad4dc593.yaml
@@ -1,13 +1,34 @@
 ---
 features:
   - |
-     Added :class:`qiskit.algorithms.minimum_eigensolvers` package to include
-     interfaces for primitive-enabled algorithms. Refactored
-     :class:`qiskit.algorithms.minimum_eigensolvers.VQE` to leverage primitives.
-deprecations:
-  - |
-     :class:`qiskit.algorithms.minimum_eigen_solvers` package will now issue a
-     ``PendingDeprecationWarning``. It will be deprecated in a future release and subsequently
-     removed after that. This is being replaced by the new
-     :class:`qiskit.algorithms.minimum_eigensolvers` package that will host primitive-enabled
-     algorithms.
+    Added the :class:`qiskit.algorithms.minimum_eigensolvers` package to include interfaces for
+    primitive-enabled algorithms. :class:`~qiskit.algorithms.minimum_eigensolvers.VQE` has been
+    refactored in this implementation to leverage primitives.
+
+    To use the new implementation with a reference primitive, one can do, for example:
+
+    .. code-block:: python
+
+        from qiskit.algorithms.minimum_eigensolvers import VQE
+        from qiskit.algorithms.optimizers import SLSQP
+        from qiskit.circuit.library import TwoLocal
+        from qiskit.primitives import Estimator
+
+        h2_op = SparsePauliOp(
+            ["II", "IZ", "ZI", "ZZ", "XX"],
+            coeffs=[
+                -1.052373245772859,
+                0.39793742484318045,
+                -0.39793742484318045,
+                -0.01128010425623538,
+                0.18093119978423156,
+            ],
+        )
+
+        estimator = Estimator()
+        ansatz = TwoLocal(rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+        optimizer = SLSQP()
+
+        vqe = VQE(estimator, ansatz, optimizer)
+        result = vqe.compute_minimum_eigenvalue(h2_op)
+        eigenvalue = result.eigenvalue        

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -19,7 +19,8 @@ import numpy as np
 from ddt import ddt, data
 
 from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
-from qiskit.opflow import PauliSumOp, X, Y, Z
+from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import SparsePauliOp
 
 
 @ddt
@@ -125,11 +126,12 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         self.assertEqual(result.eigenstate, None)
         self.assertEqual(result.aux_operator_eigenvalues, None)
 
-    @data(X, Y, Z)
+    @data("X", "Y", "Z")
     def test_cme_1q(self, op):
         """Test for 1 qubit operator"""
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(operator=op)
+        operator = PauliSumOp.from_list([(op, 1.0)])
+        result = algo.compute_minimum_eigenvalue(operator=operator)
         self.assertAlmostEqual(result.eigenvalue, -1)
 
     def test_cme_aux_ops_dict(self):

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -20,7 +20,6 @@ from ddt import ddt, data
 
 from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import SparsePauliOp
 
 
 @ddt
@@ -57,41 +56,42 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
     def test_cme_reuse(self):
         """Test reuse"""
-        # Start with no operator or aux_operators, give via compute method
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
-        self.assertEqual(result.eigenvalue.dtype, np.float64)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
-        self.assertIsNone(result.aux_operator_eigenvalues)
 
-        # Add aux_operators and go again
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_list
-        )
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+        with self.subTest("Test with no operator or aux_operators, give via compute method"):
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
+            self.assertEqual(result.eigenvalue.dtype, np.float64)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503)
+            self.assertIsNone(result.aux_operator_eigenvalues)
 
-        # "Remove" aux_operators and go again
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
-        self.assertEqual(result.eigenvalue.dtype, np.float64)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503)
-        self.assertIsNone(result.aux_operator_eigenvalues)
+        with self.subTest("Test with added aux_operators"):
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=self.aux_ops_list
+            )
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
 
-        # Set aux_operators and go again
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_list
-        )
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+        with self.subTest("Test with aux_operators removed"):
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
+            self.assertEqual(result.eigenvalue.dtype, np.float64)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503)
+            self.assertIsNone(result.aux_operator_eigenvalues)
 
-        # Finally just set one of aux_operators and main operator, remove aux_operators
-        result = algo.compute_minimum_eigenvalue(operator=self.aux_ops_list[0], aux_operators=[])
-        self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
-        self.assertIsNone(result.aux_operator_eigenvalues)
+        with self.subTest("Test with aux_operators set again"):
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=self.aux_ops_list
+            )
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+
+        with self.subTest("Test after setting first aux_operators as main operator"):
+            result = algo.compute_minimum_eigenvalue(operator=self.aux_ops_list[0], aux_operators=[])
+            self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
+            self.assertIsNone(result.aux_operator_eigenvalues)
 
     def test_cme_filter(self):
         """Basic test"""
@@ -138,27 +138,29 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         """Test dictionary compatibility of aux_operators"""
         # Start with an empty dictionary
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators={})
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertIsNone(result.aux_operator_eigenvalues)
 
-        # Add aux_operators dictionary and go again
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_dict
-        )
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+        with self.subTest("Test with an empty dictionary."):
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators={})
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertIsNone(result.aux_operator_eigenvalues)
 
-        # Add None and zero operators and go again
-        extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 3)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
-        self.assertEqual(result.aux_operator_eigenvalues["zero_op"], (0.0, 0))
+        with self.subTest("Test with two auxiliary operators."):
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=self.aux_ops_dict
+            )
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+
+        with self.subTest("Test with additional zero and None operators."):
+            extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+            self.assertEqual(result.aux_operator_eigenvalues["zero_op"], (0.0, 0))
 
     def test_aux_operators_list(self):
         """Test list-based aux_operators."""
@@ -166,30 +168,32 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
         aux_ops = [aux_op1, aux_op2]
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
 
-        # Go again with additional None and zero operators
-        extra_ops = [*aux_ops, None, 0]
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 4)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
-        self.assertIsNone(result.aux_operator_eigenvalues[2], None)
-        self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
-        self.assertEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+        with self.subTest("Test with two auxiliary operators."):
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+            # standard deviations
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+
+        with self.subTest("Test with additional zero and None operators."):
+            extra_ops = [*aux_ops, None, 0]
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+            self.assertIsNone(result.aux_operator_eigenvalues[2], None)
+            self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+            # standard deviations
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues[3][1], 0.0)
 
     def test_aux_operators_dict(self):
         """Test dict-based aux_operators."""
@@ -197,30 +201,32 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
         aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
 
-        # Go again with additional None and zero operators
-        extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
-        result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
-        self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 3)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
-        self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
-        self.assertTrue("None_operator" not in result.aux_operator_eigenvalues.keys())
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
+        with self.subTest("Test with two auxiliary operators."):
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+            # standard deviations
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+
+        with self.subTest("Test with additional zero and None operators."):
+            extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
+            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
+            self.assertTrue("None_operator" not in result.aux_operator_eigenvalues.keys())
+            # standard deviations
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -50,9 +50,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             operator=self.qubit_op, aux_operators=self.aux_ops_list
         )
         self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+        self.assertEqual(len(result.aux_operators_evaluated), 2)
+        np.testing.assert_array_almost_equal(result.aux_operators_evaluated[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operators_evaluated[1], [0, 0])
 
     def test_cme_reuse(self):
         """Test reuse"""
@@ -62,38 +62,38 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
             self.assertEqual(result.eigenvalue.dtype, np.float64)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503)
-            self.assertIsNone(result.aux_operator_eigenvalues)
+            self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with added aux_operators"):
             result = algo.compute_minimum_eigenvalue(
                 operator=self.qubit_op, aux_operators=self.aux_ops_list
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated[0], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated[1], [0, 0])
 
         with self.subTest("Test with aux_operators removed"):
             result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
             self.assertEqual(result.eigenvalue.dtype, np.float64)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503)
-            self.assertIsNone(result.aux_operator_eigenvalues)
+            self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with aux_operators set again"):
             result = algo.compute_minimum_eigenvalue(
                 operator=self.qubit_op, aux_operators=self.aux_ops_list
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated[0], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated[1], [0, 0])
 
         with self.subTest("Test after setting first aux_operators as main operator"):
             result = algo.compute_minimum_eigenvalue(
                 operator=self.aux_ops_list[0], aux_operators=[]
             )
             self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
-            self.assertIsNone(result.aux_operator_eigenvalues)
+            self.assertIsNone(result.aux_operators_evaluated)
 
     def test_cme_filter(self):
         """Basic test"""
@@ -108,9 +108,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             operator=self.qubit_op, aux_operators=self.aux_ops_list
         )
         self.assertAlmostEqual(result.eigenvalue, -0.22491125 + 0j)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[0], [2, 0])
-        np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
+        self.assertEqual(len(result.aux_operators_evaluated), 2)
+        np.testing.assert_array_almost_equal(result.aux_operators_evaluated[0], [2, 0])
+        np.testing.assert_array_almost_equal(result.aux_operators_evaluated[1], [0, 0])
 
     def test_cme_filter_empty(self):
         """Test with filter always returning False"""
@@ -126,7 +126,7 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         )
         self.assertEqual(result.eigenvalue, None)
         self.assertEqual(result.eigenstate, None)
-        self.assertEqual(result.aux_operator_eigenvalues, None)
+        self.assertEqual(result.aux_operators_evaluated, None)
 
     @data("X", "Y", "Z")
     def test_cme_1q(self, op):
@@ -144,16 +144,16 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         with self.subTest("Test with an empty dictionary."):
             result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators={})
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertIsNone(result.aux_operator_eigenvalues)
+            self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with two auxiliary operators."):
             result = algo.compute_minimum_eigenvalue(
                 operator=self.qubit_op, aux_operators=self.aux_ops_dict
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated["aux_op1"], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated["aux_op2"], [0, 0])
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
@@ -161,10 +161,10 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
                 operator=self.qubit_op, aux_operators=extra_ops
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
-            np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op2"], [0, 0])
-            self.assertEqual(result.aux_operator_eigenvalues["zero_op"], (0.0, 0))
+            self.assertEqual(len(result.aux_operators_evaluated), 3)
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated["aux_op1"], [2, 0])
+            np.testing.assert_array_almost_equal(result.aux_operators_evaluated["aux_op2"], [0, 0])
+            self.assertEqual(result.aux_operators_evaluated["zero_op"], (0.0, 0))
 
     def test_aux_operators_list(self):
         """Test list-based aux_operators."""
@@ -176,13 +176,13 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         with self.subTest("Test with two auxiliary operators."):
             result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0, places=6)
             # standard deviations
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][1], 0.0)
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = [*aux_ops, None, 0]
@@ -190,16 +190,16 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
                 operator=self.qubit_op, aux_operators=extra_ops
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 4)
+            self.assertEqual(len(result.aux_operators_evaluated), 4)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
-            self.assertIsNone(result.aux_operator_eigenvalues[2], None)
-            self.assertEqual(result.aux_operator_eigenvalues[3][0], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0, places=6)
+            self.assertIsNone(result.aux_operators_evaluated[2], None)
+            self.assertEqual(result.aux_operators_evaluated[3][0], 0.0)
             # standard deviations
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues[3][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][1], 0.0)
+            self.assertEqual(result.aux_operators_evaluated[3][1], 0.0)
 
     def test_aux_operators_dict(self):
         """Test dict-based aux_operators."""
@@ -211,13 +211,13 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
         with self.subTest("Test with two auxiliary operators."):
             result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][0], 0, places=6)
             # standard deviations
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][1], 0.0)
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
@@ -225,16 +225,16 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
                 operator=self.qubit_op, aux_operators=extra_ops
             )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            self.assertEqual(len(result.aux_operators_evaluated), 3)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=6)
-            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
-            self.assertTrue("None_operator" not in result.aux_operator_eigenvalues.keys())
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][0], 0, places=6)
+            self.assertEqual(result.aux_operators_evaluated["zero_operator"][0], 0.0)
+            self.assertTrue("None_operator" not in result.aux_operators_evaluated.keys())
             # standard deviations
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][1], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["zero_operator"][1], 0.0)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -89,7 +89,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues[1], [0, 0])
 
         with self.subTest("Test after setting first aux_operators as main operator"):
-            result = algo.compute_minimum_eigenvalue(operator=self.aux_ops_list[0], aux_operators=[])
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.aux_ops_list[0], aux_operators=[]
+            )
             self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
             self.assertIsNone(result.aux_operator_eigenvalues)
 
@@ -155,7 +157,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=extra_ops
+            )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operator_eigenvalues), 3)
             np.testing.assert_array_almost_equal(result.aux_operator_eigenvalues["aux_op1"], [2, 0])
@@ -182,7 +186,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = [*aux_ops, None, 0]
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=extra_ops
+            )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operator_eigenvalues), 4)
             # expectation values
@@ -215,7 +221,9 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=extra_ops)
+            result = algo.compute_minimum_eigenvalue(
+                operator=self.qubit_op, aux_operators=extra_ops
+            )
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operator_eigenvalues), 3)
             # expectation values

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -225,23 +225,21 @@ class TestVQE(QiskitAlgorithmsTestCase):
         result = vqe.compute_minimum_eigenvalue(tapered_qubit_op)
         self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=2)
 
-    @data({}, {"shots": 1000})
-    def test_callback(self, options):
+    def test_callback(self):
         """Test the callback on VQE."""
-        history = {"eval_count": [], "parameters": [], "mean": [], "variance": [], "shots": []}
-        expected_shots = options["shots"] if "shots" in options else 0
+        history = {"eval_count": [], "parameters": [], "mean": [], "metadata": []}
+        # expected_shots = options["shots"] if "shots" in options else 0
 
-        def store_intermediate_result(eval_count, parameters, mean, variance, shots):
+        def store_intermediate_result(eval_count, parameters, mean, metadata):
             history["eval_count"].append(eval_count)
             history["parameters"].append(parameters)
             history["mean"].append(mean)
-            history["variance"].append(variance)
-            history["shots"].append(shots)
+            history["metadata"].append(metadata)
 
         optimizer = COBYLA(maxiter=3)
         wavefunction = self.ry_wavefunction
 
-        estimator = Estimator(options=options)
+        estimator = Estimator()
 
         vqe = VQE(
             estimator,
@@ -253,10 +251,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
         self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
         self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-        self.assertTrue(all(isinstance(variance, float) for variance in history["variance"]))
-        if expected_shots == 0:
-            np.testing.assert_array_equal(history["variance"], 0.0)
-        np.testing.assert_array_equal(history["shots"], expected_shots)
+        self.assertTrue(all(isinstance(metadata, dict) for metadata in history["metadata"]))
         for params in history["parameters"]:
             self.assertTrue(all(isinstance(param, float) for param in params))
 

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -101,12 +101,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest(msg="assert optimizer_time is set"):
             self.assertIsNotNone(result.optimizer_time)
 
-    def test_default_ansatz(self):
-        """Test default ansatz is set as expected."""
-        vqe = VQE(Estimator(), None, SLSQP())
-        result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
-        self.assertAlmostEqual(result.eigenvalue, self.h2_energy, places=5)
-
     def test_invalid_initial_point(self):
         """Test the proper error is raised when the initial point has the wrong size."""
         ansatz = self.ryrz_wavefunction

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -227,13 +227,13 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
     def test_callback(self):
         """Test the callback on VQE."""
-        history = {"eval_count": [], "parameters": [], "mean": [], "variance": []}
+        history = {"eval_count": [], "parameters": [], "mean": [], "std_dev": []}
 
-        def store_intermediate_result(eval_count, parameters, mean, variance):
+        def store_intermediate_result(eval_count, parameters, mean, std_dev):
             history["eval_count"].append(eval_count)
             history["parameters"].append(parameters)
             history["mean"].append(mean)
-            history["variance"].append(variance)
+            history["std_dev"].append(std_dev)
 
         optimizer = COBYLA(maxiter=3)
         wavefunction = self.ry_wavefunction
@@ -251,7 +251,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
             self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
             self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-            self.assertTrue(all(variance == 0.0 for variance in history["variance"]))
+            self.assertTrue(all(std_dev == 0.0 for std_dev in history["std_dev"]))
 
             for params in history["parameters"]:
                 self.assertTrue(all(isinstance(param, float) for param in params))
@@ -269,7 +269,7 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
             self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
             self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-            self.assertTrue(all(isinstance(variance, float) for variance in history["variance"]))
+            self.assertTrue(all(isinstance(std_dev, float) for std_dev in history["std_dev"]))
 
             for params in history["parameters"]:
                 self.assertTrue(all(isinstance(param, float) for param in params))

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -377,35 +377,28 @@ class TestVQE(QiskitAlgorithmsTestCase):
             aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
             aux_ops = [aux_op1, aux_op2]
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
-            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
             self.assertEqual(len(result.aux_operator_eigenvalues), 2)
             # expectation values
             self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
             self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
-            # variances
-            self.assertEqual(result.aux_operator_eigenvalues[0][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues[1][1][0], 0.0)
-            # shots
-            self.assertEqual(result.aux_operator_eigenvalues[0][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues[1][1][1], 0)
+            # metadata
+            self.assertIsInstance(result.aux_operator_eigenvalues[0][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues[1][1], dict)
 
         with self.subTest("Test with additional zero operator."):
             extra_ops = [*aux_ops, 0]
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
-            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
             self.assertEqual(len(result.aux_operator_eigenvalues), 3)
             # expectation values
             self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
             self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
             self.assertAlmostEqual(result.aux_operator_eigenvalues[2][0], 0.0)
-            # variances
-            self.assertEqual(result.aux_operator_eigenvalues[0][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues[1][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues[2][1][0], 0.0)
-            # shots
-            self.assertEqual(result.aux_operator_eigenvalues[0][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues[1][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues[2][1][1], 0)
+            # metadata
+            self.assertIsInstance(result.aux_operator_eigenvalues[0][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues[1][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues[2][1], dict)
 
     def test_aux_operators_dict(self):
         """Test dictionary compatibility of aux_operators"""
@@ -426,14 +419,11 @@ class TestVQE(QiskitAlgorithmsTestCase):
             self.assertEqual(len(result.aux_operator_eigenvalues), 2)
 
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
-            # variances
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][0], 0.0)
-            # shots
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][1], 0)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2.0, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0.0, places=5)
+            # metadata
+            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op1"][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op2"][1], dict)
 
         with self.subTest("Test with additional zero operator."):
             extra_ops = {**aux_ops, "zero_operator": 0}
@@ -441,19 +431,13 @@ class TestVQE(QiskitAlgorithmsTestCase):
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
             self.assertEqual(len(result.aux_operator_eigenvalues), 3)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2.0, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0.0, places=5)
             self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
-            # variances
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][0], 0.0)
-            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][1][0], 0.0)
-            # shots
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][1], 0)
-            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][1][1], 0)
-
-    # TODO test with non-zero metadata. Affected by PR #8105.
+            # metadata
+            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op1"][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op2"][1], dict)
+            self.assertIsInstance(result.aux_operator_eigenvalues["zero_operator"][1], dict)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -411,7 +411,6 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest("Test with an empty dictionary."):
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators={})
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-            # self.assertIsNone(result.aux_operator_eigenvalues)
             self.assertIsInstance(result.aux_operator_eigenvalues, dict)
             self.assertEqual(len(result.aux_operator_eigenvalues), 0)
 

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -101,6 +101,12 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest(msg="assert optimizer_time is set"):
             self.assertIsNotNone(result.optimizer_time)
 
+        with self.subTest(msg="assert optimizer_result is set"):
+            self.assertIsNotNone(result.optimizer_result)
+
+        with self.subTest(msg="assert optimizer_result."):
+            self.assertAlmostEqual(result.optimizer_result.fun, self.h2_energy, places=5)
+
     def test_invalid_initial_point(self):
         """Test the proper error is raised when the initial point has the wrong size."""
         ansatz = self.ryrz_wavefunction

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -227,30 +227,52 @@ class TestVQE(QiskitAlgorithmsTestCase):
 
     def test_callback(self):
         """Test the callback on VQE."""
-        history = {"eval_count": [], "parameters": [], "mean": [], "std": []}
+        history = {"eval_count": [], "parameters": [], "mean": [], "variance": []}
 
-        def store_intermediate_result(eval_count, parameters, mean, std):
+        def store_intermediate_result(eval_count, parameters, mean, variance):
             history["eval_count"].append(eval_count)
             history["parameters"].append(parameters)
             history["mean"].append(mean)
-            history["std"].append(std)
+            history["variance"].append(variance)
 
         optimizer = COBYLA(maxiter=3)
         wavefunction = self.ry_wavefunction
 
-        vqe = VQE(
-            Estimator(),
-            ansatz=wavefunction,
-            optimizer=optimizer,
-            callback=store_intermediate_result,
-        )
-        vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        with self.subTest("Test without specifying shots."):
+            estimator = Estimator()
 
-        self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
-        self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-        self.assertTrue(all(isinstance(std, float) for std in history["std"]))
-        for params in history["parameters"]:
-            self.assertTrue(all(isinstance(param, float) for param in params))
+            vqe = VQE(
+                estimator,
+                ansatz=wavefunction,
+                optimizer=optimizer,
+                callback=store_intermediate_result,
+            )
+            vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+            self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
+            self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
+            self.assertTrue(all(variance == 0.0 for variance in history["variance"]))
+
+            for params in history["parameters"]:
+                self.assertTrue(all(isinstance(param, float) for param in params))
+
+        with self.subTest("Test when specifying shots."):
+            estimator = Estimator(options={"shots": 1000})
+
+            vqe = VQE(
+                estimator,
+                ansatz=wavefunction,
+                optimizer=optimizer,
+                callback=store_intermediate_result,
+            )
+            vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+
+            self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
+            self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
+            self.assertTrue(all(isinstance(variance, float) for variance in history["variance"]))
+
+            for params in history["parameters"]:
+                self.assertTrue(all(isinstance(param, float) for param in params))
 
     def test_reuse(self):
         """Test re-using a VQE algorithm instance."""

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -369,8 +369,8 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest("Test with an empty list."):
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=[])
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-            self.assertIsInstance(result.aux_operator_eigenvalues, list)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 0)
+            self.assertIsInstance(result.aux_operators_evaluated, list)
+            self.assertEqual(len(result.aux_operators_evaluated), 0)
 
         with self.subTest("Test with two auxiliary operators."):
             aux_op1 = PauliSumOp.from_list([("II", 2.0)])
@@ -378,27 +378,27 @@ class TestVQE(QiskitAlgorithmsTestCase):
             aux_ops = [aux_op1, aux_op2]
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2.0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0.0, places=6)
             # metadata
-            self.assertIsInstance(result.aux_operator_eigenvalues[0][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues[1][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated[0][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated[1][1], dict)
 
         with self.subTest("Test with additional zero operator."):
             extra_ops = [*aux_ops, 0]
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=5)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            self.assertEqual(len(result.aux_operators_evaluated), 3)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues[2][0], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2.0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0.0, places=6)
+            self.assertAlmostEqual(result.aux_operators_evaluated[2][0], 0.0)
             # metadata
-            self.assertIsInstance(result.aux_operator_eigenvalues[0][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues[1][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues[2][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated[0][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated[1][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated[2][1], dict)
 
     def test_aux_operators_dict(self):
         """Test dictionary compatibility of aux_operators"""
@@ -407,8 +407,8 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest("Test with an empty dictionary."):
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators={})
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-            self.assertIsInstance(result.aux_operator_eigenvalues, dict)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 0)
+            self.assertIsInstance(result.aux_operators_evaluated, dict)
+            self.assertEqual(len(result.aux_operators_evaluated), 0)
 
         with self.subTest("Test with two auxiliary operators."):
             aux_op1 = PauliSumOp.from_list([("II", 2.0)])
@@ -416,28 +416,28 @@ class TestVQE(QiskitAlgorithmsTestCase):
             aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            self.assertEqual(len(result.aux_operators_evaluated), 2)
 
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2.0, places=5)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0.0, places=5)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2.0, places=5)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][0], 0.0, places=5)
             # metadata
-            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op1"][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op2"][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated["aux_op1"][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated["aux_op2"][1], dict)
 
         with self.subTest("Test with additional zero operator."):
             extra_ops = {**aux_ops, "zero_operator": 0}
             result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
             self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            self.assertEqual(len(result.aux_operators_evaluated), 3)
             # expectation values
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2.0, places=5)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0.0, places=5)
-            self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2.0, places=5)
+            self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][0], 0.0, places=5)
+            self.assertAlmostEqual(result.aux_operators_evaluated["zero_operator"][0], 0.0)
             # metadata
-            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op1"][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues["aux_op2"][1], dict)
-            self.assertIsInstance(result.aux_operator_eigenvalues["zero_operator"][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated["aux_op1"][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated["aux_op2"][1], dict)
+            self.assertIsInstance(result.aux_operators_evaluated["zero_operator"][1], dict)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -101,9 +101,9 @@ class TestVQE(QiskitAlgorithmsTestCase):
         with self.subTest(msg="assert optimizer_time is set"):
             self.assertIsNotNone(result.optimizer_time)
 
-    def test_default_values(self):
-        """Test all default values are set as expected."""
-        vqe = VQE(Estimator())
+    def test_default_ansatz(self):
+        """Test default ansatz is set as expected."""
+        vqe = VQE(Estimator(), None, SLSQP())
         result = vqe.compute_minimum_eigenvalue(operator=self.h2_op)
         self.assertAlmostEqual(result.eigenvalue, self.h2_energy, places=5)
 

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -363,77 +363,93 @@ class TestVQE(QiskitAlgorithmsTestCase):
         """Test list-based aux_operators."""
         vqe = VQE(Estimator(), self.ry_wavefunction, SLSQP(maxiter=300))
 
-        # Start with an empty list
-        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=[])
-        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        self.assertIsNone(result.aux_operator_eigenvalues)
+        with self.subTest("Test with an empty list."):
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=[])
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertIsInstance(result.aux_operator_eigenvalues, list)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 0)
 
-        # Go again with two auxiliary operators
-        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
-        aux_ops = [aux_op1, aux_op2]
-        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
-        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
+        with self.subTest("Test with two auxiliary operators."):
+            aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+            aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+            aux_ops = [aux_op1, aux_op2]
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
+            # variances
+            self.assertEqual(result.aux_operator_eigenvalues[0][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues[1][1][0], 0.0)
+            # shots
+            self.assertEqual(result.aux_operator_eigenvalues[0][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues[1][1][1], 0)
 
-        # Go again with additional zero operator
-        # TODO waiting for eval_operators to be ported.
-        # extra_ops = [*aux_ops, 0]
-        # result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
-        # self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        # self.assertEqual(len(result.aux_operator_eigenvalues), 3)
-        # # # expectation values
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2, places=6)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0, places=6)
-        # self.assertEqual(result.aux_operator_eigenvalues[2][0], 0.0)
-        # # # standard deviations
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues[0][1], 0.0)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues[1][1], 0.0)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues[2][1], 0.0)
+        with self.subTest("Test with additional zero operator."):
+            extra_ops = [*aux_ops, 0]
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[0][0], 2.0, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[1][0], 0.0, places=6)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues[2][0], 0.0)
+            # variances
+            self.assertEqual(result.aux_operator_eigenvalues[0][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues[1][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues[2][1][0], 0.0)
+            # shots
+            self.assertEqual(result.aux_operator_eigenvalues[0][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues[1][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues[2][1][1], 0)
 
     def test_aux_operators_dict(self):
         """Test dictionary compatibility of aux_operators"""
         vqe = VQE(Estimator(), self.ry_wavefunction, SLSQP(maxiter=300))
 
-        # Start with an empty dictionary
-        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators={})
-        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        self.assertIsNone(result.aux_operator_eigenvalues)
+        with self.subTest("Test with an empty dictionary."):
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators={})
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            # self.assertIsNone(result.aux_operator_eigenvalues)
+            self.assertIsInstance(result.aux_operator_eigenvalues, dict)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 0)
 
-        # Go again with two auxiliary operators
-        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
-        aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
-        result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
-        self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        self.assertEqual(len(result.aux_operator_eigenvalues), 2)
-        # expectation values
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
-        # standard deviations
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-        self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
+        with self.subTest("Test with two auxiliary operators."):
+            aux_op1 = PauliSumOp.from_list([("II", 2.0)])
+            aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+            aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=aux_ops)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 2)
 
-        # TODO waiting for eval_operators to be ported.
-        # Go again with additional zero operator
-        # extra_ops = {**aux_ops, "zero_operator": 0}
-        # result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
-        # self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
-        # self.assertEqual(len(result.aux_operator_eigenvalues), 3)
-        # # expectation values
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
-        # self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
-        # # standard deviations
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][1], 0.0)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][1], 0.0)
-        # self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][1], 0.0)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
+            # variances
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][0], 0.0)
+            # shots
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][1], 0)
+
+        with self.subTest("Test with additional zero operator."):
+            extra_ops = {**aux_ops, "zero_operator": 0}
+            result = vqe.compute_minimum_eigenvalue(self.h2_op, aux_operators=extra_ops)
+            self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=6)
+            self.assertEqual(len(result.aux_operator_eigenvalues), 3)
+            # expectation values
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op1"][0], 2, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["aux_op2"][0], 0, places=5)
+            self.assertAlmostEqual(result.aux_operator_eigenvalues["zero_operator"][0], 0.0)
+            # variances
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][0], 0.0)
+            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][1][0], 0.0)
+            # shots
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op1"][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][1], 0)
+            self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][1][1], 0)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -450,6 +450,8 @@ class TestVQE(QiskitAlgorithmsTestCase):
             self.assertEqual(result.aux_operator_eigenvalues["aux_op2"][1][1], 0)
             self.assertEqual(result.aux_operator_eigenvalues["zero_operator"][1][1], 0)
 
+    # TODO test with non-zero metadata. Affected by PR #8105.
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -225,54 +225,40 @@ class TestVQE(QiskitAlgorithmsTestCase):
         result = vqe.compute_minimum_eigenvalue(tapered_qubit_op)
         self.assertAlmostEqual(result.eigenvalue.real, self.h2_energy, places=2)
 
-    def test_callback(self):
+    @data({}, {"shots": 1000})
+    def test_callback(self, options):
         """Test the callback on VQE."""
-        history = {"eval_count": [], "parameters": [], "mean": [], "std_dev": []}
+        history = {"eval_count": [], "parameters": [], "mean": [], "variance": [], "shots": []}
+        expected_shots = options["shots"] if "shots" in options else 0
 
-        def store_intermediate_result(eval_count, parameters, mean, std_dev):
+        def store_intermediate_result(eval_count, parameters, mean, variance, shots):
             history["eval_count"].append(eval_count)
             history["parameters"].append(parameters)
             history["mean"].append(mean)
-            history["std_dev"].append(std_dev)
+            history["variance"].append(variance)
+            history["shots"].append(shots)
 
         optimizer = COBYLA(maxiter=3)
         wavefunction = self.ry_wavefunction
 
-        with self.subTest("Test without specifying shots."):
-            estimator = Estimator()
+        estimator = Estimator(options=options)
 
-            vqe = VQE(
-                estimator,
-                ansatz=wavefunction,
-                optimizer=optimizer,
-                callback=store_intermediate_result,
-            )
-            vqe.compute_minimum_eigenvalue(operator=self.h2_op)
+        vqe = VQE(
+            estimator,
+            wavefunction,
+            optimizer,
+            callback=store_intermediate_result,
+        )
+        vqe.compute_minimum_eigenvalue(operator=self.h2_op)
 
-            self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
-            self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-            self.assertTrue(all(std_dev == 0.0 for std_dev in history["std_dev"]))
-
-            for params in history["parameters"]:
-                self.assertTrue(all(isinstance(param, float) for param in params))
-
-        with self.subTest("Test when specifying shots."):
-            estimator = Estimator(options={"shots": 1000})
-
-            vqe = VQE(
-                estimator,
-                ansatz=wavefunction,
-                optimizer=optimizer,
-                callback=store_intermediate_result,
-            )
-            vqe.compute_minimum_eigenvalue(operator=self.h2_op)
-
-            self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
-            self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
-            self.assertTrue(all(isinstance(std_dev, float) for std_dev in history["std_dev"]))
-
-            for params in history["parameters"]:
-                self.assertTrue(all(isinstance(param, float) for param in params))
+        self.assertTrue(all(isinstance(count, int) for count in history["eval_count"]))
+        self.assertTrue(all(isinstance(mean, float) for mean in history["mean"]))
+        self.assertTrue(all(isinstance(variance, float) for variance in history["variance"]))
+        if expected_shots == 0:
+            np.testing.assert_array_equal(history["variance"], 0.0)
+        np.testing.assert_array_equal(history["shots"], expected_shots)
+        for params in history["parameters"]:
+            self.assertTrue(all(isinstance(param, float) for param in params))
 
     def test_reuse(self):
         """Test re-using a VQE algorithm instance."""

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -53,7 +53,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         # the exact value is a list of (mean, (variance, shots)) where we expect 0 variance and
         # 0 shots
         exact = [
-            (Statevector(ansatz).expectation_value(observable), (0, 0))
+            (Statevector(ansatz).expectation_value(observable), {})
             for observable in observables_list
         ]
 
@@ -143,7 +143,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         estimator = Estimator()
         observables = [SparsePauliOp(["XX", "YY"]), 0]
         result = estimate_observables(estimator, state, observables, self.threshold)
-        expected_result = [(0.015607318055509564, (0, 0)), (0.0, (0, 0))]
+        expected_result = [(0.015607318055509564, {}), (0.0, {})]
         means = [element[0] for element in result]
         expected_means = [element[0] for element in expected_result]
         np.testing.assert_array_almost_equal(means, expected_means, decimal=0.01)
@@ -151,6 +151,34 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         vars_and_shots = [element[1] for element in result]
         expected_vars_and_shots = [element[1] for element in expected_result]
         np.testing.assert_array_equal(vars_and_shots, expected_vars_and_shots)
+
+    def test_estimate_observables_shots(self):
+        """Tests that variances and shots are returned properly."""
+        ansatz = EfficientSU2(2)
+        parameters = np.array(
+            [1.2, 4.2, 1.4, 2.0, 1.2, 4.2, 1.4, 2.0, 1.2, 4.2, 1.4, 2.0, 1.2, 4.2, 1.4, 2.0],
+            dtype=float,
+        )
+
+        bound_ansatz = ansatz.bind_parameters(parameters)
+        state = bound_ansatz
+        estimator = Estimator(options={"shots": 2048})
+        observables = [PauliSumOp.from_list([("ZZ", 2.0)])]
+        result = estimate_observables(estimator, state, observables, self.threshold)
+        exact_result = self.get_exact_expectation(bound_ansatz, observables)
+        expected_result = [(exact_result[0][0], {"variance": 1.0898, "shots": 2048})]
+
+        means = [element[0] for element in result]
+        expected_means = [element[0] for element in expected_result]
+        np.testing.assert_array_almost_equal(means, expected_means, decimal=0.01)
+
+        vars_and_shots = [element[1] for element in result]
+        print(vars_and_shots)
+        expected_vars_and_shots = [element[1] for element in expected_result]
+        print(expected_vars_and_shots)
+        for computed, expected in zip(vars_and_shots, expected_vars_and_shots):
+
+            self.assertAlmostEqual(computed, expected, 2)
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -179,8 +179,8 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         expected_vars_and_shots = [element[1] for element in expected_result]
         print(expected_vars_and_shots)
         for computed, expected in zip(vars_and_shots, expected_vars_and_shots):
-
-            self.assertAlmostEqual(computed, expected, 2)
+             self.assertAlmostEqual(computed.pop("variance"), expected.pop("variance"), 2)
+             self.assertEqual(computed.pop("shots"), expected.pop("shots"))
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -179,8 +179,8 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         expected_vars_and_shots = [element[1] for element in expected_result]
         print(expected_vars_and_shots)
         for computed, expected in zip(vars_and_shots, expected_vars_and_shots):
-             self.assertAlmostEqual(computed.pop("variance"), expected.pop("variance"), 2)
-             self.assertEqual(computed.pop("shots"), expected.pop("shots"))
+            self.assertAlmostEqual(computed.pop("variance"), expected.pop("variance"), 2)
+            self.assertEqual(computed.pop("shots"), expected.pop("shots"))
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -72,7 +72,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         observables: ListOrDict[BaseOperator | PauliSumOp],
         estimator: Estimator,
     ):
-        result = estimate_observables(estimator, quantum_state, observables, self.threshold)
+        result = estimate_observables(estimator, quantum_state, observables, None, self.threshold)
 
         if isinstance(observables, dict):
             np.testing.assert_equal(list(result.keys()), list(expected_result.keys()))
@@ -144,7 +144,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         state = bound_ansatz
         estimator = Estimator()
         observables = [SparsePauliOp(["XX", "YY"]), 0]
-        result = estimate_observables(estimator, state, observables, self.threshold)
+        result = estimate_observables(estimator, state, observables, None, self.threshold)
         expected_result = [(0.015607318055509564, {}), (0.0, {})]
         means = [element[0] for element in result]
         expected_means = [element[0] for element in expected_result]
@@ -166,7 +166,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         state = bound_ansatz
         estimator = Estimator(options={"shots": 2048})
         observables = [PauliSumOp.from_list([("ZZ", 2.0)])]
-        result = estimate_observables(estimator, state, observables, self.threshold)
+        result = estimate_observables(estimator, state, observables, None, self.threshold)
         exact_result = self.get_exact_expectation(bound_ansatz, observables)
         expected_result = [(exact_result[0][0], {"variance": 1.0898, "shots": 2048})]
 

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -9,7 +9,9 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
 """Tests evaluator of auxiliary operators for algorithms."""
+
 from __future__ import annotations
 import unittest
 from typing import Tuple

--- a/test/python/algorithms/test_observables_evaluator.py
+++ b/test/python/algorithms/test_observables_evaluator.py
@@ -175,9 +175,7 @@ class TestObservablesEvaluator(QiskitAlgorithmsTestCase):
         np.testing.assert_array_almost_equal(means, expected_means, decimal=0.01)
 
         vars_and_shots = [element[1] for element in result]
-        print(vars_and_shots)
         expected_vars_and_shots = [element[1] for element in expected_result]
-        print(expected_vars_and_shots)
         for computed, expected in zip(vars_and_shots, expected_vars_and_shots):
             self.assertAlmostEqual(computed.pop("variance"), expected.pop("variance"), 2)
             self.assertEqual(computed.pop("shots"), expected.pop("shots"))

--- a/test/python/algorithms/time_evolvers/test_trotter_qrte.py
+++ b/test/python/algorithms/time_evolvers/test_trotter_qrte.py
@@ -88,7 +88,10 @@ class TestTrotterQRTE(QiskitAlgorithmsTestCase):
         )
 
         aux_ops_result = evolution_result.aux_ops_evaluated
-        expected_aux_ops_result = [(0.078073, (0.0, 0.0)), (0.268286, (0.0, 0.0))]
+        expected_aux_ops_result = [
+            (0.078073, {"variance": 0, "shots": 0}),
+            (0.268286, {"variance": 0, "shots": 0}),
+        ]
 
         means = [element[0] for element in aux_ops_result]
         expected_means = [element[0] for element in expected_aux_ops_result]
@@ -96,7 +99,10 @@ class TestTrotterQRTE(QiskitAlgorithmsTestCase):
 
         vars_and_shots = [element[1] for element in aux_ops_result]
         expected_vars_and_shots = [element[1] for element in expected_aux_ops_result]
-        np.testing.assert_array_equal(vars_and_shots, expected_vars_and_shots)
+
+        for computed, expected in zip(vars_and_shots, expected_vars_and_shots):
+            self.assertAlmostEqual(computed.pop("variance", 0), expected["variance"], 2)
+            self.assertEqual(computed.pop("shots", 0), expected["shots"])
 
     @data(
         (

--- a/test/python/algorithms/utils/__init__.py
+++ b/test/python/algorithms/utils/__init__.py
@@ -1,0 +1,11 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.

--- a/test/python/algorithms/utils/test_validate_bounds.py
+++ b/test/python/algorithms/utils/test_validate_bounds.py
@@ -23,7 +23,7 @@ from qiskit.utils import algorithm_globals
 
 
 class TestValidateBounds(QiskitAlgorithmsTestCase):
-    """Test the ``_validate_bounds`` utility function."""
+    """Test the ``validate_bounds`` utility function."""
 
     def setUp(self):
         super().setUp()

--- a/test/python/algorithms/utils/test_validate_bounds.py
+++ b/test/python/algorithms/utils/test_validate_bounds.py
@@ -18,7 +18,7 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from qiskit.algorithms.utils import _validate_bounds
+from qiskit.algorithms.utils import validate_bounds
 from qiskit.utils import algorithm_globals
 
 
@@ -35,14 +35,14 @@ class TestValidateBounds(QiskitAlgorithmsTestCase):
         """Test with no ansatz bounds."""
         self.ansatz.num_parameters = 1
         self.ansatz.parameter_bounds = None
-        bounds = _validate_bounds(self.ansatz)
+        bounds = validate_bounds(self.ansatz)
         self.assertEqual(bounds, [(None, None)])
 
     def test_with_ansatz_bounds(self):
         """Test with ansatz bounds."""
         self.ansatz.num_parameters = 1
         self.ansatz.parameter_bounds = self.bounds
-        bounds = _validate_bounds(self.ansatz)
+        bounds = validate_bounds(self.ansatz)
         self.assertEqual(bounds, self.bounds)
 
     def test_with_mismatched_num_params(self):
@@ -50,4 +50,4 @@ class TestValidateBounds(QiskitAlgorithmsTestCase):
         self.ansatz.num_parameters = 2
         self.ansatz.parameter_bounds = self.bounds
         with self.assertRaises(ValueError):
-            _ = _validate_bounds(self.ansatz)
+            _ = validate_bounds(self.ansatz)

--- a/test/python/algorithms/utils/test_validate_bounds.py
+++ b/test/python/algorithms/utils/test_validate_bounds.py
@@ -1,0 +1,53 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test validate bounds."""
+
+from test.python.algorithms import QiskitAlgorithmsTestCase
+
+from unittest.mock import Mock
+
+import numpy as np
+
+from qiskit.algorithms.utils import _validate_bounds
+from qiskit.utils import algorithm_globals
+
+
+class TestValidateBounds(QiskitAlgorithmsTestCase):
+    """Test the ``_validate_bounds`` utility function."""
+
+    def setUp(self):
+        super().setUp()
+        algorithm_globals.random_seed = 0
+        self.bounds = [(-np.pi / 2, np.pi / 2)]
+        self.ansatz = Mock()
+
+    def test_with_no_ansatz_bounds(self):
+        """Test with no ansatz bounds."""
+        self.ansatz.num_parameters = 1
+        self.ansatz.parameter_bounds = None
+        bounds = _validate_bounds(self.ansatz)
+        self.assertEqual(bounds, [(None, None)])
+
+    def test_with_ansatz_bounds(self):
+        """Test with ansatz bounds."""
+        self.ansatz.num_parameters = 1
+        self.ansatz.parameter_bounds = self.bounds
+        bounds = _validate_bounds(self.ansatz)
+        self.assertEqual(bounds, self.bounds)
+
+    def test_with_mismatched_num_params(self):
+        """Test with a mismatched number of parameters and bounds"""
+        self.ansatz.num_parameters = 2
+        self.ansatz.parameter_bounds = self.bounds
+        with self.assertRaises(ValueError):
+            _ = _validate_bounds(self.ansatz)

--- a/test/python/algorithms/utils/test_validate_initial_point.py
+++ b/test/python/algorithms/utils/test_validate_initial_point.py
@@ -34,17 +34,17 @@ class TestValidateInitialPoint(QiskitAlgorithmsTestCase):
     def test_with_no_initial_point_or_bounds(self):
         """Test with no user-defined initial point and no ansatz bounds."""
         self.ansatz.parameter_bounds = None
-        initial_point = _validate_initial_point(None, self.ansatz)
+        initial_point = validate_initial_point(None, self.ansatz)
         np.testing.assert_array_almost_equal(initial_point, [1.721111])
 
     def test_with_no_initial_point(self):
         """Test with no user-defined initial point with ansatz bounds."""
         self.ansatz.parameter_bounds = [(-np.pi / 2, np.pi / 2)]
-        initial_point = _validate_initial_point(None, self.ansatz)
+        initial_point = validate_initial_point(None, self.ansatz)
         np.testing.assert_array_almost_equal(initial_point, [0.430278])
 
     def test_with_mismatched_params(self):
         """Test with mistmatched parameters and bounds.."""
         self.ansatz.parameter_bounds = None
         with self.assertRaises(ValueError):
-            _ = _validate_initial_point([1.0, 2.0], self.ansatz)
+            _ = validate_initial_point([1.0, 2.0], self.ansatz)

--- a/test/python/algorithms/utils/test_validate_initial_point.py
+++ b/test/python/algorithms/utils/test_validate_initial_point.py
@@ -1,0 +1,50 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test validate initial point."""
+
+from test.python.algorithms import QiskitAlgorithmsTestCase
+
+from unittest.mock import Mock
+
+import numpy as np
+
+from qiskit.algorithms.utils import _validate_initial_point
+from qiskit.utils import algorithm_globals
+
+
+class TestValidateInitialPoint(QiskitAlgorithmsTestCase):
+    """Test the ``_validate_initial_point`` utility function."""
+
+    def setUp(self):
+        super().setUp()
+        algorithm_globals.random_seed = 0
+        self.ansatz = Mock()
+        self.ansatz.num_parameters = 1
+
+    def test_with_no_initial_point_or_bounds(self):
+        """Test with no user-defined initial point and no ansatz bounds."""
+        self.ansatz.parameter_bounds = None
+        initial_point = _validate_initial_point(None, self.ansatz)
+        np.testing.assert_array_almost_equal(initial_point, [1.721111])
+
+    def test_with_no_initial_point(self):
+        """Test with no user-defined initial point with ansatz bounds."""
+        self.ansatz.parameter_bounds = [(-np.pi / 2, np.pi / 2)]
+        initial_point = _validate_initial_point(None, self.ansatz)
+        np.testing.assert_array_almost_equal(initial_point, [0.430278])
+
+    def test_with_mismatched_params(self):
+        """Test with mistmatched parameters and bounds.."""
+        self.ansatz.parameter_bounds = None
+        with self.assertRaises(ValueError):
+            _ = _validate_initial_point([1.0, 2.0], self.ansatz)

--- a/test/python/algorithms/utils/test_validate_initial_point.py
+++ b/test/python/algorithms/utils/test_validate_initial_point.py
@@ -18,12 +18,12 @@ from unittest.mock import Mock
 
 import numpy as np
 
-from qiskit.algorithms.utils import _validate_initial_point
+from qiskit.algorithms.utils import validate_initial_point
 from qiskit.utils import algorithm_globals
 
 
 class TestValidateInitialPoint(QiskitAlgorithmsTestCase):
-    """Test the ``_validate_initial_point`` utility function."""
+    """Test the ``validate_initial_point`` utility function."""
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds a standard `VQE` implementation using an `Estimator` primitive.  Closes #8471.

A `SamplingVQE` implementation that takes a `Sampler` primitive is introduced in PR #8669.

### Details and comments

This fresh implementation lives in `qiskit/algorithms/minimum_eigensolvers`. The prior implementation may still be found in `qiskit/algorithms/minimum_eigen_solvers`.

The following elements have been removed:

* The final "eigenstate". To reproduce this one may use a `Sampler` and the optimal point from VQE outside the algorithm.
* ~~The callback from the energy evaluation.  Instead the callback should be attached to the optimizer which can allow to additionally evaluate the energy at the current point.~~ After discussing with @woodsp-ibm, I decided to add back the callback on VQE as this may be simpler for users. Callbacks are not universally supplied by all optimizers.
* The `setting` property and `print_settings` method. No other algorithm has these.
* All trivial getters and setters, just use public attributes instead (expect for `initial_point`, which requires it for the `VariationalAlgorithm` interface.
* `expectation` and `include_custom`. These are not required anymore when using an `Estimator`.

