### PR TITLE
This is an implementation of repr function for some classes according to #8594

### DIFF
--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -39,7 +39,11 @@ class Gate(Instruction):
 
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20
-
+    
+    def __repr__(self):
+        """Return representation."""
+        return f"{self.name}({', '.join(map(str, self.params))})"
+        
     def to_matrix(self) -> np.ndarray:
         """Return a Numpy.array for the gate unitary matrix.
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -285,6 +285,15 @@ class QuantumCircuit:
             raise TypeError("Only a dictionary or None is accepted for circuit metadata")
         self._metadata = metadata
 
+    def __repr__(self):
+        """Return the representation."""
+        return "QuantumCircuit '%s' with %d qubits, %d clbits and %d instructions" % (
+            self.name,
+            len(self._qubits),
+            len(self._clbits),
+            len(self._data),
+        )
+
     @property
     def data(self) -> QuantumCircuitData:
         """Return the circuit data (instructions and context).

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -42,7 +42,9 @@ class Qubit(Bit):
             raise CircuitError(
                 "Qubit needs a QuantumRegister and %s was provided" % type(register).__name__
             )
-
+    def __repr__(self):
+        """Return representation Qubit."""
+        return f"{self.__class__.__name__}({self._register}, {self._index})"
 
 class QuantumRegister(Register):
     """Implement a quantum register."""
@@ -57,6 +59,9 @@ class QuantumRegister(Register):
         """Return OPENQASM string for this register."""
         return "qreg %s[%d];" % (self.name, self.size)
 
+    def __repr__(self):
+        """Return representation quantum register."""
+        return "<QuantumRegister %s with %d qbits>" % (self.name, self.size)
 
 class AncillaQubit(Qubit):
     """A qubit used as ancillary qubit."""

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -96,6 +96,10 @@ class DAGCircuit:
         self.duration = None
         self.unit = "dt"
 
+    def __repr__(self):
+        """Return representation DAG circuit."""
+        return "<DAGcircuit %s with %s qbits>" % (self.name, self.qubits)
+        
     @_optionals.HAS_NETWORKX.require_in_call
     @deprecate_function(
         "The to_networkx() method is deprecated and will be removed in a future release."

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -84,6 +84,16 @@ class Estimator(BaseEstimator):
         )
         self._is_closed = False
 
+    def __repr__(self):
+        """Return a string representation of the PassManager."""
+        return (
+            f"{type(self).__name__}("
+            f"QuantumCircuits{self._circuits}, "
+            f"observables={self.observables}, "
+            f"parameters={self.parameters},"
+            f"options={self.options})"
+        )
+    
     def _call(
         self,
         circuits: Sequence[int],

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -83,6 +83,15 @@ class Sampler(BaseSampler):
         super().__init__(preprocessed_circuits, parameters, options)
         self._is_closed = False
 
+    def __repr__(self):
+        """Return a string representation of the sampler."""
+        return (
+            f"{type(self).__name__}("
+            f"QuantumCircuits{self._circuits}, "
+            f"parameters={self.parameters},"
+            f"options={self.options})"
+        )
+
     def _call(
         self,
         circuits: Sequence[int],

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -46,6 +46,15 @@ class PassManager:
         self.max_iteration = max_iteration
         self.property_set = None
 
+    def __repr__(self):
+        """Return a string representation of the PassManager."""
+        return (
+            f"{type(self).__name__}("
+            f"pass_sets{self._pass_sets}, "
+            f"max_iteration={self.max_iteration}, "
+            f"property_set={self.property_set})"
+        )
+        
     def append(
         self,
         passes: Union[BasePass, List[BasePass]],

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -260,6 +260,17 @@ class Target(Mapping):
                     )
         self.qubit_properties = qubit_properties
 
+    def __repr__(self):
+        """Return representation of the circuit transpiler target."""
+        return (
+            f"{type(self).__name__}("
+            f" num_qubits={self.num_qubits!r}"
+            f", dt={self.dt!r}"
+            f", gate_map={self._gate_map!r}"
+ 
+            ")"
+        )
+        
     def add_instruction(self, instruction, properties=None, name=None):
         """Add a new instruction to the :class:`~qiskit.transpiler.Target`
 


### PR DESCRIPTION
This is the implementation for the repr function for some classes according to issue #8594

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Result of the repr function for the classes

class QuantumCircuit:    
QuantumCircuit 'circuit-108' with 2 qubits, 2 clbits and 1 instructions

class Gate:   
my_gate(θ)

class QuantumRegister(Register):
QuantumRegister qreg with 8 qbits

class Qubit
(<QuantumRegister qreg with 8 qbits>, 0)

class DAGcircuit 
DAGcircuit None with [Qubit(<QuantumRegister qr with 2 qbits>, 0), Qubit(<QuantumRegister qr with 2 qbits>, 1)] qbits

class Target 
Target( num_qubits=0, dt=None, gate_map={})

class Sampler
 Sampler(QuantumCircuits[QuantumCircuit 'circuit-106' with 2 qubits, 0 clbits and 2 instructions], parameters=(ParameterView([]),),options=Options())

Class Estimator
Estimator(QuantumCircuits[QuantumCircuit 'circuit-106' with 2 qubits, 2 clbits and 5 instructions], observables=(), parameters=(ParameterView([]),),options=Options())


### Details and comments


