### PR TITLE
Fix docstring surrounding whitespace

### DIFF
--- a/qiskit/algorithms/amplitude_amplifiers/__init__.py
+++ b/qiskit/algorithms/amplitude_amplifiers/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Amplitude Amplifiers Package """
+"""Amplitude Amplifiers Package"""
 
 from .amplitude_amplifier import AmplitudeAmplifier, AmplitudeAmplifierResult
 from .amplification_problem import AmplificationProblem

--- a/qiskit/algorithms/eigen_solvers/__init__.py
+++ b/qiskit/algorithms/eigen_solvers/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Eigen Solvers Package """
+"""Eigen Solvers Package"""
 
 from .numpy_eigen_solver import NumPyEigensolver
 from .eigen_solver import Eigensolver, EigensolverResult

--- a/qiskit/algorithms/factorizers/__init__.py
+++ b/qiskit/algorithms/factorizers/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Factorizers Package """
+"""Factorizers Package"""
 
 from .shor import Shor, ShorResult
 

--- a/qiskit/algorithms/minimum_eigen_solvers/__init__.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/__init__.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Minimum Eigen Solvers Package """
+"""Minimum Eigen Solvers Package"""
 
 from .vqe import VQE, VQEResult
 from .qaoa import QAOA

--- a/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigen_solvers/qaoa.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" The Quantum Approximate Optimization Algorithm. """
+"""The Quantum Approximate Optimization Algorithm."""
 
 from typing import List, Callable, Optional, Union
 import warnings

--- a/qiskit/algorithms/minimum_eigensolvers/qaoa.py
+++ b/qiskit/algorithms/minimum_eigensolvers/qaoa.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""The quantum approximate optimization algorithm. """
+"""The quantum approximate optimization algorithm."""
 
 from __future__ import annotations
 

--- a/qiskit/algorithms/optimizers/nlopts/__init__.py
+++ b/qiskit/algorithms/optimizers/nlopts/__init__.py
@@ -10,4 +10,4 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" NLopt based global optimizers """
+"""NLopt based global optimizers"""

--- a/qiskit/algorithms/optimizers/nlopts/direct_l.py
+++ b/qiskit/algorithms/optimizers/nlopts/direct_l.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" DIviding RECTangles Locally-biased optimizer. """
+"""DIviding RECTangles Locally-biased optimizer."""
 
 from .nloptimizer import NLoptOptimizer, NLoptOptimizerType
 

--- a/qiskit/algorithms/optimizers/nlopts/direct_l_rand.py
+++ b/qiskit/algorithms/optimizers/nlopts/direct_l_rand.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""DIviding RECTangles Locally-biased Randomized optimizer. """
+"""DIviding RECTangles Locally-biased Randomized optimizer."""
 
 from .nloptimizer import NLoptOptimizer, NLoptOptimizerType
 

--- a/qiskit/algorithms/optimizers/nlopts/esch.py
+++ b/qiskit/algorithms/optimizers/nlopts/esch.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ESCH evolutionary optimizer. """
+"""ESCH evolutionary optimizer."""
 
 from .nloptimizer import NLoptOptimizer, NLoptOptimizerType
 

--- a/qiskit/algorithms/optimizers/nlopts/isres.py
+++ b/qiskit/algorithms/optimizers/nlopts/isres.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Improved Stochastic Ranking Evolution Strategy optimizer. """
+"""Improved Stochastic Ranking Evolution Strategy optimizer."""
 
 from .nloptimizer import NLoptOptimizer, NLoptOptimizerType
 

--- a/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
+++ b/qiskit/algorithms/optimizers/nlopts/nloptimizer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Minimize using objective function """
+"""Minimize using objective function"""
 
 from typing import List, Optional, Tuple, Callable
 from enum import Enum

