### PR TITLE
Modify present pass managers for control-flow support

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -322,6 +322,19 @@ class PassManager:
             ret.append(item)
         return ret
 
+    def to_flow_controller(self) -> FlowController:
+        """Linearize this manager into a single :class:`.FlowController`, so that it can be nested
+        inside another :class:`.PassManager`."""
+        return FlowController.controller_factory(
+            [
+                FlowController.controller_factory(
+                    pass_set["passes"], None, **pass_set["flow_controllers"]
+                )
+                for pass_set in self._pass_sets
+            ],
+            None,
+        )
+
 
 class StagedPassManager(PassManager):
     """A Pass manager pipeline built up of individual stages

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -183,12 +183,19 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         sched = plugin_manager.get_passmanager_stage(
             "scheduling", scheduling_method, pass_manager_config, optimization_level=0
         )
+    init = common.generate_control_flow_options_check(
+        layout_method=layout_method,
+        routing_method=routing_method,
+        translation_method=translation_method,
+        optimization_method=optimization_method,
+        scheduling_method=scheduling_method,
+    )
     if init_method is not None:
-        init = plugin_manager.get_passmanager_stage(
+        init += plugin_manager.get_passmanager_stage(
             "init", init_method, pass_manager_config, optimization_level=0
         )
-    else:
-        init = unroll_3q
+    elif unroll_3q is not None:
+        init += unroll_3q
     optimization = None
     if optimization_method is not None:
         optimization = plugin_manager.get_passmanager_stage(

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -32,7 +32,7 @@ from qiskit.transpiler.passes import FixedPoint
 from qiskit.transpiler.passes import Depth
 from qiskit.transpiler.passes import Size
 from qiskit.transpiler.passes import Optimize1qGatesDecomposition
-from qiskit.transpiler.passes import Layout2qDistance
+from qiskit.transpiler.passes import CheckMap
 from qiskit.transpiler.passes import GatesInBasis
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
@@ -72,8 +72,10 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     coupling_map = pass_manager_config.coupling_map
     initial_layout = pass_manager_config.initial_layout
     init_method = pass_manager_config.init_method
-    layout_method = pass_manager_config.layout_method or "sabre"
-    routing_method = pass_manager_config.routing_method or "sabre"
+    # Unlike other presets, the layout and routing defaults aren't set here because they change
+    # based on whether the input circuit has control flow.
+    layout_method = pass_manager_config.layout_method
+    routing_method = pass_manager_config.routing_method
     translation_method = pass_manager_config.translation_method or "translator"
     optimization_method = pass_manager_config.optimization_method
     scheduling_method = pass_manager_config.scheduling_method
@@ -94,15 +96,9 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         return not property_set["layout"]
 
     def _trivial_not_perfect(property_set):
-        # Verify that a trivial layout is perfect. If trivial_layout_score > 0
-        # the layout is not perfect. The layout is unconditionally set by trivial
-        # layout so we need to clear it before contuing.
-        if (
-            property_set["trivial_layout_score"] is not None
-            and property_set["trivial_layout_score"] != 0
-        ):
-            return True
-        return False
+        # Verify that a trivial layout is perfect.  If perfect, then the circuit should already
+        # appear to be swap mapped.
+        return not property_set["is_swap_mapped"]
 
     # Use a better layout on densely connected qubits, if circuit needs swaps
     def _vf2_match_not_found(property_set):
@@ -122,10 +118,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     _choose_layout_0 = (
         []
         if pass_manager_config.layout_method
-        else [
-            TrivialLayout(coupling_map),
-            Layout2qDistance(coupling_map, property_name="trivial_layout_score"),
-        ]
+        else [TrivialLayout(coupling_map), CheckMap(coupling_map)]
     )
 
     _choose_layout_1 = (
@@ -150,6 +143,11 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         _improve_layout = SabreLayout(
             coupling_map, max_iterations=2, seed=seed_transpiler, swap_trials=5
         )
+    elif layout_method is None:
+        _improve_layout = common.if_has_control_flow_else(
+            DenseLayout(coupling_map, backend_properties, target=target),
+            SabreLayout(coupling_map, max_iterations=2, seed=seed_transpiler, swap_trials=5),
+        ).to_flow_controller()
 
     toqm_pass = False
     routing_pm = None
@@ -185,6 +183,20 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             check_trivial=True,
             use_barrier_before_measurement=not toqm_pass,
         )
+    elif pass_manager_config.routing_method is None:
+        _stochastic_routing = plugin_manager.get_passmanager_stage(
+            "routing",
+            "stochastic",
+            pass_manager_config,
+            optimization_level=1,
+        )
+        _sabre_routing = plugin_manager.get_passmanager_stage(
+            "routing",
+            "sabre",
+            pass_manager_config,
+            optimization_level=1,
+        )
+        routing_pm = common.if_has_control_flow_else(_stochastic_routing, _sabre_routing)
     else:
         routing_pm = plugin_manager.get_passmanager_stage(
             "routing",
@@ -214,7 +226,7 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             unitary_synthesis_plugin_config,
             hls_config,
         )
-        if layout_method not in {"trivial", "dense", "noise_adaptive", "sabre"}:
+        if layout_method not in {"trivial", "dense", "noise_adaptive", "sabre", None}:
             layout = plugin_manager.get_passmanager_stage(
                 "layout", layout_method, pass_manager_config, optimization_level=1
             )
@@ -289,12 +301,19 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         sched = plugin_manager.get_passmanager_stage(
             "scheduling", scheduling_method, pass_manager_config, optimization_level=1
         )
+    init = common.generate_control_flow_options_check(
+        layout_method=layout_method,
+        routing_method=routing_method,
+        translation_method=translation_method,
+        optimization_method=optimization_method,
+        scheduling_method=scheduling_method,
+    )
     if init_method is not None:
-        init = plugin_manager.get_passmanager_stage(
+        init += plugin_manager.get_passmanager_stage(
             "init", init_method, pass_manager_config, optimization_level=1
         )
-    else:
-        init = unroll_3q
+    elif unroll_3q is not None:
+        init += unroll_3q
 
     return StagedPassManager(
         init=init,

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -262,12 +262,15 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
         sched = plugin_manager.get_passmanager_stage(
             "scheduling", scheduling_method, pass_manager_config, optimization_level=2
         )
+    init = common.generate_error_on_control_flow(
+        "The optimizations in optimization_level=2 do not yet support control flow."
+    )
     if init_method is not None:
-        init = plugin_manager.get_passmanager_stage(
+        init += plugin_manager.get_passmanager_stage(
             "init", init_method, pass_manager_config, optimization_level=2
         )
-    else:
-        init = unroll_3q
+    elif unroll_3q is not None:
+        init += unroll_3q
 
     return StagedPassManager(
         init=init,

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -207,12 +207,15 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     ]
 
     # Build pass manager
+    init = common.generate_error_on_control_flow(
+        "The optimizations in optimization_level=3 do not yet support control flow."
+    )
     if init_method is not None:
-        init = plugin_manager.get_passmanager_stage(
-            "init", init_method, pass_manager_config, optimization_level=3
+        init += plugin_manager.get_passmanager_stage(
+            "init", init_method, pass_manager_config, optimization_level=2
         )
     else:
-        init = common.generate_unroll_3q(
+        init += common.generate_unroll_3q(
             target,
             basis_gates,
             approximation_degree,


### PR DESCRIPTION
### Summary

This adds control-flow support to the level 0 and level 1 pass managers directly, including neatly erroring out at runtime if the pass manager was constructed with options that are not yet compatible with control flow.  In general, we assume that plugins from outside of Terra are safe for control flow - it's highly likely that this is not in fact the case, but it's better to do things this way so an external plugin _can_ support control flow, as opposed to forbidding them from doing so.

Level 2 and level 3 both contain optimisations that are incompatible with control flow right now, and so immediately error if an input circuit has control flow.  The failing optimisations are ones that involve a two-pass process of "block collection" followed by "block replacement"; we have no updated any of the "block collection" analysis passes to be safe for control flow, since we would also likely need to communicate the control-flow structure through the property set, which is not a path we're going down just yet.

In order to construct pass managers with nested flow control (e.g. the routing-pass stages contain conditionals, but the entire routing stage needs to be conditioned on the presence of control flow), there is a new `PassManager` method `to_flow_controller`.  This produces a `FlowControllerLinear` with the same content as the pass manager, such that it can then itself be conditioned as a complete block, and embedded into other pass managers.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Depends (effectively) on #8418 - the modifications to level 1 assume that `StochasticSwap` will work with control flow.

I haven't yet written tests for this, as I'm not 100% certain this is the right direction and I don't want to waste time.  Most of them likely wouldn't pass without #8418 anyway.  I'll write tests once we've got a bit of an agreement in spirit.

I anticipate this PR being the one that will add all the release notes for the new control-flow support through the transpiler - I will also add those before merge.

Fix #8630. (This will be the last PR of that epic.)