### PR TITLE
Fix `QuantumCircuit.qasm` with `reset`

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -1683,7 +1683,7 @@ class QuantumCircuit:
                     bit_labels[clbit],
                 )
             elif operation.name == "reset":
-                string_temp += f"reset {bit_labels[instruction.qubits[0]]}\n"
+                string_temp += f"reset {bit_labels[instruction.qubits[0]]};\n"
             elif operation.name == "barrier":
                 qargs = ",".join(bit_labels[q] for q in instruction.qubits)
                 string_temp += "barrier;\n" if not qargs else f"barrier {qargs};\n"

--- a/releasenotes/notes/fix-qasm-reset-ef7b07bf55875be7.yaml
+++ b/releasenotes/notes/fix-qasm-reset-ef7b07bf55875be7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed :meth:`~.QuantumCircuit.qasm` so that it appends ``;`` after ``reset`` instruction.

--- a/test/python/circuit/test_circuit_qasm.py
+++ b/test/python/circuit/test_circuit_qasm.py
@@ -616,6 +616,18 @@ qreg q[4];
 permutation__2_1_0_ q[0],q[1],q[2];\n"""
         self.assertEqual(qc.qasm(), expected_qasm)
 
+    def test_circuit_qasm_with_reset(self):
+        """Test circuit qasm() method with Reset."""
+        qc = QuantumCircuit(2)
+        qc.reset([0, 1])
+
+        expected_qasm = """OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+reset q[0];
+reset q[1];\n"""
+        self.assertEqual(qc.qasm(), expected_qasm)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [X] I have added the tests to cover my changes.
- [X] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary

`QuantumCircuit.qasm` misses `;` after `reset` as follows. This PR fixes it.

```python
from qiskit import QuantumCircuit

qc = QuantumCircuit(2)
qc.reset(range(2))
print(qc.qasm())
```

main
```
OPENQASM 2.0;
include "qelib1.inc";
qreg q[2];
reset q[0]
reset q[1]
```

this PR
```
OPENQASM 2.0;
include "qelib1.inc";
qreg q[2];
reset q[0];
reset q[1];
```

### Details and comments


