### PR TITLE
Improve error messages in `Target`-based `GateDirection` pass

### DIFF
--- a/qiskit/transpiler/passes/utils/gate_direction.py
+++ b/qiskit/transpiler/passes/utils/gate_direction.py
@@ -195,8 +195,9 @@ class GateDirection(TransformationPass):
                     dag.substitute_node_with_dag(node, self._rzz_dag(*node.op.params))
                 else:
                     raise TranspilerError(
-                        f"Flipping of gate direction is only supported "
-                        f"for {list(self._KNOWN_REPLACEMENTS)} at this time, not '{node.name}'."
+                        f"'{node.name}' would be supported on '{qargs}' if the direction were"
+                        f" swapped, but no rules are known to do that."
+                        f" {list(self._KNOWN_REPLACEMENTS)} can be automatically flipped."
                     )
         return dag
 
@@ -295,8 +296,9 @@ class GateDirection(TransformationPass):
                 _swap_node_qargs(node)
             ):
                 raise TranspilerError(
-                    f"Flipping of gate direction is only supported "
-                    f"for {list(self._KNOWN_REPLACEMENTS)} at this time, not '{node.name}'."
+                    f"'{node.name}' would be supported on '{qargs}' if the direction were"
+                    f" swapped, but no rules are known to do that."
+                    f" {list(self._KNOWN_REPLACEMENTS)} can be automatically flipped."
                 )
             else:
                 raise TranspilerError(

--- a/test/python/transpiler/test_gate_direction.py
+++ b/test/python/transpiler/test_gate_direction.py
@@ -450,7 +450,7 @@ class TestGateDirection(QiskitTestCase):
         circuit.append(gate, (1, 0))
 
         pass_ = GateDirection(None, target)
-        with self.assertRaisesRegex(TranspilerError, "Flipping of gate direction.*"):
+        with self.assertRaisesRegex(TranspilerError, "'my_2q_gate' would be supported.*"):
             pass_(circuit)
 
     def test_target_cannot_flip_message_calibrated(self):
@@ -465,7 +465,7 @@ class TestGateDirection(QiskitTestCase):
         circuit.add_calibration(gate, (0, 1), pulse.ScheduleBlock())
 
         pass_ = GateDirection(None, target)
-        with self.assertRaisesRegex(TranspilerError, "Flipping of gate direction.*"):
+        with self.assertRaisesRegex(TranspilerError, "'my_2q_gate' would be supported.*"):
             pass_(circuit)
 
     def test_target_unknown_gate_message(self):

--- a/test/python/transpiler/test_gate_direction.py
+++ b/test/python/transpiler/test_gate_direction.py
@@ -17,8 +17,8 @@ from math import pi
 
 import ddt
 
-from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
-from qiskit.circuit import Parameter
+from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit, pulse
+from qiskit.circuit import Parameter, Gate
 from qiskit.circuit.library import (
     CXGate,
     CZGate,
@@ -438,6 +438,49 @@ class TestGateDirection(QiskitTestCase):
         target.add_instruction(RZXGate(Parameter("a")), {(1, 2): None})
         pass_ = GateDirection(None, target)
         self.assertEqual(pass_(circuit), expected)
+
+    def test_target_cannot_flip_message(self):
+        """A suitable error message should be emitted if the gate would be supported if it were
+        flipped."""
+        gate = Gate("my_2q_gate", 2, [])
+        target = Target(num_qubits=2)
+        target.add_instruction(gate, properties={(0, 1): None})
+
+        circuit = QuantumCircuit(2)
+        circuit.append(gate, (1, 0))
+
+        pass_ = GateDirection(None, target)
+        with self.assertRaisesRegex(TranspilerError, "Flipping of gate direction.*"):
+            pass_(circuit)
+
+    def test_target_cannot_flip_message_calibrated(self):
+        """A suitable error message should be emitted if the gate would be supported if it were
+        flipped."""
+        target = Target(num_qubits=2)
+        target.add_instruction(CXGate(), properties={(0, 1): None})
+
+        gate = Gate("my_2q_gate", 2, [])
+        circuit = QuantumCircuit(2)
+        circuit.append(gate, (1, 0))
+        circuit.add_calibration(gate, (0, 1), pulse.ScheduleBlock())
+
+        pass_ = GateDirection(None, target)
+        with self.assertRaisesRegex(TranspilerError, "Flipping of gate direction.*"):
+            pass_(circuit)
+
+    def test_target_unknown_gate_message(self):
+        """A suitable error message should be emitted if the gate isn't valid in either direction on
+        the target."""
+        gate = Gate("my_2q_gate", 2, [])
+        target = Target(num_qubits=2)
+        target.add_instruction(CXGate(), properties={(0, 1): None})
+
+        circuit = QuantumCircuit(2)
+        circuit.append(gate, (0, 1))
+
+        pass_ = GateDirection(None, target)
+        with self.assertRaisesRegex(TranspilerError, "'my_2q_gate'.*not supported on qubits .*"):
+            pass_(circuit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

The `Target` version of `GateDirection` has more information available to make better error messages. It can distinguish cases where the failure is because a gate would be valid if flipped but the pass doesn't know how to do it, and the case where the gate wouldn't be valid in either direction.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This addresses the error-message component of #9783.
