### PR TITLE
Remove dependency on sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
-    "sphinx_autodoc_typehints",
     "reno.sphinxext",
     "sphinx_design",
     "matplotlib.sphinxext.plot_directive",
@@ -84,6 +83,12 @@ html_css_files = []
 # Note that setting autodoc defaults here may not have as much of an effect as you may expect; any
 # documentation created by autosummary uses a template file (in autosummary in the templates path),
 # which likely overrides the autodoc defaults.
+
+# Include type hints in both signature and parameter descriptions.
+autodoc_typehints = "both"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 autosummary_generate = True
 autosummary_generate_overwrite = False

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,9 +16,8 @@ pylatexenc>=1.4
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 seaborn>=0.9.0
 reno>=3.4.0
-Sphinx>=3.0.0
+Sphinx>=5.0
 qiskit-sphinx-theme>=1.6
-sphinx-autodoc-typehints==1.21.1  # revert to >=1.18 once the incompatibilities are fixed
 sphinx-design>=0.2.0
 pygments>=2.4
 scikit-learn>=0.20.0


### PR DESCRIPTION
### Summary

This replaces the whole usage of the separate package `sphinx-autodoc-typehints` with the built-in support from `autodoc`, available (with this combination of options) since Sphinx 5.0.  This removes a docs dependency that has caused us significant problems before due to its instability, and the built-in handling in `autodoc` is much cleaner as well; rather than trying to textually modify the docstring, this version (correctly) mutates the parsed rST structure, which also naturally it 100% compatible with the Napoleon processing.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

I set the type-hint location to be both in the signatures and descriptions (our current behaviour is only in the descriptions, unless there's a `typing.overload`).  I'm happy to make it either just signatures or just descriptions, as people prefer.  Here's an example of the new output for `QuantumCircuit.if_else` (a function that currently only has type hints in the signature):

<img width="835" alt="Screenshot 2023-03-01 at 23 35 22" src="https://user-images.githubusercontent.com/5968590/222292148-e2aa87f6-9a54-4b0f-bfe3-a687b1fe8105.png">

(The slightly buggy output is because of Qiskit/qiskit_sphinx_theme#183; it's pre-existing for  this change.)

For reference, [here's what it looks like in the built documentation](https://qiskit.org/documentation/stable/0.41/stubs/qiskit.circuit.QuantumCircuit.if_else.html).

Thanks to @levbishop for pointing out that `autodoc` does this natively now.