### PR TITLE
Fix NumPy(Minimum)EigensolverResult typehints

### DIFF
--- a/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
@@ -297,11 +297,11 @@ class NumPyEigensolverResult(EigensolverResult):
         self._eigenstates = None
 
     @property
-    def eigenstates(self) -> np.ndarray | None:
+    def eigenstates(self) -> list[Statevector] | None:
         """Return eigenstates."""
         return self._eigenstates
 
     @eigenstates.setter
-    def eigenstates(self, value: np.ndarray) -> None:
+    def eigenstates(self, value: list[Statevector]) -> None:
         """Set eigenstates."""
         self._eigenstates = value

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -19,6 +19,7 @@ import logging
 import numpy as np
 
 from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 from ..eigensolvers.numpy_eigensolver import NumPyEigensolver
@@ -96,10 +97,10 @@ class NumPyMinimumEigensolverResult(MinimumEigensolverResult):
         self._eigenstate = None
 
     @property
-    def eigenstate(self) -> np.ndarray | None:
+    def eigenstate(self) -> Statevector | None:
         """Returns the eigenstate corresponding to the computed minimum eigenvalue."""
         return self._eigenstate
 
     @eigenstate.setter
-    def eigenstate(self, value: np.ndarray) -> None:
+    def eigenstate(self, value: Statevector) -> None:
         self._eigenstate = value

--- a/qiskit/algorithms/minimum_eigensolvers/sampling_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/sampling_vqe.py
@@ -325,7 +325,7 @@ class SamplingVQE(VariationalAlgorithm, SamplingMinimumEigensolver):
         optimizer_result: OptimizerResult,
         aux_operators_evaluated: ListOrDict[tuple[complex, tuple[complex, int]]],
         best_measurement: dict[str, Any],
-        final_state: list[QuasiDistribution],
+        final_state: QuasiDistribution,
         optimizer_time: float,
     ) -> SamplingVQEResult:
         result = SamplingVQEResult()

--- a/test/python/algorithms/minimum_eigensolvers/test_qaoa.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_qaoa.py
@@ -29,6 +29,7 @@ from qiskit.algorithms.optimizers import COBYLA, NELDER_MEAD
 from qiskit.circuit import Parameter
 from qiskit.opflow import PauliSumOp
 from qiskit.quantum_info import Pauli
+from qiskit.result import QuasiDistribution
 from qiskit.primitives import Sampler
 from qiskit.utils import algorithm_globals
 
@@ -275,13 +276,13 @@ class TestQAOA(QiskitAlgorithmsTestCase):
 
         return "".join([str(int(i)) for i in 1 - x])
 
-    def _sample_most_likely(self, state_vector):
+    def _sample_most_likely(self, state_vector: QuasiDistribution) -> np.ndarray:
         """Compute the most likely binary string from state vector.
         Args:
-            state_vector (numpy.ndarray or dict): state vector or counts.
+            state_vector: Quasi-distribution.
 
         Returns:
-            numpy.ndarray: binary string as numpy.ndarray of ints.
+            Binary string as numpy.ndarray of ints.
         """
         values = list(state_vector.values())
         n = int(np.log2(len(values)))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Small fix of the TypeHints in the `NumPyEigensolverResult` and `NumPyMinimumEigensolverResult` from `np.ndarray` to `list[Statevector]` and `Statevector`, respectively.

### Details and comments


