### PR TITLE
Fix a bug in QuantumCircuit.draw related to vertical_compression

### DIFF
--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -169,7 +169,6 @@ class BoxOnQuWire(DrawElement):
         bot: └───┘   └───┘
     """
 
-    # TODO:
     def __init__(self, label="", top_connect="─", conditional=False):
         super().__init__(label)
         self.top_format = "┌─%s─┐"

--- a/qiskit/visualization/circuit/text.py
+++ b/qiskit/visualization/circuit/text.py
@@ -169,6 +169,7 @@ class BoxOnQuWire(DrawElement):
         bot: └───┘   └───┘
     """
 
+    # TODO:
     def __init__(self, label="", top_connect="─", conditional=False):
         super().__init__(label)
         self.top_format = "┌─%s─┐"
@@ -907,7 +908,7 @@ class TextDrawing:
                 ret += "│"
             elif topc == "└" and botc == "┌" and icod == "top":
                 ret += "├"
-            elif topc == "┘" and botc == "┐":
+            elif topc == "┘" and botc == "┐" and icod == "top":
                 ret += "┤"
             elif botc in "┐┌" and icod == "top":
                 ret += "┬"

--- a/releasenotes/notes/fix-circuit-drawing-low-compression-965c21de51b26ad2.yaml
+++ b/releasenotes/notes/fix-circuit-drawing-low-compression-965c21de51b26ad2.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the top-right corner of low-compression circuit text-visualisations
+    Fixed the top-right corner of gates when using ``vertical_compression="low"`` in text visualizations of circuits.

--- a/releasenotes/notes/fix-circuit-drawing-low-compression-965c21de51b26ad2.yaml
+++ b/releasenotes/notes/fix-circuit-drawing-low-compression-965c21de51b26ad2.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix the top-right corner of low-compression circuit text-visualisations

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -2003,12 +2003,17 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
                 "                             ║  ",
                 "                             ║  ",
                 " cr_0: 0 ════════════════════o══",
-                "                            0x2 "
+                "                            0x2 ",
             ]
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="low", cregbundle=False, reverse_bits=True)), expected
+            str(
+                _text_circuit_drawer(
+                    circuit, vertical_compression="low", cregbundle=False, reverse_bits=True
+                )
+            ),
+            expected,
         )
 
     def test_text_conditional_reverse_bits_false(self):
@@ -2044,12 +2049,17 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
                 "                    0x2 ",
                 "                        ",
                 "  cr2: 0 ═══════════════",
-                "                        "
+                "                        ",
             ]
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, vertical_compression="low", cregbundle=False, reverse_bits=False)), expected
+            str(
+                _text_circuit_drawer(
+                    circuit, vertical_compression="low", cregbundle=False, reverse_bits=False
+                )
+            ),
+            expected,
         )
 
     def test_text_justify_right(self):

--- a/test/python/visualization/test_circuit_text_drawer.py
+++ b/test/python/visualization/test_circuit_text_drawer.py
@@ -1988,22 +1988,27 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
             [
                 "         ┌───┐     ┌─┐     ┌───┐",
                 "qr_2: |0>┤ H ├─────┤M├─────┤ X ├",
-                "         ├───┤     └╥┘     └─╥─┘",
+                "         └───┘     └╥┘     └─╥─┘",
+                "         ┌───┐      ║        ║  ",
                 "qr_1: |0>┤ H ├──────╫────────╫──",
-                "         ├───┤┌───┐ ║ ┌───┐  ║  ",
+                "         └───┘      ║        ║  ",
+                "         ┌───┐┌───┐ ║ ┌───┐  ║  ",
                 "qr_0: |0>┤ H ├┤ X ├─╫─┤ X ├──╫──",
                 "         └───┘└───┘ ║ └───┘  ║  ",
+                "                    ║        ║  ",
                 "  cr2: 0 ═══════════╬════════╬══",
+                "                    ║        ║  ",
                 "                    ║        ║  ",
                 " cr_1: 0 ═══════════╩════════■══",
                 "                             ║  ",
+                "                             ║  ",
                 " cr_0: 0 ════════════════════o══",
-                "                            0x2 ",
+                "                            0x2 "
             ]
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, reverse_bits=True)), expected
+            str(_text_circuit_drawer(circuit, vertical_compression="low", cregbundle=False, reverse_bits=True)), expected
         )
 
     def test_text_conditional_reverse_bits_false(self):
