### PR TITLE
Fix target error and duration lookup in UnitarySynthesis

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -152,7 +152,6 @@ def _error(circuit, target=None, qubits=None):
             keys = target.operation_names_for_qargs(inst_qubits)
             for key in keys:
                 target_op = target.operation_from_name(key)
-                # pylint: disable=unidiomatic-typecheck
                 if isinstance(target_op, type(inst.operation)) and (
                     target_op.is_parameterized()
                     or all(

--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -31,7 +31,7 @@ from qiskit.quantum_info.synthesis.two_qubit_decompose import (
     TwoQubitWeylDecomposition,
 )
 from qiskit.quantum_info import Operator
-from qiskit.circuit import ControlFlowOp
+from qiskit.circuit import ControlFlowOp, Gate
 from qiskit.circuit.library.standard_gates import (
     iSwapGate,
     CXGate,
@@ -153,17 +153,23 @@ def _error(circuit, target=None, qubits=None):
             for key in keys:
                 target_op = target.operation_from_name(key)
                 # pylint: disable=unidiomatic-typecheck
-                if type(target_op) == type(inst.operation) and (
+                if isinstance(target_op, type(inst.operation)) and (
                     target_op.is_parameterized()
                     or all(
                         isclose(float(p1), float(p2))
                         for p1, p2 in zip(target_op.params, inst.operation.params)
                     )
                 ):
-                    error = getattr(target[key][inst_qubits], "error", 0.0) or 0.0
-                    duration = getattr(target[key][inst_qubits], "duration", 0.0) or 0.0
-                    gate_fidelities.append(1 - error)
-                    gate_durations.append(duration)
+                    inst_props = target[key].get(inst_qubits, None)
+                    if inst_props is not None:
+                        error = getattr(inst_props, "error", 0.0) or 0.0
+                        duration = getattr(inst_props, "duration", 0.0) or 0.0
+                        gate_fidelities.append(1 - error)
+                        gate_durations.append(duration)
+                    else:
+                        gate_fidelities.append(1.0)
+                        gate_durations.append(0.0)
+
                     break
             else:
                 raise KeyError
@@ -599,7 +605,10 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
         try:
             keys = target.operation_names_for_qargs(qubits_tuple)
             for key in keys:
-                available_2q_basis[key] = target.operation_from_name(key)
+                op = target.operation_from_name(key)
+                if not isinstance(op, Gate):
+                    continue
+                available_2q_basis[key] = op
                 available_2q_props[key] = target[key][qubits_tuple]
         except KeyError:
             pass
@@ -607,7 +616,10 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
             keys = target.operation_names_for_qargs(reverse_tuple)
             for key in keys:
                 if key not in available_2q_basis:
-                    available_2q_basis[key] = target.operation_from_name(key)
+                    op = target.operation_from_name(key)
+                    if not isinstance(op, Gate):
+                        continue
+                    available_2q_basis[key] = op
                     available_2q_props[key] = target[key][reverse_tuple]
         except KeyError:
             pass
@@ -636,7 +648,11 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
             k: v for k, v in available_2q_basis.items() if is_supercontrolled(v)
         }
         for basis_1q, basis_2q in product(available_1q_basis, supercontrolled_basis.keys()):
-            basis_2q_fidelity = 1 - getattr(available_2q_props[basis_2q], "error", 0.0)
+            props = available_2q_props.get(basis_2q)
+            if props is None:
+                basis_2q_fidelity = 1.0
+            else:
+                basis_2q_fidelity = 1 - getattr(props, "error", 0.0)
             if approximation_degree is not None:
                 basis_2q_fidelity *= approximation_degree
             decomposer = TwoQubitBasisDecomposer(
@@ -654,7 +670,11 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
         for k, v in controlled_basis.items():
             strength = 2 * TwoQubitWeylDecomposition(Operator(v).data).a  # pi/2: fully entangling
             # each strength has its own fidelity
-            basis_2q_fidelity[strength] = 1 - getattr(available_2q_props[k], "error", 0.0)
+            props = available_2q_props.get(k)
+            if props is None:
+                basis_2q_fidelity[strength] = 1.0
+            else:
+                basis_2q_fidelity[strength] = 1 - getattr(props, "error", 0.0)
             # rewrite XX of the same strength in terms of it
             embodiment = XXEmbodiments[type(v)]
             if len(embodiment.parameters) == 1:

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -55,6 +55,7 @@ from qiskit.circuit.library import (
     RZZGate,
     RXXGate,
 )
+from qiskit.circuit.controlflow import IfElseOp
 from qiskit.circuit import Parameter
 
 
@@ -820,6 +821,20 @@ class TestUnitarySynthesis(QiskitTestCase):
         result_dag = unitary_synth_pass.run(dag)
         result_qc = dag_to_circuit(result_dag)
         self.assertEqual(result_qc, QuantumCircuit(1))
+
+    def test_unitary_synthesis_with_ideal_and_variable_width_ops(self):
+        """Test unitary synthesis works with a target that contains ideal and variadic ops."""
+        qc = QuantumCircuit(2)
+        qc.unitary(np.eye(4), [0, 1])
+        dag = circuit_to_dag(qc)
+        target = FakeBelemV2().target
+        target.add_instruction(IfElseOp, name="if_else")
+        target.add_instruction(ZGate())
+        target.add_instruction(ECRGate())
+        unitary_synth_pass = UnitarySynthesis(target=target)
+        result_dag = unitary_synth_pass.run(dag)
+        result_qc = dag_to_circuit(result_dag)
+        self.assertEqual(result_qc, QuantumCircuit(2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue introduced into the UnitarySynthesis pass as part of #9175. In #9715 the UnitarySynthesis pass was updated to consider multiple different target bases and select the best performing synthesis output found. When UnitarySynthesis is provided a Target object this involves querying the target for the error rates and duration of the instructions used. However, currently this lookup doesn't handle a couple of edge cases in the target data model resulting from variable width operations and ideal gates (i.e. from a simulator that don't have error or durations). In those cases some fields in the internal dictionaries used to store data can be None or the gate object stored in the target can be a class not an instance of a class. If a target with either of these properties were used as an input to UnitarySynthesis the pass would error.

### Details and comments

Fixes #9592