### PR TITLE
Add tweedledum to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,6 +25,6 @@ scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'
 jax;platform_system != 'Windows'
 jaxlib;platform_system != 'Windows'
-tweedledum;platform_system != 'Darwin'
+tweedledum;platform_system != 'Darwin' and python_version<'3.11'
 docplex
 qiskit-qasm3-import; python_version>='3.8'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -25,5 +25,6 @@ scikit-learn>=0.20.0
 scikit-quant<=0.7;platform_system != 'Windows'
 jax;platform_system != 'Windows'
 jaxlib;platform_system != 'Windows'
+tweedledum;platform_system != 'Darwin'
 docplex
 qiskit-qasm3-import; python_version>='3.8'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a tweedledum to the requirements-dev.txt list. Since the release of qiskit-terra 0.23.0 the CI docs job has started to fail. This is because tweedledum is a requirement for the classicalfunction compiler docs. It turns out we were getting tweedledum installed in docs build jobs via a weird path. The install order for docs build was installing packages that require qiskit-terra before terra itself was being installed. This would cause qiskit-terra from pypi from being isntalled first, and old versions of terra required tweedledum which would install it. Then we'd later upgrade terra to the current version under test. To fix this in the short term this adds add tweedledum to the requirements list so we unblock CI. One thing to note is that since the primary reason we removed tweedledum from the requirements list in #8947 was because macOS users were not able to install it reliably the new entry in the requirement-dev.txt list does not cause issues for developers on macOS systems.

Longer term we should make two fixes, first we need to update the classicalfunction compiler docs so they build without having tweedledum installed. The second is we should update the CI job to avoid installing terra from pypi before we build it from source. But, given that CI is currently broken just adding it to the requirements-dev.txt list is the fastest fix.

### Details and comments


