### PR TITLE
For local docs builds, error on first warning

### DIFF
--- a/.azure/docs-linux.yml
+++ b/.azure/docs-linux.yml
@@ -27,7 +27,7 @@ jobs:
         displayName: 'Install dependencies'
 
       - bash: |
-          tox -edocs
+          tox -edocs -- --keep-going
         displayName: 'Run Docs build'
         env:
           SETUPTOOLS_ENABLE_FEATURES: "legacy-editable"

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ deps =
   -r{toxinidir}/requirements-dev.txt
   qiskit-aer
 commands =
-  sphinx-build -W -j auto -T --keep-going -b html docs/ docs/_build/html {posargs}
+  sphinx-build -W -j auto -T -b html docs/ docs/_build/html {posargs}
 
 [pycodestyle]
 max-line-length = 105


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

I've heard several developers mention they get confused how to find Sphinx warnings, as you have to scroll up or search for the errors amidst a lot of noise. Another frustration is it takes too long to get feedback if docs worked or not. Both of those can be improved by removing `--keep-going` for local builds, so that now we error upon the first issue.

(Local developers can still run `tox -e docs -- --keep-going` if they prefer.)

### Details and comments

#### CI still uses `--keep-going`

CI is a different workflow than local iteration. Whereas local iteration usually prioritizes fast feedback, it's valuable for CI to instead show all errors. That allows developers to fix everything at once before pushing to CI again, which is valuable because e.g. CI has lots of overhead.

#### Before and after

I added a bad directive to some docstring.

Before, you would have to be paying attention to the Sphinx output and notice this line:

```
reading sources... [100%] stubs/qiskit.visualization.pulse.IQXDebugging.fromkeys .. stubs/qiskit.visualization.visualize_transition

/Users/arellano/code/qiskit-terra/.tox/docs/lib/python3.9/site-packages/qiskit/algorithms/optimizers/__init__.py:docstring of qiskit.algorithms.optimizers:15: ERROR: Unknown directive type "bad-directive".

.. bad-directive::
  Hello!
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  1%] apidocs/assembler .. stubs/qiskit.algorithms.EstimationProblem
```

If you didn't notice and typed ctrl-c, the build would continue for another ~1.5 minutes. Then you'd get:

```
build finished with problems, 1 warning.
ERROR: InvocationError for command /Users/arellano/code/qiskit-terra/.tox/docs/bin/sphinx-build -W -j auto -T -b html docs/ docs/_build/html --keep-going (exited with code 1)
```

You'd have to either scroll up to manually find the issue, or know to search for "ERROR:" (normally you'd search for "WARNING:").

--

After, you now get this as the last output from Tox -- no need to scroll up or search. And the build stops about 45 seconds in.

```
sphinx.errors.SphinxWarning: /Users/arellano/code/qiskit-terra/.tox/docs/lib/python3.9/site-packages/qiskit/algorithms/optimizers/__init__.py:docstring of qiskit.algorithms.optimizers:15:Unknown directive type "bad-directive".

.. bad-directive::
  Hello!

Warning, treated as error:
/Users/arellano/code/qiskit-terra/.tox/docs/lib/python3.9/site-packages/qiskit/algorithms/optimizers/__init__.py:docstring of qiskit.algorithms.optimizers:15:Unknown directive type "bad-directive".

.. bad-directive::
  Hello!
```
