### PR TITLE
providers/options: implement Mapping

### DIFF
--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -13,10 +13,10 @@
 """Container class for backend options."""
 
 import io
-from collections.abc import MutableMapping
+from collections.abc import Mapping
 
 
-class Options(MutableMapping):
+class Options(Mapping):
     """Base options object
 
     This class is what all backend options are based
@@ -26,7 +26,7 @@ class Options(MutableMapping):
     that should be a configuration of the backend class itself instead of the
     options.
 
-    Instances of this class behave like mutable dictionaries. Accessing an
+    Instances of this class behave like dictionaries. Accessing an
     option with a default value can be done with the `get()` method:
 
     >>> options = Options(opt1=1, opt2=2)
@@ -35,7 +35,7 @@ class Options(MutableMapping):
     >>> options.get("opt3", default="hello")
     'hello'
 
-    Key-value pairs for all options can be retrived using the `items()` method:
+    Key-value pairs for all options can be retrieved using the `items()` method:
 
     >>> list(options.items())
     [('opt1', 1), ('opt2', 2)]
@@ -100,22 +100,21 @@ class Options(MutableMapping):
 
     __slots__ = ("_fields", "validator")
 
-    # implementation of the MutableMapping ABC:
+    # implementation of the Mapping ABC:
 
     def __getitem__(self, key):
         return self._fields[key]
-
-    def __setitem__(self, key, value):
-        self.update_options(**{key: value})
-
-    def __delitem__(self, key):
-        del self._fields[key]
 
     def __iter__(self):
         return iter(self._fields)
 
     def __len__(self):
         return len(self._fields)
+
+    # Allow modifying the options (validated)
+
+    def __setitem__(self, key, value):
+        self.update_options(**{key: value})
 
     # backwards-compatibilty with Qiskit Experiments:
 
@@ -136,6 +135,7 @@ class Options(MutableMapping):
         except KeyError as ex:
             raise AttributeError(f"Option {name} is not defined") from ex
 
+    # setting options with the namespace interface is not validated
     def __setattr__(self, key, value):
         self._fields[key] = value
 

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -13,17 +13,52 @@
 """Container class for backend options."""
 
 import io
+from collections.abc import MutableMapping
 
 
-class Options:
+class Options(MutableMapping):
     """Base options object
 
-    This class is the abstract class that all backend options are based
+    This class is the class that all backend options are based
     on. The properties of the class are intended to be all dynamically
     adjustable so that a user can reconfigure the backend on demand. If a
     property is immutable to the user (eg something like number of qubits)
     that should be a configuration of the backend class itself instead of the
     options.
+
+    Instances of this class behave like mutable dictionaries. Accessing an
+    option with a default value can be done with the `get()` method:
+
+    >>> options = Options(opt1=1, opt2=2)
+    >>> options.get("opt1")
+    1
+    >>> options.get("opt3", default="hello")
+    'hello'
+
+    Key-value pairs for all options can be retrived using the `items()` method:
+
+    >>> list(options.items())
+    [('opt1', 1), ('opt2', 2)]
+
+    Options can be updated by name:
+
+    >>> options["opt1"] = 3
+    >>> options.get("opt1")
+    3
+
+    Runtime validators can be registered. See `set_validator`.
+    Updates through `update_options` and indexing (`__setitem__`) validate
+    the new value before peforming the update and raise `ValueError` if
+    the new value is invalid.
+
+    >>> options.set_validator("opt1", (1, 5))
+    >>> options["opt1"] = 4
+    >>> options["opt1"]
+    4
+    >>> options["opt1"] = 10  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError: ...
     """
 
     # Here there are dragons.
@@ -65,12 +100,46 @@ class Options:
 
     __slots__ = ("_fields", "validator")
 
+    # implementation of the MutableMapping ABC:
+
+    def __getitem__(self, key):
+        return self._fields[key]
+
+    def __setitem__(self, key, value):
+        self.update_options(**{key: value})
+
+    def __delitem__(self, key):
+        del self._fields[key]
+
+    def __iter__(self):
+        return iter(self._fields)
+
+    def __len__(self):
+        return len(self._fields)
+
+    # backwards-compatibilty with Qiskit Experiments:
+
     @property
     def __dict__(self):
         return self._fields
 
+    # SimpleNamespace-like access to options:
+
+    def __getattr__(self, name):
+        # This does not interrupt the normal lookup of things like methods or `_fields`, because
+        # those are successfully resolved by the normal Python lookup apparatus.  If we are here,
+        # then lookup has failed, so we must be looking for an option.  If the user has manually
+        # called `self.__getattr__("_fields")` then they'll get the option not the full dict, but
+        # that's not really our fault.  `getattr(self, "_fields")` will still find the dict.
+        try:
+            return self._fields[name]
+        except KeyError as ex:
+            raise AttributeError(f"Option {name} is not defined") from ex
+
     def __setattr__(self, key, value):
         self._fields[key] = value
+
+    # custom pickling:
 
     def __getstate__(self):
         return (self._fields, self.validator)
@@ -185,21 +254,6 @@ class Options:
                     )
 
         self._fields.update(fields)
-
-    def __getattr__(self, name):
-        # This does not interrupt the normal lookup of things like methods or `_fields`, because
-        # those are successfully resolved by the normal Python lookup apparatus.  If we are here,
-        # then lookup has failed, so we must be looking for an option.  If the user has manually
-        # called `self.__getattr__("_fields")` then they'll get the option not the full dict, but
-        # that's not really our fault.  `getattr(self, "_fields")` will still find the dict.
-        try:
-            return self._fields[name]
-        except KeyError as ex:
-            raise AttributeError(f"Option {name} is not defined") from ex
-
-    def get(self, field, default=None):
-        """Get an option value for a given key."""
-        return self._fields.get(field, default)
 
     def __str__(self):
         no_validator = super().__str__()

--- a/qiskit/providers/options.py
+++ b/qiskit/providers/options.py
@@ -19,7 +19,7 @@ from collections.abc import MutableMapping
 class Options(MutableMapping):
     """Base options object
 
