### PR TITLE
CZ gate is now shown when drawing the circuit using mpl output type.

### DIFF
--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -1220,7 +1220,7 @@ class MatplotlibDrawer:
         )
         self._line(qubit_b, qubit_t, lc=self._data[node]["lc"])
 
-        if isinstance(op, RZZGate) or isinstance(base_type, (U1Gate, PhaseGate, ZGate, RZZGate)):
+        if isinstance(op, RZZGate) or isinstance(base_type, (U1Gate, PhaseGate, RZZGate)):
             self._symmetric_gate(node, base_type)
 
         elif num_qargs == 1 and isinstance(base_type, XGate):


### PR DESCRIPTION
### Summary

A simple change was made to show the CZ gate when drawing the circuit using mpl output type.

For this simple snippet:
```
import qiskit
# Draw a circuit and plot it
circuit = qiskit.QuantumCircuit(2, 2)

circuit.cx(0, 1)
circuit.cz(0, 1)
circuit.cy(0, 1)

circuit.draw(output='mpl')
```

Before the change:
![image](https://user-images.githubusercontent.com/30632902/197629490-b89a05b0-62b1-4738-8cc7-bb7a675664d5.png)

After the change
![image](https://user-images.githubusercontent.com/30632902/197629173-b39fef25-59f7-4475-93ec-bacdc9323a44.png)


### Details and comments

When plotting a circuit using a CZ gate, the user may be confused by the image that is drawn since it's not clear **which** operation is being applied and **where**. This changes this by not making the CZ gate a case for the _symmetric_gate function.


P.S: This is my first pull request, apologies in advance for any inconvenience this may cause.

