### PR TITLE
Update docstrings on BackendV2Converter and convert_to_target 

### DIFF
--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -222,7 +222,7 @@ class BackendV2Converter(BackendV2):
     to mutate the ``BackendV1`` object before applying this converter. For example, in order to
     convert a ``BackendV1`` object with a customized ``defaults().instruction_schedule_map``,
     which has a custom calibration for an operation, the operation name must be in
-     ``configuration().basis_gates`` and  ``name_mapping`` must be supplied for the operation.
+    ``configuration().basis_gates`` and ``name_mapping`` must be supplied for the operation.
     Otherwise, the operation will be dropped in the resulting ``BackendV2`` object.
 
     Instead it is typically better to add custom calibrations **after** applying this converter

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import List, Iterable, Any, Dict, Optional
 
 from qiskit.exceptions import QiskitError
@@ -149,6 +150,14 @@ def convert_to_target(
                         if filter_faulty and any(qubit in faulty_qubits for qubit in qargs):
                             continue
                         target[inst][qargs].calibration = calibration_entry
+            if inst not in target and inst not in name_mapping:
+                warnings.warn(
+                    f"Custom calibration for '{inst}' defined in 'defaults' is dropped "
+                    "during the conversion to a target. If you don't want that, "
+                    "supply a custom_name_mapping or "
+                    "add the custom calibration to a target after building the target.",
+                    UserWarning,
+                )
     combined_global_ops = set()
     if configuration.basis_gates:
         combined_global_ops.update(configuration.basis_gates)

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import List, Iterable, Any, Dict, Optional
 
 from qiskit.exceptions import QiskitError
@@ -161,14 +160,6 @@ def convert_to_target(
                         if filter_faulty and any(qubit in faulty_qubits for qubit in qargs):
                             continue
                         target[inst][qargs].calibration = calibration_entry
-            if inst not in target and inst not in name_mapping:
-                warnings.warn(
-                    f"Custom calibration for '{inst}' defined in 'defaults' is dropped "
-                    "during the conversion to a target. If you don't want that, "
-                    "supply a custom_name_mapping or "
-                    "add the custom calibration to a target after building the target.",
-                    UserWarning,
-                )
     combined_global_ops = set()
     if configuration.basis_gates:
         combined_global_ops.update(configuration.basis_gates)

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -41,6 +41,17 @@ def convert_to_target(
 ):
     """Uses configuration, properties and pulse defaults
     to construct and return Target class.
+
+    In order to convert with a ``defaults.instruction_schedule_map``,
+    which has a custom calibration for an operation,
+    the operation name must be in ``configuration.basis_gates`` and
+    ``custom_name_mapping`` must be supplied for the operation.
+    Otherwise, the operation will be dropped in the resulting ``Target`` object.
+
+    That suggests it is recommended to add custom calibrations **after** creating a target
+    with this function instead of adding them to ``defaults`` in advance. For example::
+
+        target.add_instruction(custom_gate, {(0, 1): InstructionProperties(calibration=custom_sched)})
     """
     # pylint: disable=cyclic-import
     from qiskit.transpiler.target import (
@@ -215,6 +226,21 @@ class BackendV2Converter(BackendV2):
     common access patterns between :class:`~.BackendV1` and :class:`~.BackendV2`. This
     class should only be used if you need a :class:`~.BackendV2` and still need
     compatibility with :class:`~.BackendV1`.
+
+    Note that updating a ``BackendV1`` object before applying this converter is **not** recommended.
+    For example, in order to convert a ``BackendV1`` object with a customized
+    ``defaults().instruction_schedule_map``, which has a custom calibration for an operation,
+    the operation name must be in ``configuration().basis_gates`` and
+    ``name_mapping`` must be supplied for the operation.
+    Otherwise, the operation will be dropped in the resulting ``BackendV2`` object.
+
+    That suggests it is recommended to add custom calibrations **after** applying this converter
+    instead of updating ``BackendV1.defaults()`` in advance. For example::
+
+        backend_v2 = BackendV2Converter(backend_v1)
+        backend_v2.target.add_instruction(
+            custom_gate, {(0, 1): InstructionProperties(calibration=custom_sched)}
+        )
     """
 
     def __init__(

--- a/qiskit/providers/backend_compat.py
+++ b/qiskit/providers/backend_compat.py
@@ -218,14 +218,14 @@ class BackendV2Converter(BackendV2):
     class should only be used if you need a :class:`~.BackendV2` and still need
     compatibility with :class:`~.BackendV1`.
 
-    Note that updating a ``BackendV1`` object before applying this converter is **not** recommended.
-    For example, in order to convert a ``BackendV1`` object with a customized
-    ``defaults().instruction_schedule_map``, which has a custom calibration for an operation,
-    the operation name must be in ``configuration().basis_gates`` and
-    ``name_mapping`` must be supplied for the operation.
+    When using custom calibrations (or other custom workflows) it is **not** recommended
+    to mutate the ``BackendV1`` object before applying this converter. For example, in order to
+    convert a ``BackendV1`` object with a customized ``defaults().instruction_schedule_map``,
+    which has a custom calibration for an operation, the operation name must be in
+     ``configuration().basis_gates`` and  ``name_mapping`` must be supplied for the operation.
     Otherwise, the operation will be dropped in the resulting ``BackendV2`` object.
 
-    That suggests it is recommended to add custom calibrations **after** applying this converter
+    Instead it is typically better to add custom calibrations **after** applying this converter
     instead of updating ``BackendV1.defaults()`` in advance. For example::
 
         backend_v2 = BackendV2Converter(backend_v1)


### PR DESCRIPTION
A custom calibration defined in `backend.defaults()` was silently dropped during the conversion to a target using `convert_to_target` in a certain case. Consequently, a `BackendV2` object converted from a `BackendV1` object using `BackendV2Converter` may not contain a custom calibration added to `BackendV1.defaults()` accidentally.
This commit adds a docstring that clearly describes when a custom calibration in `defaults` may be dropped and it is not recommended to update a BackendV1 object before conversion to `convert_to_target` and `BackendV2Converter` to avoid such a case.

