### PR TITLE
Make `BarrierBeforeFinalMeasurements` deterministic

### DIFF
--- a/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
+++ b/qiskit/transpiler/passes/utils/merge_adjacent_barriers.py
@@ -57,6 +57,7 @@ class MergeAdjacentBarriers(TransformationPass):
 
     def run(self, dag):
         """Run the MergeAdjacentBarriers pass on `dag`."""
+        indices = {qubit: index for index, qubit in enumerate(dag.qubits)}
 
         # sorted to so that they are in the order they appear in the DAG
         # so ancestors/descendants makes sense
@@ -77,7 +78,9 @@ class MergeAdjacentBarriers(TransformationPass):
                 if node in node_to_barrier_qubits:
                     qubits = node_to_barrier_qubits[node]
                     # qubits are stored as a set, need to convert to a list
-                    new_dag.apply_operation_back(Barrier(len(qubits)), qargs=list(qubits))
+                    new_dag.apply_operation_back(
+                        Barrier(len(qubits)), qargs=sorted(qubits, key=indices.get)
+                    )
             else:
                 # copy the condition over too
                 new_dag.apply_operation_back(node.op, qargs=node.qargs, cargs=node.cargs)

--- a/releasenotes/notes/deterministic-barrier-before-final-measurements-04e817d995794067.yaml
+++ b/releasenotes/notes/deterministic-barrier-before-final-measurements-04e817d995794067.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    The :class:`.BarrierBeforeFinalMeasurements` transpiler pass previously had a non-deterministic
+    order of its emitted :class:`.Barrier` instructions.  This did not change the semantics of
+    circuits but could, in limited cases where there were non-full-width barriers, cause later
+    stochastic transpiler passes to see a different topological ordering of the circuit and
+    consequently have different outputs for fixed seeds.  The pass has been made deterministic to
+    avoid this.

--- a/releasenotes/notes/deterministic-barrier-before-final-measurements-04e817d995794067.yaml
+++ b/releasenotes/notes/deterministic-barrier-before-final-measurements-04e817d995794067.yaml
@@ -1,9 +1,9 @@
 ---
 fixes:
   - |
-    The :class:`.BarrierBeforeFinalMeasurements` transpiler pass previously had a non-deterministic
-    order of its emitted :class:`.Barrier` instructions.  This did not change the semantics of
-    circuits but could, in limited cases where there were non-full-width barriers, cause later
-    stochastic transpiler passes to see a different topological ordering of the circuit and
-    consequently have different outputs for fixed seeds.  The pass has been made deterministic to
-    avoid this.
+    The :class:`.BarrierBeforeFinalMeasurements` and :class:`.MergeAdjacentBarriers` transpiler
+    passes previously had a non-deterministic order of their emitted :class:`.Barrier` instructions.
+    This did not change the semantics of circuits but could, in limited cases where there were
+    non-full-width barriers, cause later stochastic transpiler passes to see a different topological
+    ordering of the circuit and consequently have different outputs for fixed seeds.  The passes
+    have been made deterministic to avoid this.


### PR DESCRIPTION
### Summary

The barrier-merging step at the end directly converted its inner (unordered) sets of bits into (ordered) lists, which is an operation dependent on `PYTHONHASHSEED`.  This can have an impact on subsequent topological iteration orders, if there are any barriers that are not full-width in the circuit, which can in turn cause later stochastic transpiler passes to have different outputs for fixed random seeds, depending on `PYTHONHASHSEED`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

This is what's causing the non-determinism in the test on #9560.