### PR TITLE
[Test] Pin maximum python version in CI to <3.11.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ parameters:
   - name: "supportedPythonVersions"
     displayName: "All supported versions of Python"
     type: object
-    default: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    default: ["3.7", "3.8", "3.9", "3.10", "3.11.0"]
 
   - name: "minimumPythonVersion"
     displayName: "Minimum supported version of Python"
@@ -43,7 +43,7 @@ parameters:
   - name: "maximumPythonVersion"
     displayName: "Maximum supported version of Python"
     type: string
-    default: "3.11"
+    default: "3.11.0"
 
   - name: "minimumRustVersion"
     displayName: "Minimum supported version of Rust"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,8 @@ parameters:
   - name: "supportedPythonVersions"
     displayName: "All supported versions of Python"
     type: object
+    # TODO remove the explicit 3.11.0 pin and set it to 3.11. The pin is currently added
+    # since 3.11.1 breaks CI, see Qiskit/qiskit-terra#9291.
     default: ["3.7", "3.8", "3.9", "3.10", "3.11.0"]
 
   - name: "minimumPythonVersion"
@@ -109,7 +111,9 @@ stages:
 
           - template: ".azure/test-macos.yml"
             parameters:
-              pythonVersion: ${{ version }}
+              # TODO Manually setting this to exclude 3.11 completely, since 3.11.1 breaks
+              # (see Qiskit/qiskit-terra#9291) and 3.11.0 is not available on azure for MacOS.
+              pythonVersion: ["3.7", "3.8", "3.9", "3.10"]
 
           - template: ".azure/test-windows.yml"
             parameters:
@@ -181,7 +185,8 @@ stages:
 
         - template: ".azure/test-macos.yml"
           parameters:
-            pythonVersion: ${{ parameters.maximumPythonVersion }}
+            # TODO remove pin to 3.10 and reset to ${{ parameters.maximumPythonVersion }}
+            pythonVersion: "3.10"
 
         - template: ".azure/test-windows.yml"
           parameters:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The CI jobs on both Mac and Linux fail with Python 3.11.1, see also #9291. While this is not a fix, using Python 3.11.0 can unblock the CI until we track down the issue that seems to be coming from wrapping `TestClass`.

### Details and comments

Not actually sure if this works, so this PR tests the fix by triggering the CI.

