### PR TITLE
Pin nbconvert version for CI

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -15,3 +15,7 @@ ipywidgets<8.0.3
 #   from coverage.files import FnmatchMatcher
 # since this is in Python 3.8 itself and not Qiskit, pinning this for now.
 coverage<7.0
+
+# With nbconvert 7.2.7 docs jobs start hanging executing jupyter-execute
+# cells. Pin until the issue is resolved.
+nbconvert==7.2.6

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,3 +15,6 @@ ipywidgets<8.0.3
 #   from coverage.files import FnmatchMatcher
 # since this is in Python 3.8 itself and not Qiskit, pinning this for now.
 coverage<7.0
+
+# ipykernel >=0.19.4 started hanging docs builds. Pin version to avoid this
+ipykernel<6.19.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -19,3 +19,4 @@ coverage<7.0
 # With nbconvert 7.2.7 docs jobs start hanging executing jupyter-execute
 # cells. Pin until the issue is resolved.
 nbconvert==7.2.6
+jupyter-server==1.23.3

--- a/constraints.txt
+++ b/constraints.txt
@@ -20,3 +20,4 @@ coverage<7.0
 # cells. Pin until the issue is resolved.
 nbconvert==7.2.6
 jupyter-server==1.23.3
+nbformat==5.7.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,6 +15,3 @@ ipywidgets<8.0.3
 #   from coverage.files import FnmatchMatcher
 # since this is in Python 3.8 itself and not Qiskit, pinning this for now.
 coverage<7.0
-
-# ipykernel >=0.19.4 started hanging docs builds. Pin version to avoid this
-ipykernel<6.19.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rustworkx>=0.12.0
-numpy>=1.17,<1.24.0 # Remove this before 0.23.0 release
+numpy>=1.17
 ply>=3.10
 psutil>=5
 scipy>=1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rustworkx>=0.12.0
-numpy>=1.17
+numpy>=1.17,<1.24.0 # Remove this before 0.23.0 release
 ply>=3.10
 psutil>=5
 scipy>=1.5


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since late December we've started seeing frequent job timeouts in the docs builds when it's running jupyter-execute cells as part of the docs builds. Looking at likely causes there were several package releases around that time (as well as a new ubuntu version which was ruled out as the root cause in #9340) In attempt to debug and potentially prevent this (in the short term) failure mode this commit pins dependencies to try and reproduce the failure and see if we can avoid the
stuck docs build by holding back a dependency version.

### Details and comments