### PR TITLE
Fix missing handling of no-synthesis case in `UnitarySynthesis`

### DIFF
--- a/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/unitary_synthesis.py
@@ -740,9 +740,10 @@ class DefaultUnitarySynthesis(plugin.UnitarySynthesisPlugin):
 
         if unitary.shape == (2, 2):
             _decomposer1q = Optimize1qGatesDecomposition(basis_gates, target)
-            return _decomposer1q._gate_sequence_to_dag(
-                _decomposer1q._resynthesize_run(unitary, qubits[0])
-            )
+            sequence = _decomposer1q._resynthesize_run(unitary, qubits[0])
+            if sequence is None:
+                return None
+            return _decomposer1q._gate_sequence_to_dag(sequence)
         elif unitary.shape == (4, 4):
             # select synthesizers that can lower to the target
             if target is not None:

--- a/test/python/transpiler/test_unitary_synthesis.py
+++ b/test/python/transpiler/test_unitary_synthesis.py
@@ -857,6 +857,12 @@ class TestUnitarySynthesis(QiskitTestCase):
         result_qc = dag_to_circuit(result_dag)
         self.assertEqual(result_qc, QuantumCircuit(2))
 
+    def test_default_does_not_fail_on_no_syntheses(self):
+        qc = QuantumCircuit(1)
+        qc.unitary(np.eye(2), [0])
+        pass_ = UnitarySynthesis(["unknown", "gates"])
+        self.assertEqual(qc, pass_(qc))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Since moving `Optimize1qDecomposition` down to the Rust level, some of its use in the default `UnitarySynthesis` plugin was allowing `None` to be passed to an internal function unchecked.  This correctly returns the "could not synthesise" value when appropriate.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fix #9842.  No changelog because the carcinisation of `Optimize1qDecomposition` isn't released yet.
