### PR TITLE
Add MinimumPoint transpiler pass

### DIFF
--- a/qiskit/transpiler/passes/__init__.py
+++ b/qiskit/transpiler/passes/__init__.py
@@ -172,6 +172,7 @@ Additional Passes
    RemoveFinalMeasurements
    DAGFixedPoint
    FixedPoint
+   MinimumPoint
    ContainsInstruction
    GatesInBasis
    ConvertConditionsToIfOps
@@ -283,6 +284,7 @@ from .utils import RemoveFinalMeasurements
 from .utils import MergeAdjacentBarriers
 from .utils import DAGFixedPoint
 from .utils import FixedPoint
+from .utils import MinimumPoint
 from .utils import Error
 from .utils import RemoveBarriers
 from .utils import ContainsInstruction

--- a/qiskit/transpiler/passes/utils/__init__.py
+++ b/qiskit/transpiler/passes/utils/__init__.py
@@ -27,6 +27,7 @@ from .remove_barriers import RemoveBarriers
 from .contains_instruction import ContainsInstruction
 from .gates_basis import GatesInBasis
 from .convert_conditions_to_if_ops import ConvertConditionsToIfOps
+from .minimum_point import MinimumPoint
 
 # Utility functions
 from . import control_flow

--- a/qiskit/transpiler/passes/utils/minimum_point.py
+++ b/qiskit/transpiler/passes/utils/minimum_point.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Check if the DAG has reached a fixed point."""
+"""Check if the DAG has reached a relative semi-stable point over previous runs."""
 
 from copy import deepcopy
 from qiskit.transpiler.basepasses import TransformationPass
@@ -71,7 +71,7 @@ class MinimumPoint(TransformationPass):
         self.minimum_dag = None
 
     def run(self, dag):
-        """Run the DAGFixedPoint pass on `dag`."""
+        """Run the MinimumPoint pass on `dag`."""
         score = tuple(self.property_set[x] for x in self.property_set_list)
 
         if self.property_set[self.backtrack_name] is None:

--- a/qiskit/transpiler/passes/utils/minimum_point.py
+++ b/qiskit/transpiler/passes/utils/minimum_point.py
@@ -78,28 +78,30 @@ class MinimumPoint(TransformationPass):
         state = self.property_set[self.backtrack_name]
 
         # The pass starts at None and the first iteration doesn't set a real
-        # score so the overall loop is treated as a do while to ensur we have
+        # score so the overall loop is treated as a do-while to ensure we have
         # at least 2 iterations.
         if state is None:
             self.property_set[self.backtrack_name] = _MinimumPointState(
                 dag=None, score=(math.inf,) * len(self.property_set_list), since=0
             )
         # If the score of this execution is worse than the previous execution
-        # increment since since we have not found a new minimum point
+        # increment 'since' since we have not found a new minimum point
         elif score > state.score:
             state.since += 1
             if state.since == self.backtrack_depth:
                 self.property_set[self.minimum_reached] = True
                 return self.property_set[self.backtrack_name].dag
-        # If the score has decreased (gotten better) than this iteration is
-        # better performing and this iteration is a new local minimum. So
-        # update the state to be this iteration and reset counter
+        # If the score has decreased (gotten better) then this iteration is
+        # better performing and this iteration should be the new minimum state.
+        # So update the state to be this iteration and reset counter
         elif score < state.score:
             state.since = 1
             state.score = score
             state.dag = deepcopy(dag)
-        # If the current execution is equal to the previous minimum value than
-        # we've reached an equivalent fixed point and we should use
+        # If the current execution is equal to the previous minimum value then
+        # we've reached an equivalent fixed point and we should use this iteration's
+        # dag as the output and set the property set flag that we've found a minimum
+        # point.
         elif score == state.score:
             self.property_set[self.minimum_reached] = True
             return dag

--- a/qiskit/transpiler/passes/utils/minimum_point.py
+++ b/qiskit/transpiler/passes/utils/minimum_point.py
@@ -109,8 +109,10 @@ class MinimumPoint(TransformationPass):
         return dag
 
 
-@dataclass(slots=True)
+@dataclass
 class _MinimumPointState:
+    __slots__ = ("dag", "score", "since")
+
     dag: DAGCircuit
     score: Tuple[float, ...]
     since: int

--- a/qiskit/transpiler/passes/utils/minimum_point.py
+++ b/qiskit/transpiler/passes/utils/minimum_point.py
@@ -44,8 +44,8 @@ class MinimumPoint(TransformationPass):
     Fields used by this pass in the property set are (all relative to the ``prefix``
     argument):
 
-     * ``{prefix}_minimum_point_state`` - Used to track the state of the minimpoint search
-     * ``{prefix}_minimum_point`` - This value gets set to ``True`` when either a fixed point
+    * ``{prefix}_minimum_point_state`` - Used to track the state of the minimpoint search
+    * ``{prefix}_minimum_point`` - This value gets set to ``True`` when either a fixed point
         is reached over the ``backtrack_depth`` executions, or ``backtrack_depth`` was exceeded
         and an earlier minimum is restored.
     """

