### PR TITLE
[WIP] Make string join from list of integers more performant

### DIFF
--- a/qiskit/pulse/builder.py
+++ b/qiskit/pulse/builder.py
@@ -2444,8 +2444,8 @@ def measure(
     # note this is not a subroutine.
     # just a macro to automate combination of stimulus and acquisition.
     # prepare unique reference name based on qubit and memory slot index.
-    qubits_repr = "&".join(map(str, qubits))
-    mslots_repr = "&".join((str(r.index) for r in registers))
+    qubits_repr = "&".join([str(q) for q in qubits])
+    mslots_repr = "&".join([str(r.index) for r in registers])
     _active_builder().call_subroutine(measure_sched, name=f"measure_{qubits_repr}..{mslots_repr}")
 
     if len(qubits) == 1:


### PR DESCRIPTION
This PR is based on the following benchmark
```python
In [1]: nums = list(range(100))

In [2]: %timeit ",".join(map(str, nums))
9.52 µs ± 63.9 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [3]: %timeit ",".join([str(n) for n in nums])
8.18 µs ± 101 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [4]: %timeit ",".join(str(n) for n in nums)
10.3 µs ± 82.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Notice that the version that allocates a list is more performant than the one that uses a generator, avoiding allocation. This advantage persists for `nums` of some other lengths.

There are a few other places in qiskit where I see the same thing. They could be included in this PR.

#### Remarks

* Some linting tools might complain about the "unnecessary" allocation.

* In any case, the extra parens here `"&".join((str(r.index) for r in registers))` are useless.