### PR TITLE
Performance improvement of `SparsePauliOp.tensor`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
+++ b/qiskit/quantum_info/operators/symplectic/sparse_pauli_op.py
@@ -335,7 +335,7 @@ class SparsePauliOp(LinearOp):
     def _tensor(cls, a, b):
         paulis = a.paulis.tensor(b.paulis)
         coeffs = np.kron(a.coeffs, b.coeffs)
-        return SparsePauliOp(paulis, coeffs, copy=False)
+        return SparsePauliOp(paulis, coeffs, ignore_pauli_phase=True, copy=False)
 
     def _add(self, other, qargs=None):
         if qargs is None:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

Performance improvement of `SparsePauliOp.tensor` by skipping a redundant phase check.

```python
import random
from timeit import timeit

from qiskit.quantum_info import SparsePauliOp

def bench(k, n):
    random.seed(123)
    op = SparsePauliOp.from_list([(''.join(random.choices('IXYZ', k=k)), 1) for _ in range(n)])
    op2 = SparsePauliOp.from_list([(''.join(random.choices('IXYZ', k=k)), 1) for _ in range(n)])

    print(f'{k}, {n}: {timeit(lambda: op.tensor(op2), number=1)} sec')

bench(10, 5000)
```

main
```
10, 5000: 3.415048268998362 sec
```

this PR
```
10, 5000: 1.9170281529986823 sec
```

### Details and comments