--- a/qiskit/algorithms/optimizers/tnc.py
+++ b/qiskit/algorithms/optimizers/tnc.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Truncated Newton (TNC) optimizer. """
+"""Truncated Newton (TNC) optimizer."""
 
 from typing import Optional
 

--- a/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/polynomial_pauli_rotations.py
@@ -25,7 +25,7 @@ from .functional_pauli_rotations import FunctionalPauliRotations
 
 
 def _binomial_coefficients(n):
-    """ "Return a dictionary of binomial coefficients
+    """Return a dictionary of binomial coefficients
 
     Based-on/forked from sympy's binomial_coefficients() function [#]
 
@@ -41,7 +41,7 @@ def _binomial_coefficients(n):
 
 
 def _large_coefficients_iter(m, n):
-    """ "Return an iterator of multinomial coefficients
+    """Return an iterator of multinomial coefficients
 
     Based-on/forked from sympy's multinomial_coefficients_iterator() function [#]
 
@@ -87,7 +87,7 @@ def _large_coefficients_iter(m, n):
 
 
 def _multinomial_coefficients(m, n):
-    """ "Return an iterator of multinomial coefficients
+    """Return an iterator of multinomial coefficients
 
     Based-on/forked from sympy's multinomial_coefficients() function [#]
 

--- a/qiskit/opflow/converters/circuit_sampler.py
+++ b/qiskit/opflow/converters/circuit_sampler.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" CircuitSampler Class """
+"""CircuitSampler Class"""
 
 
 import logging

--- a/qiskit/opflow/converters/converter_base.py
+++ b/qiskit/opflow/converters/converter_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ConverterBase Class """
+"""ConverterBase Class"""
 
 from abc import ABC, abstractmethod
 

--- a/qiskit/opflow/converters/dict_to_circuit_sum.py
+++ b/qiskit/opflow/converters/dict_to_circuit_sum.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""DictToCircuitSum Class """
+"""DictToCircuitSum Class"""
 
 from qiskit.opflow.converters.converter_base import ConverterBase
 from qiskit.opflow.list_ops.list_op import ListOp

--- a/qiskit/opflow/converters/pauli_basis_change.py
+++ b/qiskit/opflow/converters/pauli_basis_change.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" PauliBasisChange Class """
+"""PauliBasisChange Class"""
 
 from functools import partial, reduce
 from typing import Callable, List, Optional, Tuple, Union, cast

--- a/qiskit/opflow/converters/two_qubit_reduction.py
+++ b/qiskit/opflow/converters/two_qubit_reduction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Z2 Symmetry Tapering Converter Class """
+"""Z2 Symmetry Tapering Converter Class"""
 
 import logging
 from typing import List, Tuple, Union, cast

--- a/qiskit/opflow/evolutions/evolution_base.py
+++ b/qiskit/opflow/evolutions/evolution_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" EvolutionBase Class """
+"""EvolutionBase Class"""
 
 from abc import ABC, abstractmethod
 

--- a/qiskit/opflow/evolutions/evolution_factory.py
+++ b/qiskit/opflow/evolutions/evolution_factory.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" EvolutionFactory Class """
+"""EvolutionFactory Class"""
 
 from qiskit.opflow.operator_base import OperatorBase
 from qiskit.opflow.evolutions.evolution_base import EvolutionBase

--- a/qiskit/opflow/evolutions/evolved_op.py
+++ b/qiskit/opflow/evolutions/evolved_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" EvolutionOp Class """
+"""EvolutionOp Class"""
 
 from typing import List, Optional, Set, Union, cast
 

--- a/qiskit/opflow/evolutions/matrix_evolution.py
+++ b/qiskit/opflow/evolutions/matrix_evolution.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" MatrixEvolution Class """
+"""MatrixEvolution Class"""
 
 import logging
 

--- a/qiskit/opflow/evolutions/pauli_trotter_evolution.py
+++ b/qiskit/opflow/evolutions/pauli_trotter_evolution.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" PauliTrotterEvolution Class """
+"""PauliTrotterEvolution Class"""
 
 import logging
 from typing import Optional, Union, cast

