### PR TITLE
Remove implicit broadcasting from `Pauli`/label construction of `PauliList`

### DIFF
--- a/qiskit/quantum_info/operators/symplectic/pauli_list.py
+++ b/qiskit/quantum_info/operators/symplectic/pauli_list.py
@@ -190,6 +190,11 @@ class PauliList(BasePauli, LinearMixin, GroupMixin):
         base_x = np.zeros((num_paulis, num_qubits), dtype=bool)
         base_phase = np.zeros(num_paulis, dtype=int)
         for i, pauli in enumerate(paulis):
+            if pauli.num_qubits != num_qubits:
+                raise ValueError(
+                    f"The {i}th Pauli is defined over {pauli.num_qubits} qubits, "
+                    f"but num_qubits == {num_qubits} was expected."
+                )
             base_z[i] = pauli._z
             base_x[i] = pauli._x
             base_phase[i] = pauli._phase

--- a/releasenotes/notes/paulilist-do-not-broadcast-from-paulis-96de3832fba21b94.yaml
+++ b/releasenotes/notes/paulilist-do-not-broadcast-from-paulis-96de3832fba21b94.yaml
@@ -2,7 +2,7 @@
 fixes:
   - |
     A bug has been fixed which had allowed broadcasting when a
-    ``PauliList`` is initialized from ``Pauli``s or labels.  For
+    :class:`.PauliList` is initialized from :class:`.Pauli`\ s or labels.  For
     instance, the code ``PauliList(["XXX", "Z"])`` now raises a
     ``ValueError`` rather than constructing the equivalent of
     ``PauliList(["XXX", "ZZZ"])``.

--- a/releasenotes/notes/paulilist-do-not-broadcast-from-paulis-96de3832fba21b94.yaml
+++ b/releasenotes/notes/paulilist-do-not-broadcast-from-paulis-96de3832fba21b94.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    A bug has been fixed which had allowed broadcasting when a
+    ``PauliList`` is initialized from ``Pauli``s or labels.  For
+    instance, the code ``PauliList(["XXX", "Z"])`` now raises a
+    ``ValueError`` rather than constructing the equivalent of
+    ``PauliList(["XXX", "ZZZ"])``.

--- a/test/python/quantum_info/operators/symplectic/test_pauli_list.py
+++ b/test/python/quantum_info/operators/symplectic/test_pauli_list.py
@@ -198,6 +198,10 @@ class TestPauliListInit(QiskitTestCase):
             np.testing.assert_equal(pauli_list.z, z)
             np.testing.assert_equal(pauli_list.x, x)
 
+        with self.subTest(msg="str init prevent broadcasting"):
+            with self.assertRaises(ValueError):
+                PauliList(["XYZ", "I"])
+
     def test_list_init(self):
         """Test list initialization."""
         with self.subTest(msg="PauliList"):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

When constructing a `PauliList` from `Pauli`s or labels, the number of qubits is inferred from the first argument, and a `ValueError` is raised if any subsequent element has a different number of qubits.  For instance:

```python
>>> from qiskit.quantum_info import PauliList
>>> PauliList(["XXX", "ZZ"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/garrison/Qiskit/qiskit-terra3/qiskit/quantum_info/operators/symplectic/pauli_list.py", line 140, in __init__
    base_z, base_x, base_phase = self._from_paulis(data)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/garrison/Qiskit/qiskit-terra3/qiskit/quantum_info/operators/symplectic/pauli_list.py", line 193, in _from_paulis
    base_z[i] = pauli._z
    ~~~~~~^^^
ValueError: could not broadcast input array from shape (2,) into shape (3,)
```

However, if any _single_-qubit `Pauli` or label is provided, it will be implicitly broadcast to the correct number of qubits:

```python
>>> PauliList(["XXX", "Z", "I", "ZYX"])
PauliList(['XXX', 'ZZZ', 'III', 'ZYX'])
```

This PR removes this implicit broadcasting behavior and makes this expression raise a `ValueError` in all cases of mismatched qubit count.  It also provided a clearer error message in all such cases.

### Details and comments

I originally "snuck" this change into #9770, but I realized it is better to pull it out into a separate PR, as it deserves its own discussion (and release note).

IMO this should be considered a bug fix, as the broadcasting behavior is not documented.  (I only accidentally stumbled upon it after writing a test for #9770 which unexpectedly did not raise a `ValueError`.)  In the unlikely case that somebody, somewhere, is relying on this behavior, I think seeing an informative error message upon upgrading to 0.24 will be a fine outcome, i.e., I don't believe a deprecation cycle is necessary.  However, an argument _could_ be made in favor of it.  Either way, I would hesitate to include this change as part of a stable backport.