### PR TITLE
Fix typo of Target argument name

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -113,7 +113,7 @@ def convert_to_target(
         target.granularity = configuration.timing_constraints.get("granularity")
         target.min_length = configuration.timing_constraints.get("min_length")
         target.pulse_alignment = configuration.timing_constraints.get("pulse_alignment")
-        target.aquire_alignment = configuration.timing_constraints.get("acquire_alignment")
+        target.acquire_alignment = configuration.timing_constraints.get("acquire_alignment")
     # If a pulse defaults exists use that as the source of truth
     if defaults is not None:
         inst_map = defaults.instruction_schedule_map

--- a/qiskit/providers/fake_provider/utils/backend_converter.py
+++ b/qiskit/providers/fake_provider/utils/backend_converter.py
@@ -105,7 +105,7 @@ def convert_to_target(conf_dict: dict, props_dict: dict = None, defs_dict: dict 
         target.granularity = conf_dict["timing_constraints"].get("granularity")
         target.min_length = conf_dict["timing_constraints"].get("min_length")
         target.pulse_alignment = conf_dict["timing_constraints"].get("pulse_alignment")
-        target.aquire_alignment = conf_dict["timing_constraints"].get("acquire_alignment")
+        target.acquire_alignment = conf_dict["timing_constraints"].get("acquire_alignment")
     # If pulse defaults exists use that as the source of truth
     if defs_dict is not None:
         # TODO remove the usage of PulseDefaults as it will be deprecated in the future

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -16,7 +16,7 @@
 A target object represents the minimum set of information the transpiler needs
 from a backend
 """
-
+import warnings
 from typing import Union
 from collections.abc import Mapping
 from collections import defaultdict
@@ -35,6 +35,7 @@ from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.timing_constraints import TimingConstraints
+from qiskit.utils.deprecation import deprecate_arguments
 
 # import QubitProperties here to provide convenience alias for building a
 # full target
@@ -190,13 +191,14 @@ class Target(Mapping):
         "granularity",
         "min_length",
         "pulse_alignment",
-        "aquire_alignment",
+        "acquire_alignment",
         "_non_global_basis",
         "_non_global_strict_basis",
         "qubit_properties",
         "_global_operations",
     )
 
+    @deprecate_arguments({"aquire_alignment": "acquire_alignment"})
     def __init__(
         self,
         description=None,
@@ -205,7 +207,7 @@ class Target(Mapping):
         granularity=1,
         min_length=1,
         pulse_alignment=1,
-        aquire_alignment=1,
+        acquire_alignment=1,
         qubit_properties=None,
     ):
         """
@@ -264,7 +266,7 @@ class Target(Mapping):
         self.granularity = granularity
         self.min_length = min_length
         self.pulse_alignment = pulse_alignment
-        self.aquire_alignment = aquire_alignment
+        self.acquire_alignment = acquire_alignment
         self._non_global_basis = None
         self._non_global_strict_basis = None
         if qubit_properties is not None:
@@ -514,7 +516,7 @@ class Target(Mapping):
             TimingConstraints: The timing constraints represented in the Target
         """
         return TimingConstraints(
-            self.granularity, self.min_length, self.pulse_alignment, self.aquire_alignment
+            self.granularity, self.min_length, self.pulse_alignment, self.acquire_alignment
         )
 
     def instruction_schedule_map(self):
@@ -963,6 +965,22 @@ class Target(Mapping):
         else:
             self._non_global_basis = incomplete_basis_gates
         return incomplete_basis_gates
+
+    @property
+    def aquire_alignment(self):
+        """Alias of deprecated name. This will be removed."""
+        warnings.warn(
+            "aquire_alignment is deprecated. Use acquire_alignment instead.", DeprecationWarning
+        )
+        return self.acquire_alignment
+
+    @aquire_alignment.setter
+    def aquire_alignment(self, new_value: int):
+        """Alias of deprecated name. This will be removed."""
+        warnings.warn(
+            "aquire_alignment is deprecated. Use acquire_alignment instead.", DeprecationWarning
+        )
+        self.acquire_alignment = new_value
 
     def __iter__(self):
         return iter(self._gate_map)

--- a/releasenotes/notes/fix-target-aquire_alignment-typo-d32ff31742b448a1.yaml
+++ b/releasenotes/notes/fix-target-aquire_alignment-typo-d32ff31742b448a1.yaml
@@ -1,0 +1,8 @@
+---
+deprecations:
+  - |
+    Misspelled `aquire_alignment` in the class :class:`.Target` has been replaced by
+    correct spelling `acquire_alignment`.
+    The old constructor argument `aquire_alignment` and :attr:`.Target.aquire_alignment`
+    are deprecated and will be removed.
+    Use :attr:`.Target.acquire_alignment` instead to get and set the alignment constraint value.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1091,7 +1091,7 @@ class TestPulseTarget(QiskitTestCase):
     def setUp(self):
         super().setUp()
         self.pulse_target = Target(
-            dt=3e-7, granularity=2, min_length=4, pulse_alignment=8, aquire_alignment=8
+            dt=3e-7, granularity=2, min_length=4, pulse_alignment=8, acquire_alignment=8
         )
         with pulse.build(name="sx_q0") as self.custom_sx_q0:
             pulse.play(pulse.Constant(100, 0.1), pulse.DriveChannel(0))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

The misspelled `aquire_alignment` appears in the `Target` constructor and attribute. This will be replaced with the correct spelling `acquire_alignment`.

### Details and comments


