### PR TITLE
[WIP] introduce GroupingMeasure class

### DIFF
--- a/qiskit/circuit/measure.py
+++ b/qiskit/circuit/measure.py
@@ -37,3 +37,25 @@ class Measure(Instruction):
                 yield qarg, [each_carg]
         else:
             raise CircuitError("register size error")
+
+class GroupingMeasure(Instruction):
+    """
+    Quantum measurement for multiple qubits instruction
+    in the computational basis.
+    """
+
+    def __init__(self, num_qubits):
+                super().__init__("measure", num_qubits, num_qubits, [])
+
+    def broadcast_arguments(self, qargs, cargs):
+        qarg = qargs[0]
+        carg = cargs[0]
+
+        if len(carg) == len(qarg):
+            for qarg, carg in zip(qarg, carg):
+                yield [qarg], [carg]
+        elif len(qarg) == 1 and carg:
+            for each_carg in carg:
+                yield qarg, [each_carg]
+        else:
+            raise CircuitError("register size error")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
This PR introduces GroupingMeasure class which is a sub class of Instruction class and enables to n-qubits syncronized measurement in backendV2.
In previous, the class for measure, Measure class limits the number of  measured qubit is one.
I expect this PR is a first step for solving failure of schedule with backendV2 and being able to measure all qubits.

### Details and comments
related to https://github.com/Qiskit/qiskit-terra/issues/9488.
