### PR TITLE
Make VF2Layout and VF2PostLayout work with control flow

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -18,42 +18,63 @@ import random
 
 from retworkx import PyDiGraph, PyGraph
 
+from qiskit.circuit import ControlFlowOp, ForLoopOp
+from qiskit.converters import circuit_to_dag
+
 
 def build_interaction_graph(dag, strict_direction=True):
     """Build an interaction graph from a dag."""
-    if strict_direction:
-        im_graph = PyDiGraph(multigraph=False)
-    else:
-        im_graph = PyGraph(multigraph=False)
+    im_graph = PyDiGraph(multigraph=False) if strict_direction else PyGraph(multigraph=False)
     im_graph_node_map = {}
     reverse_im_graph_node_map = {}
 
-    for node in dag.op_nodes(include_directives=False):
-        len_args = len(node.qargs)
-        if len_args == 1:
-            if node.qargs[0] not in im_graph_node_map:
-                weight = defaultdict(int)
-                weight[node.name] += 1
-                im_graph_node_map[node.qargs[0]] = im_graph.add_node(weight)
-                reverse_im_graph_node_map[im_graph_node_map[node.qargs[0]]] = node.qargs[0]
-            else:
-                im_graph[im_graph_node_map[node.qargs[0]]][node.op.name] += 1
-        if len_args == 2:
-            if node.qargs[0] not in im_graph_node_map:
-                im_graph_node_map[node.qargs[0]] = im_graph.add_node(defaultdict(int))
-                reverse_im_graph_node_map[im_graph_node_map[node.qargs[0]]] = node.qargs[0]
-            if node.qargs[1] not in im_graph_node_map:
-                im_graph_node_map[node.qargs[1]] = im_graph.add_node(defaultdict(int))
-                reverse_im_graph_node_map[im_graph_node_map[node.qargs[1]]] = node.qargs[1]
-            edge = (im_graph_node_map[node.qargs[0]], im_graph_node_map[node.qargs[1]])
-            if im_graph.has_edge(*edge):
-                im_graph.get_edge_data(*edge)[node.name] += 1
-            else:
-                weight = defaultdict(int)
-                weight[node.name] += 1
-                im_graph.add_edge(*edge, weight)
-        if len_args > 2:
-            return None
+    class MultiQEncountered(Exception):
+        """Used to singal an error-status return from the DAG visitor."""
+
+    def _visit(dag, weight, wire_map):
+        for node in dag.op_nodes(include_directives=False):
+            if isinstance(node.op, ControlFlowOp):
+                if isinstance(node.op, ForLoopOp):
+                    inner_weight = len(node.op.params[0]) * weight
+                else:
+                    inner_weight = weight
+                for block in node.op.blocks:
+                    inner_wire_map = {
+                        inner: wire_map[outer] for outer, inner in zip(node.qargs, block.qubits)
+                    }
+                    _visit(circuit_to_dag(block), inner_weight, inner_wire_map)
+                continue
+            len_args = len(node.qargs)
+            qargs = [wire_map[q] for q in node.qargs]
+            if len_args == 1:
+                if qargs[0] not in im_graph_node_map:
+                    weights = defaultdict(int)
+                    weights[node.name] += weight
+                    im_graph_node_map[qargs[0]] = im_graph.add_node(weights)
+                    reverse_im_graph_node_map[im_graph_node_map[qargs[0]]] = qargs[0]
+                else:
+                    im_graph[im_graph_node_map[qargs[0]]][node.op.name] += weight
+            if len_args == 2:
+                if qargs[0] not in im_graph_node_map:
+                    im_graph_node_map[qargs[0]] = im_graph.add_node(defaultdict(int))
+                    reverse_im_graph_node_map[im_graph_node_map[qargs[0]]] = qargs[0]
+                if qargs[1] not in im_graph_node_map:
+                    im_graph_node_map[qargs[1]] = im_graph.add_node(defaultdict(int))
+                    reverse_im_graph_node_map[im_graph_node_map[qargs[1]]] = qargs[1]
+                edge = (im_graph_node_map[qargs[0]], im_graph_node_map[qargs[1]])
+                if im_graph.has_edge(*edge):
+                    im_graph.get_edge_data(*edge)[node.name] += weight
+                else:
+                    weights = defaultdict(int)
+                    weights[node.name] += weight
+                    im_graph.add_edge(*edge, weights)
+            if len_args > 2:
+                raise MultiQEncountered()
+
+    try:
+        _visit(dag, 1, {bit: bit for bit in dag.qubits})
+    except MultiQEncountered:
+        return None
     return im_graph, im_graph_node_map, reverse_im_graph_node_map
 
 

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -14,7 +14,7 @@
 
 import retworkx
 
-from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
+from qiskit import QuantumRegister, QuantumCircuit
 from qiskit.circuit import ControlFlowOp
 from qiskit.transpiler import CouplingMap, Layout, TranspilerError
 from qiskit.transpiler.passes.layout import vf2_utils

