### PR TITLE
feat: support sum(LinearMixin)

### DIFF
--- a/qiskit/quantum_info/operators/mixins/linear.py
+++ b/qiskit/quantum_info/operators/mixins/linear.py
@@ -38,12 +38,28 @@ class LinearMixin(MultiplyMixin, ABC):
     """
 
     def __add__(self, other):
+        # enable easy use of sum(...)
+        if not isinstance(other, type(self)) and other == 0:
+            return self
+
+        qargs = getattr(other, "qargs", None)
+        return self._add(other, qargs=qargs)
+
+    def __radd__(self, other):
+        # enable easy use of sum(...)
+        if not isinstance(other, type(self)) and other == 0:
+            return self
+
         qargs = getattr(other, "qargs", None)
         return self._add(other, qargs=qargs)
 
     def __sub__(self, other):
         qargs = getattr(other, "qargs", None)
         return self._add(-other, qargs=qargs)
+
+    def __rsub__(self, other):
+        qargs = getattr(other, "qargs", None)
+        return (-self)._add(other, qargs=qargs)
 
     @abstractmethod
     def _add(self, other, qargs=None):

--- a/releasenotes/notes/base-operators-sums-d331e78a9fa4b5d8.yaml
+++ b/releasenotes/notes/base-operators-sums-d331e78a9fa4b5d8.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    ``BaseOperator`` subclasses (like ScalarOp, SparsePauliOp and PauliList) can now be used with ``sum(...)``

--- a/releasenotes/notes/base-operators-sums-d331e78a9fa4b5d8.yaml
+++ b/releasenotes/notes/base-operators-sums-d331e78a9fa4b5d8.yaml
@@ -1,4 +1,5 @@
 ---
 features:
   - |
-    ``BaseOperator`` subclasses (like ScalarOp, SparsePauliOp and PauliList) can now be used with ``sum(...)``
+    ``qiskit.quantum_info.BaseOperator`` subclasses (like :class:`.ScalarOp`,
+    :class:`.SparsePauliOp` and :class:`.PauliList`) can now be used with ``sum``.

--- a/test/python/quantum_info/operators/test_scalar_op.py
+++ b/test/python/quantum_info/operators/test_scalar_op.py
@@ -168,6 +168,27 @@ class TestScalarOpLinearMethods(ScalarOpTestCase):
         target = coeff1 + coeff2
         self.assertScalarOp(val, dims, target)
 
+    @combine(coeff1=[0, 1, -3.1, 1 + 3j])
+    def test_radd(self, coeff1):
+        """Test right-side addition with ScalarOp."""
+        dims = (3, 2)
+        op1 = ScalarOp(dims, coeff=coeff1)
+
+        val = op1 + 0
+        self.assertScalarOp(val, dims, coeff1)
+
+    @combine(coeff1=[0, 1, -3.1, 1 + 3j], coeff2=[-1, -5.1 - 2j])
+    def test_sum(self, coeff1, coeff2):
+        """Test add operation with ScalarOp. ({coeff1} + {coeff2})"""
+        # Add two ScalarOps
+        dims = (3, 2)
+        op1 = ScalarOp(dims, coeff=coeff1)
+        op2 = ScalarOp(6, coeff=coeff2)
+
+        val = sum([op1, op2])
+        target = coeff1 + coeff2
+        self.assertScalarOp(val, dims, target)
+
     @combine(coeff1=[0, 1, -3.1, 1 + 3j], coeff2=[-1, -5.1 - 2j])
     def test_subtract(self, coeff1, coeff2):
         """Test add operation with ScalarOp. ({coeff1} - {coeff2})"""
@@ -176,6 +197,17 @@ class TestScalarOpLinearMethods(ScalarOpTestCase):
         op2 = ScalarOp(6, coeff=coeff2)
 
         val = op1 - op2
+        target = coeff1 - coeff2
+        self.assertScalarOp(val, dims, target)
+
+    @combine(coeff1=[0, 1, -3.1, 1 + 3j], coeff2=[-1, -5.1 - 2j])
+    def test_rsub(self, coeff1, coeff2):
+        """Test right-side subtraction with ScalarOp."""
+        dims = (3, 2)
+        op1 = ScalarOp(dims, coeff=coeff1)
+        op2 = ScalarOp(dims, coeff=coeff2)
+
+        val = op2.__rsub__(op1)
         target = coeff1 - coeff2
         self.assertScalarOp(val, dims, target)
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This enables the use of `sum(...)` for subclasses of the `LinearMixin` class. It also adds the reflective operand dunder methods `__radd__` and `__rsub__`.


### Details and comments

Since this is not part of the publicly documented API, I did not add a reno.