### PR TITLE
test_controlled_gate phase correct

### DIFF
--- a/test/python/circuit/test_controlled_gate.py
+++ b/test/python/circuit/test_controlled_gate.py
@@ -255,7 +255,7 @@ class TestControlledGate(QiskitTestCase):
         op_mat = Operator(cgate).data
         cop_mat = _compute_control_matrix(op_mat, num_ctrl)
         ref_mat = Operator(qc).data
-        self.assertTrue(matrix_equal(cop_mat, ref_mat, ignore_phase=True))
+        self.assertTrue(matrix_equal(cop_mat, ref_mat))
 
     def test_single_controlled_composite_gate(self):
         """Test a singly controlled composite gate."""
@@ -275,7 +275,7 @@ class TestControlledGate(QiskitTestCase):
         op_mat = Operator(cgate).data
         cop_mat = _compute_control_matrix(op_mat, num_ctrl)
         ref_mat = Operator(qc).data
-        self.assertTrue(matrix_equal(cop_mat, ref_mat, ignore_phase=True))
+        self.assertTrue(matrix_equal(cop_mat, ref_mat))
 
     def test_control_open_controlled_gate(self):
         """Test control(2) vs control.control where inner gate has open controls."""
@@ -358,9 +358,7 @@ class TestControlledGate(QiskitTestCase):
         for itest in tests:
             info, target, decomp = itest[0], itest[1], itest[2]
             with self.subTest(i=info):
-                self.assertTrue(
-                    matrix_equal(target, decomp, ignore_phase=True, atol=1e-8, rtol=1e-5)
-                )
+                self.assertTrue(matrix_equal(target, decomp, atol=1e-8, rtol=1e-5))
 
     def test_multi_control_u1(self):
         """Test the matrix representation of the controlled and controlled-controlled U1 gate."""
@@ -427,7 +425,7 @@ class TestControlledGate(QiskitTestCase):
             info, target, decomp = itest[0], itest[1], itest[2]
             with self.subTest(i=info):
                 self.log.info(info)
-                self.assertTrue(matrix_equal(target, decomp, ignore_phase=True))
+                self.assertTrue(matrix_equal(target, decomp))
 
     @data(1, 2, 3, 4)
     def test_multi_controlled_u1_matrix(self, num_controls):
@@ -796,7 +794,7 @@ class TestControlledGate(QiskitTestCase):
         test_op = Operator(cgate)
         cop_mat = _compute_control_matrix(base_mat, num_ctrl_qubits)
         self.assertTrue(is_unitary_matrix(base_mat))
-        self.assertTrue(matrix_equal(cop_mat, test_op.data, ignore_phase=True))
+        self.assertTrue(matrix_equal(cop_mat, test_op.data))
 
     @data(1, 2, 3, 4, 5)
     def test_controlled_random_unitary(self, num_ctrl_qubits):
@@ -807,7 +805,7 @@ class TestControlledGate(QiskitTestCase):
         cgate = base_gate.control(num_ctrl_qubits)
         test_op = Operator(cgate)
         cop_mat = _compute_control_matrix(base_mat, num_ctrl_qubits)
-        self.assertTrue(matrix_equal(cop_mat, test_op.data, ignore_phase=True))
+        self.assertTrue(matrix_equal(cop_mat, test_op.data))
 
     @combine(num_ctrl_qubits=[1, 2, 3], ctrl_state=[0, None])
     def test_open_controlled_unitary_z(self, num_ctrl_qubits, ctrl_state):
@@ -1323,7 +1321,7 @@ class TestSingleControlledRotationGates(QiskitTestCase):
             op_mat = Operator(gate).data
         ref_mat = Operator(cgate).data
         cop_mat = _compute_control_matrix(op_mat, self.num_ctrl)
-        self.assertTrue(matrix_equal(cop_mat, ref_mat, ignore_phase=True))
+        self.assertTrue(matrix_equal(cop_mat, ref_mat))
         cqc = QuantumCircuit(self.num_ctrl + self.num_target)
         cqc.append(cgate, cqc.qregs[0])
         dag = circuit_to_dag(cqc)
@@ -1391,12 +1389,7 @@ class TestControlledStandardGates(QiskitTestCase):
                     # 'object has no attribute "control"'
                     # skipping Id and Barrier
                     continue
-                if gate.name == "rz":
-                    iden = Operator.from_label("I")
-                    zgen = Operator.from_label("Z")
-                    base_mat = (np.cos(0.5 * theta) * iden - 1j * np.sin(0.5 * theta) * zgen).data
-                else:
-                    base_mat = Operator(gate).data
+                base_mat = Operator(gate).data
 
                 target_mat = _compute_control_matrix(
                     base_mat, num_ctrl_qubits, ctrl_state=ctrl_state


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [X] I have read the CONTRIBUTING document.
-->

### Summary
This PR removes a redefinition of RZGate matrix in the test file and makes the tests phase sensitive by removing the parameter `ignore_phase=True` 