--- a/qiskit/opflow/evolutions/trotterizations/suzuki.py
+++ b/qiskit/opflow/evolutions/trotterizations/suzuki.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Suzuki Class """
+"""Suzuki Class"""
 
 from typing import List, Union, cast
 

--- a/qiskit/opflow/evolutions/trotterizations/trotter.py
+++ b/qiskit/opflow/evolutions/trotterizations/trotter.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Trotter Class """
+"""Trotter Class"""
 
 from qiskit.opflow.evolutions.trotterizations.suzuki import Suzuki
 

--- a/qiskit/opflow/evolutions/trotterizations/trotterization_base.py
+++ b/qiskit/opflow/evolutions/trotterizations/trotterization_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Trotterization Algorithm Base """
+"""Trotterization Algorithm Base"""
 
 from abc import abstractmethod
 

--- a/qiskit/opflow/evolutions/trotterizations/trotterization_factory.py
+++ b/qiskit/opflow/evolutions/trotterizations/trotterization_factory.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""TrotterizationFactory Class """
+"""TrotterizationFactory Class"""
 
 from qiskit.opflow.evolutions.trotterizations.qdrift import QDrift
 from qiskit.opflow.evolutions.trotterizations.suzuki import Suzuki

--- a/qiskit/opflow/expectations/aer_pauli_expectation.py
+++ b/qiskit/opflow/expectations/aer_pauli_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" AerPauliExpectation Class """
+"""AerPauliExpectation Class"""
 
 import logging
 from functools import reduce

--- a/qiskit/opflow/expectations/expectation_base.py
+++ b/qiskit/opflow/expectations/expectation_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ExpectationBase Class """
+"""ExpectationBase Class"""
 
 from abc import abstractmethod
 from typing import Union

--- a/qiskit/opflow/expectations/expectation_factory.py
+++ b/qiskit/opflow/expectations/expectation_factory.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ExpectationFactory Class """
+"""ExpectationFactory Class"""
 
 import logging
 from typing import Optional, Union

--- a/qiskit/opflow/expectations/matrix_expectation.py
+++ b/qiskit/opflow/expectations/matrix_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" MatrixExpectation Class """
+"""MatrixExpectation Class"""
 
 from typing import Union
 

--- a/qiskit/opflow/expectations/pauli_expectation.py
+++ b/qiskit/opflow/expectations/pauli_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" PauliExpectation Class """
+"""PauliExpectation Class"""
 
 import logging
 from typing import Union

--- a/qiskit/opflow/gradients/circuit_gradients/circuit_gradient.py
+++ b/qiskit/opflow/gradients/circuit_gradients/circuit_gradient.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""CircuitGradient Class """
+"""CircuitGradient Class"""
 
 from abc import abstractmethod
 from typing import List, Union, Optional, Tuple, Set

--- a/qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py
+++ b/qiskit/opflow/gradients/circuit_qfis/circuit_qfi.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" CircuitQFI Class """
+"""CircuitQFI Class"""
 
 from abc import abstractmethod
 from typing import List, Union

--- a/qiskit/opflow/gradients/derivative_base.py
+++ b/qiskit/opflow/gradients/derivative_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" DerivativeBase Class """
+"""DerivativeBase Class"""
 
 import warnings
 from abc import abstractmethod

--- a/qiskit/opflow/gradients/natural_gradient.py
+++ b/qiskit/opflow/gradients/natural_gradient.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Natural Gradient. """
+"""Natural Gradient."""
 
 from collections.abc import Iterable
 from typing import List, Tuple, Callable, Optional, Union

--- a/qiskit/opflow/list_ops/composed_op.py
+++ b/qiskit/opflow/list_ops/composed_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ComposedOp Class """
+"""ComposedOp Class"""
 
 from functools import partial, reduce
 from typing import List, Optional, Union, cast, Dict

--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" ListOp Operator Class """
+"""ListOp Operator Class"""
 
 from functools import reduce
 from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Sequence, Union, cast

--- a/qiskit/opflow/list_ops/summed_op.py
+++ b/qiskit/opflow/list_ops/summed_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" SummedOp Class """
+"""SummedOp Class"""
 
 from typing import List, Union, cast, Dict
 

--- a/qiskit/opflow/list_ops/tensored_op.py
+++ b/qiskit/opflow/list_ops/tensored_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" TensoredOp Class """
+"""TensoredOp Class"""
 
 from functools import partial, reduce
 from typing import List, Union, cast, Dict

--- a/qiskit/opflow/operator_base.py
+++ b/qiskit/opflow/operator_base.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" OperatorBase Class """
+"""OperatorBase Class"""
 
 import itertools
 from abc import ABC, abstractmethod

--- a/qiskit/opflow/primitive_ops/circuit_op.py
+++ b/qiskit/opflow/primitive_ops/circuit_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""CircuitOp Class """
+"""CircuitOp Class"""
 
 from typing import Dict, List, Optional, Set, Union, cast
 

--- a/qiskit/opflow/primitive_ops/matrix_op.py
+++ b/qiskit/opflow/primitive_ops/matrix_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""MatrixOp Class """
+"""MatrixOp Class"""
 
 from typing import Dict, List, Optional, Set, Union, cast, get_type_hints
 

--- a/qiskit/opflow/primitive_ops/pauli_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""PauliOp Class """
+"""PauliOp Class"""
 
 from math import pi
 from typing import Dict, List, Optional, Set, Union, cast

--- a/qiskit/opflow/primitive_ops/pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/pauli_sum_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""PauliSumOp Class """
+"""PauliSumOp Class"""
 
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union, cast

--- a/qiskit/opflow/primitive_ops/primitive_op.py
+++ b/qiskit/opflow/primitive_ops/primitive_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" PrimitiveOp Class """
+"""PrimitiveOp Class"""
 
 from typing import Dict, List, Optional, Set, Union, cast
 

--- a/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
+++ b/qiskit/opflow/primitive_ops/tapered_pauli_sum_op.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" TaperedPauliSumOp Class and Z2Symmetries"""
+"""TaperedPauliSumOp Class and Z2Symmetries"""
 
 import itertools
 import logging

--- a/qiskit/opflow/state_fns/circuit_state_fn.py
+++ b/qiskit/opflow/state_fns/circuit_state_fn.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" CircuitStateFn Class """
+"""CircuitStateFn Class"""
 
 
 from typing import Dict, List, Optional, Set, Union, cast

--- a/qiskit/opflow/state_fns/dict_state_fn.py
+++ b/qiskit/opflow/state_fns/dict_state_fn.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" DictStateFn Class """
+"""DictStateFn Class"""
 
 import itertools
 from typing import Dict, List, Optional, Set, Union, cast

--- a/qiskit/opflow/state_fns/operator_state_fn.py
+++ b/qiskit/opflow/state_fns/operator_state_fn.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" OperatorStateFn Class """
+"""OperatorStateFn Class"""
 
 from typing import List, Optional, Set, Union, cast
 

--- a/qiskit/opflow/state_fns/state_fn.py
+++ b/qiskit/opflow/state_fns/state_fn.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" StateFn Class """
+"""StateFn Class"""
 
 from typing import Callable, Dict, List, Optional, Set, Tuple, Union
 

--- a/qiskit/opflow/state_fns/vector_state_fn.py
+++ b/qiskit/opflow/state_fns/vector_state_fn.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" VectorStateFn Class """
+"""VectorStateFn Class"""
 
 
 from typing import Dict, List, Optional, Set, Union, cast

