### PR TITLE
Add option to skip deepcopy on circuit_to_dag

### DIFF
--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -478,7 +478,9 @@ class QuantumCircuit:
         # TODO: remove the DAG from this function
         from qiskit.converters import circuit_to_dag
 
-        return circuit_to_dag(self) == circuit_to_dag(other)
+        return circuit_to_dag(self, copy_operations=False) == circuit_to_dag(
+            other, copy_operations=False
+        )
 
     @classmethod
     def _increment_instances(cls):

--- a/qiskit/converters/circuit_to_dag.py
+++ b/qiskit/converters/circuit_to_dag.py
@@ -16,11 +16,18 @@ import copy
 from qiskit.dagcircuit.dagcircuit import DAGCircuit
 
 
-def circuit_to_dag(circuit):
+def circuit_to_dag(circuit, copy_operations=True):
     """Build a ``DAGCircuit`` object from a ``QuantumCircuit``.
 
     Args:
         circuit (QuantumCircuit): the input circuit.
+        copy_operations (bool): Deep copy the operation objects
+            in the :class:`~.QuantumCircuit` for the output :class:`~.DAGCircuit`.
+            This should only be set to ``False`` if the input :class:`~.QuantumCircuit`
+            will not be used anymore as the operations in the output
+            :class:`~.DAGCircuit` will be shared instances and modifications to
+            operations in the :class:`~.DAGCircuit` will be reflected in the
+            :class:`~.QuantumCircuit` (and vice versa).
 
     Return:
         DAGCircuit: the DAG representing the input circuit.
@@ -57,9 +64,10 @@ def circuit_to_dag(circuit):
         dagcircuit.add_creg(register)
 
     for instruction in circuit.data:
-        dagcircuit.apply_operation_back(
-            copy.deepcopy(instruction.operation), instruction.qubits, instruction.clbits
-        )
+        op = instruction.operation
+        if copy_operations:
+            op = copy.deepcopy(op)
+        dagcircuit.apply_operation_back(op, instruction.qubits, instruction.clbits)
 
     dagcircuit.duration = circuit.duration
     dagcircuit.unit = circuit.unit

--- a/releasenotes/notes/deepcopy-option-circuit_to_dag-1d494b7f9824ec93.yaml
+++ b/releasenotes/notes/deepcopy-option-circuit_to_dag-1d494b7f9824ec93.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Added a new option, ``copy_operations``, to :func:`~.circuit_to_dag` to
+    enable optionally disabling deep copying the operations from the input
+    :class`~.QuantumCircuit` to the output :class:`~.QuantumCircuit`. In cases
+    where the input :class`~.QuantumCircuit` is not used anymore after
+    conversion this deep copying is unnecessary overhead as any shared
+    references wouldn't have any potential unwanted side effects if the input
+    :class`~.QuantumCircuit` is discarded.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Just as was done for #9825 for dag_to_circuit(), this commit adds a new option, copy_operations, which allows to disable the deepcopy on circuit_to_dag(). Previously, the circuit to dag converter would always deep copy every operation, however we don't need this extra overhead in every case; where the input QuantumCircuit is discarded after conversion. This new flag lets us avoid the copy overhead in these situations, however in general the converter still needs to default to copying.

### Details and comments