### PR TITLE
Disable pylint's import-error

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,7 +73,8 @@ disable=spelling,       # way too noisy
     no-else-return,     # relax "elif" after a clause with a return
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
-    bad-continuation, bad-whitespace # differences of opinion with black
+    bad-continuation, bad-whitespace, # differences of opinion with black
+    import-error        # overzealous with our optionals/dynamic packages
 
 
 

--- a/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
+++ b/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
@@ -40,8 +40,6 @@ class NLoptOptimizer(Optimizer):
     NLopt global optimizer base class
     """
 
-    # pylint: disable=import-error
-
     _OPTIONS = ["max_evals"]
 
     def __init__(self, max_evals: int = 1000) -> None:  # pylint: disable=unused-argument

--- a/qiskit/circuit/equivalence.py
+++ b/qiskit/circuit/equivalence.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 
-from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module
 import retworkx as rx
 
 from qiskit.exceptions import InvalidFileError

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=import-error,invalid-sequence-index
+# pylint: disable=invalid-sequence-index
 
 """Circuit transpile function"""
 import io

--- a/qiskit/opflow/gradients/gradient.py
+++ b/qiskit/opflow/gradients/gradient.py
@@ -206,7 +206,7 @@ class Gradient(GradientBase):
                 grad_combo_fn = operator.grad_combo_fn
             else:
                 _optionals.HAS_JAX.require_now("automatic differentiation")
-                from jax import jit, grad  # pylint: disable=import-error
+                from jax import jit, grad
 
                 grad_combo_fn = jit(grad(operator.combo_fn, holomorphic=True))
 

--- a/qiskit/opflow/gradients/hessian.py
+++ b/qiskit/opflow/gradients/hessian.py
@@ -236,7 +236,7 @@ class Hessian(HessianBase):
             )
 
             _optionals.HAS_JAX.require_now("automatic differentiation")
-            from jax import grad, jit  # pylint: disable=import-error
+            from jax import grad, jit
 
             if operator.grad_combo_fn:
                 first_partial_combo_fn = operator.grad_combo_fn

--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,import-error
+# pylint: disable=no-name-in-module
 
 """
 Base class for dummy backends.

--- a/qiskit/providers/fake_provider/fake_backend_v2.py
+++ b/qiskit/providers/fake_provider/fake_backend_v2.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,import-error
+# pylint: disable=no-name-in-module
 
 """Mock BackendV2 object without run implemented for testing backwards compat"""
 

--- a/qiskit/providers/fake_provider/fake_mumbai_v2.py
+++ b/qiskit/providers/fake_provider/fake_mumbai_v2.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,import-error
+# pylint: disable=no-name-in-module
 
 """Mock BackendV2 object without run implemented for testing backwards compat"""
 

--- a/qiskit/quantum_info/operators/measures.py
+++ b/qiskit/quantum_info/operators/measures.py
@@ -337,7 +337,7 @@ def _cvxpy_check(name):
     """Check that a supported CVXPY version is installed"""
     # Check if CVXPY package is installed
     _optionals.HAS_CVXPY.require_now(name)
-    import cvxpy  # pylint: disable=import-error
+    import cvxpy
 
     # Check CVXPY version
     version = cvxpy.__version__

--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -20,7 +20,7 @@ from typing import Dict, Optional
 import numpy as np
 import retworkx as rx
 
-from qiskit._accelerate.sparse_pauli_op import unordered_unique  # pylint: disable=import-error
+from qiskit._accelerate.sparse_pauli_op import unordered_unique
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.operators.custom_iterator import CustomIterator
 from qiskit.quantum_info.operators.linear_op import LinearOp

--- a/qiskit/quantum_info/states/densitymatrix.py
+++ b/qiskit/quantum_info/states/densitymatrix.py
@@ -32,7 +32,6 @@ from qiskit.quantum_info.operators.predicates import is_positive_semidefinite_ma
 from qiskit.quantum_info.operators.channel.quantum_channel import QuantumChannel
 from qiskit.quantum_info.operators.channel.superop import SuperOp
 
-# pylint: disable=import-error
 from qiskit._accelerate.pauli_expval import density_expval_pauli_no_x, density_expval_pauli_with_x
 
 

--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -31,7 +31,6 @@ from qiskit.quantum_info.operators.symplectic import Pauli, SparsePauliOp
 from qiskit.quantum_info.operators.op_shape import OpShape
 from qiskit.quantum_info.operators.predicates import matrix_equal
 
