### PR TITLE
Force skip tweedledum 1.1.1 on macOS amd64

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,7 @@ shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
 
 # To be removed as a requirement in Terra 0.23.
-tweedledum>=1.1,<2.0
+tweedledum>=1.1,<2.0; platform_machine != 'arm64' or sys_platform != 'darwin'
+# 1.1.1 has no wheel on M1 mac, which frequently causes problems for people.
+# Better just to forbid that in those cases.
+tweedledum>=1.1,<2.0,!=1.1.1; platform_machine == 'arm64' and sys_platform == 'darwin'


### PR DESCRIPTION
### Summary

There is no wheel for tweedledum 1.1.1 for M1 Mac, and attempting to compile from the sdist does not generally work.  This has caused significant problems for our users in the past, and given we are moving to remove tweedledum as a core requirement, it's simplest just to add a constraint to make life easier for users in the interrim.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #8716
