### PR TITLE
Use float-epsilon calculation in Sabre best scores

### DIFF
--- a/src/sabre_swap/mod.rs
+++ b/src/sabre_swap/mod.rs
@@ -43,6 +43,8 @@ use neighbor_table::NeighborTable;
 use sabre_dag::SabreDAG;
 use swap_map::SwapMap;
 
+const BEST_EPSILON: f64 = 1e-10; // Epsilon used in minimum-score calculations.
+
 const EXTENDED_SET_SIZE: usize = 20; // Size of lookahead window.
 const DECAY_RATE: f64 = 0.001; // Decay coefficient for penalizing serial swaps.
 const DECAY_RESET_INTERVAL: u8 = 5; // How often to reset all decay rates to 1.
@@ -522,11 +524,11 @@ fn choose_best_swap(
                         + EXTENDED_SET_WEIGHT * extended_set.score(swap, layout, dist))
             }
         };
-        if score < min_score {
+        if score < min_score - BEST_EPSILON {
             min_score = score;
             best_swaps.clear();
             best_swaps.push(swap);
-        } else if score == min_score {
+        } else if (score - min_score).abs() < BEST_EPSILON {
             best_swaps.push(swap);
         }
     }


### PR DESCRIPTION
### Summary

This should not meaningfully affect any small-scale outputs, but at larger scales, there are floating-point instabilities that can make the "best swaps" set miss swaps that are logically at the same score as others.  This does not (cannot) fully stabilise us against all minor floating-point rounding errors in calculations; the order of iteration through the swaps can still technically change the swap set, for example if three swaps with relative differences `{0, 0.8, 1.6} * BEST_EPSILON` are encountered in a different orders.  The float epsilon is chosen to be significantly larger than the actual magnitude of fluctuations, and significantly smaller than the changes caused by all the actual components of scoring, in order to mitigate this effect.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This detail is (to the best of my knowledge), the only reason that #9012 broke RNG compatibility in large circuits with the previous Rust version.

Tagging "bugfix" for the more developer-facing GitHub release notes, but there's no specific note for this in the public documentation; that will come with a later PR.
