### PR TITLE
Rename run_options to options

### DIFF
--- a/qiskit/algorithms/gradients/base_estimator_gradient.py
+++ b/qiskit/algorithms/gradients/base_estimator_gradient.py
@@ -175,6 +175,6 @@ class BaseEstimatorGradient(ABC):
         Returns:
             The updated run options.
         """
-        run_opts = copy(self._estimator.run_options)
+        run_opts = copy(self._estimator.options)
         run_opts.update_options(**run_options)
         return run_opts

--- a/qiskit/algorithms/gradients/base_sampler_gradient.py
+++ b/qiskit/algorithms/gradients/base_sampler_gradient.py
@@ -147,6 +147,6 @@ class BaseSamplerGradient(ABC):
         Returns:
             The updated run options.
         """
-        run_opts = copy(self._sampler.run_options)
+        run_opts = copy(self._sampler.options)
         run_opts.update_options(**run_options)
         return run_opts

--- a/qiskit/primitives/base_estimator.py
+++ b/qiskit/primitives/base_estimator.py
@@ -147,7 +147,7 @@ class BaseEstimator(ABC):
                 will be bound. Defaults to ``[circ.parameters for circ in circuits]``
                 The indexing is such that ``parameters[i, j]`` is the j-th formal parameter of
                 ``circuits[i]``.
-            options: runtime options.
+            options: Default options.
 
         Raises:
             QiskitError: For mismatch of circuits and parameters list.

--- a/qiskit/primitives/base_estimator.py
+++ b/qiskit/primitives/base_estimator.py
@@ -134,7 +134,7 @@ class BaseEstimator(ABC):
         circuits: Iterable[QuantumCircuit] | QuantumCircuit | None = None,
         observables: Iterable[SparsePauliOp] | SparsePauliOp | None = None,
         parameters: Iterable[Iterable[Parameter]] | None = None,
-        run_options: dict | None = None,
+        options: dict | None = None,
     ):
         """
         Creating an instance of an Estimator, or using one in a ``with`` context opens a session that
@@ -147,7 +147,7 @@ class BaseEstimator(ABC):
                 will be bound. Defaults to ``[circ.parameters for circ in circuits]``
                 The indexing is such that ``parameters[i, j]`` is the j-th formal parameter of
                 ``circuits[i]``.
-            run_options: runtime options.
+            options: runtime options.
 
         Raises:
             QiskitError: For mismatch of circuits and parameters list.
@@ -189,8 +189,8 @@ class BaseEstimator(ABC):
                         f"expected {circ.num_parameters}, actual {len(params)}."
                     )
         self._run_options = Options()
-        if run_options is not None:
-            self._run_options.update_options(**run_options)
+        if options is not None:
+            self._run_options.update_options(**options)
 
     def __new__(
         cls,
@@ -265,15 +265,15 @@ class BaseEstimator(ABC):
         return tuple(self._parameters)
 
     @property
-    def run_options(self) -> Options:
+    def options(self) -> Options:
         """Return options values for the estimator.
 
         Returns:
-            run_options
+            options
         """
         return self._run_options
 
-    def set_run_options(self, **fields) -> BaseEstimator:
+    def set_options(self, **fields) -> BaseEstimator:
         """Set options values for the estimator.
 
         Args:
@@ -409,7 +409,7 @@ class BaseEstimator(ABC):
                 f"The number of circuits is {len(self.observables)}, "
                 f"but the index {max(observables)} is given."
             )
-        run_opts = copy(self.run_options)
+        run_opts = copy(self.options)
         run_opts.update_options(**run_options)
 
         return self._call(
@@ -520,7 +520,7 @@ class BaseEstimator(ABC):
                     f"not match the number of qubits of the {i}-th observable "
                     f"({observable.num_qubits})."
                 )
