### PR TITLE
Fix a transpile issue of BackendSampler

### DIFF
--- a/qiskit/primitives/backend_sampler.py
+++ b/qiskit/primitives/backend_sampler.py
@@ -108,7 +108,9 @@ class BackendSampler(BaseSampler):
         """
         if self._skip_transpilation:
             self._transpiled_circuits = list(self._circuits)
-        elif self._transpiled_circuits is None:
+        elif self._transpiled_circuits is None or len(self._transpiled_circuits) != len(
+            self._circuits
+        ):
             # Only transpile if have not done so yet
             self._transpile()
         return self._transpiled_circuits

--- a/releasenotes/notes/fix-backend-sampler-890cbcf913667b08.yaml
+++ b/releasenotes/notes/fix-backend-sampler-890cbcf913667b08.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug of :class:`~.BackendSampler` that raises an error
+    if :meth:`~.BackendSampler.run` method is called two times sequentially.

--- a/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_sampling_vqe.py
@@ -14,22 +14,23 @@
 
 
 import unittest
+from functools import partial
 from test.python.algorithms import QiskitAlgorithmsTestCase
 
-from functools import partial
-from ddt import data, ddt
 import numpy as np
+from ddt import data, ddt
 from scipy.optimize import minimize as scipy_minimize
 
-from qiskit.circuit import QuantumCircuit, ParameterVector
 from qiskit.algorithms import AlgorithmError
 from qiskit.algorithms.minimum_eigensolvers import SamplingVQE
-from qiskit.algorithms.optimizers import L_BFGS_B, QNSPSA, OptimizerResult, SLSQP
+from qiskit.algorithms.optimizers import L_BFGS_B, QNSPSA, SLSQP, OptimizerResult
+from qiskit.algorithms.state_fidelities import ComputeUncompute
+from qiskit.circuit import ParameterVector, QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, TwoLocal
 from qiskit.opflow import PauliSumOp
-from qiskit.quantum_info import SparsePauliOp, Pauli, Operator
 from qiskit.primitives import Sampler
-from qiskit.algorithms.state_fidelities import ComputeUncompute
+from qiskit.quantum_info import Operator, Pauli, SparsePauliOp
+from qiskit.utils import algorithm_globals
 
 
 # pylint: disable=invalid-name, unused-argument
@@ -60,6 +61,7 @@ class TestSamplerVQE(QiskitAlgorithmsTestCase):
         super().setUp()
         self.optimal_value = -1.38
         self.optimal_bitstring = "10"
+        algorithm_globals.random_seed = 42
 
     @data(PAULI_OP, OP)
     def test_exact_sampler(self, op):

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -319,6 +319,19 @@ class TestBackendSampler(QiskitTestCase):
         self.assertDictAlmostEqual(result.quasi_dists[0], {0: 1}, 0.1)
         self.assertDictAlmostEqual(result.quasi_dists[1], {1: 1}, 0.1)
 
+    def test_sequential_run(self):
+        """Test sequential run."""
+        qc = QuantumCircuit(1)
+        qc.measure_all()
+        qc2 = QuantumCircuit(1)
+        qc2.x(0)
+        qc2.measure_all()
+        sampler = BackendSampler(backend=FakeNairobi())
+        result = sampler.run([qc]).result()
+        result2 = sampler.run([qc2]).result()
+        self.assertDictAlmostEqual(result.quasi_dists[0], {0: 1}, 0.1)
+        self.assertDictAlmostEqual(result2.quasi_dists[0], {1: 1}, 0.1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/primitives/test_backend_sampler.py
+++ b/test/python/primitives/test_backend_sampler.py
@@ -328,9 +328,12 @@ class TestBackendSampler(QiskitTestCase):
         qc2.measure_all()
         sampler = BackendSampler(backend=FakeNairobi())
         result = sampler.run([qc]).result()
-        result2 = sampler.run([qc2]).result()
         self.assertDictAlmostEqual(result.quasi_dists[0], {0: 1}, 0.1)
+        result2 = sampler.run([qc2]).result()
         self.assertDictAlmostEqual(result2.quasi_dists[0], {1: 1}, 0.1)
+        result3 = sampler.run([qc, qc2]).result()
+        self.assertDictAlmostEqual(result3.quasi_dists[0], {0: 1}, 0.1)
+        self.assertDictAlmostEqual(result3.quasi_dists[1], {1: 1}, 0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`BackendSampler` raises an error if two `run`s are called sequentially as follows. This PR fixes the issue.
This PR is straightforward. So, it might be better to skip circuits that are already transpiled.

```python
from qiskit import Aer, QuantumCircuit
from qiskit.primitives import BackendSampler

sampler = BackendSampler(Aer.get_backend('aer_simulator'))

qc1 = QuantumCircuit(1,1)
qc1.h(0)
qc1.measure(0, 0)
qc2 = QuantumCircuit(1,1)
qc2.x(0)
qc2.measure(0, 0)

print(sampler.run([qc1]).result())  # OK
print(sampler.run([qc2]).result())  # NG
```

output
```
SamplerResult(quasi_dists=[{1: 0.5078125, 0: 0.4921875}], metadata=[{'shots': 1024}])
Traceback (most recent call last):
  File "/home/ima/github/qiskit/terra/tmp/backendsampler.py", line 14, in <module>
    print(sampler.run([qc2]).result())
  File "/home/ima/github/qiskit/terra/qiskit/primitives/primitive_job.py", line 50, in result
    return self._future.result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 451, in result
    return self.__get_result()
  File "/usr/lib/python3.10/concurrent/futures/_base.py", line 403, in __get_result
    raise self._exception
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/ima/github/qiskit/terra/qiskit/primitives/backend_sampler.py", line 149, in _call
    bound_circuits = [
  File "/home/ima/github/qiskit/terra/qiskit/primitives/backend_sampler.py", line 150, in <listcomp>
    transpiled_circuits[i]
IndexError: list index out of range
```


### Details and comments


