### PR TITLE
Set MSRV in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "qiskit-terra"
 version = "0.24.0"
 edition = "2021"
+rust-version = "1.61"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### Summary

This formalises the MSRV policy by enforcing it at the configuration level.  This has helpful knock-on effects; `clippy` will no longer emit linter failures for rules added in new versions of `clippy` that can't be implemented in the MSRV.  This makes our CI more stable against updates to `clippy`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

We can backport this, but must remember to change the MSRV to 1.56.1 in the backport.  This PR would solve the same problem (more properly) as #9529.
