### PR TITLE
transpile: narrow the return type depending on the circuits argument

### DIFF
--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -20,7 +20,7 @@ import os
 import pickle
 import sys
 from time import time
-from typing import List, Union, Dict, Callable, Any, Optional, Tuple, Iterable
+from typing import List, Union, Dict, Callable, Any, Optional, Tuple, Iterable, TypeVar
 import warnings
 
 from qiskit import user_config
@@ -57,9 +57,11 @@ else:
 
 logger = logging.getLogger(__name__)
 
+_CircuitT = TypeVar("_CircuitT", bound=Union[QuantumCircuit, List[QuantumCircuit]])
+
 
 def transpile(
-    circuits: Union[QuantumCircuit, List[QuantumCircuit]],
+    circuits: _CircuitT,
     backend: Optional[Backend] = None,
     basis_gates: Optional[List[str]] = None,
     inst_map: Optional[List[InstructionScheduleMap]] = None,
@@ -79,13 +81,13 @@ def transpile(
     callback: Optional[Callable[[BasePass, DAGCircuit, float, PropertySet, int], Any]] = None,
     output_name: Optional[Union[str, List[str]]] = None,
     unitary_synthesis_method: str = "default",
-    unitary_synthesis_plugin_config: dict = None,
-    target: Target = None,
+    unitary_synthesis_plugin_config: Optional[dict] = None,
+    target: Optional[Target] = None,
     hls_config: Optional[HLSConfig] = None,
-    init_method: str = None,
-    optimization_method: str = None,
+    init_method: Optional[str] = None,
+    optimization_method: Optional[str] = None,
     ignore_backend_supplied_default_methods: bool = False,
-) -> Union[QuantumCircuit, List[QuantumCircuit]]:
+) -> _CircuitT:
     """Transpile one or more circuits, according to some desired transpilation targets.
 
     .. deprecated:: 0.23.0

--- a/releasenotes/notes/improve-transpile-typing-de1197f4dd13ac0c.yaml
+++ b/releasenotes/notes/improve-transpile-typing-de1197f4dd13ac0c.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Improved the typing annotations on the top-level `transpile` function.
+    The return type is now narrowed correctly depending on the whether a
+    single circuit or a list of circuit was passed.

--- a/releasenotes/notes/improve-transpile-typing-de1197f4dd13ac0c.yaml
+++ b/releasenotes/notes/improve-transpile-typing-de1197f4dd13ac0c.yaml
@@ -1,6 +1,6 @@
 ---
 fixes:
   - |
-    Improved the typing annotations on the top-level `transpile` function.
-    The return type is now narrowed correctly depending on the whether a
+    Improved the typing annotations on the top-level :func:`.transpile` function.
+    The return type is now narrowed correctly depending on whether a
     single circuit or a list of circuit was passed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This patch improves the typing of the (top-level) `qiskit.compiler.transpiler.transpile` function.

### Details and comments

The main change is the introduction of two overloads that allow narrowing the return type depending on whether a single circuit or a list of circuit was passed as the `circuits` argument. This is relevant for uses of Qiskit in a typed context. In this situation, the following snippet currently causes an error:

```python
qc = QuantumCircuit(...)

transpiled_qc = transpile(qc,...)
num_qregs = len(transpiled_qc.qregs)  # pyright: Cannot access member "qregs" for type "List[QuantumCircuit]"
```

A common workaround is to manually narrow the type, which is tedious and distracting:

 ```python
qc = QuantumCircuit(...)

transpiled_qc = transpile(qc,...)
assert isinstance(transpiled_qc, QuantumCircuit)
num_qregs = len(transpiled_qc.qregs)  # ok
```

In addition, the arguments `unitary_synthesis_plugin_config`, `target`, `init_method`, and `optimization_method` were assigned `None` as default value without having a nullable type declared.

