### PR TITLE
Remove shared `black`/`lint/`lint-incr` `envdir` in `tox.ini`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ commands =
   stestr run {posargs}
 
 [testenv:lint]
-envdir = .tox/lint
 basepython = python3
 commands =
   black --check {posargs} qiskit test tools examples setup.py
@@ -36,7 +35,6 @@ commands =
   reno lint
 
 [testenv:lint-incr]
-envdir = .tox/lint
 basepython = python3
 allowlist_externals = git
 commands =
@@ -50,7 +48,6 @@ commands =
   reno lint
 
 [testenv:black]
-envdir = .tox/lint
 commands = black {posargs} qiskit test tools examples setup.py
 
 [testenv:coverage]


### PR DESCRIPTION




<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Under tox3, it was faster to have the `black`, `lint`, and `lint-incr` environments share an `envdir`.  However, tox4 recreates the environment every time one switches from one to another when they share an `envdir`, leading to much slower execution.  Here I've changed these environments to all use the default (unique) directory rather than a shared one.

### Details and comments


Closes #9782.