### PR TITLE
Fix QEMU-based Linux wheel jobs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ before-test = "pip install --only-binary=numpy,scipy numpy scipy"
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
-environment = 'PATH="$PATH:$HOME/.cargo/bin"'
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
There appears to be an issue with memory consumption under the hood when using QEMU with Rust cargo: 
https://github.com/rust-lang/cargo/issues/10583.

This is causing the CI wheel workflow to run out of memory and fail for QEMU-based jobs, e.g.:
https://github.com/Qiskit/qiskit-terra/actions/runs/3244845622/jobs/5322060193#step:6:1964

Due to this issue the original release of Terra 0.22.0 never actually produced wheels for Linux aarch64, ppc64le, and s390x. A separate branch has been created to manually retrigger the 0.22.0 release wheel jobs, which have now completed successfully (also used in validating the changes in this PR).
https://github.com/Qiskit/qiskit-terra/compare/0.22.0...Qiskit:qiskit-terra:dnm-non-x86-64-wheels-retry?expand=1

### Details and comments
From the discussion on the linked issue, the workaround is to tell cargo to use the Git executable directly, rather than `libgit2`.

Edit:
As noted by @mtreinish below, setting `CARGO_NET_GIT_FETCH_WITH_CLI=true` in the `pyproject.toml` changes the behavior to use the Git executable for all Linux configurations, including x64.