### PR TITLE
Pin tox version in CI

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - bash: |
           set -e
           python -m pip install --upgrade pip setuptools wheel
-          pip install -U tox
+          pip install -U "tox<4.4.0"
           sudo apt-get update
           sudo apt-get install -y graphviz
         displayName: 'Install dependencies'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The most recent release tox, 4.4.0, changed the behavior of how tox interacts with constraints files. It is raising an error because it doesn't like the format of our constraints file in qiskit. This commit works around this by pinning our tox version. Given that we're preparing to release 0.23.0 pinning is the fastest solution in the short term, we can adjust things after the release is out.

### Details and comments


