### PR TITLE
Fix random failure in backend estimator tests

### DIFF
--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -225,10 +225,10 @@ class TestBackendEstimator(QiskitTestCase):
             [self.observable],
             parameter_values=[[0, 1, 1, 2, 3, 5]],
             shots=1024,
-            seed=15,
+            seed_simulator=15,
         ).result()
         self.assertIsInstance(result, EstimatorResult)
-        np.testing.assert_allclose(result.values, [-1.307397243478641], rtol=0.05)
+        np.testing.assert_allclose(result.values, [-1.307397243478641], rtol=0.1)
 
     @combine(backend=BACKENDS)
     def test_options(self, backend):
@@ -237,9 +237,9 @@ class TestBackendEstimator(QiskitTestCase):
             estimator = BackendEstimator(backend=backend, options={"shots": 3000})
             self.assertEqual(estimator.options.get("shots"), 3000)
         with self.subTest("set_options"):
-            estimator.set_options(shots=1024, seed=15)
+            estimator.set_options(shots=1024, seed_simulator=15)
             self.assertEqual(estimator.options.get("shots"), 1024)
-            self.assertEqual(estimator.options.get("seed"), 15)
+            self.assertEqual(estimator.options.get("seed_simulator"), 15)
         with self.subTest("run"):
             result = estimator.run(
                 [self.ansatz],


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The backend estimator tests are using Aer as a simulator via the fake backends to validate that we calculate an expected expectation value for the BackendEstimator. However, since #8736 merged this test has had a non-zero failure rate since being introduced due to the RNG and tolerance issues. It turns out that the tests were setting the rng seed incorrectly. Options on the BackendEstimator (and BackendSampler) are passed through to the underlying backend. So in this case to set a fixed seed for simulation we should be using `seed_simulator` instead to fix the seed for the simulation. This commit fixes this. Also just in case the rtol for the test in question is bumped too to avoid any potential issue in the future.

### Details and comments

Fixes #8819 