### PR TITLE
Pin sphinx-autodoc-typehints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,7 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
+
+# The 1.21.0 release of sphinx-autodoc-typehints seems to affect the spacing
+# in our docstrings in a way that Sphinx doesn't like.
+sphinx-autodoc-typehints==1.20.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints~=1.18,!=1.19.3
+sphinx-autodoc-typehints>=1.18
 sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0


### PR DESCRIPTION
### Summary

The 1.21.0 release appears to have changed the spacing in its outputs, which is causing a bunch of Sphinx/docutils warnings for some of our docstrings.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