--- a/qiskit/opflow/utils.py
+++ b/qiskit/opflow/utils.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Utility functions for OperatorFlow """
+"""Utility functions for OperatorFlow"""
 
 from qiskit.opflow.operator_base import OperatorBase
 

--- a/qiskit/tools/monitor/overview.py
+++ b/qiskit/tools/monitor/overview.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" A module for viewing the details of all available devices.
+"""A module for viewing the details of all available devices.
 """
 
 import math

--- a/qiskit/transpiler/fencedobjs.py
+++ b/qiskit/transpiler/fencedobjs.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Fenced objects are wraps for raising TranspilerError when they are modified."""
+"""Fenced objects are wraps for raising TranspilerError when they are modified."""
 
 from .exceptions import TranspilerError
 

--- a/qiskit/transpiler/passes/optimization/hoare_opt.py
+++ b/qiskit/transpiler/passes/optimization/hoare_opt.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Pass for Hoare logic circuit optimization. """
+"""Pass for Hoare logic circuit optimization."""
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.circuit import QuantumRegister, ControlledGate, Gate
 from qiskit.dagcircuit import DAGCircuit

--- a/qiskit/transpiler/propertyset.py
+++ b/qiskit/transpiler/propertyset.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" A property set is maintained by the PassManager to keep information
+"""A property set is maintained by the PassManager to keep information
 about the current state of the circuit """
 
 

--- a/qiskit/utils/algorithm_globals.py
+++ b/qiskit/utils/algorithm_globals.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Algorithm Globals """
+"""Algorithm Globals"""
 
 from typing import Optional
 import logging

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" backend utility functions """
+"""backend utility functions"""
 
 import logging
 

--- a/qiskit/utils/circuit_utils.py
+++ b/qiskit/utils/circuit_utils.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Circuit utility functions """
+"""Circuit utility functions"""
 
 import numpy as np
 

--- a/qiskit/utils/measurement_error_mitigation.py
+++ b/qiskit/utils/measurement_error_mitigation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Measurement error mitigation """
+"""Measurement error mitigation"""
 
 import copy
 from typing import List, Optional, Tuple, Dict, Callable

--- a/qiskit/utils/quantum_instance.py
+++ b/qiskit/utils/quantum_instance.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Quantum Instance module """
+"""Quantum Instance module"""
 
 from typing import Optional, List, Union, Dict, Callable, Tuple
 from enum import Enum

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" run circuits functions """
+"""run circuits functions"""
 
 from typing import Optional, Dict, Callable, List, Union, Tuple
 import sys

--- a/qiskit/visualization/circuit/__init__.py
+++ b/qiskit/visualization/circuit/__init__.py
@@ -10,6 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Init for circuit visualizations """
+"""Init for circuit visualizations"""
 
 from .circuit_visualization import circuit_drawer

--- a/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
+++ b/test/ipynb/mpl/circuit/test_circuit_matplotlib_drawer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Tests for circuit MPL drawer"""
+"""Tests for circuit MPL drawer"""
 
 import unittest
 

--- a/test/ipynb/mpl/graph/test_graph_matplotlib_drawer.py
+++ b/test/ipynb/mpl/graph/test_graph_matplotlib_drawer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Tests for graph MPL drawer"""
+"""Tests for graph MPL drawer"""
 
 import unittest
 

--- a/test/python/algorithms/algorithms_test_case.py
+++ b/test/python/algorithms/algorithms_test_case.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Algorithms Test Case """
+"""Algorithms Test Case"""
 
 from qiskit.test import QiskitTestCase
 

