### PR TITLE
paulihedral_2.2

### DIFF
--- a/qiskit/transpiler/passes/paulihedral/block_compilation.py
+++ b/qiskit/transpiler/passes/paulihedral/block_compilation.py
@@ -1,0 +1,773 @@
+# ......
+#
+#
+#
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+import numpy as np
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import PauliEvolutionGate
+from qiskit.opflow import I, Z, X,Y
+import qiskit
+from qiskit.circuit.library.pauli_evolution import PauliEvolutionKernel,PauliEvolutionKernels
+
+def list_to_PauliEvolustionGate(input:list)->PauliEvolutionGate:
+    operator=0
+    for i in range(len(input)-1):
+        #i[0] IIIX i[1]0.75
+        if input[i][0][0] == 'I':
+            pauli_string=I
+        if input[i][0][0] == 'X':
+            pauli_string=X
+        if input[i][0][0] == 'Z':
+            pauli_string=Z
+        if input[i][0][0] == 'Y':
+            pauli_string=Y
+
+        for j in input[i][0][1:]:
+            if j == 'I':
+                pauli_string = pauli_string ^ I
+            elif j == 'X':
+                pauli_string = pauli_string ^ X
+            elif j == 'Z':
+                pauli_string = pauli_string ^ Z
+            elif j == 'Y':
+                pauli_string = pauli_string ^ Y
+        pauli_string=input[i][1]*pauli_string
+        operator+=pauli_string
+        #print(operator)
+        pauli_string=''
+    return PauliEvolutionGate(operator,time=input[-1])
+
+def list_to_PauliEvolutionKernel(input:list)->PauliEvolutionKernel:
+    Gate_list=[]
+    for i in input:
+        Gate_list.append(list_to_PauliEvolustionGate(i))
+    return PauliEvolutionKernel(Gate_list)
+    
+def list_to_PauliEvolutionKernels(input:list)->PauliEvolutionKernels:
+    result=PauliEvolutionKernels([])
+    for i in input:
+        result.kernels.append(list_to_PauliEvolutionKernel(i))
+    return result
+
+
+def PauliEvolutionKernal_to_list(input:PauliEvolutionKernel)->list:
+    result=[]
+    for gate in input.kernel:
+        result.append(PauliEvolutionGate_to_list(gate))
+    return result
+
+def PauliEvolutionGate_to_list(input:PauliEvolutionGate)->list:
+    result=[]
+    for i in range(len(input.operator.paulis)):
+        result.append(
+            [str(input.operator.paulis[i]),input.operator.coeffs[i].real]
+        )
+    result.append(float(input.params[0]))
+    return result
+
+def PauliEvolutionKernels_to_list(input:PauliEvolutionKernels)->list:
+    result=[]
+    for kernel1 in input.kernels:
+        result.append(PauliEvolutionKernal_to_list(kernel1))
+    return result
+
+
+def matching_operator_positions(pauli_str_x, pauli_str_y):
+    positions = []
+    for i, x_op in enumerate(pauli_str_x[0]):
+        if x_op == pauli_str_y[0][i] and x_op != "I":
+            positions.append(i)
+    return positions
+
+def cancellation_potential(pauli_layers: PauliEvolutionKernels) -> list:
+    pauli_layers = PauliEvolutionKernels_to_list(pauli_layers)
+    layer_num = len(pauli_layers)
+    cancellation_potential_array = [0] * layer_num
+    for i in range(1, layer_num):
+        positions = matching_operator_positions(pauli_layers[i][0][0], pauli_layers[i - 1][0][0])
+        cancellation_potential_array[i - 1] = len(positions)
+    #print("090cancellation_potential_array\n",cancellation_potential_array)
+    return cancellation_potential_array
+
+def finding_max_matching_layer_pairs(cancellation_potential_array):
+    layer_num = len(cancellation_potential_array)
+    unmatched_layer_list = list(range(layer_num))
+    pairs = []
+    while True:
+        max_val = -1
+        max_id = 0
+        for i in range(len(unmatched_layer_list) - 1):
+            if unmatched_layer_list[i + 1] == unmatched_layer_list[i] + 1:
+                if cancellation_potential_array[unmatched_layer_list[i]] > max_val:
+                    max_id = i
+                    max_val = cancellation_potential_array[unmatched_layer_list[i]]
+        if max_val == -1:
+            for i in unmatched_layer_list:
+                pairs.append((i, i))
+            break
+        else:
+            pairs.append((unmatched_layer_list[max_id], unmatched_layer_list[max_id] + 1))
+            unmatched_layer_list = unmatched_layer_list[:max_id] + unmatched_layer_list[max_id + 2:]
+
+    pairs = sorted(pairs, key=lambda pairs: pairs[0])
+    #print("114finding_max_matching_layer_pairs\n",pairs)
+    return pairs
+
+def non_identity_positions(pauli_str: str):
+    positions = []
+    for i, op in enumerate(pauli_str[0]):
+        if op != 'I':
+            positions.append(i)
+    return positions
+
+def cnot_tree(non_id_positions, outer_qubits):
+    if len(non_id_positions) == 0:
+        return [], -1
+    elif len(non_id_positions) == 1:
+        return [], non_id_positions[0]
+
+    inner_qubits = []
+    for position in non_id_positions:
+        if position not in outer_qubits:
+            inner_qubits.append(position)
+    if outer_qubits != []:
+        r1 = []
+        r2 = []
+        for qubit in inner_qubits:
+            if qubit > outer_qubits[-1]:
+                r2.append(qubit)
+            else:
+                r1.append(qubit)
+    else:
+        r1 = []
+        r2 = inner_qubits
+    outercnot_qubits = outer_qubits + r2
+    left_cnotset = []
+    for i in range(len(outercnot_qubits) - 1):
+        left_cnotset.append((outercnot_qubits[i], outercnot_qubits[i + 1]))
+    root = outercnot_qubits[-1]
+    if r1 != []:
+        for i in range(len(r1) - 1):
+            left_cnotset.append((r1[i], r1[i + 1]))
+        left_cnotset.append((r1[-1], root))
+    right_cnotset = left_cnotset[::-1]
+    return right_cnotset, root
+
+def syn_pauli_string(qc, qubit_num: int, string: str, right_cnotset: list, root: int, coeff: int):
+    for k in range(qubit_num):
+        if string[k] == 'X':
+            qc.h(k)
+        if string[k] == 'Y':
+            qc.s(k)
+            qc.h(k)
+    for k in reversed(right_cnotset):
+        qc.cx(k[0], k[1])
+    if root >= 0:
+        qc.rz(2 * coeff, root)
+    for k in right_cnotset:
+        qc.cx(k[0], k[1])
+    for k in range(qubit_num):
+        if string[k] == 'X':
+            qc.h(k)
+        if string[k] == 'Y':
+            qc.h(k)
+            qc.sdg(k)
+
+
+def break_layer(pauli_layers: PauliEvolutionKernels) -> PauliEvolutionKernels:
+    pauli_layers = PauliEvolutionKernels_to_list(pauli_layers)
+    '''
+    broken_pauli_layers = PauliEvolutionKernels([])
+    for pauli_layer in pauli_layers.kernels:#Kernel
+        max_pauli_block_size = 2
+        for pauli_block in pauli_layer.kernel:#Gate
+            if len(str(pauli_block.operator.paulis)) > max_pauli_block_size:
+                max_pauli_block_size = len(str(pauli_block.operator.paulis))
+
+        if max_pauli_block_size == 2:
+            broken_pauli_layers.kernels.append(pauli_layer)
+        else:
+            temp_layer=PauliEvolutionKernels([0] * (max_pauli_block_size - 1))
+            #temp_layer = [0] * (max_pauli_block_size - 1)
+            #print("254",max_pauli_block_size)
+            for i in range(max_pauli_block_size - 1):
+                temp_layer.kernels[i] = PauliEvolutionKernel([])
+
+            for pauli_block in pauli_layer.kernel:#gate
+                #print("258",len(PauliEvolutionGate_to_list(pauli_block)))
+                #print("259",len(pauli_block.operator.paulis))
+                for i, pauli_str in enumerate(pauli_block.operator.paulis):
+                    pauli_str=str(pauli_str)
+                    kernel1=[
+                        [pauli_str , pauli_block.operator.coeffs[i].real]
+                        , pauli_block.params[0]]
+                    print("268",kernel1)
+                    kernel1=list_to_PauliEvolustionGate(kernel1)
+                    temp_layer.kernels[i].kernel.append(kernel1)
+            broken_pauli_layers.kernels+=temp_layer.kernels
+    '''
+    broken_pauli_layers = []
+    for pauli_layer in pauli_layers:
+        max_pauli_block_size = 2
+        for pauli_block in pauli_layer:
+            if len(pauli_block) > max_pauli_block_size:
+                max_pauli_block_size = len(pauli_block)
+
+        if max_pauli_block_size == 2:
+            broken_pauli_layers.append(pauli_layer)
+        else:
+            temp_layer = [0] * (max_pauli_block_size - 1)
+            # print("133", temp_layer)
+            for i in range(max_pauli_block_size - 1):
+                temp_layer[i] = []  # kernels
+
+            for pauli_block in pauli_layer:
+                for i, pauli_str in enumerate(pauli_block[:-1]):
+                    #print("236", len(pauli_block[:-1]), pauli_block[:-1])
+                    temp_layer[i].append([pauli_str, pauli_block[-1]])
+            broken_pauli_layers += temp_layer
+    broken_pauli_layers = list_to_PauliEvolutionKernels(broken_pauli_layers)
+    return broken_pauli_layers
+
+
+
+def opt_ft_backend(pauli_layers: PauliEvolutionKernels,adj_mat,dist_mat) -> qiskit.circuit.quantumcircuit.QuantumCircuit:
+    qubit_num = len(str(pauli_layers.kernels[0].kernel[0].operator.paulis[0]))
+    pauli_layers = break_layer(pauli_layers)
+    qc = QuantumCircuit(qubit_num)
+
+    cancellation_potential_array = cancellation_potential(pauli_layers)
+    # print("199",cancellation_potential_array)
+    pairs = finding_max_matching_layer_pairs(cancellation_potential_array)
+    # print("201",pairs)
+    for pair in pairs:
+        if pair[0] == pair[1]:
+            pauli_block = pauli_layers.kernels[pair[0]].kernel[0]  # gate
+            # pauli_block = pauli_layers[pair[0]][0]#[['IIZYZIII', 1.0], 0.3]
+
+            # pauli_str = pauli_block[0]#['IIZYZIII', 1.0]
+            pauli_str = [str(pauli_block.operator.paulis[0]), pauli_block.operator.coeffs[0].real]
+            non_id_positions = non_identity_positions(pauli_str)  # list
+            right_cnotset, root = cnot_tree(non_id_positions, [])  # list,int
+            syn_pauli_string(qc, qubit_num, pauli_str[0], right_cnotset, root, pauli_str[1] * pauli_block.params[0])
+
+            for pauli_block in pauli_layers.kernels[pair[0]].kernel[1:]:  # in pauli_layers[pair[0]][1:]: gate
+                pauli_str = str(pauli_block.operator.paulis[0])
+                non_id_positions = non_identity_positions(pauli_str)
+                right_cnotset, root = cnot_tree(non_id_positions, [])
+                syn_pauli_string(qc, qubit_num, pauli_str[0], right_cnotset, root, pauli_str[1] * pauli_block[-1])
+        else:
+            # pauli_layers[pair[0]][0][0], pauli_layers[pair[1]][0][0]
+            list1 = [str(pauli_layers.kernels[pair[0]].kernel[0].operator.paulis[0]),
+                     pauli_layers.kernels[pair[0]].kernel[0].operator.coeffs[0].real]
+            list2 = [str(pauli_layers.kernels[pair[1]].kernel[0].operator.paulis[0]),
+                     pauli_layers.kernels[pair[1]].kernel[0].operator.coeffs[0].real]
+            matching_positions = matching_operator_positions(list1, list2)  # ['XYIIIIIX', 1.0]['XYIIIIIX', 1.0]
+            non_id_positions = non_identity_positions(list1)
+            right_cnotset, root = cnot_tree(non_id_positions, matching_positions)
+            # print("393",qubit_num,list1[0])
+            syn_pauli_string(qc, qubit_num, list1[0], right_cnotset, root,
+                              list1[1] * pauli_layers.kernels[pair[0]].kernel[0].params[0])
+            # syn_pauli_string(qc, qubit_num, pauli_layers[pair[0]][0][0][0], right_cnotset, root, pauli_layers[pair[0]][0][0][1]*pauli_layers[pair[0]][0][-1])
+            for pauli_block in pauli_layers.kernels[pair[0]].kernel[1:]:  # [['IIIIIIYZ', 1.0], 0.3] or gate
+                pauli_str = [str(pauli_block.operator.paulis[0]), pauli_block.operator.coeffs[0].real]  # pauli_block[0]
+                non_id_positions = non_identity_positions(pauli_str)
+                right_cnotset, root = cnot_tree(non_id_positions, [])
+                syn_pauli_string(qc, qubit_num, pauli_str[0], right_cnotset, root,
+                                  pauli_str[1] * pauli_block.params[0])
+                # syn_pauli_string(qc, qubit_num, pauli_str[0], right_cnotset, root, pauli_str[1]*pauli_block[-1])
+            list2 = [str(pauli_layers.kernels[pair[1]].kernel[0].operator.paulis[0]),
+                     pauli_layers.kernels[pair[1]].kernel[0].operator.coeffs[0].real]
+            non_id_positions = non_identity_positions(list2)  # (pauli_layers[pair[1]][0][0])
+            right_cnotset, root = cnot_tree(non_id_positions, matching_positions)
+            syn_pauli_string(qc, qubit_num, list2[0], right_cnotset, root,
+                              list2[1] * pauli_layers.kernels[pair[1]].kernel[0].params[0])
+            #  syn_pauli_string(qc, qubit_num, pauli_layers[pair[1]][0][0][0], right_cnotset, root, pauli_layers[pair[1]][0][0][1]*pauli_layers[pair[1]][0][-1])
+
+            for pauli_block in pauli_layers.kernels[pair[1]].kernel[1:]:  # pauli_layers[pair[1]][1:]:
+                pauli_str = [str(pauli_block.operator.paulis[0]), pauli_block.operator.coeffs[0].real]  # pauli_block[0]
+                non_id_positions = non_identity_positions(pauli_str)
+                right_cnotset, root = cnot_tree(non_id_positions, [])
+                syn_pauli_string(qc, qubit_num, pauli_str[0], right_cnotset, root, pauli_str[1] * pauli_block.params[0])
+    return qc
+
+
+class pNode:
+    def __init__(self, idx):
+        # self.child = []
+        self.idx = idx
+        self.adj = []
+        self.lqb = None  # logical qubit
+        # self.parent = []
+
+    def add_adjacent(self, idx):
+        self.adj.append(idx)
+    # def add_child(self, idx):
+    #     if idx not in self.child:
+    #         self.child.append(idx)
+    # def add_parent(self, idx):
+    #     if idx not in self.parent:
+    #         self.parent.append(idx)
+
+
+class pGraph:
+    def __init__(self, G, C):
+        G = np.array(G)
+        C = np.array(C)
+
+        n = G.shape[0]
+        self.leng = n
+        self.G = G  # adj matrix
+        self.C = C  # cost matrix
+        self.data = []
+        self.coup_map = []
+        for i in range(n):
+            nd = pNode(i)
+            for j in range(n):
+                if G[i, j] == 1:
+                    nd.add_adjacent(j)
+                    self.coup_map.append([i, j])
+            self.data.append(nd)
+        #print("332\n",self.data[0].idx,self.data[0].adj)
+        #print(self.data[1].idx,self.data[1].adj)
+        #print(self.data[2].idx,self.data[2].adj)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+    def __len__(self):
+        return self.leng
+
+
+
+
+'''
+# sptSet: shortest path tree
+def minDistance(dist, sptSet):
+    # Initilaize minimum distance for next node
+    minv = max_size
+    min_index = -1
+    n = len(dist)
+    # Search not nearest vertex not in the
+    for v in range(n):
+        if dist[v] < minv and sptSet[v] == False:
+            minv = dist[v]
+            min_index = v
+    return min_index
+'''
+# Funtion that implements Dijkstra's single source
+# shortest path algorithm for a graph represented
+# using adjacency matrix representation
+'''
+def dijkstra(dist_matrix, src):
+   # print(src)
+   n = dist_matrix.shape[0]
+   dist = [dist_matrix[src, i] for i in range(n)]
+   # print('Initial:', dist)
+   sptSet = [False]*n # [dist_matrix[src, i] != max_size for i in range(n)]
+
+   for cout in range(n):
+       # Pick the minimum distance vertex from
+       # the set of vertices not yet processed.
+       # u is always equal to src in first iteration
+       u = minDistance(dist, sptSet)
+       if u == -1:
+           break
+       # Put the minimum distance vertex in the
+       # shotest path tree
+       sptSet[u] = True
+       # Update dist value of the adjacent vertices
+       # of the picked vertex only if the current
+       # distance is greater than new distance and
+       # the vertex in not in the shotest path tree
+       for v in range(n):
+           if dist_matrix[u, v] > 0 and sptSet[v] == False and \
+               dist[v] > dist[u] + dist_matrix[u, v]:
+               dist[v] = dist[u] + dist_matrix[u, v]
+   # print(dist)
+   for i in range(n):
+       dist_matrix[src, i] = dist[i]
+       dist_matrix[i, src] = dist[i]
+
+def load_graph(code, dist_comp=False):
+   pth = os.path.join(package_directory, 'data', 'ibmq_'+code+'_calibrations.csv')
+   cgs = []
+   n = 0
+   with open(pth, 'r') as cf:
+       g = csv.DictReader(cf, delimiter=',', quotechar='\"')
+       for i in g:
+           n += 1
+           for j in i['CNOT error'].split(','):
+               cgs.append(j.strip())
+   G = np.zeros((n, n))
+   C = np.ones((n, n))*max_size
+   for i in range(n):
+       C[i, i] = 0
+   for i in cgs:
+       si1 = i.find('_')
+       si2 = i.find(':')
+       iq1 = int(i[2:si1])
+       iq2 = int(i[si1+1:si2])
+       G[iq1, iq2] = 1
+       acc = float(i[si2+2:])*1000
+       C[iq1, iq2] = acc
+   if dist_comp == True:
+       for i in range(n):
+           dijkstra(C, i)
+   return G, C
+
+def load_coupling_map(code):
+   pth = os.path.join(package_directory, 'data', 'ibmq_'+code+'_calibrations.csv')
+   cgs = []
+   n = 0
+   with open(pth, 'r') as cf:
+       g = csv.DictReader(cf, delimiter=',', quotechar='\"')
+       for i in g:
+           n += 1
+           for j in i['CNOT error'].split(','):
+               cgs.append(j.strip())
+   coupling = []
+   for i in cgs:
+       si1 = i.find('_')
+       si2 = i.find(':')
+       iq1 = int(i[2:si1])
+       iq2 = int(i[si1+1:si2])
+       coupling.append([iq1, iq2])
+   return coupling
+'''
+
+# def synthesis_initial(pauli_layers, pauli_map=None, graph=None, qc=None, arch='manhattan'):
+#     lnq = len(pauli_layers[0][0][0]) # logical qubits
+#     if graph == None:
+#         G, C = load_graph(arch, dist_comp=True) # G is adj, C is dist
+#         graph = pGraph(G, C)
+#     if pauli_map == None:
+#         pauli_map = dummy_qubit_mapping(graph, lnq)
+#     else:
+#         add_pauli_map(graph, pauli_map)
+#     pnq = len(graph) # physical qubits
+#     if qc == None:
+#         qc = QuantumCircuit(pnq)
+#     return pauli_map, graph, qc
+
+
+
+
+def dummy_qubit_mapping(graph, logical_qubit_num):
+    for i in range(logical_qubit_num):
+        graph[i].lqb = i
+    return list(range(logical_qubit_num))
+
+
+
+
+def compute_block_cover(pauli_block: PauliEvolutionGate) -> list:
+    block_cover = []
+    #print('467',pauli_block.operator.paulis)
+    for idx,pauli_str in enumerate(pauli_block.operator.paulis):  # pauli_block[:-1]:
+        df=[str(pauli_str),pauli_block.operator.coeffs[0].real]
+        #print('468',df)
+        for position in non_identity_positions(df):
+            if position not in block_cover:
+                block_cover.append(position)
+    #print("470\n",block_cover)
+    return block_cover
+
+
+
+def compute_block_interior(pauli_block: PauliEvolutionGate) -> list:
+    block_interior = non_identity_positions([str(pauli_block.operator.paulis[0]),pauli_block.operator.coeffs[0]])
+    #print('481',block_interior)
+    # print("636",pauli_block.operator.paulis,len(pauli_block.operator.coeffs))
+    if len(pauli_block.operator.coeffs) > 1:
+        for pauli_str in pauli_block.operator.paulis[1:]:
+            block_interior = list(set(block_interior) & set(non_identity_positions([str(pauli_str),pauli_block.operator.coeffs[0]])))
+    return block_interior
+
+
+
+
+def logical_to_physical_cover(logical_to_physical_mapping: list, logical_cover: list):
+    #print("4701\n",[logical_to_physical_mapping[i] for i in logical_cover])
+    return [logical_to_physical_mapping[i] for i in logical_cover]
+
+def physical_to_logical_cover(graph: list, physical_cover: list) -> list:
+    #print("4702\n",[graph[i].lqb for i in physical_cover])
+    return [graph[i].lqb for i in physical_cover]
+
+
+
+
+def max_dfs_tree(graph, cover, start, path=[]):
+    max_connect_component = []
+    for i in start.adj:
+        if i not in cover:
+            continue
+        if i in path:
+            continue
+        else:
+            max_connect_component += max_dfs_tree(graph, cover, graph[i],
+                                                   path=path + max_connect_component + [start.idx])
+    return [start.idx] + max_connect_component
+
+
+
+
+def find_short_node(graph, logical_to_physical_mapping, logical_qubits_to_move, max_connected_component):
+    qubit_to_move = -1
+    qubit_in_connected_component = -1
+    mindist = 10000000
+    for i in logical_qubits_to_move:
+        for j in max_connected_component:
+            dist = graph.C[logical_to_physical_mapping[i], j]
+            if dist < mindist:
+                mindist = dist
+                qubit_to_move = i
+                qubit_in_connected_component = graph[j].lqb
+    return qubit_to_move, qubit_in_connected_component
+
+
+
+
+def swap_nodes(logical_to_physical_mapping, graph_node_a, graph_node_b):
+    t = graph_node_a.lqb
+    graph_node_a.lqb = graph_node_b.lqb
+    graph_node_b.lqb = t
+    if graph_node_a.lqb != None:
+        logical_to_physical_mapping[graph_node_a.lqb] = graph_node_a.idx
+    if graph_node_b.lqb != None:
+        logical_to_physical_mapping[graph_node_b.lqb] = graph_node_b.idx
+
+
+
+
+def connect_node(graph, logical_to_physical_mapping, physical_qubit_to_move, physical_qubit_in_connected_component,
+                  swap_list):
+    physical_qubit_in_path = -1
+    mindist = 10000000
+    for i in graph[physical_qubit_to_move].adj:
+        if graph.C[i, physical_qubit_in_connected_component] < mindist:
+            physical_qubit_in_path = i
+            mindist = graph.C[i, physical_qubit_in_connected_component]
+    if physical_qubit_in_path == physical_qubit_in_connected_component:
+        return
+    else:
+        swap_list.append(['swap', (physical_qubit_to_move, physical_qubit_in_path)])
+        swap_nodes(logical_to_physical_mapping, graph[physical_qubit_to_move], graph[physical_qubit_in_path])
+        connect_node(graph, logical_to_physical_mapping, physical_qubit_in_path, physical_qubit_in_connected_component,
+                     swap_list)
+
+
+class tree:
+    def __init__(self, graph, dp, parent=None, depth=0):
+        self.childs = []
+        self.leaf = []
+        self.depth = depth
+        self.pid = dp[0]
+        if len(dp) == 1:
+            self.status = 1
+            self.leaf = [self]
+        else:
+            self.status = 0
+            st = []
+            for i in range(1, len(dp)):
+                if dp[i] in graph[self.pid].adj:
+                    st.append(i)
+            st.append(len(dp))
+            for i in range(len(st) - 1):
+                child = tree(graph, dp[st[i]:st[i + 1]], parent=self, depth=self.depth + 1)
+                self.childs.append(child)
+                self.leaf += child.leaf
+        if parent != None:
+            self.parent = parent
+
+
+def pauli_single_gates(qc, logical_to_physical_mapping, pauli_str, left=True):
+    if left == True:
+        for i in range(len(pauli_str[0])):
+            if pauli_str[0][i] == 'X':
+                qc.h(logical_to_physical_mapping[i])
+            elif pauli_str[0][i] == 'Y':
+                qc.s(logical_to_physical_mapping[i])
+                qc.h(logical_to_physical_mapping[i])
+    else:
+        for i in range(len(pauli_str[0])):
+            if pauli_str[0][i] == 'X':
+                qc.h(logical_to_physical_mapping[i])
+            elif pauli_str[0][i] == 'Y':
+                qc.h(logical_to_physical_mapping[i])
+                qc.sdg(logical_to_physical_mapping[i])
+
+
+
+
+def tree_synthesis(qc, graph, logical_to_physical_mapping, physical_qubit_tree, pauli_str, block_coeff):
+    string = pauli_str[0]
+    non_id_positions = non_identity_positions(pauli_str)
+    pauli_single_gates(qc, logical_to_physical_mapping, pauli_str, left=True)
+    physical_qubit_tree_leaves = physical_qubit_tree.leaf  # first in, first out
+    swaps = {}
+    #    cnot_num = len(non_id_positions) - 1
+    #    lc = 0
+    while physical_qubit_tree_leaves != []:
+        physical_qubit_tree_leaves = sorted(physical_qubit_tree_leaves, key=lambda x: -x.depth)
+        first_leaf = physical_qubit_tree_leaves[0]
+        if first_leaf.depth == 0:
+            # psd.real may be zero
+            qc.rz(2 * pauli_str[1] * block_coeff, first_leaf.pid)
+            break
+        # actually, if psn is empty in the middle, we can stop it first
+        # and the choice of root is also important
+        if graph[first_leaf.pid].lqb in non_id_positions:
+            if graph[first_leaf.parent.pid].lqb in non_id_positions:
+                qc.cx(first_leaf.pid, first_leaf.parent.pid)
+            #                lc += 1
+            else:
+                qc.swap(first_leaf.pid, first_leaf.parent.pid)
+                swaps[first_leaf.parent.pid] = first_leaf
+                swap_nodes(logical_to_physical_mapping, graph[first_leaf.pid], graph[first_leaf.parent.pid])
+        else:
+            pass  # lfs.remove(l)
+        if first_leaf.parent not in physical_qubit_tree_leaves:
+            physical_qubit_tree_leaves.append(first_leaf.parent)
+        physical_qubit_tree_leaves.remove(first_leaf)
+        # print(lfs)
+    #    if lc != cnot_num:
+    #        print('lala left:',psd.ps, cnot_num, lc)
+    physical_qubit_tree_leaves = [physical_qubit_tree]
+    #    rc = 0
+    while physical_qubit_tree_leaves != []:
+        first_leaf = physical_qubit_tree_leaves[0]
+        for i in first_leaf.childs:
+            if graph[i.pid].lqb in non_id_positions:
+                qc.cx(i.pid, first_leaf.pid)
+                #                rc += 1
+                physical_qubit_tree_leaves.append(i)
+        if first_leaf.pid in swaps.keys():
+            qc.swap(first_leaf.pid, swaps[first_leaf.pid].pid)
+            swap_nodes(logical_to_physical_mapping, graph[first_leaf.pid], graph[swaps[first_leaf.pid].pid])
+            physical_qubit_tree_leaves.append(swaps[first_leaf.pid])
+        physical_qubit_tree_leaves = physical_qubit_tree_leaves[1:]
+    #    if rc != cnot_num:
+    #        print('lala left:',psd.ps, cnot_num, rc)
+    pauli_single_gates(qc, logical_to_physical_mapping, pauli_str, left=False)
+    return qc
+
+
+
+def opt_sc_backend(pauli_layers: PauliEvolutionKernels,adj_mat,dist_mat):
+
+    logical_qubit_num = len(str(pauli_layers.kernels[0].kernel[0].operator.paulis[
+                                    0]))  # construct coupling graph (undirected), cost distance matrix
+    '''handle the adj_mat to make the diagonal element is zero'''
+    #print("661",adj_mat)
+    for i in range(len(adj_mat)):
+        adj_mat[i][i] = 0
+    #print("663",adj_mat)
+    sc_device_graph = pGraph(adj_mat, dist_mat)
+    # find dense connected subset for initial mapping
+    logical_to_physical_mapping = dummy_qubit_mapping(sc_device_graph, logical_qubit_num)
+    #print("657logical_to_physical_mapping\n",logical_to_physical_mapping)
+    physical_qubit_num = len(sc_device_graph)
+    #print("926",physical_qubit_num)
+    qc = QuantumCircuit(physical_qubit_num)
+    #print("930",logical_to_physical_mapping)
+    #print("939")
+    for current_layer in pauli_layers.kernels:  # kernel
+        for current_block in current_layer.kernel:  # gate
+            logical_block_cover = compute_block_cover(current_block)  # list
+            logical_block_interior = compute_block_interior(current_block)  # list
+            #print("677",logical_block_cover,logical_block_interior)
+            physical_block_cover = logical_to_physical_cover(logical_to_physical_mapping, logical_block_cover)  # list
+            physical_block_interior = logical_to_physical_cover(logical_to_physical_mapping,
+                                                                logical_block_interior)  # list
+            #print("670whj\n",physical_block_cover,"\n", physical_block_interior)
+
+            max_connected_component_size = -1
+            root_physical_qubit = -1
+            max_connected_component = []
+
+            for physical_qubit in physical_block_interior:
+                connected_component = max_dfs_tree(sc_device_graph, physical_block_cover,
+                                                    sc_device_graph[physical_qubit])
+                if len(connected_component) > max_connected_component_size:
+                    max_connected_component_size = len(connected_component)
+                    root_physical_qubit = physical_qubit
+                    max_connected_component = connected_component
+            logical_connected_component_cover = physical_to_logical_cover(sc_device_graph, max_connected_component)
+
+            logical_qubits_to_move = []
+            for logical_qubit in logical_block_cover:
+                if logical_qubit not in logical_connected_component_cover:
+                    logical_qubits_to_move.append(logical_qubit)
+            swap_list = []
+            while logical_qubits_to_move != []:
+                qubit_to_move, qubit_in_connected_component = find_short_node(sc_device_graph,
+                                                                               logical_to_physical_mapping,
+                                                                               logical_qubits_to_move,
+                                                                               max_connected_component)
+                connect_node(sc_device_graph, logical_to_physical_mapping, logical_to_physical_mapping[qubit_to_move],
+                              logical_to_physical_mapping[qubit_in_connected_component], swap_list)
+                max_connected_component.append(logical_to_physical_mapping[qubit_to_move])
+                logical_qubits_to_move.remove(qubit_to_move)
+            for swap_step in swap_list:
+                qc.swap(swap_step[1][0], swap_step[1][1])
+            physical_block_cover = logical_to_physical_cover(logical_to_physical_mapping, logical_block_cover)
+            connected_component = max_dfs_tree(sc_device_graph, physical_block_cover,
+                                                sc_device_graph[root_physical_qubit])
+            physical_qubit_tree = tree(sc_device_graph, connected_component)
+            index = 0
+            for pauli_str in current_block.operator.paulis:  # [:-1]:
+                pauli_str1 = [str(pauli_str), current_block.operator.coeffs[index].real]
+                index += 1
+                #print("714\n",current_block.params[0].real)
+                tree_synthesis(qc, sc_device_graph, logical_to_physical_mapping, physical_qubit_tree, pauli_str1,
+                               current_block.params[0].real)
+    return qc
+
+
+# '''-------------'''
+# def connected_tree_synthesis1(pauli_layers, pauli_map=None, graph=None, qc=None, arch='manhattan'):
+#     pauli_map, graph, qc = synthesis_initial(pauli_layers, pauli_map, graph, qc, arch)
+#     for i1 in pauli_layers:
+#         for i2 in i1:
+#             lcover = compute_block_cover(i2)
+#             itir = compute_block_interior(i2)
+#             pcover = logical_list_physical(pauli_map, lcover)
+#             ptir = logical_list_physical(pauli_map, itir)
+#             lmc = -1
+#             lmi = -1
+#             lmt = []
+#             for i3 in ptir: # pauli_map, pcover
+#                 dp = max_dfs_tree(graph, pcover, graph[i3])
+#                 if len(dp) > lmc:
+#                     lmc = len(dp)
+#                     lmi = i3
+#                     lmt = dp
+#             lcover1 = physical_list_logical(graph, lmt)
+#             nc = []
+#             for i3 in lcover:
+#                 if i3 not in lcover1:
+#                     nc.append(i3)
+#             # print(nc)
+#             ins = []
+#             while nc != []:
+#                 id0, id1 = find_short_node(graph, pauli_map, nc, lmt)
+#                 # print(id0, id1)
+#                 connect_node(graph, pauli_map, pauli_map[id0], pauli_map[id1], ins)
+#                 # do we need to update lmt?
+#                 lmt.append(pauli_map[id0])
+#                 nc.remove(id0)
+#             for i3 in ins:
+#                 if i3[0] == 'swap':
+#                     qc.swap(i3[1][0], i3[1][1])
+#             pcover = logical_list_physical(pauli_map, lcover)
+#             # root is lmi
+#             dp = max_dfs_tree(graph, pcover, graph[lmi])
+#             dt = tree(graph, dp)
+#             for i3 in i2:
+#                 tree_synthesis1(qc, graph, pauli_map, dt, i3)
+#     return qc
+
+

