### PR TITLE
Improve SabreSwap error message on unexpanded circuits

### DIFF
--- a/qiskit/transpiler/passes/routing/sabre_swap.py
+++ b/qiskit/transpiler/passes/routing/sabre_swap.py
@@ -183,8 +183,21 @@ class SabreSwap(TransformationPass):
         if len(dag.qregs) != 1 or dag.qregs.get("q", None) is None:
             raise TranspilerError("Sabre swap runs on physical circuits only.")
 
-        if len(dag.qubits) > self.coupling_map.size():
-            raise TranspilerError("More virtual qubits exist than physical.")
+        num_dag_qubits = len(dag.qubits)
+        num_coupling_qubits = self.coupling_map.size()
+        if num_dag_qubits < num_coupling_qubits:
+            raise TranspilerError(
+                f"Fewer qubits in the circuit ({num_dag_qubits}) than the coupling map"
+                f" ({num_coupling_qubits})."
+                " Have you run a layout pass and then expanded your DAG with ancillas?"
+                " See `FullAncillaAllocation`, `EnlargeWithAncilla` and `ApplyLayout`."
+            )
+        if num_dag_qubits > num_coupling_qubits:
+            raise TranspilerError(
+                f"More qubits in the circuit ({num_dag_qubits}) than available in the coupling map"
+                f" ({num_coupling_qubits})."
+                " This circuit cannot be routed to this device."
+            )
 
         if self.heuristic == "basic":
             heuristic = Heuristic.Basic

--- a/test/python/transpiler/test_sabre_swap.py
+++ b/test/python/transpiler/test_sabre_swap.py
@@ -19,7 +19,7 @@ import ddt
 from qiskit.circuit.library import CCXGate, HGate, Measure, SwapGate
 from qiskit.converters import circuit_to_dag
 from qiskit.transpiler.passes import SabreSwap, TrivialLayout
-from qiskit.transpiler import CouplingMap, PassManager
+from qiskit.transpiler import CouplingMap, PassManager, TranspilerError
 from qiskit import ClassicalRegister, QuantumRegister, QuantumCircuit
 from qiskit.test import QiskitTestCase
 from qiskit.utils import optionals
@@ -159,7 +159,7 @@ class TestSabreSwap(QiskitTestCase):
         coupling = CouplingMap(cm_edges)
 
         passmanager = PassManager(SabreSwap(coupling))
-        _ = passmanager.run(QuantumCircuit(1))
+        _ = passmanager.run(QuantumCircuit(coupling.size()))
 
         self.assertEqual(set(cm_edges), set(coupling.get_edges()))
 
@@ -338,6 +338,22 @@ class TestSabreSwap(QiskitTestCase):
 
         # Check that a re-run with the same seed produces the same circuit in the exact same order.
         self.assertEqual(normalize_nodes(dag_0), normalize_nodes(pass_0.run(dag)))
+
+    def test_rejects_too_many_qubits(self):
+        """Test that a sensible Python-space error message is emitted if the DAG has an incorrect
+        number of qubits."""
+        pass_ = SabreSwap(CouplingMap.from_line(4))
+        qc = QuantumCircuit(QuantumRegister(5, "q"))
+        with self.assertRaisesRegex(TranspilerError, "More qubits in the circuit"):
+            pass_(qc)
+
+    def test_rejects_too_few_qubits(self):
+        """Test that a sensible Python-space error message is emitted if the DAG has an incorrect
+        number of qubits."""
+        pass_ = SabreSwap(CouplingMap.from_line(4))
+        qc = QuantumCircuit(QuantumRegister(3, "q"))
+        with self.assertRaisesRegex(TranspilerError, "Fewer qubits in the circuit"):
+            pass_(qc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

`SabreSwap` requires that the input circuit is exactly the same size as the system implied by the coupling map, since this is used internally in Rust for the virtual-to-physical mapping.  Failure to ensure this can lead to panics in the Rust code.  This commit catches the failure case (for free) in Python space, and attempts to help the user work out what they needed.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->


### Details and comments

This was prompted by [a discussion in Slack about the confusing error](https://qiskit.slack.com/archives/C034SHPSKSQ/p1680635772120959), though I've done approximately the same thing myself before and got confused.