### PR TITLE
Fix string formatting in pulse drawer

### DIFF
--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -598,7 +598,7 @@ class ScheduleDrawer:
                 # pylint: enable=unbalanced-tuple-unpacking
                 time, ch_name, data_str = data
                 # item
-                cell_value[r][3 * c + 0] = "t = %s" % time * dt
+                cell_value[r][3 * c + 0] = "t = %s" % (time * dt)
                 cell_value[r][3 * c + 1] = "ch %s" % ch_name
                 cell_value[r][3 * c + 2] = data_str
             table = tb.table(


### PR DESCRIPTION


### Summary

This a small fix to the formatting, which used an expression of form `"%s" % time * dt`. Since the `%` has higher priority it end up multiplying string by floating point number `dt`. I think the intent was to use `time * dt` for formatting


