### PR TITLE
Minor doc fix in `SamplingVQE` and `BaseEstimator`

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -90,8 +90,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
     the ``SamplingVQE`` object has been constructed.
 
     Attributes:
-        estimator (BaseEstimator): The estimator primitive to compute the expectation value of the
-            Hamiltonian operator.
+        sampler (BaseSampler): The sampler primitive to sample the circuits.
         ansatz (QuantumCircuit): A parameterized quantum circuit to prepare the trial state.
         optimizer (Optimizer | Minimizer): A classical optimizer to find the minimum energy. This
             can either be a Qiskit :class:`.Optimizer` or a callable implementing the

--- a/qiskit/primitives/base_estimator.py
+++ b/qiskit/primitives/base_estimator.py
@@ -263,7 +263,7 @@ class BaseEstimator(ABC):
         self._run_options.update_options(**fields)
 
     @deprecate_function(
-        "The BaseSampler.__call__ method is deprecated as of Qiskit Terra 0.22.0 "
+        "The BaseEstimator.__call__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "Use run method instead.",
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Change doc string to reflect respective primitive in SamplingVQE and BaseEstimator classes. 


### Details and comments
- SamplingVQE: Changed attribute string to reflect Sampler
- BaseEstimator: Changed deprecation message to reflect BaseEstimator

