### PR TITLE
Add commutator functions to quantum_info

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -80,6 +80,9 @@ Utility Functions
 
    partial_trace
    shannon_entropy
+   commutator
+   anti_commutator
+   double_commutator
 
 Random
 ======
@@ -122,48 +125,55 @@ Synthesis
    XXDecomposer
 """
 
-from .operators import Operator, ScalarOp, Pauli, Clifford, SparsePauliOp
-from .operators import PauliList, PauliTable, StabilizerTable, pauli_basis
-from .operators.channel import Choi, SuperOp, Kraus, Stinespring, Chi, PTM
-from .operators.measures import process_fidelity, average_gate_fidelity, gate_error, diamond_norm
+from .analysis import hellinger_distance, hellinger_fidelity
+from .operators import (
+    Clifford,
+    Operator,
+    Pauli,
+    PauliList,
+    PauliTable,
+    ScalarOp,
+    SparsePauliOp,
+    StabilizerTable,
+    anti_commutator,
+    commutator,
+    double_commutator,
+    pauli_basis,
+)
+from .operators.channel import PTM, Chi, Choi, Kraus, Stinespring, SuperOp
 from .operators.dihedral import CNOTDihedral
-
-from .states import Statevector, DensityMatrix, StabilizerState
+from .operators.measures import average_gate_fidelity, diamond_norm, gate_error, process_fidelity
+from .random import (
+    random_clifford,
+    random_cnotdihedral,
+    random_density_matrix,
+    random_hermitian,
+    random_pauli,
+    random_pauli_list,
+    random_pauli_table,
+    random_quantum_channel,
+    random_stabilizer_table,
+    random_statevector,
+    random_unitary,
+)
 from .states import (
-    partial_trace,
-    state_fidelity,
-    purity,
-    entropy,
+    DensityMatrix,
+    StabilizerState,
+    Statevector,
     concurrence,
     entanglement_of_formation,
+    entropy,
     mutual_information,
+    partial_trace,
+    purity,
     shannon_entropy,
+    state_fidelity,
 )
-
-from .random import (
-    random_quantum_channel,
-    random_unitary,
-    random_clifford,
-    random_pauli,
-    random_pauli_table,
-    random_pauli_list,
-    random_stabilizer_table,
-    random_hermitian,
-    random_statevector,
-    random_density_matrix,
-    random_cnotdihedral,
-)
-
 from .synthesis import (
     OneQubitEulerDecomposer,
-    TwoQubitBasisDecomposer,
-    two_qubit_cnot_decompose,
     Quaternion,
-    decompose_clifford,
+    TwoQubitBasisDecomposer,
     XXDecomposer,
-)
-
-from .analysis import (
-    hellinger_distance,
-    hellinger_fidelity,
+    decompose_clifford,
+    two_qubit_cnot_decompose,
 )

--- a/qiskit/quantum_info/operators/__init__.py
+++ b/qiskit/quantum_info/operators/__init__.py
@@ -14,12 +14,7 @@
 
 from .channel import PTM, Chi, Choi, Kraus, Stinespring, SuperOp
 from .dihedral import CNOTDihedral
-from .measures import (
-    average_gate_fidelity,
-    diamond_norm,
-    gate_error,
-    process_fidelity,
-)
+from .measures import average_gate_fidelity, diamond_norm, gate_error, process_fidelity
 from .operator import Operator
 from .scalar_op import ScalarOp
 from .symplectic import (
@@ -31,3 +26,4 @@ from .symplectic import (
     StabilizerTable,
     pauli_basis,
 )
+from .utils import anti_commutator, commutator, double_commutator

--- a/qiskit/quantum_info/operators/utils.py
+++ b/qiskit/quantum_info/operators/utils.py
@@ -1,0 +1,96 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""
+Quantum information utility functions for operators.
+"""
+
+from qiskit.quantum_info.operators.linear_op import LinearOp
+
+
+def commutator(a: LinearOp, b: LinearOp) -> LinearOp:
+    r"""
+    Compute commutator of a and b.
+
+    .. math::
+
+        ab - ba.
+
+    Args:
+        a: Operator a.
+        b: Operator b.
+    Returns:
+        The commutator
+    """
+    return a @ b - b @ a
+
+
+def anti_commutator(a: LinearOp, b: LinearOp) -> LinearOp:
+    r"""
+    Compute anti-commutator of a and b.
+
+    .. math::
+
+        ab + ba.
+
+    Args:
+        a: Operator a.
+        b: Operator b.
+    Returns:
+        The anti-commutator
+    """
+    return a @ b + b @ a
+
+
+def double_commutator(a: LinearOp, b: LinearOp, c: LinearOp, *, sign: bool = False) -> LinearOp:
+    r"""
+    Compute symmetric double commutator of a, b and c.
+    See McWeeny chapter 13.6 Equation of motion methods (page 479)
+
+    If `sign` is `False`, it returns
+
+    .. math::
+
+         [[A, B], C]/2 + [A, [B, C]]/2
+         = (2ABC + 2CBA - BAC - CAB - ACB - BCA)/2.
+
+    If `sign` is `True`, it returns
+
+    .. math::
+         \lbrace[A, B], C\rbrace/2 + \lbrace A, [B, C]\rbrace/2
+         = (2ABC - 2CBA - BAC + CAB - ACB + BCA)/2.
+
+    Args:
+        a: Operator a.
+        b: Operator b.
+        c: Operator c.
+        sign: False anti-commutes, True commutes.
+    Returns:
+        The double commutator
+    """
+    sign_num = 1 if sign else -1
+
+    ab = a @ b
+    ba = b @ a
+    ac = a @ c
+    ca = c @ a
+
+    abc = ab @ c
+    cba = c @ ba
+    bac = ba @ c
+    cab = c @ ab
+    acb = ac @ b
+    bca = b @ ca
+
+    res = abc - sign_num * cba + 0.5 * (-bac + sign_num * cab - acb + sign_num * bca)
+
+    return res

