### PR TITLE
Handle negative variance in Estimator

### DIFF
--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from typing import Any
+from warnings import warn
 
 import numpy as np
 
@@ -135,6 +136,12 @@ class Estimator(BaseEstimator):
                 sq_obs = (obs @ obs).simplify()
                 sq_exp_val = np.real_if_close(final_state.expectation_value(sq_obs))
                 variance = sq_exp_val - expectation_value**2
+                if variance < 0:
+                    warn(
+                        f"Negative variance encountered: {variance}. Variance is automatically treated as zero.",
+                        category=RuntimeWarning,
+                    )
+                    variance = 0.0
                 standard_deviation = np.sqrt(variance / shots)
                 expectation_value_with_error = rng.normal(expectation_value, standard_deviation)
                 expectation_values.append(expectation_value_with_error)

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from typing import Any
-from warnings import warn
 
 import numpy as np
 
@@ -136,13 +135,7 @@ class Estimator(BaseEstimator):
                 sq_obs = (obs @ obs).simplify()
                 sq_exp_val = np.real_if_close(final_state.expectation_value(sq_obs))
                 variance = sq_exp_val - expectation_value**2
-                if variance < 0:
-                    warn(
-                        f"Negative variance encountered: {variance}. Variance is automatically "
-                        "treated as zero.",
-                        category=RuntimeWarning,
-                    )
-                    variance = 0.0
+                variance = max(variance, 0)
                 standard_deviation = np.sqrt(variance / shots)
                 expectation_value_with_error = rng.normal(expectation_value, standard_deviation)
                 expectation_values.append(expectation_value_with_error)

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -138,7 +138,8 @@ class Estimator(BaseEstimator):
                 variance = sq_exp_val - expectation_value**2
                 if variance < 0:
                     warn(
-                        f"Negative variance encountered: {variance}. Variance is automatically treated as zero.",
+                        f"Negative variance encountered: {variance}. Variance is automatically "
+                        "treated as zero.",
                         category=RuntimeWarning,
                     )
                     variance = 0.0

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -138,7 +138,7 @@ class Estimator(BaseEstimator):
                 expectation_values.append(expectation_value)
             else:
                 expectation_value = np.real_if_close(expectation_value)
-                sq_obs = (obs @ obs).simplify()
+                sq_obs = (obs @ obs).simplify(atol=0)
                 sq_exp_val = np.real_if_close(final_state.expectation_value(sq_obs))
                 variance = sq_exp_val - expectation_value**2
                 variance = max(variance, 0)

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -639,13 +639,11 @@ class TestEstimator(QiskitTestCase):
 
     def test_negative_variance(self):
         """Test for negative variance caused by numerical error."""
-        bell = QuantumCircuit(2)
-        bell.h(0)
-        bell.cx(0, 1)
+        qc = QuantumCircuit(1)
 
         estimator = Estimator()
-        with self.assertWarns(RuntimeWarning):
-            result = estimator.run(bell, 1e-4 * SparsePauliOp("XX"), shots=1024).result()
+        result = estimator.run(qc, 1e-4 * SparsePauliOp("I"), shots=1024).result()
+        self.assertEqual(result.values[0], 1e-4)
         self.assertEqual(result.metadata[0]["variance"], 0.0)
 
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -637,6 +637,17 @@ class TestEstimator(QiskitTestCase):
             self.assertIsInstance(result, EstimatorResult)
             np.testing.assert_allclose(result.values, [-1.307397243478641])
 
+    def test_negative_variance(self):
+        """Test for negative variance caused by numerical error."""
+        bell = QuantumCircuit(2)
+        bell.h(0)
+        bell.cx(0, 1)
+
+        estimator = Estimator()
+        with self.assertWarns(RuntimeWarning):
+            result = estimator.run(bell, 1e-4 * SparsePauliOp("XX"), shots=1024).result()
+        self.assertEqual(result.metadata[0]["variance"], 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Variance may be negative by numerical error.
This PR warns it and change the negative variance to zero.

### Details and comments


Thank you for finding the bug @dlasecki.