### PR TITLE
Relax constraints on jupyter-core and ipywidgets

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -163,3 +163,8 @@ jobs:
 
         - bash: image_tests/bin/python -m unittest discover -v test/ipynb
           displayName: 'Run image test'
+          env:
+            # Needed to suppress a warning in jupyter-core 5.x by eagerly migrating to
+            # a new internal interface that will be the default in jupyter-core 6.x.
+            # This variable should become redundant on release of jupyter-core 6.
+            JUPYTER_PLATFORM_DIRS=1

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -167,4 +167,4 @@ jobs:
             # Needed to suppress a warning in jupyter-core 5.x by eagerly migrating to
             # a new internal interface that will be the default in jupyter-core 6.x.
             # This variable should become redundant on release of jupyter-core 6.
-            JUPYTER_PLATFORM_DIRS=1
+            JUPYTER_PLATFORM_DIRS: 1

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,3 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
-
-# jupyter-core 5.0.0 started emitting deprecation warnings with ipywidgets via
-# a seaborn import. This pin can be removed when compatibility with those
-# packages is fixed
-jupyter-core==4.11.2
-
-# ipywidgets 8.0.3 started emitting deprecation warnings via a seaborn import.
-# This pin can be removed when compatibility with those packages is fixed.
-ipywidgets<8.0.3

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -216,13 +216,13 @@ class QiskitTestCase(BaseQiskitTestCase):
             r"Back-references to from Bit instances.*",
             r"The CXDirection pass has been deprecated",
             r"The pauli_basis function with PauliTable.*",
-            # TODO: remove the following ignore after seaborn 0.12.0 releases
-            r"distutils Version classes are deprecated. Use packaging\.version",
-            # Internal deprecation warning emitted by jupyter client when
-            # calling nbconvert in python 3.10
-            r"There is no current event loop",
             # Caused by internal scikit-learn scipy usage
             r"The 'sym_pos' keyword is deprecated and should be replaced by using",
+            # jupyter_client 7.4.8 uses deprecated shims in pyzmq that raise warnings with pyzmq 25.
+            # These are due to be fixed by jupyter_client 8, see:
+            #   - https://github.com/jupyter/jupyter_client/issues/913
+            #   - https://github.com/jupyter/jupyter_client/pull/842
+            r"zmq\.eventloop\.ioloop is deprecated in pyzmq .*",
         ]
         for msg in allow_DeprecationWarning_message:
             warnings.filterwarnings("default", category=DeprecationWarning, message=msg)


### PR DESCRIPTION
### Summary

These were originally added in #9105 and #9272 respectively, but the original problem package `seaborn` has released since then, which may have fixed things.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

If this isn't sufficient, we can consider adding manual suppressions instead; the various parts of the Jupyter stack in the past have shown some apathy towards fixing warnings being emitted from low-level packages if they wouldn't be displayed to users by default, so the wait for fixes can be long.