### PR TITLE
Fix docstring format errors found by ruff

### DIFF
--- a/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
+++ b/qiskit/algorithms/time_evolvers/pvqd/pvqd.py
@@ -216,7 +216,6 @@ class PVQD(RealTimeEvolver):
         dt: float,
         current_parameters: np.ndarray,
     ) -> tuple[Callable[[np.ndarray], float], Callable[[np.ndarray], np.ndarray]] | None:
-
         """Get a function to evaluate the infidelity between Trotter step and ansatz.
 
         Args:

--- a/qiskit/circuit/controlledgate.py
+++ b/qiskit/circuit/controlledgate.py
@@ -131,7 +131,8 @@ class ControlledGate(Gate):
         """Set controlled gate definition with closed controls.
 
         Args:
-            excited_def: The circuit with all closed controls."""
+            excited_def: The circuit with all closed controls.
+        """
         self._definition = excited_def
 
     @property

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -2947,7 +2947,7 @@ class QuantumCircuit:
         Returns:
             A handle to the instructions created.
 
-        See also:
+        See Also:
             QuantumCircuit.i: the same function.
         """
         return self.i(qubit)

--- a/qiskit/opflow/gradients/qfi_base.py
+++ b/qiskit/opflow/gradients/qfi_base.py
@@ -19,7 +19,6 @@ from .circuit_qfis import CircuitQFI
 
 
 class QFIBase(DerivativeBase):
-
     r"""Base class for Quantum Fisher Information (QFI).
 
     Compute the Quantum Fisher Information (QFI) given a pure, parameterized quantum state.

--- a/qiskit/quantum_info/operators/symplectic/base_pauli.py
+++ b/qiskit/quantum_info/operators/symplectic/base_pauli.py
@@ -278,7 +278,6 @@ class BasePauli(BaseOperator, AdjointMixin, MultiplyMixin):
         return self.copy()._append_circuit(other.inverse(), qargs=qargs)
 
     def _evolve_clifford(self, other, qargs=None, frame="h"):
-
         """Heisenberg picture evolution of a Pauli by a Clifford."""
 
         if frame == "s":

