### PR TITLE
Fix handling of BackendV1 simulators in PassManagerConfig.from_backend

### DIFF
--- a/qiskit/transpiler/instruction_durations.py
+++ b/qiskit/transpiler/instruction_durations.py
@@ -74,15 +74,17 @@ class InstructionDurations:
         """
         # All durations in seconds in gate_length
         instruction_durations = []
-        for gate, insts in backend.properties()._gates.items():
-            for qubits, props in insts.items():
-                if "gate_length" in props:
-                    gate_length = props["gate_length"][0]  # Throw away datetime at index 1
-                    instruction_durations.append((gate, qubits, gate_length, "s"))
-        for q, props in backend.properties()._qubits.items():
-            if "readout_length" in props:
-                readout_length = props["readout_length"][0]  # Throw away datetime at index 1
-                instruction_durations.append(("measure", [q], readout_length, "s"))
+        backend_properties = backend.properties()
+        if hasattr(backend_properties, "_gates"):
+            for gate, insts in backend_properties._gates.items():
+                for qubits, props in insts.items():
+                    if "gate_length" in props:
+                        gate_length = props["gate_length"][0]  # Throw away datetime at index 1
+                        instruction_durations.append((gate, qubits, gate_length, "s"))
+            for q, props in backend.properties()._qubits.items():
+                if "readout_length" in props:
+                    readout_length = props["readout_length"][0]  # Throw away datetime at index 1
+                    instruction_durations.append(("measure", [q], readout_length, "s"))
 
         try:
             dt = backend.configuration().dt

--- a/qiskit/transpiler/passmanager_config.py
+++ b/qiskit/transpiler/passmanager_config.py
@@ -136,7 +136,9 @@ class PassManagerConfig:
         if res.inst_map is None:
             if backend_version < 2:
                 if hasattr(backend, "defaults"):
-                    res.inst_map = backend.defaults().instruction_schedule_map
+                    defaults = backend.defaults()
+                    if defaults is not None:
+                        res.inst_map = defaults.instruction_schedule_map
             else:
                 res.inst_map = backend.instruction_schedule_map
         if res.coupling_map is None:

--- a/releasenotes/notes/fix-backendv1-pm-config-from-backend-914869dd6e1c06be.yaml
+++ b/releasenotes/notes/fix-backendv1-pm-config-from-backend-914869dd6e1c06be.yaml
@@ -1,0 +1,9 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :meth:`.PassManagerConfig.from_backend`
+    constructor method when it was used with a :class:`~.BackendV1` based
+    simulator backend. For some simulator backends which did not populate
+    some optional fields the constructor would error.
+    Fixed `#9265 <https://github.com/Qiskit/qiskit-terra/issues/9265>`__ and
+    `#8546 <https://github.com/Qiskit/qiskit-terra/issues/8546>`__

--- a/test/python/transpiler/test_passmanager_config.py
+++ b/test/python/transpiler/test_passmanager_config.py
@@ -16,6 +16,7 @@ from qiskit import QuantumRegister
 from qiskit.providers.backend import Backend
 from qiskit.test import QiskitTestCase
 from qiskit.providers.fake_provider import FakeMelbourne, FakeArmonk, FakeHanoi, FakeHanoiV2
+from qiskit.providers.basicaer import QasmSimulatorPy
 from qiskit.transpiler.coupling import CouplingMap
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 
@@ -70,6 +71,21 @@ class TestPassManagerConfig(QiskitTestCase):
             str(config.coupling_map), str(CouplingMap(backend.configuration().coupling_map))
         )
         self.assertEqual(config.initial_layout, initial_layout)
+
+    def test_from_backendv1_inst_map_is_none(self):
+        """Test that from_backend() works with backend that has defaults defined as None."""
+        backend = FakeHanoi()
+        backend.defaults = lambda: None
+        config = PassManagerConfig.from_backend(backend)
+        self.assertIsInstance(config, PassManagerConfig)
+        self.assertIsNone(config.inst_map)
+
+    def test_simulator_backend_v1(self):
+        """Test that from_backend() works with backendv1 simulator."""
+        backend = QasmSimulatorPy()
+        config = PassManagerConfig.from_backend(backend)
+        self.assertIsInstance(config, PassManagerConfig)
+        self.assertIsNone(config.inst_map)
 
     def test_invalid_user_option(self):
         """Test from_backend() with an invalid user option."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes two small oversights that would appear when calling PassManagerConfig.from_backend() with a simulator BackendV1 backend. The handling of optional fields in the BackendProperties and PulseDefaults objects for BackendV1 backends was missing that a BackendProperties object's gates field could be None and that the defaults() method could return None in the absense of any pulse calibrations (both of which typically only are True for simulators). In these cases this would cause an error constructing the InstructionDurations object and the InstructionScheduleMap object respectively. This fixes the handling of these edge cases so that PassManagerConfig.from_backend() will work with any BackendV1 based backend.

### Details and comments

Fixes #8546
Fixes #9265