### PR TITLE
Add falqon algorithm to qiskit-terra

### DIFF
--- a/qiskit/algorithms/minimum_eigensolvers/__init__.py
+++ b/qiskit/algorithms/minimum_eigensolvers/__init__.py
@@ -48,6 +48,7 @@ from .vqe import VQE, VQEResult
 from .sampling_mes import SamplingMinimumEigensolver, SamplingMinimumEigensolverResult
 from .sampling_vqe import SamplingVQE, SamplingVQEResult
 from .qaoa import QAOA
+from .falqon import FALQON
 
 __all__ = [
     "AdaptVQE",
@@ -63,4 +64,5 @@ __all__ = [
     "SamplingVQE",
     "SamplingVQEResult",
     "QAOA",
+    "FALQON"
 ]

--- a/qiskit/algorithms/minimum_eigensolvers/falqon.py
+++ b/qiskit/algorithms/minimum_eigensolvers/falqon.py
@@ -1,0 +1,71 @@
+from collections.abc import Sequence
+
+from qiskit.primitives import BaseEstimator
+
+import numpy as np
+
+from .minimum_eigensolver import MinimumEigensolver, MinimumEigensolverResult
+from ..list_or_dict import ListOrDict
+from ...opflow import PauliSumOp, H, commutator
+from ...quantum_info import SparsePauliOp
+from ...quantum_info.operators.base_operator import BaseOperator
+from ...circuit import ParameterVector
+from ...circuit.library import PauliEvolutionGate
+
+
+class FALQON(MinimumEigensolver):
+
+    def __init__(self,
+                 estimator: BaseEstimator,
+                 n: int = 1,
+                 delta_t: float = 0.3,
+                 initial_point: Sequence[float] = None
+                 ):
+        super().__init__()
+
+        self.estimator = estimator
+        self.n = n
+        self.delta_t = delta_t
+        self.initial_point = initial_point
+
+    def build_ansatz(self, operator, driver_h, betas):
+        circ = (H ^ operator.num_qubits).to_circuit()
+        params = ParameterVector("beta", length=len(betas))
+        for param in params:
+            circ.append(PauliEvolutionGate(operator, time=self.delta_t), circ.qubits)
+            circ.append(PauliEvolutionGate(driver_h, time=self.delta_t * param), circ.qubits)
+        return circ
+
+    def compute_minimum_eigenvalue(self,
+                                   operator: BaseOperator | PauliSumOp,
+                                   aux_operators: ListOrDict[BaseOperator | PauliSumOp] | None = None
+                                   ) -> "MinimumEigensolverResult":
+
+        n_qubits = operator.num_qubits
+        driver_h = PauliSumOp(SparsePauliOp.from_sparse_list([("X", [i], 1) for i in range(n_qubits)],
+                                                             num_qubits=n_qubits))
+        comm_h = (complex(0, 1) * commutator(driver_h, operator)).reduce()
+
+        if self.initial_point is None:
+            betas = [0.0]
+        else:
+            betas = self.initial_point
+
+        energies = []
+
+        for i in range(self.n):
+            ansatz = self.build_ansatz(operator, driver_h, betas)
+            beta = -1 * self.estimator.run(ansatz, comm_h, betas).result().values[0]
+            betas.append(beta)
+
+            ansatz = self.build_ansatz(operator, driver_h, betas)
+            energy = self.estimator.run(ansatz, operator, betas).result().values[0]
+            energies.append(energy)
+
+        return self._build_falqon_result(energies)
+
+    def _build_falqon_result(self, energies):
+        result = MinimumEigensolverResult()
+        result.aux_operators_evaluated = None
+        result.eigenvalue = np.min(np.asarray(energies))
+        return result


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

To add the Feedback-based quantum optimization (falqon) algorithm ([arxiv](https://arxiv.org/abs/2103.08619)).

### Details and comments

I had to close the previous issue #8751 for some reason. I've implemented into the algorithm the `Estimator` primitive and the `MinimumEigensolver` interface. Now I have the following questions:

1.  Falqon algorithm works in a simple iteration loop, in which it measures an ansatz with some commutator operator, then it multiplies the expval by $-1$  and finally uses the result as one of the parameters of the next circuit of length $i+1$. For longer circuits it takes more time to run them so there is a high probability that users will always want to track the intermediate results:
a) should this main loop remain to be implemented inside the falqon class and handling of the intermediate results be left to a callback function implemented by users, 
b) or should the simple loop be left for implementation by the users, and the class would then only contain building ansatz and making measurements?
2. In case of QAOA we pass `Sampler`, and then `DiagonalEstimator` is created, so we can have both the eigenvalue and the eigenstate. In Falqon we can't use the `DiagonalEstimator` because the commutator Hamiltonian is not diagonal. How to manage that? Should the class constructor ask for both `Sampler` and `Estimator`?

Thanks
