### PR TITLE
PassManager.run: preserve input signature for length 1 list

### DIFF
--- a/qiskit/transpiler/passmanager.py
+++ b/qiskit/transpiler/passmanager.py
@@ -14,7 +14,7 @@
 
 import io
 import re
-from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable
+from typing import Union, List, Tuple, Callable, Dict, Any, Optional, Iterator, Iterable, TypeVar
 
 import dill
 
@@ -23,6 +23,9 @@ from qiskit.circuit import QuantumCircuit
 from .basepasses import BasePass
 from .exceptions import TranspilerError
 from .runningpassmanager import RunningPassManager, FlowController
+
+
+_CircuitsT = TypeVar("_CircuitsT", bound=Union[List[QuantumCircuit], QuantumCircuit])
 
 
 class PassManager:
@@ -183,10 +186,10 @@ class PassManager:
 
     def run(
         self,
-        circuits: Union[QuantumCircuit, List[QuantumCircuit]],
-        output_name: str = None,
-        callback: Callable = None,
-    ) -> Union[QuantumCircuit, List[QuantumCircuit]]:
+        circuits: _CircuitsT,
+        output_name: Optional[str] = None,
+        callback: Optional[Callable] = None,
+    ) -> _CircuitsT:
         """Run all the passes on the specified ``circuits``.
 
         Args:
@@ -227,7 +230,7 @@ class PassManager:
         if isinstance(circuits, QuantumCircuit):
             return self._run_single_circuit(circuits, output_name, callback)
         if len(circuits) == 1:
-            return self._run_single_circuit(circuits[0], output_name, callback)
+            return [self._run_single_circuit(circuits[0], output_name, callback)]
         return self._run_several_circuits(circuits, output_name, callback)
 
     def _create_running_passmanager(self) -> RunningPassManager:
@@ -244,7 +247,10 @@ class PassManager:
         return result
 
     def _run_several_circuits(
-        self, circuits: List[QuantumCircuit], output_name: str = None, callback: Callable = None
+        self,
+        circuits: List[QuantumCircuit],
+        output_name: Optional[str] = None,
+        callback: Optional[Callable] = None,
     ) -> List[QuantumCircuit]:
         """Run all the passes on the specified ``circuits``.
 
@@ -266,7 +272,10 @@ class PassManager:
         )
 
     def _run_single_circuit(
-        self, circuit: QuantumCircuit, output_name: str = None, callback: Callable = None
+        self,
+        circuit: QuantumCircuit,
+        output_name: Optional[str] = None,
+        callback: Optional[Callable] = None,
     ) -> QuantumCircuit:
         """Run all the passes on a ``circuit``.
 
@@ -520,10 +529,10 @@ class StagedPassManager(PassManager):
 
     def run(
         self,
-        circuits: Union[QuantumCircuit, List[QuantumCircuit]],
-        output_name: str = None,
-        callback: Callable = None,
-    ) -> Union[QuantumCircuit, List[QuantumCircuit]]:
+        circuits: _CircuitsT,
+        output_name: Optional[str] = None,
+        callback: Optional[Callable] = None,
+    ) -> _CircuitsT:
         self._update_passmanager()
         return super().run(circuits, output_name, callback)
 

--- a/releasenotes/notes/fix-9798-30c0eb0e5181b691.yaml
+++ b/releasenotes/notes/fix-9798-30c0eb0e5181b691.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    The return type of `qiskit.transpiler.passmanager.PassManager.run` is now
+    always the same as that of its first argument. Passing a single circuit
+    returns a single circuit, passing a list of circuits, even of length 1,
+    returns a list of circuits.
+    See `#9798 <https://github.com/Qiskit/qiskit-terra/issues/9798>`.

--- a/test/python/compiler/test_transpiler.py
+++ b/test/python/compiler/test_transpiler.py
@@ -384,10 +384,27 @@ class TestTranspile(QiskitTestCase):
         circuits = transpile(qc, backend)
         self.assertIsInstance(circuits, QuantumCircuit)
 
-    def test_transpile_two(self):
-        """Test transpile to circuits.
+    def test_transpile_one(self):
+        """Test transpile a single circuit.
 
-        If all correct some should exists.
+        Check that the top-level `transpile` function returns
+        a single circuit."""
+        backend = BasicAer.get_backend("qasm_simulator")
+
+        qubit_reg = QuantumRegister(2)
+        clbit_reg = ClassicalRegister(2)
+        qc = QuantumCircuit(qubit_reg, clbit_reg, name="bell")
+        qc.h(qubit_reg[0])
+        qc.cx(qubit_reg[0], qubit_reg[1])
+        qc.measure(qubit_reg, clbit_reg)
+
+        circuit = transpile(qc, backend)
+        self.assertIsInstance(circuit, QuantumCircuit)
+
+    def test_transpile_two(self):
+        """Test transpile two circuits.
+
+        Check that the transpiler returns a list of two circuits.
         """
         backend = BasicAer.get_backend("qasm_simulator")
 