--- a/qiskit/transpiler/passes/paulihedral/block_ordering.py
+++ b/qiskit/transpiler/passes/paulihedral/block_ordering.py
@@ -1,0 +1,339 @@
+# ......
+#
+#
+#
+from qiskit.circuit import QuantumCircuit
+from qiskit.circuit.library import PauliEvolutionGate
+from qiskit.circuit.library.pauli_evolution import PauliEvolutionKernel,PauliEvolutionKernels
+from qiskit.opflow import I, Z, X,Y
+#from PauliEvolutionKernel_bank import *
+def list_to_PauliEvolustionGate(input:list)->PauliEvolutionGate:
+    operator=0
+    for i in range(len(input)-1):
+        #i[0] IIIX i[1]0.75
+        if input[i][0][0] == 'I':
+            pauli_string=I
+        if input[i][0][0] == 'X':
+            pauli_string=X
+        if input[i][0][0] == 'Z':
+            pauli_string=Z
+        if input[i][0][0] == 'Y':
+            pauli_string=Y
+
+        for j in input[i][0][1:]:
+            if j == 'I':
+                pauli_string = pauli_string ^ I
+            elif j == 'X':
+                pauli_string = pauli_string ^ X
+            elif j == 'Z':
+                pauli_string = pauli_string ^ Z
+            elif j == 'Y':
+                pauli_string = pauli_string ^ Y
+        pauli_string=input[i][1]*pauli_string
+        operator+=pauli_string
+        #print(operator)
+        pauli_string=''
+    return PauliEvolutionGate(operator,time=input[-1])
+
+def list_to_PauliEvolutionKernal(input:list)->PauliEvolutionKernel:
+    result=PauliEvolutionKernel([])
+    for i in input:
+        result.kernel.append(list_to_PauliEvolustionGate(i))
+    return result
+    
+def list_to_PauliEvolutionKernels(input:list)->PauliEvolutionKernels:
+    result=PauliEvolutionKernels([])
+    for i in input:
+        result.kernels.append(list_to_PauliEvolutionKernal(i))
+    return result
+
+r"""
+
+def lex_ordering(pauliIRprogram):####
+    for i, block in enumerate(pauliIRprogram):
+        param = block[-1]
+        pauliIRprogram[i] = sorted(block[0:-1], key=str_lex_key)
+        pauliIRprogram[i].append(param)
+    pauliIRprogram = sorted(pauliIRprogram, key=block_lex_key)
+    return pauliIRprogram
+
+def gco_ordering(pauliIRprogram, *args):####
+    pauliIRprogram = lex_ordering(pauliIRprogram)
+    pauli_layers = [0] * len(pauliIRprogram)
+    for i in range(len(pauliIRprogram)):
+        pauli_layers[i] = [pauliIRprogram[i]]
+
+    #print(pauli_layers)
+    return pauli_layers
+
+"""
+
+
+
+def block_len(pauli_block: PauliEvolutionGate) -> int:
+    '''example block: [XYX, p1], [XZZ, p2], ..., [ZZZ, p5], p]'''
+    qubit_num = len(pauli_block.operator.paulis[0])
+    length = 0
+    for i in range(qubit_num):
+        for pauli_str in pauli_block.operator.paulis:
+            if str(pauli_str)[i] != 'I':
+                length += 1
+                break
+    return length
+
+
+
+
+def str_lex_key(weighted_pauli_str):
+    value = 0
+    '''q0 corresponds to the right-most pauli op'''
+    weighted_pauli_str=weighted_pauli_str[0]
+    for op in str(weighted_pauli_str):
+        value *= 4
+        if op == 'I':
+            value += 0
+        elif op == 'X':
+            value += 1
+        elif op == 'Y':
+            value += 2
+        elif op == 'Z':
+            value += 3
+    return -value
+
+
+
+
+
+
+
+def block_lex_key(pauli_block: PauliEvolutionGate):
+    value = 0
+    '''q0 corresponds to the right-most pauli op'''
+    for op in str(pauli_block.operator.paulis[0]):
+        value *= 4
+        if op == 'I':
+            value += 0
+        elif op == 'X':
+            value += 1
+        elif op == 'Y':
+            value += 2
+        elif op == 'Z':
+            value += 3
+    return -value
+
+
+
+
+def block_latency(pauli_block: PauliEvolutionGate, qubit_num: int) -> int:
+    latency = 0
+    for pauli_str in pauli_block.operator.paulis:
+        latency += max(2 * (qubit_num - str(pauli_str).count('I')) - 1, 0)
+        if qubit_num - str(pauli_str).count('I') - str(pauli_str).count('Z') > 0:
+            latency += 1  # or 2
+    # print(latency)
+    return latency
+
+
+
+
+def block_qubit_occupation(pauli_block: PauliEvolutionGate, qubit_num: int) -> list:
+    qubit_occupied = [0] * qubit_num
+    for i in range(qubit_num):
+        for pauli_str in pauli_block.operator.paulis:
+            if str(pauli_str)[i] != 'I':
+                qubit_occupied[i] = 1
+            break
+    #print("146block_qubit_occupation\n",qubit_occupied)
+    return qubit_occupied
+
+
+
+def qubit_occupation_template(qubit_occupied, qubit_num, latency):
+    template = []
+    start_index = 0
+    end_index = 0
+
+    '''0 -> qubit not occupied (I), 1 -> qubit occupied (X,Y,Z)'''
+    while start_index < qubit_num:
+        while end_index < qubit_num and qubit_occupied[end_index] == 0:
+            end_index += 1
+        if (end_index - start_index) >= 2:
+            window = [1] * start_index + [0] * (end_index - start_index) + [1] * (qubit_num - end_index)
+            template.append([window, latency])
+        while end_index < qubit_num and qubit_occupied[end_index] != 0:
+            end_index += 1
+        start_index = end_index
+    #print("166qubit_occupation_template\n",template)
+    return template
+
+
+def qubit_occupation_template(qubit_occupied: list, qubit_num: int, latency: int):
+    template = []
+    start_index = 0
+    end_index = 0
+
+    '''0 -> qubit not occupied (I), 1 -> qubit occupied (X,Y,Z)'''
+    while start_index < qubit_num:
+        while end_index < qubit_num and qubit_occupied[end_index] == 0:
+            end_index += 1
+        if (end_index - start_index) >= 2:
+            window = [1] * start_index + [0] * (end_index - start_index) + [1] * (qubit_num - end_index)
+            template.append([window, latency])
+        while end_index < qubit_num and qubit_occupied[end_index] != 0:
+            end_index += 1
+        start_index = end_index
+    #print("170\n",template)
+    return template
+
+
+
+def occupation_embedding_check(qubit_occupied_x: list, qubit_occupied_y: list):
+    for i, occupied_x in enumerate(qubit_occupied_x):
+        if occupied_x == 1 and qubit_occupied_y[i] == 1:
+            return False
+    return True
+
+
+
+def qubit_occupation_combine(qubit_occupied_x: list, qubit_occupied_y: list) -> list:
+    combined_occupation = [0] * len(qubit_occupied_x)
+    for i, occupied_x in enumerate(qubit_occupied_x):
+        if occupied_x == 1 or qubit_occupied_y[i] == 1:
+            combined_occupation[i] = 1
+    return combined_occupation
+
+
+# def generate_templates1(ps, nq, latency, lt=2):
+#     l = latency
+#     idx0 = 0
+#     idx1 = 0
+#     t = []
+#     while idx0 < nq:
+#         while idx1 < len(ps) and ps[idx1] == "I":
+#             idx1 += 1
+#         if (idx1 - idx0) >= 2:
+#             ts = (idx0-0)*'I'+(idx1-idx0)*'X'+(nq-idx1)*'I'
+#             t.append([ts, l])
+#         while idx1 < len(ps) and ps[idx1] != "I":
+#             idx1 += 1
+#         idx0 = idx1
+#     return t
+
+
+
+
+def lex_ordering(pauliIRprogram: PauliEvolutionKernel):  ####
+    '''
+    pauliIRprogram = [[['IIIX', 0.75], ['IIZX', -0.25], ['IZIX', -0.25], ['IZZX', -0.25], theta],
+                  [['IIXI', 0.75], ['IIXZ', -0.25], ['IZXI', -0.25], ['IZXZ', -0.25], theta],
+                  [['IXII', 0.375], ['IXIZ', -0.125], ['IXZI', -0.125], ['IXZZ', -0.125],
+                   ['ZXII', -0.375], ['ZXIZ', 0.125], ['ZXZI', 0.125], ['ZXZZ', 0.125],
+                   theta],
+                  [['XIII', 0.5], ['XZII', -0.5], theta]]
+    '''
+    for ind, block in enumerate(pauliIRprogram.kernel):
+        pauli_block = []
+        for i in range(len(block.operator.paulis)):
+            pauli_block.append([str(block.operator.paulis[i]), block.operator.coeffs[i].real])
+        pauli_block = sorted(pauli_block, key=str_lex_key)
+        pauli_block.append(block.time)
+        pauliIRprogram.kernel[ind] = list_to_PauliEvolustionGate(pauli_block)
+    # for i in range(pauliIRprogram)
+    pauliIRprogram.kernel = sorted(pauliIRprogram.kernel, key=block_lex_key)
+    return pauliIRprogram
+
+
+
+def gco_ordering(pauliIRprogram: PauliEvolutionKernel, *args) -> PauliEvolutionKernels:  ####
+    pauliIRprogram = lex_ordering(pauliIRprogram)
+    result = PauliEvolutionKernels([])
+    for i in range(len(pauliIRprogram.kernel)):
+        a = PauliEvolutionKernel([])
+        a.kernel.append(pauliIRprogram.kernel[i])
+        result.kernels.append(
+            a
+        )
+    return result
+
+
+
+def do_ordering(pauliIRprogram: PauliEvolutionKernel, max_iteration=20) -> PauliEvolutionKernels:
+    '''
+    pauliIRprogram = [[['IIIX', 0.75], ['IIZX', -0.25], ['IZIX', -0.25], ['IZZX', -0.25], theta],
+                  [['IIXI', 0.75], ['IIXZ', -0.25], ['IZXI', -0.25], ['IZXZ', -0.25], theta],
+                  [['IXII', 0.375], ['IXIZ', -0.125], ['IXZI', -0.125], ['IXZZ', -0.125],
+                   ['ZXII', -0.375], ['ZXIZ', 0.125], ['ZXZI', 0.125], ['ZXZZ', 0.125],
+                   theta],
+                  [['XIII', 0.5], ['XZII', -0.5], theta]]
+    '''
+    qubit_num = len(pauliIRprogram.kernel[0].operator.paulis[0])
+
+    if qubit_num >= 4:
+        large_block_threshold = qubit_num / 2
+    else:
+        large_block_threshold = 2
+
+    large_block_list = PauliEvolutionKernel([])
+    small_block_list = PauliEvolutionKernel([])
+
+    for block in pauliIRprogram.kernel:  # gate
+        if block_len(block) > large_block_threshold:
+            large_block_list.kernel.append(block)
+        else:
+            small_block_list.kernel.append(block)
+
+    large_block_list = lex_ordering(large_block_list)  # kernel
+    small_block_list = lex_ordering(small_block_list)
+
+
+    #print("large_block: ", len(large_block_list.kernel))
+    #print("small_block: ", len(small_block_list.kernel))
+
+    block_num = len(pauliIRprogram.kernel)
+
+    pauli_layers = PauliEvolutionKernels([])
+
+    while block_num > 0:
+        if len(large_block_list.kernel) > 0:
+            current_block = large_block_list.kernel[0]
+            large_block_list = PauliEvolutionKernel(large_block_list.kernel[1:])
+        elif len(small_block_list.kernel) > 0:
+            current_block = small_block_list.kernel[0]
+            small_block_list = PauliEvolutionKernel(small_block_list.kernel[1:])
+
+        current_layer = PauliEvolutionKernel([current_block])  # kernel
+
+        block_num -= 1
+
+        latency = block_latency(current_block, qubit_num)
+        layer_qubit_occupation = block_qubit_occupation(current_block, qubit_num)
+
+        current_template = qubit_occupation_template(layer_qubit_occupation, qubit_num, latency)
+        # print("285", current_template, qubit_num, latency)
+        iteration_count = 0
+        while len(current_template) > 0 and iteration_count < max_iteration:
+            iteration_count += 1
+            qubit_occupation_list = []
+            for template in current_template:  # list list
+                small_block_not_selected_list = PauliEvolutionKernel([])
+                for small_block in small_block_list.kernel:
+                    small_latency = block_latency(small_block, qubit_num)
+                    small_occupation = block_qubit_occupation(small_block, qubit_num)
+                    if small_latency <= template[1] and occupation_embedding_check(template[0], small_occupation):
+                        current_layer.kernel.append(small_block)
+                        qubit_occupation_list.append(small_occupation)
+                        template[1] -= small_latency
+                        block_num -= 1
+                    else:
+                        small_block_not_selected_list.kernel.append(small_block)
+                small_block_list = small_block_not_selected_list
+            for qubit_occupation in qubit_occupation_list:
+                layer_qubit_occupation = qubit_occupation_combine(qubit_occupation, layer_qubit_occupation)  # list
+            current_template = qubit_occupation_template(layer_qubit_occupation, qubit_num, latency)  # list
+            if len(qubit_occupation_list) == 0:
+                break
+        pauli_layers.kernels.append(current_layer)
+
+    # print(pauli_layers)
+
+    return pauli_layers

