### PR TITLE
Fix `offset` and `slope` definitions for Linear Pauli Rotations (#9861)

### DIFF
--- a/qiskit/circuit/library/arithmetic/linear_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/linear_pauli_rotations.py
@@ -38,8 +38,8 @@ class LinearPauliRotations(FunctionalPauliRotations):
             q_n: ─┤ RY(offset) ├──┤ RY(2^0 slope) ├  ...  ┤ RY(2^(n-1) slope) ├
                   └────────────┘  └───────────────┘       └───────────────────┘
 
-    This can for example be used to approximate linear functions, with :math:`a/2 =` ``slope``
-    and :math:`b/2 =` ``offset`` and the basis ``'Y'``:
+    This can for example be used to approximate linear functions, with :math:`a =` ``slope``:math:`/2`
+    and :math:`b =` ``offset``:math:`/2` and the basis ``'Y'``:
 
     .. math::
 


### PR DESCRIPTION
#### Summary

- [x] * Fix `offset`  definitions for Linear Pauli Rotations

- [x] * Fix `slope`  definitions for Linear Pauli Rotations

###### A little bit of math

For a register of state qubits $\ket{x}$, a target qubit $\ket{0}$ the operation $Y$ of a linear  rotation on a zero-input qubit is:

$$|x\rangle |0\rangle \mapsto \cos(ax + b)|x\rangle|0\rangle + \sin(ax + b)|x\rangle |1\rangle$$

with $a=$ `slope`/2 and $b=$ `offset`/2.

- link issue: https://github.com/Qiskit/qiskit-terra/issues/9861#issuecomment-1492126522
- link documentation: https://arxiv.org/pdf/1806.06893.pdf,




