### PR TITLE
add controlflow handling to Layout2qDistance transpiler pass

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -34,7 +34,6 @@ from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameterexpression import ParameterExpression
-from qiskit.circuit.controlflow import ControlFlowOp
 from qiskit.dagcircuit.exceptions import DAGCircuitError
 from qiskit.dagcircuit.dagnode import DAGNode, DAGOpNode, DAGInNode, DAGOutNode
 from qiskit.utils import optionals as _optionals
@@ -1438,10 +1437,6 @@ class DAGCircuit:
             if len(node.qargs) >= 3:
                 ops.append(node)
         return ops
-
-    def control_flow_ops(self):
-        """return control flow operations"""
-        return self.op_nodes(op=ControlFlowOp)
 
     def longest_path(self):
         """Returns the longest path in the dag as a list of DAGOpNodes, DAGInNodes, and DAGOutNodes."""

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -34,6 +34,7 @@ from qiskit.circuit.classicalregister import ClassicalRegister, Clbit
 from qiskit.circuit.gate import Gate
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameterexpression import ParameterExpression
+from qiskit.circuit.controlflow import ControlFlowOp
 from qiskit.dagcircuit.exceptions import DAGCircuitError
 from qiskit.dagcircuit.dagnode import DAGNode, DAGOpNode, DAGInNode, DAGOutNode
 from qiskit.utils import optionals as _optionals
@@ -1437,6 +1438,10 @@ class DAGCircuit:
             if len(node.qargs) >= 3:
                 ops.append(node)
         return ops
+
+    def control_flow_ops(self):
+        """return control flow operations"""
+        return self.op_nodes(op=ControlFlowOp)
 
     def longest_path(self):
         """Returns the longest path in the dag as a list of DAGOpNodes, DAGInNodes, and DAGOutNodes."""

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -18,9 +18,11 @@ The lower the number, the better the selection.
 Therefore, 0 is a perfect layout selection.
 """
 
+import math
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.converters import circuit_to_dag
 from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp
+from qiskit.circuit.controlflow import ControlFlowOp
 
 
 class Layout2qDistance(AnalysisPass):
@@ -67,47 +69,36 @@ class Layout2qDistance(AnalysisPass):
 
         virtual_physical_map = layout.get_virtual_bits()
         dist_matrix = self.coupling_map.distance_matrix
-        breakpoint()
         for gate in dag.two_qubit_ops():
             physical_q0 = virtual_physical_map[gate.qargs[0]]
             physical_q1 = virtual_physical_map[gate.qargs[1]]
 
             sum_distance += dist_matrix[physical_q0, physical_q1] - 1
-        for node in dag.control_flow_ops():
+        for node in dag.op_nodes(op=ControlFlowOp):
             sum_distance += self._control_flow_2q_distance(node.op)
 
         self.property_set[self.property_name] = sum_distance
-
 
     def _control_flow_2q_distance(self, cfop):
         distance = 0
         if self.weight_loops:
             if isinstance(cfop, IfElseOp):
                 for block in cfop.blocks:
-                    _pass = Layout2qDistance(self.coupling_map,
-                                             property_name=self.property_name)
                     dag_block = circuit_to_dag(block)
-                    _pass.run(dag_block)
-                    breakpoint()
-                    distance += _pass.property_set[self.property_name]
+                    self.run(dag_block)
+                    distance += self.property_set[self.property_name]
             elif isinstance(cfop, ForLoopOp):
                 index_set, _, block = cfop.params
-                _pass = Layout2qDistance(self.coupling_map,
-                                         property_name=self.property_name)
                 dag_block = circuit_to_dag(block)
-                _pass.run(dag_block)
-                distance += len(index_set) * _pass.property_set[self.property_name]
+                self.run(dag_block)
+                distance += len(index_set) * self.property_set[self.property_name]
             elif isinstance(cfop, WhileLoopOp):
                 body = cfop.blocks[0]
                 if body.num_nonlocal_gates():
                     # Indeterminate number of loops so indeterminate 2q distance
-                    import math
                     distance = math.nan
         else:
             for block in cfop.blocks:
-                _pass = Layout2qDistance(self.coupling_map,
-                                         property_name=self.property_name)
                 dag_block = circuit_to_dag(block)
-                _pass.run(dag_block)
+                self.run(dag_block)
         return distance
-        

--- a/qiskit/transpiler/passes/layout/layout_2q_distance.py
+++ b/qiskit/transpiler/passes/layout/layout_2q_distance.py
@@ -19,6 +19,8 @@ Therefore, 0 is a perfect layout selection.
 """
 
 from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.converters import circuit_to_dag
+from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp
 
 
 class Layout2qDistance(AnalysisPass):
@@ -30,16 +32,19 @@ class Layout2qDistance(AnalysisPass):
     No CX direction is considered.
     """
 
-    def __init__(self, coupling_map, property_name="layout_score"):
+    def __init__(self, coupling_map, property_name="layout_score", weight_loops=True):
         """Layout2qDistance initializer.
 
         Args:
             coupling_map (CouplingMap): Directed graph represented a coupling map.
             property_name (str): The property name to save the score. Default: layout_score
+            weight_loops (bool): Whether to weight 2q distance of loops by number of loops. If
+               while loop exists the returned distance will be NaN.
         """
         super().__init__()
         self.coupling_map = coupling_map
         self.property_name = property_name
+        self.weight_loops = weight_loops
 
     def run(self, dag):
         """
@@ -62,10 +67,47 @@ class Layout2qDistance(AnalysisPass):
 
         virtual_physical_map = layout.get_virtual_bits()
         dist_matrix = self.coupling_map.distance_matrix
