### PR TITLE
Run Rust tests in CI

### DIFF
--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -45,7 +45,7 @@ jobs:
       - ${{ if eq(parameters.testRust, true) }}:
         - bash: |
             set -e
-            cargo test --tests -- --nocapture
+            cargo test
           displayName: "Run Rust tests"
 
       - bash: |

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -3,13 +3,14 @@ parameters:
     type: string
     displayName: "Version of Python to test"
 
+  - name: "testRust"
+    type: boolean
+
   - name: "testQPY"
     type: boolean
-    default: false
 
   - name: "testImages"
     type: boolean
-    default: false
 
   - name: "installFromSdist"
     type: boolean
@@ -22,7 +23,7 @@ parameters:
 
 jobs:
   - job: "Linux_Tests_Python${{ replace(parameters.pythonVersion, '.', '') }}"
-    displayName: "Test Linux Python ${{ parameters.pythonVersion }}"
+    displayName: "Test Linux Rust & Python ${{ parameters.pythonVersion }}"
     pool: {vmImage: 'ubuntu-latest'}
 
     variables:
@@ -49,6 +50,12 @@ jobs:
       - bash: |
           rustup default "${{ parameters.rustVersion }}"
         displayName: "Use rust version ${{ parameters.rustVersion }}"
+
+      - ${{ if eq(parameters.testRust, true) }}:
+        - bash: |
+            set -e
+            cargo test --tests -- --nocapture
+          displayName: "Run Rust tests"
 
       - bash: |
           set -e
@@ -101,7 +108,7 @@ jobs:
         env:
           QISKIT_PARALLEL: FALSE
           RUST_BACKTRACE: 1
-        displayName: 'Run tests'
+        displayName: 'Run Python tests'
 
       - bash: |
           set -e

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,6 +106,7 @@ stages:
               pythonVersion: ${{ version }}
               testQPY: false
               testImages: false
+              testRust: false
 
           - template: ".azure/test-macos.yml"
             parameters:
@@ -151,6 +152,7 @@ stages:
         - template: ".azure/test-linux.yml"
           parameters:
             pythonVersion: ${{ parameters.minimumPythonVersion }}
+            testRust: true
             testQPY: true
             testImages: false
             rustVersion: ${{ parameters.minimumRustVersion }}
@@ -171,6 +173,7 @@ stages:
         - template: ".azure/test-linux.yml"
           parameters:
             pythonVersion: ${{ parameters.maximumPythonVersion }}
+            testRust: false
             testQPY: false
             testImages: true
             installFromSdist: true
@@ -199,6 +202,7 @@ stages:
         - template: ".azure/test-linux.yml"
           parameters:
             pythonVersion: ${{ parameters.branchPushPythonVersion }}
+            testRust: true
             testQPY: true
             testImages: true
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

We now run all Rust tests in the preliminary Linux test job and when pushing to the repo.

Why, when we already have great Python tests of our Rust interface? Because we're restricting ourselves from testing at lower levels of abstraction, like unit tests for helper functions. We will still keep our Python tests! But some of our Rust code is highly complex now, so it's valuable to have the ability to test at a lower abstraction level.

### Details and comments

These Rust tests are intended to be fast. If in the future we make more robust ~integration tests, we'll revisit the CI setup.

The tests run in the preliminary stage to give faster feedback to Rust developers. This is a tradeoff: it means non-Rust PRs are slightly slower. If this proves too slow, then we can move the tests to later.

In the future, we also can add conditional logic to only run these tests if the PR has made any changes to Rust. I didn't do that yet because it's tricky to get it 100% right and wasn't worth the engineering effort. But if our tests get slower in the future, we can revisit this.