### PR TITLE
Remove pip cache in azure pipelines jobs

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -22,9 +22,9 @@ jobs:
         inputs:
           key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
           restoreKeys: |
-            pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip | "$(Agent.OS)"
-            pip
+            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
+            pip-2 | "$(Agent.OS)"
+            pip-2
           path: $(PIP_CACHE_DIR)
         displayName: Cache pip
 

--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -18,16 +18,6 @@ jobs:
           versionSpec: '${{ parameters.pythonVersion }}'
         displayName: 'Use Python ${{ parameters.pythonVersion }}'
 
-      - task: Cache@2
-        inputs:
-          key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
-          restoreKeys: |
-            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip-2 | "$(Agent.OS)"
-            pip-2
-          path: $(PIP_CACHE_DIR)
-        displayName: Cache pip
-
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel

--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -20,9 +20,9 @@ jobs:
         inputs:
           key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
           restoreKeys: |
-            pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip | "$(Agent.OS)"
-            pip
+            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
+            pip-2 | "$(Agent.OS)"
+            pip-2
           path: $(PIP_CACHE_DIR)
         displayName: Cache pip
 

--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -16,16 +16,6 @@ jobs:
           versionSpec: '${{ parameters.pythonVersion }}'
         displayName: 'Use Python ${{ parameters.pythonVersion }}'
 
-      - task: Cache@2
-        inputs:
-          key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
-          restoreKeys: |
-            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip-2 | "$(Agent.OS)"
-            pip-2
-          path: $(PIP_CACHE_DIR)
-        displayName: Cache pip
-
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel virtualenv

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -40,9 +40,9 @@ jobs:
         inputs:
           key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" |"$(Build.BuildNumber)"'
           restoreKeys: |
-            pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip | "$(Agent.OS)"
-            pip
+            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
+            pip-2 | "$(Agent.OS)"
+            pip-2
           path: $(PIP_CACHE_DIR)
         displayName: "Cache pip"
 

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -38,16 +38,6 @@ jobs:
 
       - task: Cache@2
         inputs:
-          key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" |"$(Build.BuildNumber)"'
-          restoreKeys: |
-            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip-2 | "$(Agent.OS)"
-            pip-2
-          path: $(PIP_CACHE_DIR)
-        displayName: "Cache pip"
-
-      - task: Cache@2
-        inputs:
           key: 'stestr | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
           restoreKeys: |
             stestr | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -21,16 +21,6 @@ jobs:
 
       - task: Cache@2
         inputs:
-          key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
-          restoreKeys: |
-            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip-2 | "$(Agent.OS)"
-            pip-2
-          path: $(PIP_CACHE_DIR)
-        displayName: "Cache pip"
-
-      - task: Cache@2
-        inputs:
           key: 'stestr | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
           restoreKeys: |
             stestr | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -23,9 +23,9 @@ jobs:
         inputs:
           key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}" | "$(Build.BuildNumber)"'
           restoreKeys: |
-            pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
-            pip | "$(Agent.OS)"
-            pip
+            pip-2 | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"
+            pip-2 | "$(Agent.OS)"
+            pip-2
           path: $(PIP_CACHE_DIR)
         displayName: "Cache pip"
 

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -22,8 +22,8 @@ jobs:
         inputs:
           key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"'
           restoreKeys: |
-            pip | "$(Agent.OS)"
-            pip
+            pip-2 | "$(Agent.OS)"
+            pip-2
           path: $(PIP_CACHE_DIR)
         displayName: Cache pip
 

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -18,15 +18,6 @@ jobs:
           versionSpec: '${{ parameters.pythonVersion }}'
         displayName: 'Use Python ${{ parameters.pythonVersion }}'
 
-      - task: Cache@2
-        inputs:
-          key: 'pip | "$(Agent.OS)" | "${{ parameters.pythonVersion }}"'
-          restoreKeys: |
-            pip-2 | "$(Agent.OS)"
-            pip-2
-          path: $(PIP_CACHE_DIR)
-        displayName: Cache pip
-
       - bash: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit removes the pip cache in azure pipelines t improve the reliability of the CI jobs. Right now the pip cache has grown to be > 4GB and we're seeing a high rate of the step bogging down while downloading the data. Running with a cache in practice has proven to be quite unreliable and just pulling packages from pypi appears to be significantly faster.

### Details and comments