### PR TITLE
Better handle pending deprecations

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -195,7 +195,7 @@ class Grover(AmplitudeAmplifier):
         "The Grover.quantum_instance getter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self) -> Optional[QuantumInstance]:
         r"""Pending deprecation\; Get the quantum instance.
@@ -210,7 +210,7 @@ class Grover(AmplitudeAmplifier):
         "The Grover.quantum_instance setter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self, quantum_instance: Union[QuantumInstance, Backend]) -> None:
         r"""Pending deprecation\; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -128,7 +128,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "The AmplitudeEstimation.quantum_instance getter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -143,7 +143,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "The AmplitudeEstimation.quantum_instance setter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -113,7 +113,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "The FasterAmplitudeEstimation.quantum_instance getter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -128,7 +128,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "The FasterAmplitudeEstimation.quantum_instance setter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -136,7 +136,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "The IterativeAmplitudeEstimation.quantum_instance getter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -151,7 +151,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "The IterativeAmplitudeEstimation.quantum_instance setter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -140,7 +140,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "The MaximumLikelihoodAmplitudeEstimation.quantum_instance getter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -155,7 +155,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "The MaximumLikelihoodAmplitudeEstimation.quantum_instance setter is pending deprecation. "
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/aux_ops_evaluator.py
+++ b/qiskit/algorithms/aux_ops_evaluator.py
@@ -36,7 +36,7 @@ from .list_or_dict import ListOrDict
     "qiskit.algorithms.observables_evaluator.estimate_observables function. "
     "This function will be deprecated in a future release and subsequently "
     "removed after that.",
