### PR TITLE
Fix fake backend not to use deprecated arguments in NoiseModel construction

### DIFF
--- a/qiskit/providers/fake_provider/fake_backend.py
+++ b/qiskit/providers/fake_provider/fake_backend.py
@@ -360,7 +360,6 @@ class FakeBackendV2(BackendV2):
         temperature=0,
         gate_lengths=None,
         gate_length_units="ns",
-        standard_gates=None,
     ):
         """Build noise model from BackendV2.
 
@@ -406,7 +405,6 @@ class FakeBackendV2(BackendV2):
                 gate_lengths=gate_lengths,
                 gate_length_units=gate_length_units,
                 temperature=temperature,
-                standard_gates=standard_gates,
             )
         for name, qubits, error in gate_errors:
             noise_model.add_quantum_error(error, name, qubits)
@@ -459,7 +457,7 @@ class FakeBackend(BackendV1):
 
             self.sim = aer.AerSimulator()
             if self.properties():
-                noise_model = NoiseModel.from_backend(self, warnings=False)
+                noise_model = NoiseModel.from_backend(self)
                 self.sim.set_options(noise_model=noise_model)
                 # Update fake backend default options too to avoid overwriting
                 # it when run() is called


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Update fake backend not to use deprecated arguments, `standard_gates` and `warnings`, in the construction of a noise model for simulation.

