### PR TITLE
Disable f-string clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@
 // copyright notice, and modified files need to carry a notice indicating
 // that they have been altered from the originals.
 
+// The syntax this rule wants isn't compatible with MSRV 1.56.1.
+#![allow(clippy::uninlined_format_args)]
+
 use std::env;
 
 use pyo3::prelude::*;


### PR DESCRIPTION
### Summary

Inlining variables into format strings is now a lint failure in the most recent Rust versions, but the syntax isn't available in the stable branch's MSRV of 1.56.1.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

This disables the lint rule we fixed in #9470 but couldn't backport, since it's now causing issues.