### PR TITLE
Suppress PulseSimulator deprecation warning in tests

### DIFF
--- a/test/python/pulse/test_block.py
+++ b/test/python/pulse/test_block.py
@@ -379,7 +379,9 @@ class TestBlockOperation(BaseTestBlock):
             pulse.acquire(50, pulse.AcquireChannel(0), pulse.MemorySlot(0))
 
         backend = FakeArmonk()
-        test_result = backend.run(sched_block).result()
+        # TODO: Rewrite test to simulate with qiskit-dynamics
+        with self.assertWarns(DeprecationWarning):
+            test_result = backend.run(sched_block).result()
         self.assertDictEqual(test_result.get_counts(), {"0": 1024})
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

In the recently released qiskit-aer 0.12.0 the `PulseSimulator` backend (used as its name implies to simulate pulse schedules) was deprecated in favor of the actively maintained qiskit-dynamics package. This deprecation is causing test failures when running our test suite with qiskit-aer installed because a single test was opportunistically using the `PulseSimulator` backend when aer was installed. This commit adds an assertion to catch the `DeprecationWarning` and adds a comment to rewrite the test to use dynamics. Although we may not wish to add the optional bidirectional dependency for a single test, in which case we should just delete the test. But that is a discussion for a follow up PR when CI is not blocked by an upstream/downstream package's release. This commit is just a short term workaround to unblock forward progress.


### Details and comments


