### PR TITLE
Set a fixed seed for all BackendEstimator tests

### DIFF
--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -63,6 +63,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_estimator_run(self, backend):
         """Test Estimator.run()"""
+        backend.set_options(seed_simulator=123)
         psi1, psi2 = self.psi
         hamiltonian1, hamiltonian2, hamiltonian3 = self.hamiltonian
         theta1, theta2, theta3 = self.theta
@@ -101,6 +102,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_estimator_run_no_params(self, backend):
         """test for estimator without parameters"""
+        backend.set_options(seed_simulator=123)
         circuit = self.ansatz.bind_parameters([0, 1, 1, 2, 3, 5])
         est = BackendEstimator(backend=backend)
         result = est.run([circuit], [self.observable]).result()
@@ -110,6 +112,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_1qubit(self, backend):
         """Test for 1-qubit cases"""
+        backend.set_options(seed_simulator=123)
         qc = QuantumCircuit(1)
         qc2 = QuantumCircuit(1)
         qc2.x(0)
@@ -137,6 +140,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_2qubits(self, backend):
         """Test for 2-qubit cases (to check endian)"""
+        backend.set_options(seed_simulator=123)
         qc = QuantumCircuit(2)
         qc2 = QuantumCircuit(2)
         qc2.x(0)
@@ -173,6 +177,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_errors(self, backend):
         """Test for errors"""
+        backend.set_options(seed_simulator=123)
         qc = QuantumCircuit(1)
         qc2 = QuantumCircuit(2)
 
@@ -196,6 +201,7 @@ class TestBackendEstimator(QiskitTestCase):
     @combine(backend=BACKENDS)
     def test_run_numpy_params(self, backend):
         """Test for numpy array as parameter values"""
+        backend.set_options(seed_simulator=123)
         qc = RealAmplitudes(num_qubits=2, reps=2)
         op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
         k = 5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We're still seeing a rare occasional tolerance failure in CI from the BackendEstimator tests. To eliminate this possibility this commit sets a fixed seed for all the BackendEstimator tests which weren't currently to eliminate any non-deterministic failures in CI.

### Details and comments


