### PR TITLE
[WIP] Add utilities to build and manage recursive representations

### DIFF
--- a/examples/python/build_repr.py
+++ b/examples/python/build_repr.py
@@ -1,0 +1,717 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Example showing how to create a custom representation using a bell circuit
+  # Print a small circuit
+  python qiskit/examples/python/customer_repr.py --object=cond
+  # Print a larger circuit with wrap at 180
+  python qiskit/examples/python/customer_repr.py --object=bell
+"""
+import sys
+from getopt import getopt, GetoptError
+from typing import Optional
+from qiskit import QuantumCircuit
+from qiskit.circuit.quantumcircuitdata import CircuitInstruction
+
+from qiskit.utils.reprparse import ReprParser
+from qiskit.utils.reprbuild import is_valid_repr, build_repr
+
+_usage = "No program usage available"
+
+
+def Instruction_rebuild(class_repr=None):
+    """Return an Instruction based on the input dictionary
+
+    Args:
+        class_repr(string): string representation of the repr dictionary
+
+    Returns:
+        Instruction: The Instruction equivalent to the circuit generating the repr
+
+    Raises:
+
+    Additional Information:
+        Should be embedded as a class method if rebuilding from representations is a desired feature set
+
+        @classmethod
+        def rebuild(cls, class_repr=None):
+            from qiskit.utils.reprparse import ReprParser
+            ...
+    """
+
+    new_instruction = None
+    parser = ReprParser(class_repr, attr_rebuilders())
+    defn_parser = parser.get_parser("_definition")
+    if defn_parser is not None:
+        new_instruction = defn_parser.rebuild()
+
+    return new_instruction
+
+
+def CircuitInstruction_rebuild(class_repr=None):
+    """Return a QuantumCircuit based on the input dictionary
+
+    Args:
+        class_repr(string): string representation of the repr dictionary
+
+    Returns:
+        CircuitInstruction: The circuit equivalent to the circuit generating the repr
+
+    Raises:
+        QiskitError: if the dictionary is not valid
+    Additional Information:
+        Should be embedded as a class method if rebuilding from representations is a desired feature set
+
+        @classmethod
+        def rebuild(cls, class_repr=None):
+            from qiskit.utils.reprparse import ReprParser
+            from qiskit.utils.reprbuild import is_valid_repr
+            ...
+    """
+    from qiskit.circuit import Instruction
+
+    parser = ReprParser(class_repr, attr_rebuilders())
+
+    qubits = []
+    clbits = []
+    new_instruction = None
+
+    bits_parser = parser.get_parser("qubits")
+    if bits_parser is not None:
+        bits_tuple = bits_parser.rebuild()
+        for curbit in bits_tuple:
+            if is_valid_repr(curbit):
+                new_bit = bits_parser.get_parser(curbit).rebuild()
+            else:
+                new_bit = int(curbit)
+            qubits.append(new_bit)
+
+    bits_parser = parser.get_parser("clbits")
+    if bits_parser is not None:
+        bits_tuple = bits_parser.rebuild()
+        for curbit in bits_tuple:
+            if is_valid_repr(curbit):
+                new_bit = bits_parser.get_parser(curbit).rebuild()
+            else:
+                new_bit = int(curbit)
+            clbits.append(new_bit)
+
+    operation = parser.get_parser("operation")
+    if operation is not None:
+        new_op = operation.rebuild()
+    if isinstance(new_op, Instruction):
+        new_instruction = CircuitInstruction(new_op, qubits, clbits)
+    elif new_op is not None:
+        new_instruction = (new_op, qubits, clbits)
+
+    return new_instruction
+
+
+def QuantumCircuit_rebuild(class_repr=None):
+    """Return a QuantumCircuit based on the input representation
+
+    Args:
+        class_repr(string): string representation of the circuit to be rebuilt
+
+    Returns:
+        QuantumCircuit: The circuit equivalent to the representation input
+
+    Raises:
+        ReprError: if the dictionary is not valid
+
+    Additional Information:
+        This can be embedded as a class method in QuantumCircuit if desired
+
+        @classmethod
+        def rebuild(cls,class_repr=None):
+            from qiskit.utils.reprparse import ReprParser
+            ...
+
+    """
+    from collections import defaultdict
+
+    parser = ReprParser(class_repr, attr_rebuilders())
+
+    global_phase = parser.get_parser("_global_phase")
+    if global_phase is not None:
+        global_phase = global_phase.rebuild()
+
+    qc = QuantumCircuit(
+        parser.get_int("num_qubits"),
+        parser.get_int("num_clbits"),
+        name=parser.get_string("_base_name"),
+        global_phase=global_phase,
+    )
+
+    calibrations = parser.get_dict("_calibrations", None)
+    if calibrations is not None and isinstance(calibrations, (defaultdict, dict)):
+        qc.calibrations = calibrations
+    metadata = parser.get_dict("_metadata", None)
+    if metadata is not None and isinstance(metadata, (defaultdict, dict)):
+        qc.metadata = metadata
+
+    data_parser = parser.get_parser("_data")
+    data_list = data_parser.rebuild()
+    if isinstance(data_list, list) and len(data_list) > 0:
+        for data_item in data_list:
+            item_parser = parser.get_parser(data_item)
+            if item_parser is not None:
+                new_item = item_parser.rebuild()
+                if isinstance(new_item, tuple):
+                    qc.append(*new_item)
+                elif new_item is not None:
+                    qc.append(new_item)
+
+    return qc
+
+
+def Measure_rebuild(cls, class_repr=None):  # pylint: disable=unused-argument
+    """Return an Instruction based on the input dictionary
+
+    Args:
+        class_repr(string): string representation of the repr dictionary
+
+    Returns:
+        Instruction: The Measure Instruction equivalent to the circuit generating the repr
+
+    Raises:
+
+    Additional Information:
+        This can be embedded as a class method in Measure if rebuilding is a desired feature
+
+        @classmethod
+        def rebuild(cls,class_repr=None):  # pylint: disable=unused-argument
+
+    """
+    from qiskit.circuit import Measure
+
+    return Measure()
+
+
+def Reset_rebuild(class_repr=None):  # pylint: disable=unused-argument
+    """Return a Reset Instruction
+
+    Args:
+        class_repr(string): string representation of the repr dictionary
+
+    Returns:
+        Instruction: The Measure Instruction equivalent to the circuit generating the repr
+
+    Raises:
+
+    Additional Information:
+        This can be embedded as a class method in Reset if rebuilding is a desired feature
+
+        @classmethod
+        def rebuild(cls,class_repr=None):  # pylint: disable=unused-argument
+
+    """
+    from qiskit.circuit import Reset
+
+    return Reset()
+
+
+def Clbit_rebuild(obj_repr):
+    """Return the integer bit index
+
+    Args:
+        obj_repr(string): string representation of the repr dictionary
+
+    Returns:
+        int: The bit index
+
+    Raises:
+    """
+
+    parser = ReprParser(obj_repr)
+    index = parser.rebuild("_index")
+    return index
+
+
+def Qubit_rebuild(obj_repr):
+    """Return the integer bit index
+
+    Args:
+        obj_repr(string): string representation of the repr dictionary
+
+    Returns:
+        int: The bit index
+
+    Raises:
+    """
+    from qiskit.circuit import Qubit
+
+    parser = ReprParser(obj_repr)
+    index = parser.rebuild("_index")
+    if index is not None:
+        return index
+    return Qubit()
+
+
+def _map_barrier(gate_repr):
+    parser = ReprParser(gate_repr)
+    if parser is not None and parser.class_name == "Barrier":
+        from qiskit.circuit import Barrier
+
+        label = parser.get_string("_label")
+        num_qubits = parser.get_int("_num_qubits")
+        return Barrier(num_qubits, label=label)
+    else:
+        return None
+
+
+def _map_h_gate(gate_repr):
+    parser = ReprParser(gate_repr)
+    if parser is None:
+        return None
+
+    if parser.class_name == "HGate":
+        from qiskit.circuit.library.standard_gates.h import HGate
+
+        return HGate()
+    elif parser.class_name == "CHGate":
+        from qiskit.circuit.library.standard_gates.h import CHGate
+
+        label = parser.get_string("_label")
+        ctrl_state = parser.get_int("ctrl_state", 1)
+        return CHGate(label=label, ctrl_state=ctrl_state)
+    else:
+        return None
+
+
+def _map_x_gate(gate_repr):
+    parser = ReprParser(gate_repr)
+    # TODO: Finish the rest of the classes from x.py
+    if parser is None:
+        return_val = None
+    elif parser.class_name == "XGate":
+        from qiskit.circuit.library.standard_gates.x import XGate
+
+        label = parser.get_string("_label")
+        return_val = XGate(label=label)
+    elif parser.class_name == "CXGate":
+        from qiskit.circuit.library.standard_gates.x import CXGate
+
+        label = parser.get_string("_label")
+        ctrl_state = parser.get_int("_ctrl_state", 1)
+        return_val = CXGate(label=label, ctrl_state=ctrl_state)
+    elif parser.class_name == "CCXGate":
+        from qiskit.circuit.library.standard_gates.x import CCXGate
+
+        label = parser.get_string("_label")
+        ctrl_state = parser.get_int("_ctrl_state", 3)
+        return_val = CCXGate(label=label, ctrl_state=ctrl_state)
+    elif parser.class_name == "RCCXGate":
+        from qiskit.circuit.library.standard_gates.x import RCCXGate
+
+        label = parser.get_string("_label")
+        return_val = RCCXGate(label=label)
+    elif parser.class_name == "RC3XGate":
+        from qiskit.circuit.library.standard_gates.x import RC3XGate
+
+        label = parser.get_string("_label")
+        return_val = RC3XGate(label=label)
+    elif parser.class_name == "RXGate":
+        from qiskit.circuit.library.standard_gates.rx import RXGate
+
+        theta = None
+        label = parser.get_string("_label")
+        params_parser = parser.get_parser("_params")
+        if params_parser is not None:
+            params = params_parser.rebuild()
+        if params is not None:
+            theta = params[0]
+        return_val = RXGate(theta, label=label)
+    else:
+        return_val = None
+    return return_val
+
+
+_standard_gate_map = {
+    "HGate": _map_h_gate,
+    "CHGate": _map_h_gate,
+    "XGate": _map_x_gate,
+    "CXGate": _map_x_gate,
+    "CCXGate": _map_x_gate,
+    "RXGate": _map_x_gate,
+    "RCCXGate": _map_x_gate,
+    "C3SXGate": _map_x_gate,
+    "C3XGate": _map_x_gate,
+    "RC3SXGate": _map_x_gate,
+    "C4XGate": _map_x_gate,
+    "MCXGate": _map_x_gate,
+    "MCXGrayCode": _map_x_gate,
+    "MCXVChain": _map_x_gate,
+    "Barrier": _map_barrier,
+    "None": None,
+    "NoneType": None,
+}
+
+
+def attr_rebuilders():
+    """Name to method mapping for all the classes utilized by a quantum circuit.  The mappings
+        allow the parser(s) to rebuild attributes recursively.
+    Args:
+    Returns:
+        dict: Name to rebuilder method mapping
+
+    Raises:
+    Additional Information:
+        Should be embedded as a class method in
+            quantumcircuitdata.CircuitInstruction
+            quantumcircuit.QuantumCircuit
+            instruction.Instruction
+        if rebuilding from representations is a desired feature set
+
+    @class_method(cls):
+        from qiskit.circuit.library.standard_gates.reprbuild import get_standard_gate_map
+        from qiskit.circuit import QuantumCircuit, Instruction, Measure, Reset
+        rebuilders = {
+            "QuantumCircuit": QuantumCircuit.rebuild,
+            "CircuitInstruction": CircuitInstruction.rebuild,
+            "Instruction": Instruction.rebuild,
+            "Qubit": Qubit.rebuild,
+            "Clbit": Clbit.rebuild,
+            "Measure": Measure.rebuild,
+            "Reset": Reset.rebuild,
+        }
+        ...
+
+    """
+    rebuilders = {
+        "QuantumCircuit": QuantumCircuit_rebuild,
+        "CircuitInstruction": CircuitInstruction_rebuild,
+        "Instruction": Instruction_rebuild,
+        "Qubit": Qubit_rebuild,
+        "Clbit": Clbit_rebuild,
+        "Measure": Measure_rebuild,
+        "Reset": Reset_rebuild,
+    }
+    rebuilders.update(_standard_gate_map)
+    return rebuilders
+
+
+class myClass:
+    """class template compatible with recursive repr() generation and
+        instantiation
+
+    Args:
+        name (str): myClass instance name (if it was output by repr())
+    Raises:
+
+    Additional Information:
+        self._repr_attrs being defined is all that is reuired to allow
+        the recursive algorithm include myClass in any class in
+        which a myClass object is listed in the repr() without requiring
+        changes to any existing __repr__ methods
+        if repr_dict is passed in to __init__ it can be used to instiated
+        a new instance of myClass equivialent to the instance which generated
+        the representation
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = None,
+    ):
+        self._name = name
+        self._repr_attrs = ["_name"]
+
+    def __repr__(self) -> str:
+        """to create a recursive repr() for myClass invoke build_repr
+        as shown"""
+
+        return build_repr(self, attr_list=self._repr_attrs, depth=-1, deepdive=False)
+
+    def __str__(self):
+        # from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, myClass):
+            return False
+        else:
+            return self._name == other._name
+
+    @classmethod
+    def rebuilder(cls, class_repr=None):
+        """Return a QuantumCircuit based on the input dictionary
+
+        Args:
+            class_repr(string): string representation of the repr dictionary
+
+        Returns:
+            myClass: The object equivalent to the instance generating the repr
+
+        Raises:
+
+        Additional Information:
+            Create an instance as defined by the dictionary
+            if needed to create instances of an attribute
+        """
+
+        parser = ReprParser(class_repr)
+
+        return myClass(name=parser.get_string("_name", "None"))
+
+
+_custom_repr_attrs = ["_global_phase", "_base_name", "_data"]
+
+
+def _get_calibrated_circuit():
+    from qiskit import pulse
+    from qiskit.circuit import Parameter
+    from qiskit.circuit.library import RXGate
+    import numpy as np
+
+    theta = Parameter("theta")
+    qc = QuantumCircuit(2)
+    qc.h(0)
+    qc.rx(np.pi, 0)
+    qc.rx(theta, 1)
+    qc = qc.assign_parameters({theta: np.pi})
+
+    with pulse.build() as h_sched:
+        pulse.play(pulse.library.Drag(1, 0.15, 4, 2), pulse.DriveChannel(0))
+
+    with pulse.build() as x180:
+        pulse.play(pulse.library.Gaussian(1, 0.2, 5), pulse.DriveChannel(0))
+
+    qc.add_calibration("h", [0], h_sched)
+    qc.add_calibration(RXGate(np.pi), [0], x180)
+    return qc
+
+
+def _get_unbound_circuit():
+    from qiskit.circuit import Parameter
+
+    # create the parameter
+    phi = Parameter("phi")
+    ro = Parameter("ro")
+    qc = QuantumCircuit(1, global_phase=ro, name="Unbound")
+
+    # parameterize the rotation
+    qc.rx(phi, 0)
+    return qc
+
+
+def _get_bound_circuit():
+    from qiskit.circuit import Parameter
+    from math import sqrt
+
+    # create the parameter
+    phi = Parameter("phi")
+    ro = Parameter("ro")
+    qc = QuantumCircuit(1, global_phase=ro, name="Bound")
+
+    # parameterize the rotation
+    qc.rx(phi, 0)
+
+    # bind the parameters after circuit to create a bound circuit
+    bc = qc.bind_parameters({phi: 3.14, ro: sqrt(2)})
+    return bc
+
+
+def _get_ccx_circuit():
+    qc = QuantumCircuit(3, 3, name="CCX Circuit")
+    qc.h([0, 1])
+    qc.ccx(0, 1, 2)
+    return qc
+
+
+def _get_bell_circuit():
+    """Returns a circuit putting 2 qubits in the Bell state."""
+    qc = QuantumCircuit(2, 2, name="Hadamard")
+    qc.h(0)
+    qc.cx(0, 1, label="cx label")
+    return qc
+
+
+def _get_inner_circuit():
+    qc = QuantumCircuit(2, 2, name="Inner")
+    qc.h(0)
+    qc.cx(0, 1)
+    inner = QuantumCircuit(1, 1)
+    qc.barrier()
+    inner.h(0)
+    inner.measure(0, 0)
+    qc.append(inner, [0], [0])
+    return qc
+
+
+def _get_cond_object():
+    from qiskit.circuit import Qubit, Clbit
+
+    bits = [Qubit(), Clbit()]
+    cond = (bits[1], 0)
+    test = QuantumCircuit(bits, name="Cond")
+    test.if_test(cond)
+    test.h(0)
+    return test
+
+
+def _get_cx_gate():
+    from qiskit.circuit.library.standard_gates.x import CXGate
+
+    return CXGate(label="cx gate", ctrl_state=1)
+
+
+def _get_cx_instruction():
+    new_op = _get_cx_gate()
+    return CircuitInstruction(new_op, [0, 1], [])
+
+
+def _get_cmdline(argv):
+
+    try:
+        opts, args = getopt(  # pylint: disable=unused-variable
+            argv, "hcew:o:", ["width=", "custom", "object=", "eval"]
+        )
+    except GetoptError:
+        print(_usage)
+        sys.exit(2)
+    # Set default values
+    _options = {}
+    _options["width"] = 120
+    _options["object"] = "all"
+    _options["eval"] = False
+    for opt, arg in opts:
+        if opt == "-h":
+            print(_usage)
+            sys.exit()
+        elif opt in ("-o", "--object"):
+            _options["object"] = arg
+        elif opt in ("-c", "--custom"):
+            _options["object"] = "custom"
+        elif opt in ("-w", "--width"):
+            _options["width"] = arg
+        elif opt in ("-e", "--eval"):
+            _options["eval"] = True
+    return _options
+
+
+circuit_dict = {
+    "cxgate": _get_cx_gate,
+    "cxinstruction": _get_cx_instruction,
+    "bell": _get_bell_circuit,
+    "inner": _get_inner_circuit,
+    "ccx": _get_ccx_circuit,
+    "cond": _get_cond_object,
+    "bound": _get_bound_circuit,
+    "unbound": _get_unbound_circuit,
+    "calibrated": _get_calibrated_circuit,
+}
+
+_usage = """custom_repr.p -w <width> -e <eval> -o <object>
+         eval   : If set, evaluate returned repr and compareot original
+         object : csv list of objects to test. Default is all
+              all           : Run all the objects except custom
+              cxgate        : CXGate(0,1)
+              cxinstruction : CXGate(0,1) as Instruction
+              bell          : Bell Quantum Circuit
+              bound         : Circuit with bound parameter
+              calibrated    : Circuit with calibrations
+              ccx           : Circuit with ccx gate
+              cond          : Quantum circuit with conditional test
+              inner         : Circuit built from qc.append
+              unbound       : Circuit with unbound parameters
+              custom        : Custom repr on the bell Quantum Circuit
+                      ["_global_phase","_base_name",'_data']
+     """
+
+
+def main():
+    """Create quantum circuit and print out the representations for it
+    Args:
+
+    Returns:
+
+    Raises:
+
+    Additional Information:
+    """
+
+    options = _get_cmdline(sys.argv[1:])
+
+    disp_obj = options["object"]
+    if disp_obj == "all":
+        disp_list = circuit_dict
+        for circ in disp_list:
+            source_obj = circuit_dict[circ]()
+            obj_repr = repr(source_obj)
+            if not is_valid_repr(obj_repr) and hasattr(source_obj, "_repr_attrs"):
+                obj_repr = build_repr(source_obj, attr_list=source_obj._repr_attrs)
+            parser = ReprParser(obj_repr, attr_rebuilders())
+            print(f"------------- print( {circ} )---------------")
+            print(source_obj)
+            print(f"------------- parser({circ}).print ---------------")
+            parser.print()
+            if options["eval"] and circ != "custom":
+                try:
+                    new_obj = parser.rebuild(parser.class_name, obj_repr)
+                    if new_obj == source_obj:
+                        print(f"New Object {circ} is equivalent(==) to Original")
+                    else:
+                        print(
+                            f"---------- New Object {circ} fails equivalence(==) test -------------"
+                        )
+                    print(f"------------- print( New {circ} )---------------")
+                    print(new_obj)
+                    new_repr = repr(new_obj)
+                    if not is_valid_repr(new_repr) and hasattr(new_obj, "_repr_attrs"):
+                        new_repr = build_repr(new_obj, attr_list=new_obj._repr_attrs)
+                    print(f"------------- parser( New {circ}).print ---------------")
+                    ReprParser(new_repr).print()
+                except Exception as error:  # pylint: disable=broad-except
+                    print(
+                        f"----- Unable to rebuild {circ} to perform equivalence(==) test ---------"
+                    )
+                    print(f"Returned Exception{error}")
+    else:
+        disp_list = disp_obj.split(",")
+        for circ in disp_list:
+            source_obj = circuit_dict[circ]()
+            obj_repr = repr(source_obj)
+            if not is_valid_repr(obj_repr) and hasattr(source_obj, "_repr_attrs"):
+                obj_repr = build_repr(source_obj, attr_list=source_obj._repr_attrs)
+            parser = ReprParser(obj_repr, attr_rebuilders())
+            print(f"------------- print( {circ} )---------------")
+            print(source_obj)
+            print(f"------------- parser({circ}).print ---------------")
+            parser.print()
+            if options["eval"] and circ != "custom":
+                try:
+                    new_obj = parser.rebuild(parser.class_name, obj_repr)
+                    if new_obj == source_obj:
+                        print(f"New Object {circ} is equivalent(==) to Original")
+                    else:
+                        print(
+                            f"---------- New Object {circ} fails equivalence(==) test -------------"
+                        )
+                    print(f"------------- print( New {circ} )---------------")
+                    print(new_obj)
+                    new_repr = repr(new_obj)
+                    if not is_valid_repr(new_repr) and hasattr(new_obj, "_repr_attrs"):
+                        new_repr = build_repr(new_obj, attr_list=new_obj._repr_attrs)
+                    print(f"------------- parser( New {circ}).print ---------------")
+                    ReprParser(new_repr).print()
+                except Exception as error:  # pylint: disable=broad-except
+                    print(
+                        f"----- Unable to rebuild {disp_obj} to perform equivalence(==) test ---------"
+                    )
+                    print(f"Returned Exception{error}")
+
+
+if __name__ == "__main__":
+    main()

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -23,7 +23,7 @@ from .bit import Bit
 class Clbit(Bit):
     """Implement a classical bit."""
 