@@ -402,12 +419,19 @@ class TestTranspile(QiskitTestCase):
         qc_extra = QuantumCircuit(qubit_reg, qubit_reg2, clbit_reg, clbit_reg2, name="extra")
         qc_extra.measure(qubit_reg, clbit_reg)
         circuits = transpile([qc, qc_extra], backend)
-        self.assertIsInstance(circuits[0], QuantumCircuit)
-        self.assertIsInstance(circuits[1], QuantumCircuit)
+        self.assertIsInstance(circuits, list)
+        self.assertEqual(len(circuits), 2)
+
+        for circuit in circuits:
+            self.assertIsInstance(circuit, QuantumCircuit)
 
     def test_transpile_singleton(self):
         """Test transpile a single-element list with a circuit.
-        See https://github.com/Qiskit/qiskit-terra/issues/5260"""
+
+        Check that `transpile` returns a single-element list.
+
+        See https://github.com/Qiskit/qiskit-terra/issues/5260
+        """
         backend = BasicAer.get_backend("qasm_simulator")
 
         qubit_reg = QuantumRegister(2)
@@ -418,6 +442,7 @@ class TestTranspile(QiskitTestCase):
         qc.measure(qubit_reg, clbit_reg)
 
         circuits = transpile([qc], backend)
+        self.assertIsInstance(circuits, list)
         self.assertEqual(len(circuits), 1)
         self.assertIsInstance(circuits[0], QuantumCircuit)
 

--- a/test/python/transpiler/test_passmanager_run.py
+++ b/test/python/transpiler/test_passmanager_run.py
@@ -17,12 +17,45 @@ from qiskit.circuit.library import CXGate
 from qiskit.transpiler.preset_passmanagers import level_1_pass_manager
 from qiskit.test import QiskitTestCase
 from qiskit.providers.fake_provider import FakeMelbourne
-from qiskit.transpiler import Layout
+from qiskit.transpiler import Layout, PassManager
 from qiskit.transpiler.passmanager_config import PassManagerConfig
 
 
 class TestPassManagerRun(QiskitTestCase):
     """Test default_pass_manager.run(circuit(s))."""
+
+    def test_bare_pass_manager_single(self):
+        """Test that PassManager.run(circuit) returns a single circuit."""
+        qc = QuantumCircuit(1)
+        pm = PassManager([])
+        new_qc = pm.run(qc)
+        self.assertIsInstance(new_qc, QuantumCircuit)
+        self.assertEqual(qc, new_qc)  # pm has no passes
+
+    def test_bare_pass_manager_single_list(self):
+        """Test that PassManager.run([circuit]) returns a list with a single circuit."""
+        qc = QuantumCircuit(1)
+        pm = PassManager([])
+        result = pm.run([qc])
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertIsInstance(result[0], QuantumCircuit)
+        self.assertEqual(result[0], qc)  # pm has no passes
+
+    def test_bare_pass_manager_multiple(self):
+        """Test that PassManager.run(circuits) returns a list of circuits."""
+        qc0 = QuantumCircuit(1)
+        qc1 = QuantumCircuit(2)
+
+        pm = PassManager([])
+        result = pm.run([qc0, qc1])
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 2)
+
+        for qc, new_qc in zip([qc0, qc1], result):
+            self.assertIsInstance(new_qc, QuantumCircuit)
+            self.assertEqual(new_qc, qc)  # pm has no passes
 
     def test_default_pass_manager_single(self):
         """Test default_pass_manager.run(circuit).
@@ -61,6 +94,7 @@ class TestPassManagerRun(QiskitTestCase):
             )
         )
         new_circuit = pass_manager.run(circuit)
+        self.assertIsInstance(new_circuit, QuantumCircuit)
 
         bit_indices = {bit: idx for idx, bit in enumerate(new_circuit.qregs[0])}
 
@@ -110,8 +144,11 @@ class TestPassManagerRun(QiskitTestCase):
             )
         )
         new_circuits = pass_manager.run([circuit1, circuit2])
+        self.assertIsInstance(new_circuits, list)
+        self.assertEqual(len(new_circuits), 2)
 
         for new_circuit in new_circuits:
+            self.assertIsInstance(new_circuit, QuantumCircuit)
             bit_indices = {bit: idx for idx, bit in enumerate(new_circuit.qregs[0])}
 
             for instruction in new_circuit.data:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary

This patch fixes #9798 by returning a length-1 list if the input to `PassManager.run` was a length-1 list.

### Details and comments

- dedicated regression tests are added to `test.python.transpiler.test_passmanager_run`
- type annotations on `PassManager.run` and `StagedPassManager.run` are` fixed / improved.

Fixes #9798.