-    This class is the class that all backend options are based
+    This class is what all backend options are based
     on. The properties of the class are intended to be all dynamically
     adjustable so that a user can reconfigure the backend on demand. If a
     property is immutable to the user (eg something like number of qubits)

--- a/releasenotes/notes/options-implement-mutable-mapping-b11f4e2c6df4cf31.yaml
+++ b/releasenotes/notes/options-implement-mutable-mapping-b11f4e2c6df4cf31.yaml
@@ -2,8 +2,9 @@
 features:
   - |
     The :class:`qiskit.providers.options.Options` class now implements the
-    :class`MutableMapping`. :class:`Options` instances therefore now offer the
-    same interface as standard dictionaries.
+    :class`Mapping` and `__setitem__`. :class:`Options` instances therefore
+    now offer the same interface as standard dictionaries, except for the
+    deletion methods (`__delitem__`, `pop`, `clear`).
     Key assignments are validated by the registered validators, if any.
     See `#9686 <https://github.com/Qiskit/qiskit-terra/issues/9686>`.
 upgrade:

--- a/releasenotes/notes/options-implement-mutable-mapping-b11f4e2c6df4cf31.yaml
+++ b/releasenotes/notes/options-implement-mutable-mapping-b11f4e2c6df4cf31.yaml
@@ -1,0 +1,12 @@
+---
+features:
+  - |
+    The :class:`qiskit.providers.options.Options` class now implements the
+    :class`MutableMapping`. :class:`Options` instances therefore now offer the
+    same interface as standard dictionaries.
+    Key assignments are validated by the registered validators, if any.
+    See `#9686 <https://github.com/Qiskit/qiskit-terra/issues/9686>`.
+upgrade:
+  - |
+    Instances of `options.__dict__.items()` and related calls can be replaced
+    by the same call without the `__dict__` proxy (e.g. `options.items()`).

--- a/test/python/providers/test_options.py
+++ b/test/python/providers/test_options.py
@@ -18,7 +18,6 @@ import pickle
 
 from qiskit.providers import Options
 from qiskit.qobj.utils import MeasLevel
-
 from qiskit.test import QiskitTestCase
 
 
@@ -119,6 +118,39 @@ Where:
         self.assertEqual(cpy.opt1, 10)
         self.assertEqual(cpy.opt2, 2)
         self.assertEqual(cpy.opt3, 20)
+
+    def test_iterate(self):
+        options = Options(opt1=1, opt2=2, opt3="abc")
+        options_dict = dict(options)
+
+        self.assertEqual(options_dict, {"opt1": 1, "opt2": 2, "opt3": "abc"})
+
+    def test_iterate_items(self):
+        options = Options(opt1=1, opt2=2, opt3="abc")
+        items = list(options.items())
+
+        self.assertEqual(items, [("opt1", 1), ("opt2", 2), ("opt3", "abc")])
+
+    def test_mutate_mapping(self):
+        options = Options(opt1=1, opt2=2, opt3="abc")
+
+        options["opt4"] = "def"
+        self.assertEqual(options.opt4, "def")
+
+        options_dict = dict(options)
+        self.assertEqual(options_dict, {"opt1": 1, "opt2": 2, "opt3": "abc", "opt4": "def"})
+
+    def test_mutate_mapping_validator(self):
+        options = Options(shots=1024)
+        options.set_validator("shots", (1, 2048))
+
+        options["shots"] = 512
+        self.assertEqual(options.shots, 512)
+
+        with self.assertRaises(ValueError):
+            options["shots"] = 3096
+
+        self.assertEqual(options.shots, 512)
 
 
 class TestOptionsSimpleNamespaceBackwardCompatibility(QiskitTestCase):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This is an option for resolving #9686 by implementing the [`collections.abc.MutableMapping`](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableMapping) interface for the `Options` class. This automatically provides implementations of the suggested `items()` and of the existing `get()` methods.

### Details and comments

As a `MutableMapping`, `Options` instances behave like mutable dictionaries with the extra validator feature. The `__setitem__` implementation goes through `update_options` to make sure that the validator is running. This is inconsistent with `__setattr__` but I understand that the namespace interface is there for backwards compatibility and running the validator may break use cases (although this would arguably be a logic error).

A side effect of implementing `MutableMapping` is that there's yet another way of accessing the options (indexing) which is however natural for an object that exposes a `items()` method.

Resolves #9686