### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,23 +9,23 @@
 # The @Qiskit/terra-core team is the group who're responsible for the
 # entire qiskit-terra project and are empowered to approve merge code in any
 # part of the repository. Any member of the terra-core group should not be
-# listed in this file as it's redudant.
+# listed in this file as it's redundant.
 #
 # A PR can be merged when approved by at least one codeowner. For PRs that touch
 # more than one section with non-overlapping codeowners more than one codeowner
 # may be required to approve a PR.
 #
 # However, every contributor to Qiskit can (and should!) review open PRs. This
-# file is just about outlining responsiblity for maintainership and final
+# file is just about outlining responsibility for maintainership and final
 # review/merging of PRs in different subsections of the repository.
 
 # Global rule, unless specialized by a later one
 * @Qiskit/terra-core
 
 # Qiskit folders (also their corresponding tests)
-algorithms/           @Qiskit/terra-core @manoelmarques @woodsp-ibm @ElePT
-opflow/               @Qiskit/terra-core @manoelmarques @woodsp-ibm @ikkoham
-qiskit/utils/         @Qiskit/terra-core @manoelmarques @woodsp-ibm
+algorithms/           @Qiskit/terra-core @woodsp-ibm @ElePT
+opflow/               @Qiskit/terra-core @woodsp-ibm @ikkoham
+qiskit/utils/         @Qiskit/terra-core @woodsp-ibm
 providers/            @Qiskit/terra-core @jyu00
 quantum_info/         @Qiskit/terra-core @ikkoham
 qpy/                  @Qiskit/terra-core


### PR DESCRIPTION
Removed Manoel from codeowners since he is no longer working in this area.

Since my editor was highlighting a couple of spelling errors I fixed them.

I will note `ikkoham` is listed explicitly in a couple of places but that's redundant now since he's a member of `terra-core`, I did not change that aspect though.