### PR TITLE
Deprecate old path to QPY

### DIFF
--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -10,18 +10,17 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-# pylint: disable=wrong-import-position, unused-import
-
 """Alias for Qiskit QPY import."""
 
-# TODO deprecate this in 0.21.0
-from qiskit.qpy import dump, load
 
-# For backward compatibility. Provide, Runtime, Experiment call these private functions.
-from qiskit.qpy import (
-    _write_instruction,
-    _read_instruction,
-    _write_parameter_expression,
-    _read_parameter_expression,
-    _read_parameter_expression_v3,
-)
+def __getattr__(name):
+    import warnings
+    from qiskit import qpy
+
+    warnings.warn(
+        f"Module '{__name__}' is deprecated since Qiskit Terra 0.23,"
+        " and will be removed in a future release. Please import from 'qiskit.qpy' instead.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    return getattr(qpy, name)

--- a/qiskit/circuit/qpy_serialization.py
+++ b/qiskit/circuit/qpy_serialization.py
@@ -17,10 +17,12 @@ def __getattr__(name):
     import warnings
     from qiskit import qpy
 
-    warnings.warn(
-        f"Module '{__name__}' is deprecated since Qiskit Terra 0.23,"
-        " and will be removed in a future release. Please import from 'qiskit.qpy' instead.",
-        category=DeprecationWarning,
-        stacklevel=2,
-    )
+    # Skip warning on special Python dunders, which Python occasionally queries on its own accord.
+    if f"__{name[2:-2]}__" != name:
+        warnings.warn(
+            f"Module '{__name__}' is deprecated since Qiskit Terra 0.23,"
+            " and will be removed in a future release. Please import from 'qiskit.qpy' instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
     return getattr(qpy, name)

--- a/releasenotes/notes/deprecate-old-qpy-d39c754d82655400.yaml
+++ b/releasenotes/notes/deprecate-old-qpy-d39c754d82655400.yaml
@@ -1,0 +1,6 @@
+---
+deprecations:
+  - |
+    The import ``qiskit.circuit.qpy_serialization`` is deprecated, as QPY has been promoted to the
+    top level.  You should import the same objects from :mod:`qiskit.qpy` instead.  The old path
+    will be removed in a future of Qiskit Terra.

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1169,5 +1169,5 @@ class TestLoadFromQPY(QiskitTestCase):
     def test_qpy_deprecation(self):
         """Test the old import path's deprecations fire."""
         with self.assertWarnsRegex(DeprecationWarning, "is deprecated"):
-            # pylint: disable=no-name-in-module, unused-import, redefined-outer-name
+            # pylint: disable=no-name-in-module, unused-import, redefined-outer-name, reimported
             from qiskit.circuit.qpy_serialization import dump, load

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -1167,5 +1167,7 @@ class TestLoadFromQPY(QiskitTestCase):
         self.assertEqual(qc.cregs, new_circuit.cregs)
 
     def test_qpy_deprecation(self):
+        """Test the old import path's deprecations fire."""
         with self.assertWarnsRegex(DeprecationWarning, "is deprecated"):
+            # pylint: disable=no-name-in-module, unused-import, redefined-outer-name
             from qiskit.circuit.qpy_serialization import dump, load

--- a/test/python/circuit/test_circuit_load_from_qpy.py
+++ b/test/python/circuit/test_circuit_load_from_qpy.py
@@ -32,7 +32,7 @@ from qiskit.synthesis import LieTrotter, SuzukiTrotter
 from qiskit.extensions import UnitaryGate
 from qiskit.opflow import I, X, Y, Z
 from qiskit.test import QiskitTestCase
-from qiskit.circuit.qpy_serialization import dump, load
+from qiskit.qpy import dump, load
 from qiskit.quantum_info.random import random_unitary
 from qiskit.circuit.controlledgate import ControlledGate
 
@@ -1165,3 +1165,7 @@ class TestLoadFromQPY(QiskitTestCase):
         self.assertEqual(qc, new_circuit)
         self.assertEqual(qc.qregs, new_circuit.qregs)
         self.assertEqual(qc.cregs, new_circuit.cregs)
+
+    def test_qpy_deprecation(self):
+        with self.assertWarnsRegex(DeprecationWarning, "is deprecated"):
+            from qiskit.circuit.qpy_serialization import dump, load

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -25,11 +25,15 @@ from qiskit.circuit.classicalregister import Clbit
 from qiskit.circuit.quantumregister import Qubit
 from qiskit.circuit.parameter import Parameter
 from qiskit.circuit.parametervector import ParameterVector
-from qiskit.circuit.qpy_serialization import dump, load
 from qiskit.opflow import X, Y, Z, I
 from qiskit.quantum_info.random import random_unitary
 from qiskit.circuit.library import U1Gate, U2Gate, U3Gate, QFT, DCXGate
 from qiskit.circuit.gate import Gate
+
+try:
+    from qiskit.qpy import dump, load
+except ModuleNotFoundError:
+    from qiskit.circuit.qpy_serialization import dump, load
 
 
 # This version pattern is taken from the pypa packaging project:


### PR DESCRIPTION
### Summary

This includes a try/except for the old name in the backwards compatibility tests because we still need that test file to succeed against old versions of Terra to generate the old files.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


