### PR TITLE
Stop using mergify merge queue feature

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,19 +1,5 @@
-queue_rules:
-  - name: automerge
-    conditions:
-      - check-success=Qiskit.qiskit-terra
-
+---
 pull_request_rules:
-  - name: automatic merge on CI success and review
-    conditions:
-      - check-success=Qiskit.qiskit-terra
-      - "#approved-reviews-by>=1"
-      - label=automerge
-      - label!=on hold
-    actions:
-      queue:
-        name: automerge
-        method: squash
   - name: backport
     conditions:
       - label=stable backport potential


### PR DESCRIPTION


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Due to recent changes in the mergify configuration/service the merge queue feature of mergify is no longer working as expected. It's not clear if this just a temporary bug in mergify, a longer term change in behavior (which requires all PR authors to be registered on mergify), or some incompatibility between the github api and mergify. However, because we're no longer able to rely on it we've moved to using github's native merge queue feature [1][2] instead. Since this new merge queue would conflict with mergify's this commit removes the merge queue configuration from the mergify configuration. The configuration for stable backporting is left in place because github doesn't natively offer that feature and it appears to still work fine.

### Details and comments

[1] https://github.blog/changelog/2023-02-08-pull-request-merge-queue-public-beta/
[2] https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue