### PR TITLE
Remove deprecated redirects from visualization

### DIFF
--- a/qiskit/visualization/__init__.py
+++ b/qiskit/visualization/__init__.py
@@ -248,7 +248,6 @@ Exceptions
 
 import os
 import sys
-import warnings
 
 from .array import array_to_latex
 
@@ -279,24 +278,3 @@ from .exceptions import VisualizationError
 # These modules aren't part of the public interface, and were moved in Terra 0.22.  They're
 # re-imported here to allow a backwards compatible path, and should be deprecated in Terra 0.23.
 from .circuit import text, matplotlib, latex
-
-_DEPRECATED_NAMES = {
-    "HAS_MATPLOTLIB",
-    "HAS_PYLATEX",
-    "HAS_PIL",
-    "HAS_PDFTOCAIRO",
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_NAMES:
-        from qiskit.utils import optionals
-
-        warnings.warn(
-            f"Accessing '{name}' from '{__name__}' is deprecated since Qiskit Terra 0.21 "
-            "and will be removed in a future release. Use 'qiskit.utils.optionals' instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return getattr(optionals, name)
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/releasenotes/notes/remove-visualization-optionals-e4c3ed415bc1bbbe.yaml
+++ b/releasenotes/notes/remove-visualization-optionals-e4c3ed415bc1bbbe.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The lazy optional checkers :data:`.HAS_MATPLOTLIB`, :data:`.HAS_PIL`, :data:`.HAS_PYLATEX` and
+    :data:`.HAS_PDFTOCAIRO` are no longer exposed from :mod:`qiskit.visualization`, having been
+    deprecated in Qiskit Terra 0.21.  The canonical location for these (and many other lazy checkers)
+    is :mod:`qiskit.utils.optionals`, and all four objects can be found there.


### PR DESCRIPTION
### Summary

These were deprecated in 0.21, since the lazy optional checkers in `qiskit.utils.optionals` became available.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments


