### PR TITLE
Remove duplicate optimization loop in level 3 PassManager

### DIFF
--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -296,8 +296,6 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             optimization.append(
                 _opt + _unroll_if_out_of_basis + _depth_check + _size_check, do_while=_opt_control
             )
-        opt_loop = _depth_check + _opt + _unroll_if_out_of_basis
-        optimization.append(opt_loop, do_while=_opt_control)
     else:
         optimization = plugin_manager.get_passmanager_stage(
             "optimization", optimization_method, pass_manager_config, optimization_level=3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

For some time (I expect since #6403 but maybe before) we've been running the optimization loop for optimization level 3 twice for no reason. This is clearly a mistake as it adds a single extra run of all the optimization passes since we've already reached a steady state in depth and size by this point. This is just a waste of time and was unintentional. This commit removes the unintended duplication.

### Details and comments