### PR TITLE
Skip classical function tests if tweedledum isn't present

### DIFF
--- a/test/python/classical_function_compiler/examples.py
+++ b/test/python/classical_function_compiler/examples.py
@@ -14,47 +14,40 @@
 
 """These examples should be handle by the classicalfunction compiler"""
 
-from qiskit.circuit.classicalfunction.types import Int1
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 
+if HAS_TWEEDLEDUM:
+    from qiskit.circuit.classicalfunction.types import Int1
 
-def identity(a: Int1) -> Int1:
-    return a
+    def identity(a: Int1) -> Int1:
+        return a
 
+    def bit_and(a: Int1, b: Int1) -> Int1:
+        return a & b
 
-def bit_and(a: Int1, b: Int1) -> Int1:
-    return a & b
+    def bit_or(a: Int1, b: Int1) -> Int1:
+        return a | b
 
+    def bool_or(a: Int1, b: Int1) -> Int1:
+        return a or b
 
-def bit_or(a: Int1, b: Int1) -> Int1:
-    return a | b
+    def bool_not(a: Int1) -> Int1:
+        return not a
 
+    def and_and(a: Int1, b: Int1, c: Int1) -> Int1:
+        return a and b and c
 
-def bool_or(a: Int1, b: Int1) -> Int1:
-    return a or b
+    def multiple_binop(a: Int1, b: Int1) -> Int1:
+        return (a or b) | (b & a) and (a & b)
 
+    def id_assing(a: Int1) -> Int1:
+        b = a
+        return b
 
-def bool_not(a: Int1) -> Int1:
-    return not a
+    def example1(a: Int1, b: Int1) -> Int1:
+        c = a & b
+        d = b | a
+        return c ^ a | d
 
-
-def and_and(a: Int1, b: Int1, c: Int1) -> Int1:
-    return a and b and c
-
-
-def multiple_binop(a: Int1, b: Int1) -> Int1:
-    return (a or b) | (b & a) and (a & b)
-
-
-def id_assing(a: Int1) -> Int1:
-    b = a
-    return b
-
-
-def example1(a: Int1, b: Int1) -> Int1:
-    c = a & b
-    d = b | a
-    return c ^ a | d
-
-
-def grover_oracle(a: Int1, b: Int1, c: Int1, d: Int1) -> Int1:
-    return not a and b and not c and d
+    def grover_oracle(a: Int1, b: Int1, c: Int1, d: Int1) -> Int1:
+        return not a and b and not c and d

--- a/test/python/classical_function_compiler/test_boolean_expression.py
+++ b/test/python/classical_function_compiler/test_boolean_expression.py
@@ -18,9 +18,13 @@ from ddt import ddt, unpack, data
 
 from qiskit.test.base import QiskitTestCase
 from qiskit import execute, BasicAer
-from qiskit.circuit.classicalfunction.boolean_expression import BooleanExpression
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
+
+if HAS_TWEEDLEDUM:
+    from qiskit.circuit.classicalfunction.boolean_expression import BooleanExpression
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 @ddt
 class TestBooleanExpression(QiskitTestCase):
     """Test boolean expression."""
@@ -68,6 +72,7 @@ class TestBooleanExpression(QiskitTestCase):
         self.assertEqual(bool(int(result)), expected)
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestBooleanExpressionDIMACS(QiskitTestCase):
     """Loading from a cnf file"""
 

--- a/test/python/classical_function_compiler/test_classical_function.py
+++ b/test/python/classical_function_compiler/test_classical_function.py
@@ -11,16 +11,20 @@
 # that they have been altered from the originals.
 
 """Tests ClassicalFunction as a gate."""
-from qiskit.test import QiskitTestCase
+import unittest
 
-from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.test import QiskitTestCase
 
 from qiskit import QuantumCircuit
 from qiskit.circuit.library.standard_gates import XGate
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 
-from . import examples
+if HAS_TWEEDLEDUM:
+    from . import examples
+    from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestOracleDecomposition(QiskitTestCase):
     """Tests ClassicalFunction.decomposition."""
 

--- a/test/python/classical_function_compiler/test_parse.py
+++ b/test/python/classical_function_compiler/test_parse.py
@@ -11,13 +11,18 @@
 # that they have been altered from the originals.
 
 """Tests the classicalfunction parser."""
-from qiskit.circuit.classicalfunction import ClassicalFunctionParseError
-from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+import unittest
 
 from qiskit.test import QiskitTestCase
-from . import bad_examples as examples
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
+
+if HAS_TWEEDLEDUM:
+    from . import bad_examples as examples
+    from qiskit.circuit.classicalfunction import ClassicalFunctionParseError
+    from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestParseFail(QiskitTestCase):
     """Tests bad_examples with the classicalfunction parser."""
 

