### PR TITLE
Pin ``sphinx-autodoc-typehint``

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints>=1.18
+sphinx-autodoc-typehints==1.23.3  # revert to >=1.18 once the 1.23.4 incompatibility is fixed
 sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints==1.23.3  # revert to >=1.18 once the 1.23.4 incompatibility is fixed
+sphinx-autodoc-typehints==1.23.1  # revert to >=1.18 once the incompatibilities in >1.23.1 are fixed
 sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,7 @@ seaborn>=0.9.0
 reno>=3.4.0
 Sphinx>=3.0.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints==1.23.1  # revert to >=1.18 once the incompatibilities in >1.23.1 are fixed
+sphinx-autodoc-typehints==1.21.1  # revert to >=1.18 once the incompatibilities are fixed
 sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The 1.23.4 release of ``sphinx-autodoc-typehint`` broke the docs build of the CI.

### Details and comments

The build errors with
```
reading sources... [  3%] apidocs/algorithms .. stubs/qiskit.algorithms.SciPyImaginaryEvolver
:26: (ERROR/3) no path specified
:26: (ERROR/3) no path specified

Traceback (most recent call last):
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/cmd/build.py", line 281, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/application.py", line 347, in build
    self.builder.build_update()
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 310, in build_update
    self.build(to_build,
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 326, in build
    updated_docnames = set(self.read())
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 431, in read
    self._read_parallel(docnames, nproc=self.app.parallel)
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/builders/__init__.py", line 487, in _read_parallel
    tasks.join()
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/util/parallel.py", line 105, in join
    if not self._join_one():
  File "/home/vsts/work/1/s/.tox/docs/lib/python3.9/site-packages/sphinx/util/parallel.py", line 126, in _join_one
    raise SphinxParallelError(*result)
sphinx.errors.SphinxParallelError: sphinx.errors.ExtensionError: Handler <function process_docstring at 0x7f914bf254c0> for event 'autodoc-process-docstring' threw an exception (exception: )

Sphinx parallel build error:
sphinx.errors.ExtensionError: Handler <function process_docstring at 0x7f914bf254c0> for event 'autodoc-process-docstring' threw an exception (exception: )
docs: exit 2 (43.29 seconds) /home/vsts/work/1/s> sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html pid=5682
.pkg: _exit> python /opt/hostedtoolcache/Python/3.9.16/x64/lib/python3.9/site-packages/pyproject_api/_backend.py True setuptools.build_meta
  docs: FAIL code 2 (244.43=setup[201.14]+cmd[43.29] seconds)
  evaluation failed :( (245.89 seconds)
##[error]Bash exited with code '2'.
```
see e.g. https://dev.azure.com/qiskit-ci/qiskit-terra/_build/results?buildId=42940&view=logs&j=abfb3e93-d1ff-5b1b-cb4c-74d6dcf536f9&t=60edc4b3-4259-59c8-ae13-dc31febe2d3d

Let's see if pinning to the latest version before that, 1.23.3, works otherwise we can pin 1.23.1 which worked before.


