### PR TITLE
Simplify UnitarySynthesis pass test test_qv_natural

### DIFF
--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -40,8 +40,6 @@ from qiskit.transpiler.passes import (
     ConsolidateBlocks,
     Optimize1qGates,
     SabreLayout,
-    Depth,
-    FixedPoint,
     Unroll3qOrMore,
     CheckMap,
     BarrierBeforeFinalMeasurements,
@@ -478,9 +476,6 @@ class TestUnitarySynthesis(QiskitTestCase):
         qv64 = QuantumVolume(5, seed=15)
 
         def construct_passmanager(basis_gates, coupling_map, synthesis_fidelity, pulse_optimize):
-            def _repeat_condition(property_set):
-                return not property_set["depth_fixed_point"]
-
             seed = 2
             _map = [SabreLayout(coupling_map, max_iterations=2, seed=seed)]
             _unroll3q = Unroll3qOrMore()
@@ -489,7 +484,6 @@ class TestUnitarySynthesis(QiskitTestCase):
                 BarrierBeforeFinalMeasurements(),
                 SabreSwap(coupling_map, heuristic="lookahead", seed=seed),
             ]
-            _check_depth = [Depth(), FixedPoint("depth")]
             _optimize = [
                 Collect2qBlocks(),
                 ConsolidateBlocks(basis_gates=basis_gates),
@@ -508,9 +502,7 @@ class TestUnitarySynthesis(QiskitTestCase):
             pm.append(_unroll3q)
             pm.append(_swap_check)
             pm.append(_swap)
-            pm.append(
-                _check_depth + _optimize, do_while=_repeat_condition
-            )  # translate to & optimize over hardware native gates
+            pm.append(_optimize)
             return pm
 
         coupling_map = CouplingMap([[0, 1], [1, 2], [3, 2], [3, 4], [5, 4]])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The test_qv_natural UnitarySynthesis test is designed to test that when the pulse efficient flag is set on the default unitary synthesis plugin for the UnitarySynthesis pass the output from synthesis is only emitting entangling gates in the natural direction implemented on the target. However, when running on Windows with Python 3.11 and numpy 1.24 we're seeing a non-zero failure rate (in CI it's ~5% across all jobs) of this test likely do to fp precision. When this failure occurs it appears as the failure from detailed in issues #5832, #9177, and others as the test was creating a pass manager that mirrors the optimization loop used in the preset pass managers. The optimization loop is failing to converge on a fixed depth as the unitary synthesis is oscillating between multiple equivalent outputs. However, in this case the test doesn't need the full complexity of the optimization loop as we're just trying to verify the output of unitary synthesis is equivalent with different options and that the output is valid given different options. This can be done with a single iteration of the loop and doesn't require trying to fully optimize the circuit. This commit reduces the complexity of the test to remove the loop from the optimization stage in the custom pass manager so the test is now just running a single iteration of UnitarySynthesis and comparing the output. This will hopefully make the test stable in CI moving forward avoiding this failure mode.

### Details and comments