### PR TITLE
Fix `AmplitudeEstimation` is silently ignoring `is_good_state` in the estimation problem

### DIFF
--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -358,8 +358,9 @@ class AmplitudeEstimation(AmplitudeEstimator):
         if estimation_problem.has_good_state:
             warnings.warn(
                 "The AmplitudeEstimation class does not support an is_good_state function to "
-                "identify good states. The oracle has to be set using the grover_operator, otherwise "
-                "a good state is identified by the objective qubits being in state 1."
+                "identify good states. For this algorithm, a custom oracle has to be encoded directly "
+                "in the grover_operator. If no custom oracle is set, this algorithm identifies good "
+                "states as those, where all objective qubits are in state 1."
             )
 
         result = AmplitudeEstimationResult()

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -355,7 +355,7 @@ class AmplitudeEstimation(AmplitudeEstimator):
         if estimation_problem.objective_qubits is None:
             raise ValueError("The objective_qubits property of the estimation problem must be set.")
 
-        if estimation_problem._is_good_state is not None:
+        if estimation_problem.has_good_state:
             warnings.warn(
                 "The AmplitudeEstimation class does not support an is_good_state function to "
                 "identify good states. The oracle has to be set using the grover_operator, otherwise "

--- a/qiskit/algorithms/amplitude_estimators/ae.py
+++ b/qiskit/algorithms/amplitude_estimators/ae.py
@@ -48,6 +48,13 @@ class AmplitudeEstimation(AmplitudeEstimator):
     Using a maximum likelihood post processing, this grid constraint can be circumvented.
     This improved estimator is implemented as well, see [2] Appendix A for more detail.
 
+    .. note::
+
+        This class does not support the :attr:`.EstimationProblem.is_good_state` property,
+        as for phase estimation-based QAE, the oracle that identifes the good states
+        must be encoded in the Grover operator. To set custom oracles, the
+        :attr:`.EstimationProblem.grover_operator` attribute can be set directly.
+
     References:
         [1]: Brassard, G., Hoyer, P., Mosca, M., & Tapp, A. (2000).
              Quantum Amplitude Amplification and Estimation.
@@ -347,6 +354,13 @@ class AmplitudeEstimation(AmplitudeEstimator):
 
         if estimation_problem.objective_qubits is None:
             raise ValueError("The objective_qubits property of the estimation problem must be set.")
+
+        if estimation_problem._is_good_state is not None:
+            warnings.warn(
+                "The AmplitudeEstimation class does not support an is_good_state function to "
+                "identify good states. The oracle has to be set using the grover_operator, otherwise "
+                "a good state is identified by the objective qubits being in state 1."
+            )
 
         result = AmplitudeEstimationResult()
         result.num_evaluation_qubits = self._m

--- a/qiskit/algorithms/amplitude_estimators/estimation_problem.py
+++ b/qiskit/algorithms/amplitude_estimators/estimation_problem.py
@@ -121,6 +121,19 @@ class EstimationProblem:
         self._post_processing = post_processing
 
     @property
+    def has_good_state(self) -> bool:
+        """Check whether an :attr:`is_good_state` function is set.
+
+        Some amplitude estimators, such as :class:`.AmplitudeEstimation` do not support
+        a custom implementation of the :attr:`is_good_state` function, and can only handle
+        the default.
+
+        Returns:
+            ``True``, if a custom :attr:`is_good_state` is set, otherwise returns ``False``.
+        """
+        return self._is_good_state is not None
+
+    @property
     def is_good_state(self) -> Callable[[str], bool]:
         """Checks whether a bitstring represents a good state.
 

--- a/releasenotes/notes/ae-warns-on-goodstate-7dbb689ba6a5e5e4.yaml
+++ b/releasenotes/notes/ae-warns-on-goodstate-7dbb689ba6a5e5e4.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The :class:`.AmplitudeEstimation` class now correctly warns if an :class:`.EstimationProblem`
+    with a set ``is_good_state`` property is passed as input, as it is not supported and ignored.
+    Previously, the algorithm would silently ignore this option leading to unexpected results.

--- a/releasenotes/notes/ae-warns-on-goodstate-7dbb689ba6a5e5e4.yaml
+++ b/releasenotes/notes/ae-warns-on-goodstate-7dbb689ba6a5e5e4.yaml
@@ -4,3 +4,9 @@ fixes:
     The :class:`.AmplitudeEstimation` class now correctly warns if an :class:`.EstimationProblem`
     with a set ``is_good_state`` property is passed as input, as it is not supported and ignored.
     Previously, the algorithm would silently ignore this option leading to unexpected results.
+features:
+  - |
+    Added the :attr:`.EstimationProblem.has_good_state` attribute, which allows to check
+    whether an :class:`.EstimationProblem` has a custom :attr:`.EstimationProblem.is_good_state`
+    or if it is the default. This is useful for checks in amplitude estimators, such as
+    :class:`.AmplitudeEstimation`, which only support the default implementation.

--- a/test/python/algorithms/test_amplitude_estimators.py
+++ b/test/python/algorithms/test_amplitude_estimators.py
@@ -558,6 +558,20 @@ class TestSineIntegral(QiskitAlgorithmsTestCase):
         self.assertTrue(confint[0] <= result.estimation <= confint[1])
 
 
+class TestAmplitudeEstimation(QiskitAlgorithmsTestCase):
+    """Specific tests for canonical AE."""
+
+    def test_warns_if_good_state_set(self):
+        """Check AE warns if is_good_state is set."""
+        circuit = QuantumCircuit(1)
+        problem = EstimationProblem(circuit, objective_qubits=[0], is_good_state=lambda x: True)
+
+        qae = AmplitudeEstimation(num_eval_qubits=1, sampler=Sampler())
+
+        with self.assertWarns(Warning):
+            _ = qae.estimate(problem)
+
+
 @ddt
 class TestFasterAmplitudeEstimation(QiskitAlgorithmsTestCase):
     """Specific tests for Faster AE."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

As discussed in [Slack](https://qiskit.slack.com/archives/C7SS31917/p1680543628959579), the `AmplitudeEstimation` algorithm does not support `EstimationProblem.is_good_state` but just accept and silently ignores it, which leads to unexpected outcomes. This PR warns if the option is set and adds a note to the docs, that this option should be set differently.

### Details and comments

That `is_good_state` is not supported is a property of the algorithm itself, not laziness on the dev side 🙂 

I labelled this "bugfix" as I thought that silently ignoring arguments is a bug, but we could also label this as docs change.