-        run_opts = copy(self.run_options)
+        run_opts = copy(self.options)
         run_opts.update_options(**run_options)
 
         return self._run(

--- a/qiskit/primitives/base_sampler.py
+++ b/qiskit/primitives/base_sampler.py
@@ -119,14 +119,14 @@ class BaseSampler(ABC):
         self,
         circuits: Iterable[QuantumCircuit] | QuantumCircuit | None = None,
         parameters: Iterable[Iterable[Parameter]] | None = None,
-        run_options: dict | None = None,
+        options: dict | None = None,
     ):
         """
         Args:
             circuits: Quantum circuits to be executed.
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            run_options: Default runtime options.
+            options: Default runtime options.
 
         Raises:
             QiskitError: For mismatch of circuits and parameters list.
@@ -157,8 +157,8 @@ class BaseSampler(ABC):
                     f"and circuits ({len(self._circuits)})"
                 )
         self._run_options = Options()
-        if run_options is not None:
-            self._run_options.update_options(**run_options)
+        if options is not None:
+            self._run_options.update_options(**options)
 
     def __new__(
         cls,
@@ -216,15 +216,15 @@ class BaseSampler(ABC):
         return tuple(self._parameters)
 
     @property
-    def run_options(self) -> Options:
+    def options(self) -> Options:
         """Return options values for the estimator.
 
         Returns:
-            run_options
+            options
         """
         return self._run_options
 
-    def set_run_options(self, **fields) -> BaseSampler:
+    def set_options(self, **fields):
         """Set options values for the estimator.
 
         Args:
@@ -308,7 +308,7 @@ class BaseSampler(ABC):
                 f"The number of circuits is {len(self.circuits)}, "
                 f"but the index {max(circuits)} is given."
             )
-        run_opts = copy(self.run_options)
+        run_opts = copy(self.options)
         run_opts.update_options(**run_options)
 
         return self._call(
@@ -383,7 +383,7 @@ class BaseSampler(ABC):
                     f"The number of values ({len(parameter_value)}) does not match "
                     f"the number of parameters ({circuit.num_parameters}) for the {i}-th circuit."
                 )
-        run_opts = copy(self.run_options)
+        run_opts = copy(self.options)
         run_opts.update_options(**run_options)
 
         return self._run(

--- a/qiskit/primitives/base_sampler.py
+++ b/qiskit/primitives/base_sampler.py
@@ -127,7 +127,7 @@ class BaseSampler(ABC):
             circuits: Quantum circuits to be executed.
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            options: Default runtime options.
+            options: Default options.
 
         Raises:
             QiskitError: For mismatch of circuits and parameters list.

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -54,7 +54,7 @@ class Estimator(BaseEstimator):
         circuits: QuantumCircuit | Iterable[QuantumCircuit] | None = None,
         observables: BaseOperator | PauliSumOp | Iterable[BaseOperator | PauliSumOp] | None = None,
         parameters: Iterable[Iterable[Parameter]] | None = None,
-        run_options: dict | None = None,
+        options: dict | None = None,
     ):
         """
         Args:
@@ -62,7 +62,7 @@ class Estimator(BaseEstimator):
             observables: observables to be estimated.
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            run_options: Default runtime options.
+            options: Default runtime options.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.
@@ -81,7 +81,7 @@ class Estimator(BaseEstimator):
             circuits=circuits,
             observables=observables,  # type: ignore
             parameters=parameters,
-            run_options=run_options,
+            options=options,
         )
         self._is_closed = False
 

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -62,7 +62,7 @@ class Estimator(BaseEstimator):
             observables: observables to be estimated.
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            options: Default runtime options.
+            options: Default options.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -60,7 +60,7 @@ class Sampler(BaseSampler):
             circuits: circuits to be executed
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            options: Default runtime options.
+            options: Default options.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -53,14 +53,14 @@ class Sampler(BaseSampler):
         self,
         circuits: QuantumCircuit | Iterable[QuantumCircuit] | None = None,
         parameters: Iterable[Iterable[Parameter]] | None = None,
-        run_options: dict | None = None,
+        options: dict | None = None,
     ):
         """
         Args:
             circuits: circuits to be executed
             parameters: Parameters of each of the quantum circuits.
                 Defaults to ``[circ.parameters for circ in circuits]``.
-            run_options: Default runtime options.
+            options: Default runtime options.
 
         Raises:
             QiskitError: if some classical bits are not used for measurements.
@@ -76,7 +76,7 @@ class Sampler(BaseSampler):
                 preprocessed_circuits.append(circuit)
         else:
             preprocessed_circuits = None
