### PR TITLE
Fix sparse matrix conversion for `SciPy<Real/Imaginary>Evolver`

### DIFF
--- a/qiskit/algorithms/time_evolvers/classical_methods/evolve.py
+++ b/qiskit/algorithms/time_evolvers/classical_methods/evolve.py
@@ -109,10 +109,10 @@ def _operator_to_matrix(operator: BaseOperator | PauliSumOp):
                 "Trying dense computation",
                 type(operator),
             )
-        try:
-            op_matrix = operator.to_matrix()
-        except AttributeError as ex:
-            raise AlgorithmError(f"Unsupported operator type `{type(operator)}`.") from ex
+            try:
+                op_matrix = operator.to_matrix()
+            except AttributeError as ex:
+                raise AlgorithmError(f"Unsupported operator type `{type(operator)}`.") from ex
     return op_matrix
 
 

--- a/releasenotes/notes/fix-numpy-eigensolver-sparse-0e255d7b13b5e43b.yaml
+++ b/releasenotes/notes/fix-numpy-eigensolver-sparse-0e255d7b13b5e43b.yaml
@@ -1,6 +1,9 @@
 ---
 fixes:
   - |
-    Fixed a bug in :class:`~.minimum_eigensolvers.NumPyMinimumEigensolver` and 
-    :class:`~.eigensolvers.NumPyEigensolver` where operators that support conversion
+    Fixed a bug in the NumPy-based eigensolvers 
+    (:class:`~.minimum_eigensolvers.NumPyMinimumEigensolver` / 
+    :class:`~.eigensolvers.NumPyEigensolver`)
+    and in the SciPy-based time evolvers (:class:`.SciPyRealEvolver` / 
+    :class:`.SciPyImaginaryEvolver`), where operators that support conversion
     to sparse matrices, such as :class:`.SparsePauliOp`, were converted to dense matrices anyways.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Same issue as #9575: due to a missing indent sparse operators were accidentally converted to dense matrices.
This led to the kernel being dumped on ~20 qubit time evolution whereas this should only take seconds to minutes to run.

### Details and comments

I just updated the reno from #9575 to also include this PR as it's exactly the same problem 🙂 