-# pylint: disable=import-error
 from qiskit._accelerate.pauli_expval import (
     expval_pauli_no_x,
     expval_pauli_with_x,

--- a/qiskit/result/sampled_expval.py
+++ b/qiskit/result/sampled_expval.py
@@ -14,8 +14,6 @@
 """Routines for computing expectation values from sampled distributions"""
 import numpy as np
 
-
-# pylint: disable=import-error
 from qiskit._accelerate.sampled_exp_val import sampled_expval_float, sampled_expval_complex
 from qiskit.exceptions import QiskitError
 from .distributions import QuasiDistribution, ProbDistribution

--- a/qiskit/result/utils.py
+++ b/qiskit/result/utils.py
@@ -28,8 +28,7 @@ from qiskit.result.distributions.quasi import QuasiDistribution
 
 from qiskit.result.postprocess import _bin_to_hex
 
-# pylint: disable=import-error, no-name-in-module
-from qiskit._accelerate import results as results_rs
+from qiskit._accelerate import results as results_rs  # pylint: disable=no-name-in-module
 
 
 def marginal_counts(

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -43,7 +43,7 @@ __unittest = True  # Allows shorter stack trace for .assertDictAlmostEqual
 # unittest's TestCase. This will enable the fixtures used for capturing stdout
 # stderr, and pylogging to attach the output to stestr's result stream.
 if _optionals.HAS_TESTTOOLS:
-    import testtools  # pylint: disable=import-error
+    import testtools
 
     class BaseTestCase(testtools.TestCase):
         """Base test class."""

--- a/qiskit/tools/jupyter/__init__.py
+++ b/qiskit/tools/jupyter/__init__.py
@@ -122,7 +122,6 @@ if _IP is not None:
 
         _IP.register_magics(BackendOverview)
         if _optionals.HAS_IBMQ:
-            # pylint: disable=import-error
             from qiskit.providers.ibmq import IBMQBackend  # pylint: disable=no-name-in-module
 
             HTML_FORMATTER = _IP.display_formatter.formatters["text/html"]

--- a/qiskit/tools/jupyter/job_watcher.py
+++ b/qiskit/tools/jupyter/job_watcher.py
@@ -25,8 +25,6 @@ from .watcher_monitor import _job_monitor
 class JobWatcher(Subscriber):
     """An IBM Q job watcher."""
 
-    # pylint: disable=import-error
-
     def __init__(self):
         super().__init__()
         self.jobs = []

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -23,7 +23,7 @@ import warnings
 
 import numpy as np
 import retworkx as rx
-from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module
 
 from qiskit.transpiler.exceptions import CouplingError
 

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -20,7 +20,7 @@ from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
 from qiskit.transpiler.exceptions import TranspilerError
 
-from qiskit._accelerate.dense_layout import best_subset  # pylint: disable=import-error
+from qiskit._accelerate.dense_layout import best_subset
 
 
 class DenseLayout(AnalysisPass):

--- a/qiskit/transpiler/passes/optimization/_gate_extension.py
+++ b/qiskit/transpiler/passes/optimization/_gate_extension.py
@@ -25,7 +25,7 @@ from qiskit.circuit.library.standard_gates import SwapGate, CSwapGate, CRZGate, 
 from qiskit.utils import optionals as _optionals
 
 if _optionals.HAS_Z3:
-    import z3  # pylint: disable=import-error
+    import z3
 
     # FLIP GATES #
     # XGate

--- a/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
+++ b/qiskit/transpiler/passes/optimization/crosstalk_adaptive_schedule.py
@@ -49,8 +49,6 @@ ONEQ_XTALK_THRESH = 2
 class CrosstalkAdaptiveSchedule(TransformationPass):
     """Crosstalk mitigation through adaptive instruction scheduling."""
 
-    # pylint: disable=import-error
-
     def __init__(self, backend_prop, crosstalk_prop, weight_factor=0.5, measured_qubits=None):
         """CrosstalkAdaptiveSchedule initializer.
 

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -28,8 +28,6 @@ class HoareOptimizer(TransformationPass):
     https://arxiv.org/abs/1810.00375
     """
 
-    # pylint: disable=import-error
-
     def __init__(self, size=10):
         """
         Args:

--- a/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
+++ b/qiskit/transpiler/passes/optimization/optimize_1q_gates.py
@@ -26,7 +26,7 @@ from qiskit.circuit import ParameterExpression
 from qiskit.circuit.gate import Gate
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.quantum_info.synthesis import Quaternion
-from qiskit._accelerate.optimize_1q_gates import compose_u3_rust  # pylint: disable=import-error
+from qiskit._accelerate.optimize_1q_gates import compose_u3_rust
 
 _CHOP_THRESHOLD = 1e-15
 

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -25,14 +25,13 @@ from qiskit.transpiler.layout import Layout
 from qiskit.dagcircuit import DAGOpNode
 from qiskit.tools.parallel import CPU_COUNT
 
-# pylint: disable=import-error
 from qiskit._accelerate.sabre_swap import (
     build_swap_map,
     Heuristic,
     NeighborTable,
     SabreDAG,
 )
-from qiskit._accelerate.stochastic_swap import NLayout  # pylint: disable=import-error
+from qiskit._accelerate.stochastic_swap import NLayout
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 _UNSUPPORTED_BACKENDS = ["unitary_simulator", "clifford_simulator"]
 
-# pylint: disable=no-name-in-module, import-error, unused-import
+# pylint: disable=no-name-in-module,unused-import
 
 
 class ProviderCheck:

--- a/qiskit/utils/optionals.py
+++ b/qiskit/utils/optionals.py
@@ -257,7 +257,7 @@ HAS_NETWORKX = _LazyImportTester("networkx", install="pip install networkx")
 def _nlopt_callback(available):
     if not available:
         return
-    import nlopt  # pylint: disable=import-error
+    import nlopt
 
     _logger.info(
         "NLopt version: %s.%s.%s",

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,broad-except,cyclic-import,import-error
+# pylint: disable=no-name-in-module,broad-except,cyclic-import
 
 """Contains the terra version."""
 

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -15,7 +15,7 @@
 """
 Visualization function for DAG circuit representation.
 """
-from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module,import-error
+from retworkx.visualization import graphviz_draw  # pylint: disable=no-name-in-module
 
 from qiskit.dagcircuit.dagnode import DAGOpNode, DAGInNode, DAGOutNode
 from qiskit.circuit import Qubit

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -31,11 +31,11 @@ from qiskit.utils.measurement_error_mitigation import build_measurement_error_mi
 from qiskit.utils import optionals
 
 if optionals.HAS_AER:
-    # pylint: disable=import-error,no-name-in-module
+    # pylint: disable=no-name-in-module
     from qiskit import Aer
     from qiskit.providers.aer import noise
 if optionals.HAS_IGNIS:
-    # pylint: disable=import-error,no-name-in-module
+    # pylint: disable=no-name-in-module
     from qiskit.ignis.mitigation.measurement import (
         CompleteMeasFitter as CompleteMeasFitter_IG,
         TensoredMeasFitter as TensoredMeasFitter_IG,

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=no-name-in-module,import-error
+# pylint: disable=no-name-in-module
 
 
 """ Test Operator construction, including OpPrimitives and singletons. """

--- a/test/python/utils/mitigation/test_meas.py
+++ b/test/python/utils/mitigation/test_meas.py
@@ -45,7 +45,7 @@ from qiskit.utils.mitigation.circuits import count_keys
 from qiskit.utils import optionals
 
 if optionals.HAS_AER:
-    # pylint: disable=import-error,no-name-in-module
+    # pylint: disable=no-name-in-module
     from qiskit.providers.aer import Aer
     from qiskit.providers.aer.noise import NoiseModel
     from qiskit.providers.aer.noise.errors.standard_errors import pauli_error

--- a/tools/subunit_to_junit.py
+++ b/tools/subunit_to_junit.py
@@ -21,7 +21,7 @@
 import argparse
 import sys
 
-from junitxml import JUnitXmlResult  # pylint: disable=import-error
+from junitxml import JUnitXmlResult
 from subunit.filters import run_tests_from_stream
 from testtools import StreamToExtendedDecorator
 


### PR DESCRIPTION
### Summary

This pylint rule has a tendency to be overzealous when we're dealing with optional packages that we don't require to be installed, with compiled modules, and with packages which dynamically mutate the Python path look-up.  Overall, it was giving far more false positives than anything else, and a failure-to-import should be abundantly obvious from a standard test run, so we shouldn't be _effectively_ losing coverage.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

With the work in #8967 moving to do more testing of the no-optionals paths, and to make a cleaner split between "optional package" and "development package", the additional pain pylint is causing with its overzealous `import-error` makes it more worthwhile to remove now.  Python importability cannot generally be determined statically, despite what pylint tries.
