### PR TITLE
Bump stevedore and unpin importlib_metadata

### DIFF
--- a/releasenotes/notes/bump-stevedore-1d70d39a6d00654d.yaml
+++ b/releasenotes/notes/bump-stevedore-1d70d39a6d00654d.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The required version of ``stevedore`` has been bumped to ``> 4.0.0``.  This
+    is due to incompatible changes in ``importlib_metadata>=5.0``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ scipy>=1.5
 sympy>=1.3
 dill>=0.3
 python-dateutil>=2.8.0
-stevedore>=3.0.0
+# Stevedore 4.0.0 and below were broken by importlib_metadata 5.0.
+stevedore>4.0.0
+
 symengine>=0.9 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
 shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
@@ -14,9 +16,3 @@ typing-extensions; python_version < '3.8'
 # To be removed as a requirement in Terra 0.23.  Tweedledum's wheels are
 # hopelessly broken on M1 mac, so we skip the waiting period for that.
 tweedledum>=1.1,<2.0; platform_machine != 'arm64' or sys_platform != 'darwin'
-
-# Hack around stevedore being broken by importlib_metadata 5.0; we need to pin
-# the requirements rather than the constraints if we need to cut a release
-# before stevedore is fixed.  `importlib_metadata` is not (currently) a direct
-# requirement of Terra.
-importlib_metadata<5.0; python_version<'3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,15 @@ scipy>=1.5
 sympy>=1.3
 dill>=0.3
 python-dateutil>=2.8.0
-# Stevedore 4.0.0 and below were broken by importlib_metadata 5.0.
-stevedore>4.0.0
-
 symengine>=0.9 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
+
+# Stevedore 4.0.0 and below were broken by importlib_metadata 5.0, but stevedore
+# 4.0.1 isn't available on Python 3.7.  The importlib_metadata pin is
+# undesirable, so we limit its effects.
+stevedore>4.0.0; python_version>='3.8'
+stevedore>=3.0.0; python_version<'3.8'
+importlib_metadata<5.0; python_version<'3.8'
+
 shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
 


### PR DESCRIPTION
### Summary

Upstream fixes to `stevedore` in 4.0.1 now meant that we can relax our constraint on `importlib_metadata`.  Stevedore is a pure Python package, so compatiblity with only the version latest version of the package should not be too onerous a requirement.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

We may or may not want to backport this.  Strictly, it's an API change because it bumps the minimum version of `stevedore`, which is a pretty convincing reason to hold it until Terra 0.23.  The other argument is that we really didn't want to release with the `importlib_metadata<5` pin in place, but the updates to `stevedore` came too late for us, and we have a chance to fix it in 0.22.1.