### PR TITLE
qiskit.providers.aer is qiskit_aer in Aer 0.11

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -36,7 +36,7 @@ sys.modules["qiskit._accelerate.optimize_1q_gates"] = qiskit._accelerate.optimiz
 # Extend namespace for backwards compat
 from qiskit import namespace
 
-# Add hook to redirect imports from qiskit.providers.aer* to qiskit_aer*
+# Add hook to redirect imports from qiskit.providers.aer.* to qiskit_aer.*
 # this is necessary for backwards compatibility for users when qiskit-aer
 # and qiskit-terra shared the qiskit namespace
 new_meta_path_finder = namespace.QiskitElementImport("qiskit.providers.aer", "qiskit_aer")

--- a/qiskit/algorithms/optimizers/umda.py
+++ b/qiskit/algorithms/optimizers/umda.py
@@ -68,11 +68,10 @@ class UMDA(Optimizer):
         .. code-block:: python
 
             from qiskit.opflow import X, Z, I
-            from qiskit import Aer
             from qiskit.algorithms.optimizers import UMDA
             from qiskit.algorithms import QAOA
             from qiskit.utils import QuantumInstance
-
+            from qiskit_aer import Aer
 
             H2_op = (-1.052373245772859 * I ^ I) + \
             (0.39793742484318045 * I ^ Z) + \

--- a/qiskit/opflow/expectations/aer_pauli_expectation.py
+++ b/qiskit/opflow/expectations/aer_pauli_expectation.py
@@ -81,7 +81,7 @@ class AerPauliExpectation(ExpectationBase):
     @classmethod
     def _replace_pauli_sums(cls, operator):
         try:
