### PR TITLE
Add flipping of `swap` to `GateDirection` pass

### DIFF
--- a/qiskit/transpiler/passes/utils/gate_direction.py
+++ b/qiskit/transpiler/passes/utils/gate_direction.py
@@ -30,6 +30,7 @@ from qiskit.circuit.library.standard_gates import (
     RYYGate,
     RZZGate,
     RZXGate,
+    SwapGate,
 )
 
 
@@ -93,7 +94,17 @@ class GateDirection(TransformationPass):
         self._cz_dag.add_qreg(qr)
         self._cz_dag.apply_operation_back(CZGate(), [qr[1], qr[0]], [])
 
-        self._static_replacements = {"cx": self._cx_dag, "cz": self._cz_dag, "ecr": self._ecr_dag}
+        self._swap_dag = DAGCircuit()
+        qr = QuantumRegister(2)
+        self._swap_dag.add_qreg(qr)
+        self._swap_dag.apply_operation_back(SwapGate(), [qr[1], qr[0]], [])
+
+        self._static_replacements = {
+            "cx": self._cx_dag,
+            "cz": self._cz_dag,
+            "ecr": self._ecr_dag,
+            "swap": self._swap_dag,
+        }
 
     @staticmethod
     def _rzx_dag(parameter):

--- a/releasenotes/notes/gate-direction-swap-885b6f8ba9779853.yaml
+++ b/releasenotes/notes/gate-direction-swap-885b6f8ba9779853.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    The :class:`.GateDirection` transpiler pass can now flip the direction
+    of ``swap`` (:class`.SwapGate`) instructions.

--- a/test/python/transpiler/test_gate_direction.py
+++ b/test/python/transpiler/test_gate_direction.py
@@ -19,7 +19,16 @@ import ddt
 
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.circuit.library import CXGate, CZGate, ECRGate, RXXGate, RYYGate, RZXGate, RZZGate
+from qiskit.circuit.library import (
+    CXGate,
+    CZGate,
+    ECRGate,
+    RXXGate,
+    RYYGate,
+    RZXGate,
+    RZZGate,
+    SwapGate,
+)
 from qiskit.compiler import transpile
 from qiskit.transpiler import TranspilerError, CouplingMap, Target
 from qiskit.transpiler.passes import GateDirection
@@ -295,7 +304,7 @@ class TestGateDirection(QiskitTestCase):
 
         self.assertNotEqual(GateDirection(None, target=swapped)(circuit), circuit)
 
-    @ddt.data(CZGate(), RXXGate(pi / 3), RYYGate(pi / 3), RZZGate(pi / 3))
+    @ddt.data(CZGate(), SwapGate(), RXXGate(pi / 3), RYYGate(pi / 3), RZZGate(pi / 3))
     def test_symmetric_gates(self, gate):
         """Test symmetric gates on single direction coupling map."""
         circuit = QuantumCircuit(2)


### PR DESCRIPTION
### Summary

Swaps are inherently symmetrical like `cz`, but in cases where we're using the legacy directed `CouplingMap`, it can still be convenient to ensure that we output swaps in the preferred order.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Discovered in changes to the algorithm in #9560.
