### PR TITLE
Fix qpy custom ControlledGate with overloaded _define()

### DIFF
--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -632,6 +632,9 @@ def _write_custom_operation(file_obj, name, operation, custom_operations):
         # state is open, and the definition setter (during a subsequent read) uses the "fully
         # excited" control definition only.
         has_definition = True
+        # Build internal definition to support overloaded subclasses by
+        # calling definition getter on object
+        operation.definition  # pylint: disable=pointless-statement
         data = common.data_to_binary(operation._definition, write_circuit)
         size = len(data)
         num_ctrl_qubits = operation.num_ctrl_qubits

--- a/releasenotes/notes/fix-qpy-custom-controlled-gate-a9355df1a88a83a5.yaml
+++ b/releasenotes/notes/fix-qpy-custom-controlled-gate-a9355df1a88a83a5.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue in QPY serialization (:func:`~.qpy.dump`) when a custom
+    :class:`~.ControlledGate` subclass that overloaded the ``_define()``
+    method to provide a custom definition for the operation. Previously,
+    this case of operation was not serialized correctly because it wasn't
+    accounting for using the potentially ``_define()`` method to provide
+    a definition.
+    Fixes `#8794 <https://github.com/Qiskit/qiskit-terra/issues/8794>`__


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a bug in the QPY serialization of ControlledGate subclasses that defined custom _define() methods. The _define() method is the typical way to provide a custom definition in Gate classes. While ControlledGate class provides an alternative interface that handles custom control states at initialization, but the _define() interface is still valid even if it doesn't account for this. In #8571 we updated the QPY serialization code to use the _definition() method directly to correctly handle the open control case. But this fix neglected the case where people were providing definitions via the mechanism from Gate. This commit fixes this assumption by ensuring we load the definition that comes from _define() which will fix the serialization of these custom subclasses.

### Details and comments

Fixes #8794