### PR TITLE
QGT is hermitian, not symmetric

### DIFF
--- a/test/python/algorithms/gradients/test_qfi.py
+++ b/test/python/algorithms/gradients/test_qfi.py
@@ -123,7 +123,7 @@ class TestQFI(QiskitTestCase):
         with self.subTest("Test with DerivativeType.IMAG"):
             qfi = LinCombQFI(self.estimator, derivative_type=DerivativeType.IMAG)
             param_list = [[np.pi / 4, 0], [np.pi / 2, np.pi / 4]]
-            correct_values = [[[0, 0.707106781], [0.707106781, 0]], [[0, 1], [1, 0]]]
+            correct_values = [[[0, 0.707106781], [-0.707106781, 0]], [[0, 1], [-1, 0]]]
             for i, param in enumerate(param_list):
                 qfi_result = qfi.run([qc], [param]).result().qfis
                 np.testing.assert_allclose(qfi_result[0], correct_values[i], atol=1e-3)
@@ -131,7 +131,7 @@ class TestQFI(QiskitTestCase):
         # test real + imaginary derivative
         with self.subTest("Test with DerivativeType.IMAG"):
             qfi = LinCombQFI(self.estimator, derivative_type=DerivativeType.COMPLEX)
-            correct_values = [[[1, 0.707106781j], [0.707106781j, 0.5]], [[1, 1j], [1j, 1]]]
+            correct_values = [[[1, 0.707106781j], [-0.707106781j, 0.5]], [[1, 1j], [-1j, 1]]]
             for i, param in enumerate(param_list):
                 qfi_result = qfi.run([qc], [param]).result().qfis
                 np.testing.assert_allclose(qfi_result[0], correct_values[i], atol=1e-3)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fix a minor bug where the complex part of the `LinCombQFI` was assumed to be symmetric, when it is actually hermitian.

### Details and comments

For a quantum state `\phi`, the complex parts of the QFI is 4 times the following equation 
![image](https://user-images.githubusercontent.com/5978796/212362316-f6938d7b-8e67-4309-a8e8-2b89f7303d31.png)

which is hermitian, i.e. `G_{ij} = conj(G_{ji})`. The `LinCombQFI` however implemented `G_{ij} = G_{ji}` which led to wrong results for `derivative_type`s being any other than `DerivativeType.REAL`.

This does not include a reno since the QFIs are not yet released.
