### PR TITLE
update circuit symbol for iswap

### DIFF
--- a/qiskit/circuit/library/standard_gates/iswap.py
+++ b/qiskit/circuit/library/standard_gates/iswap.py
@@ -37,9 +37,9 @@ class iSwapGate(Gate):
 
     .. parsed-literal::
 
-        q_0: ─⨂─
+        q_0: ─⊗─
               │
-        q_1: ─⨂─
+        q_1: ─⊗─
 
     **Reference Implementation:**
 

--- a/qiskit/visualization/circuit/matplotlib.py
+++ b/qiskit/visualization/circuit/matplotlib.py
@@ -24,6 +24,7 @@ from qiskit.circuit import ControlledGate, Qubit, Clbit, ClassicalRegister
 from qiskit.circuit import Measure, QuantumCircuit, QuantumRegister
 from qiskit.circuit.library.standard_gates import (
     SwapGate,
+    iSwapGate,
     RZZGate,
     U1Gate,
     PhaseGate,
@@ -1123,6 +1124,11 @@ class MatplotlibDrawer:
             self._swap(xy, node, self._data[node]["lc"])
             return
 
+        # iSwap gate
+        if isinstance(op, iSwapGate):
+            self._iswap(xy, node, self._data[node]["lc"])
+            return
+
         # RZZ Gate
         elif isinstance(op, RZZGate):
             self._symmetric_gate(node, RZZGate)
@@ -1404,6 +1410,44 @@ class MatplotlibDrawer:
             color=color,
             linewidth=self._lwidth2,
             zorder=PORDER_LINE + 1,
+        )
+
+    def _iswap(self, xy, node, color=None):
+        """Draw a Swap gate"""
+        fc = self._data[node]["fc"]
+        tc = self._data[node]["tc"]
+        tgt_color = self._style["dispcol"]["target"]
+        tgt = tgt_color if isinstance(tgt_color, str) else tgt_color[0]
+        self._iswap_cross(xy[0], ec=color, ac=tgt)
+        self._iswap_cross(xy[1], ec=color, ac=tgt)
+        self._line(xy[0], xy[1], lc=color)
+
+    def _iswap_cross(self, xy, ec=None, ac=None):
+        """Draw the Swap cross symbol"""
+        xpos, ypos = xy
+        box = self._patches_mod.Circle(
+            xy=(xpos, ypos),
+            radius=HIG * 0.35,
+            fc=ec,
+            ec=ec,
+            linewidth=self._lwidth2,
+            zorder=PORDER_GATE,
+        )
+        self._ax.add_patch(box)
+
+        self._ax.plot(
+            [xpos - 0.20 * WID, xpos + 0.20 * WID],
+            [ypos - 0.20 * WID, ypos + 0.20 * WID],
+            color=ac,
+            linewidth=self._lwidth2,
+            zorder=PORDER_GATE + 1,
+        )
+        self._ax.plot(
+            [xpos - 0.20 * WID, xpos + 0.20 * WID],
+            [ypos + 0.20 * WID, ypos - 0.20 * WID],
+            color=ac,
+            linewidth=self._lwidth2,
+            zorder=PORDER_GATE + 1,
         )
 
     def _sidetext(self, node, xy, tc=None, text=""):

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -23,7 +23,7 @@ from qiskit.circuit import Qubit, Clbit, ClassicalRegister, QuantumRegister, Qua
 from qiskit.circuit import ControlledGate
 from qiskit.circuit import Reset
 from qiskit.circuit import Measure
-from qiskit.circuit.library.standard_gates import IGate, RZZGate, SwapGate, SXGate, SXdgGate
+from qiskit.circuit.library.standard_gates import IGate, RZZGate, SwapGate, iSwapGate, SXGate, SXdgGate
 from qiskit.circuit.tools.pi_check import pi_check
 
 from ._utils import (
@@ -400,6 +400,22 @@ class Ex(DirectOnQuWire):
 
     def __init__(self, bot_connect=" ", top_connect=" ", conditional=False):
         super().__init__("X")
+        self.bot_connect = "║" if conditional else bot_connect
+        self.top_connect = top_connect
+
+
+class CircleEx(DirectOnQuWire):
+    """Draws an ⨂ (usually with a connector). E.g. the top part of an iswap gate.
+
+    ::
+
+        top:
+        mid: ─⊗─ ───⊗───
+        bot:  │     │
+    """
+
+    def __init__(self, bot_connect=" ", top_connect=" ", conditional=False):
+        super().__init__("⊗")
         self.bot_connect = "║" if conditional else bot_connect
         self.top_connect = top_connect
 
@@ -1097,6 +1113,11 @@ class TextDrawing:
         elif isinstance(op, SwapGate):
             # swap
             gates = [Ex(conditional=conditional) for _ in range(len(node.qargs))]
+            add_connected_gate(node, gates, layer, current_cons)
+
+        elif isinstance(op, iSwapGate):
+            # iswap
+            gates = [CircleEx(conditional=conditional) for _ in range(len(node.qargs))]
             add_connected_gate(node, gates, layer, current_cons)
 
         elif isinstance(op, Reset):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
updating the text and matplotlib drawers' handling of iswap gate. I like this better than a generic box because it's a common gate and it also shows the symmetry of the gate. e.g.:

cnot, swap, iswap, cz

<img width="375" alt="image" src="https://user-images.githubusercontent.com/8622381/221338452-7ffe2f9b-7109-40fa-8f0b-598a74332d52.png">



