### PR TITLE
Add `synthesis.QDrift` to sphinx toctree

### DIFF
--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -28,6 +28,7 @@ Evolution Synthesis
    LieTrotter
    SuzukiTrotter
    MatrixExponential
+   QDrift
 
 Linear Function Synthesis
 =========================


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
While working on #9484, I realized that the `QDrift` trotterization method is not shown in the rendered docs. Adding it to the toctree to be able to link it in the guide.


### Details and comments


