### PR TITLE
Fix control-flow routing in StochasticSwap

### DIFF
--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -13,6 +13,9 @@
 """Test the Stochastic Swap pass"""
 
 import unittest
+
+import numpy.random
+
 from ddt import ddt, data
 from qiskit.transpiler.passes import StochasticSwap
 from qiskit.transpiler import CouplingMap, PassManager
@@ -21,6 +24,10 @@ from qiskit.converters import circuit_to_dag, dag_to_circuit
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.test import QiskitTestCase
 from qiskit.transpiler.passes.utils import CheckMap
+from qiskit.circuit.random import random_circuit
+from qiskit.providers.fake_provider import FakeMumbai
+from qiskit.compiler.transpiler import transpile
+from qiskit.circuit import ControlFlowOp, Clbit
 
 
 @ddt
@@ -1165,6 +1172,115 @@ class TestStochasticSwapControlFlow(QiskitTestCase):
         efor_body.swap(2, 1)
         expected.for_loop((0,), None, efor_body, [3, 4, 5], [])
         self.assertEqual(cqc, expected)
+
+
+@ddt
+class TestStochasticSwapRandomCircuitValidOutput(QiskitTestCase):
+    """Assert the output of a transpilation with stochastic swap is a physical circuit."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.backend = FakeMumbai()
+        cls.coupling_edge_set = set(tuple(x) for x in cls.backend.configuration().coupling_map)
+        cls.basis_gates = set(cls.backend.configuration().basis_gates)
+        cls.basis_gates.update(["for_loop", "while_loop", "if_else"])
+
+    def assert_valid_circuit(self, transpiled):
+        """Assert circuit complies with constraints of backend."""
+        self.assertIsInstance(transpiled, QuantumCircuit)
+        self.assertIsNotNone(getattr(transpiled, "_layout", None))
+
+        def _visit_block(circuit, qubit_mapping=None):
+            for instruction in circuit:
+                if instruction.operation.name in {"barrier", "measure"}:
+                    continue
+                self.assertIn(instruction.operation.name, self.basis_gates)
+                qargs = tuple(qubit_mapping[x] for x in instruction.qubits)
+                if not isinstance(instruction.operation, ControlFlowOp):
+                    if len(qargs) > 2 or len(qargs) < 0:
+                        raise Exception("Invalid number of qargs for instruction")
+                    if len(qargs) == 2:
+                        self.assertIn(qargs, self.coupling_edge_set)
+                    else:
+                        self.assertLessEqual(qargs[0], 26)
+                if isinstance(instruction.operation, ControlFlowOp):
+                    for block in instruction.operation.blocks:
+                        new_mapping = {
+                            inner: qubit_mapping[outer]
+                            for outer, inner in zip(instruction.qubits, block.qubits)
+                        }
+                        _visit_block(block, new_mapping)
+
+        # Assert routing ran.
+        _visit_block(
+            transpiled,
+            qubit_mapping={qubit: index for index, qubit in enumerate(transpiled.qubits)},
+        )
+
+    @data(*range(1, 27))
+    def test_random_circuit_no_control_flow(self, size):
+        """Test that transpiled random circuits without control flow are physical circuits."""
+        circuit = random_circuit(size, 3, measure=True, seed=12342)
+        tqc = transpile(
+            circuit,
+            self.backend,
+            routing_method="stochastic",
+            layout_method="dense",
+            seed_transpiler=12342,
+        )
+        self.assert_valid_circuit(tqc)
+
+    @data(*range(4, 27))
+    def test_random_circuit_for_loop(self, size):
+        """Test that transpiled random circuits with nested for loops are physical circuits."""
+        circuit = random_circuit(size, 3, measure=False, seed=12342)
+        for_block = random_circuit(3, 2, measure=False, seed=12342)
+        inner_for_block = random_circuit(2, 1, measure=False, seed=12342)
+        with circuit.for_loop((1,)):
+            with circuit.for_loop((1,)):
+                circuit.append(inner_for_block, [0, 3])
+            circuit.append(for_block, [1, 0, 2])
+        circuit.measure_all()
+
+        tqc = transpile(
+            circuit,
+            self.backend,
+            basis_gates=list(self.basis_gates),
+            routing_method="stochastic",
+            layout_method="dense",
+            seed_transpiler=12342,
+        )
+        self.assert_valid_circuit(tqc)
+
+    @data(*range(6, 27))
+    def test_random_circuit_if_else(self, size):
+        """Test that transpiled random circuits with if else blocks are physical circuits."""
+        circuit = random_circuit(size, 3, measure=True, seed=12342)
+        if_block = random_circuit(3, 2, measure=True, seed=12342)
+        else_block = random_circuit(2, 1, measure=True, seed=12342)
+
+        rng = numpy.random.default_rng(seed=12342)
+        inner_clbit_count = max((if_block.num_clbits, else_block.num_clbits))
+        if inner_clbit_count > circuit.num_clbits:
+            circuit.add_bits([Clbit() for _ in [None] * (inner_clbit_count - circuit.num_clbits)])
+        clbit_indices = list(range(circuit.num_clbits))
+        rng.shuffle(clbit_indices)
+
+        with circuit.if_test((circuit.clbits[0], True)) as else_:
+            circuit.append(if_block, [0, 2, 1], clbit_indices[: if_block.num_clbits])
+        with else_:
+            circuit.append(else_block, [2, 5], clbit_indices[: else_block.num_clbits])
+
+        tqc = transpile(
+            circuit,
+            self.backend,
+            basis_gates=list(self.basis_gates),
+            routing_method="stochastic",
+            layout_method="dense",
+            seed_transpiler=12342,
+        )
+        self.assert_valid_circuit(tqc)
 
 
 if __name__ == "__main__":

--- a/test/python/transpiler/test_stochastic_swap.py
+++ b/test/python/transpiler/test_stochastic_swap.py
@@ -569,12 +569,17 @@ class TestStochasticSwap(QiskitTestCase):
         after = circuit_to_dag(after)
         self.assertEqual(expected_dag, after)
 
-    def test_controlflow_pre_if_else_route(self):
+
+@ddt
+class TestStochasticSwapControlFlow(QiskitTestCase):
+    """Tests for control flow in stochastic swap."""
+
+    def test_pre_if_else_route(self):
         """test swap with if else controlflow construct"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
         creg = ClassicalRegister(num_qubits)
