### PR TITLE
Remove unnecessary `pip install` in CI

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -24,7 +24,6 @@ jobs:
           pip install -U -r requirements.txt -r requirements-dev.txt -c constraints.txt
           pip install -U -c constraints.txt -e .
           pip install -U "qiskit-aer" -c constraints.txt
-          pip install -e .
         displayName: 'Install dependencies'
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

For the lint job, we already are installing Terra via an editable install:

https://github.com/Qiskit/qiskit-terra/blob/fa7ac688fdce3ecc27fb7e13d8b2c3f8553b3ff8/.azure/lint-linux.yml#L25-L27

No need to reinstall Terra again. The Aer installation respects the prior editable install:

> Requirement already satisfied: qiskit-terra>=0.21.0 in ./test-job/lib/python3.11/site-packages (from qiskit-aer) (0.24.0)

### Details and comments

https://github.com/Qiskit/qiskit-terra/pull/8501 removed several calls to `python setup.py build_ext --inplace` because they already were covered by the editable install on a prior line. But for the lint job, it replaced that line with `pip install -e .` -- I suspect it was only a mistake not realizing we already had the editable install a few lines above.

