### PR TITLE
Fix NumPy 1.24.0 compatibility and pin `coverage<7.0`

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -10,3 +10,8 @@ jupyter-core==4.11.2
 # ipywidgets 8.0.3 started emitting deprecation warnings via a seaborn import.
 # This pin can be removed when compatibility with those packages is fixed.
 ipywidgets<8.0.3
+
+# coverage 7.0.0 breaks with Python 3.8.15 upon the import
+#   from coverage.files import FnmatchMatcher
+# since this is in Python 3.8 itself and not Qiskit, pinning this for now.
+coverage<7.0

--- a/qiskit/algorithms/optimizers/snobfit.py
+++ b/qiskit/algorithms/optimizers/snobfit.py
@@ -52,13 +52,14 @@ class SNOBFIT(Optimizer):
         Raises:
             MissingOptionalLibraryError: scikit-quant or SQSnobFit not installed
             QiskitError: If NumPy 1.24.0 or above is installed.
+                See https://github.com/scikit-quant/scikit-quant/issues/24 for more details.
         """
         # check version
         version = tuple(map(int, np.__version__.split(".")))
         if version >= (1, 24, 0):
             raise QiskitError(
                 "SnobFit is incompatible with NumPy 1.24.0 or above, please "
-                "install a previous version."
+                "install a previous version. See also scikit-quant/scikit-quant#24."
             )
 
         super().__init__()

--- a/qiskit/algorithms/optimizers/snobfit.py
+++ b/qiskit/algorithms/optimizers/snobfit.py
@@ -15,6 +15,7 @@
 from typing import Any, Dict, Optional, Callable, Tuple, List
 
 import numpy as np
+from qiskit.exceptions import QiskitError
 from qiskit.utils import optionals as _optionals
 from .optimizer import Optimizer, OptimizerSupportLevel, OptimizerResult, POINT
 
@@ -50,7 +51,16 @@ class SNOBFIT(Optimizer):
 
         Raises:
             MissingOptionalLibraryError: scikit-quant or SQSnobFit not installed
+            QiskitError: If NumPy 1.24.0 or above is installed.
         """
+        # check version
+        version = tuple(map(int, np.__version__.split(".")))
+        if version >= (1, 24, 0):
+            raise QiskitError(
+                "SnobFit is incompatible with NumPy 1.24.0 or above, please "
+                "install a previous version."
+            )
+
         super().__init__()
         self._maxiter = maxiter
         self._maxfail = maxfail

--- a/qiskit/circuit/instruction.py
+++ b/qiskit/circuit/instruction.py
@@ -131,11 +131,13 @@ class Instruction(Operation):
                 pass
 
             try:
