### PR TITLE
Fix pickle of Rust `ErrorMap` struct

### DIFF
--- a/src/error_map.rs
+++ b/src/error_map.rs
@@ -73,7 +73,10 @@ impl ErrorMap {
     // float]`, where `list[int]` is unhashable in Python.
 
     fn __getstate__(&self) -> HashMap<(usize, usize), f64> {
-        self.error_map.iter().map(|([a, b], value)| ((*a, *b), *value)).collect()
+        self.error_map
+            .iter()
+            .map(|([a, b], value)| ((*a, *b), *value))
+            .collect()
     }
 
     fn __setstate__(&mut self, state: HashMap<[usize; 2], f64>) {

--- a/src/error_map.rs
+++ b/src/error_map.rs
@@ -68,8 +68,12 @@ impl ErrorMap {
         self.error_map.insert(index, error_rate);
     }
 
-    fn __getstate__(&self) -> HashMap<[usize; 2], f64> {
-        self.error_map.clone()
+    // The pickle protocol methods can't return `HashMap<[usize; 2], f64>` to Python, because by
+    // PyO3's natural conversion as of 0.17.3 it will attempt to construct a `dict[list[int],
+    // float]`, where `list[int]` is unhashable in Python.
+
+    fn __getstate__(&self) -> HashMap<(usize, usize), f64> {
+        self.error_map.iter().map(|([a, b], value)| ((*a, *b), *value)).collect()
     }
 
     fn __setstate__(&mut self, state: HashMap<[usize; 2], f64>) {

--- a/test/python/transpiler/test_vf2_layout.py
+++ b/test/python/transpiler/test_vf2_layout.py
@@ -12,6 +12,8 @@
 
 """Test the VF2Layout pass"""
 
+import io
+import pickle
 import unittest
 from math import pi
 
@@ -451,6 +453,17 @@ class TestVF2LayoutBackend(LayoutTestCase):
         # Assert layout is different from backend properties
         self.assertNotEqual(property_set["layout"], pm.property_set["layout"])
         self.assertLayout(circuit_to_dag(circuit), backend.coupling_map, pm.property_set)
+
+    def test_error_map_pickle(self):
+        """Test that the `ErrorMap` Rust structure correctly pickles and depickles."""
+        errors = {(0, 1): 0.2, (1, 0): 0.2, (0, 0): 0.05, (1, 1): 0.02}
+        error_map = ErrorMap.from_dict(errors)
+        with io.BytesIO() as fptr:
+            pickle.dump(error_map, fptr)
+            fptr.seek(0)
+            loaded = pickle.load(fptr)
+        self.assertEqual(len(loaded), len(errors))
+        self.assertEqual({k: loaded[k] for k in errors}, errors)
 
     def test_perfect_fit_Manhattan(self):
         """A circuit that fits perfectly in Manhattan (65 qubits)


### PR DESCRIPTION
### Summary

The pickle method previously attempt to expose the natural type of the state of the `ErrorMap` struct to Python to handle the pickling, which is `HashMap<[usize; 2], f64>`.  Unfortunately, PyO3 has a recursive `ToPyObject` conversion for `HashMap`, which causes the `[usize; 2]` to be converted to `list[int]`, which is unhashable, causing a panic. There are sufficient traits for conversion from Python to Rust that we can _accept_ the natural type, but for Rust to Python, we have to manually convert.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

No reno bugfix because the feature hasn't been released, but it's a logical bugfix for the developer track, hence the label.

Fix #9199.
