### PR TITLE
Add mid-circuit measurement before conditional operation in `random_circuit`

### DIFF
--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -143,7 +143,7 @@ def random_circuit(
     qubits = np.array(qc.qubits, dtype=object, copy=True)
 
     # Apply arbitrary random operations in layers across all qubits.
-    for _ in range(depth):
+    for layer_number in range(depth):
         # We generate all the randomness for the layer in one go, to avoid many separate calls to
         # the randomisation routines, which can be fairly slow.
 
@@ -174,7 +174,7 @@ def random_circuit(
         # We've now generated everything we're going to need.  Now just to add everything.  The
         # conditional check is outside the two loops to make the more common case of no conditionals
         # faster, since in Python we don't have a compiler to do this for us.
-        if conditional:
+        if conditional and layer_number != 0:
             is_conditional = rng.random(size=len(gate_specs)) < 0.1
             condition_values = rng.integers(
                 0, 1 << min(num_qubits, 63), size=np.count_nonzero(is_conditional)
@@ -190,6 +190,7 @@ def random_circuit(
             ):
                 operation = gate(*parameters[p_start:p_end])
                 if is_cond:
+                    qc.measure(qc.qubits, cr)
                     operation.condition = (cr, condition_values[c_ptr])
                     c_ptr += 1
                 qc._append(CircuitInstruction(operation=operation, qubits=qubits[q_start:q_end]))

--- a/releasenotes/notes/fix_9016-2e8bc2cb10b5e204.yaml
+++ b/releasenotes/notes/fix_9016-2e8bc2cb10b5e204.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    When the parameter ``conditional=True`` is set in 
+    ``qiskit.circuit.random.random_circuit`` the conditional operations will
+    be preceded by a full mid-circuit measurment.
+    Fixes `#9016 <https://github.com/Qiskit/qiskit-terra/issues/9016>`__

--- a/test/python/circuit/test_random_circuit.py
+++ b/test/python/circuit/test_random_circuit.py
@@ -63,3 +63,17 @@ class TestCircuitRandom(QiskitTestCase):
         conditions = (getattr(instruction.operation, "condition", None) for instruction in circ)
         conditions = [x for x in conditions if x is not None]
         self.assertNotEqual(conditions, [])
+
+    def test_random_mid_circuit_measure_conditional(self):
+        """Test random circuit with mid-circuit measurements for conditionals."""
+        num_qubits = depth = 2
+        circ = random_circuit(num_qubits, depth, conditional=True, seed=4)
+        self.assertEqual(circ.width(), 2 * num_qubits)
+        op_names = [instruction.operation.name for instruction in circ]
+        # Before a condition, there needs to be measurement in all the qubits.
+        self.assertEqual(4, len(op_names))
+        self.assertEqual(["measure"] * num_qubits, op_names[1 : 1 + num_qubits])
+        conditions = [
+            bool(getattr(instruction.operation, "condition", None)) for instruction in circ
+        ]
+        self.assertEqual([False, False, False, True], conditions)


### PR DESCRIPTION
Fixes #9016

This PR add a mid-circuit measurement of all the qubits before a conditional operation in  `random_circuit`. Additionally, skips the possibility of conditional operations in the first layer, since that will implied a measure before any other operation.