### PR TITLE
Pin ubuntu version in azure-pipelines

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
   - job: 'Docs'
-    pool: {vmImage: 'ubuntu-latest'}
+    pool: {vmImage: 'ubuntu-20.04'}
 
     variables:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip

--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
   - job: 'Lint'
-    pool: {vmImage: 'ubuntu-latest'}
+    pool: {vmImage: 'ubuntu-20.04'}
 
     variables:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -23,7 +23,7 @@ parameters:
 jobs:
   - job: "Linux_Tests_Python${{ replace(parameters.pythonVersion, '.', '') }}"
     displayName: "Test Linux Python ${{ parameters.pythonVersion }}"
-    pool: {vmImage: 'ubuntu-latest'}
+    pool: {vmImage: 'ubuntu-20.04'}
 
     variables:
       QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -5,7 +5,7 @@ parameters:
 
 jobs:
   - job: "Tutorials"
-    pool: {vmImage: 'ubuntu-latest'}
+    pool: {vmImage: 'ubuntu-20.04'}
 
     variables:
       QISKIT_SUPPRESS_PACKAGING_WARNINGS: Y


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

On December 15th the runner image for `ubuntu-latest` upgrade to ubuntu 22.04. Since then we've started seeing job timeouts in the docs builds. In attempt to debug and potentially prevent this (in the short term) failure mode this commit pins the ubuntu image version used to the previous value for ubuntu-latest 20.04. We can use this commit to test CI to see if the timeouts are reproducible and if we do not encounter the docs job timeout after multiple attempts we can merge this to hopefully prevent it in CI.

### Details and comments