### PR TITLE
Add loop ops to Aer BackendV2 test

### DIFF
--- a/test/python/providers/test_fake_backends.py
+++ b/test/python/providers/test_fake_backends.py
@@ -58,7 +58,7 @@ from qiskit.quantum_info.operators.channel.kraus import Kraus
 from qiskit.quantum_info.operators.channel import SuperOp
 from qiskit.extensions import Initialize, UnitaryGate
 from qiskit.extensions.quantum_initializer import DiagonalGate, UCGate
-from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp
+from qiskit.circuit.controlflow import IfElseOp, WhileLoopOp, ForLoopOp, ContinueLoopOp, BreakLoopOp
 
 FAKE_PROVIDER_FOR_BACKEND_V2 = FakeProviderForBackendV2()
 FAKE_PROVIDER = FakeProvider()
@@ -425,6 +425,8 @@ class TestFakeBackends(QiskitTestCase):
                 "if_else": IfElseOp,
                 "while_loop": WhileLoopOp,
                 "for_loop": ForLoopOp,
+                "break_loop": BreakLoopOp,
+                "continue_loop": ContinueLoopOp,
                 "save_statevector": SaveStatevector,
                 "mcu": MCUGate,
                 "set_density_matrix": SetDensityMatrix,


### PR DESCRIPTION
### Summary

789707c61 (gh-9630) added a test for wrapping Aer in a converted `BackendV2` subject to providing an extended name mapping for all the custom instructions that Aer supports, which Terra does not generally define.  However, the supported lists were based off a slightly older version of Aer (approximately release version 0.11), and fail on the current `main` version (due to soon become version 0.12) because of `break_loop` and `continue_loop` support being added.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments


