### PR TITLE
Change pulse code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,8 @@ qiskit/utils/         @Qiskit/terra-core @manoelmarques @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00
 quantum_info/         @Qiskit/terra-core @ikkoham
 qpy/                  @Qiskit/terra-core @nkanazawa1989
-pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli
-scheduler/            @Qiskit/terra-core @eggerdj @nkanazawa1989 @danpuzzuoli
+pulse/                @Qiskit/terra-core @eggerdj @nkanazawa1989 @wshanks
+scheduler/            @Qiskit/terra-core @eggerdj @nkanazawa1989 @wshanks
 visualization/        @Qiskit/terra-core @nonhermitian @nkanazawa1989
 primitives/           @Qiskit/terra-core @ikkoham @t-imamichi
 # Override the release notes directories to have _no_ code owners, so any review


### PR DESCRIPTION
### Summary

This better represents which of the internal team have the time to devote to being a full code owner of the pulse and scheduling modules. Will has been doing great reviews of Naoki's features for the pulse module, and he's the best person to join as another code owner there. Dan doesn't have time now to be a full code owner of pulse, which is the only reason for removing him.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I've spoken to the current code owners of Pulse, plus @wshanks, @mtreinish and @kdk for sign-off already.