### PR TITLE
DOC add build dependency to contributing guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,7 +251,10 @@ build/install steps to install Qiskit Terra. This means you just run
 `pip install .` in your local git clone to build and install Qiskit Terra.
 
 Note that in order to run `python seutp.py ...` commands you need have these
-packages installed: `setuptools`, `wheel`, `setuptools-rust`
+packages installed in your environment: `setuptools`, `wheel`,
+`setuptools-rust`:
+
+    pip install setuptools wheel setuptools-rust
 
 Do note that if you do use develop mode/editable install (via `python setup.py develop` or `pip install -e .`) the Rust extension will be built in debug mode
 without any optimizations enabled. This will result in poor runtime performance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,7 +256,7 @@ If you'd like to use an editable install with an optimized binary you can
 run `python setup.py build_rust --release --inplace` after you install in
 editable mode to recompile the rust extensions in release mode.
 
-Note that in order to run `python seutp.py ...` commands you need have build
+Note that in order to run `python setup.py ...` commands you need have build
 dependency packages installed in your environment, which are listed in the
 `pyproject.toml` file under the `[build-system]` section.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,6 +250,9 @@ Once you have a rust compiler installed you can rely on the normal Python
 build/install steps to install Qiskit Terra. This means you just run
 `pip install .` in your local git clone to build and install Qiskit Terra.
 
+Note that in order to run `python seutp.py ...` commands you need have these
+packages installed: `setuptools`, `wheel`, `setuptools-rust`
+
 Do note that if you do use develop mode/editable install (via `python setup.py develop` or `pip install -e .`) the Rust extension will be built in debug mode
 without any optimizations enabled. This will result in poor runtime performance.
 If you'd like to use an editable install with an optimized binary you can

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,17 +250,15 @@ Once you have a rust compiler installed you can rely on the normal Python
 build/install steps to install Qiskit Terra. This means you just run
 `pip install .` in your local git clone to build and install Qiskit Terra.
 
-Note that in order to run `python seutp.py ...` commands you need have these
-packages installed in your environment: `setuptools`, `wheel`,
-`setuptools-rust`:
-
-    pip install setuptools wheel setuptools-rust
-
 Do note that if you do use develop mode/editable install (via `python setup.py develop` or `pip install -e .`) the Rust extension will be built in debug mode
 without any optimizations enabled. This will result in poor runtime performance.
 If you'd like to use an editable install with an optimized binary you can
 run `python setup.py build_rust --release --inplace` after you install in
 editable mode to recompile the rust extensions in release mode.
+
+Note that in order to run `python seutp.py ...` commands you need have build
+dependency packages installed in your environment, which are listed in the
+`pyproject.toml` file under the `[build-system]` section.
 
 
 ## Test


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Going through my first build and reading the contributing guides, I realized we're missing to mention that a dev environment requires `setuptools-rust`, which is picked up by `pip install ...` commands, but if a user does `python setup.py ...` they need to have them installed themselves. This PR adds a note for the dependencies.

I also noticed this in `pyproject.toml`:

```
[tool.black]
line-length = 100
target-version = ['py37', 'py38', 'py39', 'py310']
```

Do we want `py311` there (in this or a separate PR)?