### PR TITLE
[WIP] add CommuteDiagonal transpiler optimization pass

### DIFF
--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -1829,7 +1829,7 @@ class DAGCircuit:
         }
         return summary
 
-    def draw(self, scale=0.7, filename=None, style="color"):
+    def draw(self, scale=0.7, filename=None, style="color", **kwargs):
         """
         Draws the dag circuit.
 
@@ -1842,6 +1842,7 @@ class DAGCircuit:
             style (str):
                 'plain': B&W graph;
                 'color' (default): color input/output/op nodes
+            kwargs (dict): addtional kwargs understood by dag_visualization
 
         Returns:
             Ipython.display.Image: if in Jupyter notebook and not saving to file,
@@ -1849,4 +1850,4 @@ class DAGCircuit:
         """
         from qiskit.visualization.dag_visualization import dag_drawer
 
-        return dag_drawer(dag=self, scale=scale, filename=filename, style=style)
+        return dag_drawer(dag=self, scale=scale, filename=filename, style=style, **kwargs)

--- a/qiskit/transpiler/passes/optimization/commute_diagonal.py
+++ b/qiskit/transpiler/passes/optimization/commute_diagonal.py
@@ -1,0 +1,481 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Reduce CNOT count by using property that a unitary in SU4, which
+generally requires three CNOT gates, can be decomposed into a unitary
+which requires at most two CNOT gates plus a diagonal gate. For two
+qubit unitaries which are seperated by something which commutes with
+the diagonal, an overall reduction of CNOT gates can be obtained.
+"""
+
+import functools
+import enum
+import numpy as np
+from qiskit.transpiler.basepasses import TransformationPass
+from qiskit.transpiler.exceptions import TranspilerError
+from qiskit.converters import dag_to_circuit, circuit_to_dag
+from qiskit.quantum_info import Operator
+from qiskit.quantum_info.synthesis import two_qubit_decompose
+from qiskit.extensions import UnitaryGate
+from qiskit.circuit.library.standard_gates import CXGate
+from qiskit.dagcircuit import DAGCircuit
+
+
+class Diagonality(enum.Enum):
+    """Class for defining 'how' diagonal an operation is"""
+
+    # not diagonal
+    FALSE = 0
+    # diagonal
+    TRUE = 1
+    # conditionally diagonal using local 1q gates
+    LOCAL = 2
+
+
+class CommuteDiagonal(TransformationPass):
+    """Decompose 2q unitaries with diagonals and push them to the right reducing overall CNOT gates"""
+
+    def __init__(self):
+        super().__init__()
+        self._weyl_decomp = two_qubit_decompose.two_qubit_cnot_decompose
+        self._diag_decomp = two_qubit_decompose.TwoQubitDecomposeUpToDiagonal()
+        self._diag = np.identity(2, dtype=int)
+        self._nondiag = np.ones((2, 2), dtype=int)
+        self._global_index_map = None
+        self._block_list = None
+
+    def run(self, dag):
+        # identify 2-qubit runs
+        self._global_index_map = {wire: idx for idx, wire in enumerate(dag.qubits)}
+        blocks = dag.collect_2q_runs()
+        candidate_blocks = self.get_candidate_2q_blocks(blocks, dag)
+        # iterate over all 2q runs for each pair of qubits where they exist
+        oporig = Operator(dag_to_circuit(dag))
+        for block_qubits, block_list in candidate_blocks.items():
+            self._block_list = block_list
+            if len(block_list) < 2:
+                # we need at least 2 blocks to realize a reduction in cnot count
+                continue
+            num_blocks = len(block_list)
+            # iterate over 2q runs for these two qubits
+            for block_ind0, block_ind1 in zip(range(num_blocks - 1), range(1, num_blocks)):
+                block0, block1 = block_list[block_ind0], block_list[block_ind1]
+                inter_nodes = _collect_nodes_between_blocks(dag, block_qubits, block0, block1)
+                if not inter_nodes:
+                    # no nodes between blocks
+                    continue
+                # check if blocks would benefit from pass
+                circ0 = _block_to_circuit(dag, block0, remove_idle_qubits=True)
+                circ1 = _block_to_circuit(dag, block1, remove_idle_qubits=True)
+                mat0 = Operator(circ0).data
+                mat1 = Operator(circ1).data
+                num_cx = [self._weyl_decomp.num_basis_gates(mat) for mat in [mat0, mat1]]
+                if not all((ncx == 3 for ncx in num_cx)):
+                    # this block pair may not yield lower CNOT count
+                    continue
+                inter_dag = _copy_dag_bit_like(dag)
+                for node in inter_nodes:
+                    inter_dag.apply_operation_back(node.op, qargs=node.qargs, cargs=node.cargs)
+                diagonality, diag_context = self.evaluate_diagonal_commutation(
+                    inter_dag, block_qubits
+                )
+                if diagonality == Diagonality.TRUE:
+                    dmat, qc2cx = self._diag_decomp(mat0)
+                    unitary0 = qc2cx.to_gate()
+                    unitary1 = UnitaryGate(mat1 @ dmat)
+                    self._replace_block_with_unitary(dag, block0, unitary0, block_qubits)
+                    self._replace_block_with_unitary(dag, block1, unitary1, block_qubits)
+                elif diagonality == Diagonality.LOCAL:
+                    # the inter-block nodes are locally equivalent to diagonal
+                    # add local equivalence ops
+                    (
+                        local_predeccessor_nodes,
+                        nonlocal_node,
+                        local_successor_nodes,
+                        local_phase,
+                    ) = diag_context
+                    # add local ops of diag_context to pre and post blocks
+                    block0_local = block0 + [
+                        node
+                        for node in local_predeccessor_nodes
+                        if set(node.qargs).issubset(set(block_qubits))
+                    ]
+                    block1_local = [
+                        node
+                        for node in local_successor_nodes
+                        if set(node.qargs).issubset(set(block_qubits))
+                    ] + block1
+                    inter_block_local0 = [
+                        node
+                        for node in local_predeccessor_nodes
+                        if not set(node.qargs).issubset(set(block_qubits))
+                    ]
+                    inter_block_local1 = [
+                        node
+                        for node in local_successor_nodes
+                        if not set(node.qargs).issubset(set(block_qubits))
+                    ]
+                    circ0 = _block_to_circuit(dag, block0, remove_idle_qubits=True)
+                    circ1 = _block_to_circuit(dag, block1, remove_idle_qubits=True)
+                    dag0 = circuit_to_dag(circ0)
+                    dag1 = circuit_to_dag(circ1)
+                    circ0_2q = _block_to_circuit(dag0, block0_local, remove_idle_qubits=True)
+                    circ1_2q = _block_to_circuit(dag1, block1_local, remove_idle_qubits=True)
+
+                    mat0_2q = Operator(circ0_2q).data
+                    mat1_2q = Operator(circ1_2q).data
+                    dmat, qc2cx = self._diag_decomp(mat0_2q)
+                    unitary0 = qc2cx.to_gate()
+                    unitary1 = UnitaryGate(mat1_2q @ dmat)
+
+                    self._replace_block_with_unitary(dag, block0, unitary0, block_qubits)
+                    self._replace_block_with_unitary(dag, block1, unitary1, block_qubits)
+                    # add locals to controlled equivalent op
+                    inter_dag_local = dag.copy_empty_like()
+                    for node in inter_block_local0:
+                        inter_dag_local.apply_operation_back(
+                            node.op, qargs=node.qargs, cargs=node.cargs
+                        )
+                    inter_dag_local.apply_operation_back(
+                        nonlocal_node.op, qargs=nonlocal_node.qargs, cargs=nonlocal_node.cargs
+                    )
+                    for node in inter_block_local1:
+                        inter_dag_local.apply_operation_back(
+                            node.op, qargs=node.qargs, cargs=node.cargs
+                        )
+                    inter_dag_local.remove_qubits(*inter_dag_local.idle_wires())
+                    inter_op_local = dag_to_circuit(inter_dag_local).to_gate()
+
+                    dag.replace_block_with_op(
+                        inter_nodes, inter_op_local, self._global_index_map, cycle_check=True
+                    )
+
+                    dag.global_phase += local_phase
+                    # TODO: fix the need for global phase correction here.
+                    angle_offset = np.angle(
+                        oporig.data[0, 0] / Operator(dag_to_circuit(dag)).data[0, 0]
+                    )
+                    dag.global_phase += angle_offset
+                elif diagonality == Diagonality.FALSE:
+                    continue
+        return dag
+
+    def _candidate_block_printer(self, dag, candidate_blocks):
+        qubit_to_int = {bit: idx for idx, bit in enumerate(dag.qubits)}
+        for pair, block_list in candidate_blocks.items():
+            bitinds = [qubit_to_int[qubit] for qubit in pair]
+            print(f'bits: {bitinds}')
+            prestr1 = ' '*3
+            for i, block in enumerate(block_list):
+                print(f'{prestr1}block {i}')
+                prestr2 = prestr1 +  ' '*3
+                print(prestr2, end='')
+                for node in block:
+                    print(f' {node.op.name}', end='')
+                print('')
+
+    def _replace_block_with_unitary(self, dag, block, unitary, block_qubits):
+        """
+        Args:
+           dag (DAGCircuit): parent dag of replacement
+           block (List(Node)): nodes in dag to replace
+           unitary (Instruction): unitary matrix instruction
+           block_qubits (List(Qubit)): two qubit list of 2q block qubits.
+        """
+        block_index_map = _block_qargs_to_indices(block_qubits, self._global_index_map)
+        new_node = dag.replace_block_with_op(block, unitary, block_index_map)
+        # also need to update block_list
+        self._block_list[self._block_list.index(block)] = [new_node]
+
+    def get_candidate_2q_blocks(self, blocks, dag):
+        """
+        Return list of blocks which share same qubits.
+
+        Args:
+            blocks (List[DAGNode]): list of 2q DAGNode in topological order
+            dag (DAGCircuit): reference dag
+
+        Returns:
+            List[DAGNode]: list of DAGNodes which are on common qubits.
+        """
+        common_blocks = {}
+        for block in blocks:
+            active_bits = set(qubit for node in block for qubit in node.qargs)
+            key_2q = tuple(qubit for qubit in dag.qubits if qubit in active_bits)
+            if key_2q in common_blocks:
+                common_blocks[key_2q].append(block)
+            else:
+                common_blocks[key_2q] = [block]
+        return common_blocks
+
+    def evaluate_diagonal_commutation(self, inter_dag, partial_qubits, do_equiv_check=True):
+        """
+        Determine whether the circuit in dag commutes with a diagonal
+        operation on a possible subset of its qubits.
+
+        Args:
+           inter_dag (DAGCircuit): circuit to check for commutation
+           partial_qubits (List(Qubit)): qubits of dag to evaluate diagonal commutation on
+           do_equiv_check (bool): whether to check for diagonal equivalence.
+
+        Returns:
+           Diagonality: type of diagonal for operation
+           List(List(DAGNode), DAGNode, List(DAGNode)) or None: If Diagonality is LOCAL this
+              contains the local predecessor nodes and local successor nodes of a non-local
+              DAGNode which is diagonal on the partial qubits list.
+        """
+        is_diagonal = self._diagonal_commute_on_bits(dag_to_circuit(inter_dag), partial_qubits)
+        if is_diagonal:
+            return Diagonality.TRUE, None
+        idle_wires = list(inter_dag.idle_wires())
+        active_wires = [qubit for qubit in inter_dag.qubits if qubit not in idle_wires]
+        num_active_qubits = len(active_wires)
+        if do_equiv_check and not is_diagonal and num_active_qubits == 2:
+            # although the group is not diagonal; check to see if it is locally equivalent
+            # to a controlled gate.
+            # create two-qubit circuit for two-qubit decomposer
+            dag2q = self.copy_ops_like(inter_dag)
+            qubit_map = {bit: index for index, bit in enumerate(dag2q.qubits)}
+
+            dag2q.remove_qubits(*idle_wires)
+            partial_qubits_2q = [qubit for qubit in dag2q.qubits if qubit in partial_qubits]
+            mat2q = Operator(dag_to_circuit(dag2q)).data
+            decomp = two_qubit_decompose.TwoQubitWeylDecomposition(mat2q)
+            if not isinstance(decomp, two_qubit_decompose.TwoQubitWeylControlledEquiv):
+                return Diagonality.FALSE, None
+            # circuit is equivalent to controlled gate; use CX as controlled gate
+            decomp_cx = two_qubit_decompose.TwoQubitBasisDecomposer(CXGate())
+            circ_2q = decomp_cx(mat2q)
+            if circ_2q.count_ops().get("cx", 0) != 1:
+                return Diagonality.FALSE, None
+            source_dag = circuit_to_dag(circ_2q)
+            # want qubits like inter_dag but global_phase like circ_2q
+            target_dag = _copy_dag_bit_like(inter_dag)
+            target_dag.global_phase = circ_2q.global_phase
+            target_qubits = [
+                target_dag.qubits[qubit_map[active_wires[ind]]]
+                for ind in range(len(source_dag.qubits))
+            ]
+            target_dag.compose(source_dag, qubits=target_qubits)
+            diag_context = self._get_local_pre_post_nodes(target_dag, "cx")
+            nonlocal_node = diag_context[1]
+            nonlocal_dag = _copy_dag_bit_like(target_dag)
+            nonlocal_dag.apply_operation_back(
+                nonlocal_node.op, qargs=nonlocal_node.qargs, cargs=nonlocal_node.cargs
+            )
+
+            if self._diagonal_commute_on_bits(dag_to_circuit(nonlocal_dag), partial_qubits_2q):
+                return Diagonality.LOCAL, diag_context
+            else:
+                return Diagonality.FALSE, None
+        return Diagonality.FALSE, None
+
+    def _diagonal_commute_on_bits(self, circuit, partial_qubits):
+        """
+        Returns whether circuit is diagonal on specified qubits.
+
+        Args:
+            circuit (QuantumCircuit): circuit to check for diagonal commutation
+            partial_qubits (List(Qubit)): list of qubits of circuit to check for diagonal commutation.
+
+        Returns:
+            bool: whether circuit commutes with diagonal operation on selected qubits.
+        """
+        mat = Operator(circuit).data
+        components = [
+            self._diag if qubit in partial_qubits else self._nondiag for qubit in circuit.qubits
+        ]
+        pattern = functools.reduce(np.kron, components[::-1]).astype(int)
+        zero_mask = np.nonzero(pattern == 0)
+        return np.allclose(mat[zero_mask], 0)
+
+    def _get_local_pre_post_nodes(self, target_dag, node_name):
+        """
+        Split off the pre and post 1q gates of the single 2q gate.
+
+        Args:
+            target_dag (DAGCircuit): circuit from two_qubit_cnot_decompose
+            node_name (str): name of nonlocal node
+
+        Returns:
+            List(DAGNode): 1q nodes before 2q node
+            DAGNode: 2q node
+            List(DAGNode): 1q nodes after 2q node
+            float: phase angle of this decomposition
+
+        Raises:
+            TranspilerError: target_dag does not have exactly one node named node_name
+        """
+        nonlocal_nodes = target_dag.named_nodes(node_name)
+        if len(nonlocal_nodes) != 1:
+            raise TranspilerError("expected exactly one CNOT gate in circuit")
+        nonlocal_node = nonlocal_nodes[0]
+        pred_nodes = list(target_dag.quantum_predecessors(nonlocal_node))
+        succ_nodes = list(target_dag.quantum_successors(nonlocal_node))
+        return pred_nodes, nonlocal_node, succ_nodes, target_dag.global_phase
+
+    def copy_ops_like(self, dag):
+        """Return a copy of dag with same qubit and clbit instances but copies of operations
+
+        This is like copy_empty_like but includes a copy of the operations from this dag.
+
+        Args:
+            dag (DAGCircuit): circuit to copy
+
+        Returns:
+            DAGCircuit: copy of dag
+        """
+        new_dag = dag.copy_empty_like()
+        for node in dag.op_nodes():
+            new_dag.apply_operation_back(node.op.copy(), qargs=node.qargs, cargs=node.cargs)
+        return new_dag
+
+
+def _collect_nodes_between_blocks(dag, block_qubits, block0, block1):
+    """collect nodes between 2q blocks"""
+
+    _, start_node0 = _get_first_last_node(dag, block_qubits[0], block0)
+    _, start_node1 = _get_first_last_node(dag, block_qubits[1], block0)
+    if start_node0 is None and start_node1 is None:
+        return []
+    stop_node0, _ = _get_first_last_node(dag, block_qubits[0], block1)
+    stop_node1, _ = _get_first_last_node(dag, block_qubits[1], block1)
+    inter_nodes = _collect_circuit_between_nodes(
+        dag, block_qubits, (start_node0, start_node1), (stop_node0, stop_node1)
+    )
+    return inter_nodes
+
+
+def _get_first_last_node(dag, wire, block):
+    """get first and last node which are in the block and on the wire"""
+
+    wire_iter = dag.nodes_on_wire(wire)
+    # iterate to first op node of block on wire
+    node = next(wire_iter)
+    while node not in block:
+        try:
+            node = next(wire_iter)
+        except StopIteration:
+            # no nodes on wire exist in block
+            return None, None
+    first_node = node
+    # iterate to last op node
+    next_node = next(wire_iter)
+    while next_node in block:
+        node = next_node
+        next_node = next(wire_iter)
+    last_node = node
+    return first_node, last_node
+
+
+def _collect_circuit_between_nodes(dag, block_qubits, start_nodes, stop_nodes):
+    """collect circuit between 2q nodes"""
+    start_node0, start_node1 = start_nodes
+    iter_q0 = dag.nodes_on_wire(block_qubits[0], only_ops=False)  # False to allow DAGOutNode
+    iter_q1 = dag.nodes_on_wire(block_qubits[1], only_ops=False)
+    # advance iterators to start node
+    _advance_iterator_to_node(iter_q0, start_node0)
+    _advance_iterator_to_node(iter_q1, start_node1)
+    inter_nodes = _gather_to_stop_nodes(block_qubits, iter_q0, iter_q1, stop_nodes)
+    return inter_nodes
+
+
+def _advance_iterator_to_node(iterator, stop_node, gathered=None):
+    """
+    Args:
+        iterator (iterator):
+        stop_node (DAGNode): node to iterate to
+        gathered (None or List(Node)): If list, accumulate nodes into this list
+
+    Returns:
+        iterator: node iterator pointing to stop_node
+    """
+    node = next(iterator)
+    while node != stop_node:
+        if gathered is not None:
+            gathered.append(node)
+        node = next(iterator)
+    if gathered is not None and node != stop_node:
+        gathered.append(node)
+    return node
+
+
+def _gather_to_stop_nodes(block_qubits, iter_q0, iter_q1, stop_nodes):
+    """
+    Gathers nodes interacting with two qubits until stop nodes are encountered.
+
+    Works by iterating on wire0 until the stop node is encountered or there is a joint operation,
+    in which case wire1 is accumulated until it reaches the same joint operation, then
+    accumulation continues with wire0 leading the way.
+    """
+    stop_node0, stop_node1 = stop_nodes
+    gathered = []
+    node0 = next(iter_q0)
+    while node0 != stop_node0:
+        node0_qubits = set(node0.qargs) if hasattr(node0, "qargs") else set([node0.wire])
+        if set(block_qubits).issubset(node0_qubits):
+            # operation interacts with q1; accumulate on q1
+            node1 = _advance_iterator_to_node(iter_q1, node0, gathered=gathered)
+            gathered.append(node0)  # same as node1
+            node0 = next(iter_q0)
+        else:
+            gathered.append(node0)
+            node0 = next(iter_q0)
+    # catch up iter_q1 if needed
+    try:
+        node1 = next(iter_q1)
+    except StopIteration:
+        pass
+    else:
+        if node1 != stop_node1:
+            gathered.append(node1)
+            _advance_iterator_to_node(iter_q1, stop_node1, gathered=gathered)
+    return gathered
+
+
+def _block_qargs_to_indices(block_qargs, global_index_map):
+    """Map each qubit in block_qargs to its wire position among the block's wires.
+
+    This code is taken from ConsolidateBlocks.
+
+    Args:
+        block_qargs (list): list of qubits that a block acts on
+        global_index_map (dict): mapping from each qubit in the
+            circuit to its wire position within that circuit
+    Returns:
+        dict: mapping from qarg to position in block
+    """
+    block_indices = [global_index_map[q] for q in block_qargs]
+    ordered_block_indices = {bit: index for index, bit in enumerate(sorted(block_indices))}
+    block_positions = {q: ordered_block_indices[global_index_map[q]] for q in block_qargs}
+    return block_positions
+
+
+def _block_to_circuit(dag, block, remove_idle_qubits=False):
+    block_dag = _copy_dag_bit_like(dag)
+    for node in block:
+        block_dag.apply_operation_back(node.op, qargs=node.qargs, cargs=node.cargs)
+    if remove_idle_qubits:
+        block_dag.remove_qubits(*set(block_dag.idle_wires()))
+    return dag_to_circuit(block_dag)
+
+
+def _copy_dag_bit_like(dag):
+    target_dag = DAGCircuit()
+    target_dag.add_qubits(dag.qubits)
+    target_dag.add_clbits(dag.clbits)
+
+    for qreg in dag.qregs.values():
+        target_dag.add_qreg(qreg)
+    for creg in dag.cregs.values():
+        target_dag.add_creg(creg)
+    return target_dag

--- a/qiskit/visualization/dag_visualization.py
+++ b/qiskit/visualization/dag_visualization.py
@@ -25,7 +25,7 @@ from .exceptions import VisualizationError
 
 
 @_optionals.HAS_GRAPHVIZ.require_in_call
-def dag_drawer(dag, scale=0.7, filename=None, style="color"):
+def dag_drawer(dag, scale=0.7, filename=None, style="color", show_node_id=False):
     """Plot the directed acyclic graph (dag) to represent operation dependencies
     in a quantum circuit.
 
