### PR TITLE
Remove dependency to pkg_resources

### DIFF
--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -16,6 +16,7 @@
 
 import os
 import subprocess
+import sys
 from collections.abc import Mapping
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -101,7 +102,10 @@ class QiskitVersion(Mapping):
         self._loaded = False
 
     def _load_versions(self):
-        import importlib.metadata
+        if sys.version_info >= (3, 8):
+            from importlib.metadata import version
+        else:
+            from importlib_metadata import version
 
         try:
             # TODO: Update to use qiskit_aer instead when we remove the
@@ -148,7 +152,7 @@ class QiskitVersion(Mapping):
         except Exception:
             self._version_dict["qiskit-machine-learning"] = None
         try:
-            self._version_dict["qiskit"] = importlib.metadata.version("qiskit")
+            self._version_dict["qiskit"] = version("qiskit")
         except Exception:
             self._version_dict["qiskit"] = None
         self._loaded = True

--- a/qiskit/version.py
+++ b/qiskit/version.py
@@ -14,9 +14,9 @@
 
 """Contains the terra version."""
 
-from collections.abc import Mapping
 import os
 import subprocess
+from collections.abc import Mapping
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -101,7 +101,7 @@ class QiskitVersion(Mapping):
         self._loaded = False
 
     def _load_versions(self):
-        import pkg_resources
+        import importlib.metadata
 
         try:
             # TODO: Update to use qiskit_aer instead when we remove the
@@ -148,7 +148,7 @@ class QiskitVersion(Mapping):
         except Exception:
             self._version_dict["qiskit-machine-learning"] = None
         try:
-            self._version_dict["qiskit"] = pkg_resources.get_distribution("qiskit").version
+            self._version_dict["qiskit"] = importlib.metadata.version("qiskit")
         except Exception:
             self._version_dict["qiskit"] = None
         self._loaded = True


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since `pkg_resources.declare_namespace` has been deprecated, our CI is failed.
I removed the dependency to `pkg_resources`.

### Details and comments

CI message
```

==============================
Failed 1 tests - output below:
==============================

test.python.test_version.TestVersion.test_qiskit_version
--------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/Users/runner/work/1/s/test/python/test_version.py", line 25, in test_qiskit_version
    self.assertEqual(__version__, __qiskit_version__["qiskit-terra"])
                                  ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^

      File "/Users/runner/work/1/s/qiskit/version.py", line 168, in __getitem__
    self._load_versions()

      File "/Users/runner/work/1/s/qiskit/version.py", line 104, in _load_versions
    import pkg_resources

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 3257, in <module>
    @_call_aside
     ^^^^^^^^^^^

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 3232, in _call_aside
    f(*args, **kwargs)

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 3283, in _initialize_master_working_set
    tuple(dist.activate(replace=False) for dist in working_set)

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 3283, in <genexpr>
    tuple(dist.activate(replace=False) for dist in working_set)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2804, in activate
    declare_namespace(pkg)

      File "/Users/runner/work/1/s/test-job/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2298, in declare_namespace
    warnings.warn(msg, DeprecationWarning, stacklevel=2)

    DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('mpl_toolkits')`.
Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages


```
