### PR TITLE
Fix Tox installing Terra from PyPI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,11 @@ deps =
   setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
+  # Aer depends on Terra. We want to make sure pip satisfies that requirement from a local
+  # installation, not from PyPI. But Tox normally doesn't install the local installation until
+  # after `deps` is installed. So, instead, we tell pip to do the local installation at the same
+  # time as Aer. See https://github.com/Qiskit/qiskit-terra/pull/9477.
+  -e .
 commands =
   sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,6 @@ deps =
   # installation, not from PyPI. But Tox normally doesn't install the local installation until
   # after `deps` is installed. So, instead, we tell pip to do the local installation at the same
   # time as Aer. See https://github.com/Qiskit/qiskit-terra/pull/9477.
-  -e .
+  .
 commands =
   sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

Solves the issue from https://github.com/Qiskit/qiskit-terra/pull/9477. 

As explained in the code's comment, this results in pip resolving Aer's dependency on Terra via the local installation, not from PyPI.

### Details and comments

How did I test this works? 

* I changed `requirements.txt` to set `python-dateutil==2.8.2`, then added to `deps` `python-dateutil==2.8.1`. That should cause a conflict: the `deps` stage will install `2.8.1`, then when installing Terra locally, we'll try using `2.8.2`. But due to [Tox wonkiness not fixed until Tox 4.4](https://tox.wiki/en/latest/changelog.html#features-4-4-0), tox silently allows for that conflict to happen.
* But, when adding `.` to `deps` as well, pip fails due to the conflict. This indicates that Pip indeed is installing from the local installation during the `deps` stage.