+        breakpoint()
         for gate in dag.two_qubit_ops():
             physical_q0 = virtual_physical_map[gate.qargs[0]]
             physical_q1 = virtual_physical_map[gate.qargs[1]]
 
             sum_distance += dist_matrix[physical_q0, physical_q1] - 1
+        for node in dag.control_flow_ops():
+            sum_distance += self._control_flow_2q_distance(node.op)
 
         self.property_set[self.property_name] = sum_distance
+
+
+    def _control_flow_2q_distance(self, cfop):
+        distance = 0
+        if self.weight_loops:
+            if isinstance(cfop, IfElseOp):
+                for block in cfop.blocks:
+                    _pass = Layout2qDistance(self.coupling_map,
+                                             property_name=self.property_name)
+                    dag_block = circuit_to_dag(block)
+                    _pass.run(dag_block)
+                    breakpoint()
+                    distance += _pass.property_set[self.property_name]
+            elif isinstance(cfop, ForLoopOp):
+                index_set, _, block = cfop.params
+                _pass = Layout2qDistance(self.coupling_map,
+                                         property_name=self.property_name)
+                dag_block = circuit_to_dag(block)
+                _pass.run(dag_block)
+                distance += len(index_set) * _pass.property_set[self.property_name]
+            elif isinstance(cfop, WhileLoopOp):
+                body = cfop.blocks[0]
+                if body.num_nonlocal_gates():
+                    # Indeterminate number of loops so indeterminate 2q distance
+                    import math
+                    distance = math.nan
+        else:
+            for block in cfop.blocks:
+                _pass = Layout2qDistance(self.coupling_map,
+                                         property_name=self.property_name)
+                dag_block = circuit_to_dag(block)
+                _pass.run(dag_block)
+        return distance
+        

--- a/test/python/transpiler/test_layout_score.py
+++ b/test/python/transpiler/test_layout_score.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from qiskit import QuantumRegister, QuantumCircuit
+from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler.passes import Layout2qDistance
 from qiskit.transpiler import CouplingMap, Layout
 from qiskit.converters import circuit_to_dag
@@ -101,6 +101,27 @@ class TestTrivialLayoutScore(QiskitTestCase):
 
         self.assertEqual(pass_.property_set["layout_score"], 1)
 
+    def test_control_flow_if_else(self):
+        """Circuit with control flow if else blocks"""
+        qr = QuantumRegister(4)
+        cr = ClassicalRegister(4)
+        circuit = QuantumCircuit(qr, cr)
+        true_body = QuantumCircuit(qr, cr)
+        false_body = QuantumCircuit(qr, cr)
+        true_body.cx(0, 2)
+        false_body.cx(0, 2)
+        false_body.cx(0, 3)
+        circuit.h(qr)
+        circuit.cx(0, 2)
+        circuit.if_else((cr, 0), true_body, false_body, qr, cr)
+        coupling = CouplingMap([[0, 1], [1, 2], [2, 3]])
+        layout = Layout().generate_trivial_layout(qr)
+        dag = circuit_to_dag(circuit)
+        pass_ = Layout2qDistance(coupling)
+        pass_.property_set["layout"] = layout
+        pass_.run(dag)
+        breakpoint()
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/transpiler/test_layout_score.py
+++ b/test/python/transpiler/test_layout_score.py
@@ -13,7 +13,7 @@
 """Test the Layout Score pass"""
 
 import unittest
-
+import math
 from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
 from qiskit.transpiler.passes import Layout2qDistance
 from qiskit.transpiler import CouplingMap, Layout
@@ -120,8 +120,45 @@ class TestTrivialLayoutScore(QiskitTestCase):
         pass_ = Layout2qDistance(coupling)
         pass_.property_set["layout"] = layout
         pass_.run(dag)
-        breakpoint()
-        
+        self.assertEqual(pass_.property_set["layout_score"], 5)
+
+    def test_control_flow_for_loop(self):
+        """Circuit with control flow for loop"""
+        nloops = 5
+        qr = QuantumRegister(4)
+        cr = ClassicalRegister(4)
+        circuit = QuantumCircuit(qr, cr)
+        body = QuantumCircuit(qr, cr)
+        body.cx(0, 3)
+        circuit.h(qr)
+        circuit.cx(0, 2)
+        circuit.for_loop(range(nloops), None, body, qr, cr)
+        coupling = CouplingMap([[0, 1], [1, 2], [2, 3]])
+        layout = Layout().generate_trivial_layout(qr)
+        dag = circuit_to_dag(circuit)
+        pass_ = Layout2qDistance(coupling)
+        pass_.property_set["layout"] = layout
+        pass_.run(dag)
+        self.assertEqual(pass_.property_set["layout_score"], 11)
+
+    def test_control_flow_while_loop(self):
+        """Circuit with control flow while loop"""
+        qr = QuantumRegister(4)
+        cr = ClassicalRegister(4)
+        circuit = QuantumCircuit(qr, cr)
+        body = QuantumCircuit(qr, cr)
+        body.cx(0, 3)
+        circuit.h(qr)
+        circuit.cx(0, 2)
+        circuit.while_loop((cr, 0), body, qr, cr)
+        coupling = CouplingMap([[0, 1], [1, 2], [2, 3]])
+        layout = Layout().generate_trivial_layout(qr)
+        dag = circuit_to_dag(circuit)
+        pass_ = Layout2qDistance(coupling)
+        pass_.property_set["layout"] = layout
+        pass_.run(dag)
+        self.assertTrue(math.isnan(pass_.property_set["layout_score"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This pr adds controlflow handling to the Layout2qDistance transpiler pass.


### Details and comments
This implementation adds an init parameter `weight_loops` to indicate whether the number of blocks/loops should contribute to the overall 2q layout score. If True for while loops, NaN is returned.

