### PR TITLE
Issue 8991 Fix - Defaults appended to styles path from settings.conf 

### DIFF
--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -124,7 +124,6 @@ class UserConfig:
                             if path not in cpath_list:
                                 cpath_list.append(path)
                         self.settings["circuit_mpl_style_path"] = cpath_list
-                        self.settings["circuit_mpl_style_path"] = cpath_list
 
             # Parse transpile_optimization_level
             transpile_optimization_level = self.config_parser.getint(

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -115,7 +115,16 @@ class UserConfig:
                             UserWarning,
                             2,
                         )
-                self.settings["circuit_mpl_style_path"] = cpath_list
+                        # Check/Insert default paths to circuit_mpl_style_path
+                        valid_default_paths = [
+                            "~",
+                            "~/.qiskit",
+                        ]
+                        for path in valid_default_paths:
+                            if path not in cpath_list:
+                                cpath_list.append(path)
+                        self.settings["circuit_mpl_style_path"] = cpath_list
+                        self.settings["circuit_mpl_style_path"] = cpath_list
 
             # Parse transpile_optimization_level
             transpile_optimization_level = self.config_parser.getint(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Addressed issue #8991, appending styles path set via `settings.conf` to a set that includes the default directories: `'~'`, `'~/.qiskit'` as referenced https://qiskit.org/documentation/configuration.html with regards to `circuit_mpl_style_path` variable.

Fix https://github.com/Qiskit/qiskit-terra/issues/8991

### Details and comments


