### PR TITLE
Refactor test to not use deprecated `CXDirection`

### DIFF
--- a/qiskit/transpiler/passes/utils/cx_direction.py
+++ b/qiskit/transpiler/passes/utils/cx_direction.py
@@ -12,22 +12,13 @@
 
 """Rearrange the direction of the cx nodes to match the directed coupling map."""
 
-import functools
 import warnings
 from qiskit.transpiler.passes.utils.gate_direction import GateDirection
-
-
-def debug_decorator(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-    return wrapper
 
 
 class CXDirection(GateDirection):
     """Deprecated: use :class:`qiskit.transpiler.passes.GateDirection` pass instead."""
 
-    @debug_decorator
     def __init__(self, coupling_map):
         super().__init__(coupling_map)
         warnings.warn(

--- a/qiskit/transpiler/passes/utils/cx_direction.py
+++ b/qiskit/transpiler/passes/utils/cx_direction.py
@@ -12,13 +12,22 @@
 
 """Rearrange the direction of the cx nodes to match the directed coupling map."""
 
+import functools
 import warnings
 from qiskit.transpiler.passes.utils.gate_direction import GateDirection
+
+
+def debug_decorator(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
 
 
 class CXDirection(GateDirection):
     """Deprecated: use :class:`qiskit.transpiler.passes.GateDirection` pass instead."""
 
+    @debug_decorator
     def __init__(self, coupling_map):
         super().__init__(coupling_map)
         warnings.warn(

--- a/test/python/visualization/references/pass_manager_standard.dot
+++ b/test/python/visualization/references/pass_manager_standard.dot
@@ -70,18 +70,20 @@ subgraph cluster_20 {
 fontname=helvetica;
 label="[7] ";
 labeljust=l;
-21 [color=blue, fontname=helvetica, label=CXDirection, shape=rectangle];
+21 [color=blue, fontname=helvetica, label=GateDirection, shape=rectangle];
 22 [color=black, fontname=helvetica, fontsize=10, label=coupling_map, shape=ellipse, style=solid];
 22 -> 21;
+23 [color=black, fontname=helvetica, fontsize=10, label=target, shape=ellipse, style=dashed];
+23 -> 21;
 19 -> 21;
 }
 
-subgraph cluster_23 {
+subgraph cluster_24 {
 fontname=helvetica;
 label="[8] ";
 labeljust=l;
-24 [color=blue, fontname=helvetica, label=RemoveResetInZeroState, shape=rectangle];
-21 -> 24;
+25 [color=blue, fontname=helvetica, label=RemoveResetInZeroState, shape=rectangle];
+21 -> 25;
 }
 
 }

--- a/test/python/visualization/references/pass_manager_style.dot
+++ b/test/python/visualization/references/pass_manager_style.dot
@@ -70,18 +70,20 @@ subgraph cluster_20 {
 fontname=helvetica;
 label="[7] ";
 labeljust=l;
-21 [color=blue, fontname=helvetica, label=CXDirection, shape=rectangle];
+21 [color=blue, fontname=helvetica, label=GateDirection, shape=rectangle];
 22 [color=black, fontname=helvetica, fontsize=10, label=coupling_map, shape=ellipse, style=solid];
 22 -> 21;
+23 [color=black, fontname=helvetica, fontsize=10, label=target, shape=ellipse, style=dashed];
+23 -> 21;
 19 -> 21;
 }
 
-subgraph cluster_23 {
+subgraph cluster_24 {
 fontname=helvetica;
 label="[8] ";
 labeljust=l;
-24 [color=grey, fontname=helvetica, label=RemoveResetInZeroState, shape=rectangle];
-21 -> 24;
+25 [color=grey, fontname=helvetica, label=RemoveResetInZeroState, shape=rectangle];
+21 -> 25;
 }
 
 }

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -57,7 +57,6 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
     @unittest.skipIf(not optionals.HAS_GRAPHVIZ, "Graphviz not installed.")
     def test_pass_manager_drawer_basic(self):
         """Test to see if the drawer draws a normal pass manager correctly"""
-        self.maxDiff = None
         filename = "current_standard.dot"
         self.pass_manager.draw(filename=filename, raw=True)
 

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -18,9 +18,8 @@ import os
 from qiskit.transpiler import CouplingMap, Layout
 from qiskit.transpiler.passmanager import PassManager
 from qiskit import QuantumRegister
-from qiskit.transpiler.passes import Unroller
+from qiskit.transpiler.passes import GateDirection, Unroller
 from qiskit.transpiler.passes import CheckMap
-from qiskit.transpiler.passes import CXDirection
 from qiskit.transpiler.passes import SetLayout
 from qiskit.transpiler.passes import TrivialLayout
 from qiskit.transpiler.passes import BarrierBeforeFinalMeasurements
@@ -52,7 +51,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
         self.pass_manager.append(Unroller(basis_gates))
         self.pass_manager.append(CheckMap(coupling_map))
         self.pass_manager.append(BarrierBeforeFinalMeasurements(), do_while=lambda x: False)
-        self.pass_manager.append(CXDirection(coupling_map))
+        self.pass_manager.append(GateDirection(coupling_map))
         self.pass_manager.append(RemoveResetInZeroState())
 
     @unittest.skipIf(not optionals.HAS_GRAPHVIZ, "Graphviz not installed.")
@@ -62,8 +61,12 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
         filename = "current_standard.dot"
         self.pass_manager.draw(filename=filename, raw=True)
 
-        self.assertFilesAreEqual(filename, path_to_diagram_reference("pass_manager_standard.dot"))
-        os.remove(filename)
+        try:
+            self.assertFilesAreEqual(
+                filename, path_to_diagram_reference("pass_manager_standard.dot")
+            )
+        finally:
+            os.remove(filename)
 
     @unittest.skipIf(not optionals.HAS_GRAPHVIZ, "Graphviz not installed.")
     def test_pass_manager_drawer_style(self):
@@ -79,8 +82,10 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
         filename = "current_style.dot"
         self.pass_manager.draw(filename=filename, style=style, raw=True)
 
-        self.assertFilesAreEqual(filename, path_to_diagram_reference("pass_manager_style.dot"))
-        os.remove(filename)
+        try:
+            self.assertFilesAreEqual(filename, path_to_diagram_reference("pass_manager_style.dot"))
+        finally:
+            os.remove(filename)
 
 
 if __name__ == "__main__":

--- a/test/python/visualization/test_pass_manager_drawer.py
+++ b/test/python/visualization/test_pass_manager_drawer.py
@@ -58,6 +58,7 @@ class TestPassManagerDrawer(QiskitVisualizationTestCase):
     @unittest.skipIf(not optionals.HAS_GRAPHVIZ, "Graphviz not installed.")
     def test_pass_manager_drawer_basic(self):
         """Test to see if the drawer draws a normal pass manager correctly"""
+        self.maxDiff = None
         filename = "current_standard.dot"
         self.pass_manager.draw(filename=filename, raw=True)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Adding a deprecator to the constructor of `CXDirection` causes us to need new dot files for the pass manager visualization. See the first commit.

That is blocking the use of `@deprecate_func` in https://github.com/Qiskit/qiskit-terra/pull/9868.

So, @mtreinish suggested rewriting the test to no longer use `CXDirection`.

### Details and comments


