### PR TITLE
Pin ipywidgets

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -6,3 +6,7 @@ jsonschema==3.2.0
 # a seaborn import. This pin can be removed when compatibility with those
 # packages is fixed
 jupyter-core==4.11.2
+
+# ipywidgets 8.0.3 started emitting deprecation warnings via a seaborn import.
+# This pin can be removed when compatibility with those packages is fixed.
+ipywidgets<8.0.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ hypothesis>=4.24.3
 python-constraint>=1.4
 ipython<7.22.0
 ipykernel<5.5.2
-ipywidgets>=7.3.0
+ipywidgets>=7.3.0,<8.0.3
 jupyter
 matplotlib>=3.3
 pillow>=4.2.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

ipywidgets 8.0.3 (released on Dec 7 [link](https://pypi.org/project/ipywidgets/8.0.3/#history)) raises a deprecation warning as follows.

```
======================================================================
ERROR: test_plot_error_map_over_100_qubit_backend_v2 (test.python.visualization.test_gate_map.TestGateMap)
test.python.visualization.test_gate_map.TestGateMap.test_plot_error_map_over_100_qubit_backend_v2
----------------------------------------------------------------------
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/Users/ima/tasks/2_2022/qiskit/terra/test/python/visualization/test_gate_map.py", line 151, in test_plot_error_map_over_100_qubit_backend_v2
    fig = plot_error_map(backend)
  File "/Users/ima/tasks/2_2022/qiskit/terra/qiskit/utils/lazy_tester.py", line 165, in out
    return function(*args, **kwargs)
  File "/Users/ima/tasks/2_2022/qiskit/terra/qiskit/utils/lazy_tester.py", line 164, in out
    self.require_now(feature)
  File "/Users/ima/tasks/2_2022/qiskit/terra/qiskit/utils/lazy_tester.py", line 221, in require_now
    if self:
  File "/Users/ima/tasks/2_2022/qiskit/terra/qiskit/utils/lazy_tester.py", line 114, in __bool__
    self._bool = self._is_available()
  File "/Users/ima/tasks/2_2022/qiskit/terra/qiskit/utils/lazy_tester.py", line 289, in _is_available
    imported = importlib.import_module(module)
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/seaborn/__init__.py", line 12, in <module>
    from .widgets import *  # noqa: F401,F403
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/seaborn/widgets.py", line 6, in <module>
    from ipywidgets import interact, FloatSlider, IntSlider
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/__init__.py", line 25, in <module>
    from .widgets import *
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/widgets/__init__.py", line 4, in <module>
    from .widget import Widget, CallbackDispatcher, register, widget_serialization
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/widgets/widget.py", line 300, in <module>
    class Widget(LoggingHasTraits):
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/traitlets/traitlets.py", line 972, in __init__
    cls.setup_class(classdict)
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/traitlets/traitlets.py", line 1009, in setup_class
    value = getattr(cls, name)
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/widgets/widget.py", line 296, in __get__
    return self.fget()
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/widgets/widget.py", line 324, in _active_widgets
    deprecation("Widget._active_widgets is deprecated.")
  File "/Users/ima/envs/dev39/lib/python3.9/site-packages/ipywidgets/widgets/utils.py", line 64, in deprecation
    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel+1)
DeprecationWarning: Widget._active_widgets is deprecated.
```


### Details and comments


