### PR TITLE
Lift trivial transpiler passes to handle control flow

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
+++ b/qiskit/transpiler/passes/basis/unroll_3q_or_more.py
@@ -13,7 +13,9 @@
 """Recursively expands 3q+ gates until the circuit only contains 2q or 1q gates."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.exceptions import QiskitError
+from qiskit.circuit import ControlFlowOp
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 
 
@@ -61,6 +63,10 @@ class Unroll3qOrMore(TransformationPass):
                 if node.name in self.target:
                     continue
             elif self.basis_gates is not None and node.name in self.basis_gates:
+                continue
+
+            if isinstance(node.op, ControlFlowOp):
+                node.op = control_flow.map_blocks(self.run, node.op)
                 continue
 
             # TODO: allow choosing other possible decompositions

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -14,7 +14,8 @@
 
 from qiskit.exceptions import QiskitError
 from qiskit.transpiler.basepasses import TransformationPass
-from qiskit.circuit import ControlledGate
+from qiskit.transpiler.passes.utils import control_flow
+from qiskit.circuit import ControlledGate, ControlFlowOp
 from qiskit.converters.circuit_to_dag import circuit_to_dag
 
 
@@ -56,6 +57,9 @@ class UnrollCustomDefinitions(TransformationPass):
         device_insts = basic_insts | set(self._basis_gates)
 
         for node in dag.op_nodes():
+            if isinstance(node.op, ControlFlowOp):
+                node.op = control_flow.map_blocks(self.run, node.op)
+                continue
 
             if getattr(node.op, "_directive", False):
                 continue

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -13,10 +13,10 @@
 """Unroll a circuit to a given basis."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.exceptions import QiskitError
 from qiskit.circuit import ControlledGate, ControlFlowOp
 from qiskit.converters.circuit_to_dag import circuit_to_dag
-from qiskit.converters.dag_to_circuit import dag_to_circuit
 
 
 class Unroller(TransformationPass):
@@ -70,14 +70,9 @@ class Unroller(TransformationPass):
                     continue
 
             if isinstance(node.op, ControlFlowOp):
-                unrolled_blocks = []
-                for block in node.op.blocks:
-                    dag_block = circuit_to_dag(block)
-                    unrolled_dag_block = self.run(dag_block)
-                    unrolled_circ_block = dag_to_circuit(unrolled_dag_block)
-                    unrolled_blocks.append(unrolled_circ_block)
-                node.op = node.op.replace_blocks(unrolled_blocks)
+                node.op = control_flow.map_blocks(self.run, node.op)
                 continue
+
             try:
                 phase = node.op.definition.global_phase
                 rule = node.op.definition.data

--- a/qiskit/transpiler/passes/optimization/collect_linear_functions.py
+++ b/qiskit/transpiler/passes/optimization/collect_linear_functions.py
@@ -16,6 +16,7 @@
 from collections import deque
 from qiskit.circuit.library.generalized_gates import LinearFunction
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.circuit import QuantumCircuit
 from qiskit.dagcircuit import DAGOpNode
 
@@ -131,6 +132,7 @@ class CollectLinearFunctions(TransformationPass):
     """Collect blocks of linear gates (:class:`.CXGate` and :class:`.SwapGate` gates)
     and replaces them by linear functions (:class:`.LinearFunction`)."""
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the CollectLinearFunctions pass on `dag`.
 

--- a/qiskit/transpiler/passes/optimization/cx_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/cx_cancellation.py
@@ -13,11 +13,13 @@
 """Cancel back-to-back `cx` gates in dag."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 
 
 class CXCancellation(TransformationPass):
     """Cancel back-to-back `cx` gates in dag."""
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the CXCancellation pass on `dag`.
 

--- a/qiskit/transpiler/passes/optimization/optimize_cliffords.py
+++ b/qiskit/transpiler/passes/optimization/optimize_cliffords.py
@@ -13,6 +13,7 @@
 """Combine consecutive Cliffords over the same qubits."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.quantum_info.operators import Clifford
 
 
