### PR TITLE
Split out NLayout rust class into standalone Python module

### DIFF
--- a/qiskit/__init__.py
+++ b/qiskit/__init__.py
@@ -34,6 +34,7 @@ if sys.version_info < (3, 8):
 # find compiled submodules in _accelerate because it relies on file paths
 # manually define them on import so people can directly import
 # qiskit._accelerate.* submodules and not have to rely on attribute access
+sys.modules["qiskit._accelerate.nlayout"] = qiskit._accelerate.nlayout
 sys.modules["qiskit._accelerate.stochastic_swap"] = qiskit._accelerate.stochastic_swap
 sys.modules["qiskit._accelerate.sabre_swap"] = qiskit._accelerate.sabre_swap
 sys.modules["qiskit._accelerate.pauli_expval"] = qiskit._accelerate.pauli_expval

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -31,7 +31,7 @@ from qiskit._accelerate.sabre_swap import (
     NeighborTable,
     SabreDAG,
 )
-from qiskit._accelerate.stochastic_swap import NLayout
+from qiskit._accelerate.nlayout import NLayout
 
 logger = logging.getLogger(__name__)
 

--- a/qiskit/transpiler/passes/routing/stochastic_swap.py
+++ b/qiskit/transpiler/passes/routing/stochastic_swap.py
@@ -26,6 +26,7 @@ from qiskit.circuit.library.standard_gates import SwapGate
 from qiskit.transpiler.layout import Layout
 from qiskit.circuit import IfElseOp, WhileLoopOp, ForLoopOp, ControlFlowOp, Instruction
 from qiskit._accelerate import stochastic_swap as stochastic_swap_rs
+from qiskit._accelerate import nlayout
 
 from .utils import get_swap_map_dag
 
@@ -191,7 +192,7 @@ class StochasticSwap(TransformationPass):
         )
 
         layout_mapping = {self._qubit_to_int[k]: v for k, v in layout.get_virtual_bits().items()}
-        int_layout = stochastic_swap_rs.NLayout(layout_mapping, num_qubits, coupling.size())
+        int_layout = nlayout.NLayout(layout_mapping, num_qubits, coupling.size())
 
         trial_circuit = DAGCircuit()  # SWAP circuit for slice of swaps in this trial
         trial_circuit.add_qubits(layout.get_virtual_bits())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub fn getenv_use_multiple_threads() -> bool {
 
 #[pymodule]
 fn _accelerate(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_wrapped(wrap_pymodule!(nlayout::nlayout))?;
     m.add_wrapped(wrap_pymodule!(stochastic_swap::stochastic_swap))?;
     m.add_wrapped(wrap_pymodule!(sabre_swap::sabre_swap))?;
     m.add_wrapped(wrap_pymodule!(pauli_exp_val::pauli_expval))?;

--- a/src/nlayout.rs
+++ b/src/nlayout.rs
@@ -117,3 +117,9 @@ impl NLayout {
         self.clone()
     }
 }
+
+#[pymodule]
+pub fn nlayout(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_class::<NLayout>()?;
+    Ok(())
+}

--- a/src/stochastic_swap.rs
+++ b/src/stochastic_swap.rs
@@ -338,7 +338,6 @@ pub fn swap_trials(
 #[pymodule]
 pub fn stochastic_swap(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(swap_trials))?;
-    m.add_class::<NLayout>()?;
     m.add_class::<EdgeCollection>()?;
     Ok(())
 }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit moves the NLayout rust class out of the stochastic swap python module into a new standalone nlayout module in qiskit._accelerate. The NLayout class was originally added with the stochastic swap rust code, but since then it's started being used by other rust code including SabreSwap (and soon to be VF2Layout and VF2PostLayout scoring in #9026).

### Details and comments