### PR TITLE
Synthesis of a stabilizer state for LNN connectivity

### DIFF
--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -121,5 +121,5 @@ from .cnotdihedral import (
     synth_cnotdihedral_two_qubits,
     synth_cnotdihedral_general,
 )
-from .stabilizer import synth_stabilizer_layers
+from .stabilizer import synth_stabilizer_layers, synth_stabilizer_depth_lnn
 from .discrete_basis import SolovayKitaevDecomposition, generate_basic_approximations

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -78,6 +78,15 @@ CNOTDihedral Synthesis
    synth_cnotdihedral_two_qubits
    synth_cnotdihedral_general
 
+Stabilizer State Synthesis
+==========================
+
+.. autosummary::
+   :toctree: ../stubs/
+
+   synth_stabilizer_layers
+   synth_stabilizer_depth_lnn
+
 Discrete Basis Synthesis
 ========================
 

--- a/qiskit/synthesis/__init__.py
+++ b/qiskit/synthesis/__init__.py
@@ -121,4 +121,5 @@ from .cnotdihedral import (
     synth_cnotdihedral_two_qubits,
     synth_cnotdihedral_general,
 )
+from .stabilizer import synth_stabilizer_layers
 from .discrete_basis import SolovayKitaevDecomposition, generate_basic_approximations

