### PR TITLE
Add `eval`able `repr` for empty `PauliList`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -204,6 +204,8 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         return self._truncated_str(False)
 
     def _truncated_str(self, show_class):
+        if self._num_paulis == 0 and show_class:
+            return "PauliList(['" + ("I" * self.num_qubits) + "'])[:0]"
         stop = self._num_paulis
         if self.__truncate__ and self.num_qubits > 0:
             max_paulis = self.__truncate__ // self.num_qubits

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -332,6 +332,14 @@ class TestPauliListProperties(QiskitTestCase):
         self.assertEqual(pauli1, pauli1)
         self.assertNotEqual(pauli1, pauli2)
 
+    def test_repr(self):
+        """Test __repr__ method."""
+        pauli = PauliList(["XXX", "iYYY"])
+        empty_pauli = pauli[:0]
+        self.assertEqual(repr(pauli), "PauliList(['XXX', 'iYYY'])")
+        self.assertEqual(len(empty_pauli), 0)
+        self.assertEqual(repr(empty_pauli), "PauliList(['III'])[:0]")
+
     def test_len_methods(self):
         """Test __len__ method."""
         for j in range(1, 10):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This makes it so an empty `PauliList` has a `repr` that allows it to be constructed again, with the correct `num_qubits`:

```python
>>> from qiskit.quantum_info import PauliList
>>> PauliList(["XXX", "iZZZ"])[[]]
PauliList(['III'])[:0]
>>> PauliList(['III'])[:0]
PauliList(['III'])[:0]
```

### Details and comments

Fixes #9727

