### PR TITLE
Unpin jaxlib Python-version constraints

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,6 +24,6 @@ sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'
-jax;platform_system != 'Windows' and python_version < '3.11'
-jaxlib;platform_system != 'Windows' and python_version < '3.11'
+jax;platform_system != 'Windows'
+jaxlib;platform_system != 'Windows'
 docplex


### PR DESCRIPTION
### Summary

`jaxlib` released Python 3.11 wheels as of 0.3.24 on 2022-11-04, so we can release our pin on the constraint in `requirements-dev.txt`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


