### PR TITLE
Fix transpile() with a Target containing an ideal Measure

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -1043,24 +1043,25 @@ def target_to_backend_properties(target: Target):
                     continue
                 qubit = qargs[0]
                 props_list = []
-                if props.error is not None:
-                    props_list.append(
-                        {
-                            "date": datetime.datetime.utcnow(),
-                            "name": "readout_error",
-                            "unit": "",
-                            "value": props.error,
-                        }
-                    )
-                if props.duration is not None:
-                    props_list.append(
-                        {
-                            "date": datetime.datetime.utcnow(),
-                            "name": "readout_length",
-                            "unit": "s",
-                            "value": props.duration,
-                        }
-                    )
+                if props is not None:
+                    if props.error is not None:
+                        props_list.append(
+                            {
+                                "date": datetime.datetime.utcnow(),
+                                "name": "readout_error",
+                                "unit": "",
+                                "value": props.error,
+                            }
+                        )
+                    if props.duration is not None:
+                        props_list.append(
+                            {
+                                "date": datetime.datetime.utcnow(),
+                                "name": "readout_length",
+                                "unit": "s",
+                                "value": props.duration,
+                            }
+                        )
                 if not props_list:
                     qubit_props = {}
                     break

--- a/releasenotes/notes/fix-transpile-ideal-measurement-c37e04533e196ded.yaml
+++ b/releasenotes/notes/fix-transpile-ideal-measurement-c37e04533e196ded.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue with :func:`~.transpile` when targeting a :class:`~.Target`
+    (either directly via the ``target`` argument or via a
+    :class:`~.BackendV2` instance from the ``backend`` argument) that
+    contained an ideal :class:`~.Measure` instruction (one that does not have
+    any properties defined). Previously this would raise an exception
+    trying to parse the target.
+    Fixed `#8969 <https://github.com/Qiskit/qiskit-terra/issues/8969>`__

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1726,6 +1726,19 @@ class TestPostTranspileIntegration(QiskitTestCase):
         # itself doesn't throw an error, though.
         self.assertIsInstance(qasm3.dumps(transpiled).strip(), str)
 
+    @data(0, 1, 2, 3)
+    def test_transpile_target_no_measurement_error(self, opt_level):
+        """Test that transpile with a target which contains ideal measurement works
+
+        Reproduce from https://github.com/Qiskit/qiskit-terra/issues/8969
+        """
+        target = Target()
+        target.add_instruction(Measure(), {(0,): None})
+        qc = QuantumCircuit(1, 1)
+        qc.measure(0, 0)
+        res = transpile(qc, target=target, optimization_level=opt_level)
+        self.assertEqual(qc, res)
+
 
 class StreamHandlerRaiseException(StreamHandler):
     """Handler class that will raise an exception on formatting errors."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an oversight in the transpile() function when running with a Target (either directly or via a backend) that contains a Measurement operation that is ideal (either globally or locally) with no properties defined. This was not handled correctly in the function used to convert a Target to a BackendProperties payload for passes that are not yet target aware and this would cause an exception to be raised. This commit fixes this edge case and excludes readout properties from the generated BackendProperties in this case.

### Details and comments

Fixes #8969