### PR TITLE
Disable cron CI on old stable branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,13 +18,6 @@ pr:
     include:
       - '*'
 
-schedules:
-  - cron: "20 6 * * *"
-    displayName: "Complete matrix test"
-    branches:
-      include: [ "main", "stable/*" ]
-    always: false  # Only run if the code changed since the last cron sync.
-
 
 # Configuration.  In theory a manual trigger on the Azure website or embedding
 # this pipeline as a template can override these, but we're not interested in


### PR DESCRIPTION
This had got triggered again by something, and since the upstream requirements of qiskit-toqm have changed, it was impossible for any jobs to even install, and so this was just failing every night. This commit disables the cron for the old branch.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