--- a/qiskit/synthesis/clifford/__init__.py
+++ b/qiskit/synthesis/clifford/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018.
+# (C) Copyright IBM 2017 - 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/synthesis/clifford/__init__.py
+++ b/qiskit/synthesis/clifford/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017 - 2023.
+# (C) Copyright IBM 2017, 2018, 2021, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/synthesis/clifford/__init__.py
+++ b/qiskit/synthesis/clifford/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2017, 2018, 2021, 2023.
+# (C) Copyright IBM 2017, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit/synthesis/stabilizer/__init__.py
+++ b/qiskit/synthesis/stabilizer/__init__.py
@@ -1,0 +1,15 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Module containing stabilizer state preparation circuit synthesis."""
+
+from .stabilizer_decompose import synth_stabilizer_layers

--- a/qiskit/synthesis/stabilizer/__init__.py
+++ b/qiskit/synthesis/stabilizer/__init__.py
@@ -12,4 +12,4 @@
 
 """Module containing stabilizer state preparation circuit synthesis."""
 
-from .stabilizer_decompose import synth_stabilizer_layers
+from .stabilizer_decompose import synth_stabilizer_layers, synth_stabilizer_depth_lnn

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -30,7 +30,45 @@ def synth_stabilizer_layers(
     cz_func_reverse_qubits=False,
     validate=False,
 ):
-    """Synthesis of a stabilizer state into layers."""
+    """Synthesis of a stabilizer state into layers.
+
+    It provides a similar decomposition to the synthesis described in Lemma 8 of Bravyi and Maslov,
+    without the initial Hadamard-free sub-circuit which do not affect the stabilizer state.
+
+    For example, a 5-qubit Clifford circuit is decomposed into the following layers:
+
+    .. parsed-literal::
+             ┌─────┐┌─────┐┌─────┐┌─────┐┌────────┐
+        q_0: ┤0    ├┤0    ├┤0    ├┤0    ├┤0       ├
+             │     ││     ││     ││     ││        │
+        q_1: ┤1    ├┤1    ├┤1    ├┤1    ├┤1       ├
+             │     ││     ││     ││     ││        │
+        q_2: ┤2 H2 ├┤2 S1 ├┤2 CZ ├┤2 H1 ├┤2 Pauli ├
+             │     ││     ││     ││     ││        │
+        q_3: ┤3    ├┤3    ├┤3    ├┤3    ├┤3       ├
+             │     ││     ││     ││     ││        │
+        q_4: ┤4    ├┤4    ├┤4    ├┤4    ├┤4       ├
+             └─────┘└─────┘└─────┘└─────┘└────────┘
+
+    Args:
+        stab (StabilizerState): a stabilizer state.
+        cz_synth_func (Callable): a function to decompose the CZ sub-circuit.
+            It gets as input a boolean symmetric matrix, and outputs a QuantumCircuit.
+        validate (Boolean): if True, validates the synthesis process.
+        cz_func_reverse_qubits (Boolean): True only if cz_synth_func is synth_cz_depth_line_mr,
+            since this function returns a circuit that reverts the order of qubits.
+
+    Return:
+        QuantumCircuit: a circuit implementation of the Clifford.
+
+    Raises:
+        QiskitError: if the input is not a StabilizerState.
+
+    Reference:
+        1. S. Bravyi, D. Maslov, *Hadamard-free circuits expose the
+           structure of the Clifford group*,
+           `arXiv:2003.09412 [quant-ph] <https://arxiv.org/abs/2003.09412>`_
+    """
 
     if not isinstance(stab, StabilizerState):
         raise QiskitError("The input is not a StabilizerState.")
@@ -62,7 +100,23 @@ def synth_stabilizer_layers(
 
 
 def synth_stabilizer_depth_lnn(stab):
-    """Synthesis of an n-qubit stabilizer state for LNN connectivity in depth 2n+2."""
+    """Synthesis of an n-qubit stabilizer state for linear-nearest neighbour connectivity,
+    in 2-qubit depth 2*n+2, and two distinct CX layers.
+
+    Args:
+        stab (StabilizerState): a stabilizer state.
+
+    Return:
+        QuantumCircuit: a circuit implementation of the Clifford.
+
+    Reference:
+        1. S. Bravyi, D. Maslov, *Hadamard-free circuits expose the
+           structure of the Clifford group*,
+           `arXiv:2003.09412 [quant-ph] <https://arxiv.org/abs/2003.09412>`_
+        2. Dmitri Maslov, Martin Roetteler,
+           *Shorter stabilizer circuits via Bruhat decomposition and quantum circuit transformations*,
+           `arXiv:1705.09176 <https://arxiv.org/abs/1705.09176>`_.
+    """
 
     circ = synth_stabilizer_layers(
         stab,

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -1,0 +1,47 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+Circuit synthesis for a stabilizer state preparation circuit.
+"""
+# pylint: disable=invalid-name
+
+from qiskit.circuit import QuantumCircuit
+from qiskit.exceptions import QiskitError
+from qiskit.quantum_info.states import StabilizerState
+from qiskit.synthesis.clifford.clifford_decompose_layers import synth_clifford_layers
+
+
+def synth_stabilizer_layers(stab):
+    """Synthesis of a stabilizer state into layers."""
+
+    if not isinstance(stab, StabilizerState):
+        raise QiskitError("The input is not a StabilizerState.")
+
+    cliff = stab.clifford
+    num_qubits = cliff.num_qubits
+    qubit_list = list(range(num_qubits))
+
+    circ = synth_clifford_layers(cliff)
+    H2_circ = circ.data[3]
+    S1_circ = circ.data[4]
+    CZ1_circ = circ.data[5]
+    H1_circ = circ.data[6]
+    pauli_circ = circ.data[7]
+
+    stab_circuit = QuantumCircuit(num_qubits)
+    stab_circuit.append(H2_circ, qubit_list)
+    stab_circuit.append(S1_circ, qubit_list)
+    stab_circuit.append(CZ1_circ, qubit_list)
+    stab_circuit.append(H1_circ, qubit_list)
+    stab_circuit.append(pauli_circ, qubit_list)
+
+    return stab_circuit

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -21,6 +21,7 @@ from qiskit.synthesis.linear_phase import synth_cz_depth_line_mr
 from qiskit.synthesis.clifford.clifford_decompose_layers import (
     synth_clifford_layers,
     _default_cz_synth_func,
+    _default_cx_synth_func,
 )
 
 
