### PR TITLE
Limit importlib_metadata in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,9 @@ tweedledum>=1.1,<2.0; platform_machine != 'arm64' or sys_platform != 'darwin'
 # 1.1.1 has no wheel on M1 mac, which frequently causes problems for people.
 # Better just to forbid that in those cases.
 tweedledum>=1.1,<2.0,!=1.1.1; platform_machine == 'arm64' and sys_platform == 'darwin'
+
+# Hack around stevedore being broken by importlib_metadata 5.0; we need to pin
+# the requirements rather than the constraints if we need to cut a release
+# before stevedore is fixed.  `importlib_metadata` is not (currently) a direct
+# requirement of Terra.
+importlib_metadata<5.0; python_version<'3.8'


### PR DESCRIPTION
### Summary

`importlib_metadata` 5.0 broke `stevedore`.  Normally we would set this pin in `constraints.txt`, but since this is critical functionality and we may need to release before `stevedore` is fixed, we fix the problem at the requirements level, temporarily making `importlib_metadata` a direct requirement.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix broken CI for Python 3.7.