--- a/qiskit/quantum_info/synthesis/qsd.py
+++ b/qiskit/quantum_info/synthesis/qsd.py
@@ -124,7 +124,7 @@ def qs_decomposition(
 
 
 def _demultiplex(um0, um1, opt_a1=False, opt_a2=False, *, _depth=0):
-    """decomposes a generic multiplexer.
+    """Decompose a generic multiplexer.
 
           ────□────
            ┌──┴──┐

--- a/qiskit/tools/events/progressbar.py
+++ b/qiskit/tools/events/progressbar.py
@@ -157,19 +157,16 @@ class TextProgressBar(BaseProgressBar):
 
     def _init_subscriber(self):
         def _initialize_progress_bar(num_tasks):
-            """ """
             self.start(num_tasks)
 
         self.subscribe("terra.parallel.start", _initialize_progress_bar)
 
         def _update_progress_bar(progress):
-            """ """
             self.update(progress)
 
         self.subscribe("terra.parallel.done", _update_progress_bar)
 
         def _finish_progress_bar():
-            """ """
             self.unsubscribe("terra.parallel.start", _initialize_progress_bar)
             self.unsubscribe("terra.parallel.done", _update_progress_bar)
             self.unsubscribe("terra.parallel.finish", _finish_progress_bar)

--- a/qiskit/tools/events/pubsub.py
+++ b/qiskit/tools/events/pubsub.py
@@ -60,7 +60,7 @@ class _Broker:
         """Subscribes to an event, so when it's emitted all the callbacks subscribed,
         will be executed. We are not allowing double registration.
 
-        Args
+        Args:
             event (string): The event to subscribed in the form of:
                             "terra.<component>.<method>.<action>"
             callback (callable): The callback that will be executed when an event is
@@ -83,7 +83,7 @@ class _Broker:
     def dispatch(self, event, *args, **kwargs):
         """Emits an event if there are any subscribers.
 
-        Args
+        Args:
             event (String): The event to be emitted
             args: Arguments linked with the event
             kwargs: Named arguments linked with the event

--- a/qiskit/tools/jupyter/progressbar.py
+++ b/qiskit/tools/jupyter/progressbar.py
@@ -69,7 +69,7 @@ class HTMLProgressBar(BaseProgressBar):
             """When an event of compilation starts, this function will be called, and
             will initialize the progress bar.
 
-            Args
+            Args:
                 num_tasks: Number of compilation tasks the progress bar will track
             """
             self.start(num_tasks)
@@ -80,7 +80,7 @@ class HTMLProgressBar(BaseProgressBar):
             """When an event of compilation completes, this function will be called, and
             will update the progress bar indication.
 
-            Args
+            Args:
                 progress: Number of tasks completed
             """
             self.update(progress)

--- a/qiskit/utils/backend_utils.py
+++ b/qiskit/utils/backend_utils.py
@@ -50,7 +50,7 @@ def _get_backend_provider(backend):
 
 
 def has_ibmq():
-    """Check if IBMQ is installed"""
+    """Check if IBMQ is installed."""
     if not _PROVIDER_CHECK.checked_ibmq:
         try:
             from qiskit.providers.ibmq import IBMQFactory
@@ -67,7 +67,7 @@ def has_ibmq():
 
 
 def has_aer():
-    """check if Aer is installed"""
+    """Check if Aer is installed."""
     if not _PROVIDER_CHECK.checked_aer:
         try:
             from qiskit.providers.aer import AerProvider

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -65,8 +65,7 @@ def find_regs_by_name(
 def _combine_result_objects(results: List[Result]) -> Result:
     """Temporary helper function.
 
-    TODO:
-        This function would be removed after Terra supports job with infinite circuits.
+    TODO: This function would be removed after Terra supports job with infinite circuits.
     """
     if len(results) == 1:
         return results[0]

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -379,7 +379,7 @@ def _run_circuits_on_backend(
     noise_config: Dict,
     run_config: Dict,
 ) -> Job:
-    """run on backend"""
+    """Run on backend."""
     run_kwargs = {}
     if is_aer_provider(backend) or is_basicaer_provider(backend):
         for key, value in backend_options.items():

--- a/qiskit/visualization/circuit/circuit_visualization.py
+++ b/qiskit/visualization/circuit/circuit_visualization.py
@@ -603,7 +603,6 @@ def _matplotlib_circuit_drawer(
     cregbundle=None,
     wire_order=None,
 ):
-
     """Draw a quantum circuit based on matplotlib.
     If `%matplotlib inline` is invoked in a Jupyter notebook, it visualizes a circuit inline.
     We recommend `%config InlineBackend.figure_format = 'svg'` for the inline visualization.

--- a/test/python/circuit/test_commutation_checker.py
+++ b/test/python/circuit/test_commutation_checker.py
@@ -34,7 +34,6 @@ from qiskit.circuit.library import (
 
 
 class TestCommutationChecker(QiskitTestCase):
-
     """Test CommutationChecker class."""
 
     def test_simple_gates(self):

--- a/test/python/dagcircuit/test_dagcircuit.py
+++ b/test/python/dagcircuit/test_dagcircuit.py
@@ -288,7 +288,8 @@ class TestDagWireRemoval(QiskitTestCase):
         Args:
             cregs (Iterable(ClassicalRegister)): the classical registers to expect
             excluding (Set(ClassicalRegister)): classical registers to remove from
-            ``cregs`` before the comparison."""
+            ``cregs`` before the comparison.
+        """
         if excluding is None:
             excluding = set()
         self.assertEqual(
@@ -301,7 +302,8 @@ class TestDagWireRemoval(QiskitTestCase):
         Args:
             clbits (Iterable(Clbit)): the classical bits to expect
             excluding (Set(ClassicalRegister)): classical bits to remove from
-            ``clbits`` before the comparison."""
+            ``clbits`` before the comparison.
+        """
         if excluding is None:
             excluding = set()
         self.assertEqual(self.dag.clbits, [b for b in clbits if b not in excluding])

--- a/test/python/transpiler/test_commutative_cancellation.py
+++ b/test/python/transpiler/test_commutative_cancellation.py
@@ -26,7 +26,6 @@ from qiskit.quantum_info import Operator
 
 
 class TestCommutativeCancellation(QiskitTestCase):
-
     """Test the CommutativeCancellation pass."""
 
     def setUp(self):

--- a/test/python/transpiler/test_commutative_inverse_cancellation.py
+++ b/test/python/transpiler/test_commutative_inverse_cancellation.py
@@ -23,7 +23,6 @@ from qiskit.transpiler.passes import CommutativeInverseCancellation
 
 
 class TestCommutativeInverseCancellation(QiskitTestCase):
-
     """Test the CommutativeInverseCancellation pass."""
 
     # The first suite of tests is adapted from CommutativeCancellation,


### PR DESCRIPTION
Errors are found by the command `ruff check --select=D403 qiskit tools test examples setup.py`, and likewise for 
D211, D419 , D201, D208 , D405.

This PR fixes these errors, largely manually either because there is no automatic fix, or the fix suggested is not really what we want.

See #9707
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