-    __slots__ = ()
+    __slots__ = ("_repr_attrs",)
 
     def __init__(self, register=None, index=None):
         """Creates a classical bit.
@@ -42,6 +42,18 @@ class Clbit(Bit):
             raise CircuitError(
                 "Clbit needs a ClassicalRegister and %s was provided" % type(register).__name__
             )
+        self._repr_attrs = ["_index"]
+
+    def __repr__(self):
+        from qiskit.utils.reprbuild import build_repr
+
+        return build_repr(self, attr_list=self._repr_attrs)
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
 
 
 class ClassicalRegister(Register):
@@ -52,7 +64,19 @@ class ClassicalRegister(Register):
     # Prefix to use for auto naming.
     prefix = "c"
     bit_type = Clbit
+    _repr_attrs = ["_name", "_size", "prefix"]
 
     def qasm(self):
         """Return OPENQASM string for this register."""
         return "creg %s[%d];" % (self.name, self.size)
+
+    def __repr__(self):
+        from qiskit.utils.reprbuild import build_repr
+
+        return build_repr(self, attr_list=self._repr_attrs)
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -99,6 +99,19 @@ class ControlledGate(Gate):
         self._ctrl_state = None
         self.ctrl_state = ctrl_state
         self._name = name
+        self._repr_attrs.append("_num_ctrl_qubits")
+        self._repr_attrs.append("_ctrl_state")
+
+    def __repr__(self):
+        from qiskit.utils.reprbuild import build_repr
+
+        return build_repr(self, attr_list=self._repr_attrs)
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
 
     @property
     def definition(self) -> List:

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -40,6 +40,17 @@ class Gate(Instruction):
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20
 
+    def __repr__(self):
+        from qiskit.utils.reprbuild import build_repr
+
+        return build_repr(self, attr_list=self._repr_attrs)
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
+
     def to_matrix(self) -> np.ndarray:
         """Return a Numpy.array for the gate unitary matrix.
 

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -103,6 +103,23 @@ class Instruction(Operation):
         self._unit = unit
 
         self.params = params  # must be at last (other properties may be required for validation)