--- a/test/python/transpiler/test_vf2_post_layout.py
+++ b/test/python/transpiler/test_vf2_post_layout.py
@@ -14,7 +14,8 @@
 
 import retworkx
 
-from qiskit import QuantumRegister, QuantumCircuit
+from qiskit import QuantumRegister, QuantumCircuit, ClassicalRegister
+from qiskit.circuit import ControlFlowOp
 from qiskit.transpiler import CouplingMap, Layout, TranspilerError
 from qiskit.transpiler.passes.layout import vf2_utils
 from qiskit.transpiler.passes.layout.vf2_post_layout import VF2PostLayout, VF2PostLayoutStopReason
@@ -38,12 +39,23 @@ class TestVF2PostLayout(QiskitTestCase):
         )
 
         layout = property_set["post_layout"]
-        for gate in dag.two_qubit_ops():
-            if dag.has_calibration_for(gate):
-                continue
-            physical_q0 = layout[gate.qargs[0]]
-            physical_q1 = layout[gate.qargs[1]]
-            self.assertTrue(coupling_map.graph.has_edge(physical_q0, physical_q1))
+        edges = coupling_map.graph.edge_list()
+
+        def run(dag, wire_map):
+            for gate in dag.two_qubit_ops():
+                if dag.has_calibration_for(gate) or isinstance(gate.op, ControlFlowOp):
+                    continue
+                physical_q0 = wire_map[gate.qargs[0]]
+                physical_q1 = wire_map[gate.qargs[1]]
+                self.assertTrue((physical_q0, physical_q1) in edges)
+            for node in dag.op_nodes(ControlFlowOp):
+                for block in node.op.blocks:
+                    inner_wire_map = {
+                        inner: wire_map[outer] for outer, inner in zip(node.qargs, block.qubits)
+                    }
+                    run(circuit_to_dag(block), inner_wire_map)
+
+        run(dag, {bit: layout[bit] for bit in dag.qubits if bit in layout})
 
     def assertLayoutV2(self, dag, target, property_set):
         """Checks if the circuit in dag was a perfect layout in property_set for the given
@@ -53,13 +65,23 @@ class TestVF2PostLayout(QiskitTestCase):
         )
 
         layout = property_set["post_layout"]
-        for gate in dag.two_qubit_ops():
-            if dag.has_calibration_for(gate):
-                continue
-            physical_q0 = layout[gate.qargs[0]]
-            physical_q1 = layout[gate.qargs[1]]
-            qargs = (physical_q0, physical_q1)
-            self.assertTrue(target.instruction_supported(gate.name, qargs))
+
+        def run(dag, wire_map):
+            for gate in dag.two_qubit_ops():
+                if dag.has_calibration_for(gate) or isinstance(gate.op, ControlFlowOp):
+                    continue
+                physical_q0 = wire_map[gate.qargs[0]]
+                physical_q1 = wire_map[gate.qargs[1]]
+                qargs = (physical_q0, physical_q1)
+                self.assertTrue(target.instruction_supported(gate.name, qargs))
+            for node in dag.op_nodes(ControlFlowOp):
+                for block in node.op.blocks:
+                    inner_wire_map = {
+                        inner: wire_map[outer] for outer, inner in zip(node.qargs, block.qubits)
+                    }
+                    run(circuit_to_dag(block), inner_wire_map)
+
+        run(dag, {bit: layout[bit] for bit in dag.qubits if bit in layout})
 
     def test_no_constraints(self):
         """Test we raise at runtime if no target or coupling graph specified."""
@@ -112,10 +134,36 @@ class TestVF2PostLayout(QiskitTestCase):
             vf2_pass.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.MORE_THAN_2Q
         )
 
+    def test_skip_3q_circuit_control_flow(self):
+        """Test that the pass is a no-op on circuits with >2q gates."""
+        qc = QuantumCircuit(3)
+        with qc.for_loop((1,)):
+            qc.ccx(0, 1, 2)
+        backend = FakeLima()
+        cmap = CouplingMap(backend.configuration().coupling_map)
+        props = backend.properties()
+        vf2_pass = VF2PostLayout(coupling_map=cmap, properties=props)
+        vf2_pass.run(circuit_to_dag(qc))
+        self.assertEqual(
+            vf2_pass.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.MORE_THAN_2Q
+        )
+
     def test_skip_3q_circuit_v2(self):
         """Test that the pass is a no-op on circuits with >2q gates with a target."""
         qc = QuantumCircuit(3)
         qc.ccx(0, 1, 2)
+        backend = FakeLimaV2()
+        vf2_pass = VF2PostLayout(target=backend.target)
+        vf2_pass.run(circuit_to_dag(qc))
+        self.assertEqual(
+            vf2_pass.property_set["VF2PostLayout_stop_reason"], VF2PostLayoutStopReason.MORE_THAN_2Q
+        )
+
+    def test_skip_3q_circuit_control_flow_v2(self):
+        """Test that the pass is a no-op on circuits with >2q gates with a target."""
+        qc = QuantumCircuit(3)
+        with qc.for_loop((1,)):
+            qc.ccx(0, 1, 2)
         backend = FakeLimaV2()
         vf2_pass = VF2PostLayout(target=backend.target)
         vf2_pass.run(circuit_to_dag(qc))
@@ -165,6 +213,31 @@ class TestVF2PostLayout(QiskitTestCase):
         self.assertLayout(dag, cmap, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
 
+    def test_2q_circuit_5q_backend_controlflow(self):
+        """A simple example, without considering the direction
+          0 - 1
+        qr1 - qr0
+        """
+        backend = FakeYorktown()
+
+        circuit = QuantumCircuit(2, 1)
+        with circuit.for_loop((1,)):
+            circuit.cx(1, 0)  # qr1 -> qr0
+        with circuit.if_test((circuit.clbits[0], True)) as else_:
+            pass
+        with else_:
+            with circuit.while_loop((circuit.clbits[0], True)):
+                circuit.cx(1, 0)  # qr1 -> qr0
+        initial_layout = Layout(dict(enumerate(circuit.qubits)))
+        circuit._layout = initial_layout
+        dag = circuit_to_dag(circuit)
+        cmap = CouplingMap(backend.configuration().coupling_map)
+        props = backend.properties()
+        pass_ = VF2PostLayout(coupling_map=cmap, properties=props, seed=self.seed)
+        pass_.run(dag)
+        self.assertLayout(dag, cmap, pass_.property_set)
+        self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
+
     def test_best_mapping_ghz_state_full_device_multiple_qregs_v2(self):
         """Test best mappings with multiple registers"""
         backend = FakeLimaV2()
@@ -203,11 +276,48 @@ class TestVF2PostLayout(QiskitTestCase):
         self.assertLayoutV2(dag, backend.target, pass_.property_set)
         self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
 
+    def test_2q_circuit_5q_backend_v2_control_flow(self):
+        """A simple example, without considering the direction
+          0 - 1
+        qr1 - qr0
+        """
+        backend = FakeYorktownV2()
+
+        circuit = QuantumCircuit(2, 1)
+        with circuit.for_loop((1,)):
+            circuit.cx(1, 0)  # qr1 -> qr0
+        with circuit.if_test((circuit.clbits[0], True)) as else_:
+            pass
+        with else_:
+            with circuit.while_loop((circuit.clbits[0], True)):
+                circuit.cx(1, 0)  # qr1 -> qr0
+        initial_layout = Layout(dict(enumerate(circuit.qubits)))
+        circuit._layout = initial_layout
+        dag = circuit_to_dag(circuit)
+        pass_ = VF2PostLayout(target=backend.target, seed=self.seed)
+        pass_.run(dag)
+        self.assertLayoutV2(dag, backend.target, pass_.property_set)
+        self.assertNotEqual(pass_.property_set["post_layout"], initial_layout)
+
     def test_target_invalid_2q_gate(self):
         """Test that we don't find a solution with a gate outside target."""
         backend = FakeYorktownV2()
         qc = QuantumCircuit(2)
         qc.ecr(0, 1)
