### PR TITLE
Improve performance of _observable_key in Primitives

### DIFF
--- a/qiskit/primitives/utils.py
+++ b/qiskit/primitives/utils.py
@@ -168,7 +168,12 @@ def _observable_key(observable: SparsePauliOp) -> tuple:
     Returns:
         Key for observables.
     """
-    return tuple(observable.to_list())
+    return (
+        observable.paulis.z.tobytes(),
+        observable.paulis.x.tobytes(),
+        observable.paulis.phase.tobytes(),
+        observable.coeffs.tobytes(),
+    )
 
 
 def bound_circuit_to_instruction(circuit: QuantumCircuit) -> Instruction:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since `to_list` is slow, this improves the performance issue.

Question:
Does this PR have `stable backport potential`?

### Details and comments


