### PR TITLE
Use TOQM routing staged pass manager.

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -160,8 +160,7 @@ def transpile(
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"layout"`` for the ``stage_name`` argument.
         routing_method: Name of routing pass
-            ('basic', 'lookahead', 'stochastic', 'sabre', 'toqm', 'none'). Note
-            that to use method 'toqm', package 'qiskit-toqm' must be installed.
+            ('basic', 'lookahead', 'stochastic', 'sabre', 'none'). Note
             This can also be the external plugin name to use for the ``routing`` stage.
             You can see a list of installed plugins by using :func:`~.list_stage_plugins` with
             ``"routing"`` for the ``stage_name`` argument.

--- a/qiskit/transpiler/preset_passmanagers/common.py
+++ b/qiskit/transpiler/preset_passmanagers/common.py
@@ -64,7 +64,7 @@ _CONTROL_FLOW_STATES = {
         working={"trivial", "dense"}, not_working={"sabre", "noise_adaptive"}
     ),
     "routing_method": _ControlFlowState(
-        working={"none", "stochastic"}, not_working={"sabre", "lookahead", "basic", "toqm"}
+        working={"none", "stochastic"}, not_working={"sabre", "lookahead", "basic"}
     ),
     # 'synthesis' is not a supported translation method because of the block-collection passes
     # involved; we currently don't have a neat way to pass the information about nested blocks - the

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -31,7 +31,6 @@ from qiskit.transpiler.preset_passmanagers.plugin import (
     list_stage_plugins,
 )
 from qiskit.transpiler import TranspilerError
-from qiskit.utils.optionals import HAS_TOQM
 
 
 def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassManager:
@@ -91,38 +90,10 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             coupling_map, max_iterations=1, seed=seed_transpiler, swap_trials=5
         )
 
-    toqm_pass = False
     # Choose routing pass
-    # TODO: Remove when qiskit-toqm has it's own plugin and we can rely on just the plugin interface
-    if routing_method == "toqm" and "toqm" not in list_stage_plugins("routing"):
-        HAS_TOQM.require_now("TOQM-based routing")
-        from qiskit_toqm import ToqmSwap, ToqmStrategyO0, latencies_from_target
-
-        if initial_layout:
-            raise TranspilerError("Initial layouts are not supported with TOQM-based routing.")
-
-        toqm_pass = True
-        # Note: BarrierBeforeFinalMeasurements is skipped intentionally since ToqmSwap
-        #       does not yet support barriers.
-        routing_pass = ToqmSwap(
-            coupling_map,
-            strategy=ToqmStrategyO0(
-                latencies_from_target(
-                    coupling_map, instruction_durations, basis_gates, backend_properties, target
-                )
-            ),
-        )
-        routing_pm = common.generate_routing_passmanager(
-            routing_pass,
-            target,
-            coupling_map=coupling_map,
-            seed_transpiler=seed_transpiler,
-            use_barrier_before_measurement=not toqm_pass,
-        )
-    else:
-        routing_pm = plugin_manager.get_passmanager_stage(
-            "routing", routing_method, pass_manager_config, optimization_level=0
-        )
+    routing_pm = plugin_manager.get_passmanager_stage(
+        "routing", routing_method, pass_manager_config, optimization_level=0
+    )
 
     unroll_3q = None
     # Build pass manager
@@ -164,9 +135,6 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             unitary_synthesis_plugin_config,
             hls_config,
         )
-    pre_routing = None
-    if toqm_pass:
-        pre_routing = translation
 
     if (coupling_map and not coupling_map.is_symmetric) or (
         target is not None and target.get_non_global_operation_names(strict_direction=True)
@@ -205,7 +173,6 @@ def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     return StagedPassManager(
         init=init,
         layout=layout,
-        pre_routing=pre_routing,
         routing=routing,
         translation=translation,
         pre_optimization=pre_opt,

--- a/qiskit/transpiler/preset_passmanagers/level0.py
+++ b/qiskit/transpiler/preset_passmanagers/level0.py
@@ -28,9 +28,7 @@ from qiskit.transpiler.passes import SabreLayout
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
-    list_stage_plugins,
 )
-from qiskit.transpiler import TranspilerError
 
 
 def level_0_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassManager:

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -38,7 +38,6 @@ from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 
 from qiskit.transpiler import TranspilerError
-from qiskit.utils.optionals import HAS_TOQM
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
     list_stage_plugins,
@@ -149,41 +148,9 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             SabreLayout(coupling_map, max_iterations=2, seed=seed_transpiler, swap_trials=5),
         ).to_flow_controller()
 
