### PR TITLE
add control flow handling to BarrierBeforeFinalMeasurements pass

### DIFF
--- a/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
+++ b/qiskit/transpiler/passes/utils/barrier_before_final_measurements.py
@@ -16,6 +16,8 @@
 from qiskit.circuit.barrier import Barrier
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+from qiskit.circuit.controlflow import ControlFlowOp
+from qiskit.converters import dag_to_circuit, circuit_to_dag
 from .merge_adjacent_barriers import MergeAdjacentBarriers
 
 
@@ -30,22 +32,7 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
     def run(self, dag):
         """Run the BarrierBeforeFinalMeasurements pass on `dag`."""
         # Collect DAG nodes which are followed only by barriers or other measures.
-        final_op_types = ["measure", "barrier"]
-        final_ops = []
-        for candidate_node in dag.named_nodes(*final_op_types):
-            is_final_op = True
-
-            for _, child_successors in dag.bfs_successors(candidate_node):
-
-                if any(
-                    isinstance(suc, DAGOpNode) and suc.name not in final_op_types
-                    for suc in child_successors
-                ):
-                    is_final_op = False
-                    break
-
-            if is_final_op:
-                final_ops.append(candidate_node)
+        final_ops = self._get_final_ops(dag)
 
         if not final_ops:
             return dag
@@ -82,3 +69,37 @@ class BarrierBeforeFinalMeasurements(TransformationPass):
         # Merge the new barrier into any other barriers
         adjacent_pass = MergeAdjacentBarriers()
         return adjacent_pass.run(dag)
+
+
+    def _get_final_ops(self, dag, final_op_types=["measure", "barrier"]):
+        """Collect candidate final ops"""
+        final_ops = []
+        for candidate_node in dag.named_nodes(*final_op_types) + dag.op_nodes(ControlFlowOp):
+            is_final_op = True
+            for _, child_successors in dag.bfs_successors(candidate_node):
+                if any(
+                        isinstance(suc, DAGOpNode) and
+                        suc.name not in final_op_types
+                        for suc in child_successors
+                ):
+                    is_final_op = False
+                    break
+            if isinstance(candidate_node.op, ControlFlowOp):
+                #breakpoint()
+                for _, child_successors in dag.bfs_successors(candidate_node):
+                    if any(
+                            isinstance(suc, DAGOpNode)
+                            for suc in child_successors
+                    ):
+                        is_final_op = False
+                        break
+            if isinstance(candidate_node.op, ControlFlowOp) and is_final_op:
+                # since this is a "final" operation it potentially needs to be applied
+                # to the control flow blocks
+                candidate_node.op = candidate_node.op.replace_blocks(
+                    [dag_to_circuit(self.run(circuit_to_dag(block)))
+                     for block in candidate_node.op.blocks])
+
+            if is_final_op:
+                final_ops.append(candidate_node)
+        return final_ops

--- a/test/python/transpiler/test_barrier_before_final_measurements.py
+++ b/test/python/transpiler/test_barrier_before_final_measurements.py
@@ -392,6 +392,7 @@ class TestBarrierBeforeMeasurementsWhenABarrierIsAlreadyThere(QiskitTestCase):
         pass_ = BarrierBeforeFinalMeasurements()
         self.assertEqual(expected, pass_(circuit))
 
+
 class TestControlFlow(QiskitTestCase):
     """Tests the BarrierBeforeFinalMeasurements pass."""
 
@@ -420,10 +421,10 @@ class TestControlFlow(QiskitTestCase):
         expected.barrier(0)
         expected.measure(0, 0)
         test_pass = pass_(test)
-        self.assertEqual(pass_(test), expected)
+        self.assertEqual(test_pass, expected)
 
     def test_final_measure_in_if_else(self):
-        """Test that the pass is not confused by if-else."""
+        """Test if-else containing final measure."""
         pass_ = BarrierBeforeFinalMeasurements()
 
         base_test = QuantumCircuit(2, 1)
@@ -433,16 +434,13 @@ class TestControlFlow(QiskitTestCase):
         qreg = QuantumRegister(2, "q")
         creg = ClassicalRegister(1)
         test = QuantumCircuit(qreg, creg)
-        test.if_else(
-            (test.clbits[0], True), base_test.copy(), base_test.copy(), qreg[[0, 1]], creg
-        )
+        test.if_else((test.clbits[0], True), base_test.copy(), base_test.copy(), qreg[[0, 1]], creg)
 
         base_expected = QuantumCircuit(2, 1)
         base_expected.z(0)
         base_expected.barrier(base_expected.qubits)
         base_expected.measure(0, 0)
         expected = QuantumCircuit(qreg, creg)
