### PR TITLE
Improve error messages on failed circuit-equality assertions

### DIFF
--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -30,6 +30,7 @@ from unittest.util import safe_repr
 
 from qiskit.tools.parallel import get_platform_parallel_default
 from qiskit.utils import optionals as _optionals
+from qiskit.circuit import QuantumCircuit
 from .decorators import enforce_subclasses_call
 from .utils import Path, setup_test_logging
 
@@ -77,6 +78,7 @@ class BaseQiskitTestCase(BaseTestCase):
 
     def setUp(self):
         super().setUp()
+        self.addTypeEqualityFunc(QuantumCircuit, self.assertQuantumCircuitEqual)
         if self.__setup_called:
             raise ValueError(
                 "In File: %s\n"
@@ -109,6 +111,20 @@ class BaseQiskitTestCase(BaseTestCase):
             str: the absolute path to the resource.
         """
         return os.path.normpath(os.path.join(path.value, filename))
+
+    def assertQuantumCircuitEqual(self, qc1, qc2, msg=None):
+        """Extra assertion method to give a better error message when two circuits are unequal."""
+        if qc1 == qc2:
+            return
+        if msg is None:
+            msg = "The two circuits are not equal."
+        msg += f"""
+Left circuit:
+{qc1.draw(style='text')}
+
+Right circuit:
+{qc2.draw(style='text')}"""
+        raise self.failureException(msg)
 
     def assertDictAlmostEqual(
         self, dict1, dict2, delta=None, msg=None, places=None, default_value=0

--- a/qiskit/test/base.py
+++ b/qiskit/test/base.py
@@ -120,10 +120,10 @@ class BaseQiskitTestCase(BaseTestCase):
             msg = "The two circuits are not equal."
         msg += f"""
 Left circuit:
-{qc1.draw(style='text')}
+{qc1}
 
 Right circuit:
-{qc2.draw(style='text')}"""
+{qc2}"""
         raise self.failureException(msg)
 
     def assertDictAlmostEqual(


### PR DESCRIPTION
### Summary

This improves the error message when running the test suite, if an `assertEqual` is applied to two circuits; on a failed test, the circuits are now drawn so they can be compared, rather than just seeing that the two pointers are not the same.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->



### Details and comments

Given a test:

```python
a = QuantumCircuit(2)
a.h(0)
a.cx(0, 1)

b = QuantumCircuit(2)
b.cx(0, 1)
b.h(0)

self.assertEqual(a, b)
```

With this change, the output is:

```text
Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/Users/jake/code/qiskit/terra/test/python/circuit/test_circuit_registers.py", line 43, in test_bad
    self.assertEqual(a, b)

      File "/Users/jake/python/3.10.6/lib/python3.10/unittest/case.py", line 845, in assertEqual
    assertion_func(first, second, msg=msg)

      File "/Users/jake/code/qiskit/terra/qiskit/test/base.py", line 128, in assertQuantumCircuitEqual
    raise self.failureException(msg)

    AssertionError: The two circuits are not equal.
Left circuit:
     ┌───┐
q_0: ┤ H ├──■──
     └───┘┌─┴─┐
q_1: ─────┤ X ├
          └───┘

Right circuit:
          ┌───┐
q_0: ──■──┤ H ├
     ┌─┴─┐└───┘
q_1: ┤ X ├─────
     └───┘
```

while without the change, the output is:

```text
Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/Users/jake/code/qiskit/terra/test/python/circuit/test_circuit_registers.py", line 43, in test_bad
    self.assertEqual(a, b)

      File "/Users/jake/python/3.10.6/lib/python3.10/unittest/case.py", line 845, in assertEqual
    assertion_func(first, second, msg=msg)

      File "/Users/jake/python/3.10.6/lib/python3.10/unittest/case.py", line 838, in _baseAssertEqual
    raise self.failureException(msg)

    AssertionError: <qiskit.circuit.quantumcircuit.QuantumCircuit object at 0x115264af0> != <qiskit.circuit.quantumcircuit.QuantumCircuit object at 0x1156cc340>
```

