### PR TITLE
Re-enable parallel sphinx builds by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
 commands =
-  sphinx-build -W -T --keep-going -b html docs/ docs/_build/html {posargs}
+  sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}
 
 [pycodestyle]
 max-line-length = 105


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

With the recent merge of #9346 that stopped using the problematic jupyter-sphinx plugin we're no long blocked from running sphinx-build in parallel anymore. We had originally enabled this in #4477 to get a speed boost during docs builds. However, we were forced to revert that in #6539 because jupyter-sphinx was unreliable and had a race condition when 2 jupyter-execute blocks were run at the same time (see #5904 for more details). Since we've removed the jupyter-sphinx usage that is no longer a problem and we can reliably run parallel sphinx builds again. This commit makes that change and changes the default sphinx-build behavior when run via tox (as is done via ci) to use all available system cores to perform a sphinx build. Annecdoteally this provides a nice speed up, on my local workstation a full docs build went from taking 8min 42 seconds for a serial build to 2min 35sec with a parallel build.

### Details and comments