### PR TITLE
Fix typing error in `random_circuit` conditionals

### DIFF
--- a/qiskit/circuit/random/utils.py
+++ b/qiskit/circuit/random/utils.py
@@ -191,7 +191,8 @@ def random_circuit(
             ):
                 operation = gate(*parameters[p_start:p_end])
                 if is_cond:
-                    operation.condition = (cr, condition_values[c_ptr])
+                    # The condition values are required to be bigints, not Numpy's fixed-width type.
+                    operation.condition = (cr, int(condition_values[c_ptr]))
                     c_ptr += 1
                 qc._append(CircuitInstruction(operation=operation, qubits=qubits[q_start:q_end]))
         else:

--- a/releasenotes/notes/fix-random-circuit-conditional-6067272319986c63.yaml
+++ b/releasenotes/notes/fix-random-circuit-conditional-6067272319986c63.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug in :func:`.random_circuit` with 64 or more qubits and ``conditional=True``, where
+    the resulting circuit could have an incorrectly typed value in its condition, causing a variety
+    of failures during transpilation or other circuit operations.  Fixed `#9649
+    <https://github.com/Qiskit/qiskit-terra/issues/9649>`__.

--- a/test/python/circuit/test_random_circuit.py
+++ b/test/python/circuit/test_random_circuit.py
@@ -13,7 +13,7 @@
 
 """Test random circuit generation utility."""
 
-from qiskit.circuit import QuantumCircuit
+from qiskit.circuit import QuantumCircuit, ClassicalRegister, Clbit
 from qiskit.circuit import Measure
 from qiskit.circuit.random import random_circuit
 from qiskit.converters import circuit_to_dag
@@ -63,3 +63,8 @@ class TestCircuitRandom(QiskitTestCase):
         conditions = (getattr(instruction.operation, "condition", None) for instruction in circ)
         conditions = [x for x in conditions if x is not None]
         self.assertNotEqual(conditions, [])
+        for (register, value) in conditions:
+            self.assertIsInstance(register, (ClassicalRegister, Clbit))
+            # Condition values always have to be Python bigints (of which `bool` is a subclass), not
+            # any of Numpy's fixed-width types, for example.
+            self.assertIsInstance(value, int)


### PR DESCRIPTION
### Summary

The `condition` field is expected to be a comparison of a register or bit with a Python bigint (or bool, which is a subclass).  This function could previously output fixed-width Numpy types, however, which could cause problems with subsequent bitmasks if the constructed masker/maskee _was_ a Python bigint and couldn't fit in the Numpy type.  The more recent `IfElseOp` enforces the correct typing, it's just the old form that doesn't.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

Fix #9649
