### PR TITLE
validation/dd timing

### DIFF
--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -263,6 +263,10 @@ class PadDynamicalDecoupling(BasePadding):
         #
         # As you can see, constraints on t0 are all satified without explicit scheduling.
         time_interval = t_end - t_start
+        if time_interval % self._alignment != 0:
+            raise TranspilerError(
+                f"Time interval {time_interval} is not divisible by alignment {self._alignment}."
+            )
 
         if self._qubits and dag.qubits.index(qubit) not in self._qubits:
             # Target physical qubit is not the target of this DD sequence.

--- a/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
+++ b/qiskit/transpiler/passes/scheduling/padding/dynamical_decoupling.py
@@ -265,7 +265,9 @@ class PadDynamicalDecoupling(BasePadding):
         time_interval = t_end - t_start
         if time_interval % self._alignment != 0:
             raise TranspilerError(
-                f"Time interval {time_interval} is not divisible by alignment {self._alignment}."
+                f"Time interval {time_interval} is not divisible by alignment {self._alignment} "
+                f"between DAGNode {prev_node.name} on qargs {prev_node.qargs} and {next_node.name} "
+                f"on qargs {next_node.qargs}."
             )
 
         if self._qubits and dag.qubits.index(qubit) not in self._qubits:


### PR DESCRIPTION
### Summary

Added a validation check for dynamical decoupling to confirm that the `time_interval` is divisible by the pulse alignment, otherwise throw a `TranspilerError`.

