### PR TITLE
Local fidelity

### DIFF
--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -55,7 +55,7 @@ class ComputeUncompute(BaseStateFidelity):
         average_local: bool = False,
         options: Options | None = None,
     ) -> None:
-        """
+        r"""
         Args:
             sampler: Sampler primitive instance.
             average_local: If set to ``True``, the fidelity is averaged over

--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -58,6 +58,10 @@ class ComputeUncompute(BaseStateFidelity):
         r"""
         Args:
             sampler: Sampler primitive instance.
+            options: Primitive backend runtime options used for circuit execution.
+                The order of priority is: options in ``run`` method > fidelity's
+                default options > primitive's default setting.
+                Higher priority setting overrides lower priority setting.
             local: If set to ``True``, the fidelity is averaged over
                 single-qubit projectors
                 .. math::
@@ -68,10 +72,6 @@ class ComputeUncompute(BaseStateFidelity):
                 This coincides with the standard (global) fidelity in the limit of
                 the fidelity approaching 1. Might be used to increase the variance
                 to improve trainability in algorithms such as :class:`~.time_evolvers.PVQD`.
-            options: Primitive backend runtime options used for circuit execution.
-                The order of priority is: options in ``run`` method > fidelity's
-                default options > primitive's default setting.
-                Higher priority setting overrides lower priority setting.
 
         Raises:
             ValueError: If the sampler is not an instance of ``BaseSampler``.

--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -81,7 +81,7 @@ class ComputeUncompute(BaseStateFidelity):
                 f"The sampler should be an instance of BaseSampler, " f"but got {type(sampler)}"
             )
         self._sampler: BaseSampler = sampler
-        self._average_local = local
+        self._local = local
         self._default_options = Options()
         if options is not None:
             self._default_options.update_options(**options)
@@ -161,7 +161,7 @@ class ComputeUncompute(BaseStateFidelity):
         except Exception as exc:
             raise AlgorithmError("Sampler job failed!") from exc
 
-        if self._average_local:
+        if self._local:
             raw_fidelities = [
                 self._get_local_fidelity(prob_dist, circuit.num_qubits)
                 for prob_dist, circuit in zip(result.quasi_dists, circuits)

--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -67,7 +67,7 @@ class ComputeUncompute(BaseStateFidelity):
                 instead of the global projector :math:`|0\rangle\langle 0|^{\otimes n}`.
                 This coincides with the standard (global) fidelity in the limit of
                 the fidelity approaching 1. Might be used to increase the variance
-                to improve trainability in algorithms such as p-VQD.
+                to improve trainability in algorithms such as :class:`~.time_evolvers.PVQD`.
             options: Primitive backend runtime options used for circuit execution.
                 The order of priority is: options in ``run`` method > fidelity's
                 default options > primitive's default setting.

--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -64,6 +64,7 @@ class ComputeUncompute(BaseStateFidelity):
                 Higher priority setting overrides lower priority setting.
             local: If set to ``True``, the fidelity is averaged over
                 single-qubit projectors
+
                 .. math::
 
                     \hat{O} = \frac{1}{N}\sum_{i=1}^N|0_i\rangle\langle 0_i|,

--- a/qiskit/algorithms/state_fidelities/compute_uncompute.py
+++ b/qiskit/algorithms/state_fidelities/compute_uncompute.py
@@ -52,13 +52,13 @@ class ComputeUncompute(BaseStateFidelity):
     def __init__(
         self,
         sampler: BaseSampler,
-        average_local: bool = False,
         options: Options | None = None,
+        local: bool = False,
     ) -> None:
         r"""
         Args:
             sampler: Sampler primitive instance.
-            average_local: If set to ``True``, the fidelity is averaged over
+            local: If set to ``True``, the fidelity is averaged over
                 single-qubit projectors
                 .. math::
 
@@ -81,7 +81,7 @@ class ComputeUncompute(BaseStateFidelity):
                 f"The sampler should be an instance of BaseSampler, " f"but got {type(sampler)}"
             )
         self._sampler: BaseSampler = sampler
-        self._average_local = average_local
+        self._average_local = local
         self._default_options = Options()
         if options is not None:
             self._default_options.update_options(**options)

