### PR TITLE
Infer `cregbundle` for all drawers

### DIFF
--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -141,8 +141,9 @@ def circuit_drawer(
             it is redundant.
         initial_state (bool): Optional. Adds ``|0>`` in the beginning of the wire.
             Default is False.
-        cregbundle (bool): Optional. If set True, bundle classical registers.
-            Default is True, except for when ``output`` is set to  ``"text"``.
+        cregbundle (bool): Optional. If set True, bundle classical registers into a single wire.
+            Default is true if possible, and false if a block instruction needs to access an
+            individual bit from a register.
         wire_order (list): Optional. A list of integers used to reorder the display
             of the bits. The list must have an entry for every bit with the bits
             in the range 0 to (num_qubits + num_clbits).
@@ -207,13 +208,14 @@ def circuit_drawer(
             "wire_order list for the index of each qubit and each clbit in the circuit."
         )
 
-    if circuit.clbits and cregbundle and (reverse_bits or wire_order is not None):
+    if circuit.clbits and (reverse_bits or wire_order is not None):
+        if cregbundle:
+            warn(
+                "cregbundle set to False since either reverse_bits or wire_order has been set.",
+                RuntimeWarning,
+                2,
+            )
         cregbundle = False
-        warn(
-            "Cregbundle set to False since either reverse_bits or wire_order has been set.",
-            RuntimeWarning,
-            2,
-        )
     if output == "text":
         return _text_circuit_drawer(
             circuit,
@@ -241,7 +243,7 @@ def circuit_drawer(
             idle_wires=idle_wires,
             with_layout=with_layout,
             initial_state=initial_state,
-            cregbundle=cregbundle if cregbundle is not None else True,
+            cregbundle=cregbundle,
             wire_order=wire_order,
         )
     elif output == "latex_source":
@@ -256,7 +258,7 @@ def circuit_drawer(
             idle_wires=idle_wires,
             with_layout=with_layout,
             initial_state=initial_state,
-            cregbundle=cregbundle if cregbundle is not None else True,
+            cregbundle=cregbundle,
             wire_order=wire_order,
         )
     elif output == "mpl":
@@ -391,7 +393,7 @@ def _latex_circuit_drawer(
     idle_wires=True,
     with_layout=True,
     initial_state=False,
-    cregbundle=False,
+    cregbundle=None,
     wire_order=None,
 ):
     """Draw a quantum circuit based on latex (Qcircuit package)
@@ -414,8 +416,8 @@ def _latex_circuit_drawer(
             layout. Default: True
         initial_state (bool): Optional. Adds |0> in the beginning of the line.
             Default: `False`.
-        cregbundle (bool): Optional. If set True, bundle classical registers.
-            Default: ``False``.
+        cregbundle (bool): Optional. If set True, bundle classical registers.  On by default, if
+            this is possible for the given circuit, otherwise off.
         wire_order (list): Optional. A list of integers used to reorder the display
             of the bits. The list must have an entry for every bit with the bits
             in the range 0 to (num_qubits + num_clbits).
@@ -510,7 +512,7 @@ def _generate_latex_source(
     idle_wires=True,
     with_layout=True,
     initial_state=False,
-    cregbundle=False,
+    cregbundle=None,
     wire_order=None,
 ):
     """Convert QuantumCircuit to LaTeX string.
@@ -532,7 +534,6 @@ def _generate_latex_source(
         initial_state (bool): Optional. Adds |0> in the beginning of the line.
             Default: `False`.
         cregbundle (bool): Optional. If set True, bundle classical registers.
-            Default: ``False``.
         wire_order (list): Optional. A list of integers used to reorder the display
             of the bits. The list must have an entry for every bit with the bits
             in the range 0 to (num_qubits + num_clbits).
@@ -590,7 +591,7 @@ def _matplotlib_circuit_drawer(
     fold=None,
     ax=None,
     initial_state=False,
-    cregbundle=True,
+    cregbundle=None,
     wire_order=None,
 ):
 
@@ -652,7 +653,7 @@ def _matplotlib_circuit_drawer(
         fold=fold,
         ax=ax,
         initial_state=initial_state,
-        cregbundle=cregbundle if cregbundle is not None else True,
+        cregbundle=cregbundle,
         global_phase=None,
         calibrations=None,
         qregs=None,

--- a/releasenotes/notes/fix-cregbundle-warning-d3c991bb6276761d.yaml
+++ b/releasenotes/notes/fix-cregbundle-warning-d3c991bb6276761d.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    The circuit drawers (:meth:`.QuantumCircuit.draw` and :func:`.circuit_drawer`) will no
+    longer emit a warning about the ``cregbundle`` parameter when using the default arguments,
+    if the content of the circuit requires all bits to be drawn individually.  This was most
+    likely to appear when trying to draw circuits with new-style control-flow operations.

--- a/test/python/visualization/test_circuit_drawer.py
+++ b/test/python/visualization/test_circuit_drawer.py
@@ -159,5 +159,10 @@ class TestCircuitDrawer(QiskitTestCase):
                 "               ",
             ]
         )
-        result = visualization.circuit_drawer(circuit)
+        result = circuit.draw("text")
         self.assertEqual(result.__str__(), expected)
+        # Extra tests that no cregbundle (or any other) warning is raised with the default settings
+        # for the other drawers, if they're available to test.
+        circuit.draw("latex_source")
+        if optionals.HAS_MATPLOTLIB and optionals.HAS_PYLATEX:
+            circuit.draw("mpl")


### PR DESCRIPTION
### Summary

This swaps the default behaviour for the `cregbundle` to always bundle if possible, but not to emit a warning if the bundles are expanded and no concrete value was given for the parameter.  Previously, this sort of logic was only done for the text drawer.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #9129.  This was previously done for the text drawer in #8689, but this PR makes it true for all the existing drawers.