@@ -35,7 +36,7 @@ def synth_stabilizer_layers(
     It provides a similar decomposition to the synthesis described in Lemma 8 of Bravyi and Maslov,
     without the initial Hadamard-free sub-circuit which do not affect the stabilizer state.
 
-    For example, a 5-qubit Clifford circuit is decomposed into the following layers:
+    For example, a 5-qubit stabilizer state is decomposed into the following layers:
 
     .. parsed-literal::
              ┌─────┐┌─────┐┌─────┐┌─────┐┌────────┐
@@ -59,7 +60,7 @@ def synth_stabilizer_layers(
             since this function returns a circuit that reverts the order of qubits.
 
     Return:
-        QuantumCircuit: a circuit implementation of the Clifford.
+        QuantumCircuit: a circuit implementation of the stabilizer state.
 
     Raises:
         QiskitError: if the input is not a StabilizerState.
@@ -81,6 +82,7 @@ def synth_stabilizer_layers(
         cliff,
         cz_synth_func=cz_synth_func,
         cz_func_reverse_qubits=cz_func_reverse_qubits,
+        cx_synth_func=_default_cx_synth_func,
         validate=validate,
     )
     H2_circ = circ.data[-5]
@@ -101,13 +103,13 @@ def synth_stabilizer_layers(
 
 def synth_stabilizer_depth_lnn(stab):
     """Synthesis of an n-qubit stabilizer state for linear-nearest neighbour connectivity,
-    in 2-qubit depth 2*n+2, and two distinct CX layers.
+    in 2-qubit depth 2*n+2 and two distinct CX layers, using CX and phase gates (S, Sdg or Z).
 
     Args:
         stab (StabilizerState): a stabilizer state.
 
     Return:
-        QuantumCircuit: a circuit implementation of the Clifford.
+        QuantumCircuit: a circuit implementation of the stabilizer state.
 
     Reference:
         1. S. Bravyi, D. Maslov, *Hadamard-free circuits expose the

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -14,14 +14,19 @@ Circuit synthesis for a stabilizer state preparation circuit.
 """
 # pylint: disable=invalid-name
 
+import numpy as np
 from qiskit.circuit import QuantumCircuit
 from qiskit.exceptions import QiskitError
 from qiskit.quantum_info.states import StabilizerState
+from qiskit.synthesis.linear.linear_matrix_utils import (
+    calc_inverse_matrix,
+)
 from qiskit.synthesis.linear_phase import synth_cz_depth_line_mr
 from qiskit.synthesis.clifford.clifford_decompose_layers import (
-    synth_clifford_layers,
     _default_cz_synth_func,
-    _default_cx_synth_func,
+    _reverse_clifford,
+    _create_graph_state,
+    _decompose_graph_state,
 )
 
 
@@ -76,29 +81,84 @@ def synth_stabilizer_layers(
 
     cliff = stab.clifford
     num_qubits = cliff.num_qubits
-    qubit_list = list(range(num_qubits))
 
-    circ = synth_clifford_layers(
-        cliff,
-        cz_synth_func=cz_synth_func,
-        cz_func_reverse_qubits=cz_func_reverse_qubits,
-        cx_synth_func=_default_cx_synth_func,
-        validate=validate,
+    if cz_func_reverse_qubits:
+        cliff0 = _reverse_clifford(cliff)
+    else:
+        cliff0 = cliff
+
+    H1_circ, cliff1 = _create_graph_state(cliff0, validate=validate)
+
+    H2_circ, CZ1_circ, S1_circ, _ = _decompose_graph_state(
+        cliff1, validate=validate, cz_synth_func=cz_synth_func
     )
-    H2_circ = circ.data[-5]
-    S1_circ = circ.data[-4]
-    CZ1_circ = circ.data[-3]
-    H1_circ = circ.data[-2]
-    pauli_circ = circ.data[-1]
 
-    stab_circuit = QuantumCircuit(num_qubits)
-    stab_circuit.append(H2_circ, qubit_list)
-    stab_circuit.append(S1_circ, qubit_list)
-    stab_circuit.append(CZ1_circ, qubit_list)
-    stab_circuit.append(H1_circ, qubit_list)
-    stab_circuit.append(pauli_circ, qubit_list)
+    qubit_list = list(range(num_qubits))
+    layeredCircuit = QuantumCircuit(num_qubits)
 
-    return stab_circuit
+    layeredCircuit.append(H2_circ, qubit_list)
+    layeredCircuit.append(S1_circ, qubit_list)
+    layeredCircuit.append(CZ1_circ, qubit_list)
+
+    if cz_func_reverse_qubits:
+        H1_circ = H1_circ.reverse_bits()
+    layeredCircuit.append(H1_circ, qubit_list)
+
+    # Add Pauli layer to fix the Clifford phase signs
+    # pylint: disable=cyclic-import
+    from qiskit.quantum_info.operators.symplectic import Clifford
+
+    clifford_target = Clifford(layeredCircuit)
+    pauli_circ = _calc_pauli_diff_stabilizer(cliff, clifford_target)
+    layeredCircuit.append(pauli_circ, qubit_list)
+
+    return layeredCircuit
+
+
+def _calc_pauli_diff_stabilizer(cliff, cliff_target):
+    """Given two Cliffords whose stabilizers differ by a Pauli, we find this Pauli."""
+
+    # pylint: disable=cyclic-import
+    from qiskit.quantum_info.operators.symplectic import Pauli
+
+    num_qubits = cliff.num_qubits
+    if cliff.num_qubits != cliff_target.num_qubits:
+        raise QiskitError("num_qubits is not the same for the original clifford and the target.")
+
+    # stabilizer generators of the original clifford
+    stab_gen = StabilizerState(cliff).clifford.to_dict()["stabilizer"]
+
+    # stabilizer state of the target clifford
+    ts = StabilizerState(cliff_target)
+
+    phase_destab = [False] * num_qubits
+    phase_stab = [ts.expectation_value(Pauli(stab_gen[i])) == -1 for i in range(num_qubits)]
+
+    phase = []
+    phase.extend(phase_destab)
+    phase.extend(phase_stab)
+    phase = np.array(phase, dtype=int)
+
+    A = cliff.symplectic_matrix.astype(int)
+    Ainv = calc_inverse_matrix(A)
+
+    # By carefully writing how X, Y, Z gates affect each qubit, all we need to compute
+    # is A^{-1} * (phase)
+    C = np.matmul(Ainv, phase) % 2
+
+    # Create the Pauli
+    pauli_circ = QuantumCircuit(num_qubits, name="Pauli")
+    for k in range(num_qubits):
+        destab = C[k]
+        stab = C[k + num_qubits]
+        if stab and destab:
+            pauli_circ.y(k)
+        elif stab:
+            pauli_circ.x(k)
+        elif destab:
+            pauli_circ.z(k)
+
+    return pauli_circ
 
 
 def synth_stabilizer_depth_lnn(stab):

--- a/qiskit/synthesis/stabilizer/stabilizer_decompose.py
+++ b/qiskit/synthesis/stabilizer/stabilizer_decompose.py
@@ -45,11 +45,11 @@ def synth_stabilizer_layers(
         cz_func_reverse_qubits=cz_func_reverse_qubits,
         validate=validate,
     )
-    H2_circ = circ.data[3]
-    S1_circ = circ.data[4]
-    CZ1_circ = circ.data[5]
-    H1_circ = circ.data[6]
-    pauli_circ = circ.data[7]
+    H2_circ = circ.data[-5]
+    S1_circ = circ.data[-4]
+    CZ1_circ = circ.data[-3]
+    H1_circ = circ.data[-2]
+    pauli_circ = circ.data[-1]
 
     stab_circuit = QuantumCircuit(num_qubits)
     stab_circuit.append(H2_circ, qubit_list)

--- a/releasenotes/notes/stabilizer_state_synthesis-c48c0389941715a6.yaml
+++ b/releasenotes/notes/stabilizer_state_synthesis-c48c0389941715a6.yaml
@@ -3,7 +3,7 @@ features:
   - |
     Add a new synthesis method :class:`.synth_stabilizer_layers` of a stabilizer state into layers.
     It provides a similar decomposition to the synthesis described in Lemma 8 of Bravyi and Maslov,
-    (arxiv:2003.09412) without the initial Hadamard-free sub-circuit which do not affect the stabilizer state.
+    (arxiv:2003.09412) without the initial Hadamard-free sub-circuit which does not affect the stabilizer state.
   - |
     Add a new synthesis method :class:`.synth_stabilizer_lnn` of a stabilizer state
     for linear nearest neighbor connectivity in 2-qubit depth of 2n+2 and two distinct CX layers,

--- a/releasenotes/notes/stabilizer_state_synthesis-c48c0389941715a6.yaml
+++ b/releasenotes/notes/stabilizer_state_synthesis-c48c0389941715a6.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    Add a new synthesis method :class:`.synth_stabilizer_layers` of a stabilizer state into layers.
+    It provides a similar decomposition to the synthesis described in Lemma 8 of Bravyi and Maslov,
+    (arxiv:2003.09412) without the initial Hadamard-free sub-circuit which do not affect the stabilizer state.
+  - |
+    Add a new synthesis method :class:`.synth_stabilizer_lnn` of a stabilizer state
+    for linear nearest neighbor connectivity in 2-qubit depth of 2n+2 and two distinct CX layers,
+    using CX and phase gates (S, Sdg or Z).
+    The synthesis algorithm is based on the paper of Maslov and Roetteler (https://arxiv.org/abs/1705.09176).

--- a/test/python/synthesis/test_clifford_decompose_layers.py
+++ b/test/python/synthesis/test_clifford_decompose_layers.py
@@ -10,7 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Tests for Clifford class."""
+"""Tests for Clifford synthesis methods."""
 
 import unittest
 from test import combine

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -74,8 +74,8 @@ class TestStabDecomposeLayers(QiskitTestCase):
             # Verify that the two stabilizers produce the same probabilities
             self.assertEqual(stab.probabilities_dict(), stab_target.probabilities_dict())
 
-    @combine(num_qubits=[4, 5])
-    def test_reduced_inverse_clifford(self, num_qubits):
+    @combine(num_qubits=[4, 5], method_lnn=[True, False])
+    def test_reduced_inverse_clifford(self, num_qubits, method_lnn):
         """Test that one can use this stabilizer state synthesis method to calculate an inverse Clifford
         that preserves the ground state |0...0>, with a reduced circuit depth.
         This is useful for multi-qubit Randomized Benchmarking."""
@@ -86,16 +86,15 @@ class TestStabDecomposeLayers(QiskitTestCase):
             circ_orig = cliff.to_circuit()
             stab = StabilizerState(cliff)
             # Calculate the reduced-depth inverse Clifford
-            circ_inv = synth_stabilizer_layers(stab, validate=True).inverse()
-            circ_inv_lnn = synth_stabilizer_depth_lnn(stab).inverse()
+            if method_lnn:
+                circ_inv = synth_stabilizer_depth_lnn(stab).inverse()
+            else:
+                circ_inv = synth_stabilizer_layers(stab, validate=True).inverse()
             circ = circ_orig.compose(circ_inv)
-            circ_lnn = circ_orig.compose(circ_inv_lnn)
             stab = StabilizerState(circ)
-            stab_lnn = StabilizerState(circ_lnn)
             # Verify that we get back the ground state |0...0> with probability 1
             target_probs = {"0" * num_qubits: 1}
             self.assertEqual(stab.probabilities_dict(), target_probs)
-            self.assertEqual(stab_lnn.probabilities_dict(), target_probs)
 
 
 if __name__ == "__main__":

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -75,7 +75,7 @@ class TestStabDecomposeLayers(QiskitTestCase):
             self.assertEqual(stab.probabilities_dict(), stab_target.probabilities_dict())
 
     @combine(num_qubits=[4, 5])
-    def test_reduced_inverse_clifford(self, num_qubits=4):
+    def test_reduced_inverse_clifford(self, num_qubits):
         """Test that one can use this stabilizer state synthesis method to calculate an inverse Clifford
         that preserves the ground state |0...0>, with a reduced circuit depth.
         This is useful for multi-qubit Randomized Benchmarking."""

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -32,8 +32,8 @@ class TestStabDecomposeLayers(QiskitTestCase):
 
     @combine(num_qubits=[4, 5, 6, 7])
     def test_decompose_stab(self, num_qubits):
-        """Create layer decomposition for a Clifford U, and check that it
-        results in an equivalent Clifford."""
+        """Create layer decomposition for a stabilizer state, and check that it
+        results in an equivalent stabilizer state."""
         rng = np.random.default_rng(1234)
         samples = 10
         for _ in range(samples):
@@ -61,12 +61,12 @@ class TestStabDecomposeLayers(QiskitTestCase):
             cliff = random_clifford(num_qubits, seed=rng)
             stab = StabilizerState(cliff)
             circ = synth_stabilizer_depth_lnn(stab)
-            # Check that the Clifford circuit 2-qubit depth equals 2*n+2
+            # Check that the stabilizer state circuit 2-qubit depth equals 2*n+2
             depth2q = (circ.decompose()).depth(
                 filter_function=lambda x: x.operation.num_qubits == 2
             )
             self.assertTrue(depth2q == 2 * num_qubits + 2)
-            # Check that the Clifford circuit has linear nearest neighbour connectivity
+            # Check that the stabilizer state circuit has linear nearest neighbour connectivity
             self.assertTrue(check_lnn_connectivity(circ.decompose()))
             stab_target = StabilizerState(circ)
             # Verify that the two stabilizers generate the same state

--- a/test/python/synthesis/test_stabilizer_synthesis.py
+++ b/test/python/synthesis/test_stabilizer_synthesis.py
@@ -1,0 +1,58 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for stabilizer state synthesis methods."""
+
+
+import unittest
+from test import combine
+from ddt import ddt
+
+import numpy as np
+
+from qiskit.test import QiskitTestCase
+from qiskit.quantum_info.states import StabilizerState
+from qiskit.quantum_info import random_clifford
+from qiskit.synthesis.stabilizer import synth_stabilizer_layers
+
+# from qiskit.synthesis.linear.linear_circuits_utils import check_lnn_connectivity
+
+
+@ddt
+class TestStabDecomposeLayers(QiskitTestCase):
+    """Tests for stabilizer state decomposition functions."""
+
+    @combine(num_qubits=[4, 5, 6, 7])
+    def test_decompose_stab(self, num_qubits):
+        """Create layer decomposition for a Clifford U, and check that it
+        results in an equivalent Clifford."""
+        rng = np.random.default_rng(1234)
+        samples = 10
+        for _ in range(samples):
+            cliff = random_clifford(num_qubits, seed=rng)
+            stab = StabilizerState(cliff)
+            circ = synth_stabilizer_layers(stab)
+            stab_target = StabilizerState(circ)
+            # Verify that the two stabilizers generate the same state
+            self.assertTrue(stab.equiv(stab_target))
+            # Verify that the two stabilizers produce the same probabilities
+            self.assertEqual(stab.probabilities_dict(), stab_target.probabilities_dict())
+            # Verify the layered structure
+            self.assertEqual(circ.data[0].operation.name, "H2")
+            self.assertEqual(circ.data[1].operation.name, "S1")
+            self.assertEqual(circ.data[2].operation.name, "CZ")
+            self.assertEqual(circ.data[3].operation.name, "H1")
+            self.assertEqual(circ.data[4].operation.name, "Pauli")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
#9036 

Synthesis of a stabilizer state preparation. 
Based on the Clifford layered synthesis, it requires only the layers H2 - S1 - CZ1 - H1, 
so for linear nearest neighbor (LNN) connectivity it has 2q depth 2n+2.

### Details and comments

- [x] `synth_stabilizer_layers` - a general synthesis of a StabilizerState into layers
- [x]  `synth_stabilizer_depth_lnn` - synthesis of a StabilizerState for LNN connectivity in depth 2n+2

Co-authored by: @alexanderivrii 