### PR TITLE
Add `since` argument to deprecation functions

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -196,6 +196,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self) -> Optional[QuantumInstance]:
         r"""Pending deprecation\; Get the quantum instance.
@@ -211,6 +212,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: Union[QuantumInstance, Backend]) -> None:
         r"""Pending deprecation\; Set quantum instance.

--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -196,7 +196,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self) -> Optional[QuantumInstance]:
         r"""Pending deprecation\; Get the quantum instance.
@@ -212,7 +212,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: Union[QuantumInstance, Backend]) -> None:
         r"""Pending deprecation\; Set quantum instance.

--- a/qiskit/algorithms/amplitude_amplifiers/grover.py
+++ b/qiskit/algorithms/amplitude_amplifiers/grover.py
@@ -196,7 +196,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self) -> Optional[QuantumInstance]:
         r"""Pending deprecation\; Get the quantum instance.
@@ -212,7 +212,7 @@ class Grover(AmplitudeAmplifier):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self, quantum_instance: Union[QuantumInstance, Backend]) -> None:
         r"""Pending deprecation\; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -129,7 +129,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -145,7 +145,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -129,7 +129,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -145,7 +145,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -129,6 +129,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -144,6 +145,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -114,6 +114,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -129,6 +130,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -114,7 +114,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -130,7 +130,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/fae.py
+++ b/qiskit/algorithms/amplitude_estimators/fae.py
@@ -114,7 +114,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -130,7 +130,7 @@ class FasterAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -137,7 +137,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -153,7 +153,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -137,6 +137,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -152,6 +153,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/iae.py
+++ b/qiskit/algorithms/amplitude_estimators/iae.py
@@ -137,7 +137,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -153,7 +153,7 @@ class IterativeAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -141,7 +141,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -157,7 +157,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -141,6 +141,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -156,6 +157,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/amplitude_estimators/mlae.py
+++ b/qiskit/algorithms/amplitude_estimators/mlae.py
@@ -141,7 +141,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self) -> QuantumInstance | None:
         """Pending deprecation; Get the quantum instance.
@@ -157,7 +157,7 @@ class MaximumLikelihoodAmplitudeEstimation(AmplitudeEstimator):
         "This property will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def quantum_instance(self, quantum_instance: QuantumInstance | Backend) -> None:
         """Pending deprecation; Set quantum instance.

--- a/qiskit/algorithms/aux_ops_evaluator.py
+++ b/qiskit/algorithms/aux_ops_evaluator.py
@@ -37,6 +37,7 @@ from .list_or_dict import ListOrDict
     "This function will be deprecated in a future release and subsequently "
     "removed after that.",
     category=PendingDeprecationWarning,
