### PR TITLE
Add support for pulse reference to QPY

### DIFF
--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -126,6 +126,46 @@ There is a circuit payload for each circuit (where the total number is dictated
 by ``num_circuits`` in the file header). There is no padding between the
 circuits in the data.
 
+.. _qpy_version_7:
+
+Version 7
+=========
+
+Version 7 adds support for :class:`.~Reference` instruction and serialization of
+a :class:`.~ScheduleBlock` program while keeping its reference to subroutines::
+
+    from qiskit import pulse
+    from qiskit import qpy
+
+    with pulse.build() as schedule:
+        pulse.reference("cr45p", "q0", "q1")
+        pulse.reference("x", "q0")
+        pulse.reference("cr45p", "q0", "q1")
+
+    with open('template_ecr.qpy', 'wb') as fd:
+        qpy.dump(schedule, fd)
+
+Conventional :ref:`qpy_schedule_block` data model is preserved,
+but it is immediately followed by an extra :ref:`qpy_mapping` utf8 bytes block
+representing the data of the referenced subroutines.
+
+New type key character is added to the :ref:`qpy_schedule_instructions` group
+for the :class:`.~Reference` instruction.
+
+- ``y``: :class:`~qiskit.pulse.instructions.Reference` instruction
+
+New type key character is added to the :ref:`qpy_schedule_operands` group
+for the operands of :class:`.~Reference` instruction,
+which is a tuple of strings, e.g. ("cr45p", "q0", "q1").
+
+- ``o``: string (operand string)
+
+Note that this is the same encoding with the built-in Python string, however,
+the standard value encoding in QPY uses ``s`` type character for string data,
+which conflicts with the :class:`~qiskit.pulse.library.SymbolicPulse` in the scope of
+pulse instruction operands. A special type character ``o`` is reserved for
+the string data that appears in the pulse instruction operands.
+
 .. _qpy_version_6:
 
 Version 6
@@ -213,6 +253,8 @@ Note that circuit and schedule block are serialized and deserialized through
 the same QPY interface. Input data type is implicitly analyzed and
 no extra option is required to save the schedule block.
 
+.. _qpy_schedule_block_header:
+
 SCHEDULE_BLOCK_HEADER
 ---------------------
 
@@ -230,6 +272,11 @@ which is immediately followed by ``name_size`` utf8 bytes of schedule name and
 ``metadata_size`` utf8 bytes of the JSON serialized metadata dictionary
 attached to the schedule.
 
+.. _qpy_schedule_alignments:
+
+SCHEDULE_BLOCK_ALIGNMENTS
+-------------------------
+
 Then, alignment context of the schedule block starts with ``char``
 representing the supported context type followed by the :ref:`qpy_sequence` block representing
 the parameters associated with the alignment context :attr:`AlignmentKind._context_params`.
@@ -242,6 +289,11 @@ The context type char is mapped to each alignment subclass as follows:
 
 Note that :class:`~.AlignFunc` context is not supported becasue of the callback function
 stored in the context parameters.
+
+.. _qpy_schedule_instructions:
+
+SCHEDULE_BLOCK_INSTRUCTIONS
+---------------------------
 
 This alignment block is further followed by ``num_element`` length of block elements which may
 consist of nested schedule blocks and schedule instructions.
@@ -261,6 +313,12 @@ The mapping of type char to the instruction subclass is defined as follows:
 - ``r``: :class:`~qiskit.pulse.instructions.ShiftPhase` instruction
 - ``b``: :class:`~qiskit.pulse.instructions.RelativeBarrier` instruction
 - ``t``: :class:`~qiskit.pulse.instructions.TimeBlockade` instruction
+- ``y``: :class:`~qiskit.pulse.instructions.Reference` instruction (new in version 0.7)
+
+.. _qpy_schedule_operands:
+
+SCHEDULE_BLOCK_OPERANDS
+-----------------------
 
 The operands of these instances can be serialized through the standard QPY value serialization
 mechanism, however there are special object types that only appear in the schedule operands.
@@ -272,6 +330,7 @@ Special objects start with the following type key:
 - ``c``: :class:`~qiskit.pulse.channels.Channel`
 - ``w``: :class:`~qiskit.pulse.library.Waveform`
 - ``s``: :class:`~qiskit.pulse.library.SymbolicPulse`
+- ``o``: string (operand string, new in version 0.7)
 
 .. _qpy_schedule_channel:
 

--- a/qiskit/qpy/__init__.py
+++ b/qiskit/qpy/__init__.py
@@ -145,8 +145,8 @@ a :class:`.~ScheduleBlock` program while keeping its reference to subroutines::
     with open('template_ecr.qpy', 'wb') as fd:
         qpy.dump(schedule, fd)
 
-Conventional :ref:`qpy_schedule_block` data model is preserved,
-but it is immediately followed by an extra :ref:`qpy_mapping` utf8 bytes block
+The conventional :ref:`qpy_schedule_block` data model is preserved, but in
+version 7 it is immediately followed by an extra :ref:`qpy_mapping` utf8 bytes block
 representing the data of the referenced subroutines.
 
 New type key character is added to the :ref:`qpy_schedule_instructions` group

