### PR TITLE
minor formatting issue in qiskit.execute_function

### DIFF
--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -118,23 +118,24 @@ def execute(
 
             #. :class:`qiskit.transpiler.Layout` instance
             #. ``dict``:
-               virtual to physical::
+               * virtual to physical::
 
                     {qr[0]: 0,
                      qr[1]: 3,
                      qr[2]: 5}
 
-               physical to virtual::
+               * physical to virtual::
+
                     {0: qr[0],
                      3: qr[1],
                      5: qr[2]}
 
-            #. ``list``
-               virtual to physical::
+            #. ``list``:
+               * virtual to physical::
 
                     [0, 3, 5]  # virtual qubits are ordered (in addition to named)
 
-               physical to virtual::
+               * physical to virtual::
 
                     [qr[0], None, None, qr[1], None, qr[2]]
 

--- a/qiskit/execute_function.py
+++ b/qiskit/execute_function.py
@@ -118,6 +118,7 @@ def execute(
 
             #. :class:`qiskit.transpiler.Layout` instance
             #. ``dict``:
+
                * virtual to physical::
 
                     {qr[0]: 0,
@@ -131,6 +132,7 @@ def execute(
                      5: qr[2]}
 
             #. ``list``:
+
                * virtual to physical::
 
                     [0, 3, 5]  # virtual qubits are ordered (in addition to named)


### PR DESCRIPTION
Fixing this minor formatting issue in https://qiskit.org/documentation/apidoc/execute.html :
<img width="752" alt="Screenshot 2023-02-24 at 09 19 14" src="https://user-images.githubusercontent.com/766693/221128774-0129572c-a938-4178-b27a-eb873359cd20.png">
