### PR TITLE
New reprs for Gate, ControlledGate, QuantumCircuit, DAGCircuit, Sampler, Estimator and PassManager

### DIFF
--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -100,6 +100,17 @@ class ControlledGate(Gate):
         self.ctrl_state = ctrl_state
         self._name = name
 
+    def __repr__(self):
+        """Generates a representation of the ControlledGate object instance
+        Returns:
+            str: A representation of the ControlledGate instance with class name, name, label and
+                 number of control qubits, control state, and number of definition elements"""
+        return (
+            f"<{self.__class__.__name__} '{self._name}' labeled '{self._label}' with "
+            f"{self._num_ctrl_qubits} control qubits, control state = {self._ctrl_state} and"
+            f" params={self.params}>"
+        )
+
     @property
     def definition(self) -> List:
         """Return definition in terms of other basic gates. If the gate has

--- a/qiskit/circuit/gate.py
+++ b/qiskit/circuit/gate.py
@@ -40,6 +40,16 @@ class Gate(Instruction):
     # Set higher priority than Numpy array and matrix classes
     __array_priority__ = 20
 
+    def __repr__(self):
+        """Generates a representation of the Gate object instance
+        Returns:
+            str: A representation of the Gate instance with class name, name,
+                 number of qubits, number of classical bits and  params( if any )"""
+        return (
+            f"<{self.__class__.__name__} '{self.name}' labeled '{self.label}' with"
+            f" {self.num_qubits} qubits, {self.num_clbits} clbits and params={self.params}>"
+        )
+
     def to_matrix(self) -> np.ndarray:
         """Return a Numpy.array for the gate unitary matrix.
 

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -437,6 +437,14 @@ class QuantumCircuit:
             raise TypeError("Only a dictionary or None is accepted for circuit metadata")
         self._metadata = metadata
 
+    def __repr__(self):
+        return (
+            f"<QuantumCircuit '{self.name}' with"
+            f" {self.num_qubits} qubits, {self.num_clbits} clbits"
+            f", {len(self._data)} instructions, {len(self._calibrations)} calibrations"
+            f", and global_phase={self._global_phase}>"
+        )
+
     def __str__(self) -> str:
         return str(self.draw(output="text"))
 

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -95,6 +95,21 @@ class DAGCircuit:
         self.duration = None
         self.unit = "dt"
 
+    def __repr__(self):
+        op_names = "','".join(self._op_names.keys())
+        edges = self._multi_graph.edges()
+        if not isinstance(edges, list):
+            edges = []
+        num_edges = len(edges)
+
+        return (
+            f"< {type(self).__name__} '{self.name}' with "
+            f"{ len(self._op_names.keys()) } operations ('{op_names}'),"
+            f" {len(self._wires)} wires, {self.node_counter} nodes, {num_edges} edges, "
+            f" {len(self._calibrations)} calibrations"
+            f", and global_phase={self._global_phase} >"
+        )
+
     @property
     def wires(self):
         """Return a list of the wires in order."""

--- a/qiskit/primitives/estimator.py
+++ b/qiskit/primitives/estimator.py
@@ -89,6 +89,27 @@ class Estimator(BaseEstimator):
         )
         self._is_closed = False
 