--- a/qiskit/qpy/common.py
+++ b/qiskit/qpy/common.py
@@ -20,7 +20,7 @@ import struct
 
 from qiskit.qpy import formats
 
-QPY_VERSION = 6
+QPY_VERSION = 7
 ENCODE = "utf8"
 
 

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -176,6 +176,19 @@ SCHEDULE_BLOCK_HEADER = namedtuple(
 SCHEDULE_BLOCK_HEADER_PACK = "!HQH"
 SCHEDULE_BLOCK_HEADER_SIZE = struct.calcsize(SCHEDULE_BLOCK_HEADER_PACK)
 
+# SCHEDULE BLOCK binary format after qpy version 7
+SCHEDULE_BLOCK_HEADER_V7 = namedtuple(
+    "SCHEDULE_BLOCK",
+    [
+        "name_size",
+        "metadata_size",
+        "num_elements",
+        "num_references",
+    ],
+)
+SCHEDULE_BLOCK_HEADER_PACK_V7 = "!HQHH"
+SCHEDULE_BLOCK_HEADER_SIZE_V7 = struct.calcsize(SCHEDULE_BLOCK_HEADER_PACK_V7)
+
 # WAVEFORM binary format
 WAVEFORM = namedtuple("WAVEFORM", ["epsilon", "data_size", "amp_limited"])
 WAVEFORM_PACK = "!fI?"

--- a/qiskit/qpy/formats.py
+++ b/qiskit/qpy/formats.py
@@ -176,19 +176,6 @@ SCHEDULE_BLOCK_HEADER = namedtuple(
 SCHEDULE_BLOCK_HEADER_PACK = "!HQH"
 SCHEDULE_BLOCK_HEADER_SIZE = struct.calcsize(SCHEDULE_BLOCK_HEADER_PACK)
 
-# SCHEDULE BLOCK binary format after qpy version 7
-SCHEDULE_BLOCK_HEADER_V7 = namedtuple(
-    "SCHEDULE_BLOCK",
-    [
-        "name_size",
-        "metadata_size",
-        "num_elements",
-        "num_references",
-    ],
-)
-SCHEDULE_BLOCK_HEADER_PACK_V7 = "!HQHH"
-SCHEDULE_BLOCK_HEADER_SIZE_V7 = struct.calcsize(SCHEDULE_BLOCK_HEADER_PACK_V7)
-
 # WAVEFORM binary format
 WAVEFORM = namedtuple("WAVEFORM", ["epsilon", "data_size", "amp_limited"])
 WAVEFORM_PACK = "!fI?"

--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -45,6 +45,7 @@ from qiskit.pulse.instructions import (
     ShiftPhase,
     RelativeBarrier,
     TimeBlockade,
+    Reference,
 )
 from qiskit.pulse.library import Waveform, SymbolicPulse
 from qiskit.pulse.schedule import ScheduleBlock
@@ -233,6 +234,7 @@ class ScheduleInstruction(TypeKeyBase):
     SHIFT_PHASE = b"r"
     BARRIER = b"b"
     TIME_BLOCKADE = b"t"
+    REFERENCE = b"y"
 
     # 's' is reserved by ScheduleBlock, i.e. block can be nested as an element.
     # Call instructon is not supported by QPY.
@@ -261,6 +263,8 @@ class ScheduleInstruction(TypeKeyBase):
             return cls.BARRIER
         if isinstance(obj, TimeBlockade):
             return cls.TIME_BLOCKADE
+        if isinstance(obj, Reference):
+            return cls.REFERENCE
 
         raise exceptions.QpyError(
             f"Object type '{type(obj)}' is not supported in {cls.__name__} namespace."
@@ -286,6 +290,8 @@ class ScheduleInstruction(TypeKeyBase):
             return RelativeBarrier
         if type_key == cls.TIME_BLOCKADE:
             return TimeBlockade
+        if type_key == cls.REFERENCE:
+            return Reference
 
         raise exceptions.QpyError(
             f"A class corresponding to type key '{type_key}' is not found in {cls.__name__} namespace."
@@ -303,6 +309,11 @@ class ScheduleOperand(TypeKeyBase):
     # Data format of these object is somewhat opaque and not defiend well.
     # It's rarely used in the Qiskit experiements. Of course these can be added later.
 
+    # A temp hack. If pulse instruction operands involve a string,
+    # this is encoded in the standard value encode path, which assigned "s" to type_key.
+    # Note that this key conflicts with SYMBOLIC_PULSE type key.
+    OPERAND_STR = b"o"
+
     @classmethod
     def assign(cls, obj):
         if isinstance(obj, Waveform):
@@ -311,6 +322,8 @@ class ScheduleOperand(TypeKeyBase):
             return cls.SYMBOLIC_PULSE
         if isinstance(obj, Channel):
             return cls.CHANNEL
+        if isinstance(obj, str):
+            return cls.OPERAND_STR
 
         raise exceptions.QpyError(
             f"Object type '{type(obj)}' is not supported in {cls.__name__} namespace."

--- a/qiskit/qpy/type_keys.py
+++ b/qiskit/qpy/type_keys.py
@@ -309,9 +309,10 @@ class ScheduleOperand(TypeKeyBase):
     # Data format of these object is somewhat opaque and not defiend well.
     # It's rarely used in the Qiskit experiements. Of course these can be added later.
 
-    # A temp hack. If pulse instruction operands involve a string,
-    # this is encoded in the standard value encode path, which assigned "s" to type_key.
-    # Note that this key conflicts with SYMBOLIC_PULSE type key.
+    # We need to have own string type definition for operands of schedule instruction.
+    # Note that string type is already defined in the Value namespace,
+    # but its key "s" conflicts with the SYMBOLIC_PULSE in the ScheduleOperand namespace.
+    # New in QPY version 7.
     OPERAND_STR = b"o"
 
     @classmethod

--- a/releasenotes/notes/add-support-for-qpy-reference-70478baa529fff8c.yaml
+++ b/releasenotes/notes/add-support-for-qpy-reference-70478baa529fff8c.yaml
@@ -1,0 +1,19 @@
+---
+features:
+  - |
+    QPY supports pulse :class:`~.ScheduleBlock` with unassigned reference,
+    and preserves the data structure for the reference to subroutines.
+    This feature allows to save a template pulse program for tasks such as pulse calibration.
+
+    .. code-block:: python
+
+      from qiskit import pulse
+      from qiskit import qpy
+
+      with pulse.build() as schedule:
+          pulse.reference("cr45p", "q0", "q1")
+          pulse.reference("x", "q0")
+          pulse.reference("cr45p", "q0", "q1")
+
+      with open('template_ecr.qpy', 'wb') as fd:
+          qpy.dump(schedule, fd)

--- a/test/qpy_compat/test_qpy.py
+++ b/test/qpy_compat/test_qpy.py
@@ -443,6 +443,31 @@ def generate_schedule_blocks():
     return schedule_blocks
 
 
+def generate_referenced_schedule():
+    """Test for QPY serialization of unassigned reference schedules."""
+    from qiskit.pulse import builder, channels, library
+
+    schedule_blocks = []
+
+    # Completely unassigned schedule
+    with builder.build() as block:
+        builder.reference("cr45p", "q0", "q1")
+        builder.reference("x", "q0")
+        builder.reference("cr45m", "q0", "q1")
+    schedule_blocks.append(block)
+
+    # Partly assigned schedule
+    with builder.build() as x_q0:
+        builder.play(library.Constant(100, 0.1), channels.DriveChannel(0))
+    with builder.build() as block:
+        builder.reference("cr45p", "q0", "q1")
+        builder.call(x_q0)
+        builder.reference("cr45m", "q0", "q1")
+    schedule_blocks.append(block)
+
+    return schedule_blocks
+
+
 def generate_calibrated_circuits():
     """Test for QPY serialization with calibrations."""
     from qiskit.pulse import builder, Constant, DriveChannel
@@ -551,6 +576,8 @@ def generate_circuits(version_parts):
         output_circuits["pulse_gates.qpy"] = generate_calibrated_circuits()
     if version_parts >= (0, 21, 2):
         output_circuits["open_controlled_gates.qpy"] = generate_open_controlled_gates()
+    if version_parts >= (0, 24, 0):
+        output_circuits["referenced_schedule_blocks.qpy"] = generate_referenced_schedule()
 
     return output_circuits
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This PR adds support for `Reference` pulse instruction to QPY. In addition, ScheduleBlock with assigned subroutine after round-trip keeps original reference data structure. 

```python

from qiskit import pulse, qpy
import io

with pulse.build() as sub:
    pulse.play(pulse.Constant(100, 0.1), pulse.DriveChannel(0))

with pulse.build() as schedule:
    pulse.call(sub, name="subroutine")  # this immediately assigns subroutine to the reference

# Do QPY roundtrip
with io.BytesIO() as container:
    qpy.dump(schedule, container)
    binary = container.getvalue()
with io.BytesIO(binary) as container:
    schedule_load = qpy.load(container)[0]
```

Original reference structure:
```python
>>> schedule.references
ReferenceManager(references=[('subroutine',)])
```

Conventional behavior:
```python
>>> schedule_load.references
ReferenceManager(references=[])
```

With this PR:
```python
>>> schedule_load.references
ReferenceManager(references=[('subroutine',)])
```

This doesn't impact program execution (because reference doesn't appear in the wire format), but it may help saving a template program for calibration task to preserve the original context.

Close #9889 

### Details and comments

This PR avoids key conflict issue described in #9889 in bit fragile way. This introduces new reference key for string ``o`` that appears in the context of pulse instruction operands, rather than delegating serialization to the standard value encoding in QPY. Since current type key doesn't have namespace, it could cause further key conflicts in future as we add more data types. However, adding namespace requires major refactoring of the current QPY module, and I wanted avoid this effort because of the limited bandwidths.
