### PR TITLE
Ensure up-to-date `pip`, `setuptools` and `wheel` in CI

### DIFF
--- a/.azure/lint-linux.yml
+++ b/.azure/lint-linux.yml
@@ -21,6 +21,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/bin/activate
+          pip install -U pip setuptools wheel
           pip install -U \
             -c constraints.txt \
             -r requirements.txt \

--- a/.azure/test-linux.yml
+++ b/.azure/test-linux.yml
@@ -60,6 +60,7 @@ jobs:
             # Use stable Rust, rather than MSRV, to spot-check that stable builds properly.
             rustup override set stable
             source test-job/bin/activate
+            pip install -U pip setuptools wheel
             # Install setuptools-rust for building sdist
             pip install -U -c constraints.txt setuptools-rust
             python setup.py sdist

--- a/.azure/test-macos.yml
+++ b/.azure/test-macos.yml
@@ -34,6 +34,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/bin/activate
+          pip install -U pip setuptools wheel
           pip install -U \
             -c constraints.txt \
             -r requirements.txt \

--- a/.azure/test-windows.yml
+++ b/.azure/test-windows.yml
@@ -33,6 +33,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel virtualenv
           virtualenv test-job
           source test-job/Scripts/activate
+          pip install -U pip setuptools wheel
           pip install -U \
             -c constraints.txt \
             -r requirements.txt \

--- a/.azure/tutorials-linux.yml
+++ b/.azure/tutorials-linux.yml
@@ -21,7 +21,7 @@ jobs:
       - bash: |
           set -e
           git clone https://github.com/Qiskit/qiskit-tutorials --depth=1
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools wheel
           pip install -U \
             -c constraints.txt \
             -r requirements.txt \

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,13 @@ jobs:
             cargo install grcov
             sudo apt-get install lcov
 
+      # This is needed to support any requirements, particularly in the `optionals` set,
+      # that might not have 'pyproject.toml' files specifying their build requirements.
+      # Modern pip (23.1+) can error out if it doesn't have `wheel` and we ask for one
+      # of these legacy packages.
+      - name: Ensure basic build requirements
+        run: pip install --upgrade pip setuptools wheel
+
       - name: Build and install qiskit-terra
         run: pip install -e .
         env:

--- a/.github/workflows/randomized_tests.yml
+++ b/.github/workflows/randomized_tests.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: '3.8'
       - name: Install dependencies
         run: |
+          pip install -U pip setuptools wheel
           pip install -U -r requirements.txt -c constraints.txt
           pip install -U -r requirements-dev.txt coveralls -c constraints.txt
           pip install -c constraints.txt -e .

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: '3.10'
       - name: Install dependencies
         run: |
+          pip install -U pip setuptools wheel
           pip install -U -r requirements.txt -c constraints.txt
           pip install -U -r requirements-dev.txt -c constraints.txt
           pip install -c constraints.txt -e .


### PR DESCRIPTION
### Summary

Up-to-date Python packages should not require this step, however there are several packages, especially those that are optional for Terra functionality, that do not yet contain `pyproject.toml` files when building them from source.  In these cases, `pip` will begin erroring out from version 23.1 if `wheel` is not installed.

This commit proactively ensures that the minimum build dependencies for legacy Python packages is prepared and up-to-date before attempting installations; this includes ensuring that these are updated _inside_ any created venvs as well as outside them.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Details and comments

In reviewing a few recent CI runs, I've been noticing pip outputting the message (e.g.):
```text
  DEPRECATION: pyperclip is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
```
`pip` 23.1 isn't out yet, but given that it's 2023 and 23.0 is already out, it probably isn't long until it is. *edit*: it's due in April, [per `pip`'s release cadence document](https://pip.pypa.io/en/stable/development/release-process/).