### PR TITLE
Only do HLS plugin discovery once

### DIFF
--- a/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
+++ b/qiskit/transpiler/passes/synthesis/high_level_synthesis.py
@@ -116,6 +116,7 @@ class HighLevelSynthesis(TransformationPass):
             # When the config file is not provided, we will use the "default" method
             # to synthesize Operations (when available).
             self.hls_config = HLSConfig(True)
+        self.hls_plugin_manager = HighLevelSynthesisPluginManager()
 
     def run(self, dag: DAGCircuit) -> DAGCircuit:
         """Run the HighLevelSynthesis pass on `dag`.
@@ -129,8 +130,6 @@ class HighLevelSynthesis(TransformationPass):
             TranspilerError: when the specified synthesis method is not available.
         """
 
-        hls_plugin_manager = HighLevelSynthesisPluginManager()
-
         for node in dag.op_nodes():
             if node.name in self.hls_config.methods.keys():
                 # the operation's name appears in the user-provided config,
@@ -138,7 +137,7 @@ class HighLevelSynthesis(TransformationPass):
                 methods = self.hls_config.methods[node.name]
             elif (
                 self.hls_config.use_default_on_unspecified
-                and "default" in hls_plugin_manager.method_names(node.name)
+                and "default" in self.hls_plugin_manager.method_names(node.name)
             ):
                 # the operation's name does not appear in the user-specified config,
                 # we use the "default" method when instructed to do so and the "default"
@@ -167,12 +166,12 @@ class HighLevelSynthesis(TransformationPass):
                 # or directly as a class inherited from HighLevelSynthesisPlugin (which then
                 # does not need to be specified in entry_points).
                 if isinstance(plugin_specifier, str):
-                    if plugin_specifier not in hls_plugin_manager.method_names(node.name):
+                    if plugin_specifier not in self.hls_plugin_manager.method_names(node.name):
                         raise TranspilerError(
                             "Specified method: %s not found in available plugins for %s"
                             % (plugin_specifier, node.name)
                         )
-                    plugin_method = hls_plugin_manager.method(node.name, plugin_specifier)
+                    plugin_method = self.hls_plugin_manager.method(node.name, plugin_specifier)
                 else:
                     plugin_method = plugin_specifier
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit fixes an issue in the HighLevelSynthesis transpiler pass where it was doing plugin discovery each time the pass was run. This can cause unecessary overhead to discover the same thing every time a pass is run when an instance of the pass is run more than once (which in the preset pass managers is always the case). This commit just moves the plugin manager initialization to the pass initialization so that the plugins are only discovered once per pass instance. We're never in a situation where a user is able to install extra plugins and use them during the liftetime of a single pass instance anyway so re-running discovery on each call to HighLevelSynthesis.run() isn't needed.

### Details and comments