--- a/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
+++ b/test/python/algorithms/eigensolvers/test_numpy_eigensolver.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test NumPyEigensolver """
+"""Test NumPyEigensolver"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/eigensolvers/test_vqd.py
+++ b/test/python/algorithms/eigensolvers/test_vqd.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test VQD """
+"""Test VQD"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/evolvers/trotterization/test_trotter_qrte.py
+++ b/test/python/algorithms/evolvers/trotterization/test_trotter_qrte.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test TrotterQRTE. """
+"""Test TrotterQRTE."""
 
 import unittest
 

--- a/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_adapt_vqe.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test of the AdaptVQE minimum eigensolver """
+"""Test of the AdaptVQE minimum eigensolver"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
+++ b/test/python/algorithms/minimum_eigensolvers/test_numpy_minimum_eigensolver.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test NumPy minimum eigensolver """
+"""Test NumPy minimum eigensolver"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/optimizers/test_optimizer_aqgd.py
+++ b/test/python/algorithms/optimizers/test_optimizer_aqgd.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test of AQGD optimizer """
+"""Test of AQGD optimizer"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/optimizers/test_optimizer_nft.py
+++ b/test/python/algorithms/optimizers/test_optimizer_nft.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test of NFT optimizer """
+"""Test of NFT optimizer"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/optimizers/test_optimizers.py
+++ b/test/python/algorithms/optimizers/test_optimizers.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Optimizers """
+"""Test Optimizers"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
+++ b/test/python/algorithms/optimizers/test_optimizers_scikitquant.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test of scikit-quant optimizers. """
+"""Test of scikit-quant optimizers."""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/test_backendv1.py
+++ b/test/python/algorithms/test_backendv1.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Providers that support BackendV1 interface """
+"""Test Providers that support BackendV1 interface"""
 
 import unittest
 import warnings

--- a/test/python/algorithms/test_backendv2.py
+++ b/test/python/algorithms/test_backendv2.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Providers that support BackendV2 interface """
+"""Test Providers that support BackendV2 interface"""
 
 import unittest
 import warnings

--- a/test/python/algorithms/test_entangler_map.py
+++ b/test/python/algorithms/test_entangler_map.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Entangler Map """
+"""Test Entangler Map"""
 
 import unittest
 

--- a/test/python/algorithms/test_measure_error_mitigation.py
+++ b/test/python/algorithms/test_measure_error_mitigation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Measurement Error Mitigation """
+"""Test Measurement Error Mitigation"""
 
 import unittest
 

--- a/test/python/algorithms/test_numpy_eigen_solver.py
+++ b/test/python/algorithms/test_numpy_eigen_solver.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test NumPy Eigen solver """
+"""Test NumPy Eigen solver"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/test_numpy_minimum_eigen_solver.py
+++ b/test/python/algorithms/test_numpy_minimum_eigen_solver.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test NumPy Minimum Eigensolver """
+"""Test NumPy Minimum Eigensolver"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/test_qaoa.py
+++ b/test/python/algorithms/test_qaoa.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test QAOA """
+"""Test QAOA"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/test_shor.py
+++ b/test/python/algorithms/test_shor.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Shor """
+"""Test Shor"""
 
 import unittest
 import warnings

--- a/test/python/algorithms/test_skip_qobj_validation.py
+++ b/test/python/algorithms/test_skip_qobj_validation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Skip Qobj Validation """
+"""Test Skip Qobj Validation"""
 
 import unittest
 

--- a/test/python/algorithms/test_validation.py
+++ b/test/python/algorithms/test_validation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Validation """
+"""Test Validation"""
 
 import unittest
 

--- a/test/python/algorithms/test_vqd.py
+++ b/test/python/algorithms/test_vqd.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test VQD """
+"""Test VQD"""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/algorithms/test_vqe.py
+++ b/test/python/algorithms/test_vqe.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test VQE """
+"""Test VQE"""
 
 import logging
 import unittest

--- a/test/python/algorithms/time_evolvers/test_trotter_qrte.py
+++ b/test/python/algorithms/time_evolvers/test_trotter_qrte.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test TrotterQRTE. """
+"""Test TrotterQRTE."""
 
 import unittest
 from test.python.algorithms import QiskitAlgorithmsTestCase

--- a/test/python/circuit/test_hamiltonian_gate.py
+++ b/test/python/circuit/test_hamiltonian_gate.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 
-""" HamiltonianGate tests """
+"""HamiltonianGate tests"""
 
 import numpy as np
 from numpy.testing import assert_allclose

