### PR TITLE
Fix incorrect graph construction in VF2PostLayout

### DIFF
--- a/qiskit/transpiler/passes/layout/vf2_post_layout.py
+++ b/qiskit/transpiler/passes/layout/vf2_post_layout.py
@@ -169,16 +169,14 @@ class VF2PostLayout(AnalysisPass):
                             global_ops[num_qubits].append(op)
             op_names = []
             for i in range(self.target.num_qubits):
-                entry = set()
                 try:
                     entry = set(self.target.operation_names_for_qargs((i,)))
                 except KeyError:
-                    pass
+                    entry = set()
                 if global_ops is not None:
                     entry.update(global_ops[1])
                 op_names.append(entry)
-
-                cm_graph.add_nodes_from(op_names)
+            cm_graph.add_nodes_from(op_names)
             for qargs in self.target.qargs:
                 len_args = len(qargs)
                 # If qargs == 1 we already populated it and if qargs > 2 there are no instructions

--- a/releasenotes/notes/fix-vf2post-regression-d4b057ea02ce00d3.yaml
+++ b/releasenotes/notes/fix-vf2post-regression-d4b057ea02ce00d3.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in the :class:`.VF2PostLayout` pass when transpiling for backends
+    with a defined :class:`.Target`, where the interaction graph would be built
+    incorrectly.  This could result in excessive runtimes due to the graph being
+    far more complex than necessary.


### PR DESCRIPTION
### Summary

The `add_nodes` call should be outside the loop; inside, it adds nodes quadratically.  This commit also squashes a minor inefficiency in set allocation.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I couldn't immediately think of a sensible test for this, since the internal graph isn't really accessible.