+        self._repr_attrs = [
+            "_name",
+            "_num_qubits",
+            "_num_clbits",
+            "_condition",
+            "_duration",
+            "unit",
+            "_label",
+            "_definition",
+            "_params",
+        ]
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
 
     def __eq__(self, other):
         """Two instructions are the same if they have the same name,

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -284,6 +284,43 @@ class QuantumCircuit:
         if not isinstance(metadata, dict) and metadata is not None:
             raise TypeError("Only a dictionary or None is accepted for circuit metadata")
         self._metadata = metadata
+        self._repr_attrs = [
+            "_base_name",
+            "num_qubits",
+            "num_clbits",
+            "_global_phase",
+            "_metadata",
+            "_data",
+            "_calibrations",
+            "qregs",
+            "cregs",
+        ]
+
+    def __repr__(self):
+        from qiskit.utils.reprbuild import build_repr
+
+        return build_repr(
+            self,
+            attr_list=self._repr_attrs,
+            summary=f" {self.num_qubits} qubits, "
+            f"{self.num_clbits} clbits, "
+            f"{len(self._data)} instructions",
+        )
+
+    @property
+    def repr_attrs(self) -> dict:
+        """Return the list of properties necessary to build the representation."""
+        return dict(self._repr_attrs)
+
+    @repr_attrs.setter
+    def repr_attrs(self, repr_attrs):
+        """Set the list of properties necessary to build the representation.
+
+        Args:
+            repr_attrs Union[list,dict]: A list, or dictionary with recursion depths, of
+                properties to build the representation.
+        """
+        self._repr_attrs = repr_attrs
 
     @property
     def data(self) -> QuantumCircuitData:

--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -35,7 +35,7 @@ class CircuitInstruction:
         of distinct items, with no duplicates.
     """
 
