### PR TITLE
Fix deprecation warnings in `qiskit.pulse.transforms.alignments`

### DIFF
--- a/qiskit/pulse/transforms/alignments.py
+++ b/qiskit/pulse/transforms/alignments.py
@@ -19,7 +19,8 @@ import numpy as np
 from qiskit.circuit.parameterexpression import ParameterExpression, ParameterValueType
 from qiskit.pulse.exceptions import PulseError
 from qiskit.pulse.schedule import Schedule, ScheduleComponent
-from qiskit.pulse.utils import instruction_duration_validation, deprecated_functionality
+from qiskit.pulse.utils import instruction_duration_validation
+from qiskit.utils import deprecate_function
 
 
 class AlignmentKind(abc.ABC):
@@ -44,7 +45,7 @@ class AlignmentKind(abc.ABC):
         """
         pass
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
         return {"alignment": self.__class__.__name__}
@@ -329,7 +330,7 @@ class AlignEquispaced(AlignmentKind):
 
         return aligned
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment."""
         return {"alignment": self.__class__.__name__, "duration": self.duration}
@@ -413,7 +414,7 @@ class AlignFunc(AlignmentKind):
 
         return aligned
 
-    @deprecated_functionality
+    @deprecate_function
     def to_dict(self) -> Dict[str, Any]:
         """Returns dictionary to represent this alignment.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This module still called the deprecated `qiskit.pulse.utils.deprecated_functionality`.


### Details and comments
Warnings are being triggered when importing from certain modules. This PR should fix it.