+    since="0.23.0",
 )
 def eval_observables(
     quantum_instance: Union[QuantumInstance, Backend],

--- a/qiskit/algorithms/aux_ops_evaluator.py
+++ b/qiskit/algorithms/aux_ops_evaluator.py
@@ -37,7 +37,7 @@ from .list_or_dict import ListOrDict
     "This function will be deprecated in a future release and subsequently "
     "removed after that.",
     category=PendingDeprecationWarning,
-    since="0.24.0",
+    since="0.23.0",
 )
 def eval_observables(
     quantum_instance: Union[QuantumInstance, Backend],

--- a/qiskit/algorithms/aux_ops_evaluator.py
+++ b/qiskit/algorithms/aux_ops_evaluator.py
@@ -37,7 +37,7 @@ from .list_or_dict import ListOrDict
     "This function will be deprecated in a future release and subsequently "
     "removed after that.",
     category=PendingDeprecationWarning,
-    since="0.23.0",
+    since="0.24.0",
 )
 def eval_observables(
     quantum_instance: Union[QuantumInstance, Backend],

--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -42,7 +42,7 @@ class Eigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass
@@ -95,7 +95,7 @@ class EigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -42,7 +42,7 @@ class Eigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         pass
@@ -95,7 +95,7 @@ class EigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/eigen_solver.py
@@ -42,6 +42,7 @@ class Eigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass
@@ -94,6 +95,7 @@ class EigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -55,6 +55,7 @@ class NumPyEigensolver(Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -55,7 +55,7 @@ class NumPyEigensolver(Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
+++ b/qiskit/algorithms/eigen_solvers/numpy_eigen_solver.py
@@ -55,7 +55,7 @@ class NumPyEigensolver(Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/eigen_solvers/vqd.py
+++ b/qiskit/algorithms/eigen_solvers/vqd.py
@@ -102,7 +102,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,
@@ -773,7 +773,7 @@ class VQDResult(VariationalResult, EigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/vqd.py
+++ b/qiskit/algorithms/eigen_solvers/vqd.py
@@ -102,7 +102,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,
@@ -773,7 +773,7 @@ class VQDResult(VariationalResult, EigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/eigen_solvers/vqd.py
+++ b/qiskit/algorithms/eigen_solvers/vqd.py
@@ -102,6 +102,7 @@ class VQD(VariationalAlgorithm, Eigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,
@@ -772,6 +773,7 @@ class VQDResult(VariationalResult, EigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/evolvers/evolution_problem.py
+++ b/qiskit/algorithms/evolvers/evolution_problem.py
@@ -39,7 +39,7 @@ class EvolutionProblem:
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_problem.py
+++ b/qiskit/algorithms/evolvers/evolution_problem.py
@@ -39,7 +39,7 @@ class EvolutionProblem:
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_problem.py
+++ b/qiskit/algorithms/evolvers/evolution_problem.py
@@ -39,6 +39,7 @@ class EvolutionProblem:
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_result.py
+++ b/qiskit/algorithms/evolvers/evolution_result.py
@@ -37,7 +37,7 @@ class EvolutionResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_result.py
+++ b/qiskit/algorithms/evolvers/evolution_result.py
@@ -37,7 +37,7 @@ class EvolutionResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/evolution_result.py
+++ b/qiskit/algorithms/evolvers/evolution_result.py
@@ -37,6 +37,7 @@ class EvolutionResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/imaginary_evolver.py
+++ b/qiskit/algorithms/evolvers/imaginary_evolver.py
@@ -35,7 +35,7 @@ class ImaginaryEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/imaginary_evolver.py
+++ b/qiskit/algorithms/evolvers/imaginary_evolver.py
@@ -35,6 +35,7 @@ class ImaginaryEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/imaginary_evolver.py
+++ b/qiskit/algorithms/evolvers/imaginary_evolver.py
@@ -35,7 +35,7 @@ class ImaginaryEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/real_evolver.py
+++ b/qiskit/algorithms/evolvers/real_evolver.py
@@ -35,7 +35,7 @@ class RealEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/real_evolver.py
+++ b/qiskit/algorithms/evolvers/real_evolver.py
@@ -35,6 +35,7 @@ class RealEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/real_evolver.py
+++ b/qiskit/algorithms/evolvers/real_evolver.py
@@ -35,7 +35,7 @@ class RealEvolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
@@ -70,7 +70,7 @@ class TrotterQRTE(RealEvolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
@@ -70,7 +70,7 @@ class TrotterQRTE(RealEvolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
+++ b/qiskit/algorithms/evolvers/trotterization/trotter_qrte.py
@@ -70,6 +70,7 @@ class TrotterQRTE(RealEvolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/factorizers/shor.py
+++ b/qiskit/algorithms/factorizers/shor.py
@@ -60,7 +60,8 @@ class Shor:
         """The Shor class is deprecated as of Qiskit Terra 0.22.0 and will be removed
         no sooner than 3 months after the release date.
         It is replaced by the tutorial at https://qiskit.org/textbook/ch-algorithms/shor.html
-        """
+        """,
+        since="0.22.0",
     )
     def __init__(self, quantum_instance: Optional[Union[QuantumInstance, Backend]] = None) -> None:
         """

--- a/qiskit/algorithms/linear_solvers/hhl.py
+++ b/qiskit/algorithms/linear_solvers/hhl.py
@@ -110,7 +110,8 @@ class HHL(LinearSolver):
         """The HHL class is deprecated as of Qiskit Terra 0.22.0 and will be removed
         no sooner than 3 months after the release date.
         It is replaced by the tutorial at https://qiskit.org/textbook/ch-applications/hhl_tutorial.html"
-        """
+        """,
+        since="0.22.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/linear_solvers/linear_solver.py
+++ b/qiskit/algorithms/linear_solvers/linear_solver.py
@@ -34,7 +34,8 @@ class LinearSolverResult(AlgorithmResult):
 
     @deprecate_function(
         "The LinearSolverResult class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(self) -> None:
         super().__init__()
@@ -102,7 +103,8 @@ class LinearSolver(ABC):
 
     @deprecate_function(
         "The LinearSolver class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/linear_solvers/matrices/linear_system_matrix.py
+++ b/qiskit/algorithms/linear_solvers/matrices/linear_system_matrix.py
@@ -25,7 +25,8 @@ class LinearSystemMatrix(BlueprintCircuit, ABC):
 
     @deprecate_function(
         "The LinearSystemMatrix class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/linear_solvers/matrices/numpy_matrix.py
+++ b/qiskit/algorithms/linear_solvers/matrices/numpy_matrix.py
@@ -48,7 +48,8 @@ class NumPyMatrix(LinearSystemMatrix):
 
     @deprecate_function(
         "The NumPyMatrix class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
+++ b/qiskit/algorithms/linear_solvers/matrices/tridiagonal_toeplitz.py
@@ -60,7 +60,8 @@ class TridiagonalToeplitz(LinearSystemMatrix):
 
     @deprecate_function(
         "The TridiagonalToeplitz class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/linear_solvers/numpy_linear_solver.py
+++ b/qiskit/algorithms/linear_solvers/numpy_linear_solver.py
@@ -53,7 +53,8 @@ class NumPyLinearSolver(LinearSolver):
 
     @deprecate_function(
         "The NumPyLinearSolver class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date. ",
+        since="0.22.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/linear_solvers/observables/absolute_average.py
+++ b/qiskit/algorithms/linear_solvers/observables/absolute_average.py
@@ -63,7 +63,8 @@ class AbsoluteAverage(LinearSystemObservable):
 
     @deprecate_function(
         "The AbsoluteAverage class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/linear_solvers/observables/linear_system_observable.py
+++ b/qiskit/algorithms/linear_solvers/observables/linear_system_observable.py
@@ -26,7 +26,8 @@ class LinearSystemObservable(ABC):
 
     @deprecate_function(
         "The LinearSystemObservable class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(self) -> None:
         pass

--- a/qiskit/algorithms/linear_solvers/observables/matrix_functional.py
+++ b/qiskit/algorithms/linear_solvers/observables/matrix_functional.py
@@ -75,7 +75,8 @@ class MatrixFunctional(LinearSystemObservable):
 
     @deprecate_function(
         "The MatrixFunctional class is deprecated as of Qiskit Terra 0.22.0 "
-        "and will be removed no sooner than 3 months after the release date. "
+        "and will be removed no sooner than 3 months after the release date.",
+        since="0.22.0",
     )
     def __init__(self, main_diag: float, off_diag: int) -> None:
         """

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -42,7 +42,7 @@ class MinimumEigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         pass
@@ -99,7 +99,7 @@ class MinimumEigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -42,6 +42,7 @@ class MinimumEigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass
@@ -98,6 +99,7 @@ class MinimumEigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/minimum_eigen_solver.py
@@ -42,7 +42,7 @@ class MinimumEigensolver(ABC):
         "This interface will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         pass
@@ -99,7 +99,7 @@ class MinimumEigensolverResult(AlgorithmResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         super().__init__()

--- a/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -43,6 +43,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -43,7 +43,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/numpy_minimum_eigen_solver.py
@@ -43,7 +43,7 @@ class NumPyMinimumEigensolver(MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -65,7 +65,7 @@ class QAOA(VQE):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -65,6 +65,7 @@ class QAOA(VQE):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -65,7 +65,7 @@ class QAOA(VQE):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -133,7 +133,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(
         self,
@@ -673,7 +673,7 @@ class VQEResult(VariationalResult, MinimumEigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.23.0",
+        since="0.24.0",
     )
     def __init__(self) -> None:
         with warnings.catch_warnings():

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -133,6 +133,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(
         self,
@@ -672,6 +673,7 @@ class VQEResult(VariationalResult, MinimumEigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
+        since="0.23.0",
     )
     def __init__(self) -> None:
         with warnings.catch_warnings():

--- a/qiskit/algorithms/minimum_eigen_solvers/vqe.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/vqe.py
@@ -133,7 +133,7 @@ class VQE(VariationalAlgorithm, MinimumEigensolver):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(
         self,
@@ -673,7 +673,7 @@ class VQEResult(VariationalResult, MinimumEigensolverResult):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         category=PendingDeprecationWarning,
-        since="0.24.0",
+        since="0.23.0",
     )
     def __init__(self) -> None:
         with warnings.catch_warnings():

--- a/qiskit/algorithms/optimizers/adam_amsgrad.py
+++ b/qiskit/algorithms/optimizers/adam_amsgrad.py
@@ -198,7 +198,8 @@ class ADAM(Optimizer):
             "objective_function": "fun",
             "initial_point": "x0",
             "gradient_function": "jac",
-        }
+        },
+        since="0.19.0",
     )
     # pylint: disable=arguments-differ
     def minimize(

--- a/qiskit/algorithms/optimizers/spsa.py
+++ b/qiskit/algorithms/optimizers/spsa.py
@@ -651,7 +651,8 @@ class SPSA(Optimizer):
         "The SPSA.optimize method is deprecated as of Qiskit Terra 0.21.0 and will be removed no "
         "sooner than 3 months after the release date. Instead, use SPSA.minimize as a replacement, "
         "which supports the same arguments but follows the interface of scipy.optimize and returns "
-        "a complete result object containing additional information."
+        "a complete result object containing additional information.",
+        since="0.21.0",
     )
     def optimize(
         self,

--- a/qiskit/algorithms/phase_estimators/phase_estimation_result.py
+++ b/qiskit/algorithms/phase_estimators/phase_estimation_result.py
@@ -69,8 +69,9 @@ class PhaseEstimationResult(PhaseEstimatorResult):
     @property
     @deprecate_function(
         """The 'PhaseEstimationResult.most_likely_phase' attribute
-                        is deprecated as of 0.18.0 and will be removed no earlier than 3 months
-                        after the release date. It has been renamed as the 'phase' attribute."""
+        is deprecated as of 0.18.0 and will be removed no earlier than 3 months
+        after the release date. It has been renamed as the 'phase' attribute.""",
+        since="0.18.0",
     )
     def most_likely_phase(self) -> float:
         r"""DEPRECATED - Return the most likely phase as a number in :math:`[0.0, 1.0)`.

--- a/qiskit/circuit/classicalregister.py
+++ b/qiskit/circuit/classicalregister.py
@@ -61,7 +61,8 @@ class ClassicalRegister(Register):
     @deprecate_function(
         "Register.qasm() is deprecated since Terra 0.23, as correct exporting to OpenQASM 2 is "
         "the responsibility of a larger exporter; it cannot safely be done on an object-by-object "
-        "basis without context. No replacement will be provided, because the premise is wrong."
+        "basis without context. No replacement will be provided, because the premise is wrong.",
+        since="0.23.0",
     )
     def qasm(self):
         """Return OPENQASM string for this register."""

--- a/qiskit/circuit/quantumregister.py
+++ b/qiskit/circuit/quantumregister.py
@@ -61,7 +61,8 @@ class QuantumRegister(Register):
     @deprecate_function(
         "Register.qasm() is deprecated since Terra 0.23, as correct exporting to OpenQASM 2 is "
         "the responsibility of a larger exporter; it cannot safely be done on an object-by-object "
-        "basis without context. No replacement will be provided, because the premise is wrong."
+        "basis without context. No replacement will be provided, because the premise is wrong.",
+        since="0.23.0",
     )
     def qasm(self):
         """Return OPENQASM string for this register."""

--- a/qiskit/dagcircuit/dagcircuit.py
+++ b/qiskit/dagcircuit/dagcircuit.py
@@ -530,7 +530,8 @@ class DAGCircuit:
         """The DAGCircuit._copy_circuit_metadata method is deprecated as of 0.20.0. It will be removed
         no earlier than 3 months after the release date. You should use the DAGCircuit.copy_empty_like
         method instead, which acts identically.
-        """
+        """,
+        since="0.20.0",
     )
     def _copy_circuit_metadata(self):
         """DEPRECATED"""

--- a/qiskit/primitives/base/base_estimator.py
+++ b/qiskit/primitives/base/base_estimator.py
@@ -343,6 +343,7 @@ class BaseEstimator(BasePrimitive):
         "The BaseEstimator.__enter__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "BaseEstimator should be initialized directly.",
+        since="0.22.0",
     )
     def __enter__(self):
         return self
@@ -351,6 +352,7 @@ class BaseEstimator(BasePrimitive):
         "The BaseEstimator.__call__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "BaseEstimator should be initialized directly.",
+        since="0.22.0",
     )
     def __exit__(self, *exc_info):
         self.close()
@@ -363,8 +365,12 @@ class BaseEstimator(BasePrimitive):
         "The BaseEstimator.__call__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "Use the 'run' method instead.",
+        since="0.22.0",
     )
-    @deprecate_arguments({"circuit_indices": "circuits", "observable_indices": "observables"})
+    @deprecate_arguments(
+        {"circuit_indices": "circuits", "observable_indices": "observables"},
+        since="0.21.0",
+    )
     def __call__(
         self,
         circuits: Sequence[int | QuantumCircuit],

--- a/qiskit/primitives/base/base_sampler.py
+++ b/qiskit/primitives/base/base_sampler.py
@@ -260,6 +260,7 @@ class BaseSampler(BasePrimitive):
         "The BaseSampler.__enter__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "BaseSampler should be initialized directly.",
+        since="0.22.0",
     )
     def __enter__(self):
         return self
@@ -268,6 +269,7 @@ class BaseSampler(BasePrimitive):
         "The BaseSampler.__exit__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "BaseSampler should be initialized directly.",
+        since="0.22.0",
     )
     def __exit__(self, *exc_info):
         self.close()
@@ -280,8 +282,12 @@ class BaseSampler(BasePrimitive):
         "The BaseSampler.__call__ method is deprecated as of Qiskit Terra 0.22.0 "
         "and will be removed no sooner than 3 months after the releasedate. "
         "Use run method instead.",
+        since="0.22.0",
     )
-    @deprecate_arguments({"circuit_indices": "circuits"})
+    @deprecate_arguments(
+        {"circuit_indices": "circuits"},
+        since="0.21.0",
+    )
     def __call__(
         self,
         circuits: Sequence[int | QuantumCircuit],

--- a/qiskit/pulse/instructions/instruction.py
+++ b/qiskit/pulse/instructions/instruction.py
@@ -227,6 +227,7 @@ class Instruction(ABC):
         "Drawing individual pulses is deprecated since Terra 0.23, and will be removed in a future"
         " version of the library.  No direct alternative is being provided, but instructions can"
         " be visualized as part of a complete schedule using `qiskit.visualization.pulse_drawer`.",
+        since="0.23.0",
     )
     @_optionals.HAS_MATPLOTLIB.require_in_call
     def draw(

--- a/qiskit/pulse/utils.py
+++ b/qiskit/pulse/utils.py
@@ -98,7 +98,10 @@ def instruction_duration_validation(duration: int):
         )
 
 
-@deprecate_function("Deprecated since Terra 0.22.0. Use 'qiskit.utils.deprecate_function' instead.")
+@deprecate_function(
+    "Deprecated since Terra 0.22.0. Use 'qiskit.utils.deprecate_function' instead.",
+    since="0.22.0",
+)
 def deprecated_functionality(func):
     """A decorator that raises deprecation warning without showing alternative method."""
     return deprecate_function(
@@ -108,4 +111,5 @@ def deprecated_functionality(func):
         "an issue in Qiskit/qiskit-terra repository.",
         category=DeprecationWarning,
         stacklevel=2,
+        since="0.22.0",
     )(func)

--- a/qiskit/qobj/converters/pulse_instruction.py
+++ b/qiskit/qobj/converters/pulse_instruction.py
@@ -507,55 +507,64 @@ class InstructionToQobjConverter:
         return self._qobj_model(**command_dict)
 
     @deprecate_function(
-        "'convert_acquire' has been deprecated. Instead, call converter instance directly."
+        "'convert_acquire' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_acquire(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_bundled_acquires' has been deprecated. Instead, call converter instance directly."
+        "'convert_bundled_acquires' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_bundled_acquires(self, shift, instructions_):
         return self._convert_bundled_acquire(instructions_, shift)
 
     @deprecate_function(
-        "'convert_set_frequency' has been deprecated. Instead, call converter instance directly."
+        "'convert_set_frequency' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_set_frequency(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_shift_frequency' has been deprecated. Instead, call converter instance directly."
+        "'convert_shift_frequency' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_shift_frequency(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_set_phase' has been deprecated. Instead, call converter instance directly."
+        "'convert_set_phase' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_set_phase(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_shift_phase' has been deprecated. Instead, call converter instance directly."
+        "'convert_shift_phase' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_shift_phase(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_delay' has been deprecated. Instead, call converter instance directly."
+        "'convert_delay' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_delay(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_play' has been deprecated. Instead, call converter instance directly."
+        "'convert_play' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_play(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
 
     @deprecate_function(
-        "'convert_snapshot' has been deprecated. Instead, call converter instance directly."
+        "'convert_snapshot' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_snapshot(self, shift, instruction):
         return self._convert_instruction(instruction, shift)
@@ -951,7 +960,8 @@ class QobjToInstructionConverter:
             )
 
     @deprecate_function(
-        "'convert_acquire' has been deprecated. Instead, call converter instance directly."
+        "'convert_acquire' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_acquire(self, instruction):
         t0 = instruction.t0
@@ -961,7 +971,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_set_phase' has been deprecated. Instead, call converter instance directly."
+        "'convert_set_phase' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_set_phase(self, instruction):
         t0 = instruction.t0
@@ -971,7 +982,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_shift_phase' has been deprecated. Instead, call converter instance directly."
+        "'convert_shift_phase' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_shift_phase(self, instruction):
         t0 = instruction.t0
@@ -981,7 +993,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_set_frequency' has been deprecated. Instead, call converter instance directly."
+        "'convert_set_frequency' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_set_frequency(self, instruction):
         t0 = instruction.t0
@@ -991,7 +1004,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_shift_frequency' has been deprecated. Instead, call converter instance directly."
+        "'convert_shift_frequency' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_shift_frequency(self, instruction):
         t0 = instruction.t0
@@ -1001,7 +1015,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_delay' has been deprecated. Instead, call converter instance directly."
+        "'convert_delay' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_delay(self, instruction):
         t0 = instruction.t0
@@ -1011,14 +1026,16 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'bind_pulse' has been deprecated. Instantiate the class with pulse library."
+        "'bind_pulse' has been deprecated. Instantiate the class with pulse library.",
+        since="0.23.0",
     )
     def bind_pulse(self, pulse):
         if pulse.name not in self._pulse_library:
             self._pulse_library[pulse.name] = pulse.samples
 
     @deprecate_function(
-        "'convert_parametric' has been deprecated. Instead, call converter instance directly."
+        "'convert_parametric' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_parametric(self, instruction):
         t0 = instruction.t0
@@ -1028,7 +1045,8 @@ class QobjToInstructionConverter:
         return schedule
 
     @deprecate_function(
-        "'convert_snapshot' has been deprecated. Instead, call converter instance directly."
+        "'convert_snapshot' has been deprecated. Instead, call converter instance directly.",
+        since="0.23.0",
     )
     def convert_snapshot(self, instruction):
         t0 = instruction.t0

--- a/qiskit/qpy/interface.py
+++ b/qiskit/qpy/interface.py
@@ -72,7 +72,10 @@ VERSION_PATTERN = (
 VERSION_PATTERN_REGEX = re.compile(VERSION_PATTERN, re.VERBOSE | re.IGNORECASE)
 
 
-@deprecate_arguments({"circuits": "programs"})
+@deprecate_arguments(
+    {"circuits": "programs"},
+    since="0.21.0",
+)
 def dump(
     programs: Union[List[QPY_SUPPORTED_TYPES], QPY_SUPPORTED_TYPES],
     file_obj: BinaryIO,

--- a/qiskit/quantum_info/operators/symplectic/random.py
+++ b/qiskit/quantum_info/operators/symplectic/random.py
@@ -106,7 +106,8 @@ def random_pauli_table(num_qubits, size=1, seed=None):
 @deprecate_function(
     "The random_stabilizer_table function is deprecated as of Qiskit Terra 0.22.0 "
     "and will be removed no sooner than 3 months after the release date. "
-    "Use random_pauli_list method instead."  # pylint: disable=bad-docstring-quotes
+    "Use random_pauli_list method instead.",
+    since="0.22.0",
 )
 def random_stabilizer_table(num_qubits, size=1, seed=None):
     """DEPRECATED: Return a random StabilizerTable.

--- a/qiskit/quantum_info/synthesis/two_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/two_qubit_decompose.py
@@ -1085,7 +1085,7 @@ class TwoQubitBasisDecomposer:
 
         return U3r, U3l, U2r, U2l, U1r, U1l, U0r, U0l
 
-    @deprecate_arguments({"target": "unitary"})
+    @deprecate_arguments({"target": "unitary"}, since="0.23.0")
     def __call__(
         self,
         unitary: Union[Operator, np.ndarray],

--- a/qiskit/scheduler/utils.py
+++ b/qiskit/scheduler/utils.py
@@ -15,12 +15,15 @@
 from qiskit.utils.deprecation import deprecate_function
 from qiskit.pulse import macros, utils
 
-format_meas_map = deprecate_function('"format_meas_map" has been moved to "qiskit.pulse.utils"')(
-    utils.format_meas_map
+format_meas_map = deprecate_function(
+    '"format_meas_map" has been moved to "qiskit.pulse.utils"',
+    since="0.15.0",
+)(utils.format_meas_map)
+
+measure = deprecate_function('"measure" has been moved to "qiskit.pulse.macros"', since="0.15.0")(
+    macros.measure
 )
 
-measure = deprecate_function('"measure" has been moved to "qiskit.pulse.macros"')(macros.measure)
-
-measure_all = deprecate_function('"measure_all" has been moved to "qiskit.pulse.macros"')(
-    macros.measure_all
-)
+measure_all = deprecate_function(
+    '"measure_all" has been moved to "qiskit.pulse.macros"', since="0.15.0"
+)(macros.measure_all)

--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -203,7 +203,7 @@ class Target(Mapping):
         "_global_operations",
     )
 
-    @deprecate_arguments({"aquire_alignment": "acquire_alignment"})
+    @deprecate_arguments({"aquire_alignment": "acquire_alignment"}, since="0.23.0")
     def __init__(
         self,
         description=None,

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -29,7 +29,8 @@ def deprecate_arguments(
         kwarg_map: A dictionary of the old argument name to the new name.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set.
+            compatibility - this should always be set. If the deprecation is pending,
+            set the version to when the deprecation will officially start.
 
     Returns:
         Callable: The decorated callable.
@@ -61,7 +62,8 @@ def deprecate_function(
         stacklevel: The warning stacklevel to use, defaults to 2.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set.
+            compatibility - this should always be set. If the deprecation is pending,
+            set the version to when the deprecation will officially start.
 
     Returns:
         Callable: The decorated, deprecated callable.

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -21,7 +21,7 @@ def deprecate_arguments(
     kwarg_map: Dict[str, str],
     category: Type[Warning] = DeprecationWarning,
     *,
-    since: Optional[str] = None,  # pylint: disable=unused-argument
+    since: Optional[str] = None,
 ):
     """Decorator to automatically alias deprecated argument names and warn upon use.
 
@@ -35,6 +35,8 @@ def deprecate_arguments(
     Returns:
         Callable: The decorated callable.
     """
+
+    del since  # Will be used in a followup to add deprecations to our docs site.
 
     def decorator(func):
         @functools.wraps(func)
@@ -53,7 +55,7 @@ def deprecate_function(
     stacklevel: int = 2,
     category: Type[Warning] = DeprecationWarning,
     *,
-    since: Optional[str] = None,  # pylint: disable=unused-argument
+    since: Optional[str] = None,
 ):
     """Emit a warning prior to calling decorated function.
 
@@ -68,6 +70,8 @@ def deprecate_function(
     Returns:
         Callable: The decorated, deprecated callable.
     """
+
+    del since  # Will be used in a followup to add deprecations to our docs site.
 
     def decorator(func):
         @functools.wraps(func)

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -14,11 +14,26 @@
 
 import functools
 import warnings
-from typing import Type
+from typing import Any, Dict, Optional, Type
 
 
-def deprecate_arguments(kwarg_map, category: Type[Warning] = DeprecationWarning):
-    """Decorator to automatically alias deprecated argument names and warn upon use."""
+def deprecate_arguments(
+    kwarg_map: Dict[str, str],
+    category: Type[Warning] = DeprecationWarning,
+    *,
+    since: Optional[str] = None,  # pylint: disable=unused-argument
+):
+    """Decorator to automatically alias deprecated argument names and warn upon use.
+
+    Args:
+        kwarg_map: A dictionary of the old argument name to the new name.
+        category: Usually either DeprecationWarning or PendingDeprecationWarning.
+        since: The version the deprecation started at. Only Optional for backwards
+            compatibility - this should always be set.
+
+    Returns:
+        Callable: The decorated callable.
+    """
 
     def decorator(func):
         @functools.wraps(func)
@@ -32,13 +47,21 @@ def deprecate_arguments(kwarg_map, category: Type[Warning] = DeprecationWarning)
     return decorator
 
 
-def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = DeprecationWarning):
+def deprecate_function(
+    msg: str,
+    stacklevel: int = 2,
+    category: Type[Warning] = DeprecationWarning,
+    *,
+    since: Optional[str] = None,  # pylint: disable=unused-argument
+):
     """Emit a warning prior to calling decorated function.
 
     Args:
         msg: Warning message to emit.
-        stacklevel: The warning stackevel to use, defaults to 2.
-        category: warning category, defaults to DeprecationWarning
+        stacklevel: The warning stacklevel to use, defaults to 2.
+        category: Usually either DeprecationWarning or PendingDeprecationWarning.
+        since: The version the deprecation started at. Only Optional for backwards
+            compatibility - this should always be set.
 
     Returns:
         Callable: The decorated, deprecated callable.
@@ -55,7 +78,12 @@ def deprecate_function(msg: str, stacklevel: int = 2, category: Type[Warning] = 
     return decorator
 
 
-def _rename_kwargs(func_name, kwargs, kwarg_map, category: Type[Warning] = DeprecationWarning):
+def _rename_kwargs(
+    func_name: str,
+    kwargs: Dict[str, Any],
+    kwarg_map: Dict[str, str],
+    category: Type[Warning] = DeprecationWarning,
+) -> None:
     for old_arg, new_arg in kwarg_map.items():
         if old_arg in kwargs:
             if new_arg in kwargs:

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -29,7 +29,9 @@ def deprecate_arguments(
         kwarg_map: A dictionary of the old argument name to the new name.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set.
+            compatibility - this should always be set. If the deprecation is pending, set
+            the version to when that started; but later, when switching from pending to
+            deprecated, update `since` to the new version.
 
     Returns:
         Callable: The decorated callable.
@@ -63,7 +65,9 @@ def deprecate_function(
         stacklevel: The warning stacklevel to use, defaults to 2.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set.
+            compatibility - this should always be set. If the deprecation is pending, set
+            the version to when that started; but later, when switching from pending to
+            deprecated, update `since` to the new version.
 
     Returns:
         Callable: The decorated, deprecated callable.

--- a/qiskit/utils/deprecation.py
+++ b/qiskit/utils/deprecation.py
@@ -29,8 +29,7 @@ def deprecate_arguments(
         kwarg_map: A dictionary of the old argument name to the new name.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set. If the deprecation is pending,
-            set the version to when the deprecation will officially start.
+            compatibility - this should always be set.
 
     Returns:
         Callable: The decorated callable.
@@ -64,8 +63,7 @@ def deprecate_function(
         stacklevel: The warning stacklevel to use, defaults to 2.
         category: Usually either DeprecationWarning or PendingDeprecationWarning.
         since: The version the deprecation started at. Only Optional for backwards
-            compatibility - this should always be set. If the deprecation is pending,
-            set the version to when the deprecation will officially start.
+            compatibility - this should always be set.
 
     Returns:
         Callable: The decorated, deprecated callable.

--- a/qiskit/visualization/pulse/interpolation.py
+++ b/qiskit/visualization/pulse/interpolation.py
@@ -30,6 +30,7 @@ from qiskit.utils.deprecation import deprecate_function
     " The new interface for pulse visualization is `qiskit.visualization.pulse_drawer_v2`."
     " In no less than 6 months, `pulse_drawer_v2` will become `pulse_drawer`, and these old"
     " objects will be completely removed.",
+    since="0.23.0",
 )
 def interp1d(
     time: np.ndarray, samples: np.ndarray, nop: int, kind: str = "linear"
@@ -68,6 +69,7 @@ def interp1d(
     " The new interface for pulse visualization is `qiskit.visualization.pulse_drawer_v2`."
     " In no less than 6 months, `pulse_drawer_v2` will become `pulse_drawer`, and these old"
     " objects will be completely removed.",
+    since="0.23.0",
 )
 def step_wise(
     time: np.ndarray, samples: np.ndarray, nop: int

--- a/qiskit/visualization/pulse/matplotlib.py
+++ b/qiskit/visualization/pulse/matplotlib.py
@@ -54,6 +54,7 @@ class EventsOutputChannels:
         "`qiskit.visualization.pulse` and all its contents are deprecated since Terra 0.23."
         " The new interface for pulse visualization is `qiskit.visualization.pulse_drawer`."
         " In no less than 6 months the old objects will be completely removed.",
+        since="0.23.0",
     )
     def __init__(self, t0: int, tf: int):
         """Create new channel dataset.
@@ -288,6 +289,7 @@ class WaveformDrawer:
         "`qiskit.visualization.pulse` and all its contents are deprecated since Terra 0.23."
         " The new interface for pulse visualization is `qiskit.visualization.pulse_drawer`."
         " In no less than 6 months the old objects will be completely removed.",
+        since="0.23.0",
     )
     def __init__(self, style: PulseStyle):
         """Create new figure.
@@ -389,6 +391,7 @@ class ScheduleDrawer:
         " The new interface for pulse visualization is `qiskit.visualization.pulse_drawer`."
         " In no less than 6 months the old objects will be completely removed.",
         stacklevel=3,
+        since="0.23.0",
     )
     def __init__(self, style: SchedStyle):
         """Create new figure.

--- a/qiskit/visualization/state_visualization.py
+++ b/qiskit/visualization/state_visualization.py
@@ -35,7 +35,7 @@ from .utils import matplotlib_close_if_inline
 from .exceptions import VisualizationError
 
 
-@deprecate_arguments({"rho": "state"})
+@deprecate_arguments({"rho": "state"}, since="0.15.1")
 @_optionals.HAS_MATPLOTLIB.require_in_call
 def plot_state_hinton(
     state, title="", figsize=None, ax_real=None, ax_imag=None, *, rho=None, filename=None
@@ -250,7 +250,7 @@ def plot_bloch_vector(bloch, title="", ax=None, figsize=None, coord_type="cartes
     return None
 
 
-@deprecate_arguments({"rho": "state"})
+@deprecate_arguments({"rho": "state"}, since="0.15.1")
 @_optionals.HAS_MATPLOTLIB.require_in_call
 def plot_bloch_multivector(
     state, title="", figsize=None, *, rho=None, reverse_bits=False, filename=None
@@ -338,7 +338,7 @@ def plot_bloch_multivector(
         return fig.savefig(filename)
 
 
-@deprecate_arguments({"rho": "state"})
+@deprecate_arguments({"rho": "state"}, since="0.15.1")
 @_optionals.HAS_MATPLOTLIB.require_in_call
 def plot_state_city(
     state,
@@ -595,7 +595,7 @@ def plot_state_city(
         return fig.savefig(filename)
 
 
-@deprecate_arguments({"rho": "state"})
+@deprecate_arguments({"rho": "state"}, since="0.15.1")
 @_optionals.HAS_MATPLOTLIB.require_in_call
 def plot_state_paulivec(
     state, title="", figsize=None, color=None, ax=None, *, rho=None, filename=None
@@ -766,7 +766,7 @@ def phase_to_rgb(complex_number):
     return rgb
 
 
-@deprecate_arguments({"rho": "state"})
+@deprecate_arguments({"rho": "state"}, since="0.15.1")
 @_optionals.HAS_MATPLOTLIB.require_in_call
 @_optionals.HAS_SEABORN.require_in_call
 def plot_state_qsphere(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Prework for https://github.com/Qiskit/qiskit-terra/pull/9611 so that we can add deprecation information to our generated Sphinx docs. The Sphinx `.. deprecated::` directive expects a `version` argument, so we need _structured metadata_ for this value.

Builds off of https://github.com/Qiskit/qiskit-terra/pull/8600 by @1ucian0 

### Details and comments

In a future change, I'd like to improve `deprecated.py` to automatically generate the deprecation message in a standardized way, like [Nature does it](https://github.com/Qiskit/qiskit-nature/blob/main/qiskit_nature/deprecation.py). That would use this `since=` argument as part of the message.

The argument is optional to avoid breaking third-party users of `deprecated.py`. In a followup, we may want to deprecate leaving off `since`.

We may want to instead use the argument name `version` rather than `since`. But I personally find `since` more intuitive because `version` is unclear if it means the "removal" version vs. "start" version. We could use `start_version` or `since_version` for even more clarity?
