### PR TITLE
WIP - Converting the pulse library from complex amp to amp+angle

### DIFF
--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -21,7 +21,6 @@ parameter constraints.
 import functools
 import warnings
 from typing import Any, Dict, List, Optional, Union, Callable
-from types import MethodType
 
 import numpy as np
 

--- a/test/python/pulse/test_pulse_lib.py
+++ b/test/python/pulse/test_pulse_lib.py
@@ -121,6 +121,24 @@ class TestParametricPulses(QiskitTestCase):
         Constant(duration=150, amp=0.1 + 0.4j)
         Drag(duration=25, amp=0.2 + 0.3j, sigma=7.8, beta=4)
 
+    # This test should be removed once deprecation of complex amp is completed.
+    def test_complex_amp_deprecation(self):
+        """Test that deprecation warnings and errors are raised for complex amp"""
+        with self.assertWarns(PendingDeprecationWarning):
+            Gaussian(duration=25, sigma=4, amp=0.5j)
+        with self.assertRaises(PulseError):
+            Gaussian(duration=25, sigma=4, amp=0.5j, angle=1)
+
+        gauss_pulse_complex_amp = Gaussian(duration=25, sigma=4, amp=0.5j)
+        with self.assertWarns(PendingDeprecationWarning):
+            complex_amp = gauss_pulse_complex_amp.amp
+        amp_magnitude , angle = gauss_pulse_complex_amp.amp_angle
+        np.testing.assert_almost_equal(complex_amp, amp_magnitude*np.exp(1j*angle))
+
+        gauss_pulse_amp_angle = Gaussian(duration=25, sigma=4, amp=0.5, angle=np.pi/2)
+        np.testing.assert_almost_equal(gauss_pulse_amp_angle.get_waveform().samples,
+                                       gauss_pulse_complex_amp.get_waveform().samples)
+
     def test_gaussian_pulse(self):
         """Test that Gaussian sample pulse matches the pulse library."""
         gauss = Gaussian(duration=25, sigma=4, amp=0.5j)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
We convert the symbolic pulses in the pulse library from a complex amp to real (float) amp+angle. i.e., instead of calling (for example):
`Gaussian(duration=25, sigma=4, amp=0.5j)`, 
one should call:
`Gaussian(duration=25, sigma=4, amp=0.5, angle = np.pi/2)`. 
Backward compatibility is maintained, and deprecation warnings are raised when the previous API is used.

This work is in progress and presented here for comments. See below some questions.


### Details and comments
So far, only the Gaussian class was fully implemented. The other classes will be completed in a similar fashion, if no objections are raised.

Most of the changes are straight forward, and simply allow for either a complex amp or real amp+angle input parameters. However, some appearance issues arise because of the backward compatibility. To ensure the compatibility, the 'parameters' dictionary remained the same with the entry "amp" representing the complex amplitude. This means that a user using `gauss_pulse = Gaussian(duration=25, sigma=4, amp=0.5, angle = np.pi/2)` and then `gauss_pulse.amp` will receive `0.5j` and not `0.5` as he might expect.

To avoid the confusion, an 'amp' property was added directly to the SymbolicPulse class, with a deprecation warning. An additional  'amp_angle' property was similarly added to the class and it returns the (amp,angle) tuple. In the future the second property could be removed, and the parameters dictionary could include directly the (amp,angle) tuple.
(It should be noted that if someone has used the SymbolicPulse class with float 'amp' parameter - this fix will yield unnecessary warnings for him. However, no such examples currently exist in the library)

Tests were added to make sure warnings and errors are raised in the appropriate scenarios, and that the pulses created with both API choices are the same.

 ### Questions and Decisions

- The name amp_angle is temporary. Feel free to suggest a better one if you have it.
- Relating to the previous question, what should __repr__ include now? The complex amp? amp,angle tuple? Something else?
- Previous tests now raise deprecation warnings, should I update them now, or should this be done only when the deprecation is completed?
