### PR TITLE
Use raise-from, caught by ruff rule B904

### DIFF
--- a/qiskit/opflow/list_ops/list_op.py
+++ b/qiskit/opflow/list_ops/list_op.py
@@ -303,11 +303,11 @@ class ListOp(OperatorBase):
         try:
             if self.num_qubits != len(permutation):
                 raise OpflowError("New index must be defined for each qubit of the operator.")
-        except ValueError:
+        except ValueError as err:
             raise OpflowError(
                 "Permute is only possible if all operators in the ListOp have the "
                 "same number of qubits."
-            ) from ValueError
+            ) from err
         if self.num_qubits < circuit_size:
             # pad the operator with identities
             new_self = self._expand_dim(circuit_size - self.num_qubits)

--- a/qiskit/providers/basicaer/basicaerprovider.py
+++ b/qiskit/providers/basicaer/basicaerprovider.py
@@ -119,7 +119,7 @@ class BasicAerProvider(ProviderV1):
         try:
             backend_instance = backend_cls(provider=self)
         except Exception as err:
-            raise QiskitError(f"Backend {backend_cls} could not be instantiated: {err}") from err
+            raise QiskitError(f"Backend {backend_cls} could not be instantiated.") from err
 
         return backend_instance
 

--- a/qiskit/qasm3/__init__.py
+++ b/qiskit/qasm3/__init__.py
@@ -176,7 +176,7 @@ def load(filename: str):
     try:
         return qiskit_qasm3_import.parse(program)
     except qiskit_qasm3_import.ConversionError as exc:
-        raise QASM3ImporterError(str(exc)) from exc
+        raise QASM3ImporterError(f"Error converting file {filename}.") from exc
 
 
 @_optionals.HAS_QASM3_IMPORT.require_in_call("loading from OpenQASM 3")
@@ -199,4 +199,4 @@ def loads(program: str):
     try:
         return qiskit_qasm3_import.parse(program)
     except qiskit_qasm3_import.ConversionError as exc:
-        raise QASM3ImporterError(str(exc)) from exc
+        raise QASM3ImporterError("Error converting OpenQASM program.") from exc

--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -88,7 +88,7 @@ class UnrollCustomDefinitions(TransformationPass):
             try:
                 rule = node.op.definition.data
             except TypeError as err:
-                raise QiskitError(f"Error decomposing node {node.name}: {err}") from err
+                raise QiskitError(f"Error decomposing node {node.name}.") from err
             except AttributeError:
                 # definition is None
                 rule = None

--- a/qiskit/transpiler/passes/basis/unroller.py
+++ b/qiskit/transpiler/passes/basis/unroller.py
@@ -98,7 +98,7 @@ class Unroller(TransformationPass):
                 rule = node.op.definition.data
             except (TypeError, AttributeError) as err:
                 raise QiskitError(
-                    f"Error decomposing node of instruction '{node.name}': {err}. "
+                    f"Error decomposing node of instruction '{node.name}'. "
                     f"Unable to define instruction '{node.name}' in the given basis."
                 ) from err
 
@@ -122,7 +122,7 @@ class Unroller(TransformationPass):
                     rule = rule[0].operation.definition.data
                 except (TypeError, AttributeError) as err:
                     raise QiskitError(
-                        f"Error decomposing node of instruction '{node.name}': {err}. "
+                        f"Error decomposing node of instruction '{node.name}'. "
                         f"Unable to define instruction '{rule[0].operation.name}' in the basis."
                     ) from err
 

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -125,7 +125,7 @@ class UserConfig:
                 )
             except ValueError as err:
                 raise exceptions.QiskitUserConfigError(
-                    f"Value assigned to circuit_reverse_bits is not valid."
+                    "Value assigned to circuit_reverse_bits is not valid."
                 ) from err
             if circuit_reverse_bits is not None:
                 self.settings["circuit_reverse_bits"] = circuit_reverse_bits

--- a/qiskit/user_config.py
+++ b/qiskit/user_config.py
@@ -125,8 +125,8 @@ class UserConfig:
                 )
             except ValueError as err:
                 raise exceptions.QiskitUserConfigError(
-                    f"Value assigned to circuit_reverse_bits is not valid. {str(err)}"
-                )
+                    f"Value assigned to circuit_reverse_bits is not valid."
+                ) from err
             if circuit_reverse_bits is not None:
                 self.settings["circuit_reverse_bits"] = circuit_reverse_bits
 
@@ -213,8 +213,8 @@ def set_config(key, value, section=None, file_path=None):
             config.write(cfgfile)
     except OSError as ex:
         raise exceptions.QiskitUserConfigError(
-            f"Unable to load the config file {filename}. Error: '{str(ex)}'"
-        )
+            f"Unable to load the config file {filename}."
+        ) from ex
 
     # validates config
     user_config = UserConfig(filename)

--- a/qiskit/utils/run_circuits.py
+++ b/qiskit/utils/run_circuits.py
@@ -92,7 +92,7 @@ def _safe_get_job_status(job: Job, job_id: str, max_job_retries: int, wait: floa
             time.sleep(wait)
         except Exception as ex:
             raise QiskitError(
-                f"job id: {job_id}, status: 'FAIL_TO_GET_STATUS' Unknown error: ({ex})"
+                f"job id: {job_id}, status: 'FAIL_TO_GET_STATUS' Unknown error."
             ) from ex
     else:
         raise QiskitError(f"Max retry limit reached. Failed to get status for job with id {job_id}")


### PR DESCRIPTION
Fixes a few problems with `raise` statements

* `raise as err`, with no `from`
* printing a caught error `err` before raising another error with `from err`. The information will be printed twice in a stack trace.

For example:
    raise QiskitError(f"Failed with error: {err}") from err

A few other corrections are made to raising exceptions.