### PR TITLE
Update tox lint-incr job for tox 4.0.0 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,11 @@ commands =
 [testenv:lint]
 envdir = .tox/lint
 basepython = python3
+allowlist_externals =
+  {toxinidir}/tools/pylint_incr.py
+  {toxinidir}/tools/verify_headers.py
+  {toxinidir}/tools/find_optional_imports.py
+  {toxinidir}/tools/find_stray_release_notes.py
 commands =
   black --check {posargs} qiskit test tools examples setup.py
   pylint -rn qiskit test tools
@@ -38,7 +43,12 @@ commands =
 [testenv:lint-incr]
 envdir = .tox/lint
 basepython = python3
-allowlist_externals = git
+allowlist_externals =
+  git
+  {toxinidir}/tools/pylint_incr.py
+  {toxinidir}/tools/verify_headers.py
+  {toxinidir}/tools/find_optional_imports.py
+  {toxinidir}/tools/find_stray_release_notes.py
 commands =
   black --check {posargs} qiskit test tools examples setup.py
   -git fetch -q https://github.com/Qiskit/qiskit-terra.git :lint_incr_latest


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The recent release of tox 4.0.0 changed the behavior for running external commands. With tox 4.0.0 calling executable local in-repo python scripts directly without the pytho interpreter causes tox to emit an error about external commands not explicitly allowed being run. This is particularly problematic with the lint-incr and lint tox jobs both of which run small utility scripts to do checks on local files (like checking license headers or release notes are in the correct directory). To address this issue, this commit adds the scripts explicitly to the list of external commands for the 2 lint jobs. This change is backwards compatible with tox 3.x.x and should enable running lint jobs with either version of tox.

### Details and comments