### PR TITLE
More fixing extra whitespace surrounding docstrings

### DIFF
--- a/qiskit/qasm/qasmlexer.py
+++ b/qiskit/qasm/qasmlexer.py
@@ -124,7 +124,7 @@ class QasmLexer:
         return t
 
     def t_STRING(self, t):
-        r"\"([^\\\"]|\\.)*\""
+        r"\"([^\\\"]|\\.)*\""  # fmt: skip
         return t
 
     def t_INCLUDE(self, _):

--- a/qiskit/qasm/qasmlexer.py
+++ b/qiskit/qasm/qasmlexer.py
@@ -124,7 +124,7 @@ class QasmLexer:
         return t
 
     def t_STRING(self, t):
-        r"\"([^\\\"]|\\.)*\" "
+        r"\"([^\\\"]|\\.)*\""
         return t
 
     def t_INCLUDE(self, _):

--- a/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
+++ b/qiskit/quantum_info/operators/symplectic/stabilizer_table.py
@@ -1027,7 +1027,7 @@ class StabilizerTable(PauliTable, AdjointMixin):
 
     @staticmethod
     def _to_matrix(pauli, phase, sparse=False):
-        """ "Return the Pauli stabilizer matrix from symplectic representation.
+        """Return the Pauli stabilizer matrix from symplectic representation.
 
         Args:
             pauli (array): symplectic Pauli vector.

--- a/test/python/result/test_result.py
+++ b/test/python/result/test_result.py
@@ -127,8 +127,7 @@ class TestResultOperations(QiskitTestCase):
         self.assertEqual(expected, repr(result))
 
     def test_multiple_circuits_counts(self):
-        """ "
-        Test that counts are returned either as a list or a single item.
+        """Test that counts are returned either as a list or a single item.
 
         Counts are returned as a list when multiple experiments are executed
         and get_counts() is called with no arguments. In all the other cases

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-""" `_text_circuit_drawer` "draws" a circuit in "ascii art" """
+"""`_text_circuit_drawer` draws a circuit in ascii art"""
 
 import pathlib
 import os


### PR DESCRIPTION
This fixes some formatting typos in some docstrings.

This is a followup to #9689. There are four cases found as follows
```shell
> ruff check --select=D210  qiskit tools test
qiskit/qasm/qasmlexer.py:127:9: D210 [*] No whitespaces allowed surrounding docstring text
qiskit/quantum_info/operators/symplectic/stabilizer_table.py:1030:9: D210 [*] No whitespaces allowed surrounding docstring text
test/python/result/test_result.py:130:9: D210 [*] No whitespaces allowed surrounding docstring text
test/python/visualization/test_circuit_text_drawer.py:13:1: D210 [*] No whitespaces allowed surrounding docstring text
```

These cases are compounded by other quirks or typos in the docstrings. Both the extra whitespace and quirks are fixed manually here.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


