### PR TITLE
Add support for empty lists/dicts of observables in `estimate_observables`

### DIFF
--- a/qiskit/algorithms/observables_evaluator.py
+++ b/qiskit/algorithms/observables_evaluator.py
@@ -60,21 +60,24 @@ def estimate_observables(
     else:
         observables_list = observables
 
-    observables_list = _handle_zero_ops(observables_list)
-    quantum_state = [quantum_state] * len(observables)
-    if parameter_values is not None:
-        parameter_values = [parameter_values] * len(observables)
-    try:
-        estimator_job = estimator.run(quantum_state, observables_list, parameter_values)
-        expectation_values = estimator_job.result().values
-    except Exception as exc:
-        raise AlgorithmError("The primitive job failed!") from exc
+    if len(observables_list) > 0:
+        observables_list = _handle_zero_ops(observables_list)
+        quantum_state = [quantum_state] * len(observables)
+        if parameter_values is not None:
+            parameter_values = [parameter_values] * len(observables)
+        try:
+            estimator_job = estimator.run(quantum_state, observables_list, parameter_values)
+            expectation_values = estimator_job.result().values
+        except Exception as exc:
+            raise AlgorithmError("The primitive job failed!") from exc
 
-    metadata = estimator_job.result().metadata
-    # Discard values below threshold
-    observables_means = expectation_values * (np.abs(expectation_values) > threshold)
-    # zip means and metadata into tuples
-    observables_results = list(zip(observables_means, metadata))
+        metadata = estimator_job.result().metadata
+        # Discard values below threshold
+        observables_means = expectation_values * (np.abs(expectation_values) > threshold)
+        # zip means and metadata into tuples
+        observables_results = list(zip(observables_means, metadata))
+    else:
+        observables_results = []
 
     return _prepare_result(observables_results, observables)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR fixes the bug in unit tests brought up in #8812, by not calling the estimator with an empty list of observables in the `estimate_observables` utility method. 

### Details and comments


