### PR TITLE
Fix missing version-number bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ toqm_requirements = ["qiskit-toqm>=0.0.4"]
 
 setup(
     name="qiskit-terra",
-    version="0.22.1",
+    version="0.22.2",
     description="Software for developing quantum computing programs",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
[skip ci]

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

We accidentally missed the version number in `setup.py`, so 0.22.2 originally just bounced off PyPI.

### Details and comments


