### PR TITLE
fix: overwrite `AdaptVQE.supports_aux_operators`

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
+++ b/qiskit/algorithms/minimum_eigensolvers/adapt_vqe.py
@@ -29,6 +29,7 @@ from qiskit.opflow import OperatorBase, PauliSumOp
 from qiskit.circuit.library import EvolvedOperatorAnsatz
 from qiskit.utils.validation import validate_min
 
+from .minimum_eigensolver import MinimumEigensolver
 from .vqe import VQE, VQEResult
 from ..observables_evaluator import estimate_observables
 from ..variational_algorithm import VariationalAlgorithm
@@ -45,7 +46,7 @@ class TerminationCriterion(Enum):
     MAXIMUM = "Maximum number of iterations reached"
 
 
-class AdaptVQE(VariationalAlgorithm):
+class AdaptVQE(VariationalAlgorithm, MinimumEigensolver):
     """The Adaptive Variational Quantum Eigensolver algorithm.
 
     `AdaptVQE <https://arxiv.org/abs/1812.11173>`__ is a quantum algorithm which creates a compact
@@ -125,6 +126,10 @@ class AdaptVQE(VariationalAlgorithm):
     def initial_point(self, value: Sequence[float] | None) -> None:
         """Sets the initial point of the internal :class:`~.VQE` solver."""
         self.solver.initial_point = value
+
+    @classmethod
+    def supports_aux_operators(cls) -> bool:
+        return True
 
     def _compute_gradients(
         self,

--- a/releasenotes/notes/adapt-vqe-supports-aux-operators-1383103839a338c6.yaml
+++ b/releasenotes/notes/adapt-vqe-supports-aux-operators-1383103839a338c6.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    :class:`~qiskit.algorithms.minimum_eigensolver.AdaptVQE` now correctly
+    indicates that it supports auxiliary operators.

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -162,6 +162,16 @@ class TestAdaptVQE(QiskitAlgorithmsTestCase):
         # compare with manually computed reference value
         self.assertAlmostEqual(res[0][0], 2.0)
 
+    def test_supports_aux_operators(self):
+        """Test that auxiliary operators are supported"""
+        calc = AdaptVQE(VQE(Estimator(), self.ansatz, self.optimizer))
+        res = calc.compute_minimum_eigenvalue(operator=self.h2_op, aux_operators=[self.h2_op])
+
+        expected_eigenvalue = -1.85727503
+
+        self.assertAlmostEqual(res.eigenvalue, expected_eigenvalue, places=6)
+        self.assertAlmostEqual(res.aux_operators_evaluated[0][0], expected_eigenvalue, places=6)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

`AdaptVQE` does indeed support aux operators but did not overwrite the default classmethod of the `MinimumEigensolver` interface. This PR fixes that.

### Details and comments