@@ -22,6 +23,7 @@ class OptimizeCliffords(TransformationPass):
     Cliffords natively on the circuit.
     """
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the OptimizeCliffords pass on `dag`.
 

--- a/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/optimize_swap_before_measure.py
@@ -16,6 +16,7 @@
 from qiskit.circuit import Measure
 from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode, DAGOutNode
 
 
@@ -26,6 +27,7 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
     the classical bit of the measure instruction.
     """
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the OptimizeSwapBeforeMeasure pass on `dag`.
 
@@ -35,6 +37,7 @@ class OptimizeSwapBeforeMeasure(TransformationPass):
         Returns:
             DAGCircuit: the optimized DAG.
         """
+
         swaps = dag.op_nodes(SwapGate)
         for swap in swaps[::-1]:
             if getattr(swap.op, "condition", None) is not None:

--- a/qiskit/transpiler/passes/optimization/remove_diagonal_gates_before_measure.py
+++ b/qiskit/transpiler/passes/optimization/remove_diagonal_gates_before_measure.py
@@ -28,6 +28,7 @@ from qiskit.circuit.library.standard_gates import (
 )
 from qiskit.dagcircuit import DAGOpNode
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 
 
 class RemoveDiagonalGatesBeforeMeasure(TransformationPass):
@@ -37,6 +38,7 @@ class RemoveDiagonalGatesBeforeMeasure(TransformationPass):
     a measurement. Including diagonal 2Q gates.
     """
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the RemoveDiagonalGatesBeforeMeasure pass on `dag`.
 

--- a/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
+++ b/qiskit/transpiler/passes/optimization/reset_after_measure_simplification.py
@@ -13,6 +13,7 @@
 """Replace resets after measure with a conditional XGate."""
 
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 from qiskit.circuit.library.standard_gates.x import XGate
 from qiskit.circuit.reset import Reset
 from qiskit.circuit.measure import Measure
@@ -29,6 +30,7 @@ class ResetAfterMeasureSimplification(TransformationPass):
     differently.
     """
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the pass on a dag."""
         for node in dag.op_nodes(Measure):

--- a/qiskit/transpiler/passes/utils/__init__.py
+++ b/qiskit/transpiler/passes/utils/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Utility passes used for other main passes."""
+"""Utility passes and functions used for other main passes."""
 
 from .check_map import CheckMap
 from .check_cx_direction import CheckCXDirection  # Deprecated
@@ -26,3 +26,6 @@ from .error import Error
 from .remove_barriers import RemoveBarriers
 from .contains_instruction import ContainsInstruction
 from .gates_basis import GatesInBasis
+
+# Utility functions
+from . import control_flow

--- a/qiskit/transpiler/passes/utils/control_flow.py
+++ b/qiskit/transpiler/passes/utils/control_flow.py
@@ -1,0 +1,58 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Internal utilities for working with control-flow operations."""
+
+import functools
+from typing import Callable
+
+from qiskit.circuit import ControlFlowOp
+from qiskit.converters import circuit_to_dag, dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit
+
+
+def map_blocks(dag_mapping: Callable[[DAGCircuit], DAGCircuit], op: ControlFlowOp) -> ControlFlowOp:
+    """Use the ``dag_mapping`` function to replace the blocks of a :class:`.ControlFlowOp` with new
+    ones.  Each block will be automatically converted to a :class:`.DAGCircuit` and then returned
+    to a :class:`.QuantumCircuit`."""
+    return op.replace_blocks(
+        [dag_to_circuit(dag_mapping(circuit_to_dag(block))) for block in op.blocks]
+    )
+
+
+def trivial_recurse(method):
+    """Decorator that causes :class:`.BasePass.run` to iterate over all control-flow nodes,
+    replacing their operations with a new :class:`.ControlFlowOp` whose blocks have all had
+    :class`.BasePass.run` called on them.
+
+    This is only suitable for simple run calls that store no state between calls, do not need
+    circuit-specific information feeding into them (such as via a :class:`.PropertySet`), and will
+    safely do nothing to control-flow operations that are in the DAG.
+
+    If slightly finer control is needed on when the control-flow operations are modified, one can
+    use :func:`map_blocks` as::
+
+        if isinstance(node.op, ControlFlowOp):
+            node.op = map_blocks(self.run, node.op)
+
+    from with :meth:`.BasePass.run`."""
+
+    @functools.wraps(method)
+    def out(self, dag):
+        def bound_wrapped_method(dag):
+            return out(self, dag)
+
+        for node in dag.op_nodes(ControlFlowOp):
+            node.op = map_blocks(bound_wrapped_method, node.op)
+        return method(self, dag)
+
+    return out

