### PR TITLE
Fix `QuantumCircuitData` handling of `Operation`

### DIFF
--- a/qiskit/circuit/quantumcircuitdata.py
+++ b/qiskit/circuit/quantumcircuitdata.py
@@ -18,6 +18,7 @@ from typing import Tuple, Iterable, Optional
 
 from .exceptions import CircuitError
 from .instruction import Instruction
+from .operation import Operation
 from .quantumregister import Qubit
 from .classicalregister import Clbit
 
@@ -37,7 +38,7 @@ class CircuitInstruction:
 
     __slots__ = ("operation", "qubits", "clbits", "_legacy_format_cache")
 
-    operation: Instruction
+    operation: Operation
     """The logical operation that this instruction represents an execution of."""
     qubits: Tuple[Qubit, ...]
     """A sequence of the qubits that the operation is applied to."""
@@ -46,7 +47,7 @@ class CircuitInstruction:
 
     def __init__(
         self,
-        operation: Instruction,
+        operation: Operation,
         qubits: Iterable[Qubit] = (),
         clbits: Iterable[Clbit] = (),
     ):
@@ -65,7 +66,7 @@ class CircuitInstruction:
 
     def replace(
         self,
-        operation: Optional[Instruction] = None,
+        operation: Optional[Operation] = None,
         qubits: Optional[Iterable[Qubit]] = None,
         clbits: Optional[Iterable[Clbit]] = None,
     ) -> "CircuitInstruction":
@@ -142,14 +143,15 @@ class QuantumCircuitData(MutableSequence):
             operation, qargs, cargs = value
         value = self._resolve_legacy_value(operation, qargs, cargs)
         self._circuit._data[key] = value
-        self._circuit._update_parameter_table(value)
+        if isinstance(value.operation, Instruction):
+            self._circuit._update_parameter_table(value)
 
     def _resolve_legacy_value(self, operation, qargs, cargs) -> CircuitInstruction:
         """Resolve the old-style 3-tuple into the new :class:`CircuitInstruction` type."""
-        if not isinstance(operation, Instruction) and hasattr(operation, "to_instruction"):
+        if not isinstance(operation, Operation) and hasattr(operation, "to_instruction"):
             operation = operation.to_instruction()
-        if not isinstance(operation, Instruction):
-            raise CircuitError("object is not an Instruction.")
+        if not isinstance(operation, Operation):
+            raise CircuitError("object is not an Operation.")
 
         expanded_qargs = [self._circuit.qbit_argument_conversion(qarg) for qarg in qargs or []]
         expanded_cargs = [self._circuit.cbit_argument_conversion(carg) for carg in cargs or []]

--- a/releasenotes/notes/fix-setting-circuit-data-operation-1b8326b1b089f10c.yaml
+++ b/releasenotes/notes/fix-setting-circuit-data-operation-1b8326b1b089f10c.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Manually setting an item in :attr:`.QuantumCircuit.data` will now correctly allow the operation
+    to be any object that implements :class:`.Operation`, not just a :class:`.circuit.Instruction`.
+    Note that any manual mutation of :attr:`.QuantumCircuit.data` is discouraged; it is not
+    *usually* any more efficient than building a new circuit object, as checking the invariants
+    surrounding parametrised objects can be surprisingly expensive.


### PR DESCRIPTION
### Summary

The legacy ability to directly mutate `QuantumCircuit.data` was not accounting for cases where the operation could be an implementor of `Operation` that is not `Instruction`.  Actually using this functionality is still discouraged, but it should work.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Thanks to @kevinsung for pointing this out in https://github.com/Qiskit/qiskit-terra/pull/8714#discussion_r967038296.
