### PR TITLE
Remove param. test for `ComputeUncompute`

### DIFF
--- a/test/python/algorithms/state_fidelities/test_compute_uncompute.py
+++ b/test/python/algorithms/state_fidelities/test_compute_uncompute.py
@@ -21,7 +21,6 @@ from qiskit.circuit.library import RealAmplitudes
 from qiskit.primitives import Sampler
 from qiskit.algorithms.state_fidelities import ComputeUncompute
 from qiskit.test import QiskitTestCase
-from qiskit import QiskitError
 
 
 class TestComputeUncompute(QiskitTestCase):

--- a/test/python/algorithms/state_fidelities/test_compute_uncompute.py
+++ b/test/python/algorithms/state_fidelities/test_compute_uncompute.py
@@ -138,34 +138,6 @@ class TestComputeUncompute(QiskitTestCase):
             )
             job.result()
 
-    def test_param_mismatch(self):
-        """test for fidelity with different number of left/right parameters that
-        do not match the circuits'."""
-
-        fidelity = ComputeUncompute(self._sampler)
-        n = len(self._left_params)
-        with self.assertRaises(QiskitError):
-            job = fidelity.run(
-                [self._circuit[0]] * n,
-                [self._circuit[1]] * n,
-                self._left_params,
-                self._right_params[:-2],
-            )
-            job.result()
-
-        with self.assertRaises(QiskitError):
-            job = fidelity.run(
-                [self._circuit[0]] * n,
-                [self._circuit[1]] * n,
-                self._left_params[:-2],
-                self._right_params[:-2],
-            )
-            job.result()
-
-        with self.assertRaises(ValueError):
-            job = fidelity.run([self._circuit[0]] * n, [self._circuit[1]] * n)
-            job.result()
-
     def test_asymmetric_params(self):
         """test for fidelity when the 2 circuits have different number of
         left/right parameters."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR removes `test_param_mismatch` from the `ComputeUncompute` unit tests, as this check is already performed in the sampler unit test.

### Details and comments
Motivated by CI breaking because of fidelity tests in https://github.com/Qiskit/qiskit-terra/pull/8760.


