### PR TITLE
Fix deprecation warning for `deprecated_functionality`

### DIFF
--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -13,6 +13,7 @@
 
 import abc
 from typing import Callable, Dict, Any, Union, Tuple
+import warnings
 
 import numpy as np
 
@@ -20,7 +21,6 @@ from qiskit.circuit.parameterexpression import ParameterExpression, ParameterVal
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.schedule import Schedule, ScheduleComponent
 from qiskit.pulse.utils import instruction_duration_validation
-from qiskit.utils import deprecate_function
 
 
 class AlignmentKind(abc.ABC):
@@ -45,9 +45,14 @@ class AlignmentKind(abc.ABC):
         """
         pass
 
-    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
+        warnings.warn(
+            "The AlignmentKind.to_dict method is deprecated as of Qiskit Terra "
+            "0.21 and will be removed no sooner than 3 months after the release date.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return {"alignment": self.__class__.__name__}
 
     @property
@@ -330,9 +335,14 @@ class AlignEquispaced(AlignmentKind):
 
         return aligned
 
-    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
+        warnings.warn(
+            "The AlignEquispaced.to_dict method is deprecated as of Qiskit Terra "
+            "0.21 and will be removed no sooner than 3 months after the release date.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return {"alignment": self.__class__.__name__, "duration": self.duration}
 
 
@@ -414,12 +424,17 @@ class AlignFunc(AlignmentKind):
 
         return aligned
 
-    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment.
 
         .. note:: ``func`` is not presented in this dictionary. Just name.
         """
+        warnings.warn(
+            "The AlignFunc.to_dict method is deprecated as of Qiskit Terra "
+            "0.21 and will be removed no sooner than 3 months after the release date.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return {
             "alignment": self.__class__.__name__,
             "duration": self.duration,

--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -19,7 +19,8 @@ import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.schedule import Schedule, ScheduleComponent
-from qiskit.pulse.utils import instruction_duration_validation, deprecated_functionality
+from qiskit.pulse.utils import instruction_duration_validation
+from qiskit.utils import deprecate_function
 
 
 class AlignmentKind(abc.ABC):
@@ -44,7 +45,7 @@ class AlignmentKind(abc.ABC):
         """
         pass
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
         return {"alignment": self.__class__.__name__}
@@ -329,7 +330,7 @@ class AlignEquispaced(AlignmentKind):
 
         return aligned
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
         return {"alignment": self.__class__.__name__, "duration": self.duration}
@@ -413,7 +414,7 @@ class AlignFunc(AlignmentKind):
 
         return aligned
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment.
 

--- a/releasenotes/notes/0.22/deprecated-pulse-deprecator-394ec75079441cda.yaml
+++ b/releasenotes/notes/0.22/deprecated-pulse-deprecator-394ec75079441cda.yaml
@@ -1,7 +1,7 @@
 ---
 deprecations:
   - |
-    The pulse-module function ``qiskit.pulse.utils.deprecate_functionality`` is
+    The pulse-module function ``qiskit.pulse.utils.deprecated_functionality`` is
     deprecated and will be removed in a future release.  This was a primarily
     internal-only function.  The same functionality is supplied by
     ``qiskit.utils.deprecate_function``, which should be used instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This fixes some deprecation warnings that pop up during my use of `main` (or, equivalently, `qiskit-terra==0.22.0rc1`)

### Details and comments


