### PR TITLE
Add `remove_sphinx_from_runtime_deprecation_warning()`

### DIFF
--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -26,6 +26,7 @@ Utilities (:mod:`qiskit.utils`)
    deprecate_arguments
    deprecate_func
    deprecate_function
+   remove_sphinx_from_runtime_deprecation_warning
    local_hardware_info
    is_main_process
    apply_prefix
@@ -73,6 +74,7 @@ from .deprecation import (
     deprecate_arguments,
     deprecate_func,
     deprecate_function,
+    remove_sphinx_from_runtime_deprecation_warning,
 )
 from .multiprocessing import local_hardware_info
 from .multiprocessing import is_main_process
@@ -106,6 +108,7 @@ __all__ = [
     "deprecate_arguments",
     "deprecate_func",
     "deprecate_function",
+    "remove_sphinx_from_runtime_deprecation_warning",
     "local_hardware_info",
     "is_main_process",
     "apply_prefix",

--- a/releasenotes/notes/new-deprecation-utilities-066aff05e221d7b1.yaml
+++ b/releasenotes/notes/new-deprecation-utilities-066aff05e221d7b1.yaml
@@ -1,14 +1,9 @@
 ---
 features:
   - |
-    Added the functions ``add_deprecation_to_docstring()``, ``@deprecate_arg``, and
-    ``@deprecate_func`` to ``qiskit.util.deprecation``.
-
-    ``add_deprecation_to_docstring()`` will rewrite the function's docstring to include a
-    Sphinx ``.. deprecated::`` directive so that the deprecation shows up in docs and with
-    ``help()``. The deprecation decorators from ``qiskit.util.deprecation`` call
-    ``add_deprecation_to_docstring()`` already for you; but you can call it directly if you
-    are using different mechanisms for deprecations.
+    Added the functions ``add_deprecation_to_docstring()``, ``@deprecate_arg``,
+    ``@deprecate_func``, and ``remove_sphinx_from_runtime_deprecation_warning()`` to
+    ``qiskit.util.deprecation``.
 
     ``@deprecate_func`` replaces ``@deprecate_function``. It will auto-generate most of the
     deprecation message for you.
@@ -16,3 +11,17 @@ features:
     ``@deprecate_arg`` replaces ``@deprecate_arguments``. It will generate a more useful message
     than before. It is also more flexible, like allowing you to set a ``predicate`` so that you
     only deprecate certain situations, such as using a deprecated value or data type.
+
+    ``add_deprecation_to_docstring()`` will rewrite the function's docstring to include a
+    Sphinx ``.. deprecated::`` directive so that the deprecation shows up in docs and with
+    ``help()``.
+
+    ``remove_sphinx_from_runtime_deprecation_warning()`` removes certain Sphinx-isms from the
+    deprecation message, such as roles like ``:ref:``. This allows you to use Sphinx syntax in your
+    deprecation message so that it is more useful in the docs, without worrying about
+    that syntax making the runtime warning harder to read.
+
+    The deprecation decorators from ``qiskit.util.deprecation`` call
+    ``add_deprecation_to_docstring()`` and ``remove_sphinx_from_runtime_deprecation_warning()``
+    for you already. But you can call them directly if you are using different mechanisms for
+    deprecations.

--- a/test/python/utils/test_deprecation.py
+++ b/test/python/utils/test_deprecation.py
@@ -21,6 +21,7 @@ from qiskit.utils.deprecation import (
     deprecate_arguments,
     deprecate_func,
     deprecate_function,
+    remove_sphinx_from_runtime_deprecation_warning,
 )
 
 
@@ -632,3 +633,25 @@ class AddDeprecationDocstringTest(QiskitTestCase):
 
         with self.assertRaises(ValueError):
             add_deprecation_to_docstring(func, msg="Deprecated!", since="9.99", pending=False)
+
+
+class RemoveSphinxFromDeprecationTest(QiskitTestCase):
+    """Test that ``remove_sphinx_from_runtime_deprecation_warning`` removes Sphinx-isms."""
+
+    def test_remove_sphinx_normalize_code_ticks(self) -> None:
+        """Test that `` gets replaced by `."""
+        self.assertEqual(
+            remove_sphinx_from_runtime_deprecation_warning(
+                "Some ``code``, `italic`, and ``broken code` ```reference``."
+            ),
+            "Some `code`, `italic`, and `broken code` ``reference`.",
+        )
+
+    def test_remove_sphinx_roles(self) -> None:
+        """Test that roles like `:ref:` and `:py:func` are removed."""
+        self.assertEqual(
+            remove_sphinx_from_runtime_deprecation_warning(
+                ":ref:blah, :py:class:MyClass, :func:`groovy()`"
+            ),
+            "blah, MyClass, `groovy()`",
+        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Some docstring authors are interested in using Sphinx features like roles (e.g. `:class:`) in their deprecation message so that the docs are more useful: https://github.com/Qiskit/qiskit-machine-learning/pull/574

However, it would be noisy to show that Sphinx syntax in the runtime warning. There's a tension between optimizing for the docs site vs. the runtime warning.

So, this new helper will strip out certain Sphinx-isms before calling `warning.warn()`. 

### Details and comments

@woodsp-ibm and I agreed that it is better for us to go this direction than the inverse, where we try to add in Sphinx-isms like references based on the original message. That would be too hard to pull off robustly.
