### PR TITLE
Fix VF2Layout and VF2PostLayout handling of instructions without error

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_layout.py
@@ -154,6 +154,11 @@ class VF2Layout(AnalysisPass):
             if len(cm_graph) == len(im_graph):
                 chosen_layout = layout
                 break
+            # If there is no error map avilable we can just skip the scoring stage as there
+            # is nothing to score with so any match is the best we can find.
+            if not self.avg_error_map:
+                chosen_layout = layout
+                break
             layout_score = vf2_utils.score_layout(
                 self.avg_error_map,
                 layout,

--- a/qiskit/transpiler/passes/layout/vf2_utils.py
+++ b/qiskit/transpiler/passes/layout/vf2_utils.py
@@ -84,13 +84,16 @@ def score_layout(avg_error_map, layout, bit_map, reverse_bit_map, im_graph, stri
     fidelity = 1
     for bit, node_index in bit_map.items():
         gate_count = sum(im_graph[node_index].values())
-        fidelity *= (1 - avg_error_map[(bits[bit],)]) ** gate_count
+        error_rate = avg_error_map.get((bits[bit],))
+        if error_rate is not None:
+            fidelity *= (1 - avg_error_map[(bits[bit],)]) ** gate_count
     for edge in im_graph.edge_index_map().values():
         gate_count = sum(edge[2].values())
         qargs = (bits[reverse_bit_map[edge[0]]], bits[reverse_bit_map[edge[1]]])
         if not strict_direction and qargs not in avg_error_map:
             qargs = (qargs[1], qargs[0])
-        fidelity *= (1 - avg_error_map[qargs]) ** gate_count
+        if qargs in avg_error_map:
+            fidelity *= (1 - avg_error_map[qargs]) ** gate_count
     return 1 - fidelity
 
 

--- a/releasenotes/notes/fix-vf2-layout-no-noise-22261601684710c3.yaml
+++ b/releasenotes/notes/fix-vf2-layout-no-noise-22261601684710c3.yaml
@@ -1,0 +1,15 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~.VF2Layout` pass where it would error
+    when running with a :class:`~.Target` that had instructions that were
+    missing error rates. This has been corrected so in such cases the
+    lack of an error rate will be treated as an ideal implementation and
+    if no error rates are present it will just select the first matching
+    layout.
+    Fixed `#8970 <https://github.com/Qiskit/qiskit-terra/issues/8970>`__
+  - |
+    Fixed an issue with the :class:`~.VF2PostLayout` pass where it would
+    error when running with a :class:~.Target` that had instructions that
+    were missing. In such cases the lack of an error rate will be treated as
+    an ideal implementation of the operation.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the VF2Layout and VF2PostLayout pass where the passes would potentially error in cases when a target was specified and there were instructions present without any error rates defined. In such cases the instructions should be treated as ideal (having no error) and the passes shouldn't fail. In cases where there are no error rates in the target for VF2Layout the first perfect match should be used, and for VF2PostLayout it should effectively be a no-op and not select a new layout.

### Details and comments

Fixes #8970