-        coupling = CouplingMap([(i, i + 1) for i in range(num_qubits - 1)])
+        coupling = CouplingMap.from_line(num_qubits)
         qc = QuantumCircuit(qreg, creg)
         qc.h(0)
         qc.cx(0, 2)
@@ -589,28 +594,26 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=82).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
         expected.swap(0, 1)
         expected.cx(1, 2)
         expected.measure(2, 2)
-        eqreg = QuantumRegister(2, name="q")
-        etrue_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[3, 4]], creg)
         etrue_body.x(0)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        efalse_body = QuantumCircuit(qreg[[3, 4]], creg)
         efalse_body.x(1)
         new_order = [1, 0, 2, 3, 4]
         expected.if_else((creg[2], 0), etrue_body, efalse_body, qreg[[3, 4]], creg)
         expected.barrier(qreg)
         expected.measure(qreg, creg[new_order])
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-    def test_controlflow_pre_if_else_route_post_x(self):
+    def test_pre_if_else_route_post_x(self):
         """test swap with if else controlflow construct; pre-cx and post x"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -631,7 +634,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=431).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -639,22 +644,17 @@ class TestStochasticSwap(QiskitTestCase):
         expected.cx(0, 1)
         expected.measure(1, 2)
         new_order = [0, 2, 1, 3, 4]
-        eqreg = QuantumRegister(2, "q")
-        etrue_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[3, 4]], creg)
         etrue_body.x(0)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        efalse_body = QuantumCircuit(qreg[[3, 4]], creg)
         efalse_body.x(1)
         expected.if_else((creg[2], 0), etrue_body, efalse_body, qreg[[3, 4]], creg)
         expected.x(2)
         expected.barrier(qreg)
         expected.measure(qreg, creg[new_order])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-
-    def test_controlflow_post_if_else_route(self):
+    def test_post_if_else_route(self):
         """test swap with if else controlflow construct; post cx"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -676,15 +676,16 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=6508).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
         expected.measure(0, 0)
