### PR TITLE
Fix manifest entry for mpl styles

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include qiskit/schemas/examples/*.json
 include qiskit/VERSION.txt
 recursive-include qiskit *.pyx
 recursive-include qiskit *.pxd
-include qiskit/visualization/styles/*.json
+include qiskit/visualization/circuit/styles/*.json
 recursive-include qiskit/providers/fake_provider/backends *.json
 
 # Include the tests files.

--- a/releasenotes/notes/fix-styles-manifest-b8c852a07fb86966.yaml
+++ b/releasenotes/notes/fix-styles-manifest-b8c852a07fb86966.yaml
@@ -1,7 +1,10 @@
 ---
 fixes:
   - |
-    Fixed an issue where only the `default` style for the `mpl`
-    circuit drawer was working. Other built-in styles, such as
-    `iqx` did not work. This occurred in :func:`.circuit_drawer`
-    and in :func:`.QuantumCircuit.draw`.
+    Fixed an issue in the :func:`~.circuit_drawer` function and
+    :func:`.QuantumCircuit.draw` method where the only built-in style
+    for the ``mpl`` output that was usable was ``default``. If another
+    built-in style, such as ``iqx``, were used then a warning about
+    the style not being found would be emitted and the drawer would
+    fall back to use the ``default`` style.
+    Fixed `#8991 <https://github.com/Qiskit/qiskit-terra/issues/8991>`__

--- a/releasenotes/notes/fix-styles-manifest-b8c852a07fb86966.yaml
+++ b/releasenotes/notes/fix-styles-manifest-b8c852a07fb86966.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue where only the `default` style for the `mpl`
+    circuit drawer was working. Other built-in styles, such as
+    `iqx` did not work. This occurred in :func:`.circuit_drawer`
+    and in :func:`.QuantumCircuit.draw`.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8991

### Details and comments

This changes the entry for the `MANIFEST.in` file to point to `visualization/circuit/styles` for locating the built-in styles for the mpl circuit drawer. This bug was introduced in #8306.
