### PR TITLE
Fix `BarrierBeforeFinalMeasurements` with loose bits

### DIFF
--- a/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
@@ -50,10 +50,12 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
         if not final_ops:
             return dag
 
-        # Create a layer with the barrier and add registers from the original dag.
+        # Create a layer with the barrier and add both bits and registers from the original dag.
         barrier_layer = DAGCircuit()
+        barrier_layer.add_qubits(dag.qubits)
         for qreg in dag.qregs.values():
             barrier_layer.add_qreg(qreg)
+        barrier_layer.add_clbits(dag.clbits)
         for creg in dag.cregs.values():
             barrier_layer.add_creg(creg)
 

--- a/releasenotes/notes/fix-barrier-before-final-measurements-loose-1849282c11fc5eb0.yaml
+++ b/releasenotes/notes/fix-barrier-before-final-measurements-loose-1849282c11fc5eb0.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed the :class:`.BarrierBeforeFinalMeasurements` transpiler pass when there
+    are conditions on loose :class:`.Clbit`\ s immediately before the final measurement
+    layer.  Previously, this would fail claiming that the bit was not present
+    in an internal temporary circuit.


### PR DESCRIPTION
### Summary

We simply need to consider loose bits as well when constructing the new DAG layer.  This isn't `DAGCircuit.copy_empty_like` because we don't want things like metadata and global phase.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #8923.

