### PR TITLE
Add missing equivalences for XX{Plus,Minus}YYGate

### DIFF
--- a/releasenotes/notes/add-xxyy-equivalence-a941c9b9bc60747b.yaml
+++ b/releasenotes/notes/add-xxyy-equivalence-a941c9b9bc60747b.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Equivalence rules for :class:`.XXPlusYYGate` and :class:`.XXMinusYYGate` are
+    now available in the standard equivalence library shipped with Qiskit Terra.

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -16,7 +16,7 @@
 import inspect
 
 import numpy as np
-from ddt import ddt, data, unpack
+from ddt import ddt, data, idata, unpack
 
 from qiskit import QuantumCircuit, QuantumRegister
 from qiskit.quantum_info import Operator
@@ -256,63 +256,62 @@ class TestStandardGates(QiskitTestCase):
             self.assertTrue(is_identity_matrix(Operator(gate).dot(gate.inverse().definition).data))
 
 
+@ddt
 class TestGateEquivalenceEqual(QiskitTestCase):
     """Test the decomposition of a gate in terms of other gates
     yields the same matrix as the hardcoded matrix definition."""
 
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        class_list = Gate.__subclasses__() + ControlledGate.__subclasses__()
-        exclude = {
-            "ControlledGate",
-            "DiagonalGate",
-            "UCGate",
-            "MCGupDiag",
-            "MCU1Gate",
-            "UnitaryGate",
-            "HamiltonianGate",
-            "MCPhaseGate",
-            "UCPauliRotGate",
-            "SingleQubitUnitary",
-            "MCXGate",
-            "VariadicZeroParamGate",
-            "ClassicalFunction",
-            "ClassicalElement",
-            "StatePreparation",
-            "LinearFunction",
-            "Commuting2qBlock",
-        }
-        cls._gate_classes = []
-        for aclass in class_list:
-            if aclass.__name__ not in exclude:
-                cls._gate_classes.append(aclass)
+    class_list = Gate.__subclasses__() + ControlledGate.__subclasses__()
+    exclude = {
+        "ControlledGate",
+        "DiagonalGate",
+        "UCGate",
+        "MCGupDiag",
+        "MCU1Gate",
+        "UnitaryGate",
+        "HamiltonianGate",
+        "MCPhaseGate",
+        "UCPauliRotGate",
+        "SingleQubitUnitary",
+        "MCXGate",
+        "VariadicZeroParamGate",
+        "ClassicalFunction",
+        "ClassicalElement",
+        "StatePreparation",
+        "LinearFunction",
+        "Commuting2qBlock",
+        "PauliEvolutionGate",
+    }
+    # Amazingly, Python's scoping rules for class bodies means that this list creation _cannot_ be
+    # done using comprehensions or `filter` with a lambda:
+    #   https://docs.python.org/3/reference/executionmodel.html#resolution-of-names
+    gate_classes = []
+    for aclass in class_list:
+        if aclass.__name__ not in exclude:
+            gate_classes.append(aclass)
 
-    def test_equivalence_phase(self):
+    @idata(gate_classes)
+    def test_equivalence_phase(self, gate_class):
         """Test that the equivalent circuits from the equivalency_library
         have equal matrix representations"""
-        for gate_class in self._gate_classes:
-            with self.subTest(i=gate_class):
-                n_params = len(_get_free_params(gate_class))
-                params = [0.1 * i for i in range(1, n_params + 1)]
-                if gate_class.__name__ == "RXXGate":
-                    params = [np.pi / 2]
-                if gate_class.__name__ in ["MSGate"]:
-                    params[0] = 2
-                if gate_class.__name__ in ["PauliGate"]:
-                    params = ["IXYZ"]
-                if gate_class.__name__ in ["BooleanExpression"]:
-                    params = ["x | y"]
-                if gate_class.__name__ in ["PauliEvolutionGate", "PauliEvolutionGate"]:
-                    continue
+        n_params = len(_get_free_params(gate_class))
+        params = [0.1 * i for i in range(1, n_params + 1)]
+        if gate_class.__name__ == "RXXGate":
+            params = [np.pi / 2]
+        if gate_class.__name__ in ["MSGate"]:
+            params[0] = 2
+        if gate_class.__name__ in ["PauliGate"]:
+            params = ["IXYZ"]
+        if gate_class.__name__ in ["BooleanExpression"]:
+            params = ["x | y"]
 
-                gate = gate_class(*params)
-                equiv_lib_list = std_eqlib.get_entry(gate)
-                for ieq, equivalency in enumerate(equiv_lib_list):
-                    with self.subTest(msg=gate.name + "_" + str(ieq)):
-                        op1 = Operator(gate)
-                        op2 = Operator(equivalency)
-                        self.assertEqual(op1, op2)
+        gate = gate_class(*params)
+        equiv_lib_list = std_eqlib.get_entry(gate)
+        for ieq, equivalency in enumerate(equiv_lib_list):
+            with self.subTest(msg=gate.name + "_" + str(ieq)):
+                op1 = Operator(gate)
+                op2 = Operator(equivalency)
+                self.assertEqual(op1, op2)
 
 
 @ddt

--- a/test/python/circuit/test_gate_definitions.py
+++ b/test/python/circuit/test_gate_definitions.py
@@ -282,15 +282,10 @@ class TestGateEquivalenceEqual(QiskitTestCase):
         "Commuting2qBlock",
         "PauliEvolutionGate",
     }
-    # Amazingly, Python's scoping rules for class bodies means that this list creation _cannot_ be
-    # done using comprehensions or `filter` with a lambda:
+    # Amazingly, Python's scoping rules for class bodies means that this is the closest we can get
+    # to a "natural" comprehension or functional iterable definition:
     #   https://docs.python.org/3/reference/executionmodel.html#resolution-of-names
-    gate_classes = []
-    for aclass in class_list:
-        if aclass.__name__ not in exclude:
-            gate_classes.append(aclass)
-
-    @idata(gate_classes)
+    @idata(filter(lambda x, exclude=exclude: x.__name__ not in exclude, class_list))
     def test_equivalence_phase(self, gate_class):
         """Test that the equivalent circuits from the equivalency_library
         have equal matrix representations"""


### PR DESCRIPTION
### Summary

These are just copied from the `_define` method on the classes.  The equivalence-library tests are updated (since `subTest` doesn't isolate correctly with `testtools`) to print out all the names of the tests being run, so it's clear that the existing test now tests these definitions.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Bonus points to anyone who already knew the esoteric Python scoping rules that forbade me from using a list comprehension to define the test parametrisation here.