### PR TITLE
Fix Backend primitive classes for BackendV1 with no max_experiments

### DIFF
--- a/qiskit/primitives/backend_estimator.py
+++ b/qiskit/primitives/backend_estimator.py
@@ -56,7 +56,7 @@ def _run_circuits(
         metadata.append(circ.metadata)
         circ.metadata = {}
     if isinstance(backend, BackendV1):
-        max_circuits = backend.configuration().max_experiments
+        max_circuits = getattr(backend.configuration(), "max_experiments", None)
     elif isinstance(backend, BackendV2):
         max_circuits = backend.max_circuits
     if max_circuits:

--- a/releasenotes/notes/fix-backend-primitive-no-max-experiments-e2ca41ec61de353e.yaml
+++ b/releasenotes/notes/fix-backend-primitive-no-max-experiments-e2ca41ec61de353e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed an issue with the backend primitive classes :class:`~.BackendSampler`
+    and :class:`~.BackendEstimator` which prevented running with a
+    :class:`~.BackendV1` instance that does not have a ``max_experiments``
+    field set in its :class:`~.BackendConfiguration`.

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -25,7 +25,6 @@ from qiskit.providers import JobV1
 from qiskit.providers.fake_provider import FakeNairobi, FakeNairobiV2
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.test import QiskitTestCase
-from qiskit.utils.optionals import HAS_AER
 
 BACKENDS = [FakeNairobi(), FakeNairobiV2()]
 

--- a/test/python/primitives/test_backend_estimator.py
+++ b/test/python/primitives/test_backend_estimator.py
@@ -25,6 +25,7 @@ from qiskit.providers import JobV1
 from qiskit.providers.fake_provider import FakeNairobi, FakeNairobiV2
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.test import QiskitTestCase
+from qiskit.utils.optionals import HAS_AER
 
 BACKENDS = [FakeNairobi(), FakeNairobiV2()]
 
@@ -296,6 +297,31 @@ class TestBackendEstimator(QiskitTestCase):
         with unittest.mock.patch.object(backend, "run") as run_mock:
             estimator.run([qc] * k, [op] * k, params_list).result()
         self.assertEqual(run_mock.call_count, 10)
+
+    def test_no_max_circuits(self):
+        """Test BackendEstimator works with BackendV1 and no max_experiments set."""
+        backend = FakeNairobi()
+        config = backend.configuration()
+        del config.max_experiments
+        backend._configuration = config
+        backend.set_options(seed_simulator=123)
+        qc = RealAmplitudes(num_qubits=2, reps=2)
+        op = SparsePauliOp.from_list([("IZ", 1), ("XI", 2), ("ZY", -1)])
+        k = 5
+        params_array = np.random.rand(k, qc.num_parameters)
+        params_list = params_array.tolist()
+        params_list_array = list(params_array)
+        estimator = BackendEstimator(backend=backend)
+        target = estimator.run([qc] * k, [op] * k, params_list).result()
+        with self.subTest("ndarrary"):
+            result = estimator.run([qc] * k, [op] * k, params_array).result()
+            self.assertEqual(len(result.metadata), k)
+            np.testing.assert_allclose(result.values, target.values, rtol=0.2, atol=0.2)
+
+        with self.subTest("list of ndarray"):
+            result = estimator.run([qc] * k, [op] * k, params_list_array).result()
+            self.assertEqual(len(result.metadata), k)
+            np.testing.assert_allclose(result.values, target.values, rtol=0.2, atol=0.2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The ``max_experiments`` field in the BackendConfiguration for a BackendV1 backend is not a required field. While in practice most real backends set it, some simulators (including aer) do not. This causes a failure when using the Backend primitive classes with these backends as we were previously assuming the ``max_experiments`` attribute was always present.

### Details and comments