### PR TITLE
Add missing test coverage for RZXCalibration builder with target

### DIFF
--- a/qiskit/transpiler/passes/calibration/rzx_builder.py
+++ b/qiskit/transpiler/passes/calibration/rzx_builder.py
@@ -84,9 +84,6 @@ class RZXCalibrationBuilder(CalibrationBuilder):
         """
         super().__init__()
 
-        if instruction_schedule_map is None:
-            raise QiskitError("Calibrations can only be added to Pulse-enabled backends")
-
         if qubit_channel_mapping:
             warnings.warn(
                 "'qubit_channel_mapping' is no longer used. This value is ignored.",
@@ -97,6 +94,8 @@ class RZXCalibrationBuilder(CalibrationBuilder):
         self._verbose = verbose
         if target:
             self._inst_map = target.instruction_schedule_map()
+        if self._inst_map is None:
+            raise QiskitError("Calibrations can only be added to Pulse-enabled backends")
 
     def supported(self, node_op: CircuitInst, qubits: List) -> bool:
         """Determine if a given node supports the calibration.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently merged #9343 support for using the Target directly was added to the RZXCalibrartionBuilder family of passes. However, test coverage in that PR was omitted by mistake for that pass (other passes in the PR were covered). There was a bug in the code change introduced in that PR which caused an error on initialization if a target were specified without an InstructionScheduleMap (which was the intent of the new target kwarg). This commit fixes the logic bug in the pass and adds test coverage to ensure specifying only a target continues to work moving forward.

### Details and comments