### PR TITLE
Pin sphinx-autodoc-typehints to avoid 1.19.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
 qiskit-toqm>=0.0.4;platform_machine != 'aarch64' or platform_system != 'Linux'
-sphinx-autodoc-typehints~=1.18
+sphinx-autodoc-typehints~=1.18,!=1.19.3
 jupyter-sphinx
 sphinx-design>=0.2.0
 pygments>=2.4


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The just released update of `sphinx-autodoc-typehints` is crashing the docs with the error:
```
sphinx.errors.ExtensionError: Handler <function process_docstring at 0x7fbaa478e550> for event 'autodoc-process-docstring' threw an exception (exception: list index out of range)
```
Changed to avoid the new version 1.19.3 for now.


### Details and comments


