### PR TITLE
Fix `tox -e docs` for macOS

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -9,6 +9,7 @@ jobs:
 
     variables:
       PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
+      RUST_DEBUG: 1
 
     steps:
       - checkout: self
@@ -29,8 +30,6 @@ jobs:
       - bash: |
           tox -edocs
         displayName: 'Run Docs build'
-        env:
-          SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"
 
       - task: ArchiveFiles@2
         inputs:

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,7 @@
 
 import os
 import re
-import sys
-from setuptools import setup, find_packages, Extension
+from setuptools import setup, find_packages
 from setuptools_rust import Binding, RustExtension
 
 
@@ -100,7 +99,14 @@ setup(
         "Source Code": "https://github.com/Qiskit/qiskit-terra",
     },
     rust_extensions=[
-        RustExtension("qiskit._accelerate", "crates/accelerate/Cargo.toml", binding=Binding.PyO3)
+        RustExtension(
+            "qiskit._accelerate",
+            "crates/accelerate/Cargo.toml",
+            binding=Binding.PyO3,
+            # If RUST_DEBUG is set, force compiling in debug mode. Else, use the default behavior
+            # of whether it's an editable installation.
+            debug=True if os.getenv("RUST_DEBUG") == 1 else None,
+        )
     ],
     zip_safe=False,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
             binding=Binding.PyO3,
             # If RUST_DEBUG is set, force compiling in debug mode. Else, use the default behavior
             # of whether it's an editable installation.
-            debug=True if os.getenv("RUST_DEBUG") == 1 else None,
+            debug=True if os.getenv("RUST_DEBUG") == "1" else None,
         )
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ commands =
 [testenv:docs]
 # Editable mode breaks macOS: https://github.com/sphinx-doc/sphinx/issues/10943
 usedevelop = False
-basepython = python3.9
+basepython = python3
 setenv =
   {[testenv]setenv}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y

--- a/tox.ini
+++ b/tox.ini
@@ -67,24 +67,16 @@ commands =
   coverage3 report
 
 [testenv:docs]
-basepython = python3
+# Editable mode breaks macOS: https://github.com/sphinx-doc/sphinx/issues/10943
+usedevelop = False
+basepython = python3.9
 setenv =
   {[testenv]setenv}
   QISKIT_SUPPRESS_PACKAGING_WARNINGS=Y
+  RUST_DEBUG=1  # Faster to compile.
 deps =
   setuptools_rust  # This is work around for the bug of tox 3 (see #8606 for more details.)
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
 commands =
   sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}
-
-[pycodestyle]
-max-line-length = 105
-# default ignores + E741 because of opflow global variable I
-# + E203 because of a difference of opinion with black
-# codebase does currently comply with: E133, E242, E704, W505
-ignore = E121, E123, E126, E133, E226, E241, E242, E704, W503, W504, W505, E741, E203
-
-[flake8]
-max-line-length = 105
-extend-ignore = E203, E741


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

I was getting 4567 errors on my mac when using `tox -e docs`, in the form of:

```
[autosummary] failed to import qiskit.circuit.classicalfunction.ClassicalFunction.add_decomposition.
Possible hints:
* AttributeError: module 'qiskit.circuit.classicalfunction.ClassicalFunction' has no attribute 'add_decomposition'
* ModuleNotFoundError: No module named 'qiskit.circuit.classicalfunction.ClassicalFunction.add_decomposition'; 'qiskit.circuit.classicalfunction.ClassicalFunction' is not a package
```

This is because editable install can break macOS Sphinx: https://github.com/sphinx-doc/sphinx/issues/10943. (Thank you @jakelishman for the tip!)

### Details and comments

We still use an editable install for all other Tox environments. That avoids needing to rebuild the venv when changes are made to Terra, which is faster and a better developer experience.

For docs, we set `RUST_DEBUG`, which causes Rust to still be compiled in debug mode. The main benefit there is faster compilation.