-        expected.barrier(expected.qubits)
         expected.if_else(
             (expected.clbits[0], True),
             base_expected.copy(),
@@ -464,17 +462,14 @@ class TestControlFlow(QiskitTestCase):
         qreg = QuantumRegister(2, "q")
         creg = ClassicalRegister(1)
         test = QuantumCircuit(qreg, creg)
-        test.if_else(
-            (test.clbits[0], True), base_test.copy(), base_test.copy(), qreg[[0, 1]], creg
-        )
+        test.if_else((test.clbits[0], True), base_test.copy(), base_test.copy(), qreg[[0, 1]], creg)
         test.x(0)
 
         test_pass = pass_(test)
         self.assertEqual(test_pass, test)
 
-
     def test_nested_control_flow(self):
-        """Test that the pass does not add barrier into nested control flow."""
+        """Test barrier in nested control flow."""
         pass_ = BarrierBeforeFinalMeasurements()
 
         test_level2 = QuantumCircuit(2, 1)
@@ -482,38 +477,37 @@ class TestControlFlow(QiskitTestCase):
         test_level2.measure(0, 0)
 
         test_level1 = QuantumCircuit(2, 1)
-        test_level1.while_loop((test_level1.clbits[0], True),
-                               test_level2.copy(),
-                               test_level1.qubits,
-                               test_level1.clbits)
+        test_level1.while_loop(
+            (test_level1.clbits[0], True),
+            test_level2.copy(),
+            test_level1.qubits,
+            test_level1.clbits,
+        )
         test = QuantumCircuit(2, 1)
         test.for_loop((0,), None, test_level1.copy(), test.qubits, [])
-        
-        print('-'*20)
-        print(test)
-        print(test.data[0].operation.params[2])
-        print(test.data[0].operation.params[2].data[0].operation.params[0])
 
         test_pass = pass_(test)
-        print('-'*20)
-        print(test_pass)
-        print(test_pass.data[1].operation.params[2])
-        print(test_pass.data[1].operation.params[2].data[1].operation.params[0])
-        
+
         body_expected = QuantumCircuit(2, 1)
         body_expected.for_loop((0,), None, test_level1.copy(), body_expected.qubits, [])
         body_expected.measure(0, 0)
 
+        expected_level2 = QuantumCircuit(2, 1)
+        expected_level2.cz(0, 1)
+        expected_level2.barrier(expected_level2.qubits)
+        expected_level2.measure(0, 0)
+
+        expected_level1 = QuantumCircuit(2, 1)
+        expected_level1.while_loop(
+            (expected_level1.clbits[0], True),
+            expected_level2,
+            expected_level1.qubits,
+            expected_level1.clbits,
+        )
 
         expected = QuantumCircuit(2, 1)
-        expected.while_loop(
-            (expected.clbits[0], True), body_expected, expected.qubits, expected.clbits
-        )
-        expected.barrier([0, 1])
-        expected.measure(0, 0)
-
-        #breakpoint()
-        #self.assertEqual(pass_(test), expected)
+        expected.for_loop((0,), None, expected_level1.copy(), expected.qubits, [])
+        self.assertEqual(test_pass, expected)
 
     def test_control_flow_with_no_measure(self):
         """Test no barrier inserted if control flow has no final measure"""
@@ -526,22 +520,8 @@ class TestControlFlow(QiskitTestCase):
         test.if_else(
             (test.clbits[0], True), base_test.copy(), base_test.copy(), test.qubits, test.clbits
         )
-        test_pass = pass_(test)        
-        print('-'*20)
-        print(test)
-        print(test.data[0].operation.params[0])
-        print(test.data[0].operation.params[1])
-        print('-'*20)        
-        print(test_pass)
-        print(test_pass.data[0].operation.params[0])
-        print(test_pass.data[0].operation.params[1])
-        print('-'*20)        
-        print(expected)
-        print(expected.data[0].operation.params[0])
-        print(expected.data[0].operation.params[1])                
-        breakpoint()
-
-        breakpoint()
+        test_pass = pass_(test)
+        self.assertEqual(test_pass, test)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This pass adds control flow handling to the transpiler pass, BarrierBeforeFinalMeasurements.


### Details and comments
If a control flow instruction is the final instruction in a circuit and it contains a circuit with a final measure, this modification will place a barrier within the control flow block. This may, however, allow a situation where other instructions, at the same scope as the control flow instruction, could be placed after the control flow instruction containing a "final" measure.  To avoid this situation we could expand control flow instructions to full width before adding barriers, however this may defeat other optimization passes (maybe this already occurs for `while-` and `for-`loops). The other alternative is to let the composer explicitly add barriers where needed.

