### PR TITLE
Add debug prints to lint CI job

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -32,17 +32,25 @@ jobs:
       - bash: |
           set -e
           source test-job/bin/activate
+          echo "Running black, any errors reported can be fixed with 'tox -eblack'"
           black --check qiskit test tools examples setup.py
+          echo "Running rustfmt check, any errors reported can be fixed with 'cargo fmt'"
           cargo fmt --check
         displayName: "Formatting"
 
       - bash: |
           set -e
           source test-job/bin/activate
+          echo "Running pylint"
           pylint -rn qiskit test tools
+          echo "Running Cargo Clippy"
           cargo clippy -- -D warnings
+          echo "Running license header check"
           tools/verify_headers.py qiskit test
+          echo "Running check for optional imports on bare 'import qiskit'"
           python tools/find_optional_imports.py
+          echo "Running check for release notes in incorrect directories"
           tools/find_stray_release_notes.py
+          echo "Running reno lint"
           reno lint
         displayName: 'Lint'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now the lint CI job runs a number of scripts and commands which do not print any output unless there is an error, while other commands always print to stdout even on success. This can be confusing if a command towards the end prints error output after normal stdout from earlier commands. For example, this was the output from a recent failed CI run:
```
------------------------------------
Your code has been rated at 10.00/10

    Checking cfg-if v1.0.0
    Checking scopeguard v1.1.0
    Checking once_cell v1.16.0
    Checking either v1.8.0
    Checking smallvec v1.10.0
    Checking ppv-lite86 v0.2.16
    Checking rawpointer v0.2.1
    Checking unindent v0.1.10
    Checking fixedbitset v0.4.2
    Checking matrixmultiply v0.3.2
    Checking libc v0.2.137
    Checking crossbeam-utils v0.8.12
    Checking libm v0.2.5
    Checking memoffset v0.6.5
    Checking lock_api v0.4.9
    Checking crossbeam-channel v0.5.6
    Checking getrandom v0.2.8
    Checking num_cpus v1.13.1
    Checking parking_lot_core v0.9.4
    Checking crossbeam-epoch v0.9.11
    Checking num-traits v0.2.15
   Compiling pyo3-build-config v0.17.3
    Checking ahash v0.7.6
    Checking rand_core v0.6.4
    Checking ahash v0.8.0
    Checking parking_lot v0.12.1
    Checking crossbeam-deque v0.8.2
    Checking rand_chacha v0.3.1
    Checking rand_pcg v0.3.1
    Checking num-integer v0.1.45
    Checking num-complex v0.4.2
    Checking rayon-core v1.9.3
    Checking rand v0.8.5
    Checking num-bigint v0.4.3
    Checking rayon v1.5.3
   Compiling pyo3-ffi v0.17.3
   Compiling pyo3 v0.17.3
    Checking rand_distr v0.4.3
    Checking hashbrown v0.12.3
    Checking ndarray v0.15.6
    Checking hashbrown v0.11.2
    Checking indexmap v1.9.1
    Checking petgraph v0.6.2
    Checking numpy v0.17.2
    Checking retworkx-core v0.11.0
    Checking qiskit-terra v0.23.0 (/home/vsts/work/1/s)
    Finished dev [unoptimized + debuginfo] target(s) in 13.10s
ERROR: scipy.stats is imported via sklearn.utils.fixes
```
The error there comes from the find optional import script, but the output looks like it's potentially related to the cargo clippy output.

To help make the output more clear for debugging this commit adds a bunch of echo statements to the ci script that explains what is being run. This should hopefully make it easier for people not as well versed in the CI lint job to understand what is going on during a failure.

Using bash trace mode was also considered, but typically it's better to avoid that in CI jobs just in case a secret is used on command (to prevent leaking it). Also in this case it likely would have been less useful because it just prints the command being run which may not be as obvious as a text description.


### Details and comments