### PR TITLE
Use numpy.linalg.det instead of scipy's function

### DIFF
--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -220,11 +220,9 @@ class OneQubitEulerDecomposer:
     @staticmethod
     def _params_zyz(mat):
         """Return the Euler angles and phase for the ZYZ basis."""
-        import scipy.linalg as la
-
         # We rescale the input matrix to be special unitary (det(U) = 1)
         # This ensures that the quaternion representation is real
-        coeff = la.det(mat) ** (-0.5)
+        coeff = np.linalg.det(mat) ** (-0.5)
         phase = -cmath.phase(coeff)
         su_mat = coeff * mat  # U in SU(2)
         # OpenQASM SU(2) parameterization:

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -144,8 +144,6 @@ class TwoQubitWeylDecomposition:
 
         The overall decomposition scheme is taken from Drury and Love, arXiv:0806.4015 [quant-ph].
         """
-        from scipy import linalg as la
-
         if _unpickling:
             return super().__new__(cls)
 
@@ -155,7 +153,7 @@ class TwoQubitWeylDecomposition:
 
         # Make U be in SU(4)
         U = np.array(unitary_matrix, dtype=complex, copy=True)
-        detU = la.det(U)
+        detU = np.linalg.det(U)
         U *= detU ** (-0.25)
         global_phase = cmath.phase(detU) / 4
 
@@ -201,7 +199,7 @@ class TwoQubitWeylDecomposition:
         P[:, :3] = P[:, order]
 
         # Fix the sign of P to be in SO(4)
-        if np.real(la.det(P)) < 0:
+        if np.real(np.linalg.det(P)) < 0:
             P[:, -1] = -P[:, -1]
 
         # Find K1, K2 so that U = K1.A.K2, with K being product of single-qubit unitaries
@@ -1422,9 +1420,7 @@ class TwoQubitDecomposeUpToDiagonal:
         self.sysy = np.kron(sy, sy)
 
     def _u4_to_su4(self, u4):
-        from scipy import linalg as la
-
-        phase_factor = np.conj(la.det(u4) ** (-1 / u4.shape[0]))
+        phase_factor = np.conj(np.linalg.det(u4) ** (-1 / u4.shape[0]))
         su4 = u4 / phase_factor
         return su4, cmath.phase(phase_factor)
 

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -404,7 +404,7 @@ custom_{id(gate2)} q[1],q[0];\n"""
                 "OPENQASM 2.0;",
                 'include "qelib1.inc";',
                 "gate gate__valid__ p0 {",
-                "	u3(pi,pi/2,-pi/2) p0;",
+                "	u3(pi,-pi/2,pi/2) p0;",
                 "}",
                 "gate gate_A___ q0 { x q0; u(0,0,pi) q0; }",
                 "gate invalid_name_ q0,q1 { x q0; gate_A___ q1; }",

--- a/test/python/transpiler/test_dynamical_decoupling.py
+++ b/test/python/transpiler/test_dynamical_decoupling.py
@@ -356,7 +356,7 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
 
         midmeas_dd = pm.run(self.midmeas)
 
-        combined_u = UGate(0, pi / 2, -pi / 2)
+        combined_u = UGate(0, -pi / 2, pi / 2)
 
         expected = QuantumCircuit(3, 1)
         expected.cx(0, 1)
@@ -371,7 +371,7 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.cx(1, 2)
         expected.cx(0, 1)
         expected.delay(700, 2)
-        expected.global_phase = 4.71238898038469
+        expected.global_phase = pi / 2
 
         self.assertEqual(midmeas_dd, expected)
         # check the absorption into U was done correctly


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the det() function used for computing the determinant of the unitary used as part of the calculation of one and two qubit unitary deocmposers. It is now using the numpy linalg module's det() function. Previously it was using the function from scipy which required a runtime import and also marginally slower under cProfile (which might be a red herring because of profiler overhead as scipy has more python space calls). This also standardizes the det() call usage in the module as other places were already using the numpy version of the function.

### Details and comments