### PR TITLE
Handle `Initialize` on subsystem in `Statevector`

### DIFF
--- a/qiskit/quantum_info/states/statevector.py
+++ b/qiskit/quantum_info/states/statevector.py
@@ -862,7 +862,7 @@ class Statevector(QuantumState, TolerancesMixin):
             return statevec
         if isinstance(obj, Barrier):
             return statevec
-        if isinstance(obj, Initialize) and qargs is None:
+        if isinstance(obj, Initialize):
             # state is initialized to labels in the initialize object
             if all(isinstance(param, str) for param in obj.params):
                 initialization = Statevector.from_label("".join(obj.params))._data

--- a/test/python/quantum_info/states/test_statevector.py
+++ b/test/python/quantum_info/states/test_statevector.py
@@ -166,9 +166,9 @@ class TestStatevector(QiskitTestCase):
         psi = Statevector.from_instruction(circuit)
         self.assertEqual(psi, target)
 
-        target = Statevector([1, 1, 1, 1]) / 2
+        target = Statevector([1, 0, 1, 0]) / np.sqrt(2)
         circuit = QuantumCircuit(2)
-        circuit.initialize("++", [0, 1])
+        circuit.initialize("+", [1])
         psi = Statevector.from_instruction(circuit)
         self.assertEqual(psi, target)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a follow up to #8807 which provided a significant speedup if `Statevector` handled `Initialize` instructions -- however this PR didn't correctly account for initializations on a subpart of the qubits and returned a shrunken statevector! This PR fixes this and adds a test. 

### Details and comments

This causes a Qiskit ML tutorial to fail, thanks @manoelmarques for finding it! Also, since #8807 is not yet released, no reno is included (and no backport required 🙂).



