### PR TITLE
Pin jupyter-core to < 5.0.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,8 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
+
+# jupyter-core 5.0.0 started emitting deprecation warnings with ipywidgets via
+# a seaborn import. This pin can be removed when compatibility with those
+# packages is fixed
+jupyter-core==4.11.2


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of jupyter-core 5.0.0 started emitting a deprecation warning during the image comparison tests which is causing a failure caused by usage in seasborn via ipywidgets. To workaround this in the short term this commit set a constraint on the jupyter-core version. We should remove this pin after seaborn and ipywidgets are updated, or we add an explicit warning exclude to the test suite.

### Details and comments