### PR TITLE
Fix `UnrollCustomDefinitions` handling of empty definitions

### DIFF
--- a/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
+++ b/qiskit/transpiler/passes/basis/unroll_custom_definitions.py
@@ -86,25 +86,19 @@ class UnrollCustomDefinitions(TransformationPass):
                 if inst_supported or self._equiv_lib.has_entry(node.op):
                     continue
             try:
-                rule = node.op.definition.data
+                unrolled = getattr(node.op, "definition", None)
             except TypeError as err:
                 raise QiskitError(f"Error decomposing node {node.name}: {err}") from err
-            except AttributeError:
-                # definition is None
-                rule = None
 
-            if not rule:
-                if rule == []:
-                    dag.remove_op_node(node)
-                    continue
-
+            if unrolled is None:
                 # opaque node
                 raise QiskitError(
                     "Cannot unroll the circuit to the given basis, %s. "
                     "Instruction %s not found in equivalence library "
                     "and no rule found to expand." % (str(self._basis_gates), node.op.name)
                 )
-            decomposition = circuit_to_dag(node.op.definition)
+
+            decomposition = circuit_to_dag(unrolled)
             unrolled_dag = UnrollCustomDefinitions(
                 self._equiv_lib, self._basis_gates, target=self._target
             ).run(decomposition)

--- a/releasenotes/notes/fix-unroll-custom-definitions-empty-definition-4fd175c035445540.yaml
+++ b/releasenotes/notes/fix-unroll-custom-definitions-empty-definition-4fd175c035445540.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed global-phase handling in the :class:`.UnrollCustomDefinitions` transpiler pass if the
+    instruction in question had a global phase, but no instructions in its definition field.

--- a/test/python/transpiler/test_unroll_custom_definitions.py
+++ b/test/python/transpiler/test_unroll_custom_definitions.py
@@ -301,3 +301,19 @@ class TestUnrollCustomDefinitions(QiskitTestCase):
         expected_dag = circuit_to_dag(expected)
 
         self.assertEqual(out, expected_dag)
+
+    def test_unroll_empty_definition(self):
+        """Test that a gate with no operations can be unrolled."""
+        qc = QuantumCircuit(2)
+        qc.append(QuantumCircuit(2).to_gate(), [0, 1], [])
+        pass_ = UnrollCustomDefinitions(EquivalenceLibrary(), ["u"])
+        expected = QuantumCircuit(2)
+        self.assertEqual(pass_(qc), expected)
+
+    def test_unroll_empty_definition_with_phase(self):
+        """Test that a gate with no operations but with a global phase can be unrolled."""
+        qc = QuantumCircuit(2)
+        qc.append(QuantumCircuit(2, global_phase=0.5).to_gate(), [0, 1], [])
+        pass_ = UnrollCustomDefinitions(EquivalenceLibrary(), ["u"])
+        expected = QuantumCircuit(2, global_phase=0.5)
+        self.assertEqual(pass_(qc), expected)


### PR DESCRIPTION
### Summary

The previous form of the code assumed that the `data` of the definition of a custom instruction contained the complete information.  This is not the case; a definition might also have a global phase.  If the definition of a custom instruction was empty but had a global phase set, this pass would silently throw it away.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

Fixes an issue found in https://github.com/Qiskit/qiskit-terra/pull/9251#issuecomment-1494683204.