--- a/qiskit/transpiler/paulihedral.py
+++ b/qiskit/transpiler/paulihedral.py
@@ -1,0 +1,961 @@
+
+#from qiskit.transpiler.exceptions import 
+
+
+from qiskit.circuit.quantumcircuit import QuantumCircuit
+from qiskit.circuit.quantumregister import Qubit
+from qiskit.transpiler.passes.paulihedral.block_ordering import *
+from qiskit.transpiler.passes.paulihedral.block_compilation import *
+from qiskit.transpiler.passes.layout.noise_adaptive_layout import *
+
+
+import sys
+
+
+
+class Paulihedral:
+    
+    def __init__(self, inputprogram=None, input_format='pauliIR', evolution_time_step = 1, var_form_parameters = None,
+                 ordering_method=None, backend_method=None, coupling_map=None,props=None):
+        if input_format == 'qubit-op':
+            self.pauliIRprogram = self.load_from_qubit_op(inputprogram, evolution_time_step)
+        elif input_format == 'UCCSD':
+            self.pauliIRprogram = self.load_from_UCCSD(inputprogram, var_form_parameters)
+        else:
+            if inputprogram == None:
+                '''need to raise some error'''
+                print("raise some error")
+            self.pauliIRprogram = inputprogram
+        
+        if ordering_method == 'gco' or ordering_method == 'gate-count-oriented':
+            self.ordering_method = gco_ordering
+        elif ordering_method == 'do' or ordering_method == 'depth-oriented':
+            self.ordering_method = do_ordering
+        else:
+            '''need to raise some error'''
+            print('unknown ordering method')
+            
+        if backend_method == 'ft' or backend_method == 'fault-tolerant':
+            self.block_opt_method = opt_ft_backend
+        elif backend_method == 'sc' or backend_method == 'superconducting':
+            self.block_opt_method = opt_sc_backend
+            if props==None:
+                print("raise error: there is no information about backend properties which is required in superconducting backend.")
+            #if coupling_map == None:
+            #    '''need to raise some error'''
+            #    print('coupling_map missing')
+            else:
+                self.coupling_map = coupling_map
+        else:
+            '''need to raise some error'''
+            print('backend not support')
+        self.output_circuit = None
+        self.adj_mat=None
+        self.dist_mat=None
+        if props!=None:
+            noise_res = NoiseAdaptiveLayout(props)
+            noise_res._initialize_backend_prop()
+            gate_reliability=noise_res.gate_reliability
+            swap_reliabs=noise_res.swap_reliabs
+            qubit_num=len(swap_reliabs)
+            self.adj_mat=[]
+            for i in range(qubit_num):
+                self.adj_mat.append([])
+                for j in range(qubit_num):
+                    self.adj_mat[i].append(0)
+            self.dist_mat = []
+            for i in range(qubit_num):
+                self.dist_mat.append([])
+                for j in range(qubit_num):
+                    self.dist_mat[i].append(0)
+            #print(self.adj_mat)
+            for cx in gate_reliability.keys():
+                i=int(cx[0])
+                j=int(cx[1])
+                (self.adj_mat)[i][j]=1
+                (self.adj_mat)[j][i]=1
+            for key1,value1 in swap_reliabs.items():
+                for key2,value2 in value1.items():
+                    self.dist_mat[key1][key2]=1.0-value2
+            #print("80adj_mat\n",self.adj_mat)
+        
+    def load_from_qubit_op(self, qubit_op_list, evolution_time_step):
+        pauliIRprogram = []
+        for op in qubit_op_list:
+            pauliIRprogram.append([[op.primitive.to_label(), op.coeff], evolution_time_step])
+        return pauliIRprogram
+    
+    def load_from_UCCSD(self, UCCSD_instance, parameters):
+        pauliIRprogram = []
+        for i, parameter_block in enumerate(UCCSD_instance._hopping_ops):
+            pauli_block = []
+            parameter_block = parameter_block.to_dict()['paulis']
+            for j in parameter_block:
+                pauli_block.append([j['label'], j['coeff']['imag']])
+            pauli_block.append(parameters[i])
+            pauliIRprogram.append(pauli_block)
+        #print(pauliIRprogram)
+        return pauliIRprogram
+                
+            
+    def opt(self, do_max_iteration = 30):
+        self.pauli_layers = self.ordering_method(self.pauliIRprogram, do_max_iteration)
+        self.output_circuit = self.block_opt_method(self.pauli_layers,self.adj_mat,self.dist_mat)
+        return self.output_circuit
+
+    def to_circuit(self):
+        if self.output_circuit == None:
+            self.output_circuit = self.opt()
+        return self.output_circuit
+
+
+from qiskit.providers.backend import Backend
+from qiskit.providers.models import BackendProperties
+from qiskit.providers.models.backendproperties import Gate
+from typing import List, Union, Dict, Callable, Any, Optional, Tuple, Iterable
+from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.converters import circuit_to_dag,dag_to_circuit
+from qiskit.visualization import dag_drawer
+from qiskit.compiler import transpile
+import copy
+from qiskit.transpiler.passes.layout.dense_layout import *
+from qiskit.transpiler.coupling import CouplingMap
+
+def get_layout(backend:Backend,
+               layout_pre:Optional[Layout],
+               layout_next:Optional[Layout],
+               used_phy_qubits:list,
+               used_virtual_qubits:list,
+               qubit_num:int)->Layout:
+    '''
+
+    :param backend: The backend of the hardware
+    :param layout_pre:
+    :param layout_next:
+    :param used_phy_qubits:
+    :param used_virtual_qubits:
+    :param qubit_num:
+    :return:
+
+    A figure to show the variables
+    '''
+
+    noise_res = NoiseAdaptiveLayout(backend.properties())
+    noise_res._initialize_backend_prop()
+    swap_reliabs = noise_res.swap_reliabs
+    total_qubit_num = len(swap_reliabs)
+    del swap_reliabs
+    '''
+    dist_mat = []
+    for i in range(total_qubit_num):
+        dist_mat.append([])
+        for j in range(total_qubit_num):
+            dist_mat[i].append(0.0)
+    for key1, value1 in swap_reliabs.items():
+        for key2, value2 in value1.items():
+            dist_mat[key1][key2] = 1.0 - value2
+    '''
+    dist_mat = Backend_Processor(backend=backend).get_local_swap_reliab(range(total_qubit_num))
+    # print('595\n',dist_mat)
+    for i in range(len(dist_mat)):
+        for j in range(len(dist_mat)):
+            dist_mat[i][j] = 1.0 - dist_mat[i][j]
+
+    unused_phy_qubits=[]
+    for idx in range(total_qubit_num):
+        unused_phy_qubits.append(idx)
+    for qubit_idx in used_phy_qubits:
+        unused_phy_qubits.remove(qubit_idx)
+    unused_virtual_qubits = []
+    for idx in range(total_qubit_num):
+        unused_virtual_qubits.append(idx)
+    for qubit_idx in used_virtual_qubits:
+        unused_virtual_qubits.remove(qubit_idx)
+
+    layout = Layout()
+    #case 0
+    if layout_pre==None and layout_next==None:
+        qreg=QuantumCircuit(qubit_num).qregs[0]
+        for i in range(len(used_phy_qubits)):
+            layout[qreg[used_virtual_qubits[i]]]=int(used_phy_qubits[i])
+        for i in range(qubit_num-len(used_phy_qubits)):
+            layout[qreg[unused_virtual_qubits[i]]]=int(unused_phy_qubits[i])
+        layout.add_register(qreg)
+        #print("177\n",layout)
+        return layout
+
+    # case 1
+    elif layout_pre==None and layout_next!=None:
+        input_dict=copy.deepcopy(layout_next._p2v)
+        idx_to_delete=[]
+        for idx,qubit in input_dict.items():
+            if qubit.register.name!='q':
+                idx_to_delete.append(idx)
+        for idx in idx_to_delete:
+            del input_dict[idx]
+        '''maybe need to add a function to check whether the input_dict is possible'''
+        '''
+        input_dict(e.g.)
+        {16: Qubit(QuantumRegister(7, 'q'), 1),
+        11: Qubit(QuantumRegister(7, 'q'), 5),
+        17: Qubit(QuantumRegister(7, 'q'), 3),
+        12: Qubit(QuantumRegister(7, 'q'), 6),
+        4: Qubit(QuantumRegister(7, 'q'), 0),
+        5: Qubit(QuantumRegister(7, 'q'), 2),
+        6: Qubit(QuantumRegister(7, 'q'), 4)}
+        '''
+        qreg = QuantumCircuit(qubit_num).qregs[0]
+        for idx in range(len(used_phy_qubits)):
+            layout[qreg[used_virtual_qubits[idx]]]=int(used_phy_qubits[idx])###
+
+        parallel_phy_qubits=[]
+        for idx in range(total_qubit_num):
+            parallel_phy_qubits.append(idx)
+        for idx in used_phy_qubits:
+            parallel_phy_qubits.remove(idx)###
+
+        parallel_virtual_qubits=[]
+        for idx,qubit in input_dict.items():
+            parallel_virtual_qubits.append(qubit.index)
+        for idx in used_virtual_qubits:
+            parallel_virtual_qubits.remove(idx)###
+        #print("215\n",used_phy_qubits,"\n",parallel_virtual_qubits,"\n",parallel_phy_qubits)
+        '''ERROR above'''
+        for virtual_qubit in parallel_virtual_qubits:
+            phy_qubit_in_layout = None
+            for idx, qubit in input_dict.items():
+                if qubit.index == virtual_qubit:
+                    phy_qubit_in_layout=idx
+                    break
+            '''phy_qubit_in_layout means the physical qubit which match the virtual_qubit in layout_next'''
+            min_dist=99.99
+            phy_qubit_for_min_dist=None
+            for phy_qubit in parallel_phy_qubits:
+                if dist_mat[phy_qubit][phy_qubit_in_layout]<min_dist:
+                    min_dist=dist_mat[phy_qubit][phy_qubit_in_layout]
+                    phy_qubit_for_min_dist=phy_qubit
+            layout[qreg[virtual_qubit]] = int(phy_qubit_for_min_dist)
+            parallel_phy_qubits.remove(phy_qubit_for_min_dist)
+        layout.add_register(qreg)
+        return layout
+
+    #case 2
+    elif layout_pre!=None and layout_next==None:
+        input_dict=copy.deepcopy(layout_pre._p2v)
+        idx_to_delete=[]
+        for idx,qubit in input_dict.items():
+            if qubit.register.name!='q':
+                idx_to_delete.append(idx)
+        for idx in idx_to_delete:
+            del input_dict[idx]
+
+        qreg = QuantumCircuit(qubit_num).qregs[0]
+        for idx in range(len(used_phy_qubits)):
+            layout[qreg[used_virtual_qubits[idx]]]=int(used_phy_qubits[idx])
+
+        parallel_phy_qubits=[]
+        for idx in range(total_qubit_num):
+            parallel_phy_qubits.append(idx)
+        for idx in used_phy_qubits:
+            parallel_phy_qubits.remove(idx)
+        parallel_virtual_qubits=[]
+        for idx,qubit in input_dict.items():
+            parallel_virtual_qubits.append(qubit.index)
+        for idx in used_virtual_qubits:
+            parallel_virtual_qubits.remove(idx)
+        #print("215\n",parallel_virtual_qubits,"\n",unused_virtual_qubits)
+
+        for virtual_qubit in parallel_virtual_qubits:
+            phy_qubit_in_layout=None
+            for idx, qubit in input_dict.items():
+                if qubit.index == virtual_qubit:
+                    phy_qubit_in_layout=idx
+                    break
+            '''phy_qubit_in_layout means the physical qubit which match the virtual_qubit in layout_next'''
+            min_dist=99.99
+            phy_qubit_for_min_dist=None
+            for phy_qubit in parallel_phy_qubits:
+                if dist_mat[phy_qubit][phy_qubit_in_layout]<min_dist:
+                    min_dist=dist_mat[phy_qubit][phy_qubit_in_layout]
+                    phy_qubit_for_min_dist=phy_qubit
+            layout[qreg[virtual_qubit]] = int(phy_qubit_for_min_dist)
+            parallel_phy_qubits.remove(phy_qubit_for_min_dist)
+        layout.add_register(qreg)
+
+    #case 3
+    elif layout_pre != None and layout_next != None:
+        input_dict_pre = copy.deepcopy(layout_pre._p2v)
+        input_dict_next = copy.deepcopy(layout_next._p2v)
+        idx_to_delete=[]
+        for idx, qubit in input_dict_pre.items():
+            if qubit.register.name != 'q':
+                idx_to_delete.append(idx)
+        for idx in idx_to_delete:
+            del input_dict_pre[idx]
+        idx_to_delete=[]
+        for idx, qubit in input_dict_next.items():
+            if qubit.register.name != 'q':
+                del input_dict_next[idx]
+        for idx in idx_to_delete:
+            del input_dict_pre[idx]
+
+        qreg = QuantumCircuit(qubit_num).qregs[0]
+        for idx in range(len(used_phy_qubits)):
+            layout[qreg[used_virtual_qubits[idx]]] = int(used_phy_qubits[idx])
+
+        parallel_phy_qubits = []
+        for idx in range(total_qubit_num):
+            parallel_phy_qubits.append(idx)
+        for idx in used_phy_qubits:
+            parallel_phy_qubits.remove(idx)
+
+        parallel_virtual_qubits = []
+        for idx, qubit in input_dict_pre.items():
+            parallel_virtual_qubits.append(qubit.index)
+        for idx in used_virtual_qubits:
+            parallel_virtual_qubits.remove(idx)
+        #print("215\n",parallel_virtual_qubits,"\n",unused_virtual_qubits)
+
+        for virtual_qubit in parallel_virtual_qubits:
+            phy_qubit_in_layout_pre = None
+            for idx, qubit in input_dict_pre.items():
+                if qubit.index == virtual_qubit:
+                    phy_qubit_in_layout_pre = idx
+                    break
+            phy_qubit_in_layout_next = None
+            for idx, qubit in input_dict_pre.items():
+                if qubit.index == virtual_qubit:
+                    phy_qubit_in_layout_next = idx
+                    break
+            min_dist = 99.99
+            phy_qubit_for_min_dist = None
+            for phy_qubit in parallel_phy_qubits:
+                if 1.0-(1.0-dist_mat[phy_qubit][phy_qubit_in_layout_pre])*(1.0-dist_mat[phy_qubit][phy_qubit_in_layout_next]) < min_dist:
+                    min_dist = 1.0-(1.0-dist_mat[phy_qubit][phy_qubit_in_layout_pre])*(1.0-dist_mat[phy_qubit][phy_qubit_in_layout_next])
+                    phy_qubit_for_min_dist = phy_qubit
+            layout[qreg[virtual_qubit]] = int(phy_qubit_for_min_dist)
+            parallel_phy_qubits.remove(phy_qubit_for_min_dist)
+        layout.add_register(qreg)
+        return layout
+    #print("354\n",layout)
+    return layout
+
+def fill_layout_with_ancilla(
+    backend:Backend,
+    layout_without_ancilla:Layout,
+    used_phy_qubits:list,
+    qubit_num:int
+)->Layout:
+    noise_res = NoiseAdaptiveLayout(backend.properties())
+    noise_res._initialize_backend_prop()
+    swap_reliabs = noise_res.swap_reliabs
+    total_qubit_num = len(swap_reliabs)
+    unused_phy_qubits = []
+    for idx in range(total_qubit_num):
+        unused_phy_qubits.append(idx)
+    for qubit_idx in used_phy_qubits:
+        unused_phy_qubits.remove(qubit_idx)
+    layout=layout_without_ancilla
+    qreg=QuantumCircuit(total_qubit_num - qubit_num).qregs[0]
+    for i in range(total_qubit_num-qubit_num):
+        layout[qreg[i]] = int(unused_phy_qubits[i])
+
+    pass
+
+
+from qiskit.transpiler.passes.layout.apply_layout import ApplyLayout
+from qiskit.transpiler.passes.layout.full_ancilla_allocation import FullAncillaAllocation
+from qiskit.transpiler.passes.layout.enlarge_with_ancilla import EnlargeWithAncilla
+from qiskit.transpiler.passes.routing import LayoutTransformation
+
+def new_block_list_printing(new_block_list:List):
+    '''
+    ATTENTION!!!
+    ATTENTION!!!
+    This function is only for debugging!!!
+    for new_block_list in function_list
+    if Kernel:
+        layer= [ initial QuantumCircuit, True,(2) layout_without_ancilla, physical QuantumCircuit, used_phy_qubits_list, used_virtual_qubits_list]
+    if not Kernel:
+        layer = [ initial QuantumCircuit, False, layout without ancilla, QuantumCircuit after transpile ]
+    '''
+    print("-------PRINTING-------")
+    for idx,layer in enumerate(new_block_list):
+        if layer[1]==True:
+            print("The layer with number",idx)
+            initial_QuantumCircuit=layer[0]
+            is_Kernel=layer[1]
+            layout_without_ancilla=layer[2]
+            physical_QuantumCircuit=layer[3]
+            used_phy_qubits_list, used_virtual_qubits_list=layer[4],layer[5]
+            initial_QuantumCircuit._layout=None
+            print("initial_QuantumCircuit\n",initial_QuantumCircuit)
+            print("is_Kernel\n",is_Kernel)
+            print("layout_without_ancilla\n",layout_without_ancilla)
+            print("physical_QuantumCircuit\n",physical_QuantumCircuit)
+            print("used_phy_qubits_list\n",used_phy_qubits_list)
+            print("used_virtual_qubits_list\n",used_virtual_qubits_list)
+        elif layer[1]==False:
+            print("The layer with number", idx)
+            initial_QuantumCircuit = layer[0]
+            is_Kernel = layer[1]
+            layout_without_ancilla = layer[2]
+            physical_QuantumCircuit = layer[3]
+            print("initial_QuantumCircuit\n", initial_QuantumCircuit)
+            print("is_Kernel\n",is_Kernel)
+            print("layout_without_ancilla\n",layout_without_ancilla)
+            print("physical_QuantumCircuit\n", physical_QuantumCircuit)
+            print("used_phy_qubits_list\n", used_phy_qubits_list)
+            print("used_virtual_qubits_list\n", used_virtual_qubits_list)
+
+from qiskit.providers.backend import Backend
+from qiskit.transpiler.exceptions import *
+import math
+
+class Backend_Processor:
+    def __init__(self,backend:Backend):
+        '''
+        :param backend:
+        '''
+        self.backend=backend
+        self.prop_dict=backend.properties().to_dict()
+
+    def get_local_swap_reliab(self,input_qubits_list:List):
+        '''
+        :param input_qubits_list:
+            A list whose element is all in type int.
+            It stores all qubits which construct a local part.
+            Warning: make sure that the element of the list is in order, from small to big.
+        :return:
+            A matrix.
+            Its (i,j) element ([i][j]) stores a float number which represents the reliability
+            of the SWAP operation between the physical qubit with number qubits_list[i] and
+            qubit_list[j] in the backend hardware.
+            In the operations, only the CNOT or SWAP gates between the qubits with number in
+            qubit_list can be used.
+        '''
+        properties_gates_list=self.prop_dict['gates']
+        #for idx,val in enumerate(properties_gates_list):
+            #print(idx,"\n",val)
+
+        properties_cx_gates_list=[]
+        ''' {'qubits': [7, 6],'gate_error': 0.03754135340392492}'''
+        for gates in properties_gates_list:
+            if gates['gate']=='cx':
+                if gates['qubits'][0] in input_qubits_list \
+                        and gates['qubits'][1] in input_qubits_list:
+                    dict={}
+                    dict['qubits']=gates['qubits']
+                    dict['gate_error']=gates['parameters'][0]['value']
+                    dict['weight']=-3.0*math.log(1-gates['parameters'][0]['value'])
+                    properties_cx_gates_list.append(dict)
+        dict_idx_to_phynum={}
+        dict_phynum_to_idx={}
+        for idx,val in enumerate(input_qubits_list):
+            dict_idx_to_phynum[idx]=val
+            dict_phynum_to_idx[val]=idx
+        for cx_gate in properties_cx_gates_list:
+            cx_gate['qubits'][0]=dict_phynum_to_idx[cx_gate['qubits'][0]]
+            cx_gate['qubits'][1]=dict_phynum_to_idx[cx_gate['qubits'][1]]
+        '''Floyd Algorithm'''
+        result=[]
+        for i in range(len(input_qubits_list)):
+            df=[]
+            for j in range(len(input_qubits_list)):
+                df.append(0.0)
+            result.append(df)
+        #print(result)
+        for i in range(len(input_qubits_list)):
+            for j in range(len(input_qubits_list)):
+                if i==j:
+                    result[i][j]={'length':0.0,'pre':i}
+                elif i!=j:
+                    result[i][j]={'length':99999999.9,'pre':-1}
+        #print(result)#######
+        #print('224',properties_cx_gates_list)#######
+        for v in range(len(input_qubits_list)):
+            for cx_gate in properties_cx_gates_list:
+                if cx_gate['qubits'][0]==v:
+                    ''' {'qubits': [7, 6],'gate_error': 0.03754135340392492, 'weight': 0.5}'''
+                    result[v][cx_gate['qubits'][1]]['length']=cx_gate['weight']
+                    result[v][cx_gate['qubits'][1]]['pre']=v
+                #print('230',result)
+
+        reliability_mat = copy.deepcopy(result)
+        for i in range(len(input_qubits_list)):
+            for j in range(len(input_qubits_list)):
+                reliability_mat[i][j] = math.exp(-result[i][j]['length'])
+        #print(result)
+        #print('231\n',len(input_qubits_list),reliability_mat)
+
+        for v in range(len(input_qubits_list)):
+            for i in range(len(input_qubits_list)):
+                for j in range(len(input_qubits_list)):
+                    if(result[i][j]['length']>result[i][v]['length']+result[v][j]['length']):
+                        result[i][j]['length'] = result[i][v]['length'] + result[v][j]['length']
+                        result[i][j]['pre']=result[v][j]['pre']
+
+        reliability_mat=copy.deepcopy(result)
+        for i in range(len(input_qubits_list)):
+            for j in range(len(input_qubits_list)):
+                reliability_mat[i][j]=math.exp(-result[i][j]['length'])
+        #print(reliability_mat)
+        return reliability_mat
+
+    def get_local_adjacent_mat(self,input_qubits_list:List):
+        '''
+        :param input_qubits_list:
+            A list whose element is all in type int.
+            It stores all qubits which construct a local part.
+            Warning: make sure that the element of the list is in order, from small to big.
+        :return:
+            A matrix.
+            Its (i,j) element ([i][j]) stores 1 if the CNOT or SWAP gate can be used between
+            qubit i and j.
+            In the operations, only the CNOT or SWAP gates between the qubits with number in
+            qubit_list can be used.
+        '''
+        properties_gates_list=self.prop_dict['gates']
+
+
+        cx_gates_list=[]
+        ''' {'qubits': [7, 6],'gate_error': 0.03754135340392492}'''
+        for gates in properties_gates_list:
+            if gates['gate']=='cx':
+                if gates['qubits'][0] in input_qubits_list \
+                        and gates['qubits'][1] in input_qubits_list:
+                    cx_gates_list.append([gates['qubits'][0],gates['qubits'][1]])
+        dict_idx_to_phynum={}
+        dict_phynum_to_idx={}
+        for idx,val in enumerate(input_qubits_list):
+            dict_idx_to_phynum[idx]=val
+            dict_phynum_to_idx[val]=idx
+        for pair in cx_gates_list:
+            pair[0]=dict_phynum_to_idx[pair[0]]
+            pair[1]=dict_phynum_to_idx[pair[1]]
+        adj_mat=[]
+        for i in range(len(input_qubits_list)):
+            line=[]
+            for j in range(len(input_qubits_list)):
+                line.append(0)
+            adj_mat.append(line)
+        #print('533\n',input_qubits_list)
+        #print(cx_gates_list)
+        for i in range(len(input_qubits_list)):
+            for j in range(len(input_qubits_list)):
+                is_in=False
+                for cx_gate in cx_gates_list:
+                    if cx_gate[0]==i and cx_gate[1]==j:
+                        is_in=True
+                if is_in==True :
+                    adj_mat[i][j]=1
+        #print('538\n',adj_mat)
+        return adj_mat
+
+    def get_coupling_map(self)->CouplingMap:
+        properties_gates_list=self.prop_dict['gates']
+        cx_gates_list=[]
+        ''' {'qubits': [7, 6],'gate_error': 0.03754135340392492}'''
+        for gates in properties_gates_list:
+            if gates['gate']=='cx':
+                cx_gates_list.append([gates['qubits'][0],gates['qubits'][1]])
+        #print(cx_gates_list)
+        return CouplingMap(cx_gates_list)
+
+
+def Paulihedral_on_different_qubits_num(
+        input_circuit:QuantumCircuit,
+        global_backend:Backend,
+        global_coupling_map:CouplingMap,
+        ordering_method=None,
+        backend_method=None,
+        do_max_iteration = 30,
+        used_phy_qubits_list=[]
+    )->QuantumCircuit:
+    '''
+
+    :param input_circuit:
+    :param global_backend:
+    :param global_coupling_map:
+    :param ordering_method:
+    :param backend_method:
+    :param do_max_iteration:
+    :return:
+    '''
+    phy_dag = circuit_to_dag(input_circuit)
+    layout = Layout()
+    kernel_qc = None
+    for node in phy_dag.op_nodes():
+        if node.name == 'PauliEvolutionKernel':
+            '''type(node.op)) #<class 'qiskit.circuit.library.pauli_evolution.PauliEvolutionKernel'>'''
+            kernel_qc = node.op
+            qubit_num_on_Kernel=len(node.qargs)
+            qreg = QuantumCircuit(qubit_num_on_Kernel).qregs[0]
+            for idx, qubit in enumerate(list(node.qargs)):
+                layout[qreg[idx]] = int(qubit.index)
+
+    if ordering_method == 'gco' or ordering_method == 'gate-count-oriented':
+        pauli_layers = gco_ordering(kernel_qc,do_max_iteration)
+    elif ordering_method == 'do' or ordering_method == 'depth-oriented':
+        pauli_layers = do_ordering(kernel_qc,do_max_iteration)
+    else:
+        '''need to raise some error'''
+        print('unknown ordering method')
+
+    if backend_method == 'ft' or backend_method == 'fault-tolerant':
+        output_circuit = opt_ft_backend(pauli_layers,adj_mat=[],dist_mat=[])
+    elif backend_method == 'sc' or backend_method == 'superconducting':
+        adj_mat=Backend_Processor(backend=global_backend).get_local_adjacent_mat(used_phy_qubits_list)
+        dist_mat = Backend_Processor(backend=global_backend).get_local_swap_reliab(used_phy_qubits_list)
+        #print('595\n',dist_mat)
+        for i in range(len(dist_mat)):
+            for j in range(len(dist_mat)):
+                dist_mat[i][j]=1.0-dist_mat[i][j]
+        #print('605',dist_mat)
+
+        output_circuit = opt_sc_backend(pauli_layers, adj_mat=adj_mat,dist_mat=dist_mat)
+
+    output_circuit._layout = None
+    '''get physical QuantumCircuit (without layout) but Kernels folded'''
+    full_ancilla_pass = FullAncillaAllocation(coupling_map=global_coupling_map)
+    full_ancilla_pass.property_set['layout'] = copy.deepcopy(layout)
+    qc_temp = copy.deepcopy(output_circuit)
+    qc_temp._layout = None
+    #print('254\n',qc_temp,'\n\n',layout)
+    '''
+     Layout({
+    1: Qubit(QuantumRegister(4, 'q'), 0),
+    4: Qubit(QuantumRegister(4, 'q'), 1),
+    2: Qubit(QuantumRegister(4, 'q'), 2),
+    5: Qubit(QuantumRegister(4, 'q'), 3)
+    })
+    '''
+    phy_dag = full_ancilla_pass.run(circuit_to_dag(qc_temp))#bug
+    layout = full_ancilla_pass.property_set['layout']
+    apply_layout_pass = ApplyLayout()
+    apply_layout_pass.property_set['layout'] = layout
+    phy_dag = apply_layout_pass.run(phy_dag)
+    phy_circ = dag_to_circuit(phy_dag)
+    phy_circ._layout = None
+    return phy_circ
+
+def Paulihedral_on_mixed_circuit(
+        qc:QuantumCircuit,
+        backend: Optional[Backend] = None,
+        coupling_map:CouplingMap= None,
+        ordering_method=None,
+        backend_method=None,
+        do_max_iteration:int =30,
+):
+    '''
+    :param qc:
+        The input logical QuantumCircuit.
+    :param backend:
+        The hardware backend used on the optimization.
+    :param coupling_map:
+        The CouplingMap of the physical qubits of the hardware.
+    :param ordering_method:
+        The ordering_method of the class Paulihedral.
+        You can choose 'gco' ('gate-count-oriented') or 'do' ('depth-oriented').
+    :param backend_method:
+        The backend_method of the class Paulihedral.
+        You can choose 'ft' ('fault-tolerant') or 'sc' ('superconducting').
+    :param do_max_iteration:
+        A super parameter in Paulihedral.
+    :return:
+        The physical Quantum Circuit with layout after the Paulihedral optimization for PauliEvolutionKernel
+        and the regular optimization for the rest.
+    '''
+    if backend==None:
+        raise TranspilerError(f"backend is in need in function Paulihedral_on_mixed_circuit()" )
+        return None
+    if ordering_method==None:
+        raise TranspilerError( f"ordering_method is in need in function Paulihedral_on_mixed_circuit()")
+        return None
+    if backend_method==None:
+        raise TranspilerError( f"backend_method is in need in function Paulihedral_on_mixed_circuit()")
+        return None
+    if coupling_map==None:
+        backend_processor = Backend_Processor(backend=backend)
+        coupling_map=backend_processor.get_coupling_map()
+
+
+    '''
+    Next we will store the information of qc into block_list. In the process, the QuantumCircuit will spilt into layers.
+    '''
+    input_dag=circuit_to_dag(qc)
+    layers = input_dag.layers()
+    block_list = []
+    while True:
+        a = next(layers, None)
+        if (a == None):
+            break
+        circ = dag_to_circuit(a['graph'])
+        has_Kernel=False
+        num_Kernel=0
+        for node in a['graph'].op_nodes():
+            if (str(node.op.name) == 'PauliEvolutionKernel'):
+                has_Kernel=True
+                num_Kernel+=1
+
+        if has_Kernel==False:
+            block_list.append([circ,has_Kernel])
+        elif has_Kernel==True:
+            dag1=copy.deepcopy(a['graph'])
+            dag2=copy.deepcopy(a['graph'])
+            dag2_list=[]
+            #dag2_used_logical_qubits_list=[]
+            for node in dag1.op_nodes():
+                if (str(node.op.name) == 'PauliEvolutionKernel'):
+                    dag1.remove_op_node(node)
+            for node in dag2.op_nodes():
+                if (str(node.op.name) != 'PauliEvolutionKernel'):
+                    dag2.remove_op_node(node)
+            for node in dag2.op_nodes():
+                if (str(node.op.name)=='PauliEvolutionKernel'):
+                    node.name='PauliEvolutionKernel_sign'
+                    dag2_copy=copy.deepcopy(dag2)
+                    dag2_copy.remove_all_ops_named('PauliEvolutionKernel')
+                    for node_copy in dag2_copy.op_nodes():
+                        node_copy.name='PauliEvolutionKernel'
+                    dag2_list.append(dag2_copy)
+                    node.name = 'PauliEvolutionKernel'
+            if len(dag1.op_nodes())>0:
+                block_list.append([dag_to_circuit(dag1),False])
+            for idx,kernel in enumerate(dag2_list):
+                block_list.append([dag_to_circuit(kernel), True]) #,dag2_used_logical_qubits_list[idx]])
+    '''
+    In the stage, the information is stored in block_list:List.
+    Every element of the block_list represents onr layer of the logical dag.
+    For a single element,
+        [circuit of the layer, True for PauliEvolutionKernel or False for other]
+    In addition, there will be no element contains 2 or more PauliEvolutionKernel
+    '''
+
+
+    if block_list==[]:
+        raise TranspilerError(
+            f"empty input QuantumCircuit"
+        )
+        return None
+    qubit_num=qc.qregs[0]._size
+    if block_list[0][1]==False:
+        new_block_list=[[block_list[0][0],False]]
+    elif block_list[0][1]==True:
+        new_block_list=[[block_list[0][0],True]]
+
+    for idx,layer in enumerate(block_list):
+        if idx==0:
+            continue
+        if layer[1]==False and new_block_list[-1][1]==False:
+            new_block_list[-1][0].extend(layer[0])
+        elif layer[1]==False and new_block_list[-1][1]==True:
+            new_block_list.append([layer[0],False])
+        elif layer[1]==True:
+            new_block_list.append([layer[0],True])
+    del block_list
+
+    '''
+    In the stage, the information is stored in new_block_list:List.
+    For a single element in new_block_list,
+        layer=[ initial QuantumCircuit(only logical), True or False]
+    Next, we will get the used_phy_qubits_list, used_virtual_qubits_list for layers.
+        used_phy_qubits_list: A list which stores every index of the physical qubits which will be used for Kernel.
+        used_virtual_qubits_list: A list which stores every index of the virtual qubits which will be used for Kernel. 
+                In addition, the virtual qubits is as same as the qubits in the input qc in function Paulihedral_on_mixed_circuit().
+    '''
+
+    dense_layout_pass=DenseLayout(coupling_map=coupling_map ,backend_prop=backend.properties())
+    for layer in new_block_list:
+        if layer[1]==True:
+            virtual_qubits_used = []
+            node = circuit_to_dag(layer[0]).op_nodes()[0]
+            for qubit in node.qargs:
+                virtual_qubits_used.append(qubit.index)
+            best_subset=dense_layout_pass._best_subset(num_qubits= len(virtual_qubits_used),num_meas=0,num_cx=0)
+            layer.append(None)
+            layer.append(None)
+            layer.append(best_subset)
+            layer.append(virtual_qubits_used)
+        elif layer[1]==False:
+            new_layer=transpile(circuits=layer[0],backend=backend,optimization_level=3)
+            idx_to_delete = []
+            layout_1=copy.deepcopy(new_layer._layout)
+            for phy_idx,qubit in layout_1._p2v.items():
+                if qubit._register._name=='ancilla':
+                    idx_to_delete.append(phy_idx)
+            for idx in idx_to_delete:
+                del layout_1._v2p[layout_1._p2v[idx]]
+                del layout_1._p2v[idx]
+            layer.append(layout_1)
+            layer.append(copy.deepcopy(new_layer))
+
+    '''
+    Now in new_block_list:
+        if Kernel:
+            layer= [ initial QuantumCircuit, True, None, None, used_phy_qubits_list, used_virtual_qubits_list]
+        if not Kernel:
+            layer= [ initial QuantumCircuit, False, layout without ancilla, QuantumCircuit after transpile ]
+    Next we will get layout (without ancilla) and physical QuantumCircuit (without layout) for the Kernel.
+    '''
+
+    for idx,layer in enumerate(new_block_list):
+        if layer[1]==True:
+            '''get layout (without ancilla) for the Kernel'''
+            layout1=None
+            layout2=None
+            if idx==0 and len(new_block_list)>1 and new_block_list[1][1]==False:
+                layout2=new_block_list[1][2]
+            elif idx==len(new_block_list)-1 and len(new_block_list)>1 and new_block_list[-2][1]==False:
+                layout1=new_block_list[len(new_block_list)-2][2]
+            else:
+                if new_block_list[idx-1][1]==False:
+                    layout1=new_block_list[idx-1][2]
+                if new_block_list[idx+1][1]==False:
+                    layout2=new_block_list[idx+1][2]
+            layout_without_ancilla=get_layout(
+                backend=backend,layout_pre=layout1,
+                layout_next=layout2,used_phy_qubits=layer[4],used_virtual_qubits=layer[5],qubit_num=qubit_num)
+            layer[2]=copy.deepcopy(layout_without_ancilla)
+            '''get physical QuantumCircuit (without layout) but Kernels folded'''
+            full_ancilla_pass = FullAncillaAllocation(coupling_map=coupling_map)
+            full_ancilla_pass.property_set['layout'] = copy.deepcopy(layout_without_ancilla)
+            #print('675layout_without_ancilla\n',layout_without_ancilla)
+            #print('676layer[0]\n\n',layer[0])
+            qc_temp=copy.deepcopy(layer[0])
+            qc_temp._layout=None
+            phy_dag=full_ancilla_pass.run(circuit_to_dag(qc_temp))
+            layout_with_ancilla=full_ancilla_pass.property_set['layout']
+            apply_layout_pass = ApplyLayout()
+            apply_layout_pass.property_set['layout'] = layout_with_ancilla
+            phy_dag = apply_layout_pass.run(phy_dag)
+
+            unPaulihedraled_phy_circ=dag_to_circuit(phy_dag)
+            unPaulihedraled_phy_circ._layout=layout_with_ancilla
+            unPaulihedraled_phy_circ._layout=None
+            #layer[3]=unPaulihedraled_phy_circ#VI
+            '''get the unfolded physical Quantum Circuit'''
+            init_layout=Layout()
+            '''
+            layout = Layout()
+            #case 0
+            if layout_pre==None and layout_next==None:
+                qreg=QuantumCircuit(qubit_num).qregs[0]
+                for i in range(len(used_phy_qubits)):
+                    layout[qreg[used_virtual_qubits[i]]]=int(used_phy_qubits[i])
+                for i in range(qubit_num-len(used_phy_qubits)):
+                    layout[qreg[unused_virtual_qubits[i]]]=int(unused_phy_qubits[i])
+                layout.add_register(qreg)
+                #print("177\n",layout)
+                return layout
+            '''
+            #print("PRESENT")
+            #print('704\n\n',unPaulihedraled_phy_circ)
+            '''
+            noise_res = NoiseAdaptiveLayout(backend.properties())
+            noise_res._initialize_backend_prop()
+            swap_reliabs = noise_res.swap_reliabs
+            total_qubit_num = len(swap_reliabs)
+            '''
+            '''
+            qreg = QuantumCircuit(total_qubit_num).qregs[0]
+            for node in phy_dag.op_nodes():
+                if node.name=='PauliEvolutionKernel':
+                    print(node.name)
+                    print(node)
+                    print(node.qargs)
+            print("586\n", layout_without_ancilla, "\n", layer[0], "\n", phy_circ)
+            '''
+
+            #print('845\n',layer[4])
+            Paulihedraled_phy_circ=Paulihedral_on_different_qubits_num(
+                    input_circuit=unPaulihedraled_phy_circ,
+                    global_backend=backend,
+                    global_coupling_map=coupling_map,
+                    ordering_method=ordering_method,
+                    backend_method=backend_method,
+                    do_max_iteration=do_max_iteration,
+                    used_phy_qubits_list=layer[4]
+            )
+            layer[3]=Paulihedraled_phy_circ#VI
+    #new_block_list_printing(new_block_list)
+    '''
+    Now in new_block_list:
+    if Kernel:
+        layer= [ initial QuantumCircuit, True, layout_without_ancilla, physical QuantumCircuit, used_phy_qubits_list, used_virtual_qubits_list]
+    if not Kernel:
+        layer = [ initial QuantumCircuit, False, layout_without_ancilla, QuantumCircuit after transpile ]
+    Next we will get the final result which is the output circuit for the function Paulihedral_on_mixed_circuit().
+    '''
+
+    noise_res = NoiseAdaptiveLayout(backend.properties())
+    noise_res._initialize_backend_prop()
+    swap_reliabs = noise_res.swap_reliabs
+    total_qubit_num = len(swap_reliabs)
+
+
+    final_result=QuantumCircuit(total_qubit_num)
+
+    '''get the layout of final_result'''
+    if len(new_block_list[0][2]._p2v) > total_qubit_num:
+        raise TranspilerError(f"the virtual qubits number is more than physical qubits number, so it's impossible to run the function Paulihedral_on_mixed_circuit()")
+        return None
+    elif len(new_block_list[0][2]._p2v) == total_qubit_num:
+        final_layout=copy.deepcopy(new_block_list[0][2])
+    elif len(new_block_list[0][2]._p2v)<total_qubit_num:
+        final_layout=copy.deepcopy(new_block_list[0][2])
+        full_ancilla_pass = FullAncillaAllocation(coupling_map=coupling_map)
+        full_ancilla_pass.property_set['layout'] = final_layout
+        full_ancilla_pass.run(circuit_to_dag(copy.deepcopy(layer[0])))
+        final_layout = full_ancilla_pass.property_set['layout']
+
+    '''combine together and get the physical circuit of the final result'''
+    for block in new_block_list:
+        phy_qc=copy.deepcopy(block[3])
+        phy_qc._layout=None
+        block[3]=phy_qc
+    final_result.extend(new_block_list[0][3])
+    for idx,block in enumerate (new_block_list[1:]):
+        layout_transform=LayoutTransformation(
+            coupling_map=coupling_map,from_layout=new_block_list[idx-1][2],to_layout=new_block_list[idx][2]
+        )
+        final_dag=layout_transform.run(circuit_to_dag(final_result))
+        final_result=dag_to_circuit(final_dag).extend(block[3])
+
+    '''let the layout of the last layer match the layout of the first one'''
+    layout_transform = LayoutTransformation(
+        coupling_map=coupling_map, from_layout=new_block_list[idx][2], to_layout=new_block_list[0][2]
+    )
+    final_dag = layout_transform.run(circuit_to_dag(final_result))
+    final_result = dag_to_circuit(final_dag)
+
+    #print(final_layout,"\n",final_result)
+    final_result._layout=final_layout
+    #print(final_layout)
+    #print(final_result)
+    return final_result
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
### Summary
It is paulihedral_2 after making it more robust.

