### PR TITLE
fix: stabilize the flaky cyclicity test of AdaptVQE

### DIFF
--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -23,6 +23,7 @@ from qiskit.circuit.library import EvolvedOperatorAnsatz
 from qiskit.opflow import PauliSumOp
 from qiskit.primitives import Estimator
 from qiskit.quantum_info import SparsePauliOp
+from qiskit.utils import algorithm_globals
 
 
 class TestAdaptVQE(QiskitAlgorithmsTestCase):
@@ -30,6 +31,7 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
 
     def setUp(self):
         super().setUp()
+        algorithm_globals.random_seed = 42
         self.h2_op = PauliSumOp.from_list(
             [
                 ("IIII", -0.8105479805373266),
@@ -113,6 +115,7 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         calc = AdaptVQE(
             VQE(Estimator(), self.ansatz, self.optimizer),
             max_iterations=100,
+            threshold=1e-15,
         )
         res = calc.compute_minimum_eigenvalue(operator=self.h2_op)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This stabilizes the flaky test of `AdaptVQE` reported in #8806 by:
- setting `algorithm_globals.random_seed`
- decreasing the convergence threshold for good measure

Prior to this fix, I was able to reproduce flakiness after ~300 independent repetitions of the flaky test.
After this fix, I could ran 1000 repetitions without running into it again :+1: 

### Details and comments

Closes #8806