--- a/qiskit/transpiler/passes/utils/remove_barriers.py
+++ b/qiskit/transpiler/passes/utils/remove_barriers.py
@@ -14,6 +14,7 @@
 
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.passes.utils import control_flow
 
 
 class RemoveBarriers(TransformationPass):
@@ -38,6 +39,7 @@ class RemoveBarriers(TransformationPass):
 
     """
 
+    @control_flow.trivial_recurse
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the RemoveBarriers pass on `dag`."""
 

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -13,6 +13,7 @@
 """Tests for pass cancelling 2 consecutive CNOTs on the same qubits."""
 
 from qiskit import QuantumRegister, QuantumCircuit
+from qiskit.circuit import Clbit, Qubit
 from qiskit.transpiler import PassManager
 from qiskit.transpiler.passes import CXCancellation
 from qiskit.test import QiskitTestCase
@@ -136,3 +137,56 @@ class TestCXCancellation(QiskitTestCase):
         pass_manager.append(CXCancellation())
         out_circuit = pass_manager.run(circuit)
         self.assertEqual(out_circuit, circuit)
+
+    def test_if_else(self):
+        """Test that the pass recurses in a simple if-else."""
+        pass_ = CXCancellation()
+
+        inner_test = QuantumCircuit(4, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(2, 3)
+
+        inner_expected = QuantumCircuit(4, 1)
+        inner_expected.cx(2, 3)
+
+        test = QuantumCircuit(4, 1)
+        test.h(0)
+        test.measure(0, 0)
+        test.if_else((0, True), inner_test.copy(), inner_test.copy(), range(4), [0])
+
+        expected = QuantumCircuit(4, 1)
+        expected.h(0)
+        expected.measure(0, 0)
+        expected.if_else((0, True), inner_expected, inner_expected, range(4), [0])
+
+        self.assertEqual(pass_(test), expected)
+
+    def test_nested_control_flow(self):
+        """Test that collection recurses into nested control flow."""
+        pass_ = CXCancellation()
+        qubits = [Qubit() for _ in [None] * 4]
+        clbit = Clbit()
+
+        inner_test = QuantumCircuit(qubits, [clbit])
+        inner_test.cx(0, 1)
+        inner_test.cx(0, 1)
+        inner_test.cx(2, 3)
+
+        inner_expected = QuantumCircuit(qubits, [clbit])
+        inner_expected.cx(2, 3)
+
+        true_body = QuantumCircuit(qubits, [clbit])
+        true_body.while_loop((clbit, True), inner_test.copy(), [0, 1, 2, 3], [0])
+
+        test = QuantumCircuit(qubits, [clbit])
+        test.for_loop(range(2), None, inner_test.copy(), [0, 1, 2, 3], [0])
+        test.if_else((clbit, True), true_body, None, [0, 1, 2, 3], [0])
+
+        expected_if_body = QuantumCircuit(qubits, [clbit])
+        expected_if_body.while_loop((clbit, True), inner_expected, [0, 1, 2, 3], [0])
+        expected = QuantumCircuit(qubits, [clbit])
+        expected.for_loop(range(2), None, inner_expected, [0, 1, 2, 3], [0])
+        expected.if_else((clbit, True), expected_if_body, None, [0, 1, 2, 3], [0])
+
+        self.assertEqual(pass_(test), expected)

--- a/test/python/transpiler/test_linear_functions_passes.py
+++ b/test/python/transpiler/test_linear_functions_passes.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumCircuit, Qubit, Clbit
 from qiskit.transpiler.passes.optimization import CollectLinearFunctions
 from qiskit.transpiler.passes.synthesis import (
     LinearFunctionsSynthesis,
@@ -328,6 +328,53 @@ class TestLinearFunctionsPasses(QiskitTestCase):
         self.assertEqual(circuit2.count_ops()["linear_function"], 1)
         self.assertNotIn("cx", circuit2.count_ops().keys())
         self.assertNotIn("swap", circuit2.count_ops().keys())
+
+    def test_if_else(self):
+        """Test that collection recurses into a simple if-else."""
+        pass_ = CollectLinearFunctions()
+
+        circuit = QuantumCircuit(4)
+        circuit.cx(0, 1)
+        circuit.cx(1, 0)
+        circuit.cx(2, 3)
+
+        test = QuantumCircuit(4, 1)
+        test.h(0)
+        test.measure(0, 0)
+        test.if_else((0, True), circuit.copy(), circuit.copy(), range(4), [0])
+
+        expected = QuantumCircuit(4, 1)
+        expected.h(0)
+        expected.measure(0, 0)
+        expected.if_else((0, True), pass_(circuit), pass_(circuit), range(4), [0])
+
+        self.assertEqual(pass_(test), expected)
+
+    def test_nested_control_flow(self):
+        """Test that collection recurses into nested control flow."""
+        pass_ = CollectLinearFunctions()
+        qubits = [Qubit() for _ in [None] * 4]
+        clbit = Clbit()
+
+        circuit = QuantumCircuit(qubits, [clbit])
+        circuit.cx(0, 1)
+        circuit.cx(1, 0)
+        circuit.cx(2, 3)
+
+        true_body = QuantumCircuit(qubits, [clbit])
+        true_body.while_loop((clbit, True), circuit.copy(), [0, 1, 2, 3], [0])
+
+        test = QuantumCircuit(qubits, [clbit])
+        test.for_loop(range(2), None, circuit.copy(), [0, 1, 2, 3], [0])
+        test.if_else((clbit, True), true_body, None, [0, 1, 2, 3], [0])
+
+        expected_if_body = QuantumCircuit(qubits, [clbit])
+        expected_if_body.while_loop((clbit, True), pass_(circuit), [0, 1, 2, 3], [0])
+        expected = QuantumCircuit(qubits, [clbit])
+        expected.for_loop(range(2), None, pass_(circuit), [0, 1, 2, 3], [0])
+        expected.if_else((clbit, True), pass_(expected_if_body), None, [0, 1, 2, 3], [0])
+
+        self.assertEqual(pass_(test), expected)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_optimize_swap_before_measure.py
+++ b/test/python/transpiler/test_optimize_swap_before_measure.py
@@ -160,6 +160,60 @@ class TestOptimizeSwapBeforeMeasure(QiskitTestCase):
 
         self.assertEqual(circuit_to_dag(circuit), after)
 
+    def test_if_else(self):
+        """Test that the pass recurses into a simple if-else."""
+        pass_ = OptimizeSwapBeforeMeasure()
+
+        base_test = QuantumCircuit(2, 1)
+        base_test.swap(0, 1)
+        base_test.measure(0, 0)
+
+        base_expected = QuantumCircuit(2, 1)
+        base_expected.measure(1, 0)
+
+        test = QuantumCircuit(2, 1)
+        test.if_else(
+            (test.clbits[0], True), base_test.copy(), base_test.copy(), test.qubits, test.clbits
+        )
+
+        expected = QuantumCircuit(2, 1)
+        expected.if_else(
+            (expected.clbits[0], True),
+            base_expected.copy(),
+            base_expected.copy(),
+            expected.qubits,
+            expected.clbits,
+        )
+
+        self.assertEqual(pass_(test), expected)
+
+    def test_nested_control_flow(self):
+        """Test that the pass recurses into nested control flow."""
+        pass_ = OptimizeSwapBeforeMeasure()
+
+        base_test = QuantumCircuit(2, 1)
+        base_test.swap(0, 1)
+        base_test.measure(0, 0)
+
+        base_expected = QuantumCircuit(2, 1)
+        base_expected.measure(1, 0)
+
+        body_test = QuantumCircuit(2, 1)
+        body_test.for_loop((0,), None, base_expected.copy(), body_test.qubits, [])
+
+        body_expected = QuantumCircuit(2, 1)
+        body_expected.for_loop((0,), None, base_expected.copy(), body_expected.qubits, [])
+
+        test = QuantumCircuit(2, 1)
+        test.while_loop((test.clbits[0], True), body_test, test.qubits, test.clbits)
+
+        expected = QuantumCircuit(2, 1)
+        expected.while_loop(
+            (expected.clbits[0], True), body_expected, expected.qubits, expected.clbits
+        )
+
+        self.assertEqual(pass_(test), expected)
+
 
 class TestOptimizeSwapBeforeMeasureFixedPoint(QiskitTestCase):
     """Test swap-followed-by-measure optimizations in a transpiler, using fixed point."""

--- a/test/python/transpiler/test_remove_barriers.py
+++ b/test/python/transpiler/test_remove_barriers.py
@@ -52,6 +52,60 @@ class TestMergeAdjacentBarriers(QiskitTestCase):
         for ii, name in enumerate(["x", "h"]):
             self.assertEqual(op_nodes[ii].name, name)
 
+    def test_simple_if_else(self):
+        """Test that the pass recurses into an if-else."""
+        pass_ = RemoveBarriers()
+
+        base_test = QuantumCircuit(1, 1)
+        base_test.barrier()
+        base_test.measure(0, 0)
+
+        base_expected = QuantumCircuit(1, 1)
+        base_expected.measure(0, 0)
+
+        test = QuantumCircuit(1, 1)
+        test.if_else(
+            (test.clbits[0], True), base_test.copy(), base_test.copy(), test.qubits, test.clbits
+        )
+
+        expected = QuantumCircuit(1, 1)
+        expected.if_else(
+            (expected.clbits[0], True),
+            base_expected.copy(),
+            base_expected.copy(),
+            expected.qubits,
+            expected.clbits,
+        )
+
+        self.assertEqual(pass_(test), expected)
+
+    def test_nested_control_flow(self):
+        """Test that the pass recurses into nested control flow."""
+        pass_ = RemoveBarriers()
+
+        base_test = QuantumCircuit(1, 1)
+        base_test.barrier()
+        base_test.measure(0, 0)
+
+        base_expected = QuantumCircuit(1, 1)
+        base_expected.measure(0, 0)
+
+        body_test = QuantumCircuit(1, 1)
+        body_test.for_loop((0,), None, base_expected.copy(), body_test.qubits, [])
+
+        body_expected = QuantumCircuit(1, 1)
+        body_expected.for_loop((0,), None, base_expected.copy(), body_expected.qubits, [])
+
+        test = QuantumCircuit(1, 1)
+        test.while_loop((test.clbits[0], True), body_test, test.qubits, test.clbits)
+
+        expected = QuantumCircuit(1, 1)
+        expected.while_loop(
+            (expected.clbits[0], True), body_expected, expected.qubits, expected.clbits
+        )
+
+        self.assertEqual(pass_(test), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

This converts all transpiler passes whose structure allows their `run` methods to be made trivially recursive, either by eagerly modifying all control-flow operations in a depth-first pass before running the method on the top level of the circuit, or by inserting the recursion during an interior loop.

There are other passes that are relatively simple to handle as well (`UnitarySynthesis` is one), but their current structure would require just a shade more work than the trivial cases in this commit.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Close #8445 (by obsoleting it).  We can rework #8565 to do essentially this as well - we probably just want to take a bit more care than that PR currently does not to redo all the setup work in the pass.