--- a/releasenotes/notes/computeuncompute-local-fidelity-501fe175762b7593.yaml
+++ b/releasenotes/notes/computeuncompute-local-fidelity-501fe175762b7593.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Adds a flag `local` to the :class:`~.ComputeUncompute` state fidelity class that 
+    Adds a flag ``local`` to the :class:`~.ComputeUncompute` state fidelity class that 
     allows to compute the local fidelity, which is defined by averaging over 
     single-qubit projectors.

--- a/releasenotes/notes/computeuncompute-local-fidelity-501fe175762b7593.yaml
+++ b/releasenotes/notes/computeuncompute-local-fidelity-501fe175762b7593.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Adds a flag `local` to the :class:`~.ComputeUncompute` state fidelity class that 
+    allows to compute the local fidelity, which is defined by averaging over 
+    single-qubit projectors.

--- a/test/python/algorithms/state_fidelities/test_compute_uncompute.py
+++ b/test/python/algorithms/state_fidelities/test_compute_uncompute.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/python/algorithms/state_fidelities/test_compute_uncompute.py
+++ b/test/python/algorithms/state_fidelities/test_compute_uncompute.py
@@ -56,7 +56,22 @@ class TestComputeUncompute(QiskitTestCase):
         """test for fidelity with one pair of parameters"""
         fidelity = ComputeUncompute(self._sampler)
         job = fidelity.run(
-            self._circuit[0], self._circuit[1], self._left_params[0], self._right_params[0]
+            self._circuit[0],
+            self._circuit[1],
+            self._left_params[0],
+            self._right_params[0],
+        )
+        result = job.result()
+        np.testing.assert_allclose(result.fidelities, np.array([1.0]))
+
+    def test_1param_pair_local(self):
+        """test for fidelity with one pair of parameters"""
+        fidelity = ComputeUncompute(self._sampler, average_local=True)
+        job = fidelity.run(
+            self._circuit[0],
+            self._circuit[1],
+            self._left_params[0],
+            self._right_params[0],
         )
         result = job.result()
         np.testing.assert_allclose(result.fidelities, np.array([1.0]))
@@ -66,7 +81,10 @@ class TestComputeUncompute(QiskitTestCase):
         fidelity = ComputeUncompute(self._sampler)
         n = len(self._left_params)
         job = fidelity.run(
-            [self._circuit[0]] * n, [self._circuit[1]] * n, self._left_params, self._right_params
+            [self._circuit[0]] * n,
+            [self._circuit[1]] * n,
+            self._left_params,
+            self._right_params,
         )
         results = job.result()
         np.testing.assert_allclose(results.fidelities, np.array([1.0, 0.5, 0.25, 0.0]), atol=1e-16)
@@ -76,10 +94,16 @@ class TestComputeUncompute(QiskitTestCase):
         fidelity = ComputeUncompute(self._sampler)
         n = len(self._left_params)
         job_1 = fidelity.run(
-            [self._circuit[0]] * n, [self._circuit[0]] * n, self._left_params, self._right_params
+            [self._circuit[0]] * n,
+            [self._circuit[0]] * n,
+            self._left_params,
+            self._right_params,
         )
         job_2 = fidelity.run(
-            [self._circuit[0]] * n, [self._circuit[0]] * n, self._right_params, self._left_params
+            [self._circuit[0]] * n,
+            [self._circuit[0]] * n,
+            self._right_params,
+            self._left_params,
         )
         results_1 = job_1.result()
         results_2 = job_2.result()

--- a/test/python/algorithms/state_fidelities/test_compute_uncompute.py
+++ b/test/python/algorithms/state_fidelities/test_compute_uncompute.py
@@ -56,35 +56,37 @@ class TestComputeUncompute(QiskitTestCase):
         """test for fidelity with one pair of parameters"""
         fidelity = ComputeUncompute(self._sampler)
         job = fidelity.run(
-            self._circuit[0],
-            self._circuit[1],
-            self._left_params[0],
-            self._right_params[0],
+            self._circuit[0], self._circuit[1], self._left_params[0], self._right_params[0]
         )
         result = job.result()
         np.testing.assert_allclose(result.fidelities, np.array([1.0]))
 
     def test_1param_pair_local(self):
         """test for fidelity with one pair of parameters"""
