### PR TITLE
Ensure target is generated during run() with FakeBackendV2

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -121,7 +121,7 @@ class FakeBackendV2(BackendV2):
             from qiskit.providers import aer
 
             self.sim = aer.AerSimulator()
-            if self._props_dict:
+            if self.target and self._props_dict:
                 noise_model = self._get_noise_model_from_backend_v2()
                 self.sim.set_options(noise_model=noise_model)
                 # Update fake backend default too to avoid overwriting

--- a/test/python/providers/fake_provider/test_fake_backends.py
+++ b/test/python/providers/fake_provider/test_fake_backends.py
@@ -19,7 +19,7 @@ from qiskit.pulse import Schedule
 from qiskit.qobj import PulseQobj
 from qiskit.test import QiskitTestCase
 from qiskit.providers.fake_provider.utils.configurable_backend import ConfigurableFakeBackend
-from qiskit.providers.fake_provider import FakeAthens
+from qiskit.providers.fake_provider import FakeAthens, FakePerth
 from qiskit.utils import optionals
 
 
@@ -82,3 +82,14 @@ class FakeBackendsTest(QiskitTestCase):
         raw_counts = backend.run(trans_qc, shots=1000).result().get_counts()
 
         self.assertEqual(sum(raw_counts.values()), 1000)
+
+    @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
+    def test_fake_backend_v2_noise_model_always_present(self):
+        """Test that FakeBackendV2 instances always run with noise."""
+        backend = FakePerth()
+        qc = QuantumCircuit(1)
+        qc.x(0)
+        qc.measure_all()
+        res = backend.run(qc, shots=1000).result().get_counts()
+        # Assert noise was present and result wasn't ideal
+        self.assertNotEqual(res, {'1': 1000})

--- a/test/python/providers/fake_provider/test_fake_backends.py
+++ b/test/python/providers/fake_provider/test_fake_backends.py
@@ -92,4 +92,4 @@ class FakeBackendsTest(QiskitTestCase):
         qc.measure_all()
         res = backend.run(qc, shots=1000).result().get_counts()
         # Assert noise was present and result wasn't ideal
-        self.assertNotEqual(res, {'1': 1000})
+        self.assertNotEqual(res, {"1": 1000})


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes the noise model construction of instances of FakeBackendV2. Previously, the FakeBackendV2 class would try to build the noise model only if there was a stored BackendProperties JSON payload present. However, if run() is used directly without `transpile()` or something querying the Target for the backend we won't have necessarily loaded the properties yet. This commit fixes this issue by first checking we have a target defined which will load the properties json if present and then uses the presence of properties to construct the noise model.

### Details and comments

Fixes #8862
Fixes #8801