### PR TITLE
Resolve classical conditions in `QuantumCircuit.while_loop`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4511,6 +4511,8 @@ class QuantumCircuit:
         # pylint: disable=cyclic-import
         from qiskit.circuit.controlflow.while_loop import WhileLoopOp, WhileLoopContext
 
+        condition = (self._resolve_classical_resource(condition[0]), condition[1])
+
         if body is None:
             if qubits is not None or clbits is not None:
                 raise CircuitError(

--- a/releasenotes/notes/condition-in-while-loop-d6be0d6d6a1429da.yaml
+++ b/releasenotes/notes/condition-in-while-loop-d6be0d6d6a1429da.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The method :meth:`.QuantumCircuit.while_loop` will now resolve classical bit
+    references in its condition in the same way that :meth:`.QuantumCircuit.if_test`
+    and :meth:`.InstructionSet.c_if` do.

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -305,7 +305,6 @@ class TestAddingControlFlowOperations(QiskitTestCase):
     def test_appending_while_loop_op(self, condition):
         """Verify we can append a WhileLoopOp to a QuantumCircuit."""
         body = QuantumCircuit(3, 1)
-        body.add_register([condition[0]] if isinstance(condition[0], Clbit) else condition[0])
 
         op = WhileLoopOp(condition, body)
 
@@ -326,9 +325,12 @@ class TestAddingControlFlowOperations(QiskitTestCase):
     def test_quantumcircuit_while_loop(self, condition):
         """Verify we can append a WhileLoopOp to a QuantumCircuit via qc.while_loop."""
         body = QuantumCircuit(3, 1)
-        body.add_register([condition[0]] if isinstance(condition[0], Clbit) else condition[0])
 
         qc = QuantumCircuit(5, 2)
+        if isinstance(condition[0], ClassicalRegister):
+            qc.add_register(condition[0])
+        else:
+            qc.add_bits([condition[0]])
         qc.while_loop(condition, body, [1, 2, 3], [1])
 
         self.assertEqual(qc.data[0].operation.name, "while_loop")


### PR DESCRIPTION
### Summary

This makes the behaviour match that of `if_test`; the omission here was just a bug.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments


