### PR TITLE
Performance improvement of `_DiagonalEstimator`

### DIFF
--- a/releasenotes/notes/fix-sampling-vqe-performance-b5bfe92c2d3e10ab.yaml
+++ b/releasenotes/notes/fix-sampling-vqe-performance-b5bfe92c2d3e10ab.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a performance bug that :class:`.SamplingVQE` evaluated the energies of eigenstates
+    in a slow way.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

I notice that `SamplingVQE` is slower than the former `VQE` when I update a tutorial of Qiskit optimization.
The bottleneck is `_DiagonalEstimator._evaluate_sparsepuali`. See https://github.com/Qiskit/qiskit-optimization/pull/448#discussion_r1037868880 for details.
I optimized that part with numpy.


### Details and comments

microbenchmark
```python
from timeit import timeit
from qiskit.algorithms.minimum_eigensolvers.diagonal_estimator import _evaluate_sparsepauli
from qiskit.quantum_info import SparsePauliOp
from qiskit.quantum_info.random import random_pauli_list

seed = 123
n = 100
m = 100

op = SparsePauliOp(random_pauli_list(num_qubits=n, size=m, seed=seed))

print(_evaluate_sparsepauli(2<<n-1, op))
print(f'{timeit(lambda: _evaluate_sparsepauli(2<<n-1, op), number=100)} sec')
```

main
```
(-2+4j)
0.5635605140000001 sec
```

this PR
```
(-2+4j)
0.0018880719999999629 sec
```

benchmark with QAOA
```python
from qiskit_optimization.algorithms import MinimumEigenOptimizer
from qiskit.utils import algorithm_globals
from qiskit.algorithms.minimum_eigensolvers import QAOA
from qiskit.algorithms.optimizers import COBYLA
from qiskit.primitives import Sampler
from qiskit_optimization.applications import Knapsack

algorithm_globals.random_seed = 123

prob = Knapsack(values=[3, 4, 5, 6, 7], weights=[2, 3, 4, 5, 6], max_weight=10)
qp = prob.to_quadratic_program()

# QAOA
meo = MinimumEigenOptimizer(min_eigen_solver=QAOA(reps=1, sampler=Sampler(), optimizer=COBYLA(maxiter=100)))
result = meo.solve(qp)
print(result.prettyprint())
print("\nsolution:", prob.interpret(result))
print("\ntime:", result.min_eigen_solver_result.optimizer_time)
```

main
```
objective function value: 13.0
variable values: x_0=1.0, x_1=1.0, x_2=0.0, x_3=1.0, x_4=0.0
status: SUCCESS

solution: [0, 1, 3]

time: 13.972561120986938
```

this PR
```
objective function value: 13.0
variable values: x_0=1.0, x_1=1.0, x_2=0.0, x_3=1.0, x_4=0.0
status: SUCCESS

solution: [0, 1, 3]

time: 0.8536498546600342
```