### PR TITLE
Fix non-complex dtypes in OneQubitEulerDecomposer methods

### DIFF
--- a/qiskit/quantum_info/synthesis/one_qubit_decompose.py
+++ b/qiskit/quantum_info/synthesis/one_qubit_decompose.py
@@ -252,6 +252,7 @@ class OneQubitEulerDecomposer:
         Returns:
             tuple: (theta, phi, lambda).
         """
+        unitary = np.asarray(unitary, dtype=complex)
         theta, phi, lam, _ = self._params(unitary)
         return theta, phi, lam
 
@@ -264,6 +265,7 @@ class OneQubitEulerDecomposer:
         Returns:
             tuple: (theta, phi, lambda, phase).
         """
+        unitary = np.asarray(unitary, dtype=complex)
         return self._params(unitary)
 
     _params_zyz = staticmethod(euler_one_qubit_decomposer.params_zyz)

--- a/releasenotes/notes/fix-type-angles-euler-decompose-233e5cee7205ed03.yaml
+++ b/releasenotes/notes/fix-type-angles-euler-decompose-233e5cee7205ed03.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :class:`~.OneQubitEulerDecomposer` class's methods
+    :meth:`~.OneQubitEulerDecomposer.angles` and :meth:`~.OneQubitEulerDecomposer.angles_and_phase`
+    would error if the input matrix was of a dtype other than ``complex``/``np.cdouble``. While
+    only a complex matrix can be unitary if the imaginary component is 0 for
+    all elements it could be represented by a different data type. In earlier
+    releases this worked fine but this stopped working in Qiskit Terra 0.23.0
+    when the internals of :class:`~.OneQubitEulerDecomposer` were re-written
+    in Rust.
+    Fixed `#9827 <https://github.com/Qiskit/qiskit-terra/issues/9827>`__

--- a/releasenotes/notes/fix-type-angles-euler-decompose-233e5cee7205ed03.yaml
+++ b/releasenotes/notes/fix-type-angles-euler-decompose-233e5cee7205ed03.yaml
@@ -3,9 +3,7 @@ fixes:
   - |
     Fixed an issue with the :class:`~.OneQubitEulerDecomposer` class's methods
     :meth:`~.OneQubitEulerDecomposer.angles` and :meth:`~.OneQubitEulerDecomposer.angles_and_phase`
-    would error if the input matrix was of a dtype other than ``complex``/``np.cdouble``. While
-    only a complex matrix can be unitary if the imaginary component is 0 for
-    all elements it could be represented by a different data type. In earlier
+    would error if the input matrix was of a dtype other than ``complex``/``np.cdouble``. In earlier
     releases this worked fine but this stopped working in Qiskit Terra 0.23.0
     when the internals of :class:`~.OneQubitEulerDecomposer` were re-written
     in Rust.

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -591,6 +591,44 @@ class TestOneQubitEulerDecomposer(CheckDecompositions):
             self.assertTrue(np.allclose(unitary, Operator(qc_zsx).data))
             self.assertTrue(np.allclose(unitary, Operator(qc_zsxx).data))
 
+    def test_float_input_angles_and_phase(self):
+        """Test angles and phase with float input."""
+        decomposer = OneQubitEulerDecomposer("PSX")
+        input_matrix = np.array(
+            [
+                [0.70710678, 0.70710678],
+                [0.70710678, -0.70710678],
+            ],
+            dtype=np.float64,
+        )
+        (theta, phi, lam, gamma) = decomposer.angles_and_phase(input_matrix)
+        expected_theta = 1.5707963267948966
+        expected_phi = 0.0
+        expected_lam = 3.141592653589793
+        expected_gamma = -0.7853981633974483
+        self.assertAlmostEqual(theta, expected_theta)
+        self.assertAlmostEqual(phi, expected_phi)
+        self.assertAlmostEqual(lam, expected_lam)
+        self.assertAlmostEqual(gamma, expected_gamma)
+
+    def test_float_input_angles(self):
+        """Test angles with float input."""
+        decomposer = OneQubitEulerDecomposer("PSX")
+        input_matrix = np.array(
+            [
+                [0.70710678, 0.70710678],
+                [0.70710678, -0.70710678],
+            ],
+            dtype=np.float64,
+        )
+        (theta, phi, lam) = decomposer.angles_and_phase(input_matrix)
+        expected_theta = 1.5707963267948966
+        expected_phi = 0.0
+        expected_lam = 3.141592653589793
+        self.assertAlmostEqual(theta, expected_theta)
+        self.assertAlmostEqual(phi, expected_phi)
+        self.assertAlmostEqual(lam, expected_lam)
+
 
 # FIXME: streamline the set of test cases
 class TestTwoQubitWeylDecomposition(CheckDecompositions):

--- a/test/python/quantum_info/test_synthesis.py
+++ b/test/python/quantum_info/test_synthesis.py
@@ -621,7 +621,7 @@ class TestOneQubitEulerDecomposer(CheckDecompositions):
             ],
             dtype=np.float64,
         )
-        (theta, phi, lam) = decomposer.angles_and_phase(input_matrix)
+        (theta, phi, lam) = decomposer.angles(input_matrix)
         expected_theta = 1.5707963267948966
         expected_phi = 0.0
         expected_lam = 3.141592653589793


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes a regression introduced in the rewrite of the internals of the OneQubitEulerDecomposer class to be in rust. Previously the angles() and angles_and_phase() methods of OneQubitEulerDecomposer would work with a non-complex dtype in the input, however because the rust component of the module is strictly typed to only work with a complex128 dtype passing the array to rust to compute the angles and phase of the unitary would fail. To address this limitation this commit casts the input matrix to be complex before passing it to the rust function.

### Details and comments

Fixes #9827