### PR TITLE
Fix explicitly calibrated gates in `GateDirection`

### DIFF
--- a/qiskit/transpiler/passes/utils/gate_direction.py
+++ b/qiskit/transpiler/passes/utils/gate_direction.py
@@ -166,6 +166,8 @@ class GateDirection(TransformationPass):
                 continue
             if len(node.qargs) != 2:
                 continue
+            if dag.has_calibration_for(node):
+                continue
             qargs = (wire_map[node.qargs[0]], wire_map[node.qargs[1]])
             if qargs not in edges and (qargs[1], qargs[0]) not in edges:
                 raise TranspilerError(
@@ -208,6 +210,8 @@ class GateDirection(TransformationPass):
                 )
                 continue
             if len(node.qargs) != 2:
+                continue
+            if dag.has_calibration_for(node):
                 continue
             qargs = (wire_map[node.qargs[0]], wire_map[node.qargs[1]])
             swapped = (qargs[1], qargs[0])

--- a/releasenotes/notes/fix-gate-direction-calibration-c51202358d86e18f.yaml
+++ b/releasenotes/notes/fix-gate-direction-calibration-c51202358d86e18f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The :class:`.GateDirection` transpiler pass will no longer reject gates that have been given
+    explicit calibrations, but do not exist in the generic coupling map or target.

--- a/test/python/transpiler/test_gate_direction.py
+++ b/test/python/transpiler/test_gate_direction.py
@@ -17,8 +17,8 @@ from math import pi
 
 import ddt
 
-from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
-from qiskit.circuit import Parameter
+from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, pulse
+from qiskit.circuit import Parameter, Gate
 from qiskit.circuit.library import (
     CXGate,
     CZGate,
@@ -438,6 +438,33 @@ class TestGateDirection(QiskitTestCase):
         target.add_instruction(RZXGate(Parameter("a")), {(1, 2): None})
         pass_ = GateDirection(None, target)
         self.assertEqual(pass_(circuit), expected)
+
+    def test_allows_calibrated_gates_coupling_map(self):
+        """Test that the gate direction pass allows a gate that's got a calibration to pass through
+        without error."""
+        cm = CouplingMap([(1, 0)])
+
+        gate = Gate("my_2q_gate", 2, [])
+        circuit = QuantumCircuit(2)
+        circuit.append(gate, (0, 1))
+        circuit.add_calibration(gate, (0, 1), pulse.ScheduleBlock())
+
+        pass_ = GateDirection(cm)
+        self.assertEqual(pass_(circuit), circuit)
+
+    def test_allows_calibrated_gates_target(self):
+        """Test that the gate direction pass allows a gate that's got a calibration to pass through
+        without error."""
+        target = Target(num_qubits=2)
+        target.add_instruction(CXGate(), properties={(0, 1): None})
+
+        gate = Gate("my_2q_gate", 2, [])
+        circuit = QuantumCircuit(2)
+        circuit.append(gate, (0, 1))
+        circuit.add_calibration(gate, (0, 1), pulse.ScheduleBlock())
+
+        pass_ = GateDirection(None, target)
+        self.assertEqual(pass_(circuit), circuit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

If there is an explicit calibration given, this overrides the generic information from the `CouplingMap` or the `Target` for that particular instance, since one can use pulse-level control to define gates on a circuit-by-circuit basis that are not generically available in a way that can be specified in the coupling or target.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Fix #9783