-    toqm_pass = False
+    # Choose routing pass
     routing_pm = None
-    # TODO: Remove when qiskit-toqm has it's own plugin and we can rely on just the plugin interface
-    if routing_method == "toqm" and "toqm" not in list_stage_plugins("routing"):
-        HAS_TOQM.require_now("TOQM-based routing")
-        from qiskit_toqm import ToqmSwap, ToqmStrategyO1, latencies_from_target
-
-        if initial_layout:
-            raise TranspilerError("Initial layouts are not supported with TOQM-based routing.")
-
-        toqm_pass = True
-        # Note: BarrierBeforeFinalMeasurements is skipped intentionally since ToqmSwap
-        #       does not yet support barriers.
-        routing_pass = ToqmSwap(
-            coupling_map,
-            strategy=ToqmStrategyO1(
-                latencies_from_target(
-                    coupling_map, instruction_durations, basis_gates, backend_properties, target
-                )
-            ),
-        )
-        vf2_call_limit = common.get_vf2_call_limit(
-            1, pass_manager_config.layout_method, pass_manager_config.initial_layout
-        )
-        routing_pm = common.generate_routing_passmanager(
-            routing_pass,
-            target,
-            coupling_map,
-            vf2_call_limit=vf2_call_limit,
-            backend_properties=backend_properties,
-            seed_transpiler=seed_transpiler,
-            check_trivial=True,
-            use_barrier_before_measurement=not toqm_pass,
-        )
-    elif routing_method is None:
+    if routing_method is None:
         _stochastic_routing = plugin_manager.get_passmanager_stage(
             "routing",
             "stochastic",
@@ -261,10 +228,6 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             hls_config,
         )
 
-    pre_routing = None
-    if toqm_pass:
-        pre_routing = translation
-
     if (coupling_map and not coupling_map.is_symmetric) or (
         target is not None and target.get_non_global_operation_names(strict_direction=True)
     ):
@@ -318,7 +281,6 @@ def level_1_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     return StagedPassManager(
         init=init,
         layout=layout,
-        pre_routing=pre_routing,
         routing=routing,
         translation=translation,
         pre_optimization=pre_optimization,

--- a/qiskit/transpiler/preset_passmanagers/level1.py
+++ b/qiskit/transpiler/preset_passmanagers/level1.py
@@ -37,10 +37,8 @@ from qiskit.transpiler.passes import GatesInBasis
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 
-from qiskit.transpiler import TranspilerError
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
-    list_stage_plugins,
 )
 
 

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -38,7 +38,6 @@ from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 
 from qiskit.transpiler import TranspilerError
-from qiskit.utils.optionals import HAS_TOQM
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
     list_stage_plugins,
@@ -134,43 +133,10 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             coupling_map, max_iterations=2, seed=seed_transpiler, swap_trials=10
         )
 
