### PR TITLE
Remove useless `into_iter()` on `Range`

### DIFF
--- a/crates/accelerate/src/dense_layout.rs
+++ b/crates/accelerate/src/dense_layout.rs
@@ -198,7 +198,6 @@ pub fn best_subset(
             .reduce(reduce_identity_fn, reduce_fn)
     } else {
         (0..coupling_shape[0])
-            .into_iter()
             .map(map_fn)
             .reduce(reduce_fn)
             .unwrap()


### PR DESCRIPTION
### Summary

Clippy has started complaining about this on the stable branch, and it's probably correct to do so.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments


