### PR TITLE
Fix default batching in variational algorithms

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/vqe.py
@@ -181,9 +181,21 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
                 fun=evaluate_energy, x0=initial_point, jac=evaluate_gradient, bounds=bounds
             )
         else:
+            # We always want to submit as many estimations per job as possible for minimal
+            # overhead on the hardware. The minimum is set to 50 to cover the commonly used SPSA
+            # calibration or 2 * num_parameters to cover finite difference gradients,
+            # and we cap at 1000 parameter evaluations at once.
+            max_batchsize = getattr(self.optimizer, "_max_evals_grouped", None)
+            if max_batchsize is None:
+                default_batchsize = min(1000, max(50, 2 * self.ansatz.num_parameters))
+                self.optimizer.set_max_evals_grouped(default_batchsize)
+
             optimizer_result = self.optimizer.minimize(
                 fun=evaluate_energy, x0=initial_point, jac=evaluate_gradient, bounds=bounds
             )
+
+            # reset to original value
+            self.optimizer.set_max_evals_grouped(max_batchsize)
 
         optimizer_time = time() - start_time
 

--- a/qiskit/algorithms/optimizers/optimizer.py
+++ b/qiskit/algorithms/optimizers/optimizer.py
@@ -180,7 +180,7 @@ class Optimizer(ABC):
         self._bounds_support_level = self.get_support_level()["bounds"]
         self._initial_point_support_level = self.get_support_level()["initial_point"]
         self._options = {}
-        self._max_evals_grouped = 1
+        self._max_evals_grouped = None
 
     @abstractmethod
     def get_support_level(self):
@@ -205,7 +205,7 @@ class Optimizer(ABC):
 
     # pylint: disable=invalid-name
     @staticmethod
-    def gradient_num_diff(x_center, f, epsilon, max_evals_grouped=1):
+    def gradient_num_diff(x_center, f, epsilon, max_evals_grouped=None):
         """
         We compute the gradient with the numeric differentiation in the parallel way,
         around the point x_center.
@@ -214,11 +214,14 @@ class Optimizer(ABC):
             x_center (ndarray): point around which we compute the gradient
             f (func): the function of which the gradient is to be computed.
             epsilon (float): the epsilon used in the numeric differentiation.
-            max_evals_grouped (int): max evals grouped
+            max_evals_grouped (int): max evals grouped, defaults to 1 (i.e. no batching).
         Returns:
             grad: the gradient computed
 
         """
+        if max_evals_grouped is None:  # no batching by default
+            max_evals_grouped = 1
+
         forig = f(*((x_center,)))
         grad = []
         ei = np.zeros((len(x_center),), float)

--- a/releasenotes/notes/fix-vqe-default-batching-eb08e6ce17907da3.yaml
+++ b/releasenotes/notes/fix-vqe-default-batching-eb08e6ce17907da3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a performance bug where the new primitive-based variational algorithms
+    :class:`.minimum_eigensolvers.VQE`, :class:`.eigensolvers.VQD` and :class:`.SamplingVQE`
+    did not batch energy evaluations per default, which resulted in a significant slowdown
+    if a hardware backend was used.

--- a/test/python/algorithms/minimum_eigensolvers/test_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_vqe.py
@@ -300,6 +300,35 @@ class TestVQE(QiskitAlgorithmsTestCase):
             vqe.optimizer = L_BFGS_B()
             run_check()
 
+    def test_default_batch_evaluation(self):
+        """Test the default batching works."""
+        ansatz = TwoLocal(2, rotation_blocks=["ry", "rz"], entanglement_blocks="cz")
+
+        wrapped_estimator = Estimator()
+        inner_estimator = Estimator()
+
+        callcount = {"estimator": 0}
+
+        def wrapped_estimator_run(*args, **kwargs):
+            kwargs["callcount"]["estimator"] += 1
+            return inner_estimator.run(*args, **kwargs)
+
+        wrapped_estimator.run = partial(wrapped_estimator_run, callcount=callcount)
+
+        spsa = SPSA(maxiter=5)
+
+        vqe = VQE(wrapped_estimator, ansatz, spsa)
+        _ = vqe.compute_minimum_eigenvalue(Pauli("ZZ"))
+
+        # 1 calibration + 5 loss + 1 return loss
+        expected_estimator_runs = 1 + 5 + 1
+
+        with self.subTest(msg="check callcount"):
+            self.assertEqual(callcount["estimator"], expected_estimator_runs)
+
+        with self.subTest(msg="check reset to original max evals grouped"):
+            self.assertIsNone(spsa.get_max_evals_grouped())
+
     def test_batch_evaluate_with_qnspsa(self):
         """Test batch evaluating with QNSPSA works."""
         ansatz = TwoLocal(2, rotation_blocks=["ry", "rz"], entanglement_blocks="cz")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #8926.

### Details and comments

As we motivate users to use the runtime primitives over runtime programs, it is important that the code remains as efficient as possible. With the variational algorithms released in 0.22.0 however, there's a significant slowdown if hardware is used (also with Sessions), as we didn't include batching of energy evaluations. This PR fixes that performance issue by adding default batching in case the user didn't specify any, which is the same behavior users previously had with the runtime programs.

For the 0.23 release we're planning to update how batching works and then these hardcoded limits can be removed, but we probably don't want to wait 3 months to fix this slowdown of a factor of ~2 🙂 

I'm not sure if it's ok to change the default of the internal `_max_evals_grouped` (@mtreinish @jakelishman what do you think?) but I couldn't find another way to check if the user set the `_max_evals_grouped` manually. If that change blocks inlcuding this as a bugfix, we could also _not_ fix this behavior and add a very big textbox in the docs that says users really have to enable batching themselves manually. Until they discover that note, however, they likely already complained about slow runtimes... 😄 