### PR TITLE
Fix pauli_basis deprecation

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli_utils.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_utils.py
@@ -13,20 +13,30 @@
 PauliList utility functions.
 """
 
+import warnings
 from qiskit.quantum_info.operators.symplectic.pauli_list import PauliList
 
 
-def pauli_basis(num_qubits, weight=False):
+def pauli_basis(num_qubits, weight=False, pauli_list=None):
     """Return the ordered PauliTable or PauliList for the n-qubit Pauli basis.
 
     Args:
         num_qubits (int): number of qubits
         weight (bool): if True optionally return the basis sorted by Pauli weight
                        rather than lexicographic order (Default: False)
+        pauli_list (bool): [Deprecated] This argument is deprecated and remains
+                           for backwards compatability. It has no effect.
 
     Returns:
-        PauliTable, PauliList: the Paulis for the basis
+        PauliList: the Paulis for the basis
     """
+    if pauli_list is not None:
+        warnings.warn(
+            "The `pauli_list` kwarg is deprecated as of Qiskit Terra 0.22 and "
+            "no longer has an effect as `pauli_basis` always returns a PauliList.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     pauli_1q = PauliList(["I", "X", "Y", "Z"])
     if num_qubits == 1:
         return pauli_1q

--- a/releasenotes/notes/fix-pauli-basis-dep-27c0a4506ad38d2c.yaml
+++ b/releasenotes/notes/fix-pauli-basis-dep-27c0a4506ad38d2c.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    The ``pauli_list`` kwarg of :func:`.pauli_basis` has been deprecated as
+    :func:`.pauli_basis` now always returns a :class:`.PauliList`.
+fixes:
+  - |
+    Fixes the removal of ``pauli_list`` kwarg of :func:`.pauli_basis` which
+    broke existing code using the ``pauli_list=True`` future compatibility on
+    upgrade to Qiskit Terra 0.22. This kwarg has been added back to the the
+    function with a deprecation warning instead.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes the removal of `pauli_list` kwarg of `pauli_basis` which broke existing code using the `pauli_list=True` future compatibility on upgrade to Qiskit Terra 0.22. This kwarg has been added back to the the function with a deprecation warning instead.

### Details and comments


