### PR TITLE
Fix `NumPyEigensolver` with `SparsePauliOp`

### DIFF
--- a/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
@@ -20,8 +20,8 @@ import numpy as np
 from scipy import sparse as scisparse
 
 from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import SparsePauliOp, Statevector
 from qiskit.quantum_info.operators.base_operator import BaseOperator
-from qiskit.quantum_info import Operator, SparsePauliOp, Statevector
 from qiskit.utils.validation import validate_min
 
 from .eigensolver import Eigensolver, EigensolverResult
@@ -123,7 +123,7 @@ class NumPyEigensolver(Eigensolver):
                 op_matrix = operator.to_matrix()
                 sparse = False
             except AttributeError as ex:
-                raise AlgorithmError(f"Unsupported operator type {type(operator)}.") from ex
+                raise AlgorithmError(f"Unsupported operator type `{type(operator)}`.") from ex
 
         if sparse:
             # If matrix is diagonal, the elements on the diagonal are the eigenvalues. Solve by sorting.
@@ -262,24 +262,23 @@ class NumPyEigensolver(Eigensolver):
 
         # if a filter is set, loop over the given values and only keep
         if self._filter_criterion:
-
             filt_eigvals = []
             filt_eigvecs = []
             filt_aux_op_vals = []
             count = 0
-            for i in range(len(eigvals)):
-                eigvec = eigvecs[i]
-                eigval = eigvals[i]
+            for i, (eigval, eigvec) in enumerate(zip(eigvals, eigvecs)):
                 if aux_op_vals is not None:
                     aux_op_val = aux_op_vals[i]
                 else:
                     aux_op_val = None
+
                 if self._filter_criterion(eigvec, eigval, aux_op_val):
                     count += 1
                     filt_eigvecs.append(eigvec)
                     filt_eigvals.append(eigval)
                     if aux_op_vals is not None:
                         filt_aux_op_vals.append(aux_op_val)
+
                 if count == k_orig:
                     break
 

--- a/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
@@ -174,21 +174,17 @@ class NumPyEigensolver(Eigensolver):
             if operator is None:
                 continue
             value = 0.0
-            if isinstance(operator, PauliSumOp):
-                if operator.coeff != 0:
-                    mat = operator.to_spmatrix()
-                    # Terra doesn't support sparse yet, so do the matmul directly if so
-                    # This is necessary for the particle_hole and other chemistry tests because the
-                    # pauli conversions are 2^12th large and will OOM error if not sparse.
-                    if isinstance(mat, scisparse.spmatrix):
-                        value = mat.dot(wavefn).dot(np.conj(wavefn))
-                    else:
-                        value = (
-                            Statevector(wavefn).expectation_value(operator.primitive)
-                            * operator.coeff
-                        )
-            else:
+            if isinstance(operator, Operator):
                 value = Statevector(wavefn).expectation_value(operator)
+            else:
+                if isinstance(operator, PauliSumOp):
+                    if operator.coeff != 0:
+                        op_matrix = operator.to_spmatrix()
+                        value = op_matrix.dot(wavefn).dot(np.conj(wavefn))
+                else:
+                    op_matrix = operator.to_matrix(sparse=True)
+                    value = op_matrix.dot(wavefn).dot(np.conj(wavefn))
+
             value = value if np.abs(value) > threshold else 0.0
             # The value gets wrapped into a tuple: (mean, metadata).
             # The metadata includes variance (and, for other eigensolvers, shots).

--- a/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
+++ b/qiskit/algorithms/eigensolvers/numpy_eigensolver.py
@@ -189,6 +189,12 @@ class NumPyEigensolver(Eigensolver):
             if operator is None:
                 continue
 
+            if operator.num_qubits is None or operator.num_qubits < 1:
+                logger.info(
+                    "The number of qubits of the %s operator must be greater than zero.", key
+                )
+                continue
+
             op_matrix = None
             if isinstance(operator, PauliSumOp):
                 if operator.coeff != 0:
@@ -229,6 +235,9 @@ class NumPyEigensolver(Eigensolver):
     ) -> NumPyEigensolverResult:
 
         super().compute_eigenvalues(operator, aux_operators)
+
+        if operator.num_qubits is None or operator.num_qubits < 1:
+            raise AlgorithmError("The number of qubits of the operator must be greater than zero.")
 
         self._check_set_k(operator)
 

