### PR TITLE
Update PyO3 and Rust Numpy to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.6.5",
  "scopeguard",
 ]
 
@@ -196,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "ndarray"
 version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,17 +270,17 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462c1af5ba1fddec1488c4646993a23ae7931f9e170ccba23e9c7c834277797"
+checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
 dependencies = [
- "ahash 0.7.6",
  "libc",
  "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
  "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -340,16 +349,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "ccd4149c8c3975099622b4e1962dac27565cf5663b76452c3e2b66e0b6824277"
 dependencies = [
  "cfg-if",
  "hashbrown 0.12.3",
  "indexmap",
  "indoc",
  "libc",
- "memoffset",
+ "memoffset 0.8.0",
  "num-bigint",
  "num-complex",
  "parking_lot",
@@ -361,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "9cd09fe469834db21ee60e0051030339e5d361293d8cb5ec02facf7fdcf52dbf"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -371,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "0c427c9a96b9c5b12156dbc11f76b14f49e9aae8905ca783ea87c249044ef137"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -381,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "16b822bbba9d60630a44d2109bc410489bb2f439b33e3a14ddeb8a40b378a7c4"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -393,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "84ae898104f7c99db06231160770f3e40dad6eb9021daddc0fedfa3e41dff10a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -516,6 +525,12 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustworkx-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rayon = "1.6"
-numpy = "0.17.2"
+numpy = "0.18.0"
 rand = "0.8"
 rand_pcg = "0.3"
 rand_distr = "0.4.3"
@@ -21,7 +21,7 @@ num-bigint = "0.4"
 rustworkx-core = "0.12"
 
 [dependencies.pyo3]
-version = "0.17.3"
+version = "0.18.0"
 features = ["extension-module", "hashbrown", "num-complex", "num-bigint", "indexmap"]
 
 [dependencies.ndarray]

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -230,10 +230,10 @@ class SabreLayout(TransformationPass):
             self._neighbor_table,
             dist_matrix,
             Heuristic.Decay,
-            self.seed,
             self.max_iterations,
             self.swap_trials,
             self.layout_trials,
+            self.seed,
         )
         # Apply initial layout selected.
         original_dag = dag

--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -229,9 +229,9 @@ class SabreSwap(TransformationPass):
             self._neighbor_table,
             self.dist_matrix,
             heuristic,
-            self.seed,
             layout,
             self.trials,
+            self.seed,
         )
 
         layout_mapping = layout.layout_mapping()

--- a/src/results/marginalization.rs
+++ b/src/results/marginalization.rs
@@ -115,9 +115,13 @@ fn map_memory(
 }
 
 #[pyfunction(
-    return_int = "false",
-    return_hex = "false",
-    parallel_threshold = "1000"
+    signature = (
+        memory,
+        indices=None,
+        return_int=false,
+        return_hex=false,
+        parallel_threshold=1000,
+    )
 )]
 pub fn marginal_memory(
     py: Python,

--- a/src/sabre_layout.rs
+++ b/src/sabre_layout.rs
@@ -37,10 +37,10 @@ pub fn sabre_layout_and_routing(
     neighbor_table: &NeighborTable,
     distance_matrix: PyReadonlyArray2<f64>,
     heuristic: &Heuristic,
-    seed: Option<u64>,
     max_iterations: usize,
     num_swap_trials: usize,
     num_layout_trials: usize,
+    seed: Option<u64>,
 ) -> ([NLayout; 2], SwapMap, PyObject) {
     let run_in_parallel = getenv_use_multiple_threads();
     let outer_rng = match seed {

--- a/src/sabre_swap/mod.rs
+++ b/src/sabre_swap/mod.rs
@@ -152,9 +152,9 @@ pub fn build_swap_map(
     neighbor_table: &NeighborTable,
     distance_matrix: PyReadonlyArray2<f64>,
     heuristic: &Heuristic,
-    seed: Option<u64>,
     layout: &mut NLayout,
     num_trials: usize,
+    seed: Option<u64>,
     run_in_parallel: Option<bool>,
 ) -> (SwapMap, PyObject) {
     let dist = distance_matrix.as_array();


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The latest releases of PyO3 and rust numpy were just released. The changelogs for both can be found at:

https://pyo3.rs/v0.18.0/changelog

and

https://github.com/PyO3/rust-numpy/blob/main/CHANGELOG.md

Since the two releases are tightly coupled this commit opts to update them together instead of the normal dependabot workflow. Similarly some of our usage (mainly around signatures and argument ordering) for building a python interface using PyO3 has been deprecated. That usage is also updated in this PR to avoid compilation warnings, which will be treated as errors by clippy in CI.

### Details and comments