-                if numpy.shape(self_param) == numpy.shape(other_param) and numpy.allclose(
+                self_asarray = numpy.asarray(self_param)
+                other_asarray = numpy.asarray(other_param)
+                if numpy.shape(self_asarray) == numpy.shape(other_asarray) and numpy.allclose(
                     self_param, other_param, atol=_CUTOFF_PRECISION, rtol=0
                 ):
                     continue
-            except TypeError:
+            except (ValueError, TypeError):
                 pass
 
             try:

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -89,7 +89,7 @@ class Kraus(QuantumChannel):
         if isinstance(data, (list, tuple, np.ndarray)):
             # Check if it is a single unitary matrix A for channel:
             # E(rho) = A * rho * A^\dagger
-            if isinstance(data, np.ndarray) or np.array(data).ndim == 2:
+            if _is_matrix(data):
                 # Convert single Kraus op to general Kraus pair
                 kraus = ([np.asarray(data, dtype=complex)], None)
                 shape = kraus[0][0].shape
@@ -318,6 +318,14 @@ class Kraus(QuantumChannel):
             kraus_r = [val * k for k in self._data[1]]
         ret._data = (kraus_l, kraus_r)
         return ret
+
+
+def _is_matrix(data):
+    # return True if data is a 2-d array/tuple/list
+    if not isinstance(data, np.ndarray):
+        data = np.array(data, dtype=object)
+
+    return data.ndim == 2
 
 
 # Update docstrings for API docs

--- a/qiskit/quantum_info/operators/channel/kraus.py
+++ b/qiskit/quantum_info/operators/channel/kraus.py
@@ -86,6 +86,8 @@ class Kraus(QuantumChannel):
         # If the input is a list or tuple we assume it is a list of Kraus
         # matrices, if it is a numpy array we assume that it is a single Kraus
         # operator
+        # TODO properly handle array construction from ragged data (like tuple(np.ndarray, None))
+        # and document these accepted input cases. See also Qiskit/qiskit-terra#9307.
         if isinstance(data, (list, tuple, np.ndarray)):
             # Check if it is a single unitary matrix A for channel:
             # E(rho) = A * rho * A^\dagger

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-coverage>=4.4.0
+coverage>=4.4.0,<7.0
 hypothesis>=4.24.3
 python-constraint>=1.4
 ipython<7.22.0

--- a/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
+++ b/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
@@ -17,6 +17,7 @@ from test.python.algorithms import QiskitAlgorithmsTestCase
 
 from ddt import ddt, data, unpack
 
+import numpy
 from qiskit import BasicAer
 from qiskit.circuit.library import RealAmplitudes
 from qiskit.utils import QuantumInstance, algorithm_globals
@@ -63,6 +64,10 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
         except MissingOptionalLibraryError as ex:
             self.skipTest(str(ex))
 
+    @unittest.skipIf(
+        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
+    )
     def test_snobfit(self):
         """SNOBFIT optimizer test."""
         try:
@@ -71,6 +76,10 @@ class TestOptimizers(QiskitAlgorithmsTestCase):
         except MissingOptionalLibraryError as ex:
             self.skipTest(str(ex))
 
+    @unittest.skipIf(
+        tuple(map(int, numpy.__version__.split("."))) >= (1, 24, 0),
+        "scikit's SnobFit currently incompatible with NumPy 1.24.0.",
+    )
     @data((None,), ([(-1, 1), (None, None)],))
     @unpack
     def test_snobfit_missing_bounds(self, bounds):

--- a/test/python/test_util.py
+++ b/test/python/test_util.py
@@ -39,6 +39,6 @@ class TestUtil(QiskitTestCase):
         m = np.random.randint(-100, 100, size=(n, n))
         symm = (m + m.T) / 2
 
-        triu = np.array([[symm[i, j] for i in range(j, n)] for j in range(n)])
+        triu = [[symm[i, j] for i in range(j, n)] for j in range(n)]
 
         self.assertTrue(np.array_equal(symm, triu_to_dense(triu)))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

* In the 1.24.0 release, NumPy followed through on deprecating the creation of arrays with elements differing in size (like `np.array([[1,2], [3]])`, which broke several tests. This PR fixes each of these, with the exception of the `SNOBFIT` optimizer. There we rely on github.com/scikit-quant and the compatibility needs to be fixed there. Until then, the `SNOBFIT` optimizer will raise a `QiskitError` if used with NumPy 1.24.0 or above and the tests are skipped.

* Pin `coverage` to below 7.0.0 (released Dec 18th) which breaks with Python 3.8 due to a missing import of
```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.15/x64/bin/coveragepy-lcov", line 5, in <module>
    from coveragepy_lcov.cli import main
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/coveragepy_lcov/cli.py", line 3, in <module>
    from .converter import Converter
  File "/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/coveragepy_lcov/converter.py", line 5, in <module>
    from coverage.files import FnmatchMatcher, prep_patterns
ImportError: cannot import name 'FnmatchMatcher' from 'coverage.files' (/opt/hostedtoolcache/Python/3.8.15/x64/lib/python3.8/site-packages/coverage/files.py)
```

The coverage pin and the Snobfit exception for 1.24 both should be addressed in the future, and removed ideally. The Snobfit pin is likely a bug in the package and not inside of Qiskit (as @ElePT tracked down), but about `coverage` I'm not so sure, maybe @jakelishman or @mtreinish have some insights 🙂 
