### PR TITLE
Fix clippy failures with Rust 1.67.0

### DIFF
--- a/src/pauli_exp_val.rs
+++ b/src/pauli_exp_val.rs
@@ -58,8 +58,7 @@ pub fn expval_pauli_no_x(
 ) -> PyResult<f64> {
     if num_qubits >= usize::BITS as usize {
         return Err(PyOverflowError::new_err(format!(
-            "The value for num_qubits, {}, is too large and would overflow",
-            num_qubits
+            "The value for num_qubits, {num_qubits}, is too large and would overflow"
         )));
     }
     let data_arr = data.as_slice()?;
@@ -93,8 +92,7 @@ pub fn expval_pauli_with_x(
 ) -> PyResult<f64> {
     if num_qubits > usize::BITS as usize {
         return Err(PyOverflowError::new_err(format!(
-            "The value for num_qubits, {}, is too large and would overflow",
-            num_qubits
+            "The value for num_qubits, {num_qubits}, is too large and would overflow",
         )));
     }
     let data_arr = data.as_slice()?;
@@ -149,8 +147,7 @@ pub fn density_expval_pauli_no_x(
 ) -> PyResult<f64> {
     if num_qubits >= usize::BITS as usize {
         return Err(PyOverflowError::new_err(format!(
-            "The value for num_qubits, {}, is too large and would overflow",
-            num_qubits
+            "The value for num_qubits, {num_qubits}, is too large and would overflow",
         )));
     }
     let data_arr = data.as_slice()?;
@@ -185,8 +182,7 @@ pub fn density_expval_pauli_with_x(
 ) -> PyResult<f64> {
     if num_qubits >= usize::BITS as usize {
         return Err(PyOverflowError::new_err(format!(
-            "The value for num_qubits, {}, is too large and would overflow",
-            num_qubits
+            "The value for num_qubits, {num_qubits}, is too large and would overflow",
         )));
     }
     let data_arr = data.as_slice()?;

--- a/src/sabre_swap/swap_map.rs
+++ b/src/sabre_swap/swap_map.rs
@@ -36,8 +36,7 @@ impl SwapMap {
         match self.map.get(&object) {
             Some(val) => Ok(val.clone()),
             None => Err(PyIndexError::new_err(format!(
-                "Node index {} not in swap mapping",
-                object
+                "Node index {object} not in swap mapping",
             ))),
         }
     }


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Rust 1.67.0 released earlier today and with it the default set of rules in clippy changed. A new rule checking the use of the `format!()` macro was added that triggers on some of the returned exception strings we were using. This commit fixes this issue so that we're able to pass clippy with the latest version of Rust.

### Details and comments