--- a/test/python/circuit/test_unitary.py
+++ b/test/python/circuit/test_unitary.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" UnitaryGate tests """
+"""UnitaryGate tests"""
 
 import json
 import numpy

--- a/test/python/opflow/opflow_test_case.py
+++ b/test/python/opflow/opflow_test_case.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Opflow Test Case """
+"""Opflow Test Case"""
 
 from qiskit.test import QiskitTestCase
 

--- a/test/python/opflow/test_aer_pauli_expectation.py
+++ b/test/python/opflow/test_aer_pauli_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test AerPauliExpectation """
+"""Test AerPauliExpectation"""
 
 import itertools
 import unittest

--- a/test/python/opflow/test_evolution.py
+++ b/test/python/opflow/test_evolution.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Evolution """
+"""Test Evolution"""
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_gradients.py
+++ b/test/python/opflow/test_gradients.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 # =============================================================================
 
-""" Test Quantum Gradient Framework """
+"""Test Quantum Gradient Framework"""
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_matrix_expectation.py
+++ b/test/python/opflow/test_matrix_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-" Test MatrixExpectation"
+"Test MatrixExpectation"
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_op_construction.py
+++ b/test/python/opflow/test_op_construction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Operator construction, including OpPrimitives and singletons. """
+"""Test Operator construction, including OpPrimitives and singletons."""
 
 
 import itertools

--- a/test/python/opflow/test_pauli_basis_change.py
+++ b/test/python/opflow/test_pauli_basis_change.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Pauli Change of Basis Converter """
+"""Test Pauli Change of Basis Converter"""
 
 import itertools
 import unittest

--- a/test/python/opflow/test_pauli_expectation.py
+++ b/test/python/opflow/test_pauli_expectation.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test PauliExpectation """
+"""Test PauliExpectation"""
 
 import itertools
 import unittest

--- a/test/python/opflow/test_state_construction.py
+++ b/test/python/opflow/test_state_construction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Operator construction, including OpPrimitives and singletons. """
+"""Test Operator construction, including OpPrimitives and singletons."""
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_state_op_meas_evals.py
+++ b/test/python/opflow/test_state_op_meas_evals.py
@@ -13,7 +13,7 @@
 # pylint: disable=no-name-in-module
 
 
-""" Test Operator construction, including OpPrimitives and singletons. """
+"""Test Operator construction, including OpPrimitives and singletons."""
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_tapered_pauli.py
+++ b/test/python/opflow/test_tapered_pauli.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test TaperedPauliSumOp """
+"""Test TaperedPauliSumOp"""
 
 import unittest
 from test.python.opflow import QiskitOpflowTestCase

--- a/test/python/opflow/test_two_qubit_reduction.py
+++ b/test/python/opflow/test_two_qubit_reduction.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test TwoQubitReduction """
+"""Test TwoQubitReduction"""
 
 from test.python.opflow import QiskitOpflowTestCase
 

--- a/test/python/opflow/test_z2_symmetries.py
+++ b/test/python/opflow/test_z2_symmetries.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Z2Symmetries """
+"""Test Z2Symmetries"""
 
 from test.python.opflow import QiskitOpflowTestCase
 

--- a/test/python/quantum_info/test_sparse_z2_symmetries.py
+++ b/test/python/quantum_info/test_sparse_z2_symmetries.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" Test Z2Symmetries """
+"""Test Z2Symmetries"""
 
 import unittest
 


### PR DESCRIPTION
In an attempt both to make #9586 smaller/easier to review and to make some obvious easy fixes that are easily automated by `ruff`, which will be worthwhile even in the event we don't switch over to `ruff` from `pylint` I'm pulling out a few of the obvious categories of fixes.

This one is from `ruff check --select=D210 --fix qiskit tools test` and fixes "No whitespaces allowed surrounding docstring text" problems, with a small bit of handwork to cover a couple cases unhandled by the autofix.