+    def __repr__(self):
+        circ_names = []
+        for circuit in self._circuits:
+            circ_names.append(circuit.name)
+        param_counts = []
+        for param in self._parameters:
+            param_counts.append(str(len(param)))
+        circ_names = "','".join(circ_names)
+        param_counts = ",".join(param_counts)
+        observables = []
+        for observation in self._observables:
+            observables.append(repr(observation))
+        observables = ",".join(observables)
+        observables = " ".join(observables.split()).replace("\n", "")
+        return (
+            f"< {type(self).__name__} with "
+            f"{len(self._circuits)} circuits ('{circ_names}',), "
+            f"{len(self._observables)} observables ('{observables}'), "
+            f"parameter counts ({param_counts},) and {repr(self._run_options)} >"
+        )
+
     def _call(
         self,
         circuits: Sequence[int],

--- a/qiskit/primitives/sampler.py
+++ b/qiskit/primitives/sampler.py
@@ -82,6 +82,22 @@ class Sampler(BaseSampler):
         super().__init__(preprocessed_circuits, parameters, options)
         self._is_closed = False
 
+    def __repr__(self):
+        circ_names = []
+        for circuit in self._circuits:
+            circ_names.append(circuit.name)
+        param_counts = []
+        for param in self._parameters:
+            param_counts.append(str(len(param)))
+
+        return "< {} with {} circuits ('{}',) parameter counts ({},) and {} >".format(
+            type(self).__name__,
+            len(self._circuits),
+            "','".join(circ_names),
+            ",".join(param_counts),
+            repr(self._run_options),
+        )
+
     def _call(
         self,
         circuits: Sequence[int],

--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -46,6 +46,28 @@ class PassManager:
         self.max_iteration = max_iteration
         self.property_set = None
 
+    def __repr__(self):
+        if self.property_set is None or len(self.property_set) == 0:
+            nprops = 0
+            properties = "0 properties"
+        else:
+            prop_keys = list(self.property_set.keys())
+            nprops = len(prop_keys)
+            if nprops > 3:
+                _plist = "','".join(prop_keys[0:3]) + "',..."
+            else:
+                _plist = "','".join(prop_keys) + "'"
+            properties = f"{nprops} properties ('{_plist},)"
+        npass = 0
+        for cur_set in self._pass_sets:
+            npass += len(cur_set["passes"])
+
+        return (
+            f"<{type(self).__name__} with "
+            f"{len(self._pass_sets)} sets, {npass} passes, "
+            f"{self.max_iteration} max iterations, and {properties} >"
+        )
+
     def append(
         self,
         passes: Union[BasePass, List[BasePass]],

--- a/releasenotes/notes/add-circuit-repr-methods-db2f6c4cbe9f78ba.yaml
+++ b/releasenotes/notes/add-circuit-repr-methods-db2f6c4cbe9f78ba.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Added repr methods to :class:`~qiskit.circuit.QuantumCircuit`, :class:`~qiskit.circuit.Gate`,
+     :class:`~qiskit.circuit.QuantumCircuit`, :class:`~qiskit.primitives.Estimator`,
+     :class:`~qiskit.primitives.Sampler, and :class:`~qiskit.transpiler.PassManager`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
Added repr methods for Gate, ControlledGate, QuantumCircuit, DAGCircuit, Sampler, Estimator, PassManager

Partially address issue [8594](https://github.com/Qiskit/qiskit-terra/issues/8594)



### Details and comments
See linked issue for more detailed examples.

**Examples**

<QuantumCircuit 'Unbound' with 1 qubits, 0 clbits, 1 instructions, 0 calibrations, and global_phase=ro>

<QuantumCircuit 'Bound-92' with 1 qubits, 0 clbits, 1 instructions, 0 calibrations, and global_phase=1.4142135623730951>

<CCXGate 'ccx' labeled 'None' with 2 control qubits, control state = 3 and params=[]>

<RXGate 'rx' labeled 'None' with 1 qubits, 0 clbits and params=[ParameterExpression(3.14)]>

<HGate 'h' labeled 'None' with 1 qubits, 0 clbits and params=[]>

< DAGCircuit 'Bell-Rotation' with 4 operations ('h','cx','measure','rz'), 6 wires, 16 nodes, 15 edges, 0 calibrations, and global_phase=0 >

< Sampler with 3 circuits ('Hadamard','RealAmps 2','RealAmplitudes',) parameter counts (0,6,8,) and Options(shots=16, seed=345682) >

< Estimator with 1 circuits ('RealAmp psi1',), 1 observables ('SparsePauliOp(['II', 'IZ', 'XI'], coeffs=[1.+0.j, 2.+0.j, 3.+0.j])'), parameter counts (6,) and Options(shots=16, seed=345682) >

<PassManager with 2 sets, 3 passes, 200 max iterations, and 5 properties ('final_layout','node_start_time','clbit_write_latecy',...,) >