-        fidelity = ComputeUncompute(self._sampler, average_local=True)
+        fidelity = ComputeUncompute(self._sampler, local=True)
         job = fidelity.run(
-            self._circuit[0],
-            self._circuit[1],
-            self._left_params[0],
-            self._right_params[0],
+            self._circuit[0], self._circuit[1], self._left_params[0], self._right_params[0]
         )
         result = job.result()
         np.testing.assert_allclose(result.fidelities, np.array([1.0]))
+
+    def test_local(self):
+        """test difference between local and global fidelity"""
+        fidelity_global = ComputeUncompute(self._sampler, local=False)
+        fidelity_local = ComputeUncompute(self._sampler, local=True)
+        fidelities = []
+        for fidelity in [fidelity_global, fidelity_local]:
+            job = fidelity.run(self._circuit[2], self._circuit[3])
+            result = job.result()
+            fidelities.append(result.fidelities[0])
+        np.testing.assert_allclose(fidelities, np.array([0.25, 0.5]), atol=1e-16)
 
     def test_4param_pairs(self):
         """test for fidelity with four pairs of parameters"""
         fidelity = ComputeUncompute(self._sampler)
         n = len(self._left_params)
         job = fidelity.run(
-            [self._circuit[0]] * n,
-            [self._circuit[1]] * n,
-            self._left_params,
-            self._right_params,
+            [self._circuit[0]] * n, [self._circuit[1]] * n, self._left_params, self._right_params
         )
         results = job.result()
         np.testing.assert_allclose(results.fidelities, np.array([1.0, 0.5, 0.25, 0.0]), atol=1e-16)
@@ -94,16 +96,10 @@ class TestComputeUncompute(QiskitTestCase):
         fidelity = ComputeUncompute(self._sampler)
         n = len(self._left_params)
         job_1 = fidelity.run(
-            [self._circuit[0]] * n,
-            [self._circuit[0]] * n,
-            self._left_params,
-            self._right_params,
+            [self._circuit[0]] * n, [self._circuit[0]] * n, self._left_params, self._right_params
         )
         job_2 = fidelity.run(
-            [self._circuit[0]] * n,
-            [self._circuit[0]] * n,
-            self._right_params,
-            self._left_params,
+            [self._circuit[0]] * n, [self._circuit[0]] * n, self._right_params, self._left_params
         )
         results_1 = job_1.result()
         results_2 = job_2.result()
@@ -173,10 +169,7 @@ class TestComputeUncompute(QiskitTestCase):
         n = len(self._left_params)
         right_params = [[p] for p in self._right_params[:, 0]]
         job = fidelity.run(
-            [self._circuit[0]] * n,
-            [self._circuit[4]] * n,
-            self._left_params,
-            right_params,
+            [self._circuit[0]] * n, [self._circuit[4]] * n, self._left_params, right_params
         )
         result = job.result()
         np.testing.assert_allclose(result.fidelities, np.array([0.5, 0.25, 0.25, 0.0]), atol=1e-16)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adds a flag `average_local` to the `ComputeUncompute` state fidelity class that allows to compute the local fidelity, which is defined by averaging over single-qubit projectors. It has been shown that global observables, such as the global projector used in the standard fidelity, lead to cost-function induced barren plateaus that can be mitigated by employing a local cost-function instead [1].

While this local fidelity cannot replace the global fidelity in all use cases, it coincides with the global version in the case that the fidelity is 1. This is especially useful in algorithms where the fidelity is maximised variationally, such as for example in p-VQD.


### Details and Comments

I added a unit test for the case where the fidelity is 1. Open for suggestions for further unit tests if anyone has an idea of an example that would make sense.

### References

[1] Cerezo, M., Sone, A., Volkoff, T. et al. Cost function dependent barren plateaus in shallow parametrized quantum circuits. Nat Commun 12, 1791 (2021). https://doi.org/10.1038/s41467-021-21728-w
