### PR TITLE
Add retworkx to generated module list in the .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,8 +33,8 @@ unsafe-load-any-extension=no
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-allow-list=retworkx, numpy, tweedledum, qiskit._accelerate
-
+extension-pkg-allow-list=retworkx, numpy, tweedledum, qiskit._accelerate, rustworkx
+generated-members=retworkx.*
 
 [MESSAGES CONTROL]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,7 +34,8 @@ unsafe-load-any-extension=no
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
 extension-pkg-allow-list=retworkx, numpy, tweedledum, qiskit._accelerate, rustworkx
-generated-members=retworkx.*
+generated-modules=retworkx.visualization,retwork.visit
+ignore-modules=retworkx,retworkx.visualization,retworkx.visit
 
 [MESSAGES CONTROL]
 

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 
-from retworkx.visualization import graphviz_draw
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
 import retworkx as rx
 
 from qiskit.exceptions import InvalidFileError

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -23,7 +23,7 @@ import warnings
 
 import numpy as np
 import retworkx as rx
-from retworkx.visualization import graphviz_draw
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
 
 from qiskit.transpiler.exceptions import CouplingError
 

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -10,6 +10,8 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
+# pylint: disable=missing-function-docstring
+
 """Translates gates to a target basis using a given equivalence library."""
 
 import time
@@ -366,7 +368,7 @@ class StopIfBasisRewritable(Exception):
     """Custom exception that signals `retworkx.dijkstra_search` to stop."""
 
 
-class BasisSearchVisitor(retworkx.visit.DijkstraVisitor):
+class BasisSearchVisitor(retworkx.visit.DijkstraVisitor):  # pylint: disable=no-member
     """Handles events emitted during `retworkx.dijkstra_search`."""
 
     def __init__(self, graph, source_basis, target_basis, num_gates_for_rule):
@@ -412,7 +414,7 @@ class BasisSearchVisitor(retworkx.visit.DijkstraVisitor):
         # if there are gates in this `rule` that we have not yet generated, we can't apply
         # this `rule`. if `target` is already in basis, it's not beneficial to use this rule.
         if self._num_gates_remain_for_rule[index] > 0 or target in self.target_basis:
-            raise retworkx.visit.PruneSearch
+            raise retworkx.visit.PruneSearch  # pylint: disable=no-member
 
     def edge_relaxed(self, edge):
         _, target, edata = edge

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -15,7 +15,7 @@
 """
 Visualization function for DAG circuit representation.
 """
-from retworkx.visualization import graphviz_draw
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
 
 from qiskit.dagcircuit.dagnode import DAGOpNode, DAGInNode, DAGOutNode
 from qiskit.circuit import Qubit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the recent release of retworkx 0.12.0 the package has been renamed to rustworkx. For compatibility the retworkx python namespace continues to work and instead it just redirects imports to the new name. However, pylint is unable to reason about this dynamic import redirecting which causes it to fail in CI. While in 0.23.0 we'll update the requirement to the rustworkx name in order to unblock CI for the pending 0.22.0 release this commit adds the retworkx namespace to the list of generated modules which tells pylint to try not to detect members of the module.

### Details and comments


