### PR TITLE
Fix `LinCombSamplerGradient` to leverage `AerSampler`

### DIFF
--- a/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py
+++ b/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py
@@ -114,8 +114,10 @@ class LinCombSamplerGradient(BaseSamplerGradient):
             n = 2 ** circuits[i].num_qubits
             grad_dists = np.zeros((len(metadata_[i]["parameters"]), n))
             for idx, coeff, dist in zip(result_indices_all[i], coeffs_all[i], result.quasi_dists):
-                grad_dists[idx][list(dist.keys())[:n]] += np.array(list(dist.values())[:n]) * coeff
-                grad_dists[idx][list(dist.keys())[:n]] -= np.array(list(dist.values())[n:]) * coeff
+                plus = {key: val for key, val in dist.items() if key < n}
+                minus = {key - n: val for key, val in dist.items() if key >= n}
+                grad_dists[idx][list(plus.keys())] += np.fromiter(plus.values(), dtype=float) * coeff
+                grad_dists[idx][list(minus.keys())] -= np.fromiter(minus.values(), dtype=float) * coeff
 
             gradient_ = []
             for grad_dist in grad_dists:

--- a/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py
+++ b/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py
@@ -116,8 +116,12 @@ class LinCombSamplerGradient(BaseSamplerGradient):
             for idx, coeff, dist in zip(result_indices_all[i], coeffs_all[i], result.quasi_dists):
                 plus = {key: val for key, val in dist.items() if key < n}
                 minus = {key - n: val for key, val in dist.items() if key >= n}
-                grad_dists[idx][list(plus.keys())] += np.fromiter(plus.values(), dtype=float) * coeff
-                grad_dists[idx][list(minus.keys())] -= np.fromiter(minus.values(), dtype=float) * coeff
+                grad_dists[idx][list(plus.keys())] += (
+                    np.fromiter(plus.values(), dtype=float) * coeff
+                )
+                grad_dists[idx][list(minus.keys())] -= (
+                    np.fromiter(minus.values(), dtype=float) * coeff
+                )
 
             gradient_ = []
             for grad_dist in grad_dists:

--- a/qiskit/algorithms/gradients/utils.py
+++ b/qiskit/algorithms/gradients/utils.py
@@ -318,10 +318,10 @@ def _make_lin_comb_gradient_circuit(
     ]
 
     circuit2 = transpile(circuit, basis_gates=supported_gates, optimization_level=0)
-    qr_aux = QuantumRegister(1, "aux")
-    cr_aux = ClassicalRegister(1, "aux")
+    qr_aux = QuantumRegister(1, "qr_aux")
+    cr_aux = ClassicalRegister(1, "cr_aux")
     circuit2.add_register(qr_aux)
-    circuit2.add_bits(cr_aux)
+    circuit2.add_register(cr_aux)
     circuit2.h(qr_aux)
     circuit2.data.insert(0, circuit2.data.pop())
     circuit2.sdg(qr_aux)

--- a/releasenotes/notes/fix-libcomb-sampler-gradient-d759d6b0e2659abe.yaml
+++ b/releasenotes/notes/fix-libcomb-sampler-gradient-d759d6b0e2659abe.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an issue of :class:`~.LinCombSamplerGradient` that raises an error
+    with Aer Sampler.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`LinCombSamplerGradient` raises errors with `AerSampler`. This PR fixes the issue.
Note that `AerSampler` of 0.11.2 has an issue https://github.com/Qiskit/qiskit-aer/issues/1679. Need to run the following script with Aer 0.11.1.

```python
from qiskit import QuantumCircuit, BasicAer
from qiskit.circuit import Parameter
from qiskit.primitives import Sampler, BackendSampler
from qiskit_aer.primitives import Sampler as AerSampler
from qiskit.algorithms.gradients import LinCombSamplerGradient

a = Parameter("a")
qc = QuantumCircuit(2)
qc.rxx(a, 0, 1)
qc.measure_all()
for sampler in [Sampler(), AerSampler()]:
    gradient = LinCombSamplerGradient(sampler)
    result = gradient.run([qc], [[1]], shots=1000).result()
    print(sampler)
    print(result)
```

main
```
<qiskit.primitives.sampler.Sampler object at 0x1139f06a0>
SamplerGradientResult(gradients=[[{0: -0.42000000000000004, 1: 0.0, 2: 0.0, 3: 0.42000000000000004}]], metadata=[{'parameters': [Parameter(a)]}], options=Options(shots=1000))
Simulation failed and returned the following error message:
ERROR: Failed to load qobj: Invalid Qobj experiment: not enough memory slots.
Traceback (most recent call last):
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/result/result.py", line 368, in _get_experiment
    exp = self.results[key]
IndexError: list index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py", line 108, in _run
    results = [job.result() for job in jobs]
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py", line 108, in <listcomp>
    results = [job.result() for job in jobs]
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/primitives/primitive_job.py", line 50, in result
    return self._future.result()
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit_aer/primitives/sampler.py", line 131, in _call
    counts = result.data(i)["counts"]
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/result/result.py", line 187, in data
    return self._get_experiment(experiment).data.to_dict()
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/result/result.py", line 370, in _get_experiment
    raise QiskitError(f'Result for experiment "{key}" could not be found.') from ex
qiskit.exceptions.QiskitError: 'Result for experiment "0" could not be found.'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/ima/tasks/2_2022/qiskit/terra/tmp/lin_comb_sampler.py", line 13, in <module>
    result = gradient.run([qc], [[1]], shots=1000).result()
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/primitives/primitive_job.py", line 50, in result
    return self._future.result()
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 439, in result
    return self.__get_result()
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/_base.py", line 391, in __get_result
    raise self._exception
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/qiskit/algorithms/gradients/lin_comb_sampler_gradient.py", line 110, in _run
    raise AlgorithmError("Sampler job failed.") from exc
qiskit.algorithms.exceptions.AlgorithmError: 'Sampler job failed.'
```

this PR
```
<qiskit.primitives.sampler.Sampler object at 0x111ee97f0>
SamplerGradientResult(gradients=[[{0: -0.429, 1: 0.0, 2: 0.0, 3: 0.42900000000000005}]], metadata=[{'parameters': [Parameter(a)]}], options=Options(shots=1000))
<qiskit_aer.primitives.sampler.Sampler object at 0x111ee9820>
SamplerGradientResult(gradients=[[{0: -0.395, 1: 0.0, 2: 0.0, 3: 0.44299999999999995}]], metadata=[{'parameters': [Parameter(a)]}], options=Options(shots=1000))
```

### Details and comments


