### PR TITLE
Fix #8992 (SparsePauliOp.dot with real coefficients)

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -112,7 +112,7 @@ class SparsePauliOp(LinearOp):
 
         pauli_list = PauliList(data.copy() if copy and hasattr(data, "copy") else data)
 
-        dtype = coeffs.dtype if isinstance(coeffs, np.ndarray) else complex
+        dtype = object if isinstance(coeffs, np.ndarray) and coeffs.dtype == object else complex
 
         if coeffs is None:
             coeffs = np.ones(pauli_list.size, dtype=dtype)

--- a/releasenotes/notes/fix-sparse-pauli-real-63c31d87801671b1.yaml
+++ b/releasenotes/notes/fix-sparse-pauli-real-63c31d87801671b1.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix :meth:`.SparsePauliOp.dot` between operators with real coefficients.
+    To fix this, the dtype that :class:`SparsePauliOp` can take is restricted to
+    ``np.complex128`` and ``object``.

--- a/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
+++ b/test/python/quantum_info/operators/symplectic/test_sparse_pauli_op.py
@@ -940,6 +940,13 @@ class TestSparsePauliOpMethods(QiskitTestCase):
                 )
             )
 
+    def test_dot_real(self):
+        """Test dot for real coefficiets."""
+        x = SparsePauliOp("X", np.array([1]))
+        y = SparsePauliOp("Y", np.array([1]))
+        iz = SparsePauliOp("Z", 1j)
+        self.assertEqual(x.dot(y), iz)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix `SparsePauliOp.dot` between operators with real coefficients.
    To fix this, the `dtype` that `SparsePauliOp` can take is restricted to
    `np.complex128` and `object`.

Fix #8992

### Details and comments