-    toqm_pass = False
-    routing_pm = None
-    # TODO: Remove when qiskit-toqm has it's own plugin and we can rely on just the plugin interface
-    if routing_method == "toqm" and "toqm" not in list_stage_plugins("routing"):
-        HAS_TOQM.require_now("TOQM-based routing")
-        from qiskit_toqm import ToqmSwap, ToqmStrategyO2, latencies_from_target
-
-        if initial_layout:
-            raise TranspilerError("Initial layouts are not supported with TOQM-based routing.")
-        toqm_pass = True
-
-        # Note: BarrierBeforeFinalMeasurements is skipped intentionally since ToqmSwap
-        #       does not yet support barriers.
-        routing_pass = ToqmSwap(
-            coupling_map,
-            strategy=ToqmStrategyO2(
-                latencies_from_target(
-                    coupling_map, instruction_durations, basis_gates, backend_properties, target
-                )
-            ),
-        )
-        vf2_call_limit = common.get_vf2_call_limit(
-            2, pass_manager_config.layout_method, pass_manager_config.initial_layout
-        )
-        routing_pm = common.generate_routing_passmanager(
-            routing_pass,
-            target,
-            coupling_map=coupling_map,
-            vf2_call_limit=vf2_call_limit,
-            backend_properties=backend_properties,
-            seed_transpiler=seed_transpiler,
-            use_barrier_before_measurement=not toqm_pass,
-        )
-    else:
-        routing_pm = plugin_manager.get_passmanager_stage(
-            "routing", routing_method, pass_manager_config, optimization_level=2
-        )
+    # Choose routing pass
+    routing_pm = plugin_manager.get_passmanager_stage(
+        "routing", routing_method, pass_manager_config, optimization_level=2
+    )
 
     # Build optimization loop: 1q rotation merge and commutative cancellation iteratively until
     # no more change in depth
@@ -226,9 +192,7 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             unitary_synthesis_plugin_config,
             hls_config,
         )
-    pre_routing = None
-    if toqm_pass:
-        pre_routing = translation
+
     if (coupling_map and not coupling_map.is_symmetric) or (
         target is not None and target.get_non_global_operation_names(strict_direction=True)
     ):
@@ -275,7 +239,6 @@ def level_2_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     return StagedPassManager(
         init=init,
         layout=layout,
-        pre_routing=pre_routing,
         routing=routing,
         translation=translation,
         pre_optimization=pre_optimization,

--- a/qiskit/transpiler/preset_passmanagers/level2.py
+++ b/qiskit/transpiler/preset_passmanagers/level2.py
@@ -37,10 +37,8 @@ from qiskit.transpiler.passes import GatesInBasis
 from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 
-from qiskit.transpiler import TranspilerError
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
-    list_stage_plugins,
 )
 
 

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -45,9 +45,7 @@ from qiskit.transpiler.preset_passmanagers import common
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 from qiskit.transpiler.preset_passmanagers.plugin import (
     PassManagerStagePluginManager,
-    list_stage_plugins,
 )
-from qiskit.transpiler import TranspilerError
 
 
 def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassManager:

--- a/qiskit/transpiler/preset_passmanagers/level3.py
+++ b/qiskit/transpiler/preset_passmanagers/level3.py
@@ -48,7 +48,6 @@ from qiskit.transpiler.preset_passmanagers.plugin import (
     list_stage_plugins,
 )
 from qiskit.transpiler import TranspilerError
-from qiskit.utils.optionals import HAS_TOQM
 
 
 def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassManager:
@@ -140,42 +139,10 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             coupling_map, max_iterations=4, seed=seed_transpiler, swap_trials=20
         )
 
-    toqm_pass = False
-    # TODO: Remove when qiskit-toqm has it's own plugin and we can rely on just the plugin interface
-    if routing_method == "toqm" and "toqm" not in list_stage_plugins("routing"):
-        HAS_TOQM.require_now("TOQM-based routing")
-        from qiskit_toqm import ToqmSwap, ToqmStrategyO3, latencies_from_target
-
-        if initial_layout:
-            raise TranspilerError("Initial layouts are not supported with TOQM-based routing.")
-
-        toqm_pass = True
-        # Note: BarrierBeforeFinalMeasurements is skipped intentionally since ToqmSwap
-        #       does not yet support barriers.
-        routing_pass = ToqmSwap(
-            coupling_map,
-            strategy=ToqmStrategyO3(
-                latencies_from_target(
-                    coupling_map, instruction_durations, basis_gates, backend_properties, target
-                )
-            ),
-        )
-        vf2_call_limit = common.get_vf2_call_limit(
-            3, pass_manager_config.layout_method, pass_manager_config.initial_layout
-        )
-        routing_pm = common.generate_routing_passmanager(
-            routing_pass,
-            target,
-            coupling_map=coupling_map,
-            vf2_call_limit=vf2_call_limit,
-            backend_properties=backend_properties,
-            seed_transpiler=seed_transpiler,
-            use_barrier_before_measurement=not toqm_pass,
-        )
-    else:
-        routing_pm = plugin_manager.get_passmanager_stage(
-            "routing", routing_method, pass_manager_config, optimization_level=3
-        )
+    # Choose routing pass
+    routing_pm = plugin_manager.get_passmanager_stage(
+        "routing", routing_method, pass_manager_config, optimization_level=3
+    )
 
     # 8. Optimize iteratively until no more change in depth. Removes useless gates
     # after reset and before measure, commutes gates and optimizes contiguous blocks.