--- a/releasenotes/notes/add-commutator-96ef07433e8ca4e7.yaml
+++ b/releasenotes/notes/add-commutator-96ef07433e8ca4e7.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Add utility functions :func:`~qiskit.quantum_info.commutator`,
+    :func:`~qiskit.quantum_info.anti_commutator`, and
+    :func:`~qiskit.quantum_info.double_commutator`.

--- a/test/python/quantum_info/operators/test_utils.py
+++ b/test/python/quantum_info/operators/test_utils.py
@@ -1,0 +1,49 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests utility functions for operator classes."""
+
+import unittest
+
+from qiskit.quantum_info import SparsePauliOp, anti_commutator, commutator, double_commutator
+from qiskit.test import QiskitTestCase
+
+
+class TestOperatorUtils(QiskitTestCase):
+    """Test utility functions for operator classes."""
+
+    def test_commutator(self):
+        """Test commutator function on SparsePauliOp."""
+        Z = SparsePauliOp("Z")
+        I = SparsePauliOp("I")
+        zero = SparsePauliOp("I", 0)
+        self.assertTrue(commutator(Z, I).equiv(zero))
+
+    def test_anti_commutator(self):
+        """Test anti_commutator function on SparsePauliOp."""
+        Z = SparsePauliOp("Z")
+        X = SparsePauliOp("X")
+        zero = SparsePauliOp("I", 0)
+        self.assertTrue(anti_commutator(Z, X).equiv(zero))
+
+    def test_double_commutator(self):
+        """Test double_commutator function on SparsePauliOp."""
+        X = SparsePauliOp("X")
+        Y = SparsePauliOp("Y")
+        Z = SparsePauliOp("Z")
+        zero = SparsePauliOp("I", 0)
+        self.assertTrue(double_commutator(X, Y, Z, sign=False).equiv(zero))
+        self.assertTrue(double_commutator(X, Y, X, sign=True).equiv(zero))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Add commutator functions to quantum_info.

Note that unlike opflow, it does not perform `reduce` (simplify) method. This is because `LinearOp` is not guaranteed to have a simplify method. Therefore, when calling it, users must explicitly simplify after the call if necessary.

### Details and comments


