### PR TITLE
Add option to skip deepcopy on dag_to_circuit

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4808,7 +4808,7 @@ def _circuit_from_qasm(qasm: Qasm) -> "QuantumCircuit":
 
     ast = qasm.parse()
     dag = ast_to_dag(ast)
-    return dag_to_circuit(dag)
+    return dag_to_circuit(dag, copy_operations=False)
 
 
 def _standard_compare(value1, value2):

--- a/qiskit/compiler/transpiler.py
+++ b/qiskit/compiler/transpiler.py
@@ -559,7 +559,7 @@ def _remap_circuit_faulty_backend(circuit, num_qubits, backend_prop, faulty_qubi
     dag_circuit = circuit_to_dag(circuit)
     apply_layout_pass = ApplyLayout()
     apply_layout_pass.property_set["layout"] = Layout(physical_layout_dict)
-    circuit = dag_to_circuit(apply_layout_pass.run(dag_circuit))
+    circuit = dag_to_circuit(apply_layout_pass.run(dag_circuit), copy_operations=False)
     circuit._layout = new_layout
     return circuit
 

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -16,11 +16,18 @@ import copy
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
 
 
-def dag_to_circuit(dag):
+def dag_to_circuit(dag, copy_operations=True):
     """Build a ``QuantumCircuit`` object from a ``DAGCircuit``.
 
     Args:
         dag (DAGCircuit): the input dag.
+        copy_operations (bool): Deep copy the operation objects
+            in the :class:`~DAGCircuit` for the output :class:`~.QuantumCircuit`.
+            This should only be set to ``False if the input :class:`~.DAGCircuit`
+            will not be used anymore as the operations in the output
+            :class:`~.QuantumCircuit` will be shared instances and
+            modifications to operations in the :class:`~.DAGCircuit` will
+            be reflected in the :class:`~.QuantumCircuit` (and vice versa).
 
     Return:
         QuantumCircuit: the circuit representing the input dag.
@@ -60,7 +67,10 @@ def dag_to_circuit(dag):
     circuit.calibrations = dag.calibrations
 
     for node in dag.topological_op_nodes():
-        circuit._append(CircuitInstruction(copy.deepcopy(node.op), node.qargs, node.cargs))
+        op = node.op
+        if copy_operations:
+            op = copy.deepcopy(op)
+        circuit._append(CircuitInstruction(op, node.qargs, node.cargs))
 
     circuit.duration = dag.duration
     circuit.unit = dag.unit

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -22,7 +22,7 @@ def dag_to_circuit(dag, copy_operations=True):
     Args:
         dag (DAGCircuit): the input dag.
         copy_operations (bool): Deep copy the operation objects
-            in the :class:`~DAGCircuit` for the output :class:`~.QuantumCircuit`.
+            in the :class:`~.DAGCircuit` for the output :class:`~.QuantumCircuit`.
             This should only be set to ``False`` if the input :class:`~.DAGCircuit`
             will not be used anymore as the operations in the output
             :class:`~.QuantumCircuit` will be shared instances and

--- a/qiskit/converters/dag_to_circuit.py
+++ b/qiskit/converters/dag_to_circuit.py
@@ -23,7 +23,7 @@ def dag_to_circuit(dag, copy_operations=True):
         dag (DAGCircuit): the input dag.
         copy_operations (bool): Deep copy the operation objects
             in the :class:`~DAGCircuit` for the output :class:`~.QuantumCircuit`.
-            This should only be set to ``False if the input :class:`~.DAGCircuit`
+            This should only be set to ``False`` if the input :class:`~.DAGCircuit`
             will not be used anymore as the operations in the output
             :class:`~.QuantumCircuit` will be shared instances and
             modifications to operations in the :class:`~.DAGCircuit` will

--- a/qiskit/transpiler/basepasses.py
+++ b/qiskit/transpiler/basepasses.py
@@ -127,7 +127,7 @@ class BasePass(metaclass=MetaPass):
             property_set.update(self.property_set)
 
         if isinstance(result, DAGCircuit):
-            result_circuit = dag_to_circuit(result)
+            result_circuit = dag_to_circuit(result, copy_operations=False)
         elif result is None:
             result_circuit = circuit.copy()
 

--- a/qiskit/transpiler/passes/basis/basis_translator.py
+++ b/qiskit/transpiler/passes/basis/basis_translator.py
@@ -569,7 +569,7 @@ def _compose_transforms(basis_transforms, source_basis, source_dag):
                     "Updating transform for mapped instr %s %s from \n%s",
                     mapped_instr_name,
                     dag_params,
-                    dag_to_circuit(dag),
+                    dag_to_circuit(dag, copy_operations=False),
                 )
 
             for node in doomed_nodes:
@@ -588,7 +588,7 @@ def _compose_transforms(basis_transforms, source_basis, source_dag):
                     "Updated transform for mapped instr %s %s to\n%s",
                     mapped_instr_name,
                     dag_params,
-                    dag_to_circuit(dag),
+                    dag_to_circuit(dag, copy_operations=False),
                 )
 
     return mapped_instrs

--- a/qiskit/transpiler/passes/utils/control_flow.py
+++ b/qiskit/transpiler/passes/utils/control_flow.py
@@ -25,7 +25,10 @@ def map_blocks(dag_mapping: Callable[[DAGCircuit], DAGCircuit], op: ControlFlowO
     ones.  Each block will be automatically converted to a :class:`.DAGCircuit` and then returned
     to a :class:`.QuantumCircuit`."""
     return op.replace_blocks(
-        [dag_to_circuit(dag_mapping(circuit_to_dag(block))) for block in op.blocks]
+        [
+            dag_to_circuit(dag_mapping(circuit_to_dag(block)), copy_operations=False)
+            for block in op.blocks
+        ]
     )
 
 

--- a/qiskit/transpiler/runningpassmanager.py
+++ b/qiskit/transpiler/runningpassmanager.py
@@ -124,7 +124,7 @@ class RunningPassManager:
             for pass_ in passset:
                 dag = self._do_pass(pass_, dag, passset.options)
 
-        circuit = dag_to_circuit(dag)
+        circuit = dag_to_circuit(dag, copy_operations=False)
         if output_name:
             circuit.name = output_name
         else:

--- a/releasenotes/notes/deepcopy-option-dag_to_circuit-2974aa9e66dc7643.yaml
+++ b/releasenotes/notes/deepcopy-option-dag_to_circuit-2974aa9e66dc7643.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added a new option, ``copy_operations``, to :func:`~.dag_to_circuit` to
+    enable optionally disabling deep copying the operations from the input
+    :class`~.DAGCircuit` to the output :class:`~.QuantumCircuit`. In cases
+    where the input :class`~.DAGCircuit` is not used anymore after conversion
+    this deep copying is unnecessary overhead as any shared references wouldn't
+    have any potential unwanted side effects if the input :class`~.DAGCircuit`
+    is discarded.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit adds a new option, copy_operations, which allows to disable the deepcopy on dag_to_circuit(). Previously the dag to circuit converter would always deep copy the operations, however in the transpiler we don't need this extra overhead because the DAGCircuits are temporary internal artifacts and will not be resused outside of the transpiler. So we can avoid the copy overhead in these situations, however in general the converter needs to default to copying. This new argument enables this workflow by keeping the current behavior by default but enabling the transpiler to skip copying operations in the output conversion.

### Details and comments