--- a/test/python/classical_function_compiler/test_simulate.py
+++ b/test/python/classical_function_compiler/test_simulate.py
@@ -11,19 +11,25 @@
 # that they have been altered from the originals.
 
 """Tests LogicNetwork.simulate method."""
+import unittest
 from ddt import ddt, data
-from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 from qiskit.test import QiskitTestCase
-from .utils import get_truthtable_from_function, example_list
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
+
+from . import utils
+
+if HAS_TWEEDLEDUM:
+    from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 @ddt
 class TestSimulate(QiskitTestCase):
     """Tests LogicNetwork.simulate method"""
 
-    @data(*example_list())
+    @data(*utils.example_list())
     def test_(self, a_callable):
         """Tests LogicSimulate.simulate() on all the examples"""
         network = compile_classical_function(a_callable)
         truth_table = network.simulate_all()
-        self.assertEqual(truth_table, get_truthtable_from_function(a_callable))
+        self.assertEqual(truth_table, utils.get_truthtable_from_function(a_callable))

--- a/test/python/classical_function_compiler/test_synthesis.py
+++ b/test/python/classical_function_compiler/test_synthesis.py
@@ -11,16 +11,20 @@
 # that they have been altered from the originals.
 
 """Tests classicalfunction compiler synthesis."""
+import unittest
 from qiskit.test import QiskitTestCase
 
-from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library.standard_gates import XGate
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 
-from . import examples
+if HAS_TWEEDLEDUM:
+    from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+    from . import examples
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestSynthesis(QiskitTestCase):
     """Tests ClassicalFunction.synth method."""
 

--- a/test/python/classical_function_compiler/test_tweedledum2qiskit.py
+++ b/test/python/classical_function_compiler/test_tweedledum2qiskit.py
@@ -11,16 +11,22 @@
 # that they have been altered from the originals.
 
 """Tests LogicNetwork.Tweedledum2Qiskit converter."""
-from tweedledum.ir import Circuit
-from tweedledum.operators import X
+import unittest
 
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 from qiskit.test import QiskitTestCase
 
-from qiskit.circuit.classicalfunction.utils import tweedledum2qiskit
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.circuit.library.standard_gates import XGate
 
+if HAS_TWEEDLEDUM:
+    from qiskit.circuit.classicalfunction.utils import tweedledum2qiskit
 
+    from tweedledum.ir import Circuit
+    from tweedledum.operators import X
+
+
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTweedledum2Qiskit(QiskitTestCase):
     """Tests qiskit.transpiler.classicalfunction.utils.tweedledum2qiskit function."""
 

--- a/test/python/classical_function_compiler/test_typecheck.py
+++ b/test/python/classical_function_compiler/test_typecheck.py
@@ -11,13 +11,18 @@
 # that they have been altered from the originals.
 
 """Tests classicalfunction compiler type checker."""
+import unittest
+
 from qiskit.test import QiskitTestCase
-from qiskit.circuit.classicalfunction import ClassicalFunctionCompilerTypeError
-from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 
-from . import examples, bad_examples
+if HAS_TWEEDLEDUM:
+    from . import examples, bad_examples
+    from qiskit.circuit.classicalfunction import ClassicalFunctionCompilerTypeError
+    from qiskit.circuit.classicalfunction import classical_function as compile_classical_function
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTypeCheck(QiskitTestCase):
     """Tests classicalfunction compiler type checker (good examples)."""
 
@@ -66,6 +71,7 @@ class TestTypeCheck(QiskitTestCase):
         )
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestTypeCheckFail(QiskitTestCase):
     """Tests classicalfunction compiler type checker (bad examples)."""
 

--- a/test/python/classical_function_compiler/test_utils.py
+++ b/test/python/classical_function_compiler/test_utils.py
@@ -10,16 +10,19 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 """Tests .utils.get_truthtable_from_function function"""
+import unittest
 
 from qiskit.test import QiskitTestCase
+from qiskit.utils.optionals import HAS_TWEEDLEDUM
 from .utils import get_truthtable_from_function
-from .examples import grover_oracle
+from . import examples
 
 
+@unittest.skipUnless(HAS_TWEEDLEDUM, "Tweedledum is required for these tests.")
 class TestGetTruthtableFromFunction(QiskitTestCase):
     """Tests .utils.get_truthtable_from_function function"""
 
     def test_grover_oracle(self):
         """Tests get_truthtable_from_function with examples.grover_oracle"""
-        truth_table = get_truthtable_from_function(grover_oracle)
+        truth_table = get_truthtable_from_function(examples.grover_oracle)
         self.assertEqual(truth_table, "0000010000000000")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in #8849 and #8818 which made tweedledum optional for arm64 macOS systems which was the unittest suite still unconditionally depends on tweedledum being installed to run the classical function compiler tests. This commit fixes this by making the tests skip if tweedledum isn't installed so that M1 mac users are able to run the full test suite again.

### Details and comments