+        dag = circuit_to_dag(qc)
+        pass_ = VF2PostLayout(target=backend.target, seed=self.seed)
+        pass_.run(dag)
+        self.assertEqual(
+            pass_.property_set["VF2PostLayout_stop_reason"],
+            VF2PostLayoutStopReason.NO_SOLUTION_FOUND,
+        )
+
+    def test_target_invalid_2q_gate_control_flow(self):
+        """Test that we don't find a solution with a gate outside target."""
+        backend = FakeYorktownV2()
+        qc = QuantumCircuit(2)
+        with qc.for_loop((1,)):
+            qc.ecr(0, 1)
         dag = circuit_to_dag(qc)
         pass_ = VF2PostLayout(target=backend.target, seed=self.seed)
         pass_.run(dag)


### PR DESCRIPTION
### Summary

The subgraph isomorphism problem we are solving here can fairly easily be extended to account for the available types of control flow in Qiskit right now.  We just treat each control flow operation as "transparent" in the pass, i.e. as if each of its blocks were simply inserted verbatim (with the requisite wire mapping) sequentially.

We use the same weighting heuristics for control-flow loop bodies in the scoring as elsewhere; for-loops count for the number of iterations, while if-else and while loops count (all of) their bodies once.

The testing in this particular commit is slightly light, because some of the general strategies involve a `transpile` call, which isn't fully ready yet with control flow.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Getting VF2 working with control flow was very easy - this sort of "block transparency" lends itself very well to recursive closures - but filling out the tests, especially of `VF2PostLayout` was more challenging.  I'm somewhat open to more things we might want to do, given that right now, we can't yet rely on being able to route a circuit with control flow, which stymies efforts to use `transpile`.  Hopefully #8418 will make this available, however.

Adding this simplifies the work needed to get the control-flow modifications to the preset pass managers working.