-    __slots__ = ("operation", "qubits", "clbits", "_legacy_format_cache")
+    __slots__ = ("operation", "qubits", "clbits", "_legacy_format_cache", "_repr_attrs")
 
     operation: Instruction
     """The logical operation that this instruction represents an execution of."""
@@ -54,6 +54,7 @@ class CircuitInstruction:
         self.qubits = tuple(qubits)
         self.clbits = tuple(clbits)
         self._legacy_format_cache = None
+        self._repr_attrs = ["operation", "qubits", "clbits"]
 
     def copy(self) -> "CircuitInstruction":
         """Return a shallow copy of the :class:`CircuitInstruction`."""
@@ -84,6 +85,12 @@ class CircuitInstruction:
             f", clbits={self.clbits!r}"
             ")"
         )
+
+    def __str__(self):
+        from qiskit.utils.reprbuild import build_repr
+        from qiskit.utils.reprparse import format_repr
+
+        return format_repr(build_repr(self, attr_list=self._repr_attrs))
 
     def __eq__(self, other):
         if isinstance(other, type(self)):

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -23,6 +23,8 @@ from .bit import Bit
 class Qubit(Bit):
     """Implement a quantum bit."""
 
+    _repr_attrs = ["_index"]
+
     __slots__ = ()
 
     def __init__(self, register=None, index=None):
@@ -52,6 +54,7 @@ class QuantumRegister(Register):
     # Prefix to use for auto naming.
     prefix = "q"
     bit_type = Qubit
+    _repr_attrs = ["_name", "_size", "prefix"]
 
     def qasm(self):
         """Return OPENQASM string for this register."""

--- a/qiskit/circuit/register.py
+++ b/qiskit/circuit/register.py
@@ -25,7 +25,7 @@ from qiskit.circuit.exceptions import CircuitError
 class Register:
     """Implement a generic register."""
 
-    __slots__ = ["_name", "_size", "_bits", "_bit_indices", "_hash", "_repr"]
+    __slots__ = ["_name", "_size", "_bits", "_bit_indices", "_hash", "_repr", "_repr_attrs"]
 
     # Register name should conform to OpenQASM 2.0 specification
     # See appendix A of https://arxiv.org/pdf/1707.03429v2.pdf
@@ -128,6 +128,7 @@ class Register:
             # first on deepcopying or on pickling, so defer populating _bit_indices
             # until first access.
             self._bit_indices = None
+        self._repr_attrs = ["_name", "_size", "prefix"]
 
     @property
     def name(self):

