### PR TITLE
Cap stestr version in CI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ black[jupyter]~=22.0
 pydot
 astroid==2.5.6
 pylint==2.8.3
-stestr>=2.0.0
+stestr>=2.0.0,<4.0.0
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

After the recent release of stestr 4.0.0 CI started failing in a weird unexpected way 100% of the time. It's not clear why the failure started and I'm unable to reproduce it locally (which is part of why I pushed stestr 4.0.0, I did test that I passed tests locally before releasing). To try and unblock CI this commit caps the stestr version we install in CI to see if this fixes the failure and potentially unblock CI.

### Details and comments