-        eqreg = QuantumRegister(2, "q")
-        etrue_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[3, 4]], creg)
         etrue_body.x(0)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        efalse_body = QuantumCircuit(qreg[[3, 4]], creg)
         efalse_body.x(1)
         expected.barrier(qreg)
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[3, 4]], creg)
@@ -693,12 +694,9 @@ class TestStochasticSwap(QiskitTestCase):
         expected.cx(1, 2)
         expected.barrier(qreg)
         expected.measure(qreg, creg[[1, 0, 2, 3, 4]])
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-    def test_controlflow_pre_if_else2(self):
+    def test_pre_if_else2(self):
         """test swap with if else controlflow construct; cx in if statement"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -718,7 +716,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=38).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -726,21 +726,16 @@ class TestStochasticSwap(QiskitTestCase):
         expected.swap(0, 1)
         expected.cx(1, 2)
         expected.measure(1, 0)
-        eqreg = QuantumRegister(1, "q")
-        etrue_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[1]], creg)
         etrue_body.x(0)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        efalse_body = QuantumCircuit(qreg[[1]], creg)
         new_order = [1, 0, 2, 3, 4]
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[1]], creg)
         expected.barrier(qreg)
         expected.measure(qreg, creg[new_order])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-
-    def test_controlflow_intra_if_else_route(self):
+    def test_intra_if_else_route(self):
         """test swap with if else controlflow construct"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -759,7 +754,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=8).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -778,13 +775,9 @@ class TestStochasticSwap(QiskitTestCase):
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg, creg)
         new_order = [1, 2, 0, 4, 3]
         expected.measure(qreg, creg[new_order])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-
-    def test_controlflow_pre_intra_if_else(self):
+    def test_pre_intra_if_else(self):
         """test swap with if else controlflow construct; cx in if statement"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -804,12 +797,13 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=2, trials=20).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
-        eqreg = QuantumRegister(4, "q")
-        etrue_body = QuantumCircuit(eqreg, creg)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[1, 2, 3, 4]], creg)
+        efalse_body = QuantumCircuit(qreg[[1, 2, 3, 4]], creg)
         expected.h(0)
         expected.x(1)
         expected.swap(0, 1)
@@ -825,19 +819,15 @@ class TestStochasticSwap(QiskitTestCase):
         efalse_body.cx(1, 2)
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[1, 2, 3, 4]], creg)
         expected.measure(qreg, creg[[1, 2, 0, 4, 3]])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-
-    def test_controlflow_pre_intra_post_if_else(self):
+    def test_pre_intra_post_if_else(self):
         """test swap with if else controlflow construct; cx before, in, and after if
         statement"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
         creg = ClassicalRegister(num_qubits)
-        coupling = CouplingMap([(i, i + 1) for i in range(num_qubits - 1)])
+        coupling = CouplingMap.from_line(num_qubits)
         qc = QuantumCircuit(qreg, creg)
         qc.h(0)
         qc.cx(0, 2)
@@ -855,7 +845,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=1).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -864,29 +856,25 @@ class TestStochasticSwap(QiskitTestCase):
         expected.cx(0, 1)
         expected.measure(0, 0)
         etrue_body = QuantumCircuit(qreg, creg)
-        etrue_body.cx(0, 2)
-        etrue_body.swap(0, 2)
+        etrue_body.cx(0, 1)
+        etrue_body.swap(0, 1)
         etrue_body.swap(4, 3)
-        etrue_body.swap(1, 3)
+        etrue_body.swap(2, 3)
         efalse_body = QuantumCircuit(qreg, creg)
-        efalse_body.swap(0, 2)
+        efalse_body.swap(0, 1)
         efalse_body.swap(3, 4)
-        efalse_body.swap(1, 3)
-        efalse_body.cx(2, 1)
-        expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[0, 2, 1, 3, 4]], creg)
+        efalse_body.swap(2, 3)
+        efalse_body.cx(1, 2)
+        expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[0, 1, 2, 3, 4]], creg)
         expected.swap(1, 2)
         expected.h(4)
         expected.swap(3, 4)
         expected.cx(3, 2)
         expected.barrier()
         expected.measure(qreg, creg[[2, 4, 0, 3, 1]])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-
-    def test_controlflow_no_layout_change(self):
+    def test_no_layout_change(self):
         """test controlflow with no layout change needed"""
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
@@ -907,7 +895,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=23).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -915,22 +905,17 @@ class TestStochasticSwap(QiskitTestCase):
         expected.swap(1, 2)
         expected.cx(0, 1)
         expected.measure(0, 0)
-        eqreg = QuantumRegister(2, "q")
-        etrue_body = QuantumCircuit(eqreg, creg)
+        etrue_body = QuantumCircuit(qreg[[1, 4]], creg)
         etrue_body.x(0)
-        efalse_body = QuantumCircuit(eqreg, creg)
+        efalse_body = QuantumCircuit(qreg[[1, 4]], creg)
         efalse_body.x(1)
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg[[1, 4]], creg)
         expected.barrier(qreg)
         expected.measure(qreg, creg[[0, 2, 1, 3, 4]])
-
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
     @data(1, 2, 3)
