### PR TITLE
Fix PVQD loss function

### DIFF
--- a/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2019, 2022.
+# (C) Copyright IBM 2019, 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
@@ -279,7 +279,7 @@ class PVQD(RealTimeEvolver):
 
             # in principle, we could add different loss functions here, but we're currently
             # not aware of a use-case for a different one than in the paper
-            return 1 - np.abs(fidelities) ** 2
+            return 1 - fidelities
 
         if _is_gradient_supported(ansatz) and self.use_parameter_shift:
 

--- a/releasenotes/notes/fix-pvqd-loss-cb1ebe0258f225de.yaml
+++ b/releasenotes/notes/fix-pvqd-loss-cb1ebe0258f225de.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed loss function in PVQD. Removed extra abs**2 that is already covered by the fidelity primitive


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The loss function in PVQD is defined as `1 - fidelity`, in the current implementation it was `1 - |fidelity|²`.



