### PR TITLE
Relax pin on sphinx-autodoc-typehints

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,7 +1,3 @@
 # jsonschema pinning needed due nbformat==5.1.3 using deprecated behaviour in
 # 4.0+. The pin can be removed after nbformat is updated.
 jsonschema==3.2.0
-
-# The 1.21.0 release of sphinx-autodoc-typehints seems to affect the spacing
-# in our docstrings in a way that Sphinx doesn't like.
-sphinx-autodoc-typehints==1.20.2


### PR DESCRIPTION
### Summary

Version 1.21.1 was recently released, which fixes the spacing bug introduced in 1.21.0.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

See tox-dev/sphinx-autodoc-typehints#294.