### PR TITLE
Improve efficiency of CouplingMap.make_symmetric

### DIFF
--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -234,9 +234,12 @@ class CouplingMap:
         """
         Convert uni-directional edges into bi-directional.
         """
+        # TODO: replace with PyDiGraph.make_symmetric() after rustworkx
+        # 0.13.0 is released.
         edges = self.get_edges()
+        edge_set = set(edges)
         for src, dest in edges:
-            if (dest, src) not in edges:
+            if (dest, src) not in edge_set:
                 self.add_edge(dest, src)
         self._dist_matrix = None  # invalidate
         self._is_symmetric = None  # invalidate

--- a/qiskit/transpiler/coupling.py
+++ b/qiskit/transpiler/coupling.py
@@ -240,7 +240,7 @@ class CouplingMap:
         edge_set = set(edges)
         for src, dest in edges:
             if (dest, src) not in edge_set:
-                self.add_edge(dest, src)
+                self.graph.add_edge(dest, src, None)
         self._dist_matrix = None  # invalidate
         self._is_symmetric = None  # invalidate
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Right now the CouplingMap.make_symmetric has a quadratic overhead. It was iterating over a list of each edgess' endpoints in the graph and for each edge it was iterating over the same list again to check whether the reverse edge is present or not. The overhead for this for large coupling maps can be quite large, for example with a 10497 qubit heavy hex coupling map the time it took to run this method as part of SabreLayout's initialization was ~10x slower than actually running the pass (a equally sized Bernstein-Vazirani circuit). Instead of doing an O(n) contains check inside the loop this commit updates it to use a set which will be an O(1) lookup. This should address the performance issue with this method. In the future we should leverage the native rustworkx method to do this, which is being added in: Qiskit/rustworkx#814

### Details and comments