-            from qiskit.providers.aer.library import SaveExpectationValue
+            from qiskit_aer.library import SaveExpectationValue
         except ImportError as ex:
             raise MissingOptionalLibraryError(
                 libname="qiskit-aer",

--- a/qiskit/opflow/expectations/expectation_factory.py
+++ b/qiskit/opflow/expectations/expectation_factory.py
@@ -69,7 +69,7 @@ class ExpectationFactory:
             if backend_to_check is None:
                 # If user has Aer but didn't specify a backend, use the Aer fast expectation
                 if has_aer():
-                    from qiskit import Aer
+                    from qiskit_aer import Aer
 
                     backend_to_check = Aer.get_backend("qasm_simulator")
                 # If user doesn't have Aer, use statevector_simulator

--- a/qiskit/providers/__init__.py
+++ b/qiskit/providers/__init__.py
@@ -65,7 +65,7 @@ deprecation is to give providers enough time to do their own deprecation of a
 potential end user impacting change in a user facing part of the interface
 prior to bumping their version. For example, let's say we changed the signature
 to ``Backend.run()`` in ``BackendV34`` in a backwards incompatible way, before
-Aer could update its :class:`~qiskit.providers.aer.aerbackend.AerBackend` class
+Aer could update its :class:`~qiskit_aer.aerbackend.AerBackend` class
 to use version 34 they'd need to deprecate the old signature prior to switching
 over. The changeover for Aer is not guaranteed to be lockstep with Terra so we
 need to ensure there is a sufficient amount of time for Aer to complete its

--- a/qiskit/providers/fake_provider/__init__.py
+++ b/qiskit/providers/fake_provider/__init__.py
@@ -75,7 +75,7 @@ Here is an example of using a fake backend for transpilation and simulation.
     .. code-block:: python
 
         from qiskit import IBMQ
-        from qiskit.providers.aer import AerSimulator
+        from qiskit_aer import AerSimulator
 
         # get a real backend from a real provider
         provider = IBMQ.load_account()

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -370,13 +370,13 @@ class FakeBackendV2(BackendV2):
 
         from qiskit.circuit import Delay
         from qiskit.providers.exceptions import BackendPropertyError
-        from qiskit.providers.aer.noise import NoiseModel
-        from qiskit.providers.aer.noise.device.models import (
+        from qiskit_aer.noise import NoiseModel
+        from qiskit_aer.noise.device.models import (
             _excited_population,
             basic_device_gate_errors,
             basic_device_readout_errors,
         )
-        from qiskit.providers.aer.noise.passes import RelaxationNoisePass
+        from qiskit_aer.noise.passes import RelaxationNoisePass
 
         if self._props_dict is None:
             self._set_props_dict_from_json()
@@ -397,7 +397,7 @@ class FakeBackendV2(BackendV2):
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
-                module="qiskit.providers.aer.noise.device.models",
+                module="qiskit_aer.noise.device.models",
             )
             gate_errors = basic_device_gate_errors(
                 properties,
@@ -455,7 +455,7 @@ class FakeBackend(BackendV1):
     def _setup_sim(self):
         if _optionals.HAS_AER:
             from qiskit.providers import aer
-            from qiskit.providers.aer.noise import NoiseModel
+            from qiskit_aer.noise import NoiseModel
 
             self.sim = aer.AerSimulator()
             if self.properties():
@@ -548,7 +548,7 @@ class FakeBackend(BackendV1):
         if pulse_job:
             if _optionals.HAS_AER:
                 from qiskit.providers import aer
-                from qiskit.providers.aer.pulse import PulseSystemModel
+                from qiskit_aer.pulse import PulseSystemModel
 
                 system_model = PulseSystemModel.from_backend(self)
                 sim = aer.Aer.get_backend("pulse_simulator")

--- a/qiskit/test/decorators.py
+++ b/qiskit/test/decorators.py
@@ -60,7 +60,7 @@ def is_aer_provider_available():
     if sys.platform == "darwin":
         return False
     try:
-        import qiskit.providers.aer  # pylint: disable=unused-import
+        import qiskit_aer  # pylint: disable=unused-import
     except ImportError:
         return False
     return True

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -70,7 +70,7 @@ def has_aer():
     """check if Aer is installed"""
     if not _PROVIDER_CHECK.checked_aer:
         try:
-            from qiskit.providers.aer import AerProvider
+            from qiskit_aer import AerProvider
 
             _PROVIDER_CHECK.has_aer = True
         except Exception as ex:  # pylint: disable=broad-except
@@ -91,11 +91,11 @@ def is_aer_provider(backend):
         bool: True is AerProvider
     """
     if has_aer():
-        from qiskit.providers.aer import AerProvider
+        from qiskit_aer import AerProvider
 
         if isinstance(_get_backend_provider(backend), AerProvider):
             return True
-        from qiskit.providers.aer.backends.aerbackend import AerBackend
+        from qiskit_aer.backends.aerbackend import AerBackend
 
         return isinstance(backend, AerBackend)
 
@@ -153,7 +153,7 @@ def is_statevector_backend(backend):
         bool: True is statevector
     """
     if has_aer():
-        from qiskit.providers.aer.backends import AerSimulator, StatevectorSimulator
+        from qiskit_aer.backends import AerSimulator, StatevectorSimulator
 
         if isinstance(backend, StatevectorSimulator):
             return True

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -29,7 +29,7 @@ Qiskit Components
     :widths: 25 75
 
     * - .. py:data:: HAS_AER
-      - :mod:`Qiskit Aer <qiskit.providers.aer>` provides high-performance simulators for the
+      - :mod:`Qiskit Aer <qiskit_aer>` provides high-performance simulators for the
         quantum circuits constructed within Qiskit Terra.
 
     * - .. py:data:: HAS_IBMQ
@@ -199,7 +199,7 @@ from .lazy_tester import (
 _logger = _logging.getLogger(__name__)
 
 HAS_AER = _LazyImportTester(
-    "qiskit.providers.aer",
+    "qiskit_aer",
     name="Qiskit Aer",
     install="pip install qiskit-aer",
 )

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -509,7 +509,7 @@ class QuantumInstance:
 
         if self.is_statevector and "aer_simulator_statevector" in self.backend_name:
             try:
-                from qiskit.providers.aer.library import SaveStatevector
+                from qiskit_aer.library import SaveStatevector
 
                 def _find_save_state(data):
                     for instruction in reversed(data):

--- a/test/python/algorithms/test_backendv1.py
+++ b/test/python/algorithms/test_backendv1.py
@@ -104,7 +104,7 @@ class TestBackendV1(QiskitAlgorithmsTestCase):
     def test_measurement_error_mitigation_with_vqe(self):
         """measurement error mitigation test with vqe"""
         try:
-            from qiskit.providers.aer import noise
+            from qiskit_aer import noise
         except ImportError as ex:
             self.skipTest(f"Package doesn't appear to be installed. Error: '{str(ex)}'")
             return

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -33,7 +33,7 @@ from qiskit.utils import optionals
 if optionals.HAS_AER:
     # pylint: disable=import-error,no-name-in-module
     from qiskit import Aer
-    from qiskit.providers.aer import noise
+    from qiskit_aer import noise
 if optionals.HAS_IGNIS:
     # pylint: disable=import-error,no-name-in-module
     from qiskit.ignis.mitigation.measurement import (

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -35,7 +35,7 @@ if optionals.HAS_AER:
     from qiskit import Aer
     from qiskit_aer import noise
 if optionals.HAS_IGNIS:
-    # pylint: disable=import-error,no-name-in-module
+    # pylint: disable=import-error,no-name-in-module,ungrouped-imports
     from qiskit.ignis.mitigation.measurement import (
         CompleteMeasFitter as CompleteMeasFitter_IG,
         TensoredMeasFitter as TensoredMeasFitter_IG,

--- a/test/python/algorithms/test_skip_qobj_validation.py
+++ b/test/python/algorithms/test_skip_qobj_validation.py
@@ -103,7 +103,7 @@ class TestSkipQobjValidation(QiskitAlgorithmsTestCase):
         # build noise model
         # Asymmetric readout error on qubit-0 only
         try:
-            from qiskit.providers.aer.noise import NoiseModel
+            from qiskit_aer.noise import NoiseModel
             from qiskit import Aer
 
             self.backend = Aer.get_backend("qasm_simulator")

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -66,7 +66,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_coefficients_correctly_propagated(self):
         """Test that the coefficients in SummedOp and states are correctly used."""
         try:
-            from qiskit.providers.aer import Aer
+            from qiskit_aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
@@ -91,7 +91,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_is_measurement_correctly_propagated(self):
         """Test if is_measurement property of StateFn is propagated to converted StateFn."""
         try:
-            from qiskit.providers.aer import Aer
+            from qiskit_aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
@@ -104,7 +104,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_parameter_binding_on_listop(self):
         """Test passing a ListOp with differing parameters works with the circuit sampler."""
         try:
-            from qiskit.providers.aer import Aer
+            from qiskit_aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
@@ -139,7 +139,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_single_parameter_binds(self):
         """Test passing parameter binds as a dictionary to the circuit sampler."""
         try:
-            from qiskit.providers.aer import Aer
+            from qiskit_aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
@@ -159,7 +159,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_circuit_sampler_caching(self, caching):
         """Test caching all operators works."""
         try:
-            from qiskit.providers.aer import Aer
+            from qiskit_aer import Aer
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
             return
@@ -209,7 +209,7 @@ class TestStateOpMeasEvals(QiskitOpflowTestCase):
     def test_quantum_instance_with_backend_shots(self):
         """Test sampling a circuit where the backend has shots attached."""
         try:
-            from qiskit.providers.aer import AerSimulator
+            from qiskit_aer import AerSimulator
         except Exception as ex:  # pylint: disable=broad-except
             self.skipTest(f"Aer doesn't appear to be installed. Error: '{str(ex)}'")
 

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -230,7 +230,7 @@ class TestSabreSwap(QiskitTestCase):
         if not optionals.HAS_AER:
             return
 
-        from qiskit import Aer
+        from qiskit_aer import Aer
 
         sim = Aer.get_backend("aer_simulator")
         in_results = sim.run(qc, shots=4096).result().get_counts()

--- a/test/python/utils/mitigation/test_meas.py
+++ b/test/python/utils/mitigation/test_meas.py
@@ -46,9 +46,9 @@ from qiskit.utils import optionals
 
 if optionals.HAS_AER:
     # pylint: disable=import-error,no-name-in-module
-    from qiskit.providers.aer import Aer
-    from qiskit.providers.aer.noise import NoiseModel
-    from qiskit.providers.aer.noise.errors.standard_errors import pauli_error
+    from qiskit_aer import Aer
+    from qiskit_aer.noise import NoiseModel
+    from qiskit_aer.noise.errors.standard_errors import pauli_error
 
 # fixed seed for tests - for both simulator and transpiler
 SEED = 42


### PR DESCRIPTION
In the `qiskit-aer` most recent release 0.11, the import path is changing from `qiskit.providers.aer` is `qiskit_aer`. This is a silent change right now, but it will turn into a warning with `qiskit-terra 0.22` (planned for Oct 11th, 2022)

This PR change all the import paths. 