### PR TITLE
add control flow to CommutativeCancellation pass

### DIFF
--- a/qiskit/circuit/commutation_checker.py
+++ b/qiskit/circuit/commutation_checker.py
@@ -17,6 +17,7 @@ from typing import List
 import numpy as np
 
 from qiskit.circuit.operation import Operation
+from qiskit.circuit.controlflow import ControlFlowOp
 from qiskit.quantum_info.operators import Operator
 
 
@@ -86,6 +87,11 @@ class CommutationChecker:
             getattr(op1, "condition", None) is not None
             or getattr(op2, "condition", None) is not None
         ):
+            return False
+
+        # Commutation of ControlFlow gates also not supported yet. This may be
+        # pending a control flow graph.
+        if isinstance(op1, ControlFlowOp) or isinstance(op2, ControlFlowOp):
             return False
 
         # These lines are adapted from dag_dependency and say that two gates over

--- a/qiskit/transpiler/passes/optimization/commutative_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/commutative_cancellation.py
@@ -24,7 +24,7 @@ from qiskit.circuit.library.standard_gates.u1 import U1Gate
 from qiskit.circuit.library.standard_gates.rx import RXGate
 from qiskit.circuit.library.standard_gates.p import PhaseGate
 from qiskit.circuit.library.standard_gates.rz import RZGate
-
+from qiskit.transpiler.utils import control_flow
 
 _CUTOFF_PRECISION = 1e-5
 
@@ -57,6 +57,7 @@ class CommutativeCancellation(TransformationPass):
         self._var_z_map = {"rz": RZGate, "p": PhaseGate, "u1": U1Gate}
         self.requires.append(CommutationAnalysis())
 
+    @control_flow.trivial_recurse
     def run(self, dag):
         """Run the CommutativeCancellation pass on `dag`.
 

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -632,6 +632,65 @@ class TestCommutativeCancellation(QiskitTestCase):
         transpiled = PassManager([CommutativeCancellation()]).run(original)
         self.assertEqual(original, transpiled)
 
+    def test_simple_if_else(self):
+        """Test that the pass is not confused by if-else."""
+        base_test1 = QuantumCircuit(3, 3)
+
+        base_test1.cx(0, 1)
+        base_test1.x(1)
+
+        base_test2 = QuantumCircuit(3, 3)
+        base_test2.cx(1, 2)
+        base_test2.rx(0.1, 2)
+
+        test = QuantumCircuit(3, 3)
+        test.h(0)
+        test.x(0)
+        test.rx(0.2, 0)
+        test.measure(0, 0)
+        test.x(0)
+        test.if_else(
+            (test.clbits[0], True), base_test1.copy(), base_test2.copy(), test.qubits, test.clbits
+        )
+        # dag = circuit_to_dag(test)
+        # dag_body1 = circuit_to_dag(base_test1)
+        # dag_body2 = circuit_to_dag(base_test2)
+
+        passmanager = PassManager()
+        passmanager.append(CommutativeCancellation())
+        new_circuit = passmanager.run(test)
+
+        breakpoint()
+
+    def test_nested_control_flow(self):
+        """Test that the pass does not add barrier into nested control flow."""
+        pass_ = BarrierBeforeFinalMeasurements()
+
+        base_test = QuantumCircuit(2, 1)
+        base_test.cz(0, 1)
+        base_test.measure(0, 0)
+
+        body_test = QuantumCircuit(2, 1)
+        body_test.for_loop((0,), None, base_test.copy(), body_test.qubits, [])
+        body_test.measure(0, 0)
+
+        body_expected = QuantumCircuit(2, 1)
+        body_expected.for_loop((0,), None, base_test.copy(), body_expected.qubits, [])
+        body_expected.measure(0, 0)
+
+        test = QuantumCircuit(2, 1)
+        test.while_loop((test.clbits[0], True), body_test, test.qubits, test.clbits)
+        test.measure(0, 0)
+
+        expected = QuantumCircuit(2, 1)
+        expected.while_loop(
+            (expected.clbits[0], True), body_expected, expected.qubits, expected.clbits
+        )
+        expected.barrier([0, 1])
+        expected.measure(0, 0)
+
+        self.assertEqual(pass_(test), expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This adds control flow handling to the CommutativeCancellation pass. In this version the body of the control flow instructions are treated independently of the containing circuit such that the commutivity of the control flow instruction itself is not considered. Also, commutivity across the instruction block boundary is left for a future improvement.  


### Details and comments