-    def test_controlflow_for_loop(self, nloops):
+    def test_for_loop(self, nloops):
         """test stochastic swap with for_loop"""
         # if the loop has only one iteration it isn't necessary for the pass
         # to swap back to the starting layout. This test would check that
@@ -950,7 +935,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=687).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -962,18 +949,14 @@ class TestStochasticSwap(QiskitTestCase):
         loop_parameter = None
         expected.for_loop(range(nloops), loop_parameter, efor_body, qreg, creg)
         expected.measure(qreg, creg)
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-    def test_controlflow_while_loop(self):
+    def test_while_loop(self):
         """test while loop"""
         num_qubits = 4
         qreg = QuantumRegister(num_qubits, "q")
         creg = ClassicalRegister(len(qreg))
         coupling = CouplingMap.from_line(num_qubits)
-        check_map_pass = CheckMap(coupling)
         qc = QuantumCircuit(qreg, creg)
         while_body = QuantumCircuit(qreg, creg)
         while_body.reset(qreg[2:])
@@ -986,7 +969,10 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=58).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+
         expected = QuantumCircuit(qreg, creg)
         ewhile_body = QuantumCircuit(qreg, creg)
         ewhile_body.reset(qreg[2:])
@@ -1000,11 +986,9 @@ class TestStochasticSwap(QiskitTestCase):
         expected.while_loop((creg, 0), ewhile_body, expected.qubits, expected.clbits)
         expected.barrier()
         expected.measure(qreg, creg)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertEqual(cqc, expected)
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-    def test_controlflow_nested_inner_cnot(self):
+    def test_nested_inner_cnot(self):
         """test swap in nested if else controlflow construct; swap in inner"""
         seed = 1
         num_qubits = 3
@@ -1033,7 +1017,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=seed).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -1055,19 +1041,15 @@ class TestStochasticSwap(QiskitTestCase):
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg, creg)
         expected.measure(qreg, creg)
 
-        self.assertEqual(cqc, expected)
-        check_map_pass = CheckMap(coupling)
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-    def test_controlflow_nested_outer_cnot(self):
+    def test_nested_outer_cnot(self):
         """test swap with nested if else controlflow construct; swap in outer"""
         seed = 200
         num_qubits = 5
         qreg = QuantumRegister(num_qubits, "q")
         creg = ClassicalRegister(num_qubits)
         coupling = CouplingMap.from_line(num_qubits)
-        check_map_pass = CheckMap(coupling)
         qc = QuantumCircuit(qreg, creg)
         qc.h(0)
         qc.x(1)
@@ -1090,7 +1072,9 @@ class TestStochasticSwap(QiskitTestCase):
 
         dag = circuit_to_dag(qc)
         cdag = StochasticSwap(coupling, seed=seed).run(dag)
-        cqc = dag_to_circuit(cdag)
+        check_map_pass = CheckMap(coupling)
+        check_map_pass.run(cdag)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qreg, creg)
         expected.h(0)
@@ -1104,20 +1088,17 @@ class TestStochasticSwap(QiskitTestCase):
         efor_body = QuantumCircuit(qreg, creg)
         efor_body.delay(10, 0)
         efor_body.barrier(qreg)
-        efor_body.cx(1, 3)
-        etrue_body.for_loop(range(3), loop_parameter, efor_body, qreg[[0, 2, 1, 3, 4]], creg)
+        efor_body.cx(2, 3)
+        etrue_body.for_loop(range(3), loop_parameter, efor_body, qreg[[0, 1, 2, 3, 4]], creg)
 
         efalse_body = QuantumCircuit(qreg, creg)
         efalse_body.y(0)
         efalse_body.swap(1, 2)
         expected.if_else((creg[0], 0), etrue_body, efalse_body, qreg, creg)
         expected.measure(qreg, creg[[0, 2, 1, 3, 4]])
+        self.assertEqual(dag_to_circuit(cdag), expected)
 
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
-        self.assertEqual(cqc, expected)
-
-    def test_controlflow_disjoint_looping(self):
+    def test_disjoint_looping(self):
         """Test looping controlflow on different qubit register"""
         num_qubits = 4
         cm = CouplingMap.from_line(num_qubits)
@@ -1129,14 +1110,14 @@ class TestStochasticSwap(QiskitTestCase):
         cqc = StochasticSwap(cm, seed=0)(qc)
 
         expected = QuantumCircuit(qr)
-        efor_body = QuantumCircuit(3)
+        efor_body = QuantumCircuit(qr[[0, 1, 2]])
         efor_body.swap(1, 2)
         efor_body.cx(0, 1)
         efor_body.swap(1, 2)
         expected.for_loop((0,), None, efor_body, [0, 1, 2], [])
         self.assertEqual(cqc, expected)
 
