### PR TITLE
Fix exact floating-point comparison causing flaky test

### DIFF
--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -279,12 +279,12 @@ class TestAerPauliExpectation(QiskitOpflowTestCase):
         with self.subTest("integer coefficients"):
             exp = 3 * ~StateFn(X) @ (2 * Minus)
             target = self.sampler.convert(self.expect.convert(exp)).eval()
-            self.assertEqual(target, -12)
+            self.assertAlmostEqual(target, -12)
 
         with self.subTest("complex coefficients"):
             exp = 3j * ~StateFn(X) @ (2j * Minus)
             target = self.sampler.convert(self.expect.convert(exp)).eval()
-            self.assertEqual(target, -12j)
+            self.assertAlmostEqual(target, -12j)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

This triggered semi-reliably on Windows with all optional packages installed, with the output different by 2 ULP.  It's a floating-point equality check, so what we care about asserting is approximate equality, not exact.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Turned up by #8967.
