### PR TITLE
Fixissue8126v4branch

### DIFF
--- a/qiskit/opflow/evolutions/trotterizations/suzuki.py
+++ b/qiskit/opflow/evolutions/trotterizations/suzuki.py
@@ -60,6 +60,8 @@ class Suzuki(TrotterizationBase):
 
         if isinstance(operator.coeff, (float, ParameterExpression)):
             coeff = operator.coeff
+            coeff = 1
+
         else:
             if isreal(operator.coeff):
                 coeff = operator.coeff.real

--- a/qiskit/opflow/evolutions/trotterizations/suzuki.py
+++ b/qiskit/opflow/evolutions/trotterizations/suzuki.py
@@ -60,7 +60,8 @@ class Suzuki(TrotterizationBase):
 
         if isinstance(operator.coeff, (float, ParameterExpression)):
             coeff = operator.coeff
-            coeff = 1
+            if not isinstance(coeff, float):
+                coeff = 1
 
         else:
             if isreal(operator.coeff):

--- a/releasenotes/notes/fix-time-parameter-for-suzuki-trotterization-40474542c7ef2149.yaml
+++ b/releasenotes/notes/fix-time-parameter-for-suzuki-trotterization-40474542c7ef2149.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fix wrong time value in Trotterized unitary #8126.
+    When Computing a suzuki decomposition of a Hamiltonian for a given time t, if t is a float, everything works fine. 
+    If t is a Parameter object the value gets squared when it is bound.
+    This is tested with function test_suzuki_trotterization_time_parameter(self).
+    Refer to https://github.com/Qiskit/qiskit-terra/issues/8126
+    

--- a/test/python/opflow/test_evolution.py
+++ b/test/python/opflow/test_evolution.py
@@ -365,6 +365,18 @@ class TestEvolution(QiskitOpflowTestCase):
         )
         np.testing.assert_array_almost_equal(evolution.to_matrix(), matrix)
 
+    def test_suzuki_trotterization_time_parameter(self):
+        """Test for Suzuki converter"""
+
+        time = 11.0
+        ham = (X ^ X ^ X) + (Z ^ Z ^ Z)
+        u1 = Suzuki(1, order=1).convert(time * ham)
+
+        ti = Parameter("t")
+        u2 = Suzuki(1, order=1).convert(ti * ham)
+        u2_t = u2.bind_parameters({ti: time})
+        self.assertEqual(u2_t, u1)
+
     def test_evolved_op_to_instruction(self):
         """Test calling `to_instruction` on a plain EvolvedOp.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
fix #8126 


### Details and comments
Fix wrong time value in Trotterized unitary #8126.
    When Computing a suzuki decomposition of a Hamiltonian for a given time t, if t is a float, everything works fine. 
    If t is a Parameter object the value gets squared when it is bound.
    This is tested with function test_suzuki_trotterization_time_parameter(self).

