### PR TITLE
Fix random seed initialization between runs in SabreSwap

### DIFF
--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -15,7 +15,6 @@
 import logging
 from copy import copy, deepcopy
 
-import numpy as np
 import retworkx
 
 from qiskit.circuit.library.standard_gates import SwapGate

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -150,12 +150,7 @@ class SabreSwap(TransformationPass):
             self._neighbor_table = NeighborTable(retworkx.adjacency_matrix(self.coupling_map.graph))
 
         self.heuristic = heuristic
-
-        if seed is None:
-            ii32 = np.iinfo(np.int32)
-            self.seed = np.random.default_rng(None).integers(0, ii32.max, dtype=int)
-        else:
-            self.seed = seed
+        self.seed = seed
         if trials is None:
             self.trials = CPU_COUNT
         else:

--- a/releasenotes/notes/fix-sabre-swap-random-seed-dcf3dace63042791.yaml
+++ b/releasenotes/notes/fix-sabre-swap-random-seed-dcf3dace63042791.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~.SabreSwap` pass which would cause the
+    output of multiple runs of the pass without the ``seed`` argument specified
+    to reuse the same random number generator seed between runs instead of
+    using different seeds. This previously caused identical results to be
+    returned between runs even when no ``seed`` was specified.

--- a/src/sabre_swap/mod.rs
+++ b/src/sabre_swap/mod.rs
@@ -152,14 +152,17 @@ pub fn build_swap_map(
     neighbor_table: &NeighborTable,
     distance_matrix: PyReadonlyArray2<f64>,
     heuristic: &Heuristic,
-    seed: u64,
+    seed: Option<u64>,
     layout: &mut NLayout,
     num_trials: usize,
 ) -> (SwapMap, PyObject) {
     let run_in_parallel = getenv_use_multiple_threads() && num_trials > 1;
     let dist = distance_matrix.as_array();
     let coupling_graph: DiGraph<(), ()> = cmap_from_neighor_table(neighbor_table);
-    let outer_rng = Pcg64Mcg::seed_from_u64(seed);
+    let outer_rng = match seed {
+        Some(seed) => Pcg64Mcg::seed_from_u64(seed),
+        None => Pcg64Mcg::from_entropy(),
+    };
     let seed_vec: Vec<u64> = outer_rng
         .sample_iter(&rand::distributions::Standard)
         .take(num_trials)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the case no random seed is provided by the user when initializing an instance of SabreSwap. The pass was previously potentially reusing the random seed between runs even if no seed was specified. This was an artifact of storing the initial seed as an instance variable. Instead this commit just relies on the the Rust RNG to initialize from entropy if no seed is specified.

### Details and comments