-    def test_controlflow_disjoint_multiblock(self):
+    def test_disjoint_multiblock(self):
         """Test looping controlflow on different qubit register"""
         num_qubits = 4
         cm = CouplingMap.from_line(num_qubits)
@@ -1151,16 +1132,16 @@ class TestStochasticSwap(QiskitTestCase):
         cqc = StochasticSwap(cm, seed=353)(qc)
 
         expected = QuantumCircuit(qr, cr)
-        etrue_body = QuantumCircuit(true_body.qregs[0], cr)
+        etrue_body = QuantumCircuit(qr[[0, 1, 2]], cr)
         etrue_body.cx(0, 1)
         etrue_body.swap(0, 1)
-        efalse_body = QuantumCircuit(false_body.qregs[0], cr)
+        efalse_body = QuantumCircuit(qr[[0, 1, 2]], cr)
         efalse_body.swap(0, 1)
         efalse_body.cx(1, 2)
         expected.if_else((cr[0], 1), etrue_body, efalse_body, [0, 1, 2], [])
         self.assertEqual(cqc, expected)
 
-    def test_controlflow_multiple_ops_per_layer(self):
+    def test_multiple_ops_per_layer(self):
         """Test circuits with multiple operations per layer"""
         num_qubits = 6
         coupling = CouplingMap.from_line(num_qubits)
@@ -1172,18 +1153,17 @@ class TestStochasticSwap(QiskitTestCase):
         with qc.for_loop((0,)):
             qc.cx(3, 5)
         cqc = StochasticSwap(coupling, seed=0)(qc)
+        check_map_pass(cqc)
+        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
 
         expected = QuantumCircuit(qr)
         expected.swap(0, 1)
         expected.cx(1, 2)
-        efor_body = QuantumCircuit(3)
+        efor_body = QuantumCircuit(qr[[3, 4, 5]])
         efor_body.swap(1, 2)
         efor_body.cx(0, 1)
         efor_body.swap(2, 1)
         expected.for_loop((0,), None, efor_body, [3, 4, 5], [])
-
-        check_map_pass.run(circuit_to_dag(expected))
-        self.assertTrue(check_map_pass.property_set["is_swap_mapped"])
         self.assertEqual(cqc, expected)
 
 


### PR DESCRIPTION
### Summary

The `StochasticSwap` pass has some fairly complex hand-offs between
different parts of its API, including in recursive calls and the regular
hand-off between Python and Rust.  In the course of adding the
control-flow support, some of these became muddled, and the mapping
between different virtual/physical/integer representations got mixed up,
resulting in invalid swaps being output in the final circuit.

This commit simplifies much of the internal mapping, removing many
superfluous `DAGCircuit` creations and compositions.  This also removes
instances where two layouts were "chained"; this was not well typed (the
output of a "virtual -> physical" mapping can't be the input for another
"virtual -> physical" mapping), and in general was being used to "undo"
some of compositions that were about to be applied.

This fixes a tacit assumption in the original code that the initial
layout was a trivial layout in the hand-off between Rust and Python.
This worked until the recursive call added the `initial_layout` option,
making this assumption invalid. Previously, virtual qubit bit instances
were converted to integers (to allow them to be passed to Rust) using
their indices into the original DAG, but the integer outputs were then
converted _back_ using the `initial_layout`.  In the old form, this
worked anyway, but wasn't logically correct and consequently broke when
the assumptions about `initial_layout` changed.

For the recursive calls, we now ensure that the inner passes are
essentially created with the same internal structure as the outer pass;
the passed in `DAGCircuit` uses the same bit instances and same meaning
of the virtual qubits as the outer circuit, and the `initial_layout`
ensures that the inner passes start with at the same layout as the outer
pass.  This makes the inner passes more like a logical continuation of
the current operation, rather than a completely separate entity that
needs to have its virtual qubits remapped.

The changes to the tests are twofold:

- move the `CheckMap` calls earlier and apply them directly to the
  `StochasticSwap` output rather than the expected circuit, to improve
  the quality of failure error messages

- use the same physical qubits inside the expected control-flow blocks;
  the new simpler form of doing the circuit rewriting internally in the
  pass ensures that the same bit objects are used all the way through
  the control-flow stack now, rather than creating new instances.


### Details and comments

Also has a patch from Matthew to add a bunch more random-circuit tests.  Tests need #8879 to merge before they'll pass due to a bug in `Unroll3qOrMore`.