--- a/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/numpy_minimum_eigensolver.py
@@ -43,7 +43,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
     ) -> None:
         """
         Args:
-            filter_criterion: callable that allows to filter eigenvalues/eigenstates. The minimum
+            filter_criterion: Callable that allows to filter eigenvalues/eigenstates. The minimum
                 eigensolver is only searching over feasible states and returns an eigenstate that
                 has the smallest eigenvalue among feasible states. The callable has the signature
                 ``filter(eigenstate, eigenvalue, aux_values)`` and must return a boolean to indicate

--- a/qiskit/quantum_info/operators/operator.py
+++ b/qiskit/quantum_info/operators/operator.py
@@ -470,6 +470,10 @@ class Operator(LinearOp):
         ret._op_shape = self._op_shape.reverse()
         return ret
 
+    def to_matrix(self):
+        """Convert operator to NumPy matrix."""
+        return self.data
+
     @classmethod
     def _einsum_matmul(cls, tensor, mat, indices, shift=0, right_mul=False):
         """Perform a contraction using Numpy.einsum

--- a/releasenotes/notes/fix-numpy-eigensolver-sparse-pauli-op-b09a9ac8fb93fe4a.yaml
+++ b/releasenotes/notes/fix-numpy-eigensolver-sparse-pauli-op-b09a9ac8fb93fe4a.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with
+    :class:`~qiskit.algorithms.eigensolvers.NumPyEigensolver` and by extension
+    :class:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver`
+    where solving for :class:`~qiskit.operators.base_operator.BaseOperator`
+    subclasses other than :class:`~qiskit.operators.Operator` would cause an
+    error. 

--- a/releasenotes/notes/fix-numpy-eigensolver-sparse-pauli-op-b09a9ac8fb93fe4a.yaml
+++ b/releasenotes/notes/fix-numpy-eigensolver-sparse-pauli-op-b09a9ac8fb93fe4a.yaml
@@ -4,6 +4,7 @@ fixes:
     Fixed an issue with
     :class:`~qiskit.algorithms.eigensolvers.NumPyEigensolver` and by extension
     :class:`~qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver`
-    where solving for :class:`~qiskit.operators.base_operator.BaseOperator`
-    subclasses other than :class:`~qiskit.operators.Operator` would cause an
-    error. 
+    where solving for
+    :class:`~qiskit.quantum_info.operators.base_operator.BaseOperator`
+    subclasses other than :class:`~qiskit.quantum_info.operators.Operator`
+    would cause an error.

--- a/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
+++ b/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
@@ -19,8 +19,9 @@ import numpy as np
 from ddt import data, ddt
 
 from qiskit.algorithms.eigensolvers import NumPyEigensolver
+from qiskit.algorithms import AlgorithmError
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import Operator, SparsePauliOp
+from qiskit.quantum_info import Operator, SparsePauliOp, Pauli, ScalarOp
 
 H2_SPARSE_PAULI = SparsePauliOp(
     ["II", "ZI", "IZ", "ZZ", "XX"],
@@ -197,6 +198,18 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         self.assertAlmostEqual(
             result.aux_operators_evaluated[0]["zero_operator"][1].pop("variance"), 0.0
         )
+
+    def test_pauli_op(self):
+        """Test simple pauli operator"""
+        algo = NumPyEigensolver(k=1)
+        result = algo.compute_eigenvalues(operator=Pauli("X"))
+        np.testing.assert_array_almost_equal(result.eigenvalues, [-1])
+
+    def test_scalar_op(self):
+        """Test scalar operator"""
+        algo = NumPyEigensolver(k=1)
+        with self.assertRaises(AlgorithmError):
+            algo.compute_eigenvalues(operator=ScalarOp(1))
 
 
 if __name__ == "__main__":

--- a/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
+++ b/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test NumPy Eigen solver """
+""" Test NumPyEigensolver """
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase
@@ -20,26 +20,29 @@ from ddt import data, ddt
 
 from qiskit.algorithms.eigensolvers import NumPyEigensolver
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info.operators import Operator
+from qiskit.quantum_info import Operator, SparsePauliOp
 
-H2_PAULI = PauliSumOp.from_list(
-    [
-        ("II", -1.052373245772859),
-        ("ZI", 0.39793742484318045),
-        ("IZ", -0.39793742484318045),
-        ("ZZ", -0.01128010425623538),
-        ("XX", 0.18093119978423156),
-    ]
+H2_SPARSE_PAULI = SparsePauliOp(
+    ["II", "ZI", "IZ", "ZZ", "XX"],
+    coeffs=[
+        -1.052373245772859,
+        0.39793742484318045,
+        -0.39793742484318045,
+        -0.01128010425623538,
+        0.18093119978423156,
+    ],
 )
 
-H2_OP = Operator(H2_PAULI.to_matrix())
+H2_OP = Operator(H2_SPARSE_PAULI.to_matrix())
+
+H2_PAULI = PauliSumOp(H2_SPARSE_PAULI)
 
 
 @ddt
 class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
     """Test NumPy Eigen solver"""
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_ce(self, op):
         """Test basics"""
         algo = NumPyEigensolver()
@@ -49,7 +52,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         self.assertEqual(result.eigenvalues.dtype, np.float64)
         self.assertAlmostEqual(result.eigenvalues[0], -1.85727503)
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_ce_k4(self, op):
         """Test for k=4 eigenvalues"""
         algo = NumPyEigensolver(k=4)
@@ -61,7 +64,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
             result.eigenvalues, [-1.85727503, -1.24458455, -0.88272215, -0.22491125]
         )
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_ce_k4_filtered(self, op):
         """Test for k=4 eigenvalues with filter"""
 
@@ -77,7 +80,7 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         self.assertEqual(result.eigenvalues.dtype, np.float64)
         np.testing.assert_array_almost_equal(result.eigenvalues, [-0.88272215, -0.22491125])
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_ce_k4_filtered_empty(self, op):
         """Test for k=4 eigenvalues with filter always returning False"""
 
@@ -92,9 +95,9 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         self.assertEqual(len(result.eigenstates), 0)
 
     @data(
-        PauliSumOp.from_list([("X", 1)]),
-        PauliSumOp.from_list([("Y", 1)]),
-        PauliSumOp.from_list([("Z", 1)]),
+        SparsePauliOp(["X"], coeffs=[1.0]),
+        SparsePauliOp(["Y"], coeffs=[1.0]),
+        SparsePauliOp(["Z"], coeffs=[1.0]),
     )
     def test_ce_k1_1q(self, op):
         """Test for 1 qubit operator"""
@@ -103,9 +106,9 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         np.testing.assert_array_almost_equal(result.eigenvalues, [-1])
 
     @data(
-        PauliSumOp.from_list([("X", 1)]),
-        PauliSumOp.from_list([("Y", 1)]),
-        PauliSumOp.from_list([("Z", 1)]),
+        SparsePauliOp(["X"], coeffs=[1.0]),
+        SparsePauliOp(["Y"], coeffs=[1.0]),
+        SparsePauliOp(["Z"], coeffs=[1.0]),
     )
     def test_ce_k2_1q(self, op):
         """Test for 1 qubit operator"""
@@ -113,11 +116,11 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         result = algo.compute_eigenvalues(operator=op)
         np.testing.assert_array_almost_equal(result.eigenvalues, [-1, 1])
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_aux_operators_list(self, op):
         """Test list-based aux_operators."""
-        aux_op1 = Operator(PauliSumOp.from_list([("II", 2.0)]).to_matrix())
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_op1 = Operator(SparsePauliOp(["II"], coeffs=[2.0]).to_matrix())
+        aux_op2 = SparsePauliOp(["II", "ZZ", "YY", "XX"], coeffs=[0.5, 0.5, 0.5, -0.5])
         aux_ops = [aux_op1, aux_op2]
         algo = NumPyEigensolver()
         result = algo.compute_eigenvalues(operator=op, aux_operators=aux_ops)
@@ -153,11 +156,11 @@ class TestNumPyEigensolver(QiskitAlgorithmsTestCase):
         self.assertAlmostEqual(result.aux_operators_evaluated[0][1][1].pop("variance"), 0.0)
         self.assertEqual(result.aux_operators_evaluated[0][3][1].pop("variance"), 0.0)
 
-    @data(H2_PAULI, H2_OP)
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
     def test_aux_operators_dict(self, op):
         """Test dict-based aux_operators."""
-        aux_op1 = Operator(PauliSumOp.from_list([("II", 2.0)]).to_matrix())
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_op1 = Operator(SparsePauliOp(["II"], coeffs=[2.0]).to_matrix())
+        aux_op2 = SparsePauliOp(["II", "ZZ", "YY", "XX"], coeffs=[0.5, 0.5, 0.5, -0.5])
         aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
         algo = NumPyEigensolver()
         result = algo.compute_eigenvalues(operator=op, aux_operators=aux_ops)

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -20,6 +20,22 @@ from ddt import ddt, data
 
 from qiskit.algorithms.minimum_eigensolvers import NumPyMinimumEigensolver
 from qiskit.opflow import PauliSumOp
+from qiskit.quantum_info import Operator, SparsePauliOp
+
+H2_SPARSE_PAULI = SparsePauliOp(
+    ["II", "ZI", "IZ", "ZZ", "XX"],
+    coeffs=[
+        -1.052373245772859,
+        0.39793742484318045,
+        -0.39793742484318045,
+        -0.01128010425623538,
+        0.18093119978423156,
+    ],
+)
+
+H2_OP = Operator(H2_SPARSE_PAULI.to_matrix())
+
+H2_PAULI = PauliSumOp(H2_SPARSE_PAULI)
 
 
 @ddt
@@ -28,61 +44,47 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
     def setUp(self):
         super().setUp()
-        self.qubit_op = PauliSumOp.from_list(
-            [
-                ("II", -1.052373245772859),
-                ("ZI", 0.39793742484318045),
-                ("IZ", -0.39793742484318045),
-                ("ZZ", -0.01128010425623538),
-                ("XX", 0.18093119978423156),
-            ]
-        )
-
-        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
+        aux_op1 = Operator(SparsePauliOp(["II"], coeffs=[2.0]).to_matrix())
+        aux_op2 = SparsePauliOp(["II", "ZZ", "YY", "XX"], coeffs=[0.5, 0.5, 0.5, -0.5])
         self.aux_ops_list = [aux_op1, aux_op2]
         self.aux_ops_dict = {"aux_op1": aux_op1, "aux_op2": aux_op2}
 
-    def test_cme(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_cme(self, op):
         """Basic test"""
         algo = NumPyMinimumEigensolver()
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_list
-        )
+        result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
         self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
         self.assertEqual(len(result.aux_operators_evaluated), 2)
         self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2)
         self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0)
 
-    def test_cme_reuse(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_cme_reuse(self, op):
         """Test reuse"""
         algo = NumPyMinimumEigensolver()
 
         with self.subTest("Test with no operator or aux_operators, give via compute method"):
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op)
+            result = algo.compute_minimum_eigenvalue(operator=op)
             self.assertEqual(result.eigenvalue.dtype, np.float64)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503)
             self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with added aux_operators"):
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=self.aux_ops_list
-            )
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 2)
             self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2)
             self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0)
 
         with self.subTest("Test with aux_operators removed"):
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=[])
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=[])
             self.assertEqual(result.eigenvalue.dtype, np.float64)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503)
             self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with aux_operators set again"):
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=self.aux_ops_list
-            )
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 2)
             self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2)
@@ -95,7 +97,8 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             self.assertAlmostEqual(result.eigenvalue, 2 + 0j)
             self.assertIsNone(result.aux_operators_evaluated)
 
-    def test_cme_filter(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_cme_filter(self, op):
         """Basic test"""
 
         # define filter criterion
@@ -104,15 +107,14 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             return v >= -0.5
 
         algo = NumPyMinimumEigensolver(filter_criterion=criterion)
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_list
-        )
+        result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
         self.assertAlmostEqual(result.eigenvalue, -0.22491125 + 0j)
         self.assertEqual(len(result.aux_operators_evaluated), 2)
         self.assertAlmostEqual(result.aux_operators_evaluated[0][0], 2)
         self.assertAlmostEqual(result.aux_operators_evaluated[1][0], 0)
 
-    def test_cme_filter_empty(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_cme_filter_empty(self, op):
         """Test with filter always returning False"""
 
         # define filter criterion
@@ -121,9 +123,7 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             return False
 
         algo = NumPyMinimumEigensolver(filter_criterion=criterion)
-        result = algo.compute_minimum_eigenvalue(
-            operator=self.qubit_op, aux_operators=self.aux_ops_list
-        )
+        result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
         self.assertEqual(result.eigenvalue, None)
         self.assertEqual(result.eigenstate, None)
         self.assertEqual(result.aux_operators_evaluated, None)
@@ -132,24 +132,23 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
     def test_cme_1q(self, op):
         """Test for 1 qubit operator"""
         algo = NumPyMinimumEigensolver()
-        operator = PauliSumOp.from_list([(op, 1.0)])
+        operator = SparsePauliOp([op], coeffs=1.0)
         result = algo.compute_minimum_eigenvalue(operator=operator)
         self.assertAlmostEqual(result.eigenvalue, -1)
 
-    def test_cme_aux_ops_dict(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_cme_aux_ops_dict(self, op):
         """Test dictionary compatibility of aux_operators"""
         # Start with an empty dictionary
         algo = NumPyMinimumEigensolver()
 
         with self.subTest("Test with an empty dictionary."):
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators={})
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators={})
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertIsNone(result.aux_operators_evaluated)
 
         with self.subTest("Test with two auxiliary operators."):
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=self.aux_ops_dict
-            )
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_dict)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 2)
             self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2)
@@ -157,24 +156,20 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
 
         with self.subTest("Test with additional zero and None operators."):
             extra_ops = {"None_op": None, "zero_op": 0, **self.aux_ops_dict}
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=extra_ops
-            )
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=extra_ops)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 3)
             self.assertAlmostEqual(result.aux_operators_evaluated["aux_op1"][0], 2)
             self.assertAlmostEqual(result.aux_operators_evaluated["aux_op2"][0], 0)
             self.assertEqual(result.aux_operators_evaluated["zero_op"], (0.0, {"variance": 0}))
 
-    def test_aux_operators_list(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_aux_operators_list(self, op):
         """Test list-based aux_operators."""
-        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
-        aux_ops = [aux_op1, aux_op2]
         algo = NumPyMinimumEigensolver()
 
         with self.subTest("Test with two auxiliary operators."):
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_list)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 2)
             # expectation values
@@ -185,10 +180,8 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             self.assertAlmostEqual(result.aux_operators_evaluated[1][1].pop("variance"), 0.0)
 
         with self.subTest("Test with additional zero and None operators."):
-            extra_ops = [*aux_ops, None, 0]
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=extra_ops
-            )
+            extra_ops = [*self.aux_ops_list, None, 0]
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=extra_ops)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 4)
             # expectation values
@@ -201,15 +194,13 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             self.assertAlmostEqual(result.aux_operators_evaluated[1][1].pop("variance"), 0.0)
             self.assertEqual(result.aux_operators_evaluated[3][1].pop("variance"), 0.0)
 
-    def test_aux_operators_dict(self):
+    @data(H2_SPARSE_PAULI, H2_PAULI, H2_OP)
+    def test_aux_operators_dict(self, op):
         """Test dict-based aux_operators."""
-        aux_op1 = PauliSumOp.from_list([("II", 2.0)])
-        aux_op2 = PauliSumOp.from_list([("II", 0.5), ("ZZ", 0.5), ("YY", 0.5), ("XX", -0.5)])
-        aux_ops = {"aux_op1": aux_op1, "aux_op2": aux_op2}
         algo = NumPyMinimumEigensolver()
 
         with self.subTest("Test with two auxiliary operators."):
-            result = algo.compute_minimum_eigenvalue(operator=self.qubit_op, aux_operators=aux_ops)
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=self.aux_ops_dict)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 2)
             # expectation values
@@ -224,10 +215,8 @@ class TestNumPyMinimumEigensolver(QiskitAlgorithmsTestCase):
             )
 
         with self.subTest("Test with additional zero and None operators."):
-            extra_ops = {**aux_ops, "None_operator": None, "zero_operator": 0}
-            result = algo.compute_minimum_eigenvalue(
-                operator=self.qubit_op, aux_operators=extra_ops
-            )
+            extra_ops = {**self.aux_ops_dict, "None_operator": None, "zero_operator": 0}
+            result = algo.compute_minimum_eigenvalue(operator=op, aux_operators=extra_ops)
             self.assertAlmostEqual(result.eigenvalue, -1.85727503 + 0j)
             self.assertEqual(len(result.aux_operators_evaluated), 3)
             # expectation values

--- a/test/python/quantum_info/operators/test_operator.py
+++ b/test/python/quantum_info/operators/test_operator.py
@@ -206,6 +206,12 @@ class TestOperator(OperatorTestCase):
         op = Operator(mat)
         assert_allclose(mat, op.data)
 
+    def test_to_matrix(self):
+        """Test Operator to_matrix method."""
+        mat = self.rand_matrix(2, 2)
+        op = Operator(mat)
+        assert_allclose(mat, op.to_matrix())
+
     def test_dim(self):
         """Test Operator dim property."""
         mat = self.rand_matrix(4, 4)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes an issue where `NumPyEigensolver` and by extension `NumPyMinimumEigensolver` did not support all `BaseOperator` instances, in particular `SparsePauliOp`. This was because it required the data attribute, which `Operator` exposes but e.g. `SparsePauliOp` does not. Closes #9091.

### Details and comments

For all `BaseOperator` child classes, other than `Operator`, `to_matrix` is used to get the `NumPy` matrix for the operator and compute the eigenvalues and eigenstates. If an `Operator` instance, we still use `data`.

Additionally this PR:
* Refactors `NumPyEigensolver` to be stateless w.r.t. results. I.e. the result is no longer stored.
* Adds unit tests to check `NumPyEigensolver` with `SparsePauliOp`s.
* Adds units tests to check `NumPyMinimumEigensolver` with `SparsePauliOp`s and `Operator`s.
* Uses sparse matrix computation for all operators that support it, otherwise try dense computation. If this fails and error is raised.