-        super().__init__(preprocessed_circuits, parameters, run_options)
+        super().__init__(preprocessed_circuits, parameters, options)
         self._is_closed = False
 
     def _call(

--- a/test/python/algorithms/test_estimator_gradient.py
+++ b/test/python/algorithms/test_estimator_gradient.py
@@ -30,7 +30,7 @@ from qiskit.circuit import Parameter
 from qiskit.circuit.library import EfficientSU2, RealAmplitudes
 from qiskit.circuit.library.standard_gates import RXXGate, RYYGate, RZXGate, RZZGate
 from qiskit.primitives import Estimator
-from qiskit.quantum_info import SparsePauliOp, Operator
+from qiskit.quantum_info import Operator, SparsePauliOp
 from qiskit.quantum_info.random import random_pauli_list
 from qiskit.test import QiskitTestCase
 
@@ -382,13 +382,13 @@ class TestEstimatorGradient(QiskitTestCase):
             SPSAEstimatorGradient,
         ],
     )
-    def test_run_options(self, grad):
+    def test_options(self, grad):
         """Test estimator gradient's run options"""
         a = Parameter("a")
         qc = QuantumCircuit(1)
         qc.rx(a, 0)
         op = SparsePauliOp.from_list([("Z", 1)])
-        estimator = Estimator(run_options={"shots": 100})
+        estimator = Estimator(options={"shots": 100})
         with self.subTest("estimator"):
             if grad is FiniteDiffEstimatorGradient or grad is SPSAEstimatorGradient:
                 gradient = grad(estimator, epsilon=1e-6)

--- a/test/python/algorithms/test_sampler_gradient.py
+++ b/test/python/algorithms/test_sampler_gradient.py
@@ -521,7 +521,7 @@ class TestSamplerGradient(QiskitTestCase):
         qc = QuantumCircuit(1)
         qc.rx(a, 0)
         qc.measure_all()
-        sampler = Sampler(run_options={"shots": 100})
+        sampler = Sampler(options={"shots": 100})
         with self.subTest("sampler"):
             if grad is FiniteDiffSamplerGradient or grad is SPSASamplerGradient:
                 gradient = grad(sampler, epsilon=1e-6)

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -568,15 +568,15 @@ class TestEstimator(QiskitTestCase):
         self.assertIsInstance(result, EstimatorResult)
         np.testing.assert_allclose(result.values, [-1.307397243478641])
 
-    def test_run_options(self):
-        """Test for run_options"""
+    def test_options(self):
+        """Test for options"""
         with self.subTest("init"):
-            estimator = Estimator(run_options={"shots": 3000})
-            self.assertEqual(estimator.run_options.get("shots"), 3000)
-        with self.subTest("set_run_options"):
-            estimator.set_run_options(shots=1024, seed=15)
-            self.assertEqual(estimator.run_options.get("shots"), 1024)
-            self.assertEqual(estimator.run_options.get("seed"), 15)
+            estimator = Estimator(options={"shots": 3000})
+            self.assertEqual(estimator.options.get("shots"), 3000)
+        with self.subTest("set_options"):
+            estimator.set_options(shots=1024, seed=15)
+            self.assertEqual(estimator.options.get("shots"), 1024)
+            self.assertEqual(estimator.options.get("seed"), 15)
         with self.subTest("run"):
             result = estimator.run(
                 [self.ansatz],

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -658,15 +658,15 @@ class TestSampler(QiskitTestCase):
         job = sampler.run(circuits=[bell])
         self.assertEqual(job.status(), JobStatus.DONE)
 
-    def test_run_options(self):
-        """Test for run_options"""
+    def test_options(self):
+        """Test for options"""
         with self.subTest("init"):
-            sampler = Sampler(run_options={"shots": 3000})
-            self.assertEqual(sampler.run_options.get("shots"), 3000)
-        with self.subTest("set_run_options"):
-            sampler.set_run_options(shots=1024, seed=15)
-            self.assertEqual(sampler.run_options.get("shots"), 1024)
-            self.assertEqual(sampler.run_options.get("seed"), 15)
+            sampler = Sampler(options={"shots": 3000})
+            self.assertEqual(sampler.options.get("shots"), 3000)
+        with self.subTest("set_options"):
+            sampler.set_options(shots=1024, seed=15)
+            self.assertEqual(sampler.options.get("shots"), 1024)
+            self.assertEqual(sampler.options.get("seed"), 15)
         with self.subTest("run"):
             params, target = self._generate_params_target([1])
             result = sampler.run([self._pqc], parameter_values=params).result()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

@jyu00 requested renaming `run_options` to `options` for consistency with `qiskit-ibm-runtime`.

### Details and comments