-    category=PendingDeprecationWarning,
+    pending=True,
 )
 def eval_observables(
     quantum_instance: Union[QuantumInstance, Backend],

--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -41,7 +41,7 @@ class Eigensolver(ABC):
         "qiskit.algorithms.eigensolvers.Eigensolver interface. "
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         pass
@@ -93,7 +93,7 @@ class EigensolverResult(AlgorithmResult):
         "qiskit.algorithms.eigensolvers.EigensolverResult class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -54,7 +54,7 @@ class NumPyEigensolver(Eigensolver):
         "qiskit.algorithms.eigensolvers.NumPyEigensolver class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/eigen_solvers/vqd.py
+++ b/qiskit/algorithms/eigen_solvers/vqd.py
@@ -101,7 +101,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
         "qiskit.algorithms.eigensolvers.VQD class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,
@@ -771,7 +771,7 @@ class VQDResult(VariationalResult, EigensolverResult):
         "qiskit.algorithms.eigensolvers.VQDResult class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/evolvers/evolution_problem.py
+++ b/qiskit/algorithms/evolvers/evolution_problem.py
@@ -38,7 +38,7 @@ class EvolutionProblem:
         "qiskit.algorithms.time_evolvers.TimeEvolutionProblem class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_result.py
+++ b/qiskit/algorithms/evolvers/evolution_result.py
@@ -36,7 +36,7 @@ class EvolutionResult(AlgorithmResult):
         "qiskit.algorithms.time_evolvers.TimeEvolutionResult class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/imaginary_evolver.py
+++ b/qiskit/algorithms/evolvers/imaginary_evolver.py
@@ -34,7 +34,7 @@ class ImaginaryEvolver(ABC):
         "qiskit.algorithms.time_evolvers.ImaginaryTimeEvolver interface. "
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/real_evolver.py
+++ b/qiskit/algorithms/evolvers/real_evolver.py
@@ -34,7 +34,7 @@ class RealEvolver(ABC):
         "qiskit.algorithms.time_evolvers.RealTimeEvolver interface. "
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
@@ -69,7 +69,7 @@ class TrotterQRTE(RealEvolver):
         "qiskit.algorithms.time_evolvers.trotterization.TrotterQRTE class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -41,7 +41,7 @@ class MinimumEigensolver(ABC):
         "qiskit.algorithms.minimum_eigensolvers.MinimumEigensolver interface. "
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         pass
@@ -97,7 +97,7 @@ class MinimumEigensolverResult(AlgorithmResult):
         "qiskit.algorithms.minimum_eigensolvers.MinimumEigensolverResult class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -42,7 +42,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         "qiskit.algorithms.minimum_eigensolvers.NumPyMinimumEigensolver class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -64,7 +64,7 @@ class QAOA(VQE):
         "qiskit.algorithms.minimum_eigensolvers.QAOA class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -132,7 +132,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         "qiskit.algorithms.minimum_eigensolvers.VQE class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(
         self,
@@ -671,7 +671,7 @@ class VQEResult(VariationalResult, MinimumEigensolverResult):
         "qiskit.algorithms.minimum_eigensolvers.VQEResult class. "
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
-        category=PendingDeprecationWarning,
+        pending=True,
     )
     def __init__(self) -> None:
         with warnings.catch_warnings():

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -17,16 +17,14 @@ import warnings
 from typing import Any, Dict, Optional, Type
 
 
-def deprecate_arguments(
-    kwarg_map: Dict[str, Optional[str]], category: Type[Warning] = DeprecationWarning
-):
+def deprecate_arguments(kwarg_map: Dict[str, Optional[str]], *, pending: bool = False):
     """Decorator to automatically alias deprecated argument names and warn upon use."""
 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             if kwargs:
-                _rename_kwargs(func.__name__, kwargs, kwarg_map, category)
+                _rename_kwargs(func.__name__, kwargs, kwarg_map, pending=pending)
             return func(*args, **kwargs)
 
         return wrapper
@@ -34,13 +32,13 @@ def deprecate_arguments(
     return decorator
 
 
-def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = DeprecationWarning):
+def deprecate_function(msg: str, *, stacklevel: int = 2, pending: bool = False):
     """Emit a warning prior to calling decorated function.
 
     Args:
         msg: Warning message to emit.
-        stacklevel: The warning stackevel to use, defaults to 2.
-        category: warning category, defaults to DeprecationWarning
+        stacklevel: The warning stacklevel to use, defaults to 2.
+        pending: if True, use PendingDeprecationWarning rather than DeprecationWarning
 
     Returns:
         Callable: The decorated, deprecated callable.
@@ -49,7 +47,11 @@ def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = 
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            warnings.warn(msg, category=category, stacklevel=stacklevel)
+            warnings.warn(
+                msg,
+                category=PendingDeprecationWarning if pending else DeprecationWarning,
+                stacklevel=stacklevel,
+            )
             return func(*args, **kwargs)
 
         return wrapper
@@ -61,11 +63,14 @@ def _rename_kwargs(
     func_name: str,
     kwargs: Dict[str, Any],
     kwarg_map: Dict[str, Optional[str]],
-    category: Type[Warning] = DeprecationWarning,
+    pending: bool,
 ) -> None:
-    deprecation_description = (
-        "pending deprecation" if isinstance(category, PendingDeprecationWarning) else "deprecated"
-    )
+    if pending:
+        category = PendingDeprecationWarning
+        deprecation_desc = "pending deprecation"
+    else:
+        category = DeprecationWarning
+        deprecation_desc = "deprecated"
     for old_arg, new_arg in kwarg_map.items():
         if old_arg in kwargs:
             if new_arg in kwargs:
@@ -73,14 +78,14 @@ def _rename_kwargs(
 
             if new_arg is None:
                 warnings.warn(
-                    f"{func_name}'s keyword argument {old_arg} is {deprecation_description} and "
+                    f"{func_name}'s keyword argument {old_arg} is {deprecation_desc} and "
                     "will in the future be removed.",
                     category=category,
                     stacklevel=3,
                 )
             else:
                 warnings.warn(
-                    f"{func_name}'s keyword argument {old_arg} is {deprecation_description} and "
+                    f"{func_name}'s keyword argument {old_arg} is {deprecation_desc} and "
                     f"replaced with {new_arg}.",
                     category=category,
                     stacklevel=3,

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -14,10 +14,12 @@
 
 import functools
 import warnings
-from typing import Type
+from typing import Any, Dict, Optional, Type
 
 
-def deprecate_arguments(kwarg_map, category: Type[Warning] = DeprecationWarning):
+def deprecate_arguments(
+    kwarg_map: Dict[str, Optional[str]], category: Type[Warning] = DeprecationWarning
+):
     """Decorator to automatically alias deprecated argument names and warn upon use."""
 
     def decorator(func):
@@ -55,7 +57,15 @@ def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = 
     return decorator
 
 
-def _rename_kwargs(func_name, kwargs, kwarg_map, category: Type[Warning] = DeprecationWarning):
+def _rename_kwargs(
+    func_name: str,
+    kwargs: Dict[str, Any],
+    kwarg_map: Dict[str, Optional[str]],
+    category: Type[Warning] = DeprecationWarning,
+) -> None:
+    deprecation_description = (
+        "pending deprecation" if isinstance(category, PendingDeprecationWarning) else "deprecated"
+    )
     for old_arg, new_arg in kwarg_map.items():
         if old_arg in kwargs:
             if new_arg in kwargs:
@@ -63,14 +73,14 @@ def _rename_kwargs(func_name, kwargs, kwarg_map, category: Type[Warning] = Depre
 
             if new_arg is None:
                 warnings.warn(
-                    f"{func_name} keyword argument {old_arg} is deprecated and "
-                    "will in future be removed.",
+                    f"{func_name}'s keyword argument {old_arg} is {deprecation_description} and "
+                    "will in the future be removed.",
                     category=category,
                     stacklevel=3,
                 )
             else:
                 warnings.warn(
-                    f"{func_name} keyword argument {old_arg} is deprecated and "
+                    f"{func_name}'s keyword argument {old_arg} is {deprecation_description} and "
                     f"replaced with {new_arg}.",
                     category=category,
                     stacklevel=3,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Our deprecation policy distinguishes between `DeprecationWarning` vs `PendingDeprecationWarning`: https://github.com/Qiskit/qiskit/blob/82810146c5061fad17c041e7e66196f92466ec1a/docs/deprecation_policy.rst#removing-a-feature

This PR improves support for `PendingDeprecationWarning`:

1. Fixes wording for `deprecate_arguments` to clarify when something is pending.
2. Makes the interface for marking something as pending clearer.
     - Before, we had you pass in `category: type`, which was unbounded to be the whole universe of Python types. When in reality, we only expected it to be either `DeprecationWarning` or `PendingDeprecationWarning`.
     - Bounding to only `pending={False,True}` makes clear this reality. It will help in future changes (like https://github.com/Qiskit/qiskit-terra/pull/8600) to conditionally handle pending vs deprecated.

### Details and comments

This is prework for the rework ofchttps://github.com/Qiskit/qiskit-terra/pull/8600. I want to make sure our docs properly support `PendingDeprecationWarning`.
