### PR TITLE
Add ECR to calibration builders

### DIFF
--- a/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
+++ b/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+feature:
   - |
     The Calibration builders for pulse-efficient transpilation have been updated
     to handle backends that expose ecr or cx gates.

--- a/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
+++ b/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
@@ -1,5 +1,5 @@
 ---
-feature:
+features:
   - |
     The Calibration builders for pulse-efficient transpilation have been updated
     to handle backends that expose ecr or cx gates.

--- a/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
+++ b/releasenotes/notes/ecr_cal_builder-358017785a3e296a.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    The Calibration builders for pulse-efficient transpilation have been updated
+    to handle backends that expose ecr or cx gates.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Fixes #9308 

### Details and comments

Details to come but basically we look for both cx and ecr in the instruction schedule map.
Test code:
```python
from qiskit.circuit import Parameter

from qiskit import IBMQ, QuantumCircuit, transpile, schedule
from qiskit.visualization.pulse_v2 import IQXDebugging

from qiskit.transpiler import PassManager
from qiskit.circuit.library.standard_gates.equivalence_library import (
    StandardEquivalenceLibrary as std_eqlib,
)
from qiskit.transpiler.passes import (
    Collect2qBlocks,
    ConsolidateBlocks,
    UnrollCustomDefinitions,
    BasisTranslator,
    Optimize1qGatesDecomposition,
)
from qiskit.transpiler.passes.calibration.builders import RZXCalibrationBuilderNoEcho
from qiskit.transpiler.passes.optimization.echo_rzx_weyl_decomposition import (
    EchoRZXWeylDecomposition,
)

IBMQ.load_account()

provider = ...
backend = ...

inst_map = backend.defaults().instruction_schedule_map
inst_map.get("ecr", (1, 0)).draw(style=IQXDebugging())
```

![image](https://user-images.githubusercontent.com/38065505/214890063-e9ec5ab6-25eb-40f1-8b63-d765b2d04f4b.png)


```python
channel_map = backend.configuration().qubit_channel_mapping
rzx_basis = ["rzx", "rz", "x", "sx"]

pulse_efficient = PassManager(
    [
        # Consolidate consecutive two-qubit operations.
        Collect2qBlocks(),
        ConsolidateBlocks(basis_gates=["rz", "sx", "x", "rxx"]),
        # Rewrite circuit in terms of Weyl-decomposed echoed RZX gates.
        EchoRZXWeylDecomposition(backend.defaults().instruction_schedule_map),
        # Attach scaled CR pulse schedules to the RZX gates.
        RZXCalibrationBuilderNoEcho(
            instruction_schedule_map=inst_map, qubit_channel_mapping=channel_map
        ),
        # Simplify single-qubit gates.
        UnrollCustomDefinitions(std_eqlib, rzx_basis),
        BasisTranslator(std_eqlib, rzx_basis),
        Optimize1qGatesDecomposition(rzx_basis),
    ]
)

circ = QuantumCircuit(2)
circ.rzz(0.3, 1, 0)
pulse_efficient.run(circ).draw("mpl")
```

![image](https://user-images.githubusercontent.com/38065505/214890204-552959ce-8c7b-468b-bfec-a13871d63bdf.png)

```python
schedule(pulse_efficient.run(circ), backend).draw(style=IQXDebugging())
```

![image](https://user-images.githubusercontent.com/38065505/214890383-a1d8c59f-7708-4993-8b20-7a537957b1e5.png)


