### PR TITLE
Allow internal underscores in Pylint dummy variable names

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -324,7 +324,7 @@ init-import=no
 
 # A regular expression matching the name of dummy variables (i.e. expectedly
 # not used).
-dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+dummy-variables-rgx=(_+[a-zA-Z0-9_]*?$)|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.


### PR DESCRIPTION
### Summary

Previously, names like `_in_circuit` would still trigger Pylint's "unused-variable" rule, while the spirit was to allow any regular variable name that's prefixed with an underscore.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I'd be happy to revisit some of the (excessively large?) number of regexes in the pylint config file for naming, but that's most likely just a bikeshedding mess.  This is just a "spiritual" fix for a nit found in https://github.com/Qiskit/qiskit-terra/pull/9525#discussion_r1106502986.