In this pull request we are integrating Paulihedral into Qiskit terra compiler. Paulihederal (Li et al. ASPLOS 2022, https://arxiv.org/abs/2109.03371) targets a special type of quantum program segment composed by the an array of PauliEvolutionGates. It will synthesis such programs into single qubit gates and CNOTs and try to optimize the gate count and circuit depth in the follow-up compilation.

We made the following key components.

We define a new class PauliEvolutionKernel, which is the input of the Paulihedral compilation flow. It puts an array of PauliEvolutionGates in a single data structure and can be added to the QuantumCircuit object.

In the block_ordering.py, we provide two methods, the gate count oriented scheduling and the depth oriented scheduling to reorder the PauliEvolutionGates for follow-up compilation and optimization. This is the first stage in the Paulihedral compilation flow.

In the block_compilation.py, we provide two methods to optimize and synthesize for different backend configurations with or without a coupling map. If these is not coupling map, the opt_ft_backend method will try to synthe size the Pauli string simulation circuits in a way that minimizes the gate count. If a coupling map is provided, the opt_sc_backend method will focus more on minimizing the mapping overhead.

In the paulihedral.py, we provide the class Paulihedral and the function Paulihedral_on_mixed_circuit. The class Paulihedral is used to optimize an input QuantumCircuit which consists of only one PauliEvolutionKernel. The function Paulihedral_on_mixed_circuit is used to optimize an  circuit with PauliEvolutionKernels.


### Details and comments

There will soon be a demo show the detail of the work.

