### PR TITLE
Update the docsring of the circuit library

### DIFF
--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -81,6 +81,8 @@ For example:
    CRXGate
    CRYGate
    CRZGate
+   CSGate
+   CSdgGate
    CSwapGate
    CSXGate
    CUGate
@@ -89,8 +91,11 @@ For example:
    CXGate
    CYGate
    CZGate
+   CCZGate
+   ECRGate
    HGate
    IGate
+   MCPhaseGate
    MSGate
    PhaseGate
    RCCXGate
@@ -103,9 +108,8 @@ For example:
    RZGate
    RZZGate
    RZXGate
-   XXPlusYYGate
    XXMinusYYGate
-   ECRGate
+   XXPlusYYGate
    SGate
    SdgGate
    SwapGate

--- a/qiskit/circuit/library/__init__.py
+++ b/qiskit/circuit/library/__init__.py
@@ -95,7 +95,6 @@ For example:
    ECRGate
    HGate
    IGate
-   MCPhaseGate
    MSGate
    PhaseGate
    RCCXGate

--- a/qiskit/circuit/library/standard_gates/__init__.py
+++ b/qiskit/circuit/library/standard_gates/__init__.py
@@ -11,66 +11,7 @@
 # that they have been altered from the originals.
 
 """
-=============================================================
-Standard gates (:mod:`qiskit.circuit.library.standard_gates`)
-=============================================================
-
-.. autosummary::
-   :toctree: ../stubs/
-
-   C3XGate
-   C3SXGate
-   C4XGate
-   CCXGate
-   DCXGate
-   CHGate
-   CPhaseGate
-   CRXGate
-   CRYGate
-   CRZGate
-   CSwapGate
-   CSXGate
-   CUGate
-   CU1Gate
-   CU3Gate
-   CXGate
-   CYGate
-   CZGate
-   CCZGate
-   HGate
-   IGate
-   MCPhaseGate
-   PhaseGate
-   RCCXGate
-   RC3XGate
-   RXGate
-   RXXGate
-   RYGate
-   RYYGate
-   RZGate
-   RZZGate
-   RZXGate
-   XXMinusYYGate
-   XXPlusYYGate
-   ECRGate
-   SGate
-   SdgGate
-   CSGate
-   CSdgGate
-   SwapGate
-   iSwapGate
-   SXGate
-   SXdgGate
-   TGate
-   TdgGate
-   UGate
-   U1Gate
-   U2Gate
-   U3Gate
-   XGate
-   YGate
-   ZGate
-
+Standard gates
 """
 
 from .h import HGate, CHGate


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Only the docstring from ` qiskit/circuit/library/__init__.py` is actually built into the documentation - any changes to the `../standard_gates/__init__.py` docstring has no effect on the built documentation.

- Some gates were moved from `../standard_gates/__init__.py` to `qiskit/circuit/library/__init__.py`, since they do not appear in the documentation of the circuit library.
- Some gates changed their places according to the alphabetic order of their names.
- `qiskit/circuit/library/__init__.py` docstring has been removed, since it's not used.

### Details and comments


