### PR TITLE
Fix QuantumCircuit.draw without matplotlib installed

### DIFF
--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -244,7 +244,6 @@ from .array import array_to_latex
 
 from .circuit import circuit_drawer
 from .counts_visualization import plot_histogram
-from .bloch import Bloch, Arrow3D
 from .state_visualization import (
     plot_state_hinton,
     plot_bloch_vector,


### PR DESCRIPTION
### Summary

A recent change to the structure of the visualisation module in #8306 caused `matplotlib` to be eagerly imported when `qiskit.visualization` was imported, since the internal `bloch` module was imported in the `__init__`.  This means that `QuantumCircuit.draw()` in text mode had ceased working without the visualisation extra installed.

This module doesn't really need to be eagerly imported, and it's faffy to refactor it all to use lazy imports.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I've seen a couple of CI failures in the QPY backwards-compatibility tests seemingly caused by this.  It's odd they didn't prevent the initial merge, but maybe some internal dependencies re-organised themselves around the same time.