### PR TITLE
Add support to CouplingMap for disjoint qubits

### DIFF
--- a/qiskit/transpiler/passes/layout/csp_layout.py
+++ b/qiskit/transpiler/passes/layout/csp_layout.py
@@ -19,6 +19,7 @@ import random
 
 from qiskit.transpiler.layout import Layout
 from qiskit.transpiler.basepasses import AnalysisPass
+from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.utils import optionals as _optionals
 
 
@@ -60,6 +61,11 @@ class CSPLayout(AnalysisPass):
 
     def run(self, dag):
         """run the layout method"""
+        if not self.coupling_map.is_connected():
+            raise TranspilerError(
+                "Coupling Map is disjoint, this pass can't be used with a disconnected coupling "
+                "map."
+            )
         qubits = dag.qubits
         cxs = set()
 

--- a/qiskit/transpiler/passes/layout/dense_layout.py
+++ b/qiskit/transpiler/passes/layout/dense_layout.py
@@ -79,6 +79,11 @@ class DenseLayout(AnalysisPass):
             raise TranspilerError(
                 "A coupling_map or target with constrained qargs is necessary to run the pass."
             )
+        if not self.coupling_map.is_connected():
+            raise TranspilerError(
+                "Coupling Map is disjoint, this pass can't be used with a disconnected coupling "
+                "map."
+            )
         num_dag_qubits = len(dag.qubits)
         if num_dag_qubits > self.coupling_map.size():
             raise TranspilerError("Number of qubits greater than device.")

--- a/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
+++ b/qiskit/transpiler/passes/layout/noise_adaptive_layout.py
@@ -211,6 +211,11 @@ class NoiseAdaptiveLayout(AnalysisPass):
 
     def run(self, dag):
         """Run the NoiseAdaptiveLayout pass on `dag`."""
+        if not self.coupling_map.is_connected():
+            raise TranspilerError(
+                "Coupling Map is disjoint, this pass can't be used with a disconnected coupling "
+                "map."
+            )
         self.swap_graph = rx.PyDiGraph()
         self.cx_reliability = {}
         self.readout_reliability = {}

--- a/qiskit/transpiler/passes/layout/sabre_layout.py
+++ b/qiskit/transpiler/passes/layout/sabre_layout.py
@@ -166,7 +166,11 @@ class SabreLayout(TransformationPass):
         """
         if len(dag.qubits) > self.coupling_map.size():
             raise TranspilerError("More virtual qubits exist than physical.")
-
+        if not self.coupling_map.is_connected():
+            raise TranspilerError(
+                "Coupling Map is disjoint, this pass can't be used with a disconnected coupling "
+                "map."
+            )
         # Choose a random initial_layout.
         if self.routing_pass is not None:
             if self.seed is None:

--- a/qiskit/transpiler/passes/layout/trivial_layout.py
+++ b/qiskit/transpiler/passes/layout/trivial_layout.py
@@ -50,6 +50,11 @@ class TrivialLayout(AnalysisPass):
         Raises:
             TranspilerError: if dag wider than self.coupling_map
         """
+        if not self.coupling_map.is_connected():
+            raise TranspilerError(
+                "Coupling Map is disjoint, this pass can't be used with a disconnected coupling "
+                "map."
+            )
         if dag.num_qubits() > self.coupling_map.size():
             raise TranspilerError("Number of qubits greater than device.")
         self.property_set["layout"] = Layout.generate_trivial_layout(

--- a/releasenotes/notes/add-cmap-componets-7ed56cdf294150f1.yaml
+++ b/releasenotes/notes/add-cmap-componets-7ed56cdf294150f1.yaml
@@ -1,0 +1,13 @@
+---
+features:
+  - |
+    Added support to the :class:`~.CouplingMap` object to have a disjoint
+    connectivity. Previously, a :class:`~.CouplingMap` could only be
+    constructed if the graph was connected. This will enable using
+    :class:`~.CouplingMap` to represent hardware with disjoint qubits.
+  - |
+    Added a new method :meth:`.CouplingMap.get_component_subgraphs` which
+    is used to get a list of :class:`~.CouplingMap` component subgraphs for
+    a disjoint :class:`~.CouplingMap`. If the :class:`~.CouplingMap` object
+    is connected this will just return a single :class:`~.CouplingMap`
+    equivalent to the original.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Previously the `CouplingMap` class only supported graphs which were fully connected. This prevented us from modeling potential hardware which didn't have a path between all qubits. This isn't an inherent limitation of the underlying graph data structure but was a limitation put on the `CouplingMap` class because several pieces of the transpiler assume a path always exists between 2 qubits (mainly in layout and routing). This commit removes this limitation and also adds a method to get a subgraph `CouplingMap` for all the components of the `CouplingMap`. This enables us to model these devices with a `CouplingMap`, which is the first step towards supporting these devices in the transpiler.

One limitation with this PR is most fo the layout and routing algorithms do not support disjoint connectivity. The primary exception being TrivialLayout (although the output might be invalid) VF2Layout and VF2PostLayout which inherently support this already. This commit lays the groundwork to fix this limitation in a follow-up PR but for the time being it just raises an error in those passes if a disconnected CouplingMap is being used. The intent here is to follow up to this commit soon for adding support for `SabreLayout`, `SabreSwap`, `DenseLayout`, and `StochasticSwap` to leverage the method `get_component_subgraphs` added here to make them usable on such coupling maps.

### Details and comments