### PR TITLE
Add partial transpose function in quantum_info

### DIFF
--- a/qiskit/quantum_info/__init__.py
+++ b/qiskit/quantum_info/__init__.py
@@ -131,6 +131,7 @@ from .operators.dihedral import CNOTDihedral
 from .states import Statevector, DensityMatrix, StabilizerState
 from .states import (
     partial_trace,
+    partial_transpose,
     state_fidelity,
     purity,
     entropy,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -15,7 +15,7 @@
 from .statevector import Statevector
 from .stabilizerstate import StabilizerState
 from .densitymatrix import DensityMatrix
-from .utils import partial_trace, shannon_entropy
+from .utils import partial_trace, shannon_entropy,partial_transpose
 from .measures import (
     state_fidelity,
     purity,

--- a/qiskit/quantum_info/states/__init__.py
+++ b/qiskit/quantum_info/states/__init__.py
@@ -15,7 +15,7 @@
 from .statevector import Statevector
 from .stabilizerstate import StabilizerState
 from .densitymatrix import DensityMatrix
-from .utils import partial_trace, shannon_entropy,partial_transpose
+from .utils import partial_trace, shannon_entropy, partial_transpose
 from .measures import (
     state_fidelity,
     purity,

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -178,7 +178,7 @@ def partial_transpose(state, qargs):
         x = 0
         for k in qargs:
             x = x + (((i >> (k)) % 2) * 2**k)
-        l[i] = x
+        lst[i] = x
     if not set(qargs).issubset(set(np.arange(n))):
         raise QiskitError("Indices of subsystems to be transposed are invalid")
     ptden = np.empty((2**n, 2**n), complex)

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -13,9 +13,8 @@
 """
 Quantum information utility functions for states.
 """
-
-import numpy as np
 import math
+import numpy as np
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.states.statevector import Statevector
 from qiskit.quantum_info.states.densitymatrix import DensityMatrix
@@ -174,13 +173,13 @@ def partial_transpose(state, qargs):
     """
     state = _format_state(state, validate=False)
     n = len(state.dims())
-    l = np.zeros(2**n, int)
+    lst = np.zeros(2**n, int)
     for i in range(2**n):
         x = 0
         for k in qargs:
             x = x + (((i >> (k)) % 2) * 2**k)
         l[i] = x
-    if not (set(qargs).issubset(set(np.arange(n)))):
+    if not set(qargs).issubset(set(np.arange(n))):
         raise QiskitError("Indices of subsystems to be transposed are invalid")
     ptden = np.empty((2**n, 2**n), complex)
     ptden[:] = np.nan
@@ -189,8 +188,8 @@ def partial_transpose(state, qargs):
         for i in range(2**n):
             for j in range(2**n):
                 if math.isnan(ptden[i, j]):
-                    x = i - l[i] + l[j]
-                    y = j - l[j] + l[i]
+                    x = i - lst[i] + lst[j]
+                    y = j - lst[j] + lst[i]
                     ptden[i, j] = state[x] * np.conjugate(state[y])
                     ptden[x, y] = state[i] * np.conjugate(state[j])
     else:
@@ -198,8 +197,8 @@ def partial_transpose(state, qargs):
         for i in range(2**n):
             for j in range(2**n):
                 if math.isnan(ptden[i, j]):
-                    x = i - l[i] + l[j]
-                    y = j - l[j] + l[i]
+                    x = i - lst[i] + lst[j]
+                    y = j - lst[j] + lst[i]
                     ptden[i, j] = state[x, y]
                     ptden[x, y] = state[i, j]
 

--- a/qiskit/quantum_info/states/utils.py
+++ b/qiskit/quantum_info/states/utils.py
@@ -156,8 +156,9 @@ def _funm_svd(matrix, func):
     diag_func_singular = np.diag(func(singular_values))
     return unitary1.dot(diag_func_singular).dot(unitary2)
 
-def partial_transpose(state,qargs):
-    """Return partially transposed density matrix. 
+
+def partial_transpose(state, qargs):
+    """Return partially transposed density matrix.
 
     Args:
         state (DensityMatrix): the input state.
@@ -169,37 +170,37 @@ def partial_transpose(state,qargs):
     Raises:
         QiskitError: if input state is invalid.
         QiskitError: if indices of subsystems are invalid
-        
+
     """
     state = _format_state(state, validate=False)
     n = len(state.dims())
-    l = np.zeros(2**n,int)
+    l = np.zeros(2**n, int)
     for i in range(2**n):
         x = 0
         for k in qargs:
-            x = x + (((i >> (k)) % 2)*2**k)
+            x = x + (((i >> (k)) % 2) * 2**k)
         l[i] = x
-    if not(set(qargs).issubset(set(np.arange(n)))):
-            raise QiskitError("Indices of subsystems to be transposed are invalid")
-    ptden = np.empty((2**n, 2**n),complex)
+    if not (set(qargs).issubset(set(np.arange(n)))):
+        raise QiskitError("Indices of subsystems to be transposed are invalid")
+    ptden = np.empty((2**n, 2**n), complex)
     ptden[:] = np.nan
     if isinstance(state, Statevector):
         state = np.array(state)
         for i in range(2**n):
             for j in range(2**n):
-                if math.isnan(ptden[i,j]):
+                if math.isnan(ptden[i, j]):
                     x = i - l[i] + l[j]
                     y = j - l[j] + l[i]
-                    ptden[i,j] = state[x]*np.conjugate(state[y])
-                    ptden[x,y] = state[i]*np.conjugate(state[j])
+                    ptden[i, j] = state[x] * np.conjugate(state[y])
+                    ptden[x, y] = state[i] * np.conjugate(state[j])
     else:
         state = np.array(state)
         for i in range(2**n):
             for j in range(2**n):
-                if math.isnan(ptden[i,j]):
+                if math.isnan(ptden[i, j]):
                     x = i - l[i] + l[j]
                     y = j - l[j] + l[i]
-                    ptden[i,j] = state[x,y]
-                    ptden[x,y] = state[i,j]
-        
-    return(DensityMatrix(ptden))
+                    ptden[i, j] = state[x, y]
+                    ptden[x, y] = state[i, j]
+
+    return DensityMatrix(ptden)

--- a/releasenotes/notes/adding-partial-transpose-040a6ff00228841b.yaml
+++ b/releasenotes/notes/adding-partial-transpose-040a6ff00228841b.yaml
@@ -1,0 +1,5 @@
+
+features:
+  - |
+    The partial transpose operation has been integrated into the quantum_info module, allowing for partial transposition of matrices.
+    This operation is key in detecting entanglement between bipartite quantum system.

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -54,34 +54,37 @@ class TestStateUtils(QiskitTestCase):
         self.assertAlmostEqual(1.229368880382052, shannon_entropy(input_pvec, np.e))
         # Base 10
         self.assertAlmostEqual(0.533908120973504, shannon_entropy(input_pvec, 10))
-        
+
     def test_statevector_partial_transpose(self):
         psi = Statevector.from_label("10+")
-        rho1=  [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+        rho1 = [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
         self.assertEqual(partial_transpose(psi, [0, 1]), rho1)
         self.assertEqual(partial_transpose(psi, [0, 2]), rho1)
-    
 
     def test_density_matrix_partial_transpose(self):
         rho = DensityMatrix.from_label("10+")
-        rho1=  [[0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0, 0, 0]]
+        rho1 = [
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ]
         self.assertEqual(partial_transpose(rho, [0, 1]), rho1)
         self.assertEqual(partial_transpose(rho, [0, 2]), rho1)
-    	
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from qiskit.test import QiskitTestCase
 from qiskit.quantum_info.states import Statevector, DensityMatrix
-from qiskit.quantum_info.states import partial_trace, shannon_entropy
+from qiskit.quantum_info.states import partial_trace, shannon_entropy, partial_transpose
 
 
 class TestStateUtils(QiskitTestCase):
@@ -54,7 +54,27 @@ class TestStateUtils(QiskitTestCase):
         self.assertAlmostEqual(1.229368880382052, shannon_entropy(input_pvec, np.e))
         # Base 10
         self.assertAlmostEqual(0.533908120973504, shannon_entropy(input_pvec, 10))
-
+        
+    def test_statevector_partial_transpose(self):
+        psi = Statevector.from_label("10+")
+        rho1=[[0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j, 0.5+0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j, 0.5+0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j],
+               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
+                0. +0.j, 0. +0.j]]
+	    self.assertEqual(partial_transpose(rho, [0, 1]), rho1)
+    	
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -68,8 +68,8 @@ class TestStateUtils(QiskitTestCase):
             [0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0],
         ]
-        self.assertEqual(partial_transpose(psi, [0, 1]), rho1)
-        self.assertEqual(partial_transpose(psi, [0, 2]), rho1)
+        self.assertEqual(partial_transpose(psi, [0, 1]), DensityMatrix(rho1))
+        self.assertEqual(partial_transpose(psi, [0, 2]), DensityMatrix(rho1))
 
     def test_density_matrix_partial_transpose(self):
         """Test partial_transpose function on density matrices"""
@@ -84,8 +84,8 @@ class TestStateUtils(QiskitTestCase):
             [0, 0, 0, 0, 0, 0, 0, 0],
             [0, 0, 0, 0, 0, 0, 0, 0],
         ]
-        self.assertEqual(partial_transpose(rho, [0, 1]), rho1)
-        self.assertEqual(partial_transpose(rho, [0, 2]), rho1)
+        self.assertEqual(partial_transpose(rho, [0, 1]), DensityMatrix(rho1))
+        self.assertEqual(partial_transpose(rho, [0, 2]), DensityMatrix(rho1))
 
 
 if __name__ == "__main__":

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -58,32 +58,22 @@ class TestStateUtils(QiskitTestCase):
     def test_statevector_partial_transpose(self):
         """Test partial_transpose function on statevectors"""
         psi = Statevector.from_label("10+")
-        rho1 = [
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-        ]
+        rho1=np.zeros((8,8),complex)
+        rho1[4,4]=0.5
+        rho1[4,5]=0.5
+        rho1[5,4]=0.5
+        rho1[5,5]=0.5
         self.assertEqual(partial_transpose(psi, [0, 1]), DensityMatrix(rho1))
         self.assertEqual(partial_transpose(psi, [0, 2]), DensityMatrix(rho1))
 
     def test_density_matrix_partial_transpose(self):
         """Test partial_transpose function on density matrices"""
         rho = DensityMatrix.from_label("10+")
-        rho1 = [
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-            [0, 0, 0, 0, 0.5, 0.5, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0, 0, 0],
-        ]
+        rho1=np.zeros((8,8),complex)
+        rho1[4,4]=0.5
+        rho1[4,5]=0.5
+        rho1[5,4]=0.5
+        rho1[5,5]=0.5
         self.assertEqual(partial_transpose(rho, [0, 1]), DensityMatrix(rho1))
         self.assertEqual(partial_transpose(rho, [0, 2]), DensityMatrix(rho1))
 

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -56,6 +56,7 @@ class TestStateUtils(QiskitTestCase):
         self.assertAlmostEqual(0.533908120973504, shannon_entropy(input_pvec, 10))
 
     def test_statevector_partial_transpose(self):
+        """Test partial_transpose function on statevectors"""
         psi = Statevector.from_label("10+")
         rho1 = [
             [0, 0, 0, 0, 0, 0, 0, 0],
@@ -71,6 +72,7 @@ class TestStateUtils(QiskitTestCase):
         self.assertEqual(partial_transpose(psi, [0, 2]), rho1)
 
     def test_density_matrix_partial_transpose(self):
+        """Test partial_transpose function on density matrices"""
         rho = DensityMatrix.from_label("10+")
         rho1 = [
             [0, 0, 0, 0, 0, 0, 0, 0],

--- a/test/python/quantum_info/states/test_utils.py
+++ b/test/python/quantum_info/states/test_utils.py
@@ -57,23 +57,30 @@ class TestStateUtils(QiskitTestCase):
         
     def test_statevector_partial_transpose(self):
         psi = Statevector.from_label("10+")
-        rho1=[[0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j, 0.5+0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0.5+0.j, 0.5+0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j],
-               [0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j, 0. +0.j,
-                0. +0.j, 0. +0.j]]
-	    self.assertEqual(partial_transpose(rho, [0, 1]), rho1)
+        rho1=  [[0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0]]
+        self.assertEqual(partial_transpose(psi, [0, 1]), rho1)
+        self.assertEqual(partial_transpose(psi, [0, 2]), rho1)
+    
+
+    def test_density_matrix_partial_transpose(self):
+        rho = DensityMatrix.from_label("10+")
+        rho1=  [[0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+                [0, 0, 0, 0, 0.5, 0.5, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0]]
+        self.assertEqual(partial_transpose(rho, [0, 1]), rho1)
+        self.assertEqual(partial_transpose(rho, [0, 2]), rho1)
     	
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The partial transpose of a density matrix is a mathematical operation that transforms the matrix by interchanging only certain indices of the matrix elements. This operation is significant in the study of quantum entanglement as it provides information about the entanglement structure of a quantum system, with positive partial transpose indicating separable states and negative partial transpose indicating entangled states.


### Details and comments
I and @pranay1990 have contributed to this code. We have added a new function named partial_transpose in quantum_info (under utility functions). 

