### PR TITLE
Fix setting rustup toolchain override in wheel builds

### DIFF
--- a/.azure/wheels.yml
+++ b/.azure/wheels.yml
@@ -27,7 +27,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install cibuildwheel==2.11.2
           pip install -U twine
-          rustup override set stable
           cibuildwheel --output-dir wheelhouse .
 
       - task: PublishBuildArtifacts@1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ test-command = "python {project}/examples/python/stochastic_swap.py"
 # Numpy 1.22 there are no i686 wheels, so we force pip to use older ones without
 # restricting any dependencies that Numpy and Scipy might have.
 before-test = "pip install --only-binary=numpy,scipy numpy scipy"
+environment = 'RUSTUP_TOOLCHAIN="stable"'
 
 [tool.cibuildwheel.linux]
 before-all = "yum install -y wget && {package}/tools/install_rust.sh"
-environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true"'
+environment = 'PATH="$PATH:$HOME/.cargo/bin" CARGO_NET_GIT_FETCH_WITH_CLI="true" RUSTUP_TOOLCHAIN="stable"'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the recently merged #9584 which added a rustup toolchain file to the qiskit repo to default to our MSRV when using rustup. In that commit the intent was for wheel jobs to use the latest version of the stable Rust to publish precompiled wheels. However, the mechanism by which that was done in the PR won't work for linux environments. The linux cibuildwheel jobs leverage a docker container to build the binaries in that have known manylinux compatible environment so that the wheels we ship are compatible with the packaging specification. #9584 was setting the rust version override in the host environment via `rustup override` which wouldn't propogate to inside the docker container. To address this issue this commit updates the cibuildwheel config to set the RUST_TOOLCHAIN environment variable for the cibuildwheel process. This will set the environment variable throughout the wheel building ensuring that rustup will use stable inside the container when we're building our release artifacts.

### Details and comments
