### PR TITLE
Remove incorrect return type annotation from `BaseEstimator.set_options`

### DIFF
--- a/qiskit/primitives/base_estimator.py
+++ b/qiskit/primitives/base_estimator.py
@@ -251,7 +251,7 @@ class BaseEstimator(ABC):
         """
         return self._run_options
 
-    def set_options(self, **fields) -> BaseEstimator:
+    def set_options(self, **fields):
         """Set options values for the estimator.
 
         Args:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Remove incorrect return type annotation from `BaseEstimator.set_options` method

### Details and comments
The function does not return anything.

