### PR TITLE
Upgrade Pylint to 2.16.2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -74,9 +74,9 @@ disable=spelling,       # way too noisy
     import-outside-toplevel,
     import-error,        # overzealous with our optionals/dynamic packages
 
-    # TODO: these were added in modern Pylint and we want to enable them.
-    # (If we decide any of them should be ignored, then move it above this section
-    #  and add a comment with the rationale.)
+    # TODO(#9614): these were added in modern Pylint. Decide if we want to enable them. If so,
+    #  remove from here and fix the issues. Else, move it above this section and add a comment
+    #  with the rationale.
     arguments-renamed,
     broad-exception-raised,
     consider-iterating-dictionary,

--- a/.pylintrc
+++ b/.pylintrc
@@ -34,8 +34,8 @@ unsafe-load-any-extension=no
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
 extension-pkg-allow-list=retworkx, numpy, tweedledum, qiskit._accelerate, rustworkx
-generated-modules=retworkx.visualization,retwork.visit
-ignore-modules=retworkx,retworkx.visualization,retworkx.visit
+generated-members=retworkx.visualization,retwork.visit
+ignored-modules=retworkx,retworkx.visualization,retworkx.visit
 
 [MESSAGES CONTROL]
 
@@ -59,7 +59,6 @@ enable=use-symbolic-message-instead
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=spelling,       # way too noisy
-    no-self-use,        # disabled as it is too verbose
     fixme,              # disabled as TODOs would show up as warnings
     protected-access,   # disabled as we don't follow the public vs private
                         # convention strictly
@@ -73,11 +72,41 @@ disable=spelling,       # way too noisy
     no-else-return,     # relax "elif" after a clause with a return
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
-    bad-continuation, bad-whitespace, # differences of opinion with black
-    import-error        # overzealous with our optionals/dynamic packages
+    import-error,        # overzealous with our optionals/dynamic packages
 
-
-
+    # TODO: these were added in modern Pylint and we want to enable them.
+    # (If we decide any of them should be ignored, then move it above this section
+    #  and add a comment with the rationale.)
+    arguments-renamed,
+    broad-exception-raised,
+    consider-iterating-dictionary,
+    consider-using-dict-items,
+    consider-using-enumerate,
+    consider-using-f-string,
+    consider-using-from-import,
+    modified-iterating-list,
+    nested-min-max,
+    no-member,
+    no-value-for-parameter,
+    non-ascii-name,
+    not-context-manager,
+    pointless-exception-statement,
+    superfluous-parens,
+    unknown-option-value,
+    unexpected-keyword-arg,
+    unnecessary-dict-index-lookup,
+    unnecessary-direct-lambda-call,
+    unnecessary-dunder-call,
+    unnecessary-ellipsis,
+    unnecessary-lambda-assignment,
+    unnecessary-list-index-lookup,
+    unspecified-encoding,
+    unsupported-assignment-operation,
+    use-dict-literal,
+    use-list-literal,
+    use-implicit-booleaness-not-comparison,
+    use-maxsplit-arg,
+    used-before-assignment,
 
 [REPORTS]
 
@@ -85,12 +114,6 @@ disable=spelling,       # way too noisy
 # (visual studio) and html. You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=text
-
-# Put messages in a separate file for each module / package specified on the
-# command line instead of printing them on stdout. Reports (if any) will be
-# written in a file name "pylint_global.[txt|html]". This option is deprecated
-# and it will be removed in Pylint 2.0.
-files-output=no
 
 # Tells whether to display a full report or only the messages
 reports=yes
@@ -140,62 +163,32 @@ property-classes=abc.abstractproperty
 # Regular expression matching correct module names
 module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
-
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct function names
 function-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct method names
 method-rgx=(([a-z_][a-z0-9_]{2,49})|(assert[A-Z][a-zA-Z0-9]{2,43})|(test_[_a-zA-Z0-9]{2,}))$
 
-# Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$ or camelCase `assert*` in tests.
-
 # Regular expression matching correct attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$
-
-# Naming hint for attribute names
-attr-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct argument names
 argument-rgx=[a-z_][a-z0-9_]{2,30}|ax|dt$
 
-# Naming hint for argument names
-argument-name-hint=[a-z_][a-z0-9_]{2,30}$
-
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{1,30}$
-
-# Naming hint for variable names
-variable-name-hint=[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
 
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
-
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
@@ -223,12 +216,6 @@ ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
 single-line-if-stmt=no
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Maximum number of lines in a module
 max-module-lines=1000
@@ -426,4 +413,4 @@ analyse-fallback-blocks=no
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/qiskit/opflow/converters/pauli_basis_change.py
+++ b/qiskit/opflow/converters/pauli_basis_change.py
@@ -346,7 +346,9 @@ class PauliBasisChange(ConverterBase):
         y_to_x_origin = tensorall(
             [S if has_y else I for has_y in reversed(np.logical_and(pauli.x, pauli.z))]
         ).adjoint()
-        x_to_z_origin = tensorall([H if has_x else I for has_x in reversed(pauli.x)])
+        x_to_z_origin = tensorall(  # pylint: disable=assignment-from-no-return
+            [H if has_x else I for has_x in reversed(pauli.x)]
+        )
         return x_to_z_origin.compose(y_to_x_origin)
 
     def pad_paulis_to_equal_length(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,8 @@ matplotlib>=3.3
 pillow>=4.2.1
 black[jupyter]~=22.0
 pydot
-astroid==2.5.6
-pylint==2.8.3
+astroid==2.14.2
+pylint==2.16.2
 stestr>=2.0.0,!=4.0.0
 pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3

--- a/test/python/pulse/test_transforms.py
+++ b/test/python/pulse/test_transforms.py
@@ -271,7 +271,9 @@ class TestPad(QiskitTestCase):
             | Delay(delay, DriveChannel(0))
             | Delay(delay, DriveChannel(0)).shift(20)
             | Delay(delay, DriveChannel(1))
-            | Delay(2 * delay, DriveChannel(1)).shift(20)
+            | Delay(  # pylint: disable=unsupported-binary-operation
+                2 * delay, DriveChannel(1)
+            ).shift(20)
         )
 
         self.assertEqual(transforms.pad(sched), ref_sched)
@@ -294,7 +296,9 @@ class TestPad(QiskitTestCase):
             | Delay(delay, DriveChannel(0))
             | Delay(delay, DriveChannel(0)).shift(20)
             | Delay(delay, DriveChannel(1))
-            | Delay(2 * delay, DriveChannel(1)).shift(20)
+            | Delay(  # pylint: disable=unsupported-binary-operation
+                2 * delay, DriveChannel(1)
+            ).shift(20)
         )
 
         self.assertEqual(transforms.pad(sched), ref_sched)
@@ -319,7 +323,7 @@ class TestPad(QiskitTestCase):
             sched
             | Delay(delay, DriveChannel(0))
             | Delay(30, DriveChannel(0)).shift(20)
-            | Delay(40, DriveChannel(1)).shift(10)
+            | Delay(40, DriveChannel(1)).shift(10)  # pylint: disable=unsupported-binary-operation
         )
 
         self.assertEqual(transforms.pad(sched, until=50), ref_sched)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Pylint 2.16 adds support for Python 3.11 and also adds lots of great new checks.

### Details and comments

To facilitate landing this, I disabled all the new checks that we fail. This will be fixed in a followup in https://github.com/Qiskit/qiskit-terra/issues/9614. 

Why not fix those before this PR?
1. I want to use Pylint with Python 3.11
2. Landing the upgrade now means that once we fix a check and enable it, we'll proactively avoid any regressions for that check.