@@ -38,6 +38,7 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
         filename (str): file path to save image to (format inferred from name)
         style (str): 'plain': B&W graph
                      'color' (default): color input/output/op nodes
+        show_node_id (bool): show the graph node_id for each node
 
     Returns:
         PIL.Image: if in Jupyter notebook and not saving to file,
@@ -143,7 +144,10 @@ def dag_drawer(dag, scale=0.7, filename=None, style="color"):
                     n["color"] = "black"
                     n["style"] = "filled"
                     n["fillcolor"] = "red"
+                if show_node_id:
+                    n["label"] = f"{node._node_id}: {n['label']}"
                 return n
+
             else:
                 raise VisualizationError("Invalid style %s" % style)
 

--- a/test/python/transpiler/test_commute_diagonal.py
+++ b/test/python/transpiler/test_commute_diagonal.py
@@ -1,0 +1,576 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2017, 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for FlushDiagonal transpiler class"""
+
+import numpy as np
+import scipy.stats
+
+from qiskit.circuit import QuantumCircuit, Qubit
+from qiskit.circuit.library.standard_gates import (
+    XGate,
+    YGate,
+    RYGate,
+    RZGate,
+    CXGate,
+    CCXGate,
+    HGate,
+    ZGate,
+    CHGate,
+    CZGate,
+)
+from qiskit.converters import dag_to_circuit
+from qiskit.dagcircuit import DAGCircuit, DAGNode
+from qiskit.extensions.unitary import UnitaryGate
+from qiskit.quantum_info.operators import Operator
+from qiskit.test import QiskitTestCase
+from qiskit.transpiler.passes.optimization.commute_diagonal import (
+    CommuteDiagonal,
+    _collect_circuit_between_nodes,
+    Diagonality,
+)
+from qiskit import transpile
+
+
+class TestCommuteDiagonal(QiskitTestCase):
+    """Test class for CommuteDiagonal transpiler optimization class"""
+
+    def setUp(self):
+        super().setUp()
+        self._pass = CommuteDiagonal()
+
+    def test_gather_1q_between(self):
+        """
+        Test getting 1q gates between 2q groups. For the test circuit
+
+             ┌──────────┐┌───┐┌─────────┐     ┌──────────┐
+        q_0: ┤0         ├┤ X ├┤ Ry(0.2) ├─────┤1         ├
+             │  Unitary │├───┤├─────────┤┌───┐│  Unitary │
+        q_1: ┤1         ├┤ Y ├┤ Rz(0.1) ├┤ Y ├┤0         ├
+             └──────────┘└───┘└─────────┘└───┘└──────────┘
+        """
+
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat = scipy.stats.unitary_group.rvs(4, random_state=5627)
+        start_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr)
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        dag.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        stop_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[::-1])
+        inter_nodes = _collect_circuit_between_nodes(
+            dag, [qr[0], qr[1]],
+            (start_node, start_node),
+            (stop_node, stop_node)
+        )
+        inter_dag = DAGCircuit()
+        inter_dag.add_qubits(qr)
+        for node in inter_nodes:
+            inter_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+
+        expected = dag.copy_empty_like()
+        expected.apply_operation_back(XGate(), qargs=[qr[0]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+        expected.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        expected.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+
+        self.assertEqual(inter_dag, expected)
+
+    def test_gather_1q_between_non_2q(self):
+        """
+        Test getting 1q gates between 2q groups where one of the
+        2q groups ends or begins in 1q gates.
+
+             ┌──────────┐┌───┐┌─────────┐     ┌──────────┐
+        q_0: ┤0         ├┤ X ├┤ Ry(0.2) ├─────┤1         ├
+             │  Unitary │├───┤├─────────┤┌───┐│  Unitary │
+        q_1: ┤1         ├┤ Y ├┤ Rz(0.1) ├┤ Y ├┤0         ├
+             └──────────┘└───┘└─────────┘└───┘└──────────┘
+
+        """
+
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat = scipy.stats.unitary_group.rvs(4, random_state=594)
+        dag.apply_operation_back(UnitaryGate(mat), qargs=qr)
+        start_node0 = dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        start_node1 = dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        dag.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        stop_node1 = dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        stop_node0 = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[::-1])
+        inter_nodes = _collect_circuit_between_nodes(
+            dag, [qr[0], qr[1]],
+            (start_node0, start_node1),
+            (stop_node0, stop_node1)
+        )
+        inter_dag = DAGCircuit()
+        inter_dag.add_qubits(qr)
+        for node in inter_nodes:
+            inter_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+
+        expected = dag.copy_empty_like()
+        expected.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        expected.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+
+        self.assertEqual(inter_dag, expected)
+
+    def test_gather_2q_between(self):
+        """
+        Test getting 1q and 2q gates between 2q groups. For the test circuit
+
+           ┌──────────┐┌───┐┌─────────┐                ┌──────────┐
+        0: ┤0         ├┤ X ├┤ Ry(0.2) ├────────────────┤1         ├
+           │  Unitary │├───┤└─────────┘┌─────────┐┌───┐│  Unitary │
+        1: ┤1         ├┤ Y ├─────■─────┤ Rz(0.1) ├┤ Y ├┤0         ├
+           └──────────┘└───┘   ┌─┴─┐   └─────────┘└───┘└──────────┘
+        2: ────────────────────┤ X ├───────────────────────────────
+                               └───┘
+        """
+
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat = scipy.stats.unitary_group.rvs(4, random_state=974)
+        start_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[0:2])
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        dag.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        stop_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[1::-1])
+        inter_nodes = _collect_circuit_between_nodes(
+            dag, [qr[0], qr[1]],
+            (start_node, start_node),
+            (stop_node, stop_node)
+        )
+        inter_dag = DAGCircuit()
+        inter_dag.add_qubits(qr)
+        for node in inter_nodes:
+            inter_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+
+        expected = dag.copy_empty_like()
+        expected.apply_operation_back(XGate(), qargs=[qr[0]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+        expected.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        expected.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        expected.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+        self.assertEqual(inter_dag, expected)
+
+    def test_gather_2q_between_interacting(self):
+        """
+        Test getting 1q and 2q gates between 2q groups when 2q gates
+        interact within 2q of interest.
+
+           ┌──────────┐┌───┐     ┌─────────┐     ┌──────────┐
+        0: ┤0         ├┤ X ├──■──┤ Ry(0.2) ├─────┤1         ├
+           │  Unitary │├───┤┌─┴─┐├─────────┤┌───┐│  Unitary │
+        1: ┤1         ├┤ Y ├┤ X ├┤ Rz(0.1) ├┤ Y ├┤0         ├
+           └──────────┘└───┘└───┘└─────────┘└───┘└──────────┘
+
+        """
+
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat = scipy.stats.unitary_group.rvs(4, random_state=974)
+        start_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[0:2])
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        dag.apply_operation_back(CXGate(), qargs=[qr[0], qr[1]])
+        dag.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        dag.apply_operation_back(YGate(), qargs=[qr[1]])
+        stop_node = dag.apply_operation_back(UnitaryGate(mat), qargs=qr[1::-1])
+        inter_nodes = _collect_circuit_between_nodes(
+            dag, [qr[0], qr[1]],
+            (start_node, start_node),
+            (stop_node, stop_node)
+        )
+        inter_dag = DAGCircuit()
+        inter_dag.add_qubits(qr)
+        for node in inter_nodes:
+            inter_dag.apply_operation_back(node.op, node.qargs, node.cargs)
+
+        expected = dag.copy_empty_like()
+        expected.apply_operation_back(XGate(), qargs=[qr[0]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+        expected.apply_operation_back(CXGate(), qargs=[qr[0], qr[1]])
+        expected.apply_operation_back(RYGate(0.2), qargs=[qr[0]])
+        expected.apply_operation_back(RZGate(0.1), qargs=[qr[1]])
+        expected.apply_operation_back(YGate(), qargs=[qr[1]])
+        self.assertEqual(inter_dag, expected)
+
+    def test_evaluate_diagonal_commutation_2q_true(self):
+        """
+        Test evaluating diagonal commutation on qubits 0 and 1 in the circuit,
+
+              ┌───┐
+        0: ───┤ Z ├───
+           ┌──┴───┴──┐
+        1: ┤ Rz(0.2) ├
+           └─────────┘
+        """
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        dag.apply_operation_back(ZGate(), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.2), qargs=[qr[1]])
+        result, _ = self._pass.evaluate_diagonal_commutation(dag, [qr[0], qr[1]])
+        self.assertTrue(result == Diagonality.TRUE)
+
+    def test_evaluate_diagonal_commutation_2q_false(self):
+        """
+        Test evaluating diagonal commutation on qubits 0 and 1 in the circuit,
+
+              ┌───┐
+        0: ───┤ H ├───
+           ┌──┴───┴──┐
+        1: ┤ Rz(0.2) ├
+           └─────────┘
+        """
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.2), qargs=[qr[1]])
+        result, _ = self._pass.evaluate_diagonal_commutation(dag, [qr[0], qr[1]])
+        self.assertTrue(result == Diagonality.FALSE)
+
+    def test_evaluate_diagonal_commutation_non_diagonal_ops(self):
+        """
+        Test evaluating diagonal commutation on qubits 0 and 1 in the circuit when
+        individual gates are not diagonal
+              ┌───┐   ┌───┐┌───┐
+        0: ───┤ H ├───┤ X ├┤ H ├
+           ┌──┴───┴──┐└───┘└───┘
+        1: ┤ Rz(0.2) ├──────────
+           └─────────┘
+        """
+        qr = [Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(RZGate(0.2), qargs=[qr[1]])
+        result, _ = self._pass.evaluate_diagonal_commutation(dag, [qr[0], qr[1]])
+        self.assertTrue(result == Diagonality.TRUE)
+
+    def test_evaluate_diagonal_commutation_3q_true(self):
+        """
+        Test evaluating diagonal commutation on qubits 0 and 1 in the circuit,
+
+           ┌───┐┌───┐   ┌───┐
+        0: ┤ H ├┤ X ├───┤ H ├───
+           ├───┤└───┘┌──┴───┴──┐
+        1: ┤ Z ├──■──┤ Rz(0.2) ├
+           └───┘┌─┴─┐└─────────┘
+        2: ─────┤ X ├───────────
+                └───┘
+        """
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(ZGate(), qargs=[qr[1]])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        dag.apply_operation_back(RZGate(0.2), qargs=[qr[1]])
+        result, _ = self._pass.evaluate_diagonal_commutation(dag, [qr[0], qr[1]])
+        self.assertTrue(result == Diagonality.TRUE)
+
+    def test_evaluate_diagonal_commutation_3q_false(self):
+        """
+        Test evaluating diagonal commutation on qubits 0 and 2 in the circuit,
+
+           ┌───┐┌───┐   ┌───┐
+        0: ┤ H ├┤ X ├───┤ H ├───
+           ├───┤└───┘┌──┴───┴──┐
+        1: ┤ Z ├──■──┤ Rz(0.2) ├
+           └───┘┌─┴─┐└─────────┘
+        2: ─────┤ X ├───────────
+                └───┘
+        """
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(XGate(), qargs=[qr[0]])
+        dag.apply_operation_back(HGate(), qargs=[qr[0]])
+        dag.apply_operation_back(ZGate(), qargs=[qr[1]])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        dag.apply_operation_back(RZGate(0.2), qargs=[qr[1]])
+        result, _ = self._pass.evaluate_diagonal_commutation(
+            dag, [qr[0], qr[2]], do_equiv_check=False
+        )
+        self.assertTrue(result == Diagonality.FALSE)
+
+    def test_identify_simply_separated_2q_runs(self):
+        """
+        identify circuit sections where 2q runs on common qubits are separated by
+        any other 2q runs to disjoint qubits.
+                ┌───┐┌───┐        ┌─────────┐
+        0: ──■──┤ H ├┤ Z ├──■───■─┤ Ry(0.1) ├
+           ┌─┴─┐└─┬─┘└───┘  │   │ └─────────┘
+        1: ┤ X ├──■─────────■───■────────────
+           └───┘          ┌─┴─┐
+        2: ───────────────┤ X ├──────────────
+                          └───┘
+        """
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        # 2q block #1
+        dag.apply_operation_back(CXGate(), qargs=qr[0:2])
+        dag.apply_operation_back(CHGate(), qargs=[qr[1], qr[0]])
+        dag.apply_operation_back(ZGate(), qargs=[qr[0]])
+        # seperator node
+        dag.apply_operation_back(CCXGate(), qargs=[qr[0], qr[1], qr[2]])
+        # 2q block #2
+        dag.apply_operation_back(CZGate(), qargs=[qr[0], qr[1]])
+        dag.apply_operation_back(RYGate(0.1), qargs=[qr[0]])
+
+        blocks = dag.collect_2q_runs()
+        candidate_blocks = pass_.get_candidate_2q_blocks(blocks, dag)
+
+        expected_dag0 = DAGCircuit()
+        expected_dag0.add_qubits(qr)
+        expected_dag0.apply_operation_back(CXGate(), qargs=qr[0:2])
+        expected_dag0.apply_operation_back(CHGate(), qargs=[qr[1], qr[0]])
+        expected_dag0.apply_operation_back(ZGate(), qargs=[qr[0]])
+
+        expected_dag1 = DAGCircuit()
+        expected_dag1.add_qubits(qr)
+        expected_dag1.apply_operation_back(CZGate(), qargs=[qr[0], qr[1]])
+        expected_dag1.apply_operation_back(RYGate(0.1), qargs=[qr[0]])
+
+        expected_blocks = {(qr[0], qr[1]): [expected_dag0.op_nodes(), expected_dag1.op_nodes()]}
+        bit_map = {bit: ind for ind, bit in enumerate(qr)}
+        for block0, block1 in zip(candidate_blocks[qr[0], qr[1]], expected_blocks[qr[0], qr[1]]):
+            for node0, node1 in zip(block0, block1):
+                self.assertTrue(
+                    DAGNode.semantic_eq(
+                        node0, node1,
+                        bit_indices1=bit_map,
+                        bit_indices2=bit_map,
+                    )
+                )
+
+    def test_two_group_optimize(self):
+        """
+        Test pass correctly can convert two 3 CNOT unituries to one 3 CNOT
+        and one 2 CNOT unitary.
+
+           ┌───────────┐     ┌───────────┐
+        0: ┤0          ├─────┤0          ├
+           │  Unitary0 │     │  Unitary1 │
+        1: ┤1          ├──■──┤1          ├
+           └───────────┘┌─┴─┐└───────────┘
+        2: ─────────────┤ X ├─────────────
+                        └───┘
+
+        """
+        np.set_printoptions(precision=2, linewidth=200, suppress=True)
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat0 = scipy.stats.unitary_group.rvs(4, random_state=61)
+        mat1 = scipy.stats.unitary_group.rvs(4, random_state=94)
+        dag.apply_operation_back(UnitaryGate(mat0), qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        dag.apply_operation_back(UnitaryGate(mat1), qargs=qr[0:2])
+        circ = dag_to_circuit(dag)
+        cdag = pass_.run(dag)
+        ccirc = dag_to_circuit(cdag)
+        circ_opt = transpile(circ, basis_gates=["cx", "u"], optimization_level=1)
+        ccirc_opt = transpile(ccirc, basis_gates=["cx", "u"], optimization_level=1)
+        self.assertEqual(circ_opt.count_ops()["cx"], 7)
+        self.assertEqual(ccirc_opt.count_ops()["cx"], 6)
+        self.assertEqual(Operator(ccirc_opt), Operator(circ))
+
+    def test_five_group_optimize(self):
+        """
+        Test commutation chains together properly for a sequence of five 2q unitaries.
+           ┌───────────┐     ┌───────────┐     ┌───────────┐     ┌───────────┐     ┌───────────┐
+        0: ┤0          ├─────┤0          ├─────┤0          ├─────┤0          ├─────┤0          ├─────
+           │  Unitary0 │     │  Unitary1 │     │  Unitary2 │     │  Unitary3 │     │  Unitary4 │
+        1: ┤1          ├──■──┤1          ├──■──┤1          ├──■──┤1          ├──■──┤1          ├──■──
+           └───────────┘┌─┴─┐└───────────┘┌─┴─┐└───────────┘┌─┴─┐└───────────┘┌─┴─┐└───────────┘┌─┴─┐
+        2: ─────────────┤ X ├─────────────┤ X ├─────────────┤ X ├─────────────┤ X ├─────────────┤ X ├
+                        └───┘             └───┘             └───┘             └───┘             └───┘
+        """
+        np.set_printoptions(precision=2, linewidth=200, suppress=True)
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat0 = scipy.stats.unitary_group.rvs(4, random_state=61)
+        mat1 = scipy.stats.unitary_group.rvs(4, random_state=94)
+        mat2 = scipy.stats.unitary_group.rvs(4, random_state=98)
+        mat3 = scipy.stats.unitary_group.rvs(4, random_state=945)
+        mat4 = scipy.stats.unitary_group.rvs(4, random_state=45)
+        ug0 = UnitaryGate(mat0)
+        ug0.name = "unitary0"
+        dag.apply_operation_back(ug0, qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        ug1 = UnitaryGate(mat1)
+        ug1.name = "unitary1"
+        dag.apply_operation_back(ug1, qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        ug2 = UnitaryGate(mat2)
+        ug2.name = "unitary2"
+        dag.apply_operation_back(ug2, qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        ug3 = UnitaryGate(mat3)
+        ug3.name = "unitary3"
+        dag.apply_operation_back(ug3, qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        ug4 = UnitaryGate(mat4)
+        ug4.name = "unitary4"
+        dag.apply_operation_back(ug4, qargs=qr[0:2])
+        dag.apply_operation_back(CXGate(), qargs=[qr[1], qr[2]])
+        circ = dag_to_circuit(dag)
+        circ_opt = transpile(circ, basis_gates=["cx", "u"], optimization_level=1)
+        ccirc = pass_(circ_opt)
+        ccirc_opt = transpile(ccirc, basis_gates=["cx", "u"], optimization_level=1)
+        self.assertEqual(circ_opt.count_ops()["u"], 36)
+        self.assertEqual(circ_opt.count_ops()["cx"], 20)
+        self.assertEqual(ccirc_opt.count_ops()["u"], 33)
+        self.assertEqual(ccirc_opt.count_ops()["cx"], 16)
+        self.assertEqual(Operator(ccirc_opt), Operator(circ))
+
+    def test_collective_commute(self):
+        """
+        Test commutation works when gates between 2q gates collectivly commute with
+        the diagonal but don't individually commute.
+           ┌──────────┐               ┌──────────┐
+        0: ┤0         ├───────────────┤0         ├
+           │  Unitary │┌───┐┌───┐┌───┐│  Unitary │
+        1: ┤1         ├┤ H ├┤ X ├┤ H ├┤1         ├
+           └──────────┘└─┬─┘└─┬─┘└─┬─┘└──────────┘
+        2: ──────────────■────■────■──────────────
+
+        """
+        np.set_printoptions(precision=2, linewidth=200, suppress=True)
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        dag = DAGCircuit()
+        dag.add_qubits(qr)
+        mat0 = scipy.stats.unitary_group.rvs(4, random_state=61)
+        mat1 = scipy.stats.unitary_group.rvs(4, random_state=94)
+        dag.apply_operation_back(UnitaryGate(mat0), qargs=qr[0:2])
+        dag.apply_operation_back(CHGate(), qargs=[qr[2], qr[1]])
+        dag.apply_operation_back(CXGate(), qargs=[qr[2], qr[1]])
+        dag.apply_operation_back(CHGate(), qargs=[qr[2], qr[1]])
+        dag.apply_operation_back(UnitaryGate(mat1), qargs=qr[0:2])
+        circ = dag_to_circuit(dag)
+        cdag = pass_.run(dag)
+        ccirc = dag_to_circuit(cdag)
+        circ_opt = transpile(circ, basis_gates=["cx", "u"], optimization_level=1)
+        ccirc_opt = transpile(ccirc, basis_gates=["cx", "u"], optimization_level=1)
+        self.assertTrue(circ_opt.count_ops()["cx"], 9)
+        self.assertTrue(ccirc_opt.count_ops()["cx"], 8)
+        self.assertEqual(Operator(ccirc_opt), Operator(circ))
+
+    def test_equiv_commute(self):
+        """Test commutation works when gates between 2q gates collectivly
+        commute with the diagonal but don't individually commute. In
+        this case the 2q unitaries are pre-expanded to see that the
+        grouping doesn't get confused.
+
+           ┌──────────┐               ┌──────────┐
+        0: ┤0         ├───────────────┤0         ├
+           │  Unitary │┌───┐┌───┐┌───┐│  Unitary │
+        1: ┤1         ├┤ H ├┤ X ├┤ H ├┤1         ├
+           └──────────┘└─┬─┘└─┬─┘└─┬─┘└──────────┘
+        2: ──────────────■────■────■──────────────
+
+        We know the middle section of qubits on [1, 2] commutes with
+        diagonal on [1].  However, when this circuit is expanded to
+        {u, cx} and the pass collects 2q runs to identify commutation,
+        the locals of the middle section get grouped with the first
+        unitary since `collect_2q_runs` is greedy. The operation that
+        remains on [1, 2] is no longer diagonal. Fortuately, in this
+        case, the TwoQubitWeylDecomposition class can identify this as
+        locally equivalent to a controlled gate so it can still be
+        optimized.
+
+        """
+        np.set_printoptions(precision=2, linewidth=200, suppress=True)
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        circ = QuantumCircuit(qr)
+        circ.cx(0, 1)
+        circ.ry(0.2, 0)
+        circ.rz(0.2, 1)
+        circ.cx(0, 1)
+        circ.ry(0.3, 0)
+        circ.rz(0.3, 1)
+        circ.cx(0, 1)
+        circ.ch(2, 1)
+        circ.cx(2, 1)
+        circ.ch(2, 1)
+        circ.cx(0, 1)
+        circ.ry(0.2, 0)
+        circ.rz(0.2, 1)
+        circ.cx(0, 1)
+        circ.ry(0.3, 0)
+        circ.rz(0.3, 1)
+        circ.cx(0, 1)
+        circ_expand = transpile(circ, basis_gates=["u", "cx"], optimization_level=0)
+        ccirc = pass_(circ_expand)
+        ccirc_opt = transpile(ccirc, basis_gates=["cx", "u"], optimization_level=0)
+        self.assertEqual(circ_expand.count_ops()["cx"], 9)
+        self.assertEqual(ccirc_opt.count_ops()["cx"], 6)
+        self.assertEqual(Operator(ccirc_opt), Operator(circ))
+
+    def test_equiv_commute_random(self):
+        """Although this appears similar to the test above of a similar
+        name, this cought a bug in the grouping of qubits due to the
+        difference in single qubit pattern after basis translation.
+
+           ┌──────────┐               ┌──────────┐
+        0: ┤0         ├───────────────┤0         ├
+           │  Unitary │┌───┐┌───┐┌───┐│  Unitary │
+        1: ┤1         ├┤ H ├┤ X ├┤ H ├┤1         ├
+           └──────────┘└─┬─┘└─┬─┘└─┬─┘└──────────┘
+        2: ──────────────■────■────■──────────────
+
+        """
+        np.set_printoptions(precision=2, linewidth=200, suppress=True)
+        pass_ = CommuteDiagonal()
+        qr = [Qubit(), Qubit(), Qubit()]
+        circ = QuantumCircuit(qr)
+        mat0 = scipy.stats.unitary_group.rvs(4, random_state=254)
+        mat1 = scipy.stats.unitary_group.rvs(4, random_state=981)
+        circ.unitary(mat0, [0, 1])
+        circ.ch(2, 1)
+        circ.cx(2, 1)
+        circ.ch(2, 1)
+        circ.unitary(mat1, [0, 1])
+        circ_expand = transpile(circ, basis_gates=["u", "cx"], optimization_level=0)
+        ccirc = pass_(circ_expand)
+        ccirc_opt = transpile(ccirc, basis_gates=["cx", "u"], optimization_level=0)
+        self.assertEqual(circ_expand.count_ops()["cx"], 9)
+        self.assertEqual(ccirc_opt.count_ops()["cx"], 6)
+        self.assertEqual(Operator(ccirc_opt), Operator(circ))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
This pass makes use of Theorem 14 in arXiv:quant-ph/0406176 which describes the decomposition of an arbitrary two qubit gate, which takes at most three CNOTs to decompose, into the combination of a diagonal gate and a unitary which takes at most two CNOT gates. 

This pass identifies places in the circuit where runs of two qubit gates are separated by gates which commute with the diagonal.  

### Details and comments
The pass works by identifying runs of two qubit gates which are separated by a diagonal gate, or a gate which is locally equivalent to a controlled gate as identified by the TwoQubitWeylDecomposition class, and commuting the diagonal through.

In the contrived ideal case where there are many two qubit unitaries separated by the controls of another gate cnot 
reductions of ~20% can be obtained.

This pass does not check that the input circuit is decomposed into one and two qubit gates, although that would give this pass the best opportunity to find reductions.

