### PR TITLE
Fix OpenQASM 3 built-ins with classical conditions

### DIFF
--- a/releasenotes/notes/qasm3-fix-conditional-measurement-2d938cad74a9024a.yaml
+++ b/releasenotes/notes/qasm3-fix-conditional-measurement-2d938cad74a9024a.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The OpenQASM 3 exporter (:mod:`qiskit.qasm3`) will now correctly handle
+    OpenQASM built-ins (such as ``reset`` and ``measure``) that have a classical
+    condition applied by :meth:`~.InstructionSet.c_if`.  Previously the condition
+    would have been ignored.


### PR DESCRIPTION
### Summary

The `.condition` attribute for `Instruction` instances corresponding to OpenQASM 3 built-ins (such as `reset` and `measure`) would previously be ignored.  This now correctly nests them inside a a branching statement in the exporter, so the condition is preserved.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #8730.