--- a/qiskit/utils/reprbuild.py
+++ b/qiskit/utils/reprbuild.py
@@ -1,0 +1,317 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Build a representation such that eval(repr(A)) is a dictionary which can be
+unambiguous enough that we can build a class method such that cls(A).build_repr(eval(A))
+is equivalent to A for most reasonable definitions of equivalence.
+"""
+from typing import Optional
+import numpy as np
+
+REPRATTRIBUTES = "_repr_attrs"
+MAXRECURSION = 200
+
+
+class ReprBuildError(Exception):
+    """Base class for errors raised while processing a representation."""
+
+    def __init__(self, *message):
+        """Set the error message."""
+        super().__init__(" ".join(message))
+        self.message = " ".join(message)
+
+    def __str__(self):
+        """Return the message."""
+        if not isinstance(self.message, str):
+            return repr(self.message)
+        else:
+            return self.message
+
+
+def _get_summary(source):
+    """Create the summary information about the input object for the recursive representation."""
+    _summary = f"class: {source.__class__.__name__}"
+    _src_name = getattr(source, "name", None)
+    if _src_name is not None:
+        _summary += f",name: {_src_name}"
+
+    return _summary
+
+
+def split_repr(obj_repr):
+    """Parse off and return the summary and embedded definition of the input representation
+    Args:
+        obj_repr Union[str,list]: Object representation to be parsed
+    Returns:
+        dict:  Summary with the class and name elements mapped
+        Union[dict,tuple,list]:  if non-iterable built-in type return tuple(type,repr)
+                                 if recursively built representation returns attribute definition
+                                 else return iterable type of representation
+    Raises:
+
+    Additional Information:
+        The summary is a dictionary with:
+            class: The name of the original class
+            name:   The name, if it was assigned, of the original object
+            is_builtin: A boolean indicating if the class is to be treated at a builtin
+    """
+    (summary, repr_defn) = (None, None)
+    if isinstance(obj_repr, str):
+        try:
+            obj_repr = eval(obj_repr)  # pylint: disable=eval-used
+        except:  # pylint: disable=bare-except
+            obj_repr = None
+
+    if isinstance(obj_repr, list) and len(obj_repr) == 2:
+        if isinstance(obj_repr[0], str):
+            summary_list = obj_repr[0].split(",")
+            classname = summary_list[0]
+            if classname.startswith("<class '"):
+                summary = {}
+                summary["class"] = classname
+            elif classname.startswith("class: "):
+                summary = {}
+                summary["class"] = classname.split("class: ")[1]
+
+            if summary is not None:
+                repr_defn = obj_repr[1]
+                summary["name"] = ""
+                if len(summary_list) > 1:
+                    name_list = summary_list[1].split("name: ")
+                    if len(name_list) > 1 and name_list[1] is not None:
+                        summary["name"] = name_list[1]
+                summary["is_builtin"] = (
+                    isinstance(repr_defn, tuple)
+                    and (len(repr_defn) == 2)
+                    and isinstance(repr_defn[0], str)
+                    and isinstance(repr_defn[1], str)
+                )
+            if len(summary_list) < 3:
+                summary["summary"] = f"<{summary['class']} '{summary['name']}'>"
+            else:
+                custom_summary = ",".join(summary_list[2:])
+                summary["summary"] = f"<{summary['class']} '{summary['name']}' {custom_summary}>"
+
+    return summary, repr_defn
+
+
+def is_valid_repr(obj_repr):
+    """Determine if the input is a valid representation.
+    Args:
+        obj_repr (Union[list,str]): Object to be validated as representation
+    Returns:
+        Boolean: True if input can be converted to a valid representation
+                 False if not a valid representation
+    Raises:
+
+    Additional Information:
+    """
+    return split_repr(obj_repr)[0] is not None
+
+
+def build_attribute_defn(
+    source,
+    attribute,
+    depth=-1,
+    deepdive=False,
+    recursion=0,
+):
+    """
+    Args:
+        source (Unknown)    : Source object containing the attribute to be defined
+        attribute (Unknown) : Name of the source's attribute to define
+        depth (int)         : if == 0 : return object summary only as string
+                              if != 1 : return a recursively build representation for the attribute
+                                       a starting depth -1 will fully expand all attributes
+        deepdive (boolean)  : if True append attributes returned from dir() to list
+        recursion (int)     : prevent unlimited recursion in case of circular references
+    Raises:
+        ValueError: invalid value
+    Returns:
+        list: [summary, dictionary] representation of attribute
+    Raises:
+    Additional Information:
+            attr_defn[0]: Summary of the attribute
+            attr_defn[1]: Representation of a dictionary for members of the attribute
+                                listed in _repr_attrs for its class
+    """
+    if attribute is None:
+        attr = source
+    else:
+        attr = getattr(source, attribute, None)
+    attr_defn = [_get_summary(attr), None]
+    if attr is None:
+        attr_defn = None
+    elif isinstance(attr, str):
+        attr_defn = attr
+    elif isinstance(attr, (int, float, complex)):
+        attr_defn[1] = (repr(attr), attr.__class__.__name__)
+    elif isinstance(attr, (np.integer, np.floating, np.complexfloating, np.ndarray)):
+        attr_defn[1] = (repr(attr), attr.__class__.__name__)
+    elif depth != 0:
+        if hasattr(attr, REPRATTRIBUTES):
+            attr_defn = build_object_defn(
+                attr,
+                getattr(attr, REPRATTRIBUTES),
+                depth=depth - 1,
+                deepdive=deepdive,
+                recursion=recursion + 1,
+            )
+        elif isinstance(attr, (list, tuple, set)):
+            repr_list = []
+            if len(attr) > 0:
+                for cur_attr in attr:
+                    if cur_attr is None:
+                        pass
+                    elif hasattr(cur_attr, REPRATTRIBUTES):
+                        cur_repr = build_object_defn(
+                            cur_attr,
+                            getattr(cur_attr, REPRATTRIBUTES),
+                            depth=depth - 1,
+                            deepdive=deepdive,
+                            recursion=recursion + 1,
+                        )
+                    elif isinstance(cur_attr, (list, tuple, set, dict)):
+                        cur_repr = build_object_defn(
+                            cur_attr,
+                            None,
+                            depth=depth - 1,
+                            deepdive=deepdive,
+                            recursion=recursion + 1,
+                        )
+                    else:
+                        cur_repr = repr(cur_attr)
+                    repr_list.append(cur_repr)
+            if isinstance(attr, tuple):
+                repr_list = tuple(repr_list)
+            elif isinstance(attr, set):
+                repr_list = set(repr_list)
+            attr_defn[1] = repr_list
+        elif isinstance(attr, dict):
+            repr_list = {}
+            if len(attr) > 0:
+                repr_list = {}
+                for cur_key, cur_attr in attr.items():
+                    if cur_attr is None:
+                        pass
+                    elif hasattr(cur_attr, REPRATTRIBUTES):
+                        cur_repr = build_object_defn(
+                            cur_attr,
+                            getattr(cur_attr, REPRATTRIBUTES),
+                            depth=depth - 1,
+                            deepdive=deepdive,
+                            recursion=recursion + 1,
+                        )
+                    elif isinstance(cur_attr, (list, tuple, set, dict)):
+                        list_dict = build_attribute_defn(
+                            cur_attr,
+                            None,
+                            depth=depth - 1,
+                            deepdive=deepdive,
+                            recursion=recursion + 1,
+                        )
+                        cur_repr = list_dict
+                    else:
+                        cur_repr = repr(cur_attr)
+                    repr_list[cur_key] = cur_repr
+            attr_defn[1] = repr_list
+        else:
+            attr_defn[1] = repr(attr)
+
+    return attr_defn
+
+
+def build_object_defn(
+    source,
+    attr_list=None,
+    depth=-1,
+    deepdive=False,
+    recursion=0,
+):
+    """Create a list with the summary string and recursive representation for the object
+    Args:
+        source (Unknown)    : Object to be built into a dictionary
+        attr_list  (list)   : List of the object's attributes to include
+        depth (int)         : if == 0 : return object summary only as string
+                              if != 1 : return list[ object summary, dict{ attribute :,repr to depth -1]
+                                       a starting depth -1 will fully expand all attributes
+        deepdive (boolean)  : if True append attributes returned from dir() to list
+        recursion (int)     : number of levels of recursion allowable for this representation
+    Returns:
+        list: summary of source object in element [0]
+              object definition in element[1]
+    Raises:
+        ReprBuildError: if a valid list of attributes is not found
+    Additional Information:
+    """
+    attr_depths = {}
+    if isinstance(attr_list, dict):
+        attr_depths = attr_list
+    elif isinstance(attr_list, list):
+        for cur_member in attr_list:
+            attr_depths[cur_member] = depth
+    elif attr_list is not None:
+        raise ReprBuildError("member_list not of type list or dict")
+    if deepdive:
+        __obj_dict__ = getattr(source, "__dict__", None)
+        if __obj_dict__ is not None:
+            for i in __obj_dict__:
+                attr_depths[i] = depth
+        for i in dir(source):
+            attr_depths[i] = depth
+
+    if recursion > MAXRECURSION:
+        member_dict = f"<Recursion limit of {MAXRECURSION} exceeded>"
+    else:
+        member_dict = {}
+        for cur_member, cur_depth in attr_depths.items():
+            cur_defn = build_attribute_defn(
+                source,
+                cur_member,
+                depth=cur_depth,
+                deepdive=deepdive,
+                recursion=recursion + 1,
+            )
+            if cur_defn is not None:
+                member_dict[cur_member] = cur_defn
+
+    if is_valid_repr(member_dict):
+        return member_dict
+    else:
+        return [_get_summary(source), member_dict]
+
+
+def build_repr(source, summary: [Optional] = None, **kwargs):
+    """Create a recursive representation for the source object
+    Args:
+        source (Type)    : Object to be built into a dictionary
+        summary (str)    : Additional information to add to the summary
+        **kwargs (params)   :
+            attr_list  (list)   : List of the object's attributes to include
+                                  If no supplied the _repr_attrs attribute of the source will determine
+                                  the representation to be built
+            depth (int)         : if == 0 : return representation without recursion
+                                  if != 1 : recursively build representations for included attributes,
+                                            decrementing depth at each level of recursion
+                                            A starting depth -1 will fully expand all attributes
+            deepdive (boolean)  : if True append attributes returned from dir() to the representation
+    Returns:
+        str: string representation of the representation definition
+    Raises:
+    Additional Information:
+    """
+    obj_defn = build_object_defn(source, **kwargs)
+    if not is_valid_repr(obj_defn):
+        obj_defn = [_get_summary(source), obj_defn]
+    if summary is not None and isinstance(summary, str):
+        obj_defn[0] = obj_defn[0] + "," + summary
+    return repr(obj_defn)

--- a/qiskit/utils/reprparse.py
+++ b/qiskit/utils/reprparse.py
@@ -1,0 +1,521 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2019, 2020.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+A parser Class for working with the recursively built representations
+"""
+from typing import Optional
+from .reprbuild import is_valid_repr, split_repr, ReprBuildError
+
+REBUILDER = "rebuild"
+
+
+class ReprParser:
+    """Class to parse, print and manipulate a recursive object representation
+
+    Args:
+        obj_repr (str): string representation of the dictionary produced
+                        by calls to myClass.__repr__()
+
+    Raises:
+        ReprBuildError: if the representation is not a valid dictionary
+
+    Additional Information:
+    """
+
+    def __init__(self, obj_repr, rebuilders: [Optional] = None):
+        if isinstance(obj_repr, str):
+            self._repr_str = obj_repr
+            try:
+                obj_repr = eval(obj_repr)  # pylint: disable=eval-used
+            except Exception as error:
+                raise ReprBuildError("ReprParser argument is invalid representation ") from error
+        else:
+            obj_repr = repr(obj_repr)
+            self._repr_str = obj_repr
+
+        if not is_valid_repr(obj_repr):
+            raise ReprBuildError("ReprParser argument is invalid representation ")
+
+        self._repr_str = obj_repr
+        (self._summary, self._obj_defn) = split_repr(self._repr_str)
+        self._name = self._summary.get("name", "")
+        self._class_name = self._summary.get("class", "")
+        self._is_builtin = self._summary.get("is_builtin", False)
+        self._rebuilder_map = {}
+        if rebuilders is not None:
+            self.append_rebuilder(rebuilders)
+
+    def __repr__(self):
+        return f"ReprParse for {self._class_name}  {self._name}"
+
+    def get(self, name):
+        """Get item in the dictionary of type unknown
+        Args:
+            name (str): Item to be parsed
+        Returns:
+            str: name of class of item
+        Raises:
+
+        Additional Information:
+        """
+        return split_repr(self._obj_defn.get(name))
+
+    def get_complex(self, name, default: [Optional] = None):
+        """Get item in the dictionary of type complex
+        Args:
+            name (str): Item to be parsed
+            default (class): return value if name is not found
+
+        Returns:
+            complex: Item value
+        Raises:
+
+        Additional Information:
+        """
+        complex_defn = split_repr(self._obj_defn.get(name))[1]
+        if _builtin_repr(complex_defn) and complex_defn[1] == "complex":
+            return complex(complex_defn[0])
+        else:
+            return default
+
+    def get_dict(self, name, default: [Optional] = None):
+        """Get item in the dictionary and return as a dictionary
+        Args:
+            name (str): Item to be parsed
+            default (dict): Default value to return if item is not present in the dictionary
+        Returns:
+            dict: Item value
+        Raises:
+
+        Additional Information:
+        """
+        summary, item_defn = split_repr(self._obj_defn.get(name))
+        if summary is not None and summary.get("class", "") in ("dict", "defaultdict"):
+            return item_defn
+        else:
+            return default
+
+    def get_float(self, name, default: [Optional] = None):
+        """Get item in the dictionary of type complex
+        Args:
+            name (str): Item to be parsed
+            default (class): return value if name is not found
+        Returns:
+            float: Item value
+        Raises:
+
+        Additional Information:
+        """
+        item_defn = split_repr(self._obj_defn.get(name))[1]
+        if item_defn is not None and _builtin_repr(item_defn) and item_defn[1] == "complex":
+            return float(item_defn[0])
+        else:
+            return default
+
+    def get_int(self, name, default: [Optional] = None):
+        """Get item in the dictionary of type complex
+        Args:
+            name (str): Item to be parsed
+            default (class): return value if name is not found
+        Returns:
+            int: Item value
+        Raises:
+
+        Additional Information:
+        """
+        item_dict = split_repr(self._obj_defn.get(name, None))[1]
+        if item_dict is not None and _builtin_repr(item_dict) and item_dict[1] == "int":
+            return int(item_dict[0])
+        return default
+
+    def get_list(self, name, default: [Optional] = None):
+        """Get item in the dictionary and return as a list
+        Args:
+            name (str): Item to be parsed
+            default (list): Default value to return if item is not present in the dictionary
+        Returns:
+            list: Item value
+        Raises:
+
+        Additional Information:
+        """
+        item_list = self._obj_defn.get(name, None)
+        if item_list is None or not isinstance(item_list, (list, set, tuple)):
+            item_list = default
+
+        return item_list
+
+    def get_repr(self, name, default: [Optional] = None):
+        """Return an representation stored in the parser
+        Args:
+            name (str): Item to be parsed
+            default (class): return value if name is not found
+        Returns:
+            list:  a valid representation for name (if found)
+        """
+        obj_repr = self.get_list(name, None)
+        if not is_valid_repr(obj_repr):
+            obj_repr = default
+        return obj_repr
+
+    def get_set(self, name, default: [Optional] = None):
+        """Get item in the dictionary and return as a list
+        Args:
+            name (str): Item to be parsed
+            default (list): Default value to return if item is not present in the dictionary
+        Returns:
+            list: Item value
+        Raises:
+
+        Additional Information:
+        """
+        summary, item_defn = split_repr(self._obj_defn.get(name))
+        if summary is not None and summary.get("class", "") == "set":
+            return set(item_defn)
+        else:
+            return default
+
+    def get_string(self, name, default: [Optional] = None):
+        """Return a string element from the parsed representation
+        Args:
+            name (str): Item to be parsed
+            default (class): return value if name is not found
+        Returns:
+            str:  the string value for name
+        """
+        new_string = self._obj_defn.get(name)
+        if not isinstance(new_string, str) and is_valid_repr(new_string):
+            new_string = split_repr(new_string)[1]
+        if not isinstance(new_string, str):
+            new_string = default
+        return new_string
+
+    def get_tuple(self, name, default: [Optional] = None):
+        """Get item in the dictionary and return as a list
+        Args:
+            name (str): Item to be parsed
+            default (list): Default value to return if item is not present in the dictionary
+        Returns:
+            list: Item value
+        Raises:
+
+        Additional Information:
+        """
+        summary, item_defn = split_repr(self._obj_defn.get(name))
+        if summary is not None and summary.get("class", "") == "tuple":
+            return tuple(item_defn)
+        else:
+            return default
+
+    @property
+    def obj_defn(self):
+        """Return a string element from the parsed representation
+        Args:
+
+        Returns:
+            dict:  the representation as a dictionary
+        """
+        return self._obj_defn
+
+    @property
+    def class_name(self):
+        """Return the class of the object that generated the representation
+        Args:
+
+        Returns:
+            str:  the class of the object
+        """
+        return self._class_name
+
+    @property
+    def name(self):
+        """Return the name of the object that generated the representation
+        Args:
+
+        Returns:
+            str:  the object name
+        """
+        return self._name
+
+    @property
+    def summary(self):
+        """Return just the summary string from the representation
+        Args:
+
+        Returns:
+            str:  the representation summary string
+        """
+        return self._summary.get("summary", "")
+
+    def get_mapper(self, name):
+        """Return the method registered by the add_class_mapper calls for the named class
+        Args:
+            name (str): Class name of the mapping method
+        Returns:
+            method:  The method to rebuild an instance of the object from a representation
+        """
+        return self._rebuilder_map.get(name, None)
+
+    def get_parser(self, obj_repr):
+        """Retrieve a parser for the object specified
+        Args:
+            obj_repr (Union[str,list]): Either the string name of the attribute or the list
+                        representation of the attribute to build the ReprParser object for
+        Returns:
+            ReprParser: parser loaded with the requested attributes definition and current rebuild map
+        Raises:
+            ReprError: if the mapping is invalid
+        """
+        new_parser = None
+        if not is_valid_repr(obj_repr):
+            obj_repr = self.get_repr(obj_repr, None)
+        if is_valid_repr(obj_repr):
+            new_parser = ReprParser(obj_repr)
+            if isinstance(new_parser, ReprParser):
+                new_parser.append_rebuilder(self._rebuilder_map)
+        return new_parser
+
+    def append_rebuilder(self, rebuilder):
+        """Register the method(s) used to rebuild from the recursive representation
+        Args:
+            rebuilder (Union[list, dict, class]):
+                    A list of classes to be registered,
+                    a dictionary of name,method pairs to be registered, or
+                    a single class to be registered
+        Returns:
+        Raises:
+            ReprBuildError: if the method(s) can not be found
+        """
+        if isinstance(rebuilder, list):
+            for obj_class in rebuilder:
+                if hasattr(obj_class, REBUILDER):
+                    self._rebuilder_map[obj_class.__class_name__] = getattr(obj_class, REBUILDER)
+                else:
+                    raise ReprBuildError(
+                        f"Rebuild method, {REBUILDER} not found in {obj_class.__class_name__}"
+                    )
+        elif isinstance(rebuilder, dict):
+            for class_name, mapper in rebuilder.items():
+                self._rebuilder_map[class_name] = mapper
+        else:
+            if hasattr(rebuilder, REBUILDER):
+                self._rebuilder_map[rebuilder.__class_name__] = getattr(rebuilder, REBUILDER)
+            else:
+                raise ReprBuildError(
+                    f"No rebuilder {REBUILDER} method in {rebuilder.__class_name__}"
+                )
+
+    def rebuild(self, name: [Optional] = None, obj_repr: [Optional] = None):
+        """Build an instance of the specified object according to the representation
+        Args:
+            name (str): Optional class name as string. If none name from obj_repr will be used
+            obj_repr(str): The representation of the object to be instantiated
+        Returns:
+            object:  The newly instantiated instance defined in the representation
+        Raises:
+            ReprBuildError: if the mapping is invalid
+        """
+        new_obj = None
+        if obj_repr is None and name is not None:
+            obj_repr = self.get_repr(name)
+        else:
+            obj_repr = self._repr_str
+
+        if obj_repr is not None:
+            if name is None:
+                summary = split_repr(obj_repr)[0]
+                if summary is not None:
+                    name = summary.get("class", "")
+
+            new_obj = self._rebuild_builtin(obj_repr)
+            if new_obj is None:
+                mapper = self._rebuilder_map.get(name, None)
+                if mapper is None:
+                    raise ReprBuildError(f"No {REBUILDER} method found for {name}")
+                if not is_valid_repr(obj_repr):
+                    raise ReprBuildError(f"Invalid representation for {name}")
+                new_obj = mapper(obj_repr)
+        return new_obj
+
+    def _rebuild_builtin(self, obj_repr):
+        summary, obj_dict = split_repr(obj_repr)
+        if summary is None:
+            new_attr = None
+        elif isinstance(obj_dict, str):
+            try:
+                new_attr = eval(obj_dict)  # pylint: disable=eval-used
+            except:  # pylint: disable=bare-except
+                new_attr = obj_dict
+        elif isinstance(obj_dict, (tuple, list, dict, set)):
+            if summary.get("class", "") == "str":
+                new_attr = obj_dict[0]
+            elif summary.get("class", "") == "int":
+                new_attr = int(obj_dict[0])
+            elif summary.get("class", "") == "float":
+                new_attr = float(obj_dict[0])
+            elif summary.get("class", "") == "complex":
+                new_attr = complex(obj_dict[0])
+            elif summary.get("class", "") in ("list", "dict"):
+                new_attr = obj_dict
+            elif summary.get("class", "") == "tuple":
+                new_attr = tuple(obj_dict)
+            elif summary.get("class", "") == "set":
+                new_attr = set(obj_dict)
+            else:
+                # TODO: Support numpy and sympy types as builtins
+                new_attr = None
+        else:
+            new_attr = None
+        return new_attr
+
+    def format_repr(self, indent=""):
+        """Return a user friendly version of the representation
+        Args:
+            indent (str):    Indentation level for the output
+        Returns:
+            str: Nicely formatted representation
+        Raises:
+
+        Additional Information:
+        """
+        if self._class_name in ("str", "int", "float", "complex"):
+            return_str = f"{indent}{self._obj_defn}\n"
+        elif self._class_name in ("tuple", "set", "list"):
+            return_str = ""
+            if self._name != "":
+                return_str += f"{indent}{self._name} : {self._class_name}\n"
+                indent += "    "
+            return_str += _format_repr_list(self._obj_defn, indent=indent)
+        elif self._class_name in ("defaultdict", "dict"):
+            return_str = f"{indent}{self._name} : {self._class_name}\n"
+            return_str += _format_repr_dict(self._obj_defn, indent=indent + "    ")
+        else:
+            return_str = f"{indent}{self._name} : {self._class_name}\n"
+            return_str += _format_repr_dict(self._obj_defn, indent + "    ")
+        return return_str
+
+    def print(self, indent=""):
+        """Print a user friendly version of the representation
+        Args:
+            indent (str):    Indentation level for the output
+        Returns:
+        Raises:
+
+        Additional Information:
+        """
+        print(self.format_repr(indent=indent))
+
+
+def print_repr(obj_repr, indent="    "):
+    """Print the current object registration
+    Args:
+        obj_repr (Union[str,list]):  Recursive object representation
+        indent (str): The starting indentation for this representation
+    Returns:
+    Raises:
+        ReprBuildError: If argument is not a valid representation
+    """
+    print(format_repr(obj_repr, indent=indent))
+
+
+def format_repr(obj_repr, indent="    "):
+    """Print the current object registration
+    Args:
+        obj_repr (Union[str,list]):  Recursive object representation
+        indent (str): The starting indentation for this representation
+    Returns:
+        str: Nice formatted representation
+    Raises:
+        ReprBuildError: If argument is not a valid representation
+    """
+    return ReprParser(obj_repr).format_repr(indent=indent)
+
+
+def _format_repr_dict(obj_dict, indent="", name: Optional = ""):
+    """print an element that is of type dict"""
+    if is_valid_repr(obj_dict):
+        return_str = format_repr(obj_dict, indent)
+    elif isinstance(obj_dict, str):
+        return_str = f"{indent}{obj_dict}\n"
+    elif _builtin_repr(obj_dict):
+        return_str = f"{indent}{name} : {obj_dict[0]} : {obj_dict[1]}\n"
+    elif isinstance(obj_dict, dict):
+        return_str = ""
+        for cur_name, cur_obj in obj_dict.items():
+            return_str += _format_repr_element(
+                cur_obj,
+                indent,
+                name=cur_name,
+                header=f"{indent}{cur_name}: {cur_obj.__class__.__name__}\n",
+            )
+    elif isinstance(obj_dict, (set, list, tuple)):
+        return_str = ""
+        for item in obj_dict:
+            return_str += _format_repr_element(item, indent, name=name)
+    elif obj_dict is not None:
+        return_str = f"Type mismatch, expecting 'dict' got {type(obj_dict)}\n"
+    return return_str
+
+
+def _format_repr_element(cur_defn, indent="", header: Optional = None, name: Optional = ""):
+    """print the details of a single element of the representation s"""
+    return_str = ""
+    if isinstance(cur_defn, (str, int, float, complex)):
+        return_str = f"{indent}{name} : {cur_defn}\n"
+    elif _builtin_repr(cur_defn):
+        item_defn = split_repr(cur_defn)[1]
+        return_str = f"{indent}{name} : {item_defn[1]}: {item_defn[0]}\n"
+    elif is_valid_repr(cur_defn):
+        if header is not None and not _builtin_repr(cur_defn):
+            return_str += header
+            indent += "    "
+        return_str += format_repr(cur_defn, indent)
+    elif isinstance(cur_defn, (tuple, set, list)):
+        if header is not None:
+            return_str += header
+            indent += "    "
+        return_str += _format_repr_list(cur_defn, indent)
+    elif isinstance(cur_defn, dict):
+        if header is not None:
+            return_str += header
+            indent += "    "
+        return_str += _format_repr_dict(cur_defn, indent, name=name)
+    else:
+        return_str = format_repr(cur_defn, indent)
+    return return_str
+
+
+def _format_repr_list(obj_list, indent):
+    """print an element that is of type list, set or tuple"""
+    return_str = ""
+    if is_valid_repr(obj_list):
+        (summary, list_dict) = split_repr(obj_list)
+        return_str += f"{indent}{summary.get('name','')} : {summary.get('class','Unknown')}\n"
+        return_str += format_repr(list_dict, indent + "    ")
+    elif isinstance(obj_list, (tuple, set, list)):
+        for cur_obj in obj_list:
+            return_str += _format_repr_element(cur_obj, indent)
+    else:
+        return_str = f"Type mismatch expecting 'list' go {type(cur_obj)}\n"
+    return return_str
+
+
+def _builtin_repr(list_dict):
+    if is_valid_repr(list_dict):
+        list_dict = split_repr(list_dict)[1]
+    is_builtin = (
+        isinstance(list_dict, tuple)
+        and (len(list_dict) == 2)
+        and isinstance(list_dict[0], str)
+        and isinstance(list_dict[1], str)
+    )
+    return is_builtin


### PR DESCRIPTION
Added
-    qiskit/utils/reprbuild.py
-    qiskit/utils/reprparse.py

Implement a QuantumCircuit representation recursivley including:
-    CircuitInstruction, Instruction
-    ControlledGate, Gate,
-    Qubit, QuantumRegister,
-    Clbit, ClassicalRegister,
-    Register

Added example code, examples/python/build_repr.py, to rebuild and compare objects, including:
-    Bell Circuit
-    cx gate
-    cx instruction

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Address Issue [8594 ](https://github.com/Qiskit/qiskit-terra/issues/8594) with formatting and manipulation utilities for better \_\_repr\_\_ generation.  

Implement tools to build recursive representations that provide a single, unambiguous, authoritative representation of any variable within a system.  The tools attempt to balance the python standards regarding the machine readable (__repr__) representation, human readable (__str__) representation, and the recreation of equivalent objects via eval( repr( _obj_ ) ).  Tools to build, parse, print and recreate an equivalent instance from the recursive representations are provided.  When using the utilities:
- repr(_obj_) results in a string providing safer evaluation and less complexity than fully recreating an object
- eval(repr(_obj_)) results in a python list containing a summary and object details for attributes included
- if rebuild methods are implemented (see example code), the ReprParser class can reconstruct equivalent objects
- recursive representation do not require modification to __repr__ and __str__ for included attributes (see Qubit and QuantumRegister in example)
- additional information can be added to the summary to make the machine readable representation more user human friendly (see QuantumCircuit)

### Details and comments
See attached markdown file and zipped jupyter notebook (notebook and html output) for examples. 

The following issues are relevant to this discussion:
- Qiskit-terra: Add good \_\_repr\_\_ methods to all public classes [#8594 ](https://github.com/Qiskit/qiskit-terra/issues/8594)
- Qiskit-terra: add QuantumCircuit.from_instructions [#9006](https://github.com/Qiskit/qiskit-terra/pull/9006) and [#8709](https://github.com/Qiskit/qiskit-terra/issues/8709)
- QAMP: Add good \_\_repr\_\_ methods to all public classes [#37](https://github.com/qiskit-advocate/qamp-fall-22/issues/37)

**Included:**

1. Implementations of \_\_repr\_\_ for QuantumCircuit, ControlledGate, Gate, Clbit, and ClassicalRegister.  The QuantumCircuit representation customizes the summary section of the machine readable representation to be more user friendly.  **_['class: QuantumCircuit,name: Inner, 2 qubits, 2 clbits, 4 instructions', {....._**
2. Definition of attribute lists for QuantumCircuit, CircuitInstruction, Instruction, ControlledGate, Gate, Qubit, QuantumRegister, Clbit, ClassicalRegister, and Register
3. Implementations of  \_\_str\_\_ method for CircuitInstruction, Instruction, ControlledGate, Gate, Clbit, ClassicalRegister
4. Leaves untouched pre-existing methods for QuantumCircuit.\_\_str\_\_, CircuitInstruction.\_\_repr\_\_, Instruction.\_\_repr\_\_, Register.\_\_str\_\_

Note, currently the following tests will fail if \_\_str\_\_ is configured in Qubit, QuantumRegister or if \_\_repr\_\_ is configured in Qubit, QuantumRegister, Register:
- test.python.transpiler.test_layout.LayoutTest.test_layout_repr_with_holes
- test.python.transpiler.test_layout.LayoutTest.test_layout_repr,  


WIP Tasks Remaining:
- Address test case failure for Qubit,QuantumRegister and Register in test_layout_repr_with_holes
- Address test case failure for Qubit,QuantumRegister and Register in test_layout_repr
- Build test cases, using examples as starting point
- Release Notes

Attachments:

[utils-build-repr-jupyter-Notebook.zip](https://github.com/Qiskit/qiskit-terra/files/9882669/utils-build-repr-jupyter-Notebook.zip)
[README.md](https://github.com/Qiskit/qiskit-terra/files/9882850/README.md)
