### PR TITLE
Manage edge case of pickling instmap.

### DIFF
--- a/qiskit/pulse/calibration_entries.py
+++ b/qiskit/pulse/calibration_entries.py
@@ -78,7 +78,14 @@ class ScheduleDef(CalibrationEntry):
 
         Args:
             arguments: User provided argument names for this entry, if parameterized.
+
+        Raises:
+            PulseError: When `arguments` is not a sequence of string.
         """
+        if arguments and not all(isinstance(arg, str) for arg in arguments):
+            raise PulseError(f"Arguments must be name of parameters. Not {arguments}.")
+        if arguments:
+            arguments = list(arguments)
         self._user_arguments = arguments
 
         self._definition = None

--- a/releasenotes/notes/fix-instmap-add-with-arguments-250de2a7960565dc.yaml
+++ b/releasenotes/notes/fix-instmap-add-with-arguments-250de2a7960565dc.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    An edge case of pickle :class:`.InstructionScheduleMap` with
+    non-picklable iterable ``arguments`` is supported.
+    When :meth:`InstructionScheduleMap.add` is called with
+    ``arguments``, this method typecasts the user value to a python list
+    to guarantee the added entry is picklable.
+    For example, a user may supply a python dict keys as ``arguments``.
+    This also guarantees parallel transpile works with such a custom
+    instruction schedule map, where the map object is pickled and
+    distributed to every parallel threads.

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -551,6 +551,31 @@ class TestInstructionScheduleMap(QiskitTestCase):
 
         self.assertEqual(instmap, deser_instmap)
 
+    def test_instmap_picklable_with_arguments(self):
+        """Test instmap pickling with an edge case.
+
+        This test attempts to pickle instmap with custom entry,
+        in which arguments are provided by users in the form of
+        python dict key object that is not picklable.
+        """
+        instmap = FakeAthens().defaults().instruction_schedule_map
+
+        param1 = Parameter("P1")
+        param2 = Parameter("P2")
+        sched = Schedule()
+        sched.insert(0, Play(Constant(100, param1), DriveChannel(0)), inplace=True)
+        sched.insert(0, Play(Constant(100, param2), DriveChannel(1)), inplace=True)
+        to_assign = {"P1": 0.1, "P2": 0.2}
+
+        # Note that dict keys is not picklable
+        # Instmap should typecast it into list to pickle itself.
+        instmap.add("custom", (0, 1), sched, arguments=to_assign.keys())
+
+        ser_obj = pickle.dumps(instmap)
+        deser_instmap = pickle.loads(ser_obj)
+
+        self.assertEqual(instmap, deser_instmap)
+
     def test_check_backend_provider_cals(self):
         """Test if schedules provided by backend provider is distinguishable."""
         instmap = FakeOpenPulse2Q().defaults().instruction_schedule_map


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This is a followup PR of #8885 for (edge case) bug fix. When `InstructionScheduleMap.add` is called with `arguments` and non-picklable value is specified (such as python dict key), parallel transpile will fail with the inst map due to this line.
https://github.com/Qiskit/qiskit-terra/blob/a3b359b899d5d963272a7b424c8a283bc6bd4c0d/qiskit/compiler/transpiler.py#L365-L368


### Details and comments

See new test case for code to reproduce the bug. This PR typecast `arguments` to python list so that any iterable is stored in the picklable format.