### PR TITLE
Remove tweedledum from macOS arm64 immediately

### DIFF
--- a/releasenotes/notes/begin-tweedledum-removal-25bb68fc72804f00.yaml
+++ b/releasenotes/notes/begin-tweedledum-removal-25bb68fc72804f00.yaml
@@ -1,11 +1,18 @@
 ---
 upgrade:
   - |
-    Starting in the following release of Qiskit Terra, 0.23, the ``tweedledum``
-    package will become an optional dependency, instead of a requirement.  This
-    is currently used by some classical phase-oracle functions.  If your
-    application or library needs this functionality, you may want to prepare by
-    adding ``tweedledum`` to your package's dependencies immediately.
+    For most architectures starting in the following release of Qiskit Terra,
+    0.23, the ``tweedledum`` package will become an optional dependency, instead
+    of a requirement.  This is currently used by some classical phase-oracle
+    functions.  If your application or library needs this functionality, you may
+    want to prepare by adding ``tweedledum`` to your package's dependencies
+    immediately.
+
+    ``tweedledum`` is no longer a requirement on macOS arm64 (M1) with immediate
+    effect in Qiskit Terra 0.22.  This is because the provided wheels for this
+    platform are broken, and building from the sdist is not reliable for most
+    ppeople.  If you manually install a working version of ``tweedledum``, all
+    the dependent functionality will continue to work.
 deprecations:
   - |
     Importing the names ``Int1``, ``Int2``, ``classical_function`` and

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,9 @@ symengine>=0.9 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' o
 shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
 
-# To be removed as a requirement in Terra 0.23.
+# To be removed as a requirement in Terra 0.23.  Tweedledum's wheels are
+# hopelessly broken on M1 mac, so we skip the waiting period for that.
 tweedledum>=1.1,<2.0; platform_machine != 'arm64' or sys_platform != 'darwin'
-# 1.1.1 has no wheel on M1 mac, which frequently causes problems for people.
-# Better just to forbid that in those cases.
-tweedledum>=1.1,<2.0,!=1.1.1; platform_machine == 'arm64' and sys_platform == 'darwin'
 
 # Hack around stevedore being broken by importlib_metadata 5.0; we need to pin
 # the requirements rather than the constraints if we need to cut a release


### PR DESCRIPTION
### Summary

In gh-8818 we prevented macOS arm64 from attempting to use tweedledum 1.1.1 as no arm64 wheels are supplied for that version.  In fact, the "arm64" and "universal2" wheels supplied for 1.1.0 are actually mislabelled x86_64 wheels as well, and so there is no working binary version of tweedledum for arm64, and the sdist build process works only rarely for most people.

Since the work of gh-8738 makes `tweedledum` _effectively_ optional for `import qiskit` with immediate effect, and the only way to have a working installation on M1 mac is essentially to have already manually built `tweedledum` from source, the effects of immediately removing the requirement from arm64 macs only should be very slight at worst, and a good quality of life improvement for normal M1 users.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See also https://github.com/Qiskit/qiskit-terra/issues/8716#issuecomment-1270723729 and next reply.

