### PR TITLE
Reinstate `pulse.Instruction.draw`

### DIFF
--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -27,6 +27,7 @@ from typing import Callable, Iterable, List, Optional, Set, Tuple
 from qiskit.circuit import Parameter
 from qiskit.pulse.channels import Channel
 from qiskit.pulse.exceptions import PulseError
+from qiskit.utils import optionals as _optionals
 
 
 # pylint: disable=missing-return-doc
@@ -220,6 +221,7 @@ class Instruction(ABC):
         """Return True iff the instruction is parameterized."""
         return any(self.parameters)
 
+    @_optionals.HAS_MATPLOTLIB.require_in_call
     def draw(
         self,
         dt: float = 1,
@@ -256,23 +258,29 @@ class Instruction(ABC):
             matplotlib.figure: A matplotlib figure object of the pulse schedule
         """
         # pylint: disable=cyclic-import
-        from qiskit import visualization
+        from qiskit.visualization.pulse.matplotlib import ScheduleDrawer
+        from qiskit.visualization.utils import matplotlib_close_if_inline
 
-        return visualization.pulse_drawer(
+        drawer = ScheduleDrawer(style=style)
+        image = drawer.draw(
             self,
             dt=dt,
-            style=style,
-            filename=filename,
             interp_method=interp_method,
             scale=scale,
-            plot_all=plot_all,
             plot_range=plot_range,
-            interactive=interactive,
+            plot_all=plot_all,
             table=table,
             label=label,
             framechange=framechange,
             channels=channels,
         )
+        if filename:
+            image.savefig(filename, dpi=drawer.style.dpi, bbox_inches="tight")
+
+        matplotlib_close_if_inline(image)
+        if image and interactive:
+            image.show()
+        return image
 
     def __eq__(self, other: "Instruction") -> bool:
         """Check if this Instruction is equal to the `other` instruction.

--- a/releasenotes/notes/reinstate-pulse-instruction-draw-7bf4bbabaa1f1862.yaml
+++ b/releasenotes/notes/reinstate-pulse-instruction-draw-7bf4bbabaa1f1862.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The :meth:`.pulse.Instruction.draw` will now succeed, as before.
+    This method is deprecated with no replacement planned, but it should
+    still work for the period of deprecation.


### PR DESCRIPTION
### Summary

This was erroneously broken by gh-8306 and not detected by lint because of the existence of `qiskit.visualization.__getattr__`.  This reinstates the functionality using the deprecated old instruction drawers.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

I'm using the deprecated functionality, achieved by inlining what the old `pulse_drawer` (v1) code did for this path, because the paths in use haven't been triggering their deprecation warnings properly due to `stacklevel` issues, so are not eligible for immediate removal.  This PR is stable for backport (fixes a bug in the deprecation period), and I'll follow it with a PR for 0.23 that applies the deprecations to the v1 pulse drawer (and this method) correctly.
