### PR TITLE
Stabilising  test_squ

### DIFF
--- a/qiskit/extensions/quantum_initializer/squ.py
+++ b/qiskit/extensions/quantum_initializer/squ.py
@@ -168,7 +168,7 @@ def squ(
     """Decompose an arbitrary 2*2 unitary into three rotation gates.
 
     Note that the decomposition is up to a global phase shift.
-    (This is a well known decomposition, which can be found for example in Nielsen and Chuang's book
+    (This is a well known decomposition which can be found for example in Nielsen and Chuang's book
     "Quantum computation and quantum information".)
 
     Args:

--- a/test/python/circuit/test_squ.py
+++ b/test/python/circuit/test_squ.py
@@ -33,7 +33,7 @@ squs = [
     np.array([[0.0, 1.0], [1.0, 0.0]]),
     1 / np.sqrt(2) * np.array([[1.0, 1.0], [-1.0, 1.0]]),
     np.array([[np.exp(1j * 5.0 / 2), 0], [0, np.exp(-1j * 5.0 / 2)]]),
-    random_unitary(2).data,
+    random_unitary(2, seed=42).data,
 ]
 
 up_to_diagonal_list = [True, False]

--- a/test/python/circuit/test_squ.py
+++ b/test/python/circuit/test_squ.py
@@ -14,9 +14,10 @@
 
 """Single-qubit unitary tests."""
 
-import itertools
 import unittest
+from test import combine
 import numpy as np
+from ddt import ddt
 from qiskit.quantum_info.random import random_unitary
 from qiskit import BasicAer
 from qiskit import QuantumCircuit
@@ -38,27 +39,27 @@ squs = [
 up_to_diagonal_list = [True, False]
 
 
+@ddt
 class TestSingleQubitUnitary(QiskitTestCase):
     """Qiskit ZYZ-decomposition tests."""
 
-    def test_squ(self):
+    @combine(u=squs, up_to_diagonal=up_to_diagonal_list)
+    def test_squ(self, u, up_to_diagonal):
         """Tests for single-qubit unitary decomposition."""
-        for u, up_to_diagonal in itertools.product(squs, up_to_diagonal_list):
-            with self.subTest(u=u, up_to_diagonal=up_to_diagonal):
-                qr = QuantumRegister(1, "qr")
-                qc = QuantumCircuit(qr)
-                qc.squ(u, qr[0], up_to_diagonal=up_to_diagonal)
-                # Decompose the gate
-                qc = transpile(qc, basis_gates=["u1", "u3", "u2", "cx", "id"])
-                # Simulate the decomposed gate
-                simulator = BasicAer.get_backend("unitary_simulator")
-                result = execute(qc, simulator).result()
-                unitary = result.get_unitary(qc)
-                if up_to_diagonal:
-                    squ = SingleQubitUnitary(u, up_to_diagonal=up_to_diagonal)
-                    unitary = np.dot(np.diagflat(squ.diag), unitary)
-                unitary_desired = u
-                self.assertTrue(matrix_equal(unitary_desired, unitary, ignore_phase=True))
+        qr = QuantumRegister(1, "qr")
+        qc = QuantumCircuit(qr)
+        qc.squ(u, qr[0], up_to_diagonal=up_to_diagonal)
+        # Decompose the gate
+        qc = transpile(qc, basis_gates=["u1", "u3", "u2", "cx", "id"])
+        # Simulate the decomposed gate
+        simulator = BasicAer.get_backend("unitary_simulator")
+        result = execute(qc, simulator).result()
+        unitary = result.get_unitary(qc)
+        if up_to_diagonal:
+            squ = SingleQubitUnitary(u, up_to_diagonal=up_to_diagonal)
+            unitary = np.dot(np.diagflat(squ.diag), unitary)
+        unitary_desired = u
+        self.assertTrue(matrix_equal(unitary_desired, unitary, ignore_phase=True))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Coveralls had been complaining about `/qiskit/extensions/quantum_initializer/squ.py` unstable coverage. For [example](https://coveralls.io/builds/53938134/source?filename=qiskit%2Fextensions%2Fquantum_initializer%2Fsqu.py#L142):
![Screenshot 2022-11-06 at 14 10 35](https://user-images.githubusercontent.com/766693/200172622-d4e39b22-de9e-471c-b484-a8500ea00541.png)

There was a missing seeding in a test. I also moved it to ddt. 
