### PR TITLE
Optional `Sampler` for measuring final eigenstate in `VQE`

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
+++ b/qiskit/algorithms/minimum_eigensolvers/minimum_eigensolver.py
@@ -18,6 +18,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from qiskit.opflow import PauliSumOp
+from qiskit.result import QuasiDistribution
 from qiskit.quantum_info.operators.base_operator import BaseOperator
 
 from ..algorithm_result import AlgorithmResult
@@ -73,6 +74,7 @@ class MinimumEigensolverResult(AlgorithmResult):
     def __init__(self) -> None:
         super().__init__()
         self._eigenvalue = None
+        self._eigenstate = None
         self._aux_operators_evaluated = None
 
     @property
@@ -83,6 +85,17 @@ class MinimumEigensolverResult(AlgorithmResult):
     @eigenvalue.setter
     def eigenvalue(self, value: complex) -> None:
         self._eigenvalue = value
+
+    @property
+    def eigenstate(self) -> QuasiDistribution | None:
+        """Return the quasi-distribution sampled from the final state, if the
+        eigensolver support sampling.
+        """
+        return self._eigenstate
+
+    @eigenstate.setter
+    def eigenstate(self, value: QuasiDistribution | None) -> None:
+        self._eigenstate = value
 
     @property
     def aux_operators_evaluated(self) -> ListOrDict[tuple[complex, dict[str, Any]]] | None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Allow user to supply a `Sampler` for `VQE`, so that `VQE` can be used in `qiskit_optimization.algorithms.MinimumEigenOptimizer`.

### Details and comments

This reworks #9254 to extend the functionality of `VQE`, keeping `SamplingVQE` dedicated to diagonal Hamiltonians. This PR aims to allow an arbitrary Estimator to be used in the optimization process before obtaining a final eigenstate. For more detailed context see https://github.com/Qiskit/qiskit-terra/pull/9254#issuecomment-1343423892.

The design of the interface is still under discussion. I am also not sure how to incorporate the new changes in `QAOA`: should we have separate `QAOA` and `SamplingQAOA` implementation, or do we have a better strategy reducing the redundancy?

