### PR TITLE
Skip QPY backwards compatibility tests for pre-release tags

### DIFF
--- a/test/qpy_compat/run_tests.sh
+++ b/test/qpy_compat/run_tests.sh
@@ -24,8 +24,13 @@ qiskit_venv/bin/pip install ../..
 
 for version in $(git tag --sort=-creatordate) ; do
     parts=( ${version//./ } )
+    # Stop when we've reached old versions that were pre-QPY
     if [[ ${parts[1]} -lt 18 ]] ; then
         break
+    fi
+    # Skip pre-release tags
+    if [[ "$version" =~ rc[0-9]$ ]] ; then
+        continue
     fi
     echo "Building venv for qiskit-terra $version"
     python -m venv $version


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The QPY backwards compatibility tests install historical versions of qiskit-terra to generate different QPY payloads with previous payload formats and then load them and compare the output to verify that we don't break QPY's backwards compatibility guarantees. This testing is just getting the list of git tags and works it's way backwards until it reaches the release that QPY was first released. However, as part of this process the tests are also running on rc pre-release tags. In general there is no harm to doing this as the guarantees should also hold for the pre-release tags. But in practice this is just wasted CI time because we're essentially testing the release twice. This wasn't a concern when we first introduced QPY because Qiskit did not do pre-release tags back then. But since we've started doing at least one pre-release. As time goes on we're basically doubling our CI load for these tests with little benefit.  This commit adds a skip condition to the test runner script when it encounters an rc tag so we don't build a venv or run the tests for that tag. This should hopefully save some CI time (not a ton right now but over time this would be more significant).

### Details and comments