### PR TITLE
Fix the random seed for `TestSamplerVQE`

### DIFF
--- a/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
@@ -14,22 +14,23 @@
 
 
 import unittest
+from functools import partial
 from test.python.algorithms import QiskitAlgorithmsTestCase
 
-from functools import partial
-from ddt import data, ddt
 import numpy as np
+from ddt import data, ddt
 from scipy.optimize import minimize as scipy_minimize
 
-from qiskit.circuit import QuantumCircuit, ParameterVector
 from qiskit.algorithms import AlgorithmError
 from qiskit.algorithms.minimum_eigensolvers import SamplingVQE
-from qiskit.algorithms.optimizers import L_BFGS_B, QNSPSA, OptimizerResult, SLSQP
+from qiskit.algorithms.optimizers import L_BFGS_B, QNSPSA, SLSQP, OptimizerResult
+from qiskit.algorithms.state_fidelities import ComputeUncompute
+from qiskit.circuit import ParameterVector, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, TwoLocal
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import SparsePauliOp, Pauli, Operator
 from qiskit.primitives import Sampler
-from qiskit.algorithms.state_fidelities import ComputeUncompute
+from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
+from qiskit.utils import algorithm_globals
 
 
 # pylint: disable=invalid-name, unused-argument
@@ -60,6 +61,7 @@ class TestSamplerVQE(QiskitAlgorithmsTestCase):
         super().setUp()
         self.optimal_value = -1.38
         self.optimal_bitstring = "10"
+        algorithm_globals.random_seed = 42
 
     @data(PAULI_OP, OP)
     def test_exact_sampler(self, op):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

I noticed `TestSamplerVQE` sometimes fails as follows. This PR fixes the random seed of the test.

```
======================================================================
FAIL: test_ansatz_resize_1 (test.python.algorithms.minimum_eigensolvers.test_sampling_vqe.TestSamplerVQE)
test.python.algorithms.minimum_eigensolvers.test_sampling_vqe.TestSamplerVQE.test_ansatz_resize_1
----------------------------------------------------------------------
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ddt.py", line 220, in wrapper
    return func(self, *args, **kwargs)
  File "/Users/ima/tasks/2_2022/qiskit/terra/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py", line 120, in test_ansatz_resize
    self.assertAlmostEqual(result.eigenvalue, self.optimal_value, places=5)
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/unittest/case.py", line 891, in assertAlmostEqual
    raise self.failureException(msg)
AssertionError: -0.37999997126373175 != -1.38 within 5 places (1.000000028736268 difference)
```

### Details and comments