@@ -2024,22 +2029,27 @@ class TestTextDrawerVerticalCompressionLow(QiskitTestCase):
             [
                 "         ┌───┐┌───┐┌───┐",
                 "qr_0: |0>┤ H ├┤ X ├┤ X ├",
-                "         ├───┤└───┘└───┘",
+                "         └───┘└───┘└───┘",
+                "         ┌───┐          ",
                 "qr_1: |0>┤ H ├──────────",
-                "         ├───┤ ┌─┐ ┌───┐",
+                "         └───┘          ",
+                "         ┌───┐ ┌─┐ ┌───┐",
                 "qr_2: |0>┤ H ├─┤M├─┤ X ├",
                 "         └───┘ └╥┘ └─╥─┘",
+                "                ║    ║  ",
                 " cr_0: 0 ═══════╬════o══",
+                "                ║    ║  ",
                 "                ║    ║  ",
                 " cr_1: 0 ═══════╩════■══",
                 "                    0x2 ",
-                "  cr2: 0 ═══════════════",
                 "                        ",
+                "  cr2: 0 ═══════════════",
+                "                        "
             ]
         )
 
         self.assertEqual(
-            str(_text_circuit_drawer(circuit, cregbundle=False, reverse_bits=False)), expected
+            str(_text_circuit_drawer(circuit, vertical_compression="low", cregbundle=False, reverse_bits=False)), expected
         )
 
     def test_text_justify_right(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ x ] I have added the tests to cover my changes.
- [ x ] I have updated the documentation accordingly. No need, just a bugfix.
- [ x ] I have read the CONTRIBUTING document.
-->

### Summary
When using `QuantumCircuit.draw('text')` there was a wrong character used for drawing boxes in case of `vertical_compression="low"`. I fixed this bug by a oneliner and updated the tests. I did not find a corresponding open issue.


### Details and comments
The bug is appears in this example:

```python
from qiskit import QuantumCircuit

qc = QuantumCircuit(2)
qc.h(0)
qc.h(1)

drawing_high = qc.draw("text", vertical_compression="high")
drawing_normal = qc.draw("text")
drawing_low = qc.draw("text", vertical_compression="low")

# Skip drawing_normal since it leads to the same result as drawing_high
print(drawing_high)
print(drawing_low)
```

The "high"-circuit is drawn correctly, but the second Hadamard of the seconed circuit is drawn incorrectly. It incorrectly uses the character `┤` for the upper right corner of the Box of the Gate.

```
     ┌───┐
q_0: ┤ H ├
     ├───┤
q_1: ┤ H ├
     └───┘
     ┌───┐
q_0: ┤ H ├
     └───┘
     ┌───┤
q_1: ┤ H ├
     └───┘
```

After the fix the output looks like this:

```
     ┌───┐
q_0: ┤ H ├
     ├───┤
q_1: ┤ H ├
     └───┘
     ┌───┐
q_0: ┤ H ├
     └───┘
     ┌───┐
q_1: ┤ H ├
     └───┘
```

Btw: I observed that the argument `icod` of the method `merge_lines` is somewhat "abused". Its docstring says `icod (top or bot): in case of doubt, which line should have priority? Default: "top".`. I am aware that I did not adhere to this statement. But My code change is consistent with other similar cases. See for example the case for the upper _left_ corner which is treated in the same way. If somebody feels that this inconsistency is an issue I would propose to open an issue, but right now my change just fixes the bug in the simplest way possible without introducing more inconsistencies.

**Tests**: I actually found another kind of bug in the tests. The test class `TestTextDrawerVerticalCompressionLow` certainly wants to test the `vertical_compression="low"` feature. But two of those tests actually did not use low compression. I changed those to use low compression hence establishing two tests for my fix. I carefully checked that otherwise the output looks as before.