### PR TITLE
Add github actions workflow to trigger azure

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,0 +1,19 @@
+---
+name: Main CI
+on:
+  pull_request:
+    branches: [ main ]
+  merge_group:
+    branches: [ main ]
+concurrency:
+  group: ${{ github.repository }}-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Azure/pipelines@v1.2
+        with:
+          azure-devops-project-url: 'https://dev.azure.com/qiskit-ci/qiskit-terra'
+          azure-pipeline-name: 'Qiskit.qiskit-terra'
+          azure-devops-token: '${{ secrets.AZURE_DEVOPS_TOKEN }}'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Since the recent adoption of the github merge queue feature CI is not running correctly on enqueued PRs. This is because github emits a different type of event, `merge_group`, for PRs in the merge queue. Unfortunately azure pipelines doesn't appear to have native support to trigger jobs based on this even yet. In the meantime this tries to workaround this limitation by triggering azure CI pipeline runs via github actions. So gha will trigger when we run CI on PRs and in the merge queue instead of azure natively.

### Details and comments