### PR TITLE
Add user config option to control default reverse_bits value in circuit_drawer

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1804,7 +1804,9 @@ class QuantumCircuit:
                 `latex_source` output type this has no effect and will be silently
                 ignored. Defaults to False.
             reverse_bits (bool): when set to True, reverse the bit order inside
-                registers for the output visualization. Defaults to False.
+                registers for the output visualization. Defaults to False unless the 
+                user config file (usually ``~/.qiskit/settings.conf``) has an 
+                alternative value set. For example, ``circuit_reverse_bits = False``.
             plot_barriers (bool): enable/disable drawing barriers in the output
                 circuit. Defaults to True.
             justify (string): options are ``left``, ``right`` or ``none``. If

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1804,8 +1804,8 @@ class QuantumCircuit:
                 `latex_source` output type this has no effect and will be silently
                 ignored. Defaults to False.
             reverse_bits (bool): when set to True, reverse the bit order inside
-                registers for the output visualization. Defaults to False unless the 
-                user config file (usually ``~/.qiskit/settings.conf``) has an 
+                registers for the output visualization. Defaults to False unless the
+                user config file (usually ``~/.qiskit/settings.conf``) has an
                 alternative value set. For example, ``circuit_reverse_bits = False``.
             plot_barriers (bool): enable/disable drawing barriers in the output
                 circuit. Defaults to True.

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1743,7 +1743,7 @@ class QuantumCircuit:
         style: Optional[Union[dict, str]] = None,
         interactive: bool = False,
         plot_barriers: bool = True,
-        reverse_bits: bool = False,
+        reverse_bits: bool = None,
         justify: Optional[str] = None,
         vertical_compression: Optional[str] = "medium",
         idle_wires: bool = True,

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -69,16 +69,19 @@ class UserConfig:
                 self.settings["circuit_drawer"] = circuit_drawer
 
             # Parse circuit_drawer_reverse_bits
-            circuit_reverse_bits = self.config_parser.get("default", "circuit_reverse_bits", fallback=None)
+            circuit_reverse_bits = self.config_parser.get(
+                "default", "circuit_reverse_bits", fallback=None
+            )
             if circuit_reverse_bits:
                 circuit_reverse_bits = circuit_reverse_bits.capitalize()
-                valid_circuit_reverse_bits = {
-                    "True": True,
-                    "False": False
-                }
+                valid_circuit_reverse_bits = {"True": True, "False": False}
                 if circuit_reverse_bits not in valid_circuit_reverse_bits:
-                    raise exceptions.QiskitUserConfigError("%s must be True or False." % circuit_reverse_bits)
-                self.settings["circuit_reverse_bits"] = valid_circuit_reverse_bits[circuit_reverse_bits]
+                    raise exceptions.QiskitUserConfigError(
+                        "%s must be True or False." % circuit_reverse_bits
+                    )
+                self.settings["circuit_reverse_bits"] = valid_circuit_reverse_bits[
+                    circuit_reverse_bits
+                ]
 
             # Parse state_drawer
             state_drawer = self.config_parser.get("default", "state_drawer", fallback=None)

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -30,6 +30,7 @@ class UserConfig:
     circuit_drawer = mpl
     circuit_mpl_style = default
     circuit_mpl_style_path = ~/.qiskit:<default location>
+    circuit_reverse_bits = True
     transpile_optimization_level = 1
     parallel = False
     num_processes = 4
@@ -66,6 +67,18 @@ class UserConfig:
                         "'auto'." % circuit_drawer
                     )
                 self.settings["circuit_drawer"] = circuit_drawer
+
+            # Parse circuit_drawer_reverse_bits
+            circuit_reverse_bits = self.config_parser.get("default", "circuit_reverse_bits", fallback=None)
+            if circuit_reverse_bits:
+                circuit_reverse_bits = circuit_reverse_bits.capitalize()
+                valid_circuit_reverse_bits = {
+                    "True": True,
+                    "False": False
+                }
+                if circuit_reverse_bits not in valid_circuit_reverse_bits:
+                    raise exceptions.QiskitUserConfigError("%s must be True or False." % circuit_reverse_bits)
+                self.settings["circuit_reverse_bits"] = valid_circuit_reverse_bits[circuit_reverse_bits]
 
             # Parse state_drawer
             state_drawer = self.config_parser.get("default", "state_drawer", fallback=None)

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -68,7 +68,7 @@ class UserConfig:
                     )
                 self.settings["circuit_drawer"] = circuit_drawer
 
-            # Parse circuit_drawer_reverse_bits
+            # Parse circuit_reverse_bits
             circuit_reverse_bits = self.config_parser.get(
                 "default", "circuit_reverse_bits", fallback=None
             )
@@ -193,6 +193,7 @@ def set_config(key, value, section=None, file_path=None):
         "circuit_drawer",
         "circuit_mpl_style",
         "circuit_mpl_style_path",
+        "circuit_reverse_bits",
         "transpile_optimization_level",
         "parallel",
         "num_processes",

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -77,7 +77,8 @@ class UserConfig:
                 valid_circuit_reverse_bits = {"True": True, "False": False}
                 if circuit_reverse_bits not in valid_circuit_reverse_bits:
                     raise exceptions.QiskitUserConfigError(
-                        "%s must be True or False." % circuit_reverse_bits
+                        "%s is not a valid value for circuit_reverse_bits. Must be True or False."
+                        % circuit_reverse_bits
                     )
                 self.settings["circuit_reverse_bits"] = valid_circuit_reverse_bits[
                     circuit_reverse_bits

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -51,7 +51,7 @@ def circuit_drawer(
     output=None,
     interactive=False,
     plot_barriers=True,
-    reverse_bits=False,
+    reverse_bits=None,
     justify=None,
     vertical_compression="medium",
     idle_wires=True,
@@ -180,8 +180,10 @@ def circuit_drawer(
     config = user_config.get_config()
     # Get default from config file else use text
     default_output = "text"
+    default_reverse_bits = False
     if config:
         default_output = config.get("circuit_drawer", "text")
+        default_reverse_bits = config.get("circuit_reverse_bits", False)
         if default_output == "auto":
             if _optionals.HAS_MATPLOTLIB:
                 default_output = "mpl"
@@ -189,6 +191,9 @@ def circuit_drawer(
                 default_output = "text"
     if output is None:
         output = default_output
+
+    if reverse_bits is None:
+        reverse_bits = default_reverse_bits
 
     if wire_order is not None and reverse_bits:
         raise VisualizationError(

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -111,8 +111,8 @@ def circuit_drawer(
             `latex_source` output type this has no effect and will be silently
             ignored. Defaults to False.
         reverse_bits (bool): when set to True, reverse the bit order inside
-            registers for the output visualization. Defaults to False unless the 
-            user config file (usually ``~/.qiskit/settings.conf``) has an 
+            registers for the output visualization. Defaults to False unless the
+            user config file (usually ``~/.qiskit/settings.conf``) has an
             alternative value set. For example, ``circuit_reverse_bits = False``.
         plot_barriers (bool): enable/disable drawing barriers in the output
             circuit. Defaults to True.

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -111,7 +111,9 @@ def circuit_drawer(
             `latex_source` output type this has no effect and will be silently
             ignored. Defaults to False.
         reverse_bits (bool): when set to True, reverse the bit order inside
-            registers for the output visualization. Defaults to False.
+            registers for the output visualization. Defaults to False unless the 
+            user config file (usually ``~/.qiskit/settings.conf``) has an 
+            alternative value set. For example, ``circuit_reverse_bits = False``.
         plot_barriers (bool): enable/disable drawing barriers in the output
             circuit. Defaults to True.
         justify (string): options are ``left``, ``right`` or ``none``. If

--- a/releasenotes/notes/add-reverse-bits-to-user-config-options-063a4491bc90d353.yaml
+++ b/releasenotes/notes/add-reverse-bits-to-user-config-options-063a4491bc90d353.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    The user_config file has a new configuration option, 
+    ``circuit_reverse_bits``. This allows users to set the local behavior of 
+    the `reverse_bits` option of the ``circuitdrawer`` to default to ``True``. 
+    For example, the format of the config file ``settings.conf`` should be:
+
+      .. code-block:: text
+
+      [default]
+      circuit_drawer = mpl
+      circuit_mpl_style = default
+      circuit_reverse_bits = True

--- a/test/python/test_user_config.py
+++ b/test/python/test_user_config.py
@@ -69,6 +69,31 @@ class TestUserConfig(QiskitTestCase):
             config.read_config_file()
             self.assertEqual({"circuit_drawer": "latex"}, config.settings)
 
+    def test_invalid_circuit_reverse_bits(self):
+        test_config = """
+        [default]
+        circuit_reverse_bits = Neither
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, "w") as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            self.assertRaises(exceptions.QiskitUserConfigError, config.read_config_file)
+
+    def test_circuit_reverse_bits_valid(self):
+        test_config = """
+        [default]
+        circuit_reverse_bits = false
+        """
+        self.addCleanup(os.remove, self.file_path)
+        with open(self.file_path, "w") as file:
+            file.write(test_config)
+            file.flush()
+            config = user_config.UserConfig(self.file_path)
+            config.read_config_file()
+            self.assertEqual({"circuit_reverse_bits": False}, config.settings)
+
     def test_optimization_level_valid(self):
         test_config = """
         [default]
@@ -126,6 +151,7 @@ class TestUserConfig(QiskitTestCase):
         circuit_drawer = latex
         circuit_mpl_style = default
         circuit_mpl_style_path = ~:~/.qiskit
+        circuit_reverse_bits = false
         transpile_optimization_level = 3
         suppress_packaging_warnings = true
         parallel = false
@@ -143,6 +169,7 @@ class TestUserConfig(QiskitTestCase):
                 "circuit_drawer": "latex",
                 "circuit_mpl_style": "default",
                 "circuit_mpl_style_path": ["~", "~/.qiskit"],
+                "circuit_reverse_bits": False,
                 "transpile_optimization_level": 3,
                 "num_processes": 15,
                 "parallel_enabled": False,
@@ -156,6 +183,7 @@ class TestUserConfig(QiskitTestCase):
         user_config.set_config("circuit_drawer", "latex", file_path=self.file_path)
         user_config.set_config("circuit_mpl_style", "default", file_path=self.file_path)
         user_config.set_config("circuit_mpl_style_path", "~:~/.qiskit", file_path=self.file_path)
+        user_config.set_config("circuit_reverse_bits", "false", file_path=self.file_path)
         user_config.set_config("transpile_optimization_level", "3", file_path=self.file_path)
         user_config.set_config("parallel", "false", file_path=self.file_path)
         user_config.set_config("num_processes", "15", file_path=self.file_path)
@@ -169,6 +197,7 @@ class TestUserConfig(QiskitTestCase):
                 "circuit_drawer": "latex",
                 "circuit_mpl_style": "default",
                 "circuit_mpl_style_path": ["~", "~/.qiskit"],
+                "circuit_reverse_bits": False,
                 "transpile_optimization_level": 3,
                 "num_processes": 15,
                 "parallel_enabled": False,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Fixes #9150. 

### Details and comments
This PR adds the option `circuit_reverse_bits` to the user config file to modify the default behavior of the `reverse_bits` option in the `circuit_drawer`. For example, the following configuration in the `settings.conf` file:
```text
[default]
circuit_drawer = mpl
state_drawer = latex
circuit_reverse_bits = True
```
the circuit drawer will display a circuit with the most significant bit at the top without explicitly passing the `reverse_bits=True` option to the `draw()` method:
``` python
from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
n = 4
qr = QuantumRegister(n, name='q')
cr = ClassicalRegister(n, name='c')
qc = QuantumCircuit(qr,cr)
qc.h(range(n))
for i in range(n-1,0,-1):
    qc.cx(i,i-1)
qc.barrier()
qc.measure(qr,cr)
qc.draw()
```
<img width="513" alt="image" src="https://user-images.githubusercontent.com/65074936/203426621-44eff852-bae4-4349-9be2-b78f73e88783.png">
