### PR TITLE
Fix loose-bit handling in QPY

### DIFF
--- a/qiskit/qpy/binary_io/circuits.py
+++ b/qiskit/qpy/binary_io/circuits.py
@@ -950,12 +950,12 @@ def read_circuit(file_obj, version, metadata_deserializer=None):
             qubits = [Qubit() for _ in range(num_qubits - len(circ.qubits))]
             circ.add_bits(qubits)
         if len(circ.clbits) < num_clbits:
-            clbits = [Clbit() for _ in range(num_qubits - len(circ.clbits))]
+            clbits = [Clbit() for _ in range(num_clbits - len(circ.clbits))]
             circ.add_bits(clbits)
     else:
         circ = QuantumCircuit(
-            num_qubits,
-            num_clbits,
+            [Qubit() for _ in [None] * num_qubits],
+            [Clbit() for _ in [None] * num_clbits],
             name=name,
             global_phase=global_phase,
             metadata=metadata,

--- a/releasenotes/notes/fix-qpy-loose-bits-5283dc4ad3823ce3.yaml
+++ b/releasenotes/notes/fix-qpy-loose-bits-5283dc4ad3823ce3.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    QPY deserialisation will no longer add extra :class:`.Clbit` instances to the
+    circuit if there are both loose :class:`.Clbit`\ s in the circuit and more
+    :class:`.Qubit`\ s than :class:`.Clbit`\ s.
+  - |
+    QPY deserialisation will no longer add registers named `q` and `c` if the
+    input circuit contained only loose bits.

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1054,3 +1054,23 @@ class TestLoadFromQPY(QiskitTestCase):
         qpy_file.seek(0)
         new_circuit = load(qpy_file)[0]
         self.assertEqual(qc, new_circuit)
+
+    def test_load_with_loose_bits(self):
+        """Test that loading from a circuit with loose bits works."""
+        qc = QuantumCircuit([Qubit(), Qubit(), Clbit()])
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circuit = load(qpy_file)[0]
+        self.assertEqual(tuple(new_circuit.qregs), ())
+        self.assertEqual(tuple(new_circuit.cregs), ())
+        self.assertEqual(qc, new_circuit)
+
+    def test_load_with_loose_bits_and_registers(self):
+        """Test that loading from a circuit with loose bits and registers works."""
+        qc = QuantumCircuit(QuantumRegister(3), ClassicalRegister(1), [Clbit()])
+        qpy_file = io.BytesIO()
+        dump(qc, qpy_file)
+        qpy_file.seek(0)
+        new_circuit = load(qpy_file)[0]
+        self.assertEqual(qc, new_circuit)


### PR DESCRIPTION
### Summary

A typo in clbit-reconstruction was generating the incorrect number of loose clbits in circuits that contained registers and loose bits, and had more qubits than clbits.  A bug elsewhere in the code caused circuits with _no_ registers to be deserialised as containing registers, since the `QuantumCircuit(int, int)` constructor actually does produce two registers (slightly surprisingly, perhaps).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


