### PR TITLE
Add reference circuits

### DIFF
--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -19,6 +19,18 @@ class ReferenceCircuits:
     """Container for reference circuits used by the tests."""
 
     @staticmethod
+    def flip():
+        """Return an inverted state."""
+        qr = QuantumRegister(1, name="qr")
+        cr = ClassicalRegister(1, name="qc")
+        qc = QuantumCircuit(qr, cr, name="flip")
+        qc.x(qr[0])
+        qc.measure(qr, cr)
+
+        return qc
+
+
+    @staticmethod
     def bell():
         """Return a Bell circuit."""
         qr = QuantumRegister(2, name="qr")

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -20,7 +20,7 @@ class ReferenceCircuits:
 
     @staticmethod
     def flip():
-        """Return an inverted state."""
+        """Return an inverter circuit."""
         qr = QuantumRegister(1, name="qr")
         cr = ClassicalRegister(1, name="qc")
         qc = QuantumCircuit(qr, cr, name="flip")
@@ -42,6 +42,7 @@ class ReferenceCircuits:
 
         return qc
 
+
     @staticmethod
     def bell_no_measure():
         """Return a Bell circuit."""
@@ -51,6 +52,7 @@ class ReferenceCircuits:
         qc.cx(qr[0], qr[1])
 
         return qc
+
 
     @staticmethod
     def toffoli_measure_one():

--- a/qiskit/test/reference_circuits.py
+++ b/qiskit/test/reference_circuits.py
@@ -51,3 +51,14 @@ class ReferenceCircuits:
         qc.cx(qr[0], qr[1])
 
         return qc
+
+    @staticmethod
+    def toffoli_measure_one():
+        """Return a Toffoli circuit."""
+        qr = QuantumRegister(3, name="qr")
+        cr = ClassicalRegister(1, name="qc")
+        qc = QuantumCircuit(qr, cr, name="toffoli_measure_one")
+        qc.ccx(qr[0], qr[1], qr[2])
+        qc.measure(qr[2], cr)
+
+        return qc


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Adds one and three qubit reference circuits for testing.


### Details and comments
Inverter circuit. Flips input qubit and measures the register.
Toffoli circuit: Applies a controlled-controlled-not to the target qubit and measures 
