### PR TITLE
Add GaussianSquareDrag symbolic pulse shape

### DIFF
--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -141,6 +141,7 @@ from qiskit.pulse.library import (
     Drag,
     Gaussian,
     GaussianSquare,
+    GaussianSquareDrag,
     ParametricPulse,
     SymbolicPulse,
     Waveform,

--- a/qiskit/pulse/library/__init__.py
+++ b/qiskit/pulse/library/__init__.py
@@ -92,6 +92,7 @@ Parametric Pulse Representation
    Drag
    Gaussian
    GaussianSquare
+   GaussianSquareDrag
 
 """
 
@@ -111,6 +112,13 @@ from .discrete import (
     drag,
 )
 from .parametric_pulses import ParametricPulse
-from .symbolic_pulses import SymbolicPulse, Gaussian, GaussianSquare, Drag, Constant
+from .symbolic_pulses import (
+    SymbolicPulse,
+    Gaussian,
+    GaussianSquare,
+    GaussianSquareDrag,
+    Drag,
+    Constant,
+)
 from .pulse import Pulse
 from .waveform import Waveform

--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -842,9 +842,11 @@ def GaussianSquareDrag(
     This pulse shape is similar to :class:`~.GaussianSquare` but uses
     :class:`~.Drag` for its rise and fall instead of :class:`~.Gaussian`. The
     addition of the DRAG component of the rise and fall is sometimes helpful in
-    suppressing the spectral content of the pulse at frequencies near the
-    fundamental frequency of the drive which can cause unwanted excitation of
-    spectators close in frequency to that fundamental frequency.
+    suppressing the spectral content of the pulse at frequencies near to, but
+    slightly offset from, the fundamental frequency of the drive. When there is
+    a spectator qubit close in frequency to the fundamental frequency,
+    suppressing the drive at the spectator's frequency can help avoid unwanted
+    excitation of the spectator.
 
     Exactly one of the ``risefall_sigma_ratio`` and ``width`` parameters has to be specified.
 

--- a/qiskit/pulse/library/symbolic_pulses.py
+++ b/qiskit/pulse/library/symbolic_pulses.py
@@ -826,6 +826,151 @@ class GaussianSquare(metaclass=_PulseType):
         return instance
 
 
+def GaussianSquareDrag(
+    duration: Union[int, ParameterExpression],
+    amp: Union[float, ParameterExpression],
+    sigma: Union[float, ParameterExpression],
+    beta: Union[float, ParameterExpression],
+    width: Optional[Union[float, ParameterExpression]] = None,
+    angle: Optional[Union[float, ParameterExpression]] = 0.0,
+    risefall_sigma_ratio: Optional[Union[float, ParameterExpression]] = None,
+    name: Optional[str] = None,
+    limit_amplitude: Optional[bool] = None,
+) -> SymbolicPulse:
+    """A square pulse with a Drag shaped rise and fall
+
+    This pulse shape is similar to :class:`~.GaussianSquare` but uses
+    :class:`~.Drag` for its rise and fall instead of :class:`~.Gaussian`. The
+    addition of the DRAG component of the rise and fall is sometimes helpful in
+    suppressing the spectral content of the pulse at frequencies near the
+    fundamental frequency of the drive which can cause unwanted excitation of
+    spectators close in frequency to that fundamental frequency.
+
+    Exactly one of the ``risefall_sigma_ratio`` and ``width`` parameters has to be specified.
+
+    If ``risefall_sigma_ratio`` is not ``None`` and ``width`` is ``None``:
+
+    .. math::
+
+        \\text{risefall} &= \\text{risefall_sigma_ratio} \\times \\text{sigma}\\\\
+        \\text{width} &= \\text{duration} - 2 \\times \\text{risefall}
+
+    If ``width`` is not None and ``risefall_sigma_ratio`` is None:
+
+    .. math:: \\text{risefall} = \\frac{\\text{duration} - \\text{width}}{2}
+
+    Gaussian :math:`g(x, c, σ)` and lifted gaussian :math:`g'(x, c, σ)` curves
+    can be written as:
+
+    .. math::
+
+        g(x, c, σ) &= \\exp\\Bigl(-\\frac12 \\frac{(x - c)^2}{σ^2}\\Bigr)\\\\
+        g'(x, c, σ) &= \\frac{g(x, c, σ)-g(-1, c, σ)}{1-g(-1, c, σ)}
+
+    From these, the lifted DRAG curve :math:`d'(x, c, σ, β)` can be written as
+
+    .. math::
+
+        d'(x, c, σ, β) = g'(x, c, σ) \\times \\Bigl(1 + 1j \\times β \\times\
+            \\Bigl(-\\frac{x - c}{σ^2}\\Bigr)\\Bigr)
+
+    The lifted gaussian square drag pulse :math:`f'(x)` is defined as:
+
+    .. math::
+
+        f'(x) &= \\begin{cases}\
+            \\text{A} \\times d'(x, \\text{risefall}, \\text{sigma}, \\text{beta})\
+                & x < \\text{risefall}\\\\
+            \\text{A}\
+                & \\text{risefall} \\le x < \\text{risefall} + \\text{width}\\\\
+            \\text{A} \\times \\times d'(\
+                    x - (\\text{risefall} + \\text{width}),\
+                    \\text{risefall},\
+                    \\text{sigma},\
+                    \\text{beta}\
+                )\
+                & \\text{risefall} + \\text{width} \\le x\
+        \\end{cases}\\\\
+
+    where :math:`\\text{A} = \\text{amp} \\times
+    \\exp\\left(i\\times\\text{angle}\\right)`.
+
+    Args:
+        duration: Pulse length in terms of the sampling period `dt`.
+        amp: The amplitude of the DRAG rise and fall and of the square pulse.
+        sigma: A measure of how wide or narrow the DRAG risefall is; see the class
+               docstring for more details.
+        beta: The DRAG correction amplitude.
+        width: The duration of the embedded square pulse.
+        angle: The angle in radians of the complex phase factor uniformly
+            scaling the pulse. Default value 0.
+        risefall_sigma_ratio: The ratio of each risefall duration to sigma.
+        name: Display name for this pulse envelope.
+        limit_amplitude: If ``True``, then limit the amplitude of the
+            waveform to 1. The default is ``True`` and the amplitude is constrained to 1.
+
+    Returns:
+        SymbolicPulse instance.
+
+    Raises:
+        PulseError: When width and risefall_sigma_ratio are both empty or both non-empty.
+    """
+    # Convert risefall_sigma_ratio into width which is defined in OpenPulse spec
+    if width is None and risefall_sigma_ratio is None:
+        raise PulseError(
+            "Either the pulse width or the risefall_sigma_ratio parameter must be specified."
+        )
+    if width is not None and risefall_sigma_ratio is not None:
+        raise PulseError(
+            "Either the pulse width or the risefall_sigma_ratio parameter can be specified"
+            " but not both."
+        )
+    if width is None and risefall_sigma_ratio is not None:
+        width = duration - 2.0 * risefall_sigma_ratio * sigma
+
+    parameters = {"amp": amp, "sigma": sigma, "width": width, "beta": beta, "angle": angle}
+
+    # Prepare symbolic expressions
+    _t, _duration, _amp, _sigma, _beta, _width, _angle = sym.symbols(
+        "t, duration, amp, sigma, beta, width, angle"
+    )
+    _center = _duration / 2
+
+    _sq_t0 = _center - _width / 2
+    _sq_t1 = _center + _width / 2
+
+    _gaussian_ledge = _lifted_gaussian(_t, _sq_t0, -1, _sigma)
+    _gaussian_redge = _lifted_gaussian(_t, _sq_t1, _duration + 1, _sigma)
+    _deriv_ledge = -(_t - _sq_t0) / (_sigma**2) * _gaussian_ledge
+    _deriv_redge = -(_t - _sq_t1) / (_sigma**2) * _gaussian_redge
+
+    envelope_expr = (
+        _amp
+        * sym.exp(sym.I * _angle)
+        * sym.Piecewise(
+            (_gaussian_ledge + sym.I * _beta * _deriv_ledge, _t <= _sq_t0),
+            (_gaussian_redge + sym.I * _beta * _deriv_redge, _t >= _sq_t1),
+            (1, True),
+        )
+    )
+    consts_expr = sym.And(_sigma > 0, _width >= 0, _duration >= _width)
+    valid_amp_conditions_expr = sym.And(sym.Abs(_amp) <= 1.0, sym.Abs(_beta) < _sigma)
+
+    instance = SymbolicPulse(
+        pulse_type="GaussianSquareDrag",
+        duration=duration,
+        parameters=parameters,
+        name=name,
+        limit_amplitude=limit_amplitude,
+        envelope=envelope_expr,
+        constraints=consts_expr,
+        valid_amp_conditions=valid_amp_conditions_expr,
+    )
+    instance.validate_parameters()
+
+    return instance
+
+
 class Drag(metaclass=_PulseType):
     """The Derivative Removal by Adiabatic Gate (DRAG) pulse is a standard Gaussian pulse
     with an additional Gaussian derivative component and lifting applied.

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -43,6 +43,7 @@ class ParametricPulseShapes(Enum):
 
     gaussian = "Gaussian"
     gaussian_square = "GaussianSquare"
+    gaussian_square_drag = "GaussianSquareDrag"
     drag = "Drag"
     constant = "Constant"
 

--- a/releasenotes/notes/gaussian-square-drag-pulse-1e54fe77e59d5247.yaml
+++ b/releasenotes/notes/gaussian-square-drag-pulse-1e54fe77e59d5247.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Add new :class:`~qiskit.pulse.GaussianSquareDrag` pulse shape. This pulse
+    shape is similar to :class:`~qiskit.pulse.GaussianSquare` but uses the
+    :class:`~qiskit.pulse.Drag` shape during its rise and fall. The correction
+    from the DRAG pulse shape can suppress part of the frequency spectrum of
+    the rise and fall of the pulse which can help avoid exciting spectator
+    qubits when they are close in frequency to the drive frequency of the
+    pulse.


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add GaussianSquareDrag symbolic pulse shape

### Details and comments

Add new `qiskit.pulse.GaussianSquareDrag` pulse shape. This pulse
shape is similar to `qiskit.pulse.GaussianSquare` but uses the
`qiskit.pulse.Drag` shape during its rise and fall. The correction
from the DRAG pulse shape can suppress part of the frequency spectrum of
the rise and fall of the pulse which can help avoid exciting spectator
qubits when they are close in frequency to the drive frequency of the
pulse.

`GaussianSquareDrag` is sometimes used on IBM backends and its absence from qiskit requires those backends to report calibrations using the pulse with `Waveform`s instead of `SymbolicPulse` which obscures the parameters and is less efficient to transfer.

Depending on the timing, either this PR or #9314 will need to be updated to account for the other one as `GaussianSquareDrag` should also be a `ScalableSymbolicPulse`.