@@ -252,9 +219,7 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
             unitary_synthesis_plugin_config,
             hls_config,
         )
-    pre_routing = None
-    if toqm_pass:
-        pre_routing = translation
+
     if optimization_method is None:
         optimization = PassManager()
         unroll = [pass_ for x in translation.passes() for pass_ in x["passes"]]
@@ -322,7 +287,6 @@ def level_3_pass_manager(pass_manager_config: PassManagerConfig) -> StagedPassMa
     return StagedPassManager(
         init=init,
         layout=layout,
-        pre_routing=pre_routing,
         routing=routing,
         translation=translation,
         pre_optimization=pre_optimization,

--- a/releasenotes/notes/toqm-extra-0.1.0-4fedfa1ff0fedfa0.yaml
+++ b/releasenotes/notes/toqm-extra-0.1.0-4fedfa1ff0fedfa0.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    Optional feature package ``toqm`` installable via
+    ``pip install qiskit-terra[toqm]`` has been upgraded from version
+    ``0.0.4`` to ``0.1.0``. To use the ``toqm`` routing method
+    with :meth:`~.transpile` you must now use qiskit-toqm version
+    ``0.1.0`` or newer. Older versions are no longer discoverable by
+    the transpiler.

--- a/releasenotes/notes/toqm-extra-0.1.0-4fedfa1ff0fedfa0.yaml
+++ b/releasenotes/notes/toqm-extra-0.1.0-4fedfa1ff0fedfa0.yaml
@@ -1,9 +1,9 @@
 ---
 upgrade:
   - |
-    Optional feature package ``toqm`` installable via
+    The version requirement for the optional feature package ``qiskit-toqm`` installable via
     ``pip install qiskit-terra[toqm]`` has been upgraded from version
     ``0.0.4`` to ``0.1.0``. To use the ``toqm`` routing method
-    with :meth:`~.transpile` you must now use qiskit-toqm version
+    with :func:`~.transpile` you must now use qiskit-toqm version
     ``0.1.0`` or newer. Older versions are no longer discoverable by
     the transpiler.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-qiskit-toqm>=0.0.4;platform_machine != 'aarch64' or platform_system != 'Linux'
+qiskit-toqm>=0.1.0;platform_machine != 'aarch64' or platform_system != 'Linux'
 sphinx-autodoc-typehints~=1.18,!=1.19.3
 jupyter-sphinx
 sphinx-design>=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ z3_requirements = [
 ]
 bip_requirements = ["cplex", "docplex"]
 csp_requirements = ["python-constraint>=1.4"]
-toqm_requirements = ["qiskit-toqm>=0.0.4"]
+toqm_requirements = ["qiskit-toqm>=0.1.0"]
 
 setup(
     name="qiskit-terra",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Qiskit TOQM is now available as a `PassManagerStagePlugin` as of version `0.1.0`.

### Details and comments
Removes special casing previously needed to use TOQM routing from preset pass managers.

The TOQM integration, namely `optionals.HAS_TOQM`, the advertised `"toqm"` extra and unit testing conditioned on the TOQM module's presence are left intact.