--- a/qiskit/transpiler/passes/utils/minimum_point.py
+++ b/qiskit/transpiler/passes/utils/minimum_point.py
@@ -1,0 +1,93 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Check if the DAG has reached a fixed point."""
+
+from copy import deepcopy
+from qiskit.transpiler.basepasses import TransformationPass
+
+
+class MinimumPoint(TransformationPass):
+    """Check if the DAG has reached a relative semi-stable point over previous runs
+
+    This pass is similar to the :class:`~.FixedPoint` transpiler pass and is intended
+    primarily to be used to set a loop break condition in the property set.
+    However, unlike the :class:`~.FixedPoint` class which only sets the
+    condition if 2 consecutive runs have the same value property set value
+    this pass is designed to find a local minimum and use that instead. This
+    pass is designed for an optimization loop where a fixed point may never
+    get reached (for example if synthesis is used and there are multiple
+    equivalent outputs for some cases).
+
+    This pass will track the state of fields in the property set over its past
+    executions and set a boolean field when either a fixed point is reached
+    over the backtracking depth or selecting the minimum value found if the
+    backtracking depth is reached. To do this it stores a deep copy of the
+    current minimum DAG in the property set and when ``backtrack_depth`` number
+    of executions is reached since the last minimum the output dag is set to
+    that copy of the earlier minimum.
+
+    Fields used by this pass in the property set are (all relative to the ``prefix``
+    argument):
+
+     * ``{prefix}_minimum_point_count`` - Used to track the number of executions since
+        the current minimum was found
+     * ``{prefix}_backtrack_history`` - Stores the current minimum value and :class:`~.DAGCircuit`
+     * ``{prefix}_minimum_point`` - This value gets set to ``True`` when either a fixed point
+        is reached over the ``backtrack_depth`` executions, or ``backtrack_depth`` was exceeded
+        and an earlier minimum is restored.
+    """
+
+    def __init__(self, property_set_list, prefix, backtrack_depth=5):
+        """Initialize an instance of this pass
+
+        Args:
+            property_set_list (list): A list of property set keys that will
+                be used to evaluate the local minimum. The values of these
+                property set keys will be used as a tuple for comparison
+            prefix (str): The prefix to use for the property set key that is used
+                for tracking previous evaluations
+            backtrack_depth (int): The maximum number of entries to store. If
+                this number is reached and the next iteration doesn't have
+                a decrease in the number of values the minimum of the previous
+                n will be set as the output dag and ``minimum_point`` will be set to
+                ``True`` in the property set
+        """
+        super().__init__()
+        self.property_set_list = property_set_list
+        self.backtrack_name = f"{prefix}_minimum_point_count"
+        self.backtrack_min_name = f"{prefix}_backtrack_history"
+        self.minimum_reached = f"{prefix}_minimum_point"
+        self.backtrack_depth = backtrack_depth
+        self.minimum_dag = None
+
+    def run(self, dag):
+        """Run the DAGFixedPoint pass on `dag`."""
+        score = tuple(self.property_set[x] for x in self.property_set_list)
+
+        if self.property_set[self.backtrack_name] is None:
+            self.property_set[self.backtrack_name] = 1
+        elif self.property_set[self.backtrack_min_name] is None:
+            self.property_set[self.backtrack_min_name] = (score, deepcopy(dag))
+        elif score > self.property_set[self.backtrack_min_name][0]:
+            self.property_set[self.backtrack_name] += 1
+            if self.property_set[self.backtrack_name] == self.backtrack_depth:
+                self.property_set[self.minimum_reached] = True
+                return self.property_set[self.backtrack_min_name][1]
+        elif score < self.property_set[self.backtrack_min_name][0]:
+            self.property_set[self.backtrack_name] = 1
+            self.property_set[self.backtrack_min_name] = (score, deepcopy(dag))
+        elif score == self.property_set[self.backtrack_min_name][0]:
+            self.property_set[self.minimum_reached] = True
+            return self.property_set[self.backtrack_min_name][1]
+
+        return dag

--- a/releasenotes/notes/add-minimum-point-pass-09cf9a9eec86fd48.yaml
+++ b/releasenotes/notes/add-minimum-point-pass-09cf9a9eec86fd48.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added a new transpiler pass, :class:`~.MinimumPoint` which is used primarily as
+    a pass to check a loop condition in a :class:`~.PassManager`. This pass will
+    track the state of fields in the property set over its past executions and set
+    a boolean field when either a fixed point is reached over the backtracking depth
+    or selecting the minimum value found if the backtracking depth is reached. This
+    is an alternative to the :class:`~.FixedPoint` which simply checks for a fixed
+    value in a property set field between subsequent executions.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -1364,7 +1364,7 @@ class TestTranspile(QiskitTestCase):
         out = transpile(qc, FakeBoeblingen(), optimization_level=optimization_level)
 
         self.assertEqual(len(out.qubits), FakeBoeblingen().configuration().num_qubits)
-        self.assertEqual(out.clbits, clbits)
+        self.assertEqual(len(out.clbits), len(clbits))
 
     @data(0, 1, 2, 3)
     def test_translate_ecr_basis(self, optimization_level):

--- a/test/python/transpiler/test_minimum_point.py
+++ b/test/python/transpiler/test_minimum_point.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""FixedPoint pass testing"""
+"""MinimumPoint pass testing"""
 
 from qiskit.transpiler.passes import MinimumPoint
 from qiskit.dagcircuit import DAGCircuit

--- a/test/python/transpiler/test_minimum_point.py
+++ b/test/python/transpiler/test_minimum_point.py
@@ -1,0 +1,181 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""FixedPoint pass testing"""
+
+from qiskit.transpiler.passes import MinimumPoint
+from qiskit.dagcircuit import DAGCircuit
+from qiskit.test import QiskitTestCase
+
+
+class TestMinimumPointtPass(QiskitTestCase):
+    """Tests for MinimumPoint pass."""
+
+    def test_minimum_point_reached_fixed_point_single_field(self):
+        """Test a fixed point is reached with a single field."""
+        min_pass = MinimumPoint(["depth"], prefix="test")
+        dag = DAGCircuit()
+        min_pass.property_set["depth"] = 42
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((42,), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((42,), min_pass.property_set["test_backtrack_history"][0])
+        self.assertTrue(min_pass.property_set["test_minimum_point"])
+
+    def test_minimum_point_reached_fixed_point_multiple_fields(self):
+        """Test a fixed point is reached with a multiple fields."""
+        min_pass = MinimumPoint(["fidelity", "depth", "size"], prefix="test")
+        dag = DAGCircuit()
+        min_pass.property_set["fidelity"] = 0.875
+        min_pass.property_set["depth"] = 15
+        min_pass.property_set["size"] = 20
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((0.875, 15, 20), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((0.875, 15, 20), min_pass.property_set["test_backtrack_history"][0])
+        self.assertTrue(min_pass.property_set["test_minimum_point"])
+
+    def test_min_over_backtrack_range(self):
+        """Test minimum returned over backtrack depth."""
+        min_pass = MinimumPoint(["fidelity", "depth", "size"], prefix="test")
+        dag = DAGCircuit()
+        min_pass.property_set["fidelity"] = 0.875
+        min_pass.property_set["depth"] = 15
+        min_pass.property_set["size"] = 20
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 25
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 45
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 5)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertTrue(min_pass.property_set["test_minimum_point"])
+
+    def test_min_reset_backtrack_range(self):
+        """Test minimum resets backtrack depth."""
+        min_pass = MinimumPoint(["fidelity", "depth", "size"], prefix="test")
+        dag = DAGCircuit()
+        min_pass.property_set["fidelity"] = 0.875
+        min_pass.property_set["depth"] = 15
+        min_pass.property_set["size"] = 20
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 25
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 45
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
+        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 10
+        min_pass.property_set["size"] = 10
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
+        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 25
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
+        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_min_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 45
+        min_pass.property_set["size"] = 35
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
+        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
+        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
+        min_pass.property_set["fidelity"] = 0.775
+        min_pass.property_set["depth"] = 36
+        min_pass.property_set["size"] = 40
+        min_pass.run(dag)
+        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 5)
+        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        self.assertTrue(min_pass.property_set["test_minimum_point"])

--- a/test/python/transpiler/test_minimum_point.py
+++ b/test/python/transpiler/test_minimum_point.py
@@ -12,6 +12,8 @@
 
 """MinimumPoint pass testing"""
 
+import math
+
 from qiskit.transpiler.passes import MinimumPoint
 from qiskit.dagcircuit import DAGCircuit
 from qiskit.test import QiskitTestCase
@@ -22,21 +24,37 @@ class TestMinimumPointtPass(QiskitTestCase):
 
     def test_minimum_point_reached_fixed_point_single_field(self):
         """Test a fixed point is reached with a single field."""
+
         min_pass = MinimumPoint(["depth"], prefix="test")
         dag = DAGCircuit()
         min_pass.property_set["depth"] = 42
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        # After first iteration state is only initialized but not populated
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 0)
+        self.assertEqual((math.inf,), state.score)
+        self.assertIsNone(state.dag)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Second iteration
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((42,), min_pass.property_set["test_backtrack_history"][0])
+        # After second iteration the state is initialized
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual(state.score, (42,))
         self.assertIsNone(min_pass.property_set["test_min_point"])
-        min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((42,), min_pass.property_set["test_backtrack_history"][0])
+
+        # Third iteration
+        out_dag = min_pass.run(dag)
+        # After 3rd iteration we've reached a fixed point equal to our minimum
+        # ooint so we return the minimum dag
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual((42,), state.score)
         self.assertTrue(min_pass.property_set["test_minimum_point"])
+        # In case of fixed point we don't return copy but the state of the dag
+        # after the fixed point so only assert equality
+        self.assertEqual(out_dag, state.dag)
 
     def test_minimum_point_reached_fixed_point_multiple_fields(self):
         """Test a fixed point is reached with a multiple fields."""
@@ -46,17 +64,32 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 15
         min_pass.property_set["size"] = 20
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        # After first iteration state is only initialized but not populated
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 0)
+        self.assertEqual((math.inf, math.inf, math.inf), state.score)
+        self.assertIsNone(state.dag)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration Two
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((0.875, 15, 20), min_pass.property_set["test_backtrack_history"][0])
+        # After second iteration the state is initialized
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual(state.score, (0.875, 15, 20))
         self.assertIsNone(min_pass.property_set["test_min_point"])
-        min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((0.875, 15, 20), min_pass.property_set["test_backtrack_history"][0])
+
+        # Iteration Three
+        out_dag = min_pass.run(dag)
+        # After 3rd iteration we've reached a fixed point equal to our minimum
+        # ooint so we return the minimum dag
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual(state.score, (0.875, 15, 20))
         self.assertTrue(min_pass.property_set["test_minimum_point"])
+        # In case of fixed point we don't return copy but the state of the dag
+        # after the fixed point so only assert equality
+        self.assertEqual(out_dag, state.dag)
 
     def test_min_over_backtrack_range(self):
         """Test minimum returned over backtrack depth."""
@@ -66,44 +99,69 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 15
         min_pass.property_set["size"] = 20
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        # After first iteration state is only initialized but not populated
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 0)
+        self.assertEqual((math.inf, math.inf, math.inf), state.score)
+        self.assertIsNone(state.dag)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration Two
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 25
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # After second iteration we've set a current minimum state
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration three
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 45
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # After third iteration score is worse than minimum point just bump since
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 2)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration four
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # After fourth iteration score is worse than minimum point just bump since
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 3)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration five
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # After fifth iteration score is worse than minimum point just bump since
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 4)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration six
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
-        min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 5)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        out_dag = min_pass.run(dag)
+        # After sixth iteration score is worse, but we've reached backtrack depth and the
+        # dag copy is returned
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 5)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertTrue(min_pass.property_set["test_minimum_point"])
+        self.assertIs(out_dag, state.dag)
 
     def test_min_reset_backtrack_range(self):
         """Test minimum resets backtrack depth."""
@@ -113,69 +171,119 @@ class TestMinimumPointtPass(QiskitTestCase):
         min_pass.property_set["depth"] = 15
         min_pass.property_set["size"] = 20
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertIsNone(min_pass.property_set["test_backtrack_history"])
+        # After first iteration state is only initialized but not populated
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 0)
+        self.assertEqual((math.inf, math.inf, math.inf), state.score)
+        self.assertIsNone(state.dag)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration two:
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 25
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # After second iteration we've set a current minimum state
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration three:
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 45
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # Third iteration the score is worse (because of depth increasing) so do
+        # not set new minimum point
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 2)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration four:
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # Fourth iteration the score is also worse than minmum although depth
+        # is better than iteration three it's still higher than the minimum point
+        # Also size has increased:. Do not update minimum point and since is increased
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 3)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration five
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
-        self.assertEqual((0.775, 25, 35), min_pass.property_set["test_backtrack_history"][0])
+        # Fifth iteration the score is also worse than minmum although the same
+        # with previous iteration. This means do not update minimum point and bump since
+        # value
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 4)
+        self.assertEqual((0.775, 25, 35), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration Six
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 10
         min_pass.property_set["size"] = 10
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 1)
-        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        # Sixth iteration the score is lower (fidelity is the same but depth and size decreased)
+        # set new minimum point
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 1)
+        self.assertEqual((0.775, 10, 10), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration seven
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 25
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 2)
-        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        # Iteration seven the score is worse than the minimum point.  Do not update minimum point
+        # and since is bumped
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 2)
+        self.assertEqual((0.775, 10, 10), state.score)
         self.assertIsNone(min_pass.property_set["test_min_point"])
+
+        # Iteration Eight
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 45
         min_pass.property_set["size"] = 35
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 3)
-        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        # Iteration eight the score is worse than the minimum point. Do not update minimum point
+        # and since is bumped
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 3)
+        self.assertEqual((0.775, 10, 10), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration Nine
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
         min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 4)
-        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        # Iteration nine the score is worse than the minium point. Do not update minimum point
+        # and since is bumped
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 4)
+        self.assertEqual((0.775, 10, 10), state.score)
         self.assertIsNone(min_pass.property_set["test_minimum_point"])
+
+        # Iteration 10
         min_pass.property_set["fidelity"] = 0.775
         min_pass.property_set["depth"] = 36
         min_pass.property_set["size"] = 40
-        min_pass.run(dag)
-        self.assertEqual(min_pass.property_set["test_minimum_point_count"], 5)
-        self.assertEqual((0.775, 10, 10), min_pass.property_set["test_backtrack_history"][0])
+        out_dag = min_pass.run(dag)
+        # Iteration 10 score is worse, but we've reached the set backtrack
+        # depth of 5 iterations since the last minimum so we exit here
+        state = min_pass.property_set["test_minimum_point_state"]
+        self.assertEqual(state.since, 5)
+        self.assertEqual((0.775, 10, 10), state.score)
         self.assertTrue(min_pass.property_set["test_minimum_point"])
+        self.assertIs(out_dag, state.dag)

--- a/test/python/transpiler/test_minimum_point.py
+++ b/test/python/transpiler/test_minimum_point.py
@@ -34,7 +34,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         self.assertEqual(state.since, 0)
         self.assertEqual((math.inf,), state.score)
         self.assertIsNone(state.dag)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Second iteration
         min_pass.run(dag)
@@ -42,7 +42,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 1)
         self.assertEqual(state.score, (42,))
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Third iteration
         out_dag = min_pass.run(dag)
@@ -69,7 +69,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         self.assertEqual(state.since, 0)
         self.assertEqual((math.inf, math.inf, math.inf), state.score)
         self.assertIsNone(state.dag)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration Two
         min_pass.run(dag)
@@ -77,7 +77,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 1)
         self.assertEqual(state.score, (0.875, 15, 20))
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration Three
         out_dag = min_pass.run(dag)
@@ -104,7 +104,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         self.assertEqual(state.since, 0)
         self.assertEqual((math.inf, math.inf, math.inf), state.score)
         self.assertIsNone(state.dag)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration Two
         min_pass.property_set["fidelity"] = 0.775
@@ -115,7 +115,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 1)
         self.assertEqual((0.775, 25, 35), state.score)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration three
         min_pass.property_set["fidelity"] = 0.775
@@ -176,7 +176,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         self.assertEqual(state.since, 0)
         self.assertEqual((math.inf, math.inf, math.inf), state.score)
         self.assertIsNone(state.dag)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration two:
         min_pass.property_set["fidelity"] = 0.775
@@ -187,7 +187,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 1)
         self.assertEqual((0.775, 25, 35), state.score)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration three:
         min_pass.property_set["fidelity"] = 0.775
@@ -249,7 +249,7 @@ class TestMinimumPointtPass(QiskitTestCase):
         state = min_pass.property_set["test_minimum_point_state"]
         self.assertEqual(state.since, 2)
         self.assertEqual((0.775, 10, 10), state.score)
-        self.assertIsNone(min_pass.property_set["test_min_point"])
+        self.assertIsNone(min_pass.property_set["test_minimum_point"])
 
         # Iteration Eight
         min_pass.property_set["fidelity"] = 0.775


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new transpiler pass MinimumPoint which is used to find a local minimum point from the property set between executions of the pass. This is similar to the existing FixedPoint pass but will find the minimum fixed point over the past n exeuctions as opposed to finding a when two subsequent exectuions are at the same point. This is then used in optimization level 3 because the 2q unitary synthesis optimization that is part of the optimization loop can occasionally get stuck oscillating between multiple different equivalent decompositions which prevents the fixed point condition from ever being reached. By checking that we've reached the minimum over the last 5 executions we ensure we're reaching an exit condition in this situation.

### Details and comments

Fixes #5832
Fixes #9177
Fixes #9776

(the underlying cause of the optimization loop's inability to converge at optimization level 3 is not fixed here, there is still a root cause of instability in `UnitarySynthesis` this just changes the loop exit condition so we're never stuck in an infinte loop)