### PR TITLE
Fix up docstring for VF2PostLayout

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -51,25 +51,26 @@ class VF2PostLayout(AnalysisPass):
     """A pass for choosing a Layout after transpilation of a circuit onto a
     Coupling graph, as a subgraph isomorphism problem, solved by VF2++.
 
-    Unlike the :class:`~.VF2PostLayout` transpiler pass which is designed to find an
+    Unlike the :class:`~.VF2Layout` transpiler pass which is designed to find an
     initial layout for a circuit early in the transpilation pipeline this transpiler
     pass is designed to try and find a better layout after transpilation is complete.
     The initial layout phase of the transpiler doesn't have as much information available
     as we do after transpilation. This pass is designed to be paired in a similar pipeline
     as the layout passes. This pass will strip any idle wires from the circuit, use VF2
     to find a subgraph in the coupling graph for the circuit to run on with better fidelity
-    and then update the circuit layout to use the new qubits.
+    and then update the circuit layout to use the new qubits. The algorithm used in this
+    pass is described in `arXiv:2209.15512 <https://arxiv.org/abs/2209.15512>`__.
 
-    If a solution is found that means there is a "perfect layout" and that no
-    further swap mapping or routing is needed. If a solution is found the layout
-    will be set in the property set as ``property_set['layout']``. However, if no
-    solution is found, no ``property_set['layout']`` is set. The stopping reason is
+    If a solution is found that means there is a lower error layout available for the
+    circuit. If a solution is found the layout will be set in the property set as
+    will be set in the property set as ``property_set['post_layout']``. However, if no
+    solution is found, no ``property_set['post_layout']`` is set. The stopping reason is
     set in ``property_set['VF2PostLayout_stop_reason']`` in all the cases and will be
     one of the values enumerated in ``VF2PostLayoutStopReason`` which has the
     following values:
 
-        * ``"solution found"``: If a perfect layout was found.
-        * ``"nonexistent solution"``: If no perfect layout was found.
+        * ``"solution found"``: If a solution was found.
+        * ``"nonexistent solution"``: If no solution was found.
         * ``">2q gates in basis"``: If VF2PostLayout can't work with basis
 
     """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a few copy paste errors and errors in the docstring for the VF2PostLayout pass. It also adds a a link to the paper for the pass.

### Details and comments

This was originally part of #9026 as these fixes were part of modifying the docstring to document the new feature being added in that PR. This commit just extracts those docstring fixes from that PR.