### PR TITLE
Update Target to use CalibrationEntry to create inst map

### DIFF
--- a/qiskit/pulse/calibration_entries.py
+++ b/qiskit/pulse/calibration_entries.py
@@ -122,6 +122,9 @@ class ScheduleDef(CalibrationEntry):
 
     def define(self, definition: Union[Schedule, ScheduleBlock]):
         self._definition = definition
+        # add metadata
+        if "publisher" not in definition.metadata:
+            definition.metadata["publisher"] = CalibrationPublisher.QISKIT
         self._parse_argument()
 
     def get_signature(self) -> inspect.Signature:
@@ -184,7 +187,11 @@ class CallableDef(CalibrationEntry):
         except TypeError as ex:
             raise PulseError("Assigned parameter doesn't match with function signature.") from ex
 
-        return self._definition(**to_bind.arguments)
+        schedule = self._definition(**to_bind.arguments)
+        # add metadata
+        if "publisher" not in schedule.metadata:
+            schedule.metadata["publisher"] = CalibrationPublisher.QISKIT
+        return schedule
 
     def __eq__(self, other):
         # We cannot evaluate function equality without parsing python AST.

--- a/qiskit/pulse/instruction_schedule_map.py
+++ b/qiskit/pulse/instruction_schedule_map.py
@@ -34,7 +34,6 @@ from typing import Callable, Iterable, List, Tuple, Union, Optional
 from qiskit.circuit.instruction import Instruction
 from qiskit.circuit.parameterexpression import ParameterExpression
 from qiskit.pulse.calibration_entries import (
-    CalibrationPublisher,
     CalibrationEntry,
     ScheduleDef,
     CallableDef,
@@ -248,9 +247,6 @@ class InstructionScheduleMap:
         # generate signature
         if isinstance(schedule, (Schedule, ScheduleBlock)):
             entry = ScheduleDef(arguments)
-            # add metadata
-            if "publisher" not in schedule.metadata:
-                schedule.metadata["publisher"] = CalibrationPublisher.QISKIT
         elif callable(schedule):
             if arguments:
                 warnings.warn(
@@ -404,3 +400,9 @@ def _get_instruction_string(inst: Union[str, Instruction]):
             raise PulseError(
                 'Input "inst" has no attribute "name". This should be a circuit "Instruction".'
             ) from ex
+
+
+def __getattr__(name):
+    from qiskit.pulse import calibration_entries
+
+    return getattr(calibration_entries, name)

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -29,7 +29,7 @@ import rustworkx as rx
 
 from qiskit.circuit.parameter import Parameter
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
-from qiskit.pulse.calibration_entries import CalibrationEntry
+from qiskit.pulse.calibration_entries import CalibrationEntry, ScheduleDef
 from qiskit.pulse.schedule import Schedule, ScheduleBlock
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.exceptions import TranspilerError
@@ -72,20 +72,25 @@ class InstructionProperties:
                 set of qubits.
             calibration: The pulse representation of the instruction.
         """
+        self._calibration = None
+
         self.duration = duration
         self.error = error
-        self._calibration = calibration
+        self.calibration = calibration
 
     @property
     def calibration(self):
         """The pulse representation of the instruction."""
-        if isinstance(self._calibration, CalibrationEntry):
-            return self._calibration.get_schedule()
-        return self._calibration
+        return self._calibration.get_schedule()
 
     @calibration.setter
     def calibration(self, calibration: Union[Schedule, ScheduleBlock, CalibrationEntry]):
-        self._calibration = calibration
+        if isinstance(calibration, (Schedule, ScheduleBlock)):
+            new_entry = ScheduleDef()
+            new_entry.define(calibration)
+        else:
+            new_entry = calibration
+        self._calibration = new_entry
 
     def __repr__(self):
         return (
@@ -532,8 +537,12 @@ class Target(Mapping):
         out_inst_schedule_map = InstructionScheduleMap()
         for instruction, qargs in self._gate_map.items():
             for qarg, properties in qargs.items():
-                if properties is not None and properties.calibration is not None:
-                    out_inst_schedule_map.add(instruction, qarg, properties.calibration)
+                # Directly getting CalibrationEntry not to invoke .get_schedule().
+                # This keeps PulseQobjDef un-parsed.
+                cal_entry = getattr(properties, "_calibration", None)
+                if cal_entry is not None:
+                    # Use fast-path to add entries to the inst map.
+                    out_inst_schedule_map._add(instruction, qarg, cal_entry)
         self._instruction_schedule_map = out_inst_schedule_map
         return out_inst_schedule_map
 

--- a/releasenotes/notes/fix-instmap-from-target-f38962c3fd03e5d3.yaml
+++ b/releasenotes/notes/fix-instmap-from-target-f38962c3fd03e5d3.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug that :meth:`.InstructionScheduleMap.has_custom_gate` returns always
+    True when the inst map is created by :class:`.Target`.

--- a/test/python/pulse/test_instruction_schedule_map.py
+++ b/test/python/pulse/test_instruction_schedule_map.py
@@ -30,7 +30,7 @@ from qiskit.pulse import (
     ShiftPhase,
     Constant,
 )
-from qiskit.pulse.instruction_schedule_map import CalibrationPublisher
+from qiskit.pulse.calibration_entries import CalibrationPublisher
 from qiskit.pulse.channels import DriveChannel
 from qiskit.qobj import PulseQobjInstruction
 from qiskit.qobj.converters import QobjToInstructionConverter
@@ -602,8 +602,12 @@ class TestInstructionScheduleMap(QiskitTestCase):
 
         self.assertFalse(instmap.has_custom_gate())
 
-        # add something
+        # add custom schedule
         some_sched = Schedule()
         instmap.add("u3", (0,), some_sched)
 
         self.assertTrue(instmap.has_custom_gate())
+
+        # delete custom schedule
+        instmap.remove("u3", (0,))
+        self.assertFalse(instmap.has_custom_gate())

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -35,6 +35,7 @@ from qiskit.circuit.measure import Measure
 from qiskit.circuit.parameter import Parameter
 from qiskit import pulse
 from qiskit.pulse.instruction_schedule_map import InstructionScheduleMap
+from qiskit.pulse.calibration_entries import CalibrationPublisher
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.instruction_durations import InstructionDurations
 from qiskit.transpiler.timing_constraints import TimingConstraints
@@ -42,7 +43,7 @@ from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler import Target
 from qiskit.transpiler import InstructionProperties
 from qiskit.test import QiskitTestCase
-from qiskit.providers.fake_provider import FakeBackendV2, FakeMumbaiFractionalCX
+from qiskit.providers.fake_provider import FakeBackendV2, FakeMumbaiFractionalCX, FakeGeneva
 
 
 class TestTarget(QiskitTestCase):
@@ -1227,6 +1228,31 @@ Instructions:
                 f"Generated constraints differs from expected for attribute {i}"
                 f"{getattr(generated_constraints, i)}!={getattr(expected_constraints, i)}",
             )
+
+    def test_default_instmap_has_no_custom_gate(self):
+        backend = FakeGeneva()
+        target = backend.target
+
+        # This copies .calibraiton of InstructionProperties of each instruction
+        # This must not convert PulseQobj to Schedule during this.
+        # See qiskit-terra/#9595
+        inst_map = target.instruction_schedule_map()
+        self.assertFalse(inst_map.has_custom_gate())
+
+        # Get pulse schedule. This generates Schedule provided by backend.
+        sched = inst_map.get("sx", (0,))
+        self.assertEqual(sched.metadata["publisher"], CalibrationPublisher.BACKEND_PROVIDER)
+        self.assertFalse(inst_map.has_custom_gate())
+
+        # Update target with custom instruction. This is user provided schedule.
+        new_prop = InstructionProperties(
+            duration=self.custom_sx_q0.duration,
+            error=None,
+            calibration=self.custom_sx_q0,
+        )
+        target.update_instruction_properties(instruction="sx", qargs=(0,), properties=new_prop)
+        inst_map = target.instruction_schedule_map()
+        self.assertTrue(inst_map.has_custom_gate())
 
 
 class TestGlobalVariableWidthOperations(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes a bug that `InstructionScheduleMap.has_custom_gate()` always return True when the inst map is created by `Target.instruction_schedule_map`. 

In previous implementation, `.get_schedule()` method is called via `InstructionProperties.calibration`, which generates a schedule from `PulseQobjDef`, to create an inst map. In this PR, `Target.instruction_schedule_map` is updated to bypass `get_schedule` call to keep `PulseQobjDef` un-parsed.

Fix #9595 

### Details and comments

`InstructionProperties._calibration` is updated to only store `CalibrationEntry`, which was previously `Union[CalibrationEntry, Schedule, ScheduleBlock]`. 