### PR TITLE
🐛 fix deprecated `Loader.load_module()`

### DIFF
--- a/qiskit/namespace.py
+++ b/qiskit/namespace.py
@@ -42,6 +42,7 @@ class QiskitLoader(Loader):
         return self.load_module(spec.name)
 
     def exec_module(self, module):
+        """Executes the module. Not needed in Qiskit."""
         pass
 
     def load_module(self, fullname):

--- a/qiskit/namespace.py
+++ b/qiskit/namespace.py
@@ -38,6 +38,12 @@ class QiskitLoader(Loader):
     def module_repr(self, module):
         return repr(module)
 
+    def create_module(self, spec):
+        return self.load_module(spec.name)
+
+    def exec_module(self, module):
+        pass
+
     def load_module(self, fullname):
         old_name = fullname
         fullname = _new_namespace(fullname, self.old_namespace, self.new_package)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This PR ports a fix from https://github.com/Qiskit/rustworkx/pull/728 that fixes the following `ImportWarning` under `Python>=3.10`

```console
ImportWarning: QiskitLoader.exec_module() not found; falling back to load_module()
```

### Details and comments

Some further context can be found in the corresponding retworkx PR https://github.com/Qiskit/rustworkx/pull/728.
The underlying code was introduced in https://github.com/Qiskit/qiskit-terra/pull/5089.

Fixes https://github.com/Qiskit/qiskit-terra/issues/8853.





