### PR TITLE
Stop raising AttributeError when accessing missing calibration

### DIFF
--- a/qiskit/transpiler/target.py
+++ b/qiskit/transpiler/target.py
@@ -81,6 +81,8 @@ class InstructionProperties:
     @property
     def calibration(self):
         """The pulse representation of the instruction."""
+        if self._calibration is None:
+            return None
         return self._calibration.get_schedule()
 
     @calibration.setter

--- a/releasenotes/notes/fix-missing-instproperty-calibration-e578052819592a0b.yaml
+++ b/releasenotes/notes/fix-missing-instproperty-calibration-e578052819592a0b.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Getting empty calibration from :class:`.InstructionProperties` raises
+    AttributeError has been fixed. Now it returns ``None``.

--- a/test/python/transpiler/test_target.py
+++ b/test/python/transpiler/test_target.py
@@ -1259,6 +1259,13 @@ Instructions:
         inst_map = target.instruction_schedule_map()
         self.assertFalse(inst_map.has_custom_gate())
 
+    def test_get_empty_target_calibration(self):
+        target = Target()
+        properties = {(0,): InstructionProperties(duration=100, error=0.1)}
+        target.add_instruction(XGate(), properties)
+
+        self.assertIsNone(target["x"][(0,)].calibration)
+
 
 class TestGlobalVariableWidthOperations(QiskitTestCase):
     def setUp(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In #9597 we updated the `InstructionProperties.calibration` to internally store `CalibrationEntry` subclass. However, there still be the case `None` is stored instead when user/system doesn't provide any calibration, e.g. `reset` instruction or any control flow operation. Accessing calibration of such entry raises AttributeError, which must be suppressed and it must return `None` instead.

### Details and comments


