### PR TITLE
Remove qiskit-toqm tests and requirements-dev.txt entry

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,6 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-qiskit-toqm>=0.1.0;platform_machine != 'aarch64' or platform_system != 'Linux'
 sphinx-autodoc-typehints~=1.18,!=1.19.3
 jupyter-sphinx
 sphinx-design>=0.2.0

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -39,8 +39,6 @@ from qiskit.providers.fake_provider import (
     FakeTokyo,
     FakePoughkeepsie,
     FakeLagosV2,
-    FakeLima,
-    FakeWashington,
 )
 from qiskit.converters import circuit_to_dag
 from qiskit.circuit.library import GraphState

--- a/test/python/transpiler/test_preset_passmanagers.py
+++ b/test/python/transpiler/test_preset_passmanagers.py
@@ -47,7 +47,6 @@ from qiskit.circuit.library import GraphState
 from qiskit.quantum_info import random_unitary
 from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
 from qiskit.transpiler.preset_passmanagers import level0, level1, level2, level3
-from qiskit.utils.optionals import HAS_TOQM
 from qiskit.transpiler.passes import Collect2qBlocks, GatesInBasis
 
 
@@ -265,51 +264,6 @@ class TestPresetPassManager(QiskitTestCase):
             translation_method="synthesis",
         )
         self.assertEqual(gates_in_basis_true_count + 1, collect_2q_blocks_count)
-
-
-@ddt
-@unittest.skipUnless(HAS_TOQM, "qiskit-toqm needs to be installed")
-class TestToqmIntegration(QiskitTestCase):
-    """Test transpiler with TOQM-based routing"""
-
-    @combine(
-        level=[0, 1, 2, 3],
-        layout_method=[None, "trivial", "dense", "noise_adaptive", "sabre"],
-        backend_vbits_pair=[(FakeWashington(), 10), (FakeLima(), 5)],
-        dsc="TOQM-based routing with '{layout_method}' layout"
-        + "method on '{backend_vbits_pair[0]}' backend at level '{level}'",
-        name="TOQM_{layout_method}_{backend_vbits_pair[0]}_level{level}",
-    )
-    def test_basic_circuit(self, level, layout_method, backend_vbits_pair):
-        """
-        Basic circuits transpile across all opt levels and layout
-        methods when using TOQM-based routing.
-        """
-        backend, circuit_size = backend_vbits_pair
-        qr = QuantumRegister(circuit_size, "q")
-        qc = QuantumCircuit(qr)
-
-        # Generate a circuit that should need swaps.
-        for i in range(1, qr.size):
-            qc.cx(0, i)
-
-        result = transpile(
-            qc,
-            layout_method=layout_method,
-            routing_method="toqm",
-            backend=backend,
-            optimization_level=level,
-            seed_transpiler=4222022,
-        )
-
-        self.assertIsInstance(result, QuantumCircuit)
-
-    def test_initial_layout_is_rejected(self):
-        """Initial layout is rejected when using TOQM-based routing"""
-        with self.assertRaisesRegex(
-            TranspilerError, "Initial layouts are not supported with TOQM-based routing."
-        ):
-            transpile(QuantumCircuit(2), initial_layout=[1, 0], routing_method="toqm")
 
 
 @ddt


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #9042 we removed the special case code to enable using toqm as an optional routing method. This was needed prior to qiskit-terra 0.22.0 as we didn't have the transpiler stage plugin interface. However, now that we've added a dedicated interface for external transpiler passes to integrate into transpile() the toqm passes are using that interface. However, in #9042 the tests for verifying the previously hard-coded toqm routing method path worked as before were left intact. In general this would be a good approach to ensure we're maintaining backwards compatibilty with the new modular interface with earlier releases. However, in this specific case this is causing an issue with how tests are run. Since qiskit-toqm has a necessary dependency on qiskit-terra this means when we install our development requirements before running tests toqm is pulling in the latest stable release of qiskit-terra from pypi. Then we later upgrade that with the source build before running tests. However this bi-directional test dependency introduces a tension in a number of places. For the most recent example, when we're trying to add support for new platforms (see #9028 for an example) where the stable version of qiskit-terra does not support the platform. We're unable to run CI with qiskit-toqm being installed first since installing stable qiskit-terra won't work/

This commit removes qiskit-toqm from the requirements-dev.txt list and also removes the test cases using it to fix this conflict. In general the testing for qiskit-toqm can now be self contained since it's exercising a stable interface in terra that's tested independently. When weighing the backwards compatibility coverage vs the CI and build complexities having the bidirectional test dependency has just removing the toqm tests and development requirement is the simplest path forward.


### Details and comments


