### PR TITLE
pin symengine to `<0.10.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ stevedore>=3.0.0
 # symengine pinning needed due lowered precision handling complex
 # multiplication in version 0.10 wich breaks parameter assignment test
 # (can be removed once issue is fix)
-symengine==0.9.2 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
+symengine>=0.9, <0.10; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
 shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
 singledispatchmethod; python_version < '3.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,10 @@ sympy>=1.3
 dill>=0.3
 python-dateutil>=2.8.0
 stevedore>=3.0.0
-symengine>=0.9 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
+# symengine pinning needed due lowered precision handling complex
+# multiplication in version 0.10 wich breaks parameter assignment test
+# (can be removed once issue is fix)
+symengine==0.9.2 ; platform_machine == 'x86_64' or platform_machine == 'aarch64' or platform_machine == 'ppc64le' or platform_machine == 'amd64' or platform_machine == 'arm64'
 shared-memory38;python_version<'3.8'
 typing-extensions; python_version < '3.8'
 singledispatchmethod; python_version < '3.8'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The recent release of symengine 0.10.0 has changed the precision of complex multiplications, breaking some tests that expect a pure imaginary result (i.e `2.3j`) and get a complex with a real part (`1.408343819019456e-16+2.3j`):

- ` test.python.circuit.test_parameters.TestParameterExpressions.test_complex_parameter_bound_to_real`
- `test.python.circuit.test_parameters.TestParameterExpressions.test_expressions_of_parameter_with_constant`

While we find a permanent solution (either opening an issue on symengine or dealing with the truncation ourselves), pinning the symengine version can help to keep the merge queue moving.

### Details and comments
This pin can be reverted once the issue is fixed.

EDIT: This PR might not be necessary if https://github.com/Qiskit/qiskit-terra